### PR TITLE
Add note to Migrations guide for migrations_paths option [ci skip]

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -112,6 +112,9 @@ another application or generating a file yourself, be aware of its position in
 the order. You can read more about how the timestamps are used in the [Rails
 Migration Version Control section](#rails-migration-version-control).
 
+NOTE: You can override the directory that migrations are stored in by setting the
+`migrations_paths` option in your `config/database.yml`.
+
 When generating a migration, Active Record automatically prepends the current
 timestamp to the file name of the migration. For example, running the command
 below will create an empty migration file whereby the filename is made up of a


### PR DESCRIPTION
* ~Adds link to Configuring guide for more~
* Add note to Migrations guide for `migrations_paths` option
* ~Adds descriptions for undocumented public getters on HashConfig~

**Edit**: I backtracked on using the API docs to provide a reference of available config/database.yml flags