### PR TITLE
Bump required PostgreSQL version to 10.0

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Bump the minimum PostgreSQL version to 10.0.
+
+    As part of this change, `supports_pgcrypto_uuid?` is deprecated because
+    `pgcrypto` provides `gen_random_uuid()` since PostgreSQL 9.4, which is
+    below the new 10.0 minimum.
+
+    *Yasuo Honda*
+
 *   Let `add_column` raise `ArgumentError` if `:null` is set to a true value
     when defining a primary key.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -508,11 +508,7 @@ module ActiveRecord
 
             def select_min_column_value_sql(sequence)
               quoted_sequence = @adapter.quote_table_name(sequence)
-              if @adapter.database_version >= 10_00_00
-                "SELECT seqmin FROM pg_sequence WHERE seqrelid = #{@adapter.quote(quoted_sequence)}::regclass"
-              else
-                "SELECT min_value FROM #{quoted_sequence}"
-              end
+              "SELECT seqmin FROM pg_sequence WHERE seqrelid = #{@adapter.quote(quoted_sequence)}::regclass"
             end
 
             def reset_sequence_sql(sequence, max_value, min_value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -284,7 +284,7 @@ module ActiveRecord
       end
 
       def supports_insert_on_conflict?
-        database_version >= 9_05_00 # >= 9.5
+        true
       end
       alias supports_insert_on_duplicate_skip? supports_insert_on_conflict?
       alias supports_insert_on_duplicate_update? supports_insert_on_conflict?
@@ -295,7 +295,7 @@ module ActiveRecord
       end
 
       def supports_identity_columns? # :nodoc:
-        database_version >= 10_00_00 # >= 10.0
+        true
       end
 
       def supports_nulls_not_distinct?
@@ -303,7 +303,7 @@ module ActiveRecord
       end
 
       def supports_native_partitioning? # :nodoc:
-        database_version >= 10_00_00 # >= 10.0
+        true
       end
 
       if PG::Connection.method_defined?(:close_prepared) # pg 1.6.0 & libpq 17
@@ -474,8 +474,9 @@ module ActiveRecord
       end
 
       def supports_pgcrypto_uuid?
-        database_version >= 9_04_00 # >= 9.4
+        true
       end
+      deprecate :supports_pgcrypto_uuid?, deprecator: ActiveRecord.deprecator
 
       def supports_optimizer_hints?
         unless defined?(@has_pg_hint_plan)
@@ -646,10 +647,6 @@ module ActiveRecord
 
       # Rename enum value on an existing enum type.
       def rename_enum_value(type_name, **options)
-        unless database_version >= 10_00_00 # >= 10.0
-          raise ArgumentError, "Renaming enum values is only supported in PostgreSQL 10 or later"
-        end
-
         from = options.fetch(:from) { raise ArgumentError, ":from is required" }
         to = options.fetch(:to) { raise ArgumentError, ":to is required" }
 
@@ -709,8 +706,8 @@ module ActiveRecord
       end
 
       def check_version # :nodoc:
-        if database_version < 9_05_00 # < 9.5
-          raise "Your version of PostgreSQL (#{database_version}) is too old. Active Record supports PostgreSQL >= 9.5."
+        if database_version < 10_00_00 # < 10.0
+          raise "Your version of PostgreSQL (#{database_version}) is too old. Active Record supports PostgreSQL >= 10.0."
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -232,6 +232,12 @@ module ActiveRecord
       end
     end
 
+    def test_supports_pgcrypto_uuid_deprecation
+      assert_deprecated(ActiveRecord.deprecator) do
+        @connection.supports_pgcrypto_uuid?
+      end
+    end
+
     private
       def cause_server_side_disconnect
         unless @connection.instance_variable_get(:@raw_connection).transaction_status == ::PG::PQTRANS_INTRANS

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -132,8 +132,6 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_schema_dump_added_enum_value
-    skip("Adding enum values can not be run in a transaction") if @connection.database_version < 10_00_00
-
     @connection.add_enum_value :mood, :angry, before: :ok
     @connection.add_enum_value :mood, :nervous, after: :ok
     @connection.add_enum_value :mood, :glad
@@ -149,8 +147,6 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_schema_dump_renamed_enum_value
-    skip("Renaming enum values is only supported in PostgreSQL 10 or later") if @connection.database_version < 10_00_00
-
     @connection.rename_enum_value :mood, from: :ok, to: :okay
 
     output = dump_table_schema("postgresql_enums")

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -254,9 +254,6 @@ class PostgreSQLGeometricLineTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlLine < ActiveRecord::Base; end
 
   setup do
-    unless ActiveRecord::Base.lease_connection.database_version >= 90400
-      skip("line type is not fully implemented")
-    end
     @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("postgresql_lines") do |t|
       t.line :a_line

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -241,18 +241,14 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
 
   if ActiveRecord::Base.lease_connection.prepared_statements
     def test_schema_change_with_prepared_stmt
-      altered = false
       assert_nothing_raised do
         @connection.exec_query "select * from developers where id = $1", "sql", [bind_param(1)]
         @connection.exec_query "alter table developers add column zomg int", "sql", []
-        altered = true
         @connection.exec_query "select * from developers where id = $1", "sql", [bind_param(1)]
       end
       pass
     ensure
-      # We are not using DROP COLUMN IF EXISTS because that syntax is only
-      # supported by pg 9.X
-      @connection.exec_query("alter table developers drop column zomg", "sql", []) if altered
+      @connection.exec_query("alter table developers drop column if exists zomg", "sql", [])
     end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -11,14 +11,6 @@ module PostgresqlUUIDHelper
   def drop_table(name)
     connection.drop_table name, if_exists: true
   end
-
-  def uuid_function
-    connection.supports_pgcrypto_uuid? ? "gen_random_uuid()" : "uuid_generate_v4()"
-  end
-
-  def uuid_default
-    connection.supports_pgcrypto_uuid? ? {} : { default: uuid_function }
-  end
 end
 
 class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
@@ -31,7 +23,7 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
 
   setup do
     enable_extension!("uuid-ossp", connection)
-    enable_extension!("pgcrypto",  connection) if connection.supports_pgcrypto_uuid?
+    enable_extension!("pgcrypto",  connection)
 
     connection.create_table "uuid_data_type" do |t|
       t.uuid "guid"
@@ -43,14 +35,11 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
     drop_table "uuid_data_type"
   end
 
-  if ActiveRecord::Base.lease_connection.respond_to?(:supports_pgcrypto_uuid?) &&
-      ActiveRecord::Base.lease_connection.supports_pgcrypto_uuid?
-    def test_uuid_column_default
-      connection.add_column :uuid_data_type, :thingy, :uuid, null: false, default: "gen_random_uuid()"
-      UUIDType.reset_column_information
-      column = UUIDType.columns_hash["thingy"]
-      assert_equal "gen_random_uuid()", column.default_function
-    end
+  def test_uuid_column_default
+    connection.add_column :uuid_data_type, :thingy, :uuid, null: false, default: "gen_random_uuid()"
+    UUIDType.reset_column_information
+    column = UUIDType.columns_hash["thingy"]
+    assert_equal "gen_random_uuid()", column.default_function
   end
 
   def test_change_column_default
@@ -228,7 +217,7 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
     # to test dumping tables which columns have defaults with custom functions
     connection.execute <<~SQL
       CREATE OR REPLACE FUNCTION my_uuid_generator() RETURNS uuid
-      AS $$ SELECT * FROM #{uuid_function} $$
+      AS $$ SELECT * FROM gen_random_uuid() $$
       LANGUAGE SQL VOLATILE;
     SQL
 
@@ -238,7 +227,7 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
       t.uuid "other_uuid_2", default: "my_uuid_generator()"
     end
 
-    connection.create_table("pg_uuids_3", id: :uuid, **uuid_default) do |t|
+    connection.create_table("pg_uuids_3", id: :uuid) do |t|
       t.string "name"
     end
   end
@@ -286,11 +275,7 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
 
   def test_schema_dumper_for_uuid_primary_key_default
     schema = dump_table_schema "pg_uuids_3"
-    if connection.supports_pgcrypto_uuid?
-      assert_match(/\bcreate_table "pg_uuids_3", id: :uuid, default: -> { "gen_random_uuid\(\)" }/, schema)
-    else
-      assert_match(/\bcreate_table "pg_uuids_3", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
-    end
+    assert_match(/\bcreate_table "pg_uuids_3", id: :uuid, default: -> { "gen_random_uuid\(\)" }/, schema)
   end
 
   def test_schema_dumper_for_uuid_primary_key_default_in_legacy_migration
@@ -384,10 +369,10 @@ class PostgresqlUUIDTestInverseOf < ActiveRecord::PostgreSQLTestCase
 
   setup do
     connection.transaction do
-      connection.create_table("pg_uuid_posts", id: :uuid, **uuid_default) do |t|
+      connection.create_table("pg_uuid_posts", id: :uuid) do |t|
         t.string "title"
       end
-      connection.create_table("pg_uuid_comments", id: :uuid, **uuid_default) do |t|
+      connection.create_table("pg_uuid_comments", id: :uuid) do |t|
         t.references :uuid_post, type: :uuid
         t.string "content"
       end
@@ -443,14 +428,14 @@ class PostgresqlUUIDHasManyThroughDisableJoinsTest < ActiveRecord::PostgreSQLTes
 
   setup do
     connection.transaction do
-      connection.create_table("pg_uuid_forums", id: :uuid, **uuid_default) do |t|
+      connection.create_table("pg_uuid_forums", id: :uuid) do |t|
         t.string "name"
       end
-      connection.create_table("pg_uuid_posts", id: :uuid, **uuid_default) do |t|
+      connection.create_table("pg_uuid_posts", id: :uuid) do |t|
         t.references :uuid_forum, type: :uuid
         t.string "title"
       end
-      connection.create_table("pg_uuid_comments", id: :uuid, **uuid_default) do |t|
+      connection.create_table("pg_uuid_comments", id: :uuid) do |t|
         t.references :uuid_post, type: :uuid
         t.string "content"
       end

--- a/activerecord/test/cases/adapters/postgresql/well_known_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/well_known_test.rb
@@ -9,10 +9,10 @@ module ActiveRecord
       class WellKnownTest < ActiveRecord::TestCase
         test "uses version 11 mappings for earlier server versions" do
           version_11 = OID::WellKnown.mappings_for(server_version: 11_00_00)
-          version_9_5 = OID::WellKnown.mappings_for(server_version: 9_05_00)
+          version_10 = OID::WellKnown.mappings_for(server_version: 10_00_00)
 
-          assert_equal version_11.fetch(:type_aliases), version_9_5.fetch(:type_aliases)
-          assert_equal version_11.fetch(:array_types), version_9_5.fetch(:array_types)
+          assert_equal version_11.fetch(:type_aliases), version_10.fetch(:type_aliases)
+          assert_equal version_11.fetch(:array_types), version_10.fetch(:array_types)
         end
 
         test "uses latest known mappings for newer server versions" do

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -2,11 +2,9 @@
 
 ActiveRecord::Schema.define do
   ActiveRecord::TestCase.enable_extension!("uuid-ossp", connection)
-  ActiveRecord::TestCase.enable_extension!("pgcrypto",  connection) if supports_pgcrypto_uuid?
+  ActiveRecord::TestCase.enable_extension!("pgcrypto",  connection)
 
-  uuid_default = supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }
-
-  create_table :chat_messages, id: :uuid, force: true, **uuid_default do |t|
+  create_table :chat_messages, id: :uuid, force: true do |t|
     t.text :content
   end
 
@@ -15,11 +13,11 @@ ActiveRecord::Schema.define do
     t.text :content
   end
 
-  create_table :uuid_parents, id: :uuid, force: true, **uuid_default do |t|
+  create_table :uuid_parents, id: :uuid, force: true do |t|
     t.string :name
   end
 
-  create_table :uuid_children, id: :uuid, force: true, **uuid_default do |t|
+  create_table :uuid_children, id: :uuid, force: true do |t|
     t.string :name
     t.uuid :uuid_parent_id
   end
@@ -139,23 +137,23 @@ _SQL
   end
 
   create_table :uuid_comments, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :content
   end
 
   create_table :uuid_entries, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :entryable_type, null: false
     t.uuid :entryable_uuid, null: false
   end
 
   create_table :uuid_items, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :title
   end
 
   create_table :uuid_messages, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :subject
   end
 

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -18,7 +18,7 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-In order to use the PostgreSQL adapter you need to have at least version 9.5
+In order to use the PostgreSQL adapter you need to have at least version 10.0
 installed. Older versions are not supported.
 
 To get started with PostgreSQL have a look at the
@@ -362,9 +362,8 @@ SELECT n.nspname AS enum_schema,
 
 * [type definition](https://www.postgresql.org/docs/current/static/datatype-uuid.html)
 * [pgcrypto generator function](https://www.postgresql.org/docs/current/static/pgcrypto.html)
-* [uuid-ossp generator functions](https://www.postgresql.org/docs/current/static/uuid-ossp.html)
 
-NOTE: If you're using PostgreSQL earlier than version 13.0 you may need to enable special extensions to use UUIDs. Enable the `pgcrypto` extension (PostgreSQL >= 9.4) or `uuid-ossp` extension (for even earlier releases).
+NOTE: If you're using PostgreSQL earlier than version 13.0 you may need to enable the `pgcrypto` extension to use UUIDs.
 
 ```ruby
 # db/migrate/20131220144913_create_revisions.rb
@@ -547,8 +546,7 @@ With that configuration in place, generate and apply new migrations, then verify
 UUID Primary Keys
 -----------------
 
-NOTE: You need to enable the `pgcrypto` (only PostgreSQL >= 9.4) or `uuid-ossp`
-extension to generate random UUIDs.
+NOTE: You need to enable the `pgcrypto` extension to generate random UUIDs.
 
 ```ruby
 # db/migrate/20131220144913_create_devices.rb

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -181,7 +181,7 @@ The main difference is the content of the `config/database.yml` file. With the
 PostgreSQL option, it looks like this:
 
 ```yaml
-# PostgreSQL. Versions 9.5 and up are supported.
+# PostgreSQL. Versions 10.0 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -1,4 +1,4 @@
-# PostgreSQL. Versions 9.5 and up are supported.
+# PostgreSQL. Versions 10.0 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg


### PR DESCRIPTION
This pull request is based on the discussion at https://discuss.rubyonrails.org/t/proposal-bump-the-minimum-supported-postgresql-version-from-9-3-to-10/89422

### Motivation / Background

This pull request bumps the required PostgreSQL version to 10.0.

### Detail

PostgreSQL 18 (scheduled for release around September/October 2025) changes
the format of the cancel request key, which causes the following test to fail on Rails main.

This change was introduced in PostgreSQL core via https://github.com/postgres/postgres/commit/a460251f0a1ac987f0225203ff9593704da0b1a9

The issue is already addressed in https://github.com/ged/ruby-pg/pull/614 and the fix is included in the upcoming pg gem version v1.6.0 (currently released as v1.6.0.rc1).

The pg gem v1.6 raises its minimum required PostgreSQL version to 10 via https://github.com/ged/ruby-pg/pull/606

Rails main currently claims support for PostgreSQL 9.3+, which is incompatible with PostgreSQL 18 unless we raise the minimum supported version to 10.

I propose updating Rails main to require PostgreSQL 10 or newer, to ensure compatibility with PostgreSQL 18 and future releases.

### Additional information

- PostgreSQL 18 Beta 1

```sql
$ psql -d postgres
psql (18beta1)
Type "help" for help.

postgres=# select version();
                              version
--------------------------------------------------------------------
 PostgreSQL 18beta1 on x86_64-linux, compiled by gcc-15.1.1, 64-bit
(1 row)

postgres=#
```

- With pg 1.5.9 ActiveRecord::PostgresqlTransactionTest#test_raises_Interrupt_when_canceling_statement_via_interrupt fails
```ruby
$ bundle info pg
  * pg (1.5.9)
    Summary: Pg is the Ruby interface to the PostgreSQL RDBMS
    Homepage: https://github.com/ged/ruby-pg
    Documentation: http://deveiate.org/code/pg
    Source Code: https://github.com/ged/ruby-pg
    Changelog: https://github.com/ged/ruby-pg/blob/master/History.md
    Path: /home/yahonda/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/pg-1.5.9
    Reverse Dependencies:
        queue_classic (4.0.0) depends on pg (>= 1.1, < 2.0)
$
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/transaction_test.rb -n test_raises_Interrupt_when_canceling_statement_via_interrupt
Using postgresql
Run options: -n test_raises_Interrupt_when_canceling_statement_via_interrupt --seed 17678

F

Failure:
ActiveRecord::PostgresqlTransactionTest#test_raises_Interrupt_when_canceling_statement_via_interrupt [test/cases/adapters/postgresql/transaction_test.rb:199]:
Expected 10.014372003 to be < 5.

bin/test test/cases/adapters/postgresql/transaction_test.rb:183

Finished in 10.067954s, 0.0993 runs/s, 0.1987 assertions/s.
1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
