### PR TITLE
Fix cut off CurrentAttributes option description [ci skip]

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -109,9 +109,9 @@ module ActiveSupport
       # ==== Options
       #
       # * <tt>:default</tt> - The default value for the attributes. If the value
-      # is a proc or lambda, it will be called whenever an instance is
-      # constructed. Otherwise, the value will be duplicated with +#dup+.
-      # Default values are re-assigned when the attributes are reset.
+      #   is a proc or lambda, it will be called whenever an instance is
+      #   constructed. Otherwise, the value will be duplicated with +#dup+.
+      #   Default values are re-assigned when the attributes are reset.
       def attribute(*names, default: NOT_SET)
         invalid_attribute_names = names.map(&:to_sym) & INVALID_ATTRIBUTE_NAMES
         if invalid_attribute_names.any?


### PR DESCRIPTION
Fix that the description of the `:default` option for `CurrentAttributes#attribute` was cut off.

![Screenshot_20250708_115345](https://github.com/user-attachments/assets/74ba37fe-a147-4469-923f-259bbe27554a)

