### PR TITLE
Implement ActiveSupport::BacktraceCleaner#first_clean_location

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,10 +1,18 @@
+*   The new method `ActiveSupport::BacktraceCleaner#first_clean_location`
+    returns the first clean location of the caller's call stack, or `nil`.
+    Locations are `Thread::Backtrace::Location` objects. Useful when you want to
+    report the application-level location where something happened as an object.
+
+    *Xavier Noria*
+
 *   FileUpdateChecker and EventedFileUpdateChecker ignore changes in Gem.path now.
 
     *Ermolaev Andrey*, *zzak*
 
 *   The new method `ActiveSupport::BacktraceCleaner#first_clean_frame` returns
     the first clean frame of the caller's backtrace, or `nil`. Useful when you
-    want to report the application-level location where something happened.
+    want to report the application-level frame where something happened as a
+    string.
 
     *Xavier Noria*
 

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -77,6 +77,8 @@ module ActiveSupport
     # Thread.each_caller_location does not accept a start in Ruby < 3.4.
     if Thread.method(:each_caller_location).arity == 0
       # Returns the first clean frame of the caller's backtrace, or +nil+.
+      #
+      # Frames are strings.
       def first_clean_frame(kind = :silent)
         caller_location_skipped = false
 
@@ -92,10 +94,40 @@ module ActiveSupport
       end
     else
       # Returns the first clean frame of the caller's backtrace, or +nil+.
+      #
+      # Frames are strings.
       def first_clean_frame(kind = :silent)
         Thread.each_caller_location(2) do |location|
           frame = clean_frame(location, kind)
           return frame if frame
+        end
+      end
+    end
+
+    # Thread.each_caller_location does not accept a start in Ruby < 3.4.
+    if Thread.method(:each_caller_location).arity == 0
+      # Returns the first clean location of the caller's call stack, or +nil+.
+      #
+      # Locations are Thread::Backtrace::Location objects.
+      def first_clean_location(kind = :silent)
+        caller_location_skipped = false
+
+        Thread.each_caller_location do |location|
+          unless caller_location_skipped
+            caller_location_skipped = true
+            next
+          end
+
+          return location if clean_frame(location, kind)
+        end
+      end
+    else
+      # Returns the first clean location of the caller's call stack, or +nil+.
+      #
+      # Locations are Thread::Backtrace::Location objects.
+      def first_clean_location(kind = :silent)
+        Thread.each_caller_location(2) do |location|
+          return location if clean_frame(location, kind)
         end
       end
     end

--- a/activesupport/test/backtrace_cleaner_test.rb
+++ b/activesupport/test/backtrace_cleaner_test.rb
@@ -137,7 +137,7 @@ class BacktraceCleanerDefaultFilterAndSilencerTest < ActiveSupport::TestCase
   end
 end
 
-class BacktraceCleanerFirstCleanFrame < ActiveSupport::TestCase
+class BacktraceCleanerFirstCleanFrameTest < ActiveSupport::TestCase
   def setup
     @bc = ActiveSupport::BacktraceCleaner.new
   end
@@ -178,5 +178,57 @@ class BacktraceCleanerFirstCleanFrame < ActiveSupport::TestCase
   test "returns nil if there is no clean frame" do
     @bc.add_silencer { true }
     assert_nil invoke_first_clean_frame_defaults
+  end
+end
+
+class BacktraceCleanerFirstCleanLocationTest < ActiveSupport::TestCase
+  def setup
+    @bc = ActiveSupport::BacktraceCleaner.new
+  end
+
+  def invoke_first_clean_location_defaults
+    -> do
+      @bc.first_clean_location.tap { @line = __LINE__ + 1 }
+    end.call
+  end
+
+  def invoke_first_clean_location(kind = :silent)
+    -> do
+      @bc.first_clean_location(kind).tap { @line = __LINE__ + 1 }
+    end.call
+  end
+
+  test "returns the first clean location (defaults)" do
+    location = invoke_first_clean_location_defaults
+
+    assert_equal __FILE__, location.path
+    assert_equal @line, location.lineno
+  end
+
+  test "returns the first clean location (:silent)" do
+    location = invoke_first_clean_location(:silent)
+
+    assert_equal __FILE__, location.path
+    assert_equal @line, location.lineno
+  end
+
+  test "returns the first clean location (:noise)" do
+    @bc.add_silencer { true }
+    location = invoke_first_clean_location(:noise)
+
+    assert_equal __FILE__, location.path
+    assert_equal @line, location.lineno
+  end
+
+  test "returns the first clean location (:any)" do
+    location = invoke_first_clean_location(:any) # fallback of the case statement
+
+    assert_equal __FILE__, location.path
+    assert_equal @line, location.lineno
+  end
+
+  test "returns nil if there is no clean location" do
+    @bc.add_silencer { true }
+    assert_nil invoke_first_clean_location_defaults
   end
 end


### PR DESCRIPTION
We added `ActiveSupport::BacktraceCleaner#first_clean_frame` in https://github.com/rails/rails/pull/55222, but sometimes you'd like to have an object, not a string. This method returns a `Thread::Backtrace::Location` object.

Regarding the implementation, I considered writing a common private method that returns a frame or a location depending on what the caller asks for. Then, the public-facing ones would become one-liners calling such method with some extra parameter.

However, if we ignore for a moment that there are two implementations per Ruby version and imagine we only have the one for Ruby 3.4, I believe the real simple approach is to duplicate the few lines of code needed.