### PR TITLE
Add `require "rails"` to generated engines

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -104,6 +104,8 @@ that provides the following:
     standard Rails application's `config/application.rb` file:
 
     ```ruby
+    require "rails"
+
     module Blorgh
       class Engine < ::Rails::Engine
       end
@@ -175,6 +177,8 @@ perfect for that. Place the methods inside the module and you'll be good to go.
 Within `lib/blorgh/engine.rb` is the base class for the engine:
 
 ```ruby
+require "rails"
+
 module Blorgh
   class Engine < ::Rails::Engine
     isolate_namespace Blorgh

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/engine.rb.tt
@@ -1,3 +1,5 @@
+require "rails"
+
 <%= wrap_in_modules <<~rb
   class Engine < ::Rails::Engine
   #{mountable? ? "  isolate_namespace " + camelized_modules : " "}

--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/railtie.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%/railtie.rb.tt
@@ -1,3 +1,5 @@
+require "rails"
+
 <%= wrap_in_modules <<~rb
   class Railtie < ::Rails::Railtie
   end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -589,6 +589,16 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_plugin_can_be_required_in_isolation
+    run_generator
+    prepare_plugin(destination_root)
+
+    in_plugin_context(destination_root) do
+      output = `bundle exec ruby -e 'require "bukkits"'`
+      assert_predicate $?, :success?, "Command failed: #{output}"
+    end
+  end
+
   def test_dummy_application_sets_include_all_helpers_to_false_for_mountable
     run_generator [destination_root, "--mountable"]
 


### PR DESCRIPTION
### Motivation / Background

Normally, gems get loaded in `application.rb` after `require "rails"` has already been run, so there is not much of an issue.

However, trying to require the gem in isolation will fail since the all sorts of things have not been set up yet (like the `Rails` constant).

### Additional information

I encountered this with `good_job` and `bundle console` but I don't think it's a very rare issue. `solid_queue` for example runs into the same thing (and also other problems).

If `rails` comes first in the gemfile, it works. If it comes after, it doesn't. Additionally, if you cherry-pick your frameworks and don't pull in all of rails, the gem order doesn't seem to matter at all.

cc @bensheldon 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
