### PR TITLE
Do not clear `ExecutionContext` for nestable contexts

### DIFF
--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -94,7 +94,7 @@ module ActiveSupport
       end
 
       def clear
-        IsolatedExecutionState[:active_support_execution_context] = nil
+        IsolatedExecutionState[:active_support_execution_context] = nil unless @nestable
       end
 
       def current_attributes_instances


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/55247

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

From https://github.com/rails/rails/commit/d43dc9af18766f91eb450e1c6b8c8c5e64f925e6, a push and pop logic was implemented for `ExecutionContext`. 

However, in Shopify, there is an edge case where a test calls `Rails.application.reloader.reload!`. This causes the `ExecutionContext` to clear and the stack would be corrupted. I think we should skip this clear for nestable contexts since the pop after the reload is complete would set the context to the correct state.

### Bug Reproduction script

<details>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  CLOUDSMITH = "https://pkgs.shopify.io/basic/gems/ruby"

  # gem "rails"
  # If you want to test against edge Rails replace the previous line with this:
  gem "rails", github: "rails/rails", branch: "main"
  gem "job-iteration"
end

require "active_job/railtie"
require "minitest/autorun"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.secret_key_base = "secret_key_base"
  config.active_job.queue_adapter = :test

  config.logger = Logger.new($stdout)
end
Rails.application.initialize!

class Current < ActiveSupport::CurrentAttributes
  attribute :string_value, default: "default value set in Current"
end

class ReloadTest < ActiveJob::TestCase
  def test_1
    Current.string_value = "value set in test_1" 

    Rails.application.reloader.reload!

    assert_equal(
      "value set in test_1",
      Current.string_value,
      "Coming out of `ActiveSupport::CurrentAttributes.set`, the attributes should be restored to the values they were before the block"
    )
  end
end
```

### Expected
`Current.string_value` is `value set in test_1`

### Actual 
`NoMethodError: undefined method '[]' for nil`

</details>

cc: @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
