### PR TITLE
Add `tsort` as a runtime dependency to `railties`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ PATH
       rackup (>= 1.0.0)
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
       zeitwerk (~> 2.6)
 
 PATH
@@ -681,6 +682,7 @@ GEM
     tomlrb (2.0.3)
     trailblazer-option (0.1.2)
     trilogy (2.9.0)
+    tsort (0.2.0)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency "thor", "~> 1.0", ">= 1.2.2"
   s.add_dependency "zeitwerk", "~> 2.6"
   s.add_dependency "irb", "~> 1.13"
+  s.add_dependency "tsort", ">= 0.2"
 
   s.add_development_dependency "actionview", version
 end


### PR DESCRIPTION
### Motivation / Background

TSort is getting removed: https://bugs.ruby-lang.org/issues/21442

Railties mainly uses tsort to find the order in which initializers are supposed to be run in regard with `before`/`after` hooks.

railties is the only consumer of `tsort`.

### Additional information

Maybe it can be replaced by a custom implementation. For now this gets rid of the warning.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
