### PR TITLE
Put image and registry next to each other in deploy.yml template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -4,6 +4,16 @@ service: <%= app_name %>
 # Name of the container image.
 image: your-user/<%= app_name %>
 
+# Credentials for your image host.
+registry:
+  # Specify the registry server, if you're not using Docker Hub
+  # server: registry.digitalocean.com / ghcr.io / ...
+  username: your-user
+
+  # Always use an access token rather than real password when possible.
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
 # Deploy to these servers.
 servers:
   web:
@@ -20,16 +30,6 @@ servers:
 proxy:
   ssl: true
   host: app.example.com
-
-# Credentials for your image host.
-registry:
-  # Specify the registry server, if you're not using Docker Hub
-  # server: registry.digitalocean.com / ghcr.io / ...
-  username: your-user
-
-  # Always use an access token rather than real password when possible.
-  password:
-    - KAMAL_REGISTRY_PASSWORD
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:


### PR DESCRIPTION
Make it more obvious within the default deploy.yml that the image and registry settings for kamal are related by putting them together in the same section.
