### PR TITLE
Implement ActiveSupport::BacktraceCleaner#first_clean_frame

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -256,11 +256,7 @@ module ActiveJob
       end
 
       def enqueue_source_location
-        Thread.each_caller_location do |location|
-          frame = backtrace_cleaner.clean_frame(location)
-          return frame if frame
-        end
-        nil
+        backtrace_cleaner.first_clean_frame
       end
 
       def enqueued_jobs_message(adapter, enqueued_jobs)

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -127,11 +127,7 @@ module ActiveRecord
       end
 
       def query_source_location
-        Thread.each_caller_location do |location|
-          frame = backtrace_cleaner.clean_frame(location)
-          return frame if frame
-        end
-        nil
+        backtrace_cleaner.first_clean_frame
       end
 
       def filter(name, value)

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -153,11 +153,7 @@ module ActiveRecord
       end
 
       def query_source_location # :nodoc:
-        Thread.each_caller_location do |location|
-          frame = LogSubscriber.backtrace_cleaner.clean_frame(location)
-          return frame if frame
-        end
-        nil
+        LogSubscriber.backtrace_cleaner.first_clean_frame
       end
 
       ActiveSupport::ExecutionContext.after_change { ActiveRecord::QueryLogs.clear_cache }

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   The new method `ActiveSupport::BacktraceCleaner#first_clean_frame` returns
+    the first clean frame of the caller's backtrace, or `nil`. Useful when you
+    want to report the application-level location where something happened.
+
+    *Xavier Noria*
+
 *   Always clear `CurrentAttribute` instances.
 
     Previously `CurrentAttribute` instance would be reset at the end of requests.

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -74,6 +74,32 @@ module ActiveSupport
       end
     end
 
+    # Thread.each_caller_location does not accept a start in Ruby < 3.4.
+    if Thread.method(:each_caller_location).arity == 0
+      # Returns the first clean frame of the caller's backtrace, or +nil+.
+      def first_clean_frame(kind = :silent)
+        caller_location_skipped = false
+
+        Thread.each_caller_location do |location|
+          unless caller_location_skipped
+            caller_location_skipped = true
+            next
+          end
+
+          frame = clean_frame(location, kind)
+          return frame if frame
+        end
+      end
+    else
+      # Returns the first clean frame of the caller's backtrace, or +nil+.
+      def first_clean_frame(kind = :silent)
+        Thread.each_caller_location(2) do |location|
+          frame = clean_frame(location, kind)
+          return frame if frame
+        end
+      end
+    end
+
     # Adds a filter from the block provided. Each line in the backtrace will be
     # mapped against this filter.
     #


### PR DESCRIPTION
This pattern has emerged in the framework, as seen in the patch, and I have also needed it in my own applications.
