### PR TITLE
Restore Active Storage config to disable variants and analyzers

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Allow analyzers and variant transformer to be fully configurable
+
+    ```ruby
+    # ActiveStorage.analyzers can be set to an empty array:
+    config.active_storage.analyzers = []
+    # => ActiveStorage.analyzers = []
+
+    # or use custom analyzer:
+    config.active_storage.analyzers = [ CustomAnalyzer ]
+    # => ActiveStorage.analyzers = [ CustomAnalyzer ]
+    ```
+
+    If no configuration is provided, it will use the default analyzers.
+
+    You can also disable variant processor to remove warnings on startup about missing gems.
+
+    ```ruby
+    config.active_storage.variant_processor = :disabled
+    ```
+
+    *zzak*, *Alexandre Ruban*
+
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Remove deprecated `:azure` storage service.

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -377,6 +377,7 @@ module ActiveStorage
     extend ActiveSupport::Autoload
 
     autoload :Transformer
+    autoload :NullTransformer
     autoload :ImageProcessingTransformer
     autoload :Vips
     autoload :ImageMagick

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 begin
+  require "nokogiri"
+rescue LoadError
+  # Ensure nokogiri is loaded before vips, which also depends on libxml2.
+  # See Nokogiri RFC: Stop exporting symbols:
+  #   https://github.com/sparklemotion/nokogiri/discussions/2746
+end
+
+begin
   gem "ruby-vips"
   require "ruby-vips"
 rescue LoadError => error

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -25,7 +25,7 @@ module ActiveStorage
 
     config.active_storage = ActiveSupport::OrderedOptions.new
     config.active_storage.previewers = [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
-    config.active_storage.analyzers = [ ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
+    config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
     config.active_storage.paths = ActiveSupport::OrderedOptions.new
     config.active_storage.queues = ActiveSupport::InheritableOptions.new
     config.active_storage.precompile_assets = true
@@ -88,26 +88,20 @@ module ActiveStorage
 
       config.after_initialize do |app|
         ActiveStorage.logger            = app.config.active_storage.logger || Rails.logger
-        ActiveStorage.variant_processor = app.config.active_storage.variant_processor
+        ActiveStorage.variant_processor = app.config.active_storage.variant_processor || :mini_magick
         ActiveStorage.previewers        = app.config.active_storage.previewers || []
+        ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
 
         begin
-          analyzer, transformer =
+          ActiveStorage.variant_transformer =
             case ActiveStorage.variant_processor
+            when :disabled
+              ActiveStorage::Transformers::NullTransformer
             when :vips
-              [
-                ActiveStorage::Analyzer::ImageAnalyzer::Vips,
-                ActiveStorage::Transformers::Vips
-              ]
+              ActiveStorage::Transformers::Vips
             when :mini_magick
-              [
-                ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick,
-                ActiveStorage::Transformers::ImageMagick
-              ]
+              ActiveStorage::Transformers::ImageMagick
             end
-
-          ActiveStorage.analyzers = [analyzer].compact.concat(app.config.active_storage.analyzers || [])
-          ActiveStorage.variant_transformer = transformer
         rescue LoadError => error
           case error.message
           when /libvips/

--- a/activestorage/lib/active_storage/transformers/null_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/null_transformer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  module Transformers
+    class NullTransformer < Transformer # :nodoc:
+      private
+        def process(file, format:)
+          file
+        end
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3138,7 +3138,7 @@ The value must respond to Ruby's `Digest` interface.
 
 #### `config.active_storage.variant_processor`
 
-Accepts a symbol `:mini_magick` or `:vips`, specifying whether variant transformations and blob analysis will be performed with MiniMagick or ruby-vips.
+Accepts a symbol `:mini_magick`, `:vips`, or `:disabled` specifying whether or not variant transformations and blob analysis will be performed with MiniMagick or ruby-vips.
 
 The default value depends on the `config.load_defaults` target version:
 
@@ -3153,10 +3153,21 @@ Accepts an array of classes indicating the analyzers available for Active Storag
 By default, this is defined as:
 
 ```ruby
-config.active_storage.analyzers = [ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer]
+config.active_storage.analyzers = [
+  ActiveStorage::Analyzer::ImageAnalyzer::Vips,
+  ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick,
+  ActiveStorage::Analyzer::VideoAnalyzer,
+  ActiveStorage::Analyzer::AudioAnalyzer
+]
 ```
 
 The image analyzers can extract width and height of an image blob; the video analyzer can extract width, height, duration, angle, aspect ratio, and presence/absence of video/audio channels of a video blob; the audio analyzer can extract duration and bit rate of an audio blob.
+
+If you want to disable analyzers, you can set this to an empty array:
+
+```ruby
+config.active_storage.analyzers = []
+```
 
 #### `config.active_storage.previewers`
 

--- a/railties/test/application/active_storage/analyzers_integration_test.rb
+++ b/railties/test/application/active_storage/analyzers_integration_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class ActiveStorageEngineTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    include ActiveJob::TestHelper
+
+    self.file_fixture_path = "#{RAILS_FRAMEWORK_ROOT}/activestorage/test/fixtures/files"
+
+    def setup
+      build_app
+
+      rails "active_storage:install"
+
+      rails "generate", "model", "user", "name:string", "avatar:attachment"
+      rails "db:migrate"
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_analyzers_default
+      app("development")
+
+      user = User.new(name: "Test User", avatar: file_fixture("racecar.jpg"))
+
+      assert_enqueued_with(job: ActiveStorage::AnalyzeJob) do
+        user.save!
+      end
+    end
+
+    def test_analyzers_empty
+      add_to_config "config.active_storage.analyzers = []"
+
+      app("development")
+
+      user = User.new(name: "Test User", avatar: file_fixture("racecar.jpg"))
+
+      assert_no_enqueued_jobs do
+        user.save!
+      end
+    end
+
+    def test_analyzers_not_empty
+      add_to_config "config.active_storage.analyzers = [ActiveStorage::Analyzer::ImageAnalyzer]"
+
+      app("development")
+
+      user = User.new(name: "Test User", avatar: file_fixture("racecar.jpg"))
+
+      assert_enqueued_with(job: ActiveStorage::AnalyzeJob) do
+        user.save!
+      end
+    end
+  end
+end

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+require "env_helpers"
+
+module ApplicationTests
+  class ActiveStorageEngineTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    include EnvHelpers
+
+    def setup
+      build_app
+
+      File.write app_path("Gemfile"), <<~GEMFILE
+        source "https://rubygems.org"
+        gem "rails", path: "#{RAILS_FRAMEWORK_ROOT}"
+
+        gem "propshaft"
+        gem "importmap-rails"
+        gem "sqlite3"
+      GEMFILE
+
+      add_to_env_config :development, "config.active_storage.logger = ActiveSupport::Logger.new(STDOUT)"
+
+      File.open("#{app_path}/config/boot.rb", "w") do |f|
+        f.puts "ENV['BUNDLE_GEMFILE'] = '#{app_path}/Gemfile'"
+        f.puts 'require "bundler/setup"'
+      end
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_default_transformer_missing_gem_warning
+      output = run_command("puts ActiveStorage.variant_transformer")
+
+      assert_includes(output, "Generating image variants require the image_processing gem. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+    end
+
+    def test_default_transformer_with_gem_no_warning
+      File.open("#{app_path}/Gemfile", "a") do |f|
+        f.puts <<~GEMFILE
+          gem "image_processing", "~> 1.2"
+        GEMFILE
+      end
+
+      output = run_command("puts ActiveStorage.variant_transformer")
+
+      assert_not_includes(output, "Generating image variants require the image_processing gem. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+      assert_includes(output, "ActiveStorage::Transformers::Vips")
+    end
+
+    def test_disabled_transformer_no_warning
+      add_to_config "config.active_storage.variant_processor = :disabled"
+
+      output = run_command("puts ActiveStorage.variant_transformer")
+
+      assert_not_includes(output, "Generating image variants require the image_processing gem. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+      assert_includes(output, "ActiveStorage::Transformers::NullTransformer")
+    end
+
+    private
+      def run_command(cmd)
+        Dir.chdir(app_path) do
+          Bundler.with_original_env do
+            with_rails_env "development" do
+              `bin/rails runner "#{cmd}" 2>&1`
+            end
+          end
+        end
+      end
+  end
+end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4110,6 +4110,37 @@ module ApplicationTests
       MESSAGE
     end
 
+    test "ActiveStorage.analyzers default value" do
+      app "development"
+
+      assert_equal [
+        ActiveStorage::Analyzer::ImageAnalyzer::Vips,
+        ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick,
+        ActiveStorage::Analyzer::VideoAnalyzer,
+        ActiveStorage::Analyzer::AudioAnalyzer
+      ], ActiveStorage.analyzers
+    end
+
+    test "ActiveStorage.analyzers can be configured to be an empty array" do
+      add_to_config <<-RUBY
+        config.active_storage.analyzers = []
+      RUBY
+
+      app "development"
+
+      assert_empty ActiveStorage.analyzers
+    end
+
+    test "ActiveStorage.analyzers can be configured to custom analyzers" do
+      add_to_config <<-RUBY
+        config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::Vips ]
+      RUBY
+
+      app "development"
+
+      assert_equal [ ActiveStorage::Analyzer::ImageAnalyzer::Vips ], ActiveStorage.analyzers
+    end
+
     test "ActiveStorage.draw_routes can be configured via config.active_storage.draw_routes" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do
@@ -4147,7 +4178,7 @@ module ApplicationTests
 
       app "development"
 
-      assert_nil ActiveStorage.variant_processor
+      assert_equal :mini_magick, ActiveStorage.variant_processor
     end
 
     test "ActiveStorage.variant_processor uses vips by default" do


### PR DESCRIPTION
Fixes a couple of mistakes made in e978ef0 (#45100).

* Allow setting `config.active_storage.analyzers = []`
* Allow disabling `config.active_storage.variant_processor` to remove warning
* Ensure original default `ActiveStorage.analyzers` array is not broken (all available analyzers)
* Ensure original default `ActiveStorage.variant_processor` is not broken (`:mini_magick` until `load_defaults(7.0)`)

This change restores the configuration of analyzers back to 8.0, instead of trying to gracefully handle loading those constants if the associated gem is missing.

Due to that config being set at require time, this happens prior to initialization and we don't have access to a logger or deprecator to warn the user.

Since `image_processing` gem transitively depends on `ruby-vips` and `mini_magick`, you only need to install that to remove the warning.

However, if you're not using variant transformers, but still using the default analyzers you can remove the warning by including those gems or setting the analyzers config to an empty array.

We determine the variant transformer based on `config.active_storage.variant_processor` value, or nothing if you passed an invalid value (like `mmmmmini_magick`).

Passing an invalid value, should have the same existing behavior and not impact a working application but in the future we'd like to deprecate it.

Fixes: #54391
Alternative to: #54402

Fixes: #54152
Alternative to: #54166

/cc @alexandreruban @Earlopain @Edouard-chin @skipkayhil 