### PR TITLE
Include `author_addresses` fixtures when using `authors` fixtures

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1728,7 +1728,7 @@ end
 class DeprecatedHasManyThroughAssociationsTest < ActiveRecord::TestCase
   include DeprecatedAssociationsTestHelpers
 
-  fixtures :authors
+  fixtures :authors, :author_addresses
 
   setup do
     @model = DATS::Author

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -482,7 +482,7 @@ end
 class DeprecatedHasOneThroughAssociationsTest < ActiveRecord::TestCase
   include DeprecatedAssociationsTestHelpers
 
-  fixtures :authors
+  fixtures :authors, :author_addresses
 
   setup do
     @model = DATS::Author

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2659,7 +2659,7 @@ end
 class DeprecatedAssociationsRelationComplexTest < ActiveRecord::TestCase
   include DeprecatedAssociationsTestHelpers
 
-  fixtures :posts, :authors
+  fixtures :posts, :authors, :author_addresses
 
   setup do
     @model = DATS::Post


### PR DESCRIPTION
This fixes an existing (https://buildkite.com/rails/rails/builds/119881#019804bb-8c58-4be4-83fb-38b3b9bea422) and potentially future flaky tests.

The flaky test case started appearing after merging https://github.com/rails/rails/pull/55285.

To reproduce, run
```
ARCONN=postgresql TESTOPTS="-v" bin/test --seed 20799 test/cases/fixtures_test.rb test/cases/associations/has_one_through_associations_test.rb -n "/^(?:DeprecatedHasOneThroughAssociationsTest#(?:test_the_source_association_is_deprecated)|FixturesWithForeignKeyViolationsTest#(?:test_does_not_raise_if_no_fk_violations|test_raises_fk_violations))$/"
```