### PR TITLE
[7-1-stable] Add `tsort` as a runtime dependency to `railties`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ PATH
       rackup (>= 1.0.0)
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
       zeitwerk (~> 2.6)
 
 PATH
@@ -539,6 +540,7 @@ GEM
     tomlrb (2.0.3)
     trailblazer-option (0.1.2)
     trilogy (2.5.0)
+    tsort (0.2.0)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_dependency "thor", "~> 1.0", ">= 1.2.2"
   s.add_dependency "zeitwerk", "~> 2.6"
   s.add_dependency "irb"
+  s.add_dependency "tsort", ">= 0.2"
 
   s.add_development_dependency "actionview", version
 end


### PR DESCRIPTION
Backports https://github.com/rails/rails/pull/55322 to handle https://bugs.ruby-lang.org/issues/21442