### PR TITLE
Deprecate implicit size attribute when maxlength is specified on text fields

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate implicit `size` attribute when `maxlength` is specified on text fields.
+
+    Setting `maxlength` will no longer automatically set `size` in Rails 8.2.
+    Specify both attributes explicitly or set
+    `ActionView::Helpers::FormHelper.text_field_maxlength_implies_size = false`
+    to opt into the new behavior early.
+
+    *Caio Chassot*
+
 *   Add `dom_target` helper to create `dom_id`-like strings from an unlimited
     number of objects.
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -484,6 +484,8 @@ module ActionView
 
       mattr_accessor :multiple_file_field_include_hidden, default: false
 
+      mattr_accessor :text_field_maxlength_implies_size, default: true
+
       # Creates a form tag based on mixing URLs, scopes, or models.
       #
       #   # Using just a URL:

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -10,7 +10,18 @@ module ActionView
 
         def render
           options = @options.stringify_keys
-          options["size"] = options["maxlength"] unless options.key?("size")
+
+          if ActionView::Helpers::FormHelper.text_field_maxlength_implies_size &&
+             options.key?("maxlength") && !options.key?("size")
+            ActionView.deprecator.warn(
+              "Setting maxlength without size will no longer imply size in Rails 8.2. " \
+              "Specify size explicitly if needed, or set " \
+              "ActionView::Helpers::FormHelper.text_field_maxlength_implies_size = false " \
+              "to opt into the new behavior early."
+            )
+            options["size"] = options["maxlength"]
+          end
+
           options["type"] ||= field_type
           options["value"] = options.fetch("value") { value_before_type_cast } unless field_type == "file"
           add_default_name_and_id(options)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -519,10 +519,31 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, text_field("post", "title", size: 35)
   end
 
-  def test_text_field_assuming_size
+  def test_text_field_maxlength_implies_size_with_deprecation_warning
     expected = '<input id="post_title" maxlength="35" name="post[title]" size="35" type="text" value="Hello World" />'
+
+    assert_deprecated("Setting maxlength without size will no longer imply size", ActionView.deprecator) do
+      assert_dom_equal expected, text_field("post", "title", "maxlength" => 35)
+    end
+
+    assert_deprecated("Setting maxlength without size will no longer imply size", ActionView.deprecator) do
+      assert_dom_equal expected, text_field("post", "title", maxlength: 35)
+    end
+  end
+
+  def test_text_field_maxlength_doesnt_imply_size_when_disabled
+    ActionView::Helpers::FormHelper.text_field_maxlength_implies_size = false
+
+    expected = '<input id="post_title" maxlength="35" name="post[title]" type="text" value="Hello World" />'
     assert_dom_equal expected, text_field("post", "title", "maxlength" => 35)
     assert_dom_equal expected, text_field("post", "title", maxlength: 35)
+  ensure
+    ActionView::Helpers::FormHelper.text_field_maxlength_implies_size = true
+  end
+
+  def test_text_field_explicit_size_overrides_maxlength
+    expected = '<input id="post_title" maxlength="35" name="post[title]" size="20" type="text" value="Hello World" />'
+    assert_dom_equal expected, text_field("post", "title", maxlength: 35, size: 20)
   end
 
   def test_text_field_removing_size


### PR DESCRIPTION
### Motivation / Background

This Pull Request removes the implicit behavior where specifying `maxlength` on text field helpers would also set the `size` attribute. These attributes serve different purposes and should not be coupled by default.

The current coupling creates several issues:

- **Can harm UX**: High `maxlength` values could result in excessively wide input fields.
- **Different concerns**: `maxlength` is about input constraints; `size` is about visual width. One is semantic, the other presentational.
- **Surprising behavior**: Developers don't expect a visual side effect from setting a validation attribute.
- **Asymmetric coupling**: Setting `size` doesn't affect `maxlength`, making the reverse relationship inconsistent.

### Detail

We add a deprecation path following Rails guidelines for breaking changes:

1. **Framework Default**: Adds `ActionView::Helpers::FormHelper.text_field_maxlength_implies_size = true` to maintain backwards compatibility
2. **Deprecation Warning**: Shows warning when `maxlength` is used without explicit `size`
3. **Migration Path**: Allows early adoption by setting the framework default to `false`

The behavior would change in Rails 8.2 (?) to make text field behavior more explicit and predictable.

### Additional information

I consider this breakage very minor as most real-world inputs have their width set via CSS. Out of an abundance of caution and desire to follow the guidelines for breaking changes, I am introducing this through a deprecation path.