### PR TITLE
[Fix #51044] Deprecate boolean flag arguments in query methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Deprecate passing boolean arguments to the following relation query methods:
+    * `#lock`
+    * `#readonly`
+    * `#strict_loading`
+    * `#distinct`
+
+    And the following model methods:
+    * `#lock!`
+    * `#with_lock`
+
+    The argument can be omitted to maintain the behaviour of enabling these features, and the
+    following relation query methods have been introduced to support disabling them:
+    * `#unscope_lock`
+    * `#unscope_readonly`
+    * `#unscope_strict_loading`
+    * `#unscope_distinct`
+
+    *Joshua Young*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -714,7 +714,7 @@ module ActiveRecord
       #   person.pets.select(:name).distinct
       #   # => [#<Pet name: "Fancy-Fancy">]
       #
-      #   person.pets.select(:name).distinct.distinct(false)
+      #   person.pets.select(:name).distinct.unscope_distinct
       #   # => [
       #   #      #<Pet name: "Fancy-Fancy">,
       #   #      #<Pet name: "Fancy-Fancy">

--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -65,10 +65,10 @@ module ActiveRecord
     #   https://www.postgresql.org/docs/current/interactive/sql-select.html#SQL-FOR-UPDATE-SHARE
     module Pessimistic
       # Obtain a row lock on this record. Reloads the record to obtain the requested
-      # lock. Pass an SQL locking clause to append the end of the SELECT statement
-      # or pass true for "FOR UPDATE" (the default, an exclusive row lock). Returns
+      # lock. Pass an SQL locking clause to append to the end of the SELECT statement;
+      # otherwise, this will default to "FOR UPDATE" (an exclusive row lock). Returns
       # the locked record.
-      def lock!(lock = true)
+      def lock!(lock = "FOR UPDATE")
         if self.class.current_preventing_writes
           raise ActiveRecord::ReadOnlyError, "Lock query attempted while in readonly mode"
         end
@@ -99,7 +99,7 @@ module ActiveRecord
       # ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction).
       def with_lock(*args)
         transaction_opts = args.extract_options!
-        lock = args.present? ? args.first : true
+        lock = args.present? ? args.first : "FOR UPDATE"
         transaction(**transaction_opts) do |transaction|
           lock!(lock)
           yield transaction

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,11 +13,11 @@ module ActiveRecord
       :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :regroup, :in_order_of, :reorder, :default_order, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
-      :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
+      :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :unscope_lock, :readonly, :unscope_readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,
-      :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
+      :having, :create_with, :distinct, :unscope_distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
-      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with_recursive,
+      :pluck, :pick, :ids, :async_ids, :strict_loading, :unscope_strict_loading, :excluding, :without, :with_recursive,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
       :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all
     ].freeze # :nodoc:

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -55,7 +55,7 @@ module ActiveRecord
     # expected <tt>person.visits == 4</tt>.
     #
     #   Person.transaction do
-    #     person = Person.lock(true).find(1)
+    #     person = Person.lock.find(1)
     #     person.visits += 1
     #     person.save!
     #   end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1301,16 +1301,32 @@ module ActiveRecord
       self
     end
 
-    # Specifies locking settings (default to +true+). For more information
+    # Specifies locking settings (defaults to `"FOR UPDATE"`). For more information
     # on locking, please see ActiveRecord::Locking.
-    def lock(locks = true)
-      spawn.lock!(locks)
+    def lock(lock = (lock_not_given = "FOR UPDATE"))
+      unless lock_not_given || lock.is_a?(String)
+        ActiveRecord.deprecator.warn(<<~MSG)
+          Passing a non-`String` argument to `lock` is deprecated and will be removed in Rails 8.2.
+          Use `lock` without arguments, or with a custom lock statement to specify the lock type,
+          and `unscope_lock` to unspecify the lock.
+        MSG
+      end
+
+      spawn.lock!(lock)
     end
 
-    def lock!(locks = true) # :nodoc:
-      case locks
-      when String, TrueClass, NilClass
-        self.lock_value = locks || true
+    # Unspecifies locking settings. For more information on locking, please see
+    # ActiveRecord::Locking.
+    def unscope_lock
+      spawn.lock!(false)
+    end
+
+    def lock!(lock = "FOR UPDATE") # :nodoc:
+      case lock
+      when String
+        self.lock_value = lock
+      when TrueClass, NilClass
+        self.lock_value = "FOR UPDATE"
       else
         self.lock_value = false
       end
@@ -1368,14 +1384,26 @@ module ActiveRecord
     #   users = User.readonly
     #   users.first.save
     #   # => ActiveRecord::ReadOnlyRecord: User is marked as readonly
+    def readonly(value = (value_not_given = true))
+      unless value_not_given
+        ActiveRecord.deprecator.warn(<<~MSG)
+          Passing an argument to `readonly` is deprecated and will be removed in Rails 8.2.
+          Use `readonly` without arguments to mark as readonly, and `unscope_readonly`
+          to unmark as readonly.
+        MSG
+      end
+
+      spawn.readonly!(value)
+    end
+
+    # Unmark a relation as readonly. Attempting to update a record will no longer
+    # result in an error.
     #
-    # To make a readonly relation writable, pass +false+.
-    #
-    #   users.readonly(false)
+    #   users = User.readonly.unscope_readonly
     #   users.first.save
     #   # => true
-    def readonly(value = true)
-      spawn.readonly!(value)
+    def unscope_readonly
+      spawn.readonly!(false)
     end
 
     def readonly!(value = true) # :nodoc:
@@ -1389,8 +1417,26 @@ module ActiveRecord
     #   user = User.strict_loading.first
     #   user.comments.to_a
     #   # => ActiveRecord::StrictLoadingViolationError
-    def strict_loading(value = true)
+    def strict_loading(value = (value_not_given = true))
+      unless value_not_given
+        ActiveRecord.deprecator.warn(<<~MSG)
+          Passing an argument to `strict_loading` is deprecated and will be removed in Rails 8.2.
+          Use `strict_loading` without arguments to set strict_loading mode, and `unscope_strict_loading`
+          to unset strict_loading mode.
+        MSG
+      end
+
       spawn.strict_loading!(value)
+    end
+
+    # Unsets the returned relation from strict_loading mode. This will not raise
+    # an error if the record tries to lazily load an association.
+    #
+    #   user = User.strict_loading.unscope_strict_loading.first
+    #   user.comments.to_a
+    #   # => []
+    def unscope_strict_loading
+      spawn.strict_loading!(false)
     end
 
     def strict_loading!(value = true) # :nodoc:
@@ -1472,11 +1518,24 @@ module ActiveRecord
     #
     #   User.select(:name).distinct
     #   # Returns 1 record per distinct name
-    #
-    #   User.select(:name).distinct.distinct(false)
-    #   # You can also remove the uniqueness
-    def distinct(value = true)
+    def distinct(value = (value_not_given = true))
+      unless value_not_given
+        ActiveRecord.deprecator.warn(<<~MSG)
+          Passing an argument to `distinct` is deprecated and will be removed in Rails 8.2.
+          Use `distinct` without arguments to specify uniqueness, and `unscope_distinct`
+          to remove the uniqueness.
+        MSG
+      end
+
       spawn.distinct!(value)
+    end
+
+    # Removes the uniqueness constraint from the relation.
+    #
+    #   User.select(:name).distinct.unscope_distinct
+    #   # Returns all records, including duplicates
+    def unscope_distinct
+      spawn.distinct!(false)
     end
 
     # Like #distinct, but modifies relation in place.

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1362,7 +1362,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     Reader.create(post_id: post2.id, person_id: person3.id)
     Reader.create(post_id: post2.id, person_id: person4.id)
 
-    active_persons = Person.joins(:readers).joins(:posts).distinct(true).where("posts.title" => "active")
+    active_persons = Person.joins(:readers).joins(:posts).distinct.where("posts.title" => "active")
 
     assert_equal 10, active_persons.map(&:followers_count).reduce(:+)
     assert_equal 10, active_persons.sum(:followers_count)

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -144,8 +144,8 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert authors.all? { |a| !a.readonly? }, "expected no authors to be readonly"
   end
 
-  def test_find_with_implicit_inner_joins_honors_readonly_false
-    authors = Author.joins(:posts).readonly(false).to_a
+  def test_find_with_implicit_inner_joins_honors_unscope_readonly
+    authors = Author.joins(:posts).unscope_readonly.to_a
     assert_not authors.empty?, "expected authors to be non-empty"
     assert authors.all? { |a| !a.readonly? }, "expected no authors to be readonly"
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -677,7 +677,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_count_with_manual_distinct_select_and_distinct
-    assert_equal 4, Account.select("DISTINCT accounts.firm_id").distinct(true).count
+    assert_equal 4, Account.select("DISTINCT accounts.firm_id").distinct.count
   end
 
   def test_should_count_manual_select_with_group_with_count_all

--- a/activerecord/test/cases/custom_locking_test.rb
+++ b/activerecord/test/cases/custom_locking_test.rb
@@ -14,6 +14,13 @@ module ActiveRecord
           Person.all.merge!(lock: "LOCK IN SHARE MODE").find(1)
         end
       end
+
+      def test_custom_lock_with_unscope_lock
+        assert_no_match "SHARE MODE", Person.lock("LOCK IN SHARE MODE").unscope_lock.to_sql
+        assert_no_queries_match(/LOCK IN SHARE MODE/) do
+          Person.all.merge!(lock: "LOCK IN SHARE MODE").unscope_lock.find(1)
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -881,6 +881,20 @@ class PessimisticLockingTest < ActiveRecord::TestCase
       assert first.end > second.end
     end
 
+    def test_lock_with_true_argument_deprecation
+      person = Person.find 1
+      assert_deprecated(ActiveRecord.deprecator) { person.lock!(true) }
+      assert_not_deprecated(ActiveRecord.deprecator) { person.lock!("FOR UPDATE") }
+      assert_not_deprecated(ActiveRecord.deprecator) { person.lock!(Arel.sql("FOR UPDATE")) }
+    end
+
+    def test_with_lock_with_true_argument_deprecation
+      person = Person.find 1
+      assert_deprecated(ActiveRecord.deprecator) { person.with_lock(true) { } }
+      assert_not_deprecated(ActiveRecord.deprecator) { person.with_lock("FOR UPDATE") { } }
+      assert_not_deprecated(ActiveRecord.deprecator) { person.with_lock(Arel.sql("FOR UPDATE")) { } }
+    end
+
     private
       def duel(&block)
         t0, t1, t2, t3 = nil, nil, nil, nil
@@ -1012,6 +1026,14 @@ class PessimisticLockingWhilePreventingWritesTest < ActiveRecord::TestCase
     ActiveRecord::Base.while_preventing_writes do
       assert_raises(ActiveRecord::ReadOnlyError) do
         Person.lock.find_by id: 1
+      end
+    end
+  end
+
+  def test_relation_unscope_lock_when_preventing_writes
+    ActiveRecord::Base.while_preventing_writes do
+      assert_nothing_raised do
+        Person.lock.unscope_lock.find_by id: 1
       end
     end
   end

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -80,18 +80,18 @@ class ReadOnlyTest < ActiveRecord::TestCase
   def test_find_with_readonly_option
     Developer.all.each { |d| assert_not d.readonly? }
     Developer.all.tap { |rel| assert_not rel.readonly? }
-    Developer.readonly(false).each { |d| assert_not d.readonly? }
-    Developer.readonly(true).each { |d| assert_predicate d, :readonly? }
+    Developer.unscope_readonly.each { |d| assert_not d.readonly? }
+    Developer.readonly.each { |d| assert_predicate d, :readonly? }
     Developer.readonly.each { |d| assert_predicate d, :readonly? }
     Developer.readonly.tap { |rel| assert_predicate rel, :readonly? }
   end
 
   def test_find_with_joins_option_does_not_imply_readonly
     Developer.joins("  ").each { |d| assert_not d.readonly? }
-    Developer.joins("  ").readonly(true).each { |d| assert_predicate d, :readonly? }
+    Developer.joins("  ").readonly.each { |d| assert_predicate d, :readonly? }
 
     Developer.joins(", projects").each { |d| assert_not d.readonly? }
-    Developer.joins(", projects").readonly(true).each { |d| assert_predicate d, :readonly? }
+    Developer.joins(", projects").readonly.each { |d| assert_predicate d, :readonly? }
   end
 
   def test_has_many_find_readonly
@@ -99,7 +99,7 @@ class ReadOnlyTest < ActiveRecord::TestCase
     assert_not_empty post.comments
     assert_not post.comments.any?(&:readonly?)
     assert_not post.comments.to_a.any?(&:readonly?)
-    assert post.comments.readonly(true).all?(&:readonly?)
+    assert post.comments.readonly.all?(&:readonly?)
   end
 
   def test_has_many_with_through_is_not_implicitly_marked_readonly
@@ -122,26 +122,26 @@ class ReadOnlyTest < ActiveRecord::TestCase
   def test_readonly_scoping
     Post.where("1=1").scoping do
       assert_not_predicate Post.find(1), :readonly?
-      assert_predicate Post.readonly(true).find(1), :readonly?
-      assert_not_predicate Post.readonly(false).find(1), :readonly?
+      assert_predicate Post.readonly.find(1), :readonly?
+      assert_not_predicate Post.unscope_readonly.find(1), :readonly?
     end
 
     Post.joins("   ").scoping do
       assert_not_predicate Post.find(1), :readonly?
       assert_predicate Post.readonly.find(1), :readonly?
-      assert_not_predicate Post.readonly(false).find(1), :readonly?
+      assert_not_predicate Post.unscope_readonly.find(1), :readonly?
     end
 
     Post.joins(", developers").scoping do
       assert_not_predicate Post.find(1), :readonly?
       assert_predicate Post.readonly.find(1), :readonly?
-      assert_not_predicate Post.readonly(false).find(1), :readonly?
+      assert_not_predicate Post.unscope_readonly.find(1), :readonly?
     end
 
-    Post.readonly(true).scoping do
+    Post.readonly.scoping do
       assert_predicate Post.find(1), :readonly?
       assert_predicate Post.readonly.find(1), :readonly?
-      assert_not_predicate Post.readonly(false).find(1), :readonly?
+      assert_not_predicate Post.unscope_readonly.find(1), :readonly?
     end
   end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -226,9 +226,9 @@ module ActiveRecord
       assert_equal Relation::WhereClause.new([Arel.sql("(foo = ?)", "bar")]), relation.where_clause
     end
 
-    def test_merging_readonly_false
+    def test_merging_unscope_readonly
       relation = Relation.new(FakeKlass)
-      readonly_false_relation = relation.readonly(false)
+      readonly_false_relation = relation.unscope_readonly
       # test merging in both directions
       assert_equal false, relation.merge(readonly_false_relation).readonly_value
       assert_equal false, readonly_false_relation.merge(relation).readonly_value

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1103,11 +1103,11 @@ class RelationTest < ActiveRecord::TestCase
   def test_count_with_distinct
     posts = Post.all
 
-    assert_equal 4, posts.distinct(true).count(:comments_count)
-    assert_equal 11, posts.distinct(false).count(:comments_count)
+    assert_equal 4, posts.distinct.count(:comments_count)
+    assert_equal 11, posts.unscope_distinct.count(:comments_count)
 
-    assert_equal 4, posts.distinct(true).select(:comments_count).count
-    assert_equal 11, posts.distinct(false).select(:comments_count).count
+    assert_equal 4, posts.distinct.select(:comments_count).count
+    assert_equal 11, posts.unscope_distinct.select(:comments_count).count
   end
 
   def test_size_with_distinct
@@ -1893,9 +1893,9 @@ class RelationTest < ActiveRecord::TestCase
       assert_equal ["Foo"], query.distinct.map(&:name)
     end
     assert_queries_match(/DISTINCT/) do
-      assert_equal ["Foo"], query.distinct(true).map(&:name)
+      assert_equal ["Foo"], query.distinct.map(&:name)
     end
-    assert_equal ["Foo", "Foo"], query.distinct(true).distinct(false).map(&:name)
+    assert_equal ["Foo", "Foo"], query.distinct.unscope_distinct.map(&:name)
   end
 
   def test_doesnt_add_having_values_if_options_are_blank
@@ -2567,6 +2567,33 @@ class RelationTest < ActiveRecord::TestCase
       authors = Author.public_send(method, [""])
       assert_empty authors.public_send(:"#{method}_values")
     end
+  end
+
+  def test_lock_with_boolean_or_nil_argument_deprecation
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.lock(nil).to_a }
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.lock(true).to_a }
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.lock(false).to_a }
+    assert_not_deprecated(ActiveRecord.deprecator) { Post.all.lock.to_a }
+    assert_not_deprecated(ActiveRecord.deprecator) { Post.all.lock("FOR UPDATE").to_a }
+    assert_not_deprecated(ActiveRecord.deprecator) { Post.all.lock(Arel.sql("FOR UPDATE")).to_a }
+  end
+
+  def test_readonly_with_argument_deprecation
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.readonly(true).to_a }
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.readonly(false).to_a }
+    assert_not_deprecated(ActiveRecord.deprecator) { Post.all.readonly.to_a }
+  end
+
+  def test_strict_loading_with_argument_deprecation
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.strict_loading(true).to_a }
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.strict_loading(false).to_a }
+    assert_not_deprecated(ActiveRecord.deprecator) { Post.all.strict_loading.to_a }
+  end
+
+  def test_distinct_with_argument_deprecation
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.distinct(true).to_a }
+    assert_deprecated(ActiveRecord.deprecator) { Post.all.distinct(false).to_a }
+    assert_not_deprecated(ActiveRecord.deprecator) { Post.all.distinct.to_a }
   end
 
   private

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -144,7 +144,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
   def test_strict_loading_by_default
     with_strict_loading_by_default(Developer) do
       Developer.all.each { |d| assert_predicate d, :strict_loading? }
-      Developer.strict_loading(false).each { |d| assert_not d.strict_loading? }
+      Developer.unscope_strict_loading.each { |d| assert_not d.strict_loading? }
     end
   end
 
@@ -415,7 +415,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
 
     assert dev.strict_loading_audit_logs.all?(&:strict_loading?), "Expected all audit logs to be strict_loading"
 
-    dev = Developer.eager_load(:strict_loading_audit_logs).strict_loading(false).first
+    dev = Developer.eager_load(:strict_loading_audit_logs).unscope_strict_loading.first
 
     assert dev.audit_logs.none?(&:strict_loading?), "Expected no audit logs to be strict_loading"
   end
@@ -432,7 +432,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
     assert_predicate dev, :strict_loading?
     assert dev.audit_logs.all?(&:strict_loading?), "Expected all audit logs to be strict_loading"
 
-    dev = Developer.eager_load(:audit_logs).strict_loading(false).first
+    dev = Developer.eager_load(:audit_logs).unscope_strict_loading.first
 
     assert_not_predicate dev, :strict_loading?
     assert dev.audit_logs.none?(&:strict_loading?), "Expected no audit logs to be strict_loading"

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1808,7 +1808,7 @@ You can also remove the uniqueness constraint:
 query = Customer.select(:last_name).distinct
 
 # Returns a list of all last_names, even if there are duplicates
-query.distinct(false)
+query.unscope_distinct
 ```
 
 Grouping Records


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Closes https://github.com/rails/rails/issues/51044
Supersedes https://github.com/rails/rails/pull/51045
Addresses https://github.com/rails/rails/pull/51045#issuecomment-2214613080

cc @fatkodima @nvasilevski

### Detail

Deprecates providing boolean and `nil` (where explicitly supported) arguments to the following relation query methods:
- `#lock`
- `#readonly`
- `#strict_loading`
- `#distinct`

By extension, the changes to `#lock` will also affect the following model methods:
- `#lock!`
- `#with_lock`

In the case of `true` or `nil`, all that is needed to address the deprecation is omit the argument. In the case of `false`, I've introduced new `#unscope_<query_method>` methods which users can migrate to instead.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Some or all of these methods may have unintentionally accepted truthy and falsy values as arguments, which creates ambiguity—one of the key motivations behind these changes. Considering none of these behaviours have been documented or tested against, neither the deprecation message nor the changelog entry refer to them.

I've only changed public APIs in these changes. All these methods call out to undocumented relation query methods (e.g. `#lock!`) that actually mutate the relation, and those in turn may be relying on similar arel methods, both of which may and will continue to handle truthy/falsy arguments.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.