### PR TITLE
Rails New: Only add browser restrictions when using importmap

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -104,4 +104,8 @@
 
     *Petrik de Heus*
 
+*   Only add browser restrictions for a new Rails app when using importmap.
+
+    *Lucas Dohmen*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
@@ -1,11 +1,9 @@
 class ApplicationController < ActionController::<%= options.api? ? "API" : "Base" %>
-<%- unless options.api? -%>
+<%- if using_importmap? -%>
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-<%- if using_importmap? -%>
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
-<% end -%>
 <% end -%>
 end


### PR DESCRIPTION
### Motivation / Background

When you generate a new Rails application right now, it will block older browsers. This behavior makes sense if you are using [`importmap-rails`](https://github.com/rails/importmap-rails), but if you for example use jsbundling-rails, it does not. This PR suggests only adding this blocker when you are using importmap, and not for all Rails applications.

### Detail

This Pull Request changes the generator for new Rails applications to only add:

```ruby
# Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
allow_browser versions: :modern
```

if the application is generated with `--javascript=importmap`. This is the default, so this PR does not change anything for people that do not override the JavaScript option.

If you, for example, set `--javascript=esbuild`, you don't need to block older browsers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~~Tests are added or updated if you fix a bug or add a feature.~~ _There are no tests for the generators at this level from what I can see._
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
