### PR TITLE
Make sure that `CurrentAttributes.set` works on the current instance

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -151,7 +151,21 @@ module ActiveSupport
       end
       alias_method :after_reset, :resets
 
-      delegate :set, :reset, to: :instance
+      delegate :reset, to: :instance
+
+      # Expose one or more attributes within a block. Old values are returned after the block concludes.
+      # Example demonstrating the common use of needing to set Current attributes outside the request-cycle:
+      #
+      #   class Chat::PublicationJob < ApplicationJob
+      #     def perform(attributes, room_number, creator)
+      #       Current.set(person: creator) do
+      #         Chat::Publisher.publish(attributes: attributes, room_number: room_number)
+      #       end
+      #     end
+      #   end
+      def set(attributes, &block)
+        with(**attributes, &block)
+      end
 
       def clear_all # :nodoc:
         current_instances.each_value(&:reset)
@@ -207,16 +221,10 @@ module ActiveSupport
       @attributes.dup
     end
 
-    # Expose one or more attributes within a block. Old values are returned after the block concludes.
-    # Example demonstrating the common use of needing to set Current attributes outside the request-cycle:
-    #
-    #   class Chat::PublicationJob < ApplicationJob
-    #     def perform(attributes, room_number, creator)
-    #       Current.set(person: creator) do
-    #         Chat::Publisher.publish(attributes: attributes, room_number: room_number)
-    #       end
-    #     end
-    #   end
+    # Keeping this for backward compatibility,
+    # but calling `#set` on the instance of a `CurrentAttributes` class
+    # can produce unexpected results.
+    # You should use the class method instead.
     def set(attributes, &block)
       with(**attributes, &block)
     end

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -178,6 +178,20 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     end
   end
 
+  test "set and restore attributes when the block clears" do
+    Current.world = "world/1"
+    Current.account = "account/1"
+
+    Current.set(world: "world/2", account: "account/2") do
+      assert_equal "world/2", Current.world
+      assert_equal "account/2", Current.account
+      ActiveSupport::CurrentAttributes.clear_all
+    end
+
+    assert_equal "world/1", Current.world
+    assert_equal "account/1", Current.account
+  end
+
   test "using keyword arguments" do
     Current.set_world_and_account(world: "world/1", account: "account/1")
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

If the block passed to `CurrentAttributes.set` happens to clear all current attributes (which happens for example when performing jobs), then `.set` is unable to restore attribute values on the proper singleton instance of the `CurrentAttributes` class.
See the added test for details.

The problem has always existed, but was emphasized by PR #55139, causing tests that perform enqueued jobs in a `Current.set` block to reset current attributes to their defaults when exiting the block, instead of the values that were set previously in the test.

### Detail

#### Before
`CurrentAttributes.set` delegates to the singleton instance, eventually calling `Object#with` on the current instance.
This can be a problem when the block clears the current instances.

#### After
`CurrentAttributes.set` does not delegate. Instead, it calls `Object#with` directly, ensuring it always acts on the right instance.

### Additional information

I also wrote a single-file executable test case to check behavior on different versions of Rails and to illustrate a closer-to-real-life scenario using jobs.
Using jobs, this actually demonstrates a regression between Rails 8.0.2 and HEAD.

<details><summary>You'll find the code here.</summary>

```rb
#!/usr/bin/env ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  if ENV["RAILS_VERSION"]
    gem "rails", ENV["RAILS_VERSION"]
  else
    gem "rails", github: "rails/rails", branch: "main"
  end
end

require "active_job/railtie"
require "active_support/railtie"
require "minitest/autorun"

puts "🎯 Rails version: #{Rails::VERSION::STRING}"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.secret_key_base = "secret_key_base"
  config.active_job.queue_adapter = :test

  config.logger = Logger.new($stdout)
end
Rails.application.initialize!

class Current < ActiveSupport::CurrentAttributes
  if Rails::VERSION::STRING.to_f >= 7.2
    attribute :string_value, default: "default value set in Current"
  else
    attribute :string_value
  end
end

class MyJob < ActiveJob::Base
  def perform
    Current.string_value = "value set in MyJob#perform"
  end
end

class MyJobTest < ActiveJob::TestCase
  def test_1
    Current.string_value = "value set in test_1" 

    Current.set(string_value: "temporary value for the block") do
      perform_enqueued_jobs do
	MyJob.perform_later
      end
    end

    assert_equal(
      "value set in test_1",
      Current.string_value,
      "Coming out of `ActiveSupport::CurrentAttributes.set`, the attributes should be restored to the values they were before the block"
    )
  end
end
```

</details> 

<details><summary>And how to run it, and its output, here.</summary>

```sh-session
$ RAILS_VERSION=8.0.2 ruby test_current_attributes_job_set_clear.rb
...
🎯 Rails version: 8.0.2
...
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

$ ruby test_current_attributes_job_set_clear.rb
...
│🎯 Rails version: 8.1.0.alpha
...
  1) Failure:
MyJobTest#test_1 [test_current_attributes_job_set_clear.rb:56]:
Coming out of `ActiveSupport::CurrentAttributes.set`, the attributes should be restored to the values they were before the block.
--- expected
+++ actual
@@ -1 +1 @@
-"value set in test_1"
+"default value set in Current"


1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

</details> 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. **Minor bug fixes** and documentation changes should not be included.
