### PR TITLE
Add params expect Method to Action Pack's Notable Changes in 8.0 Release Notes [ci skip]

### DIFF
--- a/guides/source/8_0_release_notes.md
+++ b/guides/source/8_0_release_notes.md
@@ -124,6 +124,9 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 ### Notable changes
 
+*   Introduce safer, more explicit params handling method with [`params#expect`](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect) such that
+    `params.expect(table: [ :attr ])` replaces `params.require(:table).permit(:attr)`.
+
 Action View
 -----------
 


### PR DESCRIPTION
Add `params.expect` replacing `params.require` in Action Pack's Notable changes in 8.0 Release Notes.