### PR TITLE
Add callable support to allow_nil and allow_blank

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Allow passing method name or proc to `allow_nil` and `allow_blank`
+
+    ```ruby
+    class EnrollmentForm
+      include ActiveModel::Validations
+
+      attr_accessor :course
+
+      validates :course,
+                inclusion: { in: :open_courses },
+                allow_nil: :saving_progress?
+    end
+    ```
+
+    *Richard Lynch*
+
 *   Add error type support arguments to `ActiveModel::Errors#messages_for` and `ActiveModel::Errors#full_messages_for`
 
     ```ruby

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -75,8 +75,12 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>except: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
-      # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
-      # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
+      # * <tt>:allow_nil</tt> - Specify a method, proc, or boolean, to skip
+      #   validation if attribute is +nil+ (e.g. <tt>allow_nil: true</tt>, or
+      #   <tt>allow_nil: Proc.new { |user| user.signup_step > 2 }</tt>).
+      # * <tt>:allow_blank</tt> - Specify a method, proc, or boolean, to skip
+      #   validation if attribute is +blank+ (e.g. <tt>allow_blank: true</tt>,
+      #   or <tt>allow_blank: Proc.new { |user| user.signup_step > 2 }</tt>).
       # * <tt>:if</tt> - Specifies a method, proc, or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -150,7 +150,7 @@ module ActiveModel
     def validate(record)
       attributes.each do |attribute|
         value = record.read_attribute_for_validation(attribute)
-        next if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
+        next if (value.nil? && allow_nil?(record)) || (value.blank? && allow_blank?(record))
         value = prepare_value_for_validation(value, record, attribute)
         validate_each(record, attribute, value)
       end
@@ -171,6 +171,22 @@ module ActiveModel
     private
       def prepare_value_for_validation(value, record, attr_name)
         value
+      end
+
+      def allow_nil?(record)
+        if options[:allow_nil].respond_to?(:to_proc)
+          !!options[:allow_nil].to_proc.call(record)
+        else
+          !!options[:allow_nil]
+        end
+      end
+
+      def allow_blank?(record)
+        if options[:allow_blank].respond_to?(:to_proc)
+          !!options[:allow_blank].to_proc.call(record)
+        else
+          !!options[:allow_blank]
+        end
       end
   end
 

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -143,12 +143,104 @@ class ValidatesWithTest < ActiveModel::TestCase
     assert_equal ["Value is "], topic.errors[:content]
   end
 
+  test "each validator skip nil values if :allow_nil is a method name evaluating to true" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_nil: :condition_is_true
+    )
+    topic = Topic.new content: nil
+    assert_predicate topic, :valid?
+    assert_empty topic.errors[:title]
+    assert_empty topic.errors[:content]
+  end
+
+  test "each validator does not skip nil values if :allow_nil is a method name evaluating to false" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_nil: :condition_is_false
+    )
+    topic = Topic.new content: nil
+    assert_predicate topic, :invalid?
+    assert_not_empty topic.errors[:content]
+  end
+
+  test "each validator skip nil values if :allow_nil is a proc evaluating to true" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_nil: -> topic { topic.condition_is_true }
+    )
+    topic = Topic.new content: nil
+    assert_predicate topic, :valid?
+    assert_empty topic.errors[:title]
+    assert_empty topic.errors[:content]
+  end
+
+  test "each validator does not skip nil values if :allow_nil is a proc evaluating to false" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_nil: -> topic { topic.condition_is_false }
+    )
+    topic = Topic.new content: nil
+    assert_predicate topic, :invalid?
+    assert_not_empty topic.errors[:content]
+  end
+
   test "each validator skip blank values if :allow_blank is set to true" do
     Topic.validates_with(ValidatorPerEachAttribute, attributes: [:title, :content], allow_blank: true)
     topic = Topic.new content: ""
     assert_predicate topic, :valid?
     assert_empty topic.errors[:title]
     assert_empty topic.errors[:content]
+  end
+
+  test "each validator skip blank values if :allow_blank is a method name evaluating to true" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_blank: :condition_is_true
+    )
+    topic = Topic.new content: ""
+    assert_predicate topic, :valid?
+    assert_empty topic.errors[:title]
+    assert_empty topic.errors[:content]
+  end
+
+  test "each validator does not skip blank values if :allow_blank is a method name evaluating to false" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_blank: :condition_is_false
+    )
+    topic = Topic.new content: ""
+    assert_predicate topic, :invalid?
+    assert_not_empty topic.errors[:content]
+  end
+
+  test "each validator skip blank values if :allow_blank is a proc evaluating to true" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_blank: -> topic { topic.condition_is_true }
+    )
+    topic = Topic.new content: ""
+    assert_predicate topic, :valid?
+    assert_empty topic.errors[:title]
+    assert_empty topic.errors[:content]
+  end
+
+  test "each validator does not skip blank values if :allow_blank is a proc evaluating to false" do
+    Topic.validates_with(
+      ValidatorPerEachAttribute,
+      attributes: [:title, :content],
+      allow_blank: -> topic { topic.condition_is_false }
+    )
+    topic = Topic.new content: ""
+    assert_predicate topic, :invalid?
+    assert_not_empty topic.errors[:content]
   end
 
   test "validates_with can validate with an instance method" do


### PR DESCRIPTION
Adds the ability to pass a callable to `allow_nil` and `allow_blank`. This allows handling scenarios where you want to conditionally allow an empty value to be saved but ensure other values are validated.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

We ran into a limitation with `allow_nil` while implementing a form as part of a multi step wizard.

We wanted to conditionally allow a `nil` value for an attribute but otherwise ensure the value was included in a collection, eg

```ruby
validates(
  :course_id,
  inclusion: {
    in: -> (form) { form.permitted_courses.map(&:id) }
  },
  allow_nil: :saving_progress?
)
```

While there are work arounds for this (duplicating validation or conditionally appending a nil to the collection), they're noisy, and reduce readability, eg
```ruby
validates(
  :course_id,
  inclusion: {
    in: -> form { form.permitted_courses.map(&:id) }
  },
  unless: :saving_progress?
)
validates(
  :course_id,
  inclusion: {
    in: -> (form) { form.permitted_courses.map(&:id) << nil } # note we use this list for the select and don't want nil as an option in the view
  },
  if: :saving_progress?
)
```

We created this pull request as we were surprised this behaviour wasn't already supported, usually with Rails everything just works as you'd expect!

### Detail
This Pull Request changes the `ActiveModel::Validator#validate` method to allow passing a callable (responds to `to_proc`) as an option for `allow_nil` and `allow_blank`

### Additional information
I saw this functionality was [previous proposed](https://github.com/rails/rails/pull/26811/) in 2016 but shot down due to being achievable with the `if` and `unless` options. Just close this PR if you still think this option isn't necessary, I appreciate you're very busy so no hard feelings!


Our [work around](https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/3918/commits/5963d89bda76bdfdd9964634f4a02e576ab32cb5) was to implement a custom inclusion validator with callable support for allow nil, but that approach isn't ideal as  `allow_nil: :some_callable` doesn't work as expected for other validators.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
