### PR TITLE
Pass the user-facing reflection when notifying deprecated HABTMs

### DIFF
--- a/activerecord/lib/active_record/associations/deprecation.rb
+++ b/activerecord/lib/active_record/associations/deprecation.rb
@@ -37,6 +37,8 @@ module ActiveRecord::Associations::Deprecation # :nodoc:
     end
 
     def report(reflection, context:)
+      reflection = user_facing_reflection(reflection)
+
       message = +"The association #{reflection.active_record}##{reflection.name} is deprecated, #{context}"
       message << " (#{backtrace_cleaner.first_clean_frame})"
 
@@ -74,6 +76,15 @@ module ActiveRecord::Associations::Deprecation # :nodoc:
 
       def set_backtrace_supports_array_of_locations?
         @backtrace_supports_array_of_locations ||= Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
+      end
+
+      def user_facing_reflection(reflection)
+        case reflection.parent_reflection
+        when ActiveRecord::Reflection::HasAndBelongsToManyReflection
+          reflection.parent_reflection
+        else
+          reflection
+        end
       end
   end
 


### PR DESCRIPTION
It is more consistent that `deprecated_association.active_record` payloads carry the same reflection `reflect_on_association` would return for the name of the association being reported.

This was already the case except for HABTMs. In practice, the code deals with their internal through, so we need to special-case them.