### PR TITLE
Fix TimeWithZoneTest to correctly test beginning_of_minute

### DIFF
--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -861,7 +861,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     utc = Time.utc(2000, 1, 1, 0, 30, 10)
     twz = ActiveSupport::TimeWithZone.new(utc, @time_zone)
     assert_equal "1999-12-31 19:30:10.000000000 EST -05:00", twz.inspect
-    assert_equal "1999-12-31 19:00:00.000000000 EST -05:00", twz.beginning_of_hour.inspect
+    assert_equal "1999-12-31 19:30:00.000000000 EST -05:00", twz.beginning_of_minute.inspect
   end
 
   def test_end_of_minute


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

While reviewing the TimeWithZoneTest class, I discovered an issue with the beginning_of_minute test.
Fix test for beginning_of_minute method which was incorrectly testing beginning_of_hour instead.

### Detail

This PR fixes the test to properly verify the `beginning_of_minute` functionality by:

- Replacing `twz.beginning_of_hour.inspect` with `twz.beginning_of_minute.inspect`

- Updating the expected result from "1999-12-31 19:00:00.000000000 EST -05:00" to "1999-12-31 19:30:00.000000000 EST -05:00"

### Additional information

Test execution results
```
bundle exec ruby -I test test/core_ext/time_with_zone_test.rb -n test_beginning_of_minute
Running 179 tests in parallel using 10 processes
Run options: -n test_beginning_of_minute --seed 10173

# Running:

.

Finished in 0.204209s, 4.8969 runs/s, 9.7939 assertions/s.

1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
