### PR TITLE
Improve XmlMini date parsing

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -62,11 +62,12 @@ module ActiveSupport
       "yaml"     => Proc.new { |yaml| yaml.to_yaml }
     } unless defined?(FORMATTING)
 
-    # TODO use regexp instead of Date.parse
+    DATE_REGEX = /\A(\d{4})-(\d{2})-(\d{2})\z/ unless defined?(DATE_REGEX)
+
     unless defined?(PARSING)
       PARSING = {
         "symbol"       => Proc.new { |symbol|  symbol.to_s.to_sym },
-        "date"         => Proc.new { |date|    ::Date.parse(date) },
+        "date"         => Proc.new { |date|    (m = DATE_REGEX.match(date)) ? ::Date.new(m[1].to_i, m[2].to_i, m[3].to_i) : ::Date.parse(date) },
         "datetime"     => Proc.new { |time|    Time.xmlschema(time).utc rescue ::DateTime.parse(time).utc },
         "duration"     => Proc.new { |duration| Duration.parse(duration) },
         "integer"      => Proc.new { |integer| integer.to_i },


### PR DESCRIPTION
Parse dates in "YYYY-MM-DD" format with a regex, falling back to `Date.parse`.

Implementation uses a proc-local match-data variable to be threadsafe (instead of using globals `$1`, `$2`, and `$3`).

This fixes a [longstanding TODO](https://github.com/rails/rails/commit/24077a1ffc3d7e944ba0e78df9a387523fb4f419#diff-f805b1a36e26831e5eee78fb55549de44fb842f78443b178d5d5438105152017R70-R71), added by @jeremy in October 2007. Let's fix this TODO before it's old enough to vote, buy a lottery ticket, and get a face tattoo!

Here is a micro-benchmark that demonstrates the performance improvement in the typical case, when the regex matches:

```ruby
require "benchmark/ips"
require "date"

DATE_STR = "2025-06-25"
DATE_REGEX = /\A(\d{4})-(\d{2})-(\d{2})\z/

def parse_with_regex
  m = DATE_REGEX.match(DATE_STR)
  Date.new(m[1].to_i, m[2].to_i, m[3].to_i)
end

def parse_with_date_parse
  Date.parse(DATE_STR)
end

Benchmark.ips do |x|
  x.config(time: 5, warmup: 2)

  x.report('Regex + Date.new') { parse_with_regex }
  x.report('Date.parse')       { parse_with_date_parse }

  x.compare!
end
```

Here is the output of the benchmark on my laptop:

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [arm64-darwin24]
Warming up --------------------------------------
    Regex + Date.new   175.876k i/100ms
          Date.parse    60.591k i/100ms
Calculating -------------------------------------
    Regex + Date.new      1.775M (± 0.5%) i/s  (563.43 ns/i) -      8.970M in   5.053946s
          Date.parse    607.273k (± 0.3%) i/s    (1.65 μs/i) -      3.090M in   5.088588s

Comparison:
    Regex + Date.new:  1774838.2 i/s
          Date.parse:   607272.8 i/s - 2.92x  slower
```