### PR TITLE
`action_cable_meta_tag` uses `Rack::Request#script_name` to build the mount path

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `action_cable_meta_tag` uses `Rack::Request#script_name` to generate the Action Cable mount path.
+
+    The Action Cable server route, if it is configured via `config.action_cable.mount_path`, now has
+    a name, "action_cable_mount", which is used by the meta tag helper.
+
+    *Mike Dalessio*
+
 *   Allow setting nil as subscription connection identifier for Redis.
 
     *Nguyen Nguyen*

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -64,7 +64,7 @@ module ActionCable
         config = app.config
         unless config.action_cable.mount_path.nil?
           app.routes.prepend do
-            mount ActionCable.server => config.action_cable.mount_path, internal: true, anchor: true
+            mount ActionCable.server => config.action_cable.mount_path, internal: true, anchor: true, as: "action_cable_mount"
           end
         end
       end

--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -36,7 +36,7 @@ module ActionCable
       def action_cable_meta_tag
         tag "meta", name: "action-cable-url", content: (
           ActionCable.server.config.url ||
-          ActionCable.server.config.mount_path ||
+          action_cable_mount_path(request, script_name: request.script_name) ||
           raise("No Action Cable URL configured -- please configure this at config.action_cable.url")
         )
       end


### PR DESCRIPTION
### Motivation / Background

When setting `Rack::Request#script_name` in middleware (for example, in a multi-tenant application), the Action Cable url set in the meta tag is incorrect.

### Detail

This PR adds a name to the Action Cable server route, so that we can use ordinary URL helpers to generate the path correctly. The `action_cable_meta_tag` helper now uses that URL helper.

### Additional information

I couldn't find any existing direct test coverage for the contents of this meta tag, so I have not added test coverage for this new behavior.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
