### PR TITLE
Implement ActiveSupport::BacktraceCleaner#clean_locations

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Given an array of `Thread::Backtrace::Location` objects, the new method
+    `ActiveSupport::BacktraceCleaner#clean_locations` returns an array with the
+    clean ones:
+
+    ```ruby
+    clean_locations = backtrace_cleaner.clean_locations(caller_locations)
+    ```
+
+    Filters and silencers receive strings as usual. However, the `path`
+    attributes of the locations in the returned array are the original,
+    unfiltered ones, since locations are immutable.
+
+    *Xavier Noria*
+
 *   Improve `CurrentAttribute` and `ExecutionContext` state managment in test cases.
 
     Previously these two global state would be entirely cleared out whenever calling

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -56,6 +56,18 @@ module ActiveSupport
     end
     alias :filter :clean
 
+    # Given an array of Thread::Backtrace::Location objects, returns an array
+    # with the clean ones:
+    #
+    #     clean_locations = backtrace_cleaner.clean_locations(caller_locations)
+    #
+    # Filters and silencers receive strings as usual. However, the +path+
+    # attributes of the locations in the returned array are the original,
+    # unfiltered ones, since locations are immutable.
+    def clean_locations(locations, kind = :silent)
+      locations.select { |location| clean_frame(location, kind) }
+    end
+
     # Returns the frame with all filters applied.
     # returns +nil+ if the frame was silenced.
     def clean_frame(frame, kind = :silent)


### PR DESCRIPTION
PR title and `CHANGELOG.md` says it all.

Locations are sometimes more helpful than strings when working programmatically with backtraces.