### PR TITLE
Ensure RequestForgeryProtection#normalize_action_path is private

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -642,7 +642,7 @@ module ActionController # :nodoc:
         end
       end
 
-      def normalize_action_path(action_path) # :doc:
+      def normalize_action_path(action_path)
         uri = URI.parse(action_path)
 
         if uri.relative? && (action_path.blank? || !action_path.start_with?("/"))
@@ -652,7 +652,7 @@ module ActionController # :nodoc:
         end
       end
 
-      def normalize_relative_action_path(rel_action_path) # :doc:
+      def normalize_relative_action_path(rel_action_path)
         uri = URI.parse(request.path)
         # add the action path to the request.path
         uri.path += "/#{rel_action_path}"


### PR DESCRIPTION
`normalize_relative_action_path` added in 033acf8, but was not intended to be public.

It was following the pattern set in bc47815 for `normalize_action_path` which also should not be public.

The only seemingly real usage that I could find of this was removed from gitlab years ago:
https://gitlab.com/gitlab-org/gitlab/-/commit/834b6d69

Based on:
https://github.com/search?q=normalize_action_path+language%3ARuby&type=code&ref=advsearch&p=1

---

Even though it's a documented _private_ method, it can be considered public API (because it's in the docs) -- so that may warrant deprecation.

Leaving that decision up to reviewers. :bow: