### PR TITLE
query_logs.rb: Doc source_location being expensive

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -29,6 +29,7 @@ module ActiveRecord
   # * +source_location+
   #
   # WARNING: Calculating the +source_location+ of a query can be slow, so you should consider its impact if using it in a production environment.
+  #
   # Also see {config.active_record.verbose_query_logs}[https://guides.rubyonrails.org/debugging_rails_applications.html#verbose-query-logs].
   #
   # Action Controller adds default tags when loaded:

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -28,6 +28,9 @@ module ActiveRecord
   # * +database+
   # * +source_location+
   #
+  # WARNING: Calculating the +source_location+ of a query can be slow, so you should consider its impact if using it in a production environment.
+  # Also see {config.active_record.verbose_query_logs}[https://guides.rubyonrails.org/debugging_rails_applications.html#verbose-query-logs].
+  #
   # Action Controller adds default tags when loaded:
   #
   # * +controller+


### PR DESCRIPTION
The changelog in https://github.com/rails/rails/releases/tag/v7.2.0 mentions this, but it was not mentioned in these docs.

It seems an easy mistake to make.