### PR TITLE
Raise on missing translations by default in new applications

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -71,7 +71,7 @@ Rails.application.configure do
 
   <%- end -%>
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true


### PR DESCRIPTION
Enables `config.i18n.raise_on_missing_translations` by default in development and test environments when generating new applications.

In every new Rails app I worked on (and old ones that have been upgraded to newer versions), we've eventually turned this setting on because it's more useful than the default "Translation missing: ..." string, which hides away the fact your translations are not set up correctly (and this often goes unnoticed in the test suite), so I think raising instead is a sensible default.
