### PR TITLE
Moved LD_PRELOAD variable initialization to the Dockerfile from the entrypoint

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -17,13 +17,15 @@ WORKDIR /rails
 # Install base packages
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y <%= dockerfile_base_packages.join(" ") %> && \
+    ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Set production environment
+# Set production environment variables and enable jemalloc for reduced memory usage and latency.
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development" \
+    LD_PRELOAD=/usr/local/lib/libjemalloc.so
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build

--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -1,11 +1,5 @@
 #!/bin/bash -e
 
-# Enable jemalloc for reduced memory usage and latency.
-if [ -z "${LD_PRELOAD+x}" ]; then
-    LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
-    export LD_PRELOAD
-fi
-
 <% unless skip_active_record? -%>
 # If running the rails server then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the `LD_PRELOAD` variable was initialized only for the shell used to start the process from the `docker-entrypoint` file. 

### Detail

This Pull Request changes the way `LD_PRELOAD` variable is initialized.

Libvips and jemalloc are both installed out of the box in Rails 8. However, libvips does not know that jemalloc is installed. `LD_PRELOAD` variable was only set in the `docker-entrypoint`script for the shell session that starts the Rails server, and does not get propagated to the list of environment variables of the container.

The official libvips guide suggests using jemalloc if you are on glibc-based distro: https://libvips.org/API/current/developer-checklist.html#linux-memory-allocator. 

The solution is to move the `LD_PRELOAD` variable initialization to the Dockerfile, so that it is available to all processes in the container.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
