### PR TITLE
Fix #55208 envelope_encryption_key_provider when switching between deterministic and non-deterministic

### DIFF
--- a/activerecord/lib/active_record/encryption/envelope_encryption_key_provider.rb
+++ b/activerecord/lib/active_record/encryption/envelope_encryption_key_provider.rb
@@ -38,6 +38,8 @@ module ActiveRecord
         end
 
         def decrypt_data_key(encrypted_message)
+          raise ActiveRecord::Encryption::Errors::Decryption if encrypted_message.headers.encrypted_data_key.nil?
+
           encrypted_data_key = encrypted_message.headers.encrypted_data_key
           key = primary_key_provider.decryption_keys(encrypted_message)&.collect(&:secret)
           ActiveRecord::Encryption.cipher.decrypt encrypted_data_key, key: key if key

--- a/activerecord/test/cases/encryption/envelope_encryption_key_provider_test.rb
+++ b/activerecord/test/cases/encryption/envelope_encryption_key_provider_test.rb
@@ -29,6 +29,16 @@ class ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest < ActiveRecord
     assert_equal key.secret, @key_provider.decryption_keys(encrypted_message).first.secret
   end
 
+  test "decryption_key_for raises ActiveRecord::Encryption::Errors::Decryption when encryption key is nil" do
+    @previous_key_provider = ActiveRecord::Encryption::KeyProvider.new(build_keys(1))
+    key = @previous_key_provider.encryption_key
+    encrypted_encoded_message = ActiveRecord::Encryption.encryptor.encrypt("some message", key_provider: ActiveRecord::Encryption::KeyProvider.new(key))
+    encrypted_message = ActiveRecord::Encryption.message_serializer.load encrypted_encoded_message
+    assert_raises(ActiveRecord::Encryption::Errors::Decryption) do
+      @key_provider.decryption_keys(encrypted_message)
+    end
+  end
+
   test "work with multiple keys when config.store_key_references is false" do
     ActiveRecord::Encryption.config.primary_key = ["key 1", "key 2"]
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes #55208

### Detail

This Pull Request changes the behavior of the `ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider `class when switching between encryption types. Previously, it would raise a `NoMethodError` when the encryption key is nil, after the change, it's going to raise `ActiveRecord::Encryption::Errors::Decryption`, which will cause fallback to the previous encryption type, and as a result, we're going to get a correctly decrypted message.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
