### PR TITLE
Ensure consistent mailer preview content across iframe requests

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add email object caching to mailer previews for consistent dynamic content.
+
+    Mailer previews now cache email objects to ensure consistent content across
+    iframe loads and format switches. Previously, dynamic content like random
+    values or timestamps would differ between the subject line and body content.
+
+    *Caio Chassot*
+
 *   Do not assume and force SSL in production by default when using Kamal, to allow for out of the box Kamal deployments.
 
     It is still recommended to assume and force SSL in production as soon as you can.

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -38,7 +38,10 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
 
       if @preview.email_exists?(@email_action)
         @page_title = "Mailer Preview for #{@preview.preview_name}##{@email_action}"
-        @email = @preview.call(@email_action, params)
+        @@emails ||= {}
+        @email = params[:email_id] && @@emails[params[:email_id]] || @preview.call(@email_action, params)
+        @email_id = @preview.object_id.to_s
+        @@emails[@email_id] = @email
         @attachments = attachments_for(@email).reject { |filename, attachment| attachment.inline? }
         @inline_attachments = attachments_for(@email).select { |filename, attachment| attachment.inline? }
 
@@ -109,7 +112,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
     end
 
     def part_query(mime_type)
-      request.query_parameters.merge(part: mime_type).to_query
+      request.query_parameters.merge(part: mime_type, email_id: @email_id).to_query
     end
 
     def locale_query(locale)

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -1151,6 +1151,261 @@ module ApplicationTests
       assert_includes last_response.body, "bar"
     end
 
+    test "email persistence caches email objects across requests" do
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            @random_value = rand(1000)
+            mail to: "to@example.org", subject: "Random: \#{@random_value}"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+        Random value: <%= @random_value %>
+      RUBY
+
+      html_template "notifier/foo", <<-RUBY
+        <p>Random value: <%= @random_value %></p>
+      RUBY
+
+      mailer_preview "notifier", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app("development")
+
+      # First request generates email and caches it
+      get "/rails/mailers/notifier/foo"
+      assert_equal 200, last_response.status
+
+      # Extract email_id from response
+      email_id = nil
+      assert_select "iframe[src*='email_id']" do |iframe|
+        email_id = Rack::Utils.parse_nested_query(URI.parse(iframe.first["src"]).query)["email_id"]
+      end
+      assert_not_nil email_id
+
+      # Get the HTML content
+      get "/rails/mailers/notifier/foo?part=text%2Fhtml&email_id=#{email_id}"
+      html_content = last_response.body
+      random_match = html_content.match(/Random value: (\d+)/)
+      assert_not_nil random_match
+      first_random = random_match[1]
+
+      # Get the plain text content with same email_id
+      get "/rails/mailers/notifier/foo?part=text%2Fplain&email_id=#{email_id}"
+      text_content = last_response.body
+      text_random_match = text_content.match(/Random value: (\d+)/)
+      assert_not_nil text_random_match
+      second_random = text_random_match[1]
+
+      # Both should have the same random value due to caching
+      assert_equal first_random, second_random
+    end
+
+    test "email persistence generates new emails without email_id and reuses with valid email_id" do
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            @unique_id = SecureRandom.hex(8)
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+        Unique ID: <%= @unique_id %>
+      RUBY
+
+      mailer_preview "notifier", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app("development")
+
+      # First request without email_id should generate new email
+      get "/rails/mailers/notifier/foo?part=text%2Fplain"
+      first_content = last_response.body
+      first_unique_id = first_content.match(/Unique ID: ([a-f0-9]+)/)[1]
+
+      # Second request without email_id should generate different email
+      get "/rails/mailers/notifier/foo?part=text%2Fplain"
+      second_content = last_response.body
+      second_unique_id = second_content.match(/Unique ID: ([a-f0-9]+)/)[1]
+
+      # Should be different since no caching without email_id
+      assert_not_equal first_unique_id, second_unique_id
+
+      # Get email_id for caching test
+      get "/rails/mailers/notifier/foo"
+      email_id = nil
+      assert_select "iframe[src*='email_id']" do |iframe|
+        email_id = Rack::Utils.parse_nested_query(URI.parse(iframe.first["src"]).query)["email_id"]
+      end
+
+      # Requests with same email_id should reuse cached email
+      get "/rails/mailers/notifier/foo?part=text%2Fplain&email_id=#{email_id}"
+      cached_content = last_response.body
+      cached_unique_id = cached_content.match(/Unique ID: ([a-f0-9]+)/)[1]
+
+      get "/rails/mailers/notifier/foo?part=text%2Fplain&email_id=#{email_id}"
+      reused_content = last_response.body
+      reused_unique_id = reused_content.match(/Unique ID: ([a-f0-9]+)/)[1]
+
+      # Should be identical due to caching
+      assert_equal cached_unique_id, reused_unique_id
+    end
+
+    test "email persistence maintains consistency across iframe requests" do
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            @counter = rand(10000)
+            mail to: "to@example.org", subject: "Counter: \#{@counter}"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+        Counter: <%= @counter %>
+      RUBY
+
+      html_template "notifier/foo", <<-RUBY
+        <p>Counter: <%= @counter %></p>
+      RUBY
+
+      mailer_preview "notifier", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      app("development")
+
+      # Get main preview page with HTML format to ensure multipart
+      get "/rails/mailers/notifier/foo.html"
+      assert_equal 200, last_response.status
+
+      # Store main page content for subject verification
+      main_page_content = last_response.body
+
+      # Verify iframe src contains email_id
+      iframe_src = nil
+      assert_select "iframe[name='messageBody']" do |iframe|
+        iframe_src = iframe.first["src"]
+      end
+      assert_not_nil iframe_src
+      assert_match(/email_id=/, iframe_src)
+
+      # Extract email_id from iframe src
+      query_params = Rack::Utils.parse_nested_query(URI.parse(iframe_src).query)
+      email_id = query_params["email_id"]
+      assert_not_nil email_id
+
+      # Request HTML content with email_id
+      get "/rails/mailers/notifier/foo?part=text%2Fhtml&email_id=#{email_id}"
+      html_content = last_response.body
+      html_counter_match = html_content.match(/Counter: (\d+)/)
+      assert_not_nil html_counter_match
+      html_counter = html_counter_match[1]
+
+      # Request plain text content with same email_id
+      get "/rails/mailers/notifier/foo?part=text%2Fplain&email_id=#{email_id}"
+      text_content = last_response.body
+      text_counter_match = text_content.match(/Counter: (\d+)/)
+      assert_not_nil text_counter_match
+      text_counter = text_counter_match[1]
+
+      # Both should have same counter value due to persistence
+      assert_equal html_counter, text_counter
+
+      # Test subject consistency - subject is shown in main preview page header
+      subject_match = main_page_content.match(/<strong id="subject">Counter: (\d+)<\/strong>/)
+      assert_not_nil subject_match
+      subject_counter = subject_match[1]
+
+      # Subject should match body counter
+      assert_equal html_counter, subject_counter
+    end
+
+
+
+    test "email persistence works with parameterized previews" do
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo(name)
+            @name = name
+            @random = rand(1000)
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+        Hello, <%= @name %>! Random: <%= @random %>
+      RUBY
+
+      html_template "notifier/foo", <<-RUBY
+        <p>Hello, <%= @name %>! Random: <%= @random %></p>
+      RUBY
+
+      mailer_preview "notifier", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo(params[:name] || "World")
+          end
+        end
+      RUBY
+
+      app("development")
+
+      # Request with parameters
+      get "/rails/mailers/notifier/foo?name=Ruby"
+      assert_equal 200, last_response.status
+
+      # Extract email_id
+      email_id = nil
+      assert_select "iframe[src*='email_id']" do |iframe|
+        email_id = Rack::Utils.parse_nested_query(URI.parse(iframe.first["src"]).query)["email_id"]
+      end
+
+      # Get HTML version
+      get "/rails/mailers/notifier/foo?name=Ruby&part=text%2Fhtml&email_id=#{email_id}"
+      html_content = last_response.body
+      html_random = html_content.match(/Random: (\d+)/)[1]
+
+      # Get plain text version with same email_id
+      get "/rails/mailers/notifier/foo?name=Ruby&part=text%2Fplain&email_id=#{email_id}"
+      text_content = last_response.body
+      text_random = text_content.match(/Random: (\d+)/)[1]
+
+      # Random values should match due to persistence
+      assert_equal html_random, text_random
+
+      # Both should contain the correct name
+      assert_match "Hello, Ruby!", html_content
+      assert_match "Hello, Ruby!", text_content
+    end
+
     private
       def build_app
         super

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -711,14 +711,17 @@ module ApplicationTests
       assert_select "iframe[name='messageBody'][src]" do |iframe,|
         query = Rack::Utils.parse_nested_query(URI.parse(iframe["src"]).query)
         assert_equal "text/plain", query["part"]
+        assert query.key?("email_id")
       end
       assert_select "option[selected][value*='plain']" do |option,|
         query = Rack::Utils.parse_nested_query(option["value"])
         assert_equal "text/plain", query["part"]
+        assert query.key?("email_id")
       end
       assert_select "option[value*='html']:not([selected])" do |option,|
         query = Rack::Utils.parse_nested_query(option["value"])
         assert_equal "text/html", query["part"]
+        assert query.key?("email_id")
       end
 
       get "/rails/mailers/notifier/foo?part=text%2Fplain"
@@ -731,17 +734,20 @@ module ApplicationTests
         query = Rack::Utils.parse_nested_query(URI.parse(iframe["src"]).query)
         assert_equal "Ruby", query["name"]
         assert_equal "text/html", query["part"]
+        assert query.key?("email_id")
       end
 
       assert_select "option[selected][value*='html']" do |option,|
         query = Rack::Utils.parse_nested_query(option["value"])
         assert_equal "text/html", query["part"]
+        assert query.key?("email_id")
       end
 
       assert_select "option[value*='plain']:not([selected])" do |option,|
         query = Rack::Utils.parse_nested_query(option["value"])
         assert_equal "Ruby", query["name"]
         assert_equal "text/plain", query["part"]
+        assert query.key?("email_id")
       end
 
       get "/rails/mailers/notifier/foo?name=Ruby&part=text%2Fhtml"


### PR DESCRIPTION
### Motivation / Background

Mailer previews use iframes requiring multiple requests to display a single email: one for the header/controls, one for the message body, and additional requests when switching between HTML/plain text formats. 

When email content contains dynamic data (timestamps, random values, database queries), each request generates a new email object with different values, causing inconsistencies where the subject line shows one random value while the body shows another.

### Detail

This Pull Request adds email object caching to mailer previews to ensure consistent content across all requests for the same preview session. Changes include:

- Cache generated email objects using preview object_id as key and reuse across requests
- Add email_id parameter to part selection URLs and iframe src to maintain cache consistency  
- Update existing tests to handle additional URL parameters and verify email_id presence
- Add comprehensive test coverage for email persistence functionality

The caching is transparent to users. Previews work exactly as before but now show consistent dynamic content across format switches and iframe loads.

Instead of one squashed commit, I kept each commit logically separate and self-explanatory. I hope it aids in review. I can squash for merge.

### Additional information

The caching uses a class-level simple hash without size limits or expiration since mailer previews are primarily used in development environments with limited concurrent usage. I made an optional [LRU cache implementation][lru-commit] but deemed unnecessary given the usage pattern. Let me know if it's warranted and I'll pull it in.

The cache prevents potential memory accumulation in long-running development sessions, but this is acceptable given the development-focused nature of mailer previews.

[lru-commit]: https://github.com/kch/rails/commit/80b555326ecd78545af2594ce9aa15874a495bb5