### PR TITLE
Allow for nested ExecutionContext in test

### DIFF
--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -12,6 +12,7 @@ require "active_support/core_ext/object/try"
 require "active_support/testing/autorun"
 require "image_processing/mini_magick"
 
+require "active_support/current_attributes/test_helper"
 require "active_record/testing/query_assertions"
 
 require "active_job"
@@ -25,6 +26,7 @@ ActiveStorage::FixtureSet.file_fixture_path = File.expand_path("fixtures/files",
 class ActiveSupport::TestCase
   self.file_fixture_path = ActiveStorage::FixtureSet.file_fixture_path
 
+  include ActiveSupport::CurrentAttributes::TestHelper
   include ActiveRecord::TestFixtures
   include ActiveRecord::Assertions::QueryAssertions
 
@@ -32,10 +34,6 @@ class ActiveSupport::TestCase
 
   setup do
     ActiveStorage::Current.url_options = { protocol: "https://", host: "example.com", port: nil }
-  end
-
-  teardown do
-    ActiveStorage::Current.reset
   end
 
   private

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Improve `CurrentAttribute` and `ExecutionContext` state managment in test cases.
+
+    Previously these two global state would be entirely cleared out whenever calling
+    into code that is wrapped by the Rails executor, typically Action Controller or
+    Active Job helpers:
+
+    ```ruby
+    test "#index works" do
+      CurrentUser.id = 42
+      get :index
+      CurrentUser.id == nil
+    end
+    ```
+
+    Now re-entering the executor properly save and restore that state.
+
+    *Jean Boussier*
+
 *   The new method `ActiveSupport::BacktraceCleaner#first_clean_location`
     returns the first clean location of the caller's call stack, or `nil`.
     Locations are `Thread::Backtrace::Location` objects. Useful when you want to

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/callbacks"
+require "active_support/execution_context"
 require "active_support/core_ext/object/with"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/delegation"
@@ -154,8 +155,10 @@ module ActiveSupport
       delegate :set, :reset, to: :instance
 
       def clear_all # :nodoc:
-        current_instances.each_value(&:reset)
-        current_instances.clear
+        if instances = current_instances
+          instances.values.each(&:reset)
+          instances.clear
+        end
       end
 
       private
@@ -164,7 +167,7 @@ module ActiveSupport
         end
 
         def current_instances
-          IsolatedExecutionState[:current_attributes_instances] ||= {}
+          ExecutionContext.current_attributes_instances
         end
 
         def current_instances_key

--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -2,8 +2,41 @@
 
 module ActiveSupport
   module ExecutionContext # :nodoc:
+    class Record
+      attr_reader :store, :current_attributes_instances
+
+      def initialize
+        @store = {}
+        @current_attributes_instances = {}
+        @stack = []
+      end
+
+      def push
+        @stack << @store << @current_attributes_instances
+        @store = {}
+        @current_attributes_instances = {}
+        self
+      end
+
+      def pop
+        @current_attributes_instances = @stack.pop
+        @store = @stack.pop
+        self
+      end
+    end
+
     @after_change_callbacks = []
+
+    # Execution context nesting should only legitimately happen during test
+    # because the test case itself is wrapped in an executor, and it might call
+    # into a controller or job which should be executed with their own fresh context.
+    # However in production this should never happen, and for extra safety we make sure to
+    # fully clear the state at the end of the request or job cycle.
+    @nestable = false
+
     class << self
+      attr_accessor :nestable
+
       def after_change(&block)
         @after_change_callbacks << block
       end
@@ -14,9 +47,11 @@ module ActiveSupport
         options.symbolize_keys!
         keys = options.keys
 
-        store = self.store
+        store = record.store
 
-        previous_context = keys.zip(store.values_at(*keys)).to_h
+        previous_context = if block_given?
+          keys.zip(store.values_at(*keys)).to_h
+        end
 
         store.merge!(options)
         @after_change_callbacks.each(&:call)
@@ -32,21 +67,43 @@ module ActiveSupport
       end
 
       def []=(key, value)
-        store[key.to_sym] = value
+        record.store[key.to_sym] = value
         @after_change_callbacks.each(&:call)
       end
 
       def to_h
-        store.dup
+        record.store.dup
+      end
+
+      def push
+        if @nestable
+          record.push
+        else
+          clear
+        end
+        self
+      end
+
+      def pop
+        if @nestable
+          record.pop
+        else
+          clear
+        end
+        self
       end
 
       def clear
-        store.clear
+        IsolatedExecutionState[:active_support_execution_context] = nil
+      end
+
+      def current_attributes_instances
+        record.current_attributes_instances
       end
 
       private
-        def store
-          IsolatedExecutionState[:active_support_execution_context] ||= {}
+        def record
+          IsolatedExecutionState[:active_support_execution_context] ||= Record.new
         end
     end
   end


### PR DESCRIPTION
`ActiveSupport::CurrentAttribute` lifetime in test always have been a bit wonky.

This was addressed in the past by https://github.com/rails/rails/pull/43734 and then https://github.com/rails/rails/pull/43550 but a problem remained that various states would leak from the test case into the controller or job being tested, and back.

Ideally when executing a controller or job from a test case, we want to "save and restore" current attributes and the execution context.

This is what this commit does, by implementing `push` and `pop` logic for `ActiveSupport::ExecutionContext`.

For extra safety, since such use case isn't supposed to ever happen in production, this behavior is test only and in production we keep dropping all the state.

Fix: https://github.com/rails/rails/pull/55240
Fix: https://github.com/rails/rails/issues/49227