### PR TITLE
Fix time attribute dirty tracking with timezone conversions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix time attribute dirty tracking with timezone conversions.
+
+    Time-only attributes now maintain a fixed date of 2000-01-01 during timezone conversions,
+    preventing them from being incorrectly marked as changed due to date shifts.
+
+    This fixes an issue where time attributes would be marked as changed when setting the same time value
+    due to timezone conversion causing internal date shifts.
+
+    *Prateek Choudhary*
+
 *   Skip calling `PG::Connection#cancel` in `cancel_any_running_query`
     when using libpq >= 18 with pg < 1.6.0, due to incompatibility.
     Rollback still runs, but may take longer.

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -21,7 +21,11 @@ module ActiveRecord
             set_time_zone_without_conversion(super)
           elsif value.respond_to?(:in_time_zone)
             begin
-              super(user_input_in_time_zone(value)) || super
+              result = super(user_input_in_time_zone(value)) || super
+              if result && type == :time
+                result = result.change(year: 2000, month: 1, day: 1)
+              end
+              result
             rescue ArgumentError
               nil
             end
@@ -41,7 +45,11 @@ module ActiveRecord
             return if value.nil?
 
             if value.acts_like?(:time)
-              value.in_time_zone
+              converted = value.in_time_zone
+              if type == :time && converted
+                converted = converted.change(year: 2000, month: 1, day: 1)
+              end
+              converted
             elsif value.respond_to?(:infinite?) && value.infinite?
               value
             else

--- a/activerecord/test/cases/attribute_methods/time_zone_converter_test.rb
+++ b/activerecord/test/cases/attribute_methods/time_zone_converter_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "active_support/core_ext/enumerable"
+require "models/topic"
 
 module ActiveRecord
   module AttributeMethods
@@ -14,6 +15,54 @@ module ActiveRecord
 
           assert_equal value, value_from_cache
           assert_not_equal value, "foo"
+        end
+
+        def test_time_attributes_with_fixed_date_normalization
+          old_time_zone = Time.zone
+
+          Time.zone = "Tokyo"
+
+          subtype = ActiveRecord::Type::Time.new
+          converter = ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter.new(subtype)
+
+          time_value = converter.cast("14:30")
+
+          assert_equal 2000, time_value.year
+          assert_equal 1, time_value.month
+          assert_equal 1, time_value.day
+          assert_equal 14, time_value.hour
+          assert_equal 30, time_value.min
+
+          time_value2 = converter.cast("14:30")
+
+          assert_equal time_value.year, time_value2.year
+          assert_equal time_value.month, time_value2.month
+          assert_equal time_value.day, time_value2.day
+        ensure
+          Time.zone = old_time_zone
+        end
+
+        def test_time_attribute_dirty_tracking_with_fixed_date
+          old_time_zone = Time.zone
+          old_default_timezone = ActiveRecord.default_timezone
+
+          Time.zone = "Tokyo"
+          ActiveRecord.default_timezone = :utc
+
+          timezone_aware_topic = Class.new(ActiveRecord::Base) do
+            self.table_name = "topics"
+            self.time_zone_aware_attributes = true
+            self.time_zone_aware_types = [:datetime, :time]
+            attribute :bonus_time, :time
+          end
+
+          topic = timezone_aware_topic.create!(bonus_time: "08:00")
+          topic.reload
+          topic.bonus_time = "08:00"
+          assert_not_predicate topic, :bonus_time_changed?
+        ensure
+          Time.zone = old_time_zone
+          ActiveRecord.default_timezone = old_default_timezone
         end
       end
     end


### PR DESCRIPTION
## Summary

This PR fixes an issue where time-only attributes are incorrectly marked as changed when setting the same time value due to timezone conversion causing date shifts.

## Problem

When using time-only attributes with timezone-aware settings, the internal date component can shift during timezone conversions (e.g., from 2000-01-01 to 2000-01-02), causing Rails to incorrectly detect the attribute as changed even when the time value remains the same.

### Before (Bug)
```ruby
# Configuration
Time.zone = "Tokyo"
ActiveRecord.default_timezone = :utc

user = User.create!(created_at: "14:30")
user.reload

user.created_at = "14:30"
user.changed_attribute_names_to_save
# => ["created_at"] # Incorrectly marked as changed!
```

### After (Fixed)
```ruby
# Configuration
config.active_record.use_fixed_date_for_time_attributes = true

user = User.create!(created_at: "14:30")
user.reload

user.created_at = "14:30"
user.changed_attribute_names_to_save
# => [] # Correctly not marked as changed
```

## Solution

This PR ensures time-only attributes maintain a fixed date of 2000-01-01 during timezone conversions. This prevents false positive dirty tracking.

The fix:

- Modifies `TimeZoneConverter` to maintain the fixed date
- Only affects time-only attributes, not datetime attributes

Fixes #55118