### PR TITLE
Set `ActiveStorage::Current.url_options[:script_name]` properly before Active Storage controller actions

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActiveStorage::Current.url_options[:script_name]` is set before Active Storage controller actions.
+
+    *Mike Dalessio*
+
 *   Direct upload progress accounts for server processing time.
 
     *Jeremy Daer*

--- a/activestorage/app/controllers/concerns/active_storage/set_current.rb
+++ b/activestorage/app/controllers/concerns/active_storage/set_current.rb
@@ -9,7 +9,12 @@ module ActiveStorage::SetCurrent
 
   included do
     before_action do
-      ActiveStorage::Current.url_options = { protocol: request.protocol, host: request.host, port: request.port }
+      ActiveStorage::Current.url_options = {
+        protocol: request.protocol,
+        host: request.host,
+        port: request.port,
+        script_name: request.script_name
+      }
     end
   end
 end

--- a/activestorage/test/controllers/base_controller_test.rb
+++ b/activestorage/test/controllers/base_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::BaseControllerTest
+  class PlainController < ActiveStorage::BaseController
+    def index
+      self.response_body = ActiveStorage::Current.url_options.to_yaml
+    end
+  end
+
+  class TestUrlOptions < ActionDispatch::IntegrationTest
+    test "host, protocol, and port are set based on the request" do
+      app = PlainController.action(:index)
+
+      result = app.call(Rack::MockRequest.env_for("http://example.com/blurgh"))
+      response = YAML.load(result[2].body)
+
+      assert_equal("http://", response[:protocol])
+      assert_equal("example.com", response[:host])
+      assert_equal(80, response[:port])
+
+      result = app.call(Rack::MockRequest.env_for("https://www.example.org/blurgh"))
+      response = YAML.load(result[2].body)
+
+      assert_equal("https://", response[:protocol])
+      assert_equal("www.example.org", response[:host])
+      assert_equal(443, response[:port])
+    end
+  end
+end

--- a/activestorage/test/controllers/base_controller_test.rb
+++ b/activestorage/test/controllers/base_controller_test.rb
@@ -9,6 +9,26 @@ class ActiveStorage::BaseControllerTest
     end
   end
 
+  class ScriptNameMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = Rack::Request.new(env)
+      request.script_name = "/foo"
+      @app.call(env)
+    end
+  end
+
+  class ScriptNameController < ActiveStorage::BaseController
+    use ScriptNameMiddleware
+
+    def index
+      self.response_body = ActiveStorage::Current.url_options.to_yaml
+    end
+  end
+
   class TestUrlOptions < ActionDispatch::IntegrationTest
     test "host, protocol, and port are set based on the request" do
       app = PlainController.action(:index)
@@ -19,6 +39,7 @@ class ActiveStorage::BaseControllerTest
       assert_equal("http://", response[:protocol])
       assert_equal("example.com", response[:host])
       assert_equal(80, response[:port])
+      assert_equal("", response[:script_name])
 
       result = app.call(Rack::MockRequest.env_for("https://www.example.org/blurgh"))
       response = YAML.load(result[2].body)
@@ -26,6 +47,27 @@ class ActiveStorage::BaseControllerTest
       assert_equal("https://", response[:protocol])
       assert_equal("www.example.org", response[:host])
       assert_equal(443, response[:port])
+      assert_equal("", response[:script_name])
+    end
+
+    test "script name is set if present" do
+      app = ScriptNameController.action(:index)
+
+      result = app.call(Rack::MockRequest.env_for("http://example.com/blurgh"))
+      response = YAML.load(result[2].body)
+
+      assert_equal("http://", response[:protocol])
+      assert_equal("example.com", response[:host])
+      assert_equal(80, response[:port])
+      assert_equal("/foo", response[:script_name])
+
+      result = app.call(Rack::MockRequest.env_for("https://www.example.org/blurgh"))
+      response = YAML.load(result[2].body)
+
+      assert_equal("https://", response[:protocol])
+      assert_equal("www.example.org", response[:host])
+      assert_equal(443, response[:port])
+      assert_equal("/foo", response[:script_name])
     end
   end
 end

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -28,6 +28,22 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "url_for_direct_upload uses script_name if set" do
+    original_url_options = Rails.application.routes.default_url_options.dup
+    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001, script_name: "/foo")
+
+    key      = SecureRandom.base58(24)
+    data     = "Something else entirely!"
+    checksum = Digest::MD5.base64digest(data)
+
+    begin
+      assert_match(/^https:\/\/example.com\/foo\/rails\/active_storage\/disk\/.*$/,
+        @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum))
+    ensure
+      Rails.application.routes.default_url_options = original_url_options
+    end
+  end
+
   test "URL generation" do
     original_url_options = Rails.application.routes.default_url_options.dup
     Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)


### PR DESCRIPTION

### Motivation / Background

When setting `Rack::Request#script_name` in middleware (for example, in a multi-tenant application), the Rails Active Storage Disk Service does not generate correct URLs.

### Detail

This pull request sets `ActiveStorage::Current.url_options[:script_name]` to the value of the request's script_name, so that Active Storage controllers will generate correct URLs.

### Additional information

I've also backfilled tests for the exissting ActiveStorage::SetCurrent behavior (which did not have test coverage other than indirect `:host` coverage).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
