### PR TITLE
Fix errors when querystring keys have invalid encoding 

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Always check query string keys for valid encoding just like values are checked.
+
+    *Casper Smits*
+
 *   Always return empty body for HEAD requests in `PublicExceptions` and
     `DebugExceptions`.
 

--- a/actionpack/lib/action_dispatch/http/param_builder.rb
+++ b/actionpack/lib/action_dispatch/http/param_builder.rb
@@ -111,6 +111,10 @@ module ActionDispatch
 
         return if k.empty?
 
+        unless k.valid_encoding?
+          raise InvalidParameterError, "Invalid encoding for parameter: #{k}"
+        end
+
         if depth == 0 && String === v
           # We have to wait until we've found the top part of the name,
           # because that's what the encoding template is configured with

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1121,6 +1121,11 @@ class RequestParameters < BaseRequestTest
     assert_raises(ActionController::BadRequest) { request.parameters }
   end
 
+  test "parameters key containing an invalid UTF8 character" do
+    request = stub_request("QUERY_STRING" => "%81E=bar")
+    assert_raises(ActionController::BadRequest) { request.parameters }
+  end
+
   test "parameters containing a deeply nested invalid UTF8 character" do
     request = stub_request("QUERY_STRING" => "foo[bar]=%81E")
     assert_raises(ActionController::BadRequest) { request.parameters }


### PR DESCRIPTION
### Motivation / Background

We encountered a lot of errors when bots were firing malformed requests at our servers. In query strings, when bad **values** are supplied, these get checked and the request gets killed. However, when bad **keys** are supplied, there will be a 500 error. This pull request fixes #52114 (and replaces #52116)

A coleague of mine already attempted a fix in the other repo, but the tests are still failing (didn't fix the issue) so I took another shot at it. Shout out to Chris for pinpointing where in the code I had to look!

### Detail

This Pull Request add a little encoding check in the parsing of query strings. It is a small change but resolves our 500 errors.

### Additional information

Benchmark

```ruby
require "benchmark/ips"

require "action_dispatch"
require "active_support/all"

require_relative "param_builder"
require_relative "param_builder_original"

QUERY_STRING = "foo=bar"
QUERY_STRING_INVALID = "foo=%81E"

def check_param_encoding
  request_params = ActionDispatch::ParamBuilder.from_query_string(QUERY_STRING, encoding_template: nil)
  request_params.inspect
end

def check_param_encoding_original
  request_params = ActionDispatch::ParamBuilderOriginal.from_query_string(QUERY_STRING, encoding_template: nil)
  request_params.inspect
end


Benchmark.ips do |x|
  x.report("new") { check_param_encoding }
  x.report("original") { check_param_encoding_original }

  x.compare!
end
```

Result
```
$ bundle exec ruby benchmark.rb
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [arm64-darwin24]
Warming up --------------------------------------
                 new    40.767k i/100ms
            original    41.113k i/100ms
Calculating -------------------------------------
                 new    408.540k (± 1.5%) i/s    (2.45 μs/i) -      2.079M in   5.090267s
            original    408.498k (± 3.2%) i/s    (2.45 μs/i) -      2.056M in   5.037672s

Comparison:
                 new:   408540.0 i/s
            original:   408498.2 i/s - same-ish: difference falls within error
```

and because I did not believe it, a second time the same benchmark:
```
$ bundle exec ruby benchmark.rb
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [arm64-darwin24]
Warming up --------------------------------------
                 new    41.459k i/100ms
            original    41.624k i/100ms
Calculating -------------------------------------
                 new    411.373k (± 1.6%) i/s    (2.43 μs/i) -      2.073M in   5.040512s
            original    414.142k (± 1.3%) i/s    (2.41 μs/i) -      2.081M in   5.026239s

Comparison:
            original:   414142.1 i/s
                 new:   411373.2 i/s - same-ish: difference falls within error
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
