### PR TITLE
Fix incorrect module include in Getting Started guide [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2336,7 +2336,7 @@ Notifications module.
 
 ```ruby#2
 class Product < ApplicationRecord
-  include Notifications
+  include Product::Notifications
 
   has_one_attached :featured_image
   has_rich_text :description


### PR DESCRIPTION
The guide defines `module Product::Notifications` but shows `include Notifications`. This should be `include Product::Notifications` to match the module's namespaced definition.

Fixes getting_started.md line 2339.

### Motivation / Background

This Pull Request has been created because Section 16.4 of the Getting Started guide defines `module Product::Notifications` but then shows `include Notifications`, which would cause a `NameError`.

### Detail

This Pull Request fixes line 2339 in the Getting Started guide (Section 16.4 "Extracting a Concern"). The code example incorrectly shows `include Notifications` when it should be `include Product::Notifications` to match the module definition shown earlier.

### Additional information

Alternative would be to place the module in the standard `app/models/concerns/` directory and define as `module Notifications`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
