### PR TITLE
A few grammar fixes

### DIFF
--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -14,7 +14,7 @@ module ActionController # :nodoc:
       # aren't reporting a user-agent header, will be allowed access.
       #
       # A browser that's blocked will by default be served the file in
-      # public/406-unsupported-browser.html with a HTTP status code of "406 Not
+      # public/406-unsupported-browser.html with an HTTP status code of "406 Not
       # Acceptable".
       #
       # In addition to specifically named browser versions, you can also pass

--- a/actionview/test/fixtures/test/_js_html_fallback.html.erb
+++ b/actionview/test/fixtures/test/_js_html_fallback.html.erb
@@ -1,1 +1,1 @@
-<b>Hello from a HTML partial!</b>
+<b>Hello from an HTML partial!</b>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -60,7 +60,7 @@ module RenderTestCases
 
   def test_explicit_js_format_adds_html_fallback
     rendered_templates = @controller_view.render(template: "test/js_html_fallback", formats: :js)
-    assert_equal(%Q(document.write("<b>Hello from a HTML partial!<\\/b>")\n), rendered_templates)
+    assert_equal(%Q(document.write("<b>Hello from an HTML partial!<\\/b>")\n), rendered_templates)
   end
 
   def test_render_without_options

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -198,7 +198,7 @@ module ActiveRecord
       end
 
       def sanitize_as_sql_comment(value) # :nodoc:
-        # Sanitize a string to appear within a SQL comment
+        # Sanitize a string to appear within an SQL comment
         # For compatibility, this also surrounding "/*+", "/*", and "*/"
         # charcacters, possibly with single surrounding space.
         # Then follows that by replacing any internal "*/" or "/*" with

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -211,7 +211,7 @@ module ActiveRecord
         end
 
         def escape_sql_comment(content)
-          # Sanitize a string to appear within a SQL comment
+          # Sanitize a string to appear within an SQL comment
           # For compatibility, this also surrounding "/*+", "/*", and "*/"
           # characters, possibly with single surrounding space.
           # Then follows that by replacing any internal "*/" or "/ *" with

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -6,7 +6,7 @@ module Arel # :nodoc: all
     #
     # Active Record uses Arel to compose SQL statements. Instead of building SQL strings directly, it's building an
     # abstract syntax tree (AST) of the statement using various types of Arel::Nodes::Node. Each node represents a
-    # fragment of a SQL statement.
+    # fragment of an SQL statement.
     #
     # The intermediate representation allows Arel to compile the statement into the database's specific SQL dialect
     # only before sending it without having to care about the nuances of each database when building the statement.

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -80,7 +80,7 @@ specified.
 
 This means that all other unknown browsers, as well as agents that aren't reporting a user-agent header, will be allowed access.
 
-A browser that's blocked will by default be served the file in `public/406-unsupported-browser.html` with a HTTP status
+A browser that's blocked will by default be served the file in `public/406-unsupported-browser.html` with an HTTP status
 code of "406 Not Acceptable".
 
 Examples:

--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -132,7 +132,7 @@ class MessagesController < ApplicationController
 end
 ```
 
-A browser that’s blocked will, by default, be served the file in `public/406-unsupported-browser.html` with a HTTP status code of “406 Not Acceptable”.
+A browser that’s blocked will, by default, be served the file in `public/406-unsupported-browser.html` with an HTTP status code of “406 Not Acceptable”.
 
 HTTP Authentication
 -------------------

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -499,7 +499,7 @@ the `LOCATION` environment variable:
 $ bin/rails app:template LOCATION=~/template.rb
 ```
 
-Templates don't have to be stored locally, you can also specify an URL instead
+Templates don't have to be stored locally, you can also specify a URL instead
 of a path:
 
 ```bash


### PR DESCRIPTION
Did a pass revising a few articles:

* "a" should be "an" before "HTML" or "HTTP".
* "an" was decided long time ago to go before "SQL", as documented in the [guidelines](https://guides.rubyonrails.org/api_documentation_guidelines.html#naming).
* "an" should be "a" before "URL".