### PR TITLE
Declare block param on NilClass#try and NilClass#try!

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -145,14 +145,14 @@ class NilClass
   #
   # With +try+
   #   @person.try(:children).try(:first).try(:name)
-  def try(*)
+  def try(*, &)
     nil
   end
 
   # Calling +try!+ on +nil+ always returns +nil+.
   #
   #   nil.try!(:name) # => nil
-  def try!(*)
+  def try!(*, &)
     nil
   end
 end


### PR DESCRIPTION
### Motivation / Background

With ruby 3.4, a warning is raised when a block is passed to a method and the method does not define the block param. This commit solves it by ensuring that the method signature of try and try! on NilClass is similar to Tryable.

This Pull Request has been created so Ruby 3.4 no longer issues a warning on calling `#try` on `nil` with a block.

### Additional information

Similar to the issue here: https://github.com/rails/rails/issues/51926 and the solution: https://github.com/rails/rails/commit/9ce4d4468eb5f69eab6a0e56da2a19601432d970

Currently, when using `try` with a block and on a `nil` value, it prints:

```
warning: the block passed to 'NilClass#try' defined at /usr/local/rvm/gems/default/gems/activesupport-7.2.2.1/lib/active_support/core_ext/object/try.rb:148 may be ignored
```