### PR TITLE
Address TestERBTemplate test failure with Ruby 3.5.0dev

### DIFF
--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -246,7 +246,7 @@ class TestERBTemplate < ActiveSupport::TestCase
       render
     end
 
-    assert_match(/in ['`]hello'/, error.backtrace.first)
+    assert_match(/in ['`].*hello'/, error.backtrace.first)
     assert_instance_of ArgumentError, error.cause
   end
 


### PR DESCRIPTION
Addressed CI failure at https://buildkite.com/rails/rails-nightly/builds/2429#0197a3be-292e-429d-ad37-635e803ba2d2/1244-1256

### Motivation / Background

This commit addresses the `TestERBTemplate#test_argument_error_in_the_template_is_not_hijacked_by_strict_locals_checking` failure with Ruby 3.5.0dev including https://github.com/ruby/ruby/commit/3546cedde3f6f46f00fd67b73081cbfbb83144de

### Detail
This pull request addresses the following failure.

```ruby
$ cd actionview
$ ruby -v ; rm ../Gemfile.lock ; bundle ; bin/test test/template/template_test.rb:243
ruby 3.5.0dev (2025-06-24T02:39:58Z master 3546cedde3) +PRISM [x86_64-linux]
... snip ...

F

Failure:
TestERBTemplate#test_argument_error_in_the_template_is_not_hijacked_by_strict_locals_checking [test/template/template_test.rb:249]:
Expected /in ['`]hello'/ to match "/home/yahonda/src/github.com/rails/rails/actionview/test/template/template_test.rb:27:in 'TestERBTemplate::Context#hello'".

bin/test test/template/template_test.rb:243

Finished in 0.006231s, 160.4981 runs/s, 481.4942 assertions/s.
1 runs, 3 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information

Here are `pp error.backtrace.first` differences between Ruby versions:

```ruby
$ git diff
diff --git a/actionview/test/template/template_test.rb b/actionview/test/template/template_test.rb
index e8fa3c8e81..688b5b1f0f 100644
--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -245,7 +245,7 @@ def test_argument_error_in_the_template_is_not_hijacked_by_strict_locals_checkin
       @template = new_template("<%# locals: () -%>\n<%= hello(:invalid_argument) %>")
       render
     end
-
+    pp error.backtrace.first
     assert_match(/in ['`].*hello'/, error.backtrace.first)
     assert_instance_of ArgumentError, error.cause
   end
$
```

- Ruby 3.3.8 `ruby 3.3.8 (2025-04-09 revision b200bad6cd) [x86_64-linux]` "/home/yahonda/src/github.com/rails/rails/actionview/test/template/template_test.rb:27:in `hello'"

- Ruby 3.4.4 `ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]` "/home/yahonda/src/github.com/rails/rails/actionview/test/template/template_test.rb:27:in 'hello'"

- Ruby master `ruby 3.5.0dev (2025-06-24T02:39:58Z master 3546cedde3) +PRISM [x86_64-linux]` "/home/yahonda/src/github.com/rails/rails/actionview/test/template/template_test.rb:27:in 'TestERBTemplate::Context#hello'"

Refer to:
https://github.com/ruby/ruby/pull/13679
https://bugs.ruby-lang.org/issues/20968#change-113811

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
