### PR TITLE
Modernize tag helper examples to use `tag.<tag name>` syntax [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -453,29 +453,26 @@ module ActionView
       #
       # ==== Examples
       #
-      #   tag("br")
-      #   # => <br />
-      #
-      #   tag("br", nil, true)
+      #   tag.br
       #   # => <br>
       #
-      #   tag("input", type: 'text', disabled: true)
-      #   # => <input type="text" disabled="disabled" />
+      #   tag.input(type: "text", disabled: true)
+      #   # => <input type="text" disabled="disabled">
       #
-      #   tag("input", type: 'text', class: ["strong", "highlight"])
-      #   # => <input class="strong highlight" type="text" />
+      #   tag.input(type: "text", class: ["strong", "highlight"])
+      #   # => <input type="text" class="strong highlight">
       #
-      #   tag("img", src: "open & shut.png")
-      #   # => <img src="open &amp; shut.png" />
+      #   tag.img(src: "open & shut.png")
+      #   # => <img src="open &amp; shut.png">
       #
-      #   tag("img", { src: "open &amp; shut.png" }, false, false)
-      #   # => <img src="open &amp; shut.png" />
+      #   tag.img(src: "open &amp; shut.png", escape: false)
+      #   # => <img src="open &amp; shut.png">
       #
-      #   tag("div", data: { name: 'Stephen', city_state: %w(Chicago IL) })
-      #   # => <div data-name="Stephen" data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]" />
+      #   tag.div(data: { name: "Stephen", city_state: %w(Chicago IL) })
+      #   # => <div data-name="Stephen" data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]"></div>
       #
-      #   tag("div", class: { highlight: current_user.admin? })
-      #   # => <div class="highlight" />
+      #   tag.div(class: { highlight: current_user.admin? })
+      #   # => <div class="highlight"></div>
       def tag(name = nil, options = nil, open = false, escape = true)
         if name.nil?
           tag_builder


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because the documentation of Action View Tag Helper's `#tag` contains a set of examples but they are formatted using what the same documentation considers as legacy syntax[^1]

[^1]: https://api.rubyonrails.org/v8.0.2/classes/ActionView/Helpers/TagHelper.html#method-i-tag

### Detail
This Pull Request replaces legacy `tag("element")` examples with modern `tag.<tag name>` and highlights HTML5-compliant formatting output in which trailing slashes are unnecessary.

### Additional information
The new syntax was added at a65a3bde0be. It seems it was planned to deprecate the legacy syntax but apparently the deprecation has not been commenced. I am not sure if I would like to see the deprecation resumed after years, but separately I guess it would be great to show modern syntax for developers to learn a better practice from examples.

### Checklist
Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
