### PR TITLE
Revert workaround from #55182 and update to latest devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3.4, 3.3, 3.2
-ARG VARIANT="1.1.3-3.4.4"
+ARG VARIANT="3.4.4"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -34,5 +34,5 @@ COPY tools/releaser/releaser.gemspec /tmp/rails/tools/releaser/
 RUN sudo chown -R vscode:vscode /tmp/rails
 USER vscode
 RUN cd /tmp/rails \
-    && /home/vscode/.rbenv/shims/bundle install \
+    && bash -i -c 'bundle install' \
     && rm -rf /tmp/rails


### PR DESCRIPTION
### Motivation / Background

This commit updates the devcontainer image to ghcr.io/rails/devcontainer/images/ruby:3.4.4 , reflecting the latest version from rails/devcontainer@ruby-2.0.0. It also reverts the temporary workaround introduced in #55182, which used an older image to avoid issues caused by the transition from rbenv to mise.

- With this commit

```bash
vscode ➜ /workspaces/rails (use_mise_in_devcontainer) $ ruby -v
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [aarch64-linux]
vscode ➜ /workspaces/rails (use_mise_in_devcontainer) $ which ruby
/home/vscode/.local/share/mise/installs/ruby/3.4.4/bin/ruby
```

### Detail
In the updated image, Ruby is no longer installed via rbenv, so /home/vscode/.rbenv/shims/bundle no longer exists.

- Using `ghcr.io/rails/devcontainer/images/ruby:3.4.4` image without changing the path to bundler
```bash
 => ERROR [dev_container_auto_added_stage_label 19/19] RUN cd /tmp/rails   0.1s
------
 > [dev_container_auto_added_stage_label 19/19] RUN cd /tmp/rails     && /home/vscode/.rbenv/shims/bundle install     && rm -rf /tmp/rails:
0.127 /bin/sh: 1: /home/vscode/.rbenv/shims/bundle: not found
------
```
Rather than hard-coding a mise-specific path, this change runs bundle install in an interactive Bash shell (bash -i -c) to ensure that mise’s environment setup in ~/.bashrc is applied.

This avoids introducing a direct dependency on mise internals and ensures compatibility with future changes to the Ruby installation mechanism.

### Additional information
By default, Docker’s RUN instruction uses the shell form ["/bin/sh", "-c"], as documented in the Dockerfile reference.

https://docs.docker.com/reference/dockerfile/#shell
> The default shell on Linux is ["/bin/sh", "-c"],

This shell does not source ~/.bashrc, so any environment configuration added by mise would be ignored. To address this, bash -i -c is explicitly used to invoke an interactive shell. According to the GNU Bash manual, interactive non-login shells source ~/.bashrc by default.

https://www.gnu.org/software/bash/manual/bash.html#Bash-Startup-Files

> Invoked as an interactive non-login shell
> When an interactive shell that is not a login shell is started,
> Bash reads and executes commands from ~/.bashrc, if that file exists.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
