### PR TITLE
Add support to open files in the source code editor from the crash page

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow to open source file with a crash from the browser.
+
+    *Igor Kasyanchuk*
+
 *   Always check query string keys for valid encoding just like values are checked.
 
     *Casper Smits*

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -55,6 +55,17 @@ module ActionDispatch
       end
     end
 
+    def editor_url(location, line: nil)
+      if editor = ActiveSupport::Editor.current
+        line ||= location&.lineno
+        absolute_path = location&.absolute_path
+
+        if absolute_path && line && File.exist?(absolute_path)
+          editor.url_for(absolute_path, line)
+        end
+      end
+    end
+
     def protect_against_forgery?
       false
     end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
@@ -11,8 +11,9 @@
           <tr>
             <td>
               <pre class="line_numbers">
-                <% source_extract[:code].each_key do |line_number| %>
-<span><%= line_number -%></span>
+                <% source_extract[:code].each_key do |line| %>
+                  <% file_url = editor_url(source_extract[:trace], line: line) %>
+<span><%= link_to_if file_url, line, file_url -%></span>
                 <% end %>
               </pre>
             </td>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
@@ -13,13 +13,17 @@
   <% end %>
 
   <% traces.each do |name, trace| %>
-    <div id="<%= "#{name.gsub(/\s/, '-')}-#{error_index}" %>" style="display: <%= (name == trace_to_show) ? 'block' : 'none' %>;">
+    <div id="<%= "#{name.gsub(/\s/, '-')}-#{error_index}" %>" class="trace-container" style="display: <%= (name == trace_to_show) ? 'block' : 'none' %>;">
       <code class="traces">
         <% trace.each do |frame| %>
-          <a class="trace-frames trace-frames-<%= error_index %>" data-exception-object-id="<%= frame[:exception_object_id] %>" data-frame-id="<%= frame[:id] %>" href="#">
-            <%= frame[:trace] %>
-          </a>
-          <br>
+          <div class="trace">
+            <% file_url = editor_url(frame[:trace]) %>
+            <%= file_url && link_to("✏️", file_url, class: "edit-icon") %>
+            <a class="trace-frames trace-frames-<%= error_index %>" data-exception-object-id="<%= frame[:exception_object_id] %>" data-frame-id="<%= frame[:id] %>" href="#">
+              <%= frame[:trace] %>
+            </a>
+            <br>
+          </div>
         <% end %>
       </code>
     </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -54,6 +54,30 @@
       font-size: 11px;
     }
 
+    .trace-container {
+      margin-top: 10px;
+    }
+
+    code.traces .trace {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
+
+    .edit-icon {
+      width: 16px;
+      height: 16px;
+      display: flex;
+      font-size: 13px;
+      align-items: center;
+      justify-content: center;
+      text-decoration: none;
+    }
+
+    .edit-icon:hover {
+      scale: 1.05;
+    }
+
     .response-heading, .request-heading {
       margin-top: 30px;
     }

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -868,6 +868,16 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "shows the link to edit the file in the editor" do
+    @app = DevelopmentApp
+    ActiveSupport::Editor.stub(:current, ActiveSupport::Editor.find("atom")) do
+      get "/actionable_error"
+
+      assert_select "code a.edit-icon"
+      assert_includes body, "atom://core/open"
+    end
+  end
+
   test "shows a buttons for every action in an actionable error" do
     @app = DevelopmentApp
     Rails.stub :root, Pathname.new(".") do

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -44,6 +44,7 @@ module ActiveSupport
   autoload :CurrentAttributes
   autoload :Dependencies
   autoload :DescendantsTracker
+  autoload :Editor
   autoload :ExecutionWrapper
   autoload :Executor
   autoload :ErrorReporter

--- a/activesupport/lib/active_support/editor.rb
+++ b/activesupport/lib/active_support/editor.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveSupport
+  class Editor
+    @editors = {}
+    @current = false
+
+    class << self
+      # Registers a URL pattern for opening file in a given editor.
+      # This allows Rails to generate clickable links to control known editors.
+      #
+      # Example:
+      #
+      #  ActiveSupport::Editor.register("myeditor", "myeditor://%s:%d")
+      def register(name, url_pattern, aliases: [])
+        editor = new(url_pattern)
+        @editors[name] = editor
+        aliases.each do |a|
+          @editors[a] = editor
+        end
+      end
+
+      # Returns the current editor pattern if it is known.
+      # First check for the `RAILS_EDITOR` environment variable, and if it's
+      # missing, check for the `EDITOR` environment variable.
+      def current
+        if @current == false
+          @current = if editor_name = ENV["RAILS_EDITOR"] || ENV["EDITOR"]
+            @editors[editor_name]
+          end
+        end
+        @current
+      end
+
+      # :nodoc:
+
+      def find(name)
+        @editors[name]
+      end
+
+      def reset
+        @current = false
+      end
+    end
+
+    def initialize(url_pattern)
+      @url_pattern = url_pattern
+    end
+
+    def url_for(path, line)
+      sprintf(@url_pattern, path, line)
+    end
+
+    register "atom", "atom://core/open/file?filename=%s&line=%d"
+    register "cursor", "cursor://file/%s:%f"
+    register "emacs", "emacs://open?url=file://%s&line=%d", aliases: ["emacsclient"]
+    register "idea", "idea://open?file=%s&line=%d"
+    register "macvim", "mvim://open?url=file://%s&line=%d", aliases: ["mvim"]
+    register "nova", "nova://open?path=%s&line=%d"
+    register "rubymine", "x-mine://open?file=%s&line=%d"
+    register "sublime", "subl://open?url=file://%s&line=%d", aliases: ["subl"]
+    register "textmate", "txmt://open?url=file://%s&line=%d", aliases: ["mate"]
+    register "vscode", "vscode://file/%s:%d", aliases: ["code"]
+    register "vscodium", "vscodium://file/%s:%d", aliases: ["codium"]
+    register "windsurf", "windsurf://file/%s:%d"
+    register "zed", "zed://file/%s:%d"
+  end
+end

--- a/activesupport/test/editor_test.rb
+++ b/activesupport/test/editor_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+module ActiveSupport
+  class EditorTest < ActiveSupport::TestCase
+    setup do
+      Editor.reset
+    end
+
+    teardown do
+      Editor.reset
+    end
+
+    def test_current
+      with_env("EDITOR" => nil, "RAILS_EDITOR" => nil) do
+        assert_nil Editor.current
+      end
+
+      with_env("EDITOR" => "mate", "RAILS_EDITOR" => nil) do
+        assert_equal "txmt://open?url=file://foo.rb&line=42", Editor.current.url_for("foo.rb", 42)
+      end
+
+      with_env("EDITOR" => "mate", "RAILS_EDITOR" => "unknown") do
+        assert_nil Editor.current
+      end
+
+      with_env("EDITOR" => "code", "RAILS_EDITOR" => "mate") do
+        assert_equal "txmt://open?url=file://foo.rb&line=42", Editor.current.url_for("foo.rb", 42)
+      end
+    end
+
+    private
+      def with_env(kv)
+        old_values = {}
+        kv.each { |key, value| old_values[key], ENV[key] = ENV[key], value }
+        yield
+      ensure
+        old_values.each { |key, value| ENV[key] = value }
+        Editor.reset
+      end
+  end
+end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/46378

### Motivation / Background

My main motivation is to make life easier. I want to be able to open my Cursor directly from the browser.

### Detail

I want to make it a part of Rails. For backward compatibility, I created a gem: https://github.com/igorkasyanchuk/editor_opener

I added support for the most popular editors (copied some code from the `better_errors` gem).

The developer can set an editor using the ENV variable (ENV["EDITOR"]). If it's not set, no changes will be applied.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
