### PR TITLE
Add support for flag parameters in URL generation

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Add support for flag parameters (parameters without values) in URL generation.
+
+    You can now generate URLs with flag parameters by setting parameter values to `nil`
+    and enabling the `include_nil_params` option:
+
+    ```ruby
+    # Traditional behavior (backward compatible)
+    url_for(controller: 'posts', debug: nil, only_path: true)
+    # => "/posts"
+
+    # New flag parameter support
+    url_for(controller: 'posts', debug: nil, only_path: true, include_nil_params: true)
+    # => "/posts?debug"
+
+    # Mixed parameters
+    url_for(controller: 'posts', debug: nil, category: 'tech', only_path: true, include_nil_params: true)
+    # => "/posts?category=tech&debug"
+    ```
+
+    Flag parameters are useful for boolean options in URLs where the presence of the
+    parameter indicates a true value, such as `?debug`, `?preview`, or `?mobile`.
+
+    The default behavior remains unchanged for backward compatibility.
+
+    *Katsuhiko Yoshida*
+
 *   Always return empty body for HEAD requests in `PublicExceptions` and
     `DebugExceptions`.
 

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -75,16 +75,16 @@ module ActionDispatch
 
           path = "/" if options[:trailing_slash] && path.blank?
 
-          add_params(path, options[:params]) if options.key?(:params)
+          add_params(path, options[:params], include_nil_params: options[:include_nil_params]) if options.key?(:params)
           add_anchor(path, options[:anchor]) if options.key?(:anchor)
 
           path
         end
 
         private
-          def add_params(path, params)
+          def add_params(path, params, include_nil_params: false)
             params = { params: params } unless params.is_a?(Hash)
-            params.reject! { |_, v| v.to_param.nil? }
+            params.reject! { |_, v| v.to_param.nil? } unless include_nil_params
             query = params.to_query
             path << "?#{query}" unless query.empty?
           end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -839,7 +839,7 @@ module ActionDispatch
 
       RESERVED_OPTIONS = [:host, :protocol, :port, :subdomain, :domain, :tld_length,
                           :trailing_slash, :anchor, :params, :only_path, :script_name,
-                          :original_script_name]
+                          :original_script_name, :include_nil_params]
 
       def optimize_routes_generation?
         default_url_options.empty?

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -595,6 +595,33 @@ module AbstractController
         end
       end
 
+      def test_nil_values_generate_flag_parameters_with_include_nil_params
+        assert_equal "/posts?debug", W.new.url_for(controller: "posts", action: "index", debug: nil, only_path: true, include_nil_params: true)
+      end
+
+      def test_mixed_flag_and_regular_parameters_with_include_nil_params
+        assert_equal "/posts?category=tech&debug",
+                     W.new.url_for(controller: "posts", action: "index", debug: nil, category: "tech", only_path: true, include_nil_params: true)
+      end
+
+      def test_multiple_flag_parameters_with_include_nil_params
+        assert_equal "/posts?debug&featured",
+                     W.new.url_for(controller: "posts", action: "index", debug: nil, featured: nil, only_path: true, include_nil_params: true)
+      end
+
+      def test_nil_values_are_excluded_by_default
+        assert_equal "/posts", W.new.url_for(controller: "posts", action: "index", debug: nil, only_path: true)
+      end
+
+      def test_nil_values_are_excluded_by_included_nil_params_false
+        assert_equal "/posts", W.new.url_for(controller: "posts", action: "index", debug: nil, only_path: true, include_nil_params: false)
+      end
+
+      def test_empty_string_still_generates_equals_with_include_nil_params
+        assert_equal "/posts?search=",
+                     W.new.url_for(controller: "posts", action: "index", search: "", only_path: true, include_nil_params: true)
+      end
+
       private
         def extract_params(url)
           url.split("?", 2).last.split("&").sort


### PR DESCRIPTION
### Summary

Add support for flag parameters (parameters without values) in URL generation.

This feature allows generating URLs with flag parameters by setting parameter values to `nil` and enabling the `include_nil_params` option. Flag parameters are useful for boolean options where the presence of the parameter indicates a true value, such as `?debug`, `?preview`, or `?mobile`.

### Motivation / Background

Currently, Rails URL helpers automatically remove parameters with `nil` values during URL generation. While this is generally desired behavior, there are cases where developers want to generate "flag parameters" - parameters without values that indicate boolean states by their presence alone.

Common use cases include:

- Debug modes: `?debug`
- Preview modes: `?preview`
- Mobile versions: `?mobile`

### Detail

- Added `include_nil_params` option to URL generation methods
- Modified `ActionDispatch::Http::URL#add_params` to conditionally preserve `nil` values
- Added `include_nil_params` to `RESERVED_OPTIONS` to prevent it from being treated as a route parameter
- Maintained full backward compatibility (default behavior unchanged)

### Usage

```ruby
# Traditional behavior (unchanged)
url_for(controller: 'posts', debug: nil, only_path: true)
# => "/posts"

# New flag parameter support
url_for(controller: 'posts', debug: nil, only_path: true, include_nil_params: true)
# => "/posts?debug"

# Mixed regular and flag parameters
url_for(controller: 'posts', debug: nil, category: 'tech', only_path: true, include_nil_params: true)
# => "/posts?category=tech&debug"

# Multiple flag parameters
url_for(controller: 'posts', debug: nil, preview: nil, only_path: true, include_nil_params: true)
# => "/posts?debug&preview"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
