### PR TITLE
[ci skip][doc]Fix engineering notation -> scientific notation

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2187,13 +2187,13 @@ Extensions to `BigDecimal`
 
 ### `to_s`
 
-The method `to_s` provides a default specifier of "F". This means that a simple call to `to_s` will result in floating-point representation instead of engineering notation:
+The method `to_s` provides a default specifier of "F". This means that a simple call to `to_s` will result in floating-point representation instead of scientific notation:
 
 ```ruby
 BigDecimal(5.00, 6).to_s       # => "5.0"
 ```
 
-Engineering notation is still supported:
+Scientific notation is still supported:
 
 ```ruby
 BigDecimal(5.00, 6).to_s("e")  # => "0.5E1"


### PR DESCRIPTION
Ref: https://github.com/ruby/bigdecimal/pull/365

I guess the fix should be backported to previous versions of Rails Guides as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
