### PR TITLE
Cleanup typos and grammer in database adapter comments

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -168,7 +168,7 @@ module ActiveRecord
         end
       end
 
-      # Clears the cache which maps classes.
+      # Clears reloadable connection caches in all connection pools.
       #
       # See ConnectionPool#clear_reloadable_connections! for details.
       def clear_reloadable_connections!(role = nil)

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -129,7 +129,7 @@ module ActiveRecord
       else
         class WeakThreadKeyMap # :nodoc:
           # FIXME: On 3.3 we could use ObjectSpace::WeakKeyMap
-          # but it currently cause GC crashes: https://github.com/byroot/rails/pull/3
+          # but it currently causes GC crashes: https://github.com/byroot/rails/pull/3
           def initialize
             @map = {}
           end
@@ -518,7 +518,7 @@ module ActiveRecord
         @connections.nil?
       end
 
-      # Clears the cache which maps classes and re-connects connections that
+      # Clears reloadable connections from the pool and re-connects connections that
       # require reloading.
       #
       # Raises:
@@ -541,7 +541,7 @@ module ActiveRecord
         end
       end
 
-      # Clears the cache which maps classes and re-connects connections that
+      # Clears reloadable connections from the pool and re-connects connections that
       # require reloading.
       #
       # The pool first tries to gain ownership of all connections. If unable to

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -612,7 +612,7 @@ module ActiveRecord
         }
       end
 
-      # Returns the configured supported identifier length supported by PostgreSQL
+      # Returns the configured maximum supported identifier length supported by PostgreSQL
       def max_identifier_length
         @max_identifier_length ||= query_value("SHOW max_identifier_length", "SCHEMA").to_i
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -134,8 +134,8 @@ module ActiveRecord
           end
 
           def cast_result(result)
-            # Given that SQLite3 doesn't really a Result type, raw_execute already return an ActiveRecord::Result
-            # and we have nothing to cast here.
+            # Given that SQLite3 doesn't have a Result type, raw_execute already returns an ActiveRecord::Result
+            # so we have nothing to cast here.
             result
           end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -41,7 +41,7 @@ module ActiveRecord
     #
     # There may be other options available specific to the SQLite3 driver. Please read the
     # documentation for
-    # {SQLite::Database.new}[https://sparklemotion.github.io/sqlite3-ruby/SQLite3/Database.html#method-c-new]
+    # {SQLite3::Database.new}[https://sparklemotion.github.io/sqlite3-ruby/SQLite3/Database.html#method-c-new]
     #
     class SQLite3Adapter < AbstractAdapter
       ADAPTER_NAME = "SQLite"
@@ -337,7 +337,7 @@ module ActiveRecord
       # Creates a virtual table
       #
       # Example:
-      #   create_virtual_table :emails, :fts5, ['sender', 'title',' body']
+      #   create_virtual_table :emails, :fts5, ['sender', 'title', 'body']
       def create_virtual_table(table_name, module_name, values)
         exec_query "CREATE VIRTUAL TABLE IF NOT EXISTS #{table_name} USING #{module_name} (#{values.join(", ")})"
       end


### PR DESCRIPTION
### Motivation / Background

While working on creating a [activerecord-duckdb](https://github.com/tarellel/activerecord-duckdb) adapter I was browsing the frameworks currently supported database adapters and noticed some comments with typos, broken grammar, or otherwise places where minor corrections should be made.

### Detail

This Pull Request changes minor typos and grammer within some of the active_record connection adapters.
