### PR TITLE
Fix link in guides/action_mailer_basics

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -1013,7 +1013,7 @@ Previewing and Testing Mailers
 ------------------------------
 
 You can find detailed instructions on how to test your mailers in the [testing
-guide](testing.html#testing-your-mailers).
+guide](testing.html#testing-mailers).
 
 ### Previewing Emails
 


### PR DESCRIPTION
The link to "testing guide" used an invalid fragment identifier.

See [guides/source/testing.md#testing-mailers](https://github.com/rails/rails/blob/main/guides/source/testing.md#testing-mailers)