### PR TITLE
Disable Minitest/AssertPredicate cop on 8-0-stable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -376,9 +376,6 @@ Performance/RedundantStringChars:
 Performance/StringInclude:
   Enabled: true
 
-Minitest/AssertPredicate:
-  Enabled: true
-
 Minitest/AssertRaisesWithRegexpArgument:
   Enabled: true
 


### PR DESCRIPTION
### Motivation / Background

This pull request addresses the RuboCop offense at https://buildkite.com/rails/rails/builds/119305#0197973c-5b4a-427d-a6a3-85f3ae1593ac/1214-1323


### Detail

The Minitest/AssertPredicate cop has been removed from the main branch in commit https://github.com/rails/rails/pull/54693/commits/55b072dbfd5810263ee50d7531254738c10fae9f . To maintain consistency with this decision, disable the cop on 8-0-stable rather than auto-correcting the offense.

- Offenses disabled by this commit:
```ruby
$ bundle exec rubocop
... snip ....
Offenses:

actioncable/test/channel/base_test.rb:136:5: C: [Correctable] Minitest/AssertPredicate: Prefer using assert_predicate(@channel, :unsubscribed?).
    assert @channel.unsubscribed?
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

3331 files inspected, 1 offense detected, 1 offense autocorrectable
$
```

### Additional information
Follow up https://github.com/rails/rails/pull/55201 and https://github.com/rails/rails/commit/f5b8826cd03edbaf4a0a7bb40323c0de2e6cda91

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
