### PR TITLE
filter sensitive attributes in logs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Attributes filtered by `filter_attributes` will now also be filtered by `filter_parameters`
+    so sensitive information is not leaked.
+
+    *Jill Klang*
+
 *   Add `connection.current_transaction.isolation` API to check current transaction's isolation level.
 
     Returns the isolation level if it was explicitly set via the `isolation:` parameter

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -53,6 +53,7 @@ module ActiveRecord
   autoload :Enum
   autoload :Explain
   autoload :FixtureSet, "active_record/fixtures"
+  autoload :FilterAttributeHandler
   autoload :Inheritance
   autoload :Integration
   autoload :InternalMetadata

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -357,6 +357,8 @@ module ActiveRecord
       def filter_attributes=(filter_attributes)
         @inspection_filter = nil
         @filter_attributes = filter_attributes
+
+        FilterAttributeHandler.sensitive_attribute_was_declared(self, filter_attributes)
       end
 
       def inspection_filter # :nodoc:

--- a/activerecord/lib/active_record/filter_attribute_handler.rb
+++ b/activerecord/lib/active_record/filter_attribute_handler.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class FilterAttributeHandler # :nodoc:
+    class << self
+      def on_sensitive_attribute_declared(&block)
+        @sensitive_attribute_declaration_listeners ||= Concurrent::Array.new
+        @sensitive_attribute_declaration_listeners << block
+      end
+
+      def sensitive_attribute_was_declared(klass, list)
+        @sensitive_attribute_declaration_listeners&.each do |block|
+          block.call(klass, list)
+        end
+      end
+    end
+
+    def initialize(app)
+      @app = app
+      @attributes_by_class = Concurrent::Map.new
+      @collecting = true
+    end
+
+    def enable
+      install_collecting_hook
+
+      apply_collected_attributes
+      @collecting = false
+    end
+
+    private
+      attr_reader :app
+
+      def install_collecting_hook
+        self.class.on_sensitive_attribute_declared do |klass, list|
+          attribute_was_declared(klass, list)
+        end
+      end
+
+      def attribute_was_declared(klass, list)
+        if collecting?
+          collect_for_later(klass, list)
+        else
+          apply_filter(klass, list)
+        end
+      end
+
+      def apply_collected_attributes
+        @attributes_by_class.each do |klass, list|
+          apply_filter(klass, list)
+        end
+      end
+
+      def collecting?
+        @collecting
+      end
+
+      def collect_for_later(klass, list)
+        @attributes_by_class[klass] ||= Concurrent::Array.new
+        @attributes_by_class[klass] += list
+      end
+
+      def apply_filter(klass, list)
+        list.each do |attribute|
+          next if klass.abstract_class?
+
+          klass_name = klass.name ? klass.model_name.element : nil
+          filter = [klass_name, attribute.to_s].compact.join(".")
+          app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
+        end
+      end
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -331,6 +331,10 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+    initializer "active_record.filter_attributes_as_log_parameters" do |app|
+      ActiveRecord::FilterAttributeHandler.new(app).enable
+    end
+
     initializer "active_record.configure_message_verifiers" do |app|
       ActiveRecord.message_verifiers = app.message_verifiers
 

--- a/railties/test/application/active_record_railtie_test.rb
+++ b/railties/test/application/active_record_railtie_test.rb
@@ -31,5 +31,59 @@ module ApplicationTests
       end
       assert_includes exception.message, "ActiveJob::Continuation::CheckpointError: Cannot checkpoint job with open transactions"
     end
+
+    test "filter_attributes include filter_parameters" do
+      app_file "config/initializers/parameter_filter.rb", <<~RUBY
+        Rails.application.config.filter_parameters += [ :special_param ]
+      RUBY
+      app "development"
+
+      assert_includes ActiveRecord::Base.filter_attributes, :special_param
+    end
+
+    test "filter_paramenters include filter_attributes for an AR::Base subclass" do
+      app "development"
+
+      assert_not_includes ActiveRecord::Base.filter_attributes, "messsage.special_attr"
+
+      class Message < ActiveRecord::Base
+        self.table_name = "messages"
+        self.filter_attributes += [:special_attr]
+      end
+
+      assert_includes Rails.application.config.filter_parameters, "message.special_attr"
+    end
+
+    test "filter_paramenters include filter_attributes for AR::Base subclasses" do
+      app "development"
+
+      assert_not_includes ActiveRecord::Base.filter_attributes, "special_attr"
+
+      class Message < ActiveRecord::Base
+        self.table_name = "messages"
+      end
+
+      Message.filter_attributes += [ :special_attr ]
+
+      assert_includes Rails.application.config.filter_parameters, "message.special_attr"
+    end
+
+    test "filter_parameters are inherited from AR parent classes" do
+      app "development"
+
+      class ApplicationRecord < ActiveRecord::Base
+        self.abstract_class = true
+        self.filter_attributes += [ "expires_at" ]
+      end
+
+      class CreditCard < ApplicationRecord
+        self.table_name = "credit_cards"
+        self.filter_attributes += [ "digits" ]
+      end
+
+      assert_includes Rails.application.config.filter_parameters, "credit_card.expires_at"
+      assert_includes Rails.application.config.filter_parameters, "credit_card.digits"
+      assert_not_includes Rails.application.config.filter_parameters, "application_record.expires_at"
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

We have two ways to configure things that get filtered in logs: `filter_parameters` and `filter_attributes`.  The [latter was added in 2018](https://github.com/rails/rails/pull/33756) and ensures that things added to `filter_parameters` are also added to `filter attributes`. However, the opposite is not true, which makes for some weird behavior right out of the box: 

Take this example with a model called `CreditCard` with two attributes: `digits` and `cvv`. 

`cvv` is added to `filter_parameters` by default:

<img width="717" alt="Screenshot 2025-06-26 at 5 20 03 PM" src="https://github.com/user-attachments/assets/bf4ad409-6cec-4077-b4c6-96d44ec95aec" />


`digits` is added to `filter_attributes`: 

<img width="403" alt="Screenshot 2025-06-26 at 5 21 05 PM" src="https://github.com/user-attachments/assets/cc376385-f4f0-4620-985a-80c0c20070d5" />


Which results in logs that look like this:

<img width="512" alt="Screenshot 2025-07-03 at 11 19 03 AM" src="https://github.com/user-attachments/assets/2e1a9625-304d-441d-afaa-df111c83e0b4" />


cvv gets filtered in both places because `filter_parameters` also adds it to `filter_attributes`. However, the opposite is not true, despite the fact that it's typical for parameters that are passed into a controller to match attributes on the model. Let's make sure we can define what needs filtering in one place and ensure it's filtered in every place.

### Detail

This PR aims to ensure that if you've added something to `filter_attributes`, it is filtered by default in the logs. 

### Additional information

I looked at several places to put this code. I don't love where it is now, but we do have a circular loading problem because the AR classes get loaded well after filter_parameters are precompiled. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
