### PR TITLE
Structured Event Reporting in Rails

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,44 @@
+*   Add Structured Event Reporter, accessible via `Rails.event`.
+
+    The Event Reporter provides a unified interface for producing structured events in Rails
+    applications:
+
+    ```ruby
+    Rails.event.notify("user.signup", user_id: 123, email: "user@example.com")
+    ```
+
+    It supports adding tags to events:
+
+    ```ruby
+    Rails.event.tagged("graphql") do
+      # Event includes tags: { graphql: true }
+      Rails.event.notify("user.signup", user_id: 123, email: "user@example.com")
+    end
+    ```
+
+    As well as context:
+    ```ruby
+    # All events will contain context: {request_id: "abc123", shop_id: 456}
+    Rails.event.set_context(request_id: "abc123", shop_id: 456)
+    ```
+
+    Events are emitted to subscribers. Applications register subscribers to
+    control how events are serialized and emitted. Rails provides several default
+    encoders that can be used to serialize events to common formats:
+
+    ```ruby
+    class MySubscriber
+      def emit(event)
+        encoded_event = ActiveSupport::EventReporter.encoder(:json).encode(event)
+        StructuredLogExporter.export(encoded_event)
+      end
+    end
+
+    Rails.event.subscribe(MySubscriber.new)
+    ```
+
+    *Adrianna Chang*
+
 *   Make `ActiveSupport::Logger` `#freeze`-friendly.
 
     *Joshua Young*

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -48,6 +48,7 @@ module ActiveSupport
   autoload :ExecutionWrapper
   autoload :Executor
   autoload :ErrorReporter
+  autoload :EventReporter
   autoload :FileUpdateChecker
   autoload :EventedFileUpdateChecker
   autoload :ForkTracker
@@ -109,6 +110,9 @@ module ActiveSupport
 
   @error_reporter = ActiveSupport::ErrorReporter.new
   singleton_class.attr_accessor :error_reporter # :nodoc:
+
+  @event_reporter = ActiveSupport::EventReporter.new
+  singleton_class.attr_accessor :event_reporter # :nodoc:
 
   def self.cache_format_version
     Cache.format_version

--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -1,0 +1,540 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "event_reporter/encoders"
+
+module ActiveSupport
+  class TagStack # :nodoc:
+    EMPTY_TAGS = {}.freeze
+    FIBER_KEY = :event_reporter_tags
+
+    class << self
+      def tags
+        Fiber[FIBER_KEY] || EMPTY_TAGS
+      end
+
+      def with_tags(*args, **kwargs)
+        existing_tags = tags
+        tags = existing_tags.dup
+        tags.merge!(resolve_tags(args, kwargs))
+        new_tags = tags.freeze
+
+        begin
+          Fiber[FIBER_KEY] = new_tags
+          yield
+        ensure
+          Fiber[FIBER_KEY] = existing_tags
+        end
+      end
+
+      private
+        def resolve_tags(args, kwargs)
+          tags = args.each_with_object({}) do |arg, tags|
+            case arg
+            when String
+              tags[arg.to_sym] = true
+            when Symbol
+              tags[arg] = true
+            when Hash
+              arg.each { |key, value| tags[key.to_sym] = value }
+            else
+              tags[arg.class.name.to_sym] = arg
+            end
+          end
+          kwargs.each { |key, value| tags[key.to_sym] = value }
+          tags
+        end
+    end
+  end
+
+  class EventContext # :nodoc:
+    EMPTY_CONTEXT = {}.freeze
+    FIBER_KEY = :event_reporter_context
+
+    class << self
+      def context
+        Fiber[FIBER_KEY] || EMPTY_CONTEXT
+      end
+
+      def set_context(context_hash)
+        new_context = self.context.dup
+        context_hash.each { |key, value| new_context[key.to_sym] = value }
+
+        Fiber[FIBER_KEY] = new_context.freeze
+      end
+
+      def clear
+        Fiber[FIBER_KEY] = EMPTY_CONTEXT
+      end
+    end
+  end
+
+  # = Active Support \Event Reporter
+  #
+  # +ActiveSupport::EventReporter+ provides an interface for reporting structured events to subscribers.
+  #
+  # To report an event, you can use the +notify+ method:
+  #
+  #   Rails.event.notify("user_created", { id: 123 })
+  #   # Emits event:
+  #   #  {
+  #   #    name: "user_created",
+  #   #    payload: { id: 123 },
+  #   #    timestamp: 1738964843208679035,
+  #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+  #   #  }
+  #
+  # ==== Filtered Subscriptions
+  #
+  # Subscribers can be configured with an optional filter proc to only receive a subset of events:
+  #
+  #   # Only receive events with names starting with "user."
+  #   Rails.event.subscribe(user_subscriber) { |event| event[:name].start_with?("user.") }
+  #
+  #   # Only receive events with specific payload types
+  #   Rails.event.subscribe(audit_subscriber) { |event| event[:payload].is_a?(AuditEvent) }
+  #
+  # The +notify+ API can receive either an event name and a payload hash, or an event object. Names are coerced to strings.
+  #
+  # ==== Event Objects
+  #
+  # If an event object is passed to the +notify+ API, it will be passed through to subscribers as-is, and the name of the
+  # object's class will be used as the event name.
+  #
+  # class UserCreatedEvent
+  #   def initialize(id:, name:)
+  #     @id = id
+  #     @name = name
+  #   end
+  #
+  #   def to_h
+  #     {
+  #       id: @id,
+  #       name: @name
+  #     }
+  #   end
+  # end
+  #
+  #   Rails.event.notify(UserCreatedEvent.new(id: 123, name: "John Doe"))
+  #   # Emits event:
+  #   #  {
+  #   #    name: "UserCreatedEvent",
+  #   #    payload: #<UserCreatedEvent:0x111>,
+  #   #    timestamp: 1738964843208679035,
+  #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+  #   #  }
+  #
+  # An event is any Ruby object representing a schematized event. While payload hashes allow arbitrary,
+  # implicitly-structured data, event objects are intended to enforce a particular schema.
+  #
+  # ==== Default Encoders
+  #
+  # Rails provides default encoders for common serialization formats. Event objects and tags MUST
+  # implement +to_h+ to be serialized.
+  #
+  #   class JSONLogSubscriber
+  #     def emit(event)
+  #       # event = { name: "UserCreatedEvent", payload: { UserCreatedEvent: #<UserCreatedEvent:0x111> } }
+  #       json_data = ActiveSupport::EventReporter.encoder(:json).encode(event)
+  #       # => {
+  #       #      "name": "UserCreatedEvent",
+  #       #      "payload": {
+  #       #        "id": 123,
+  #       #        "name": "John Doe"
+  #       #      }
+  #       #    }
+  #       Rails.logger.info(json_data)
+  #     end
+  #   end
+  #
+  #   class MessagePackSubscriber
+  #     def emit(event)
+  #       msgpack_data = ActiveSupport::EventReporter.encoder(:msgpack).encode(event)
+  #       BatchExporter.export(msgpack_data)
+  #     end
+  #   end
+  #
+  # ==== Debug Events
+  #
+  # You can use the +debug+ method to report an event that will only be reported if the
+  # event reporter is in debug mode:
+  #
+  #   Rails.event.debug("my_debug_event", { foo: "bar" })
+  #
+  # ==== Tags
+  #
+  # To add additional context to an event, separate from the event payload, you can add
+  # tags via the +tagged+ method:
+  #
+  #   Rails.event.tagged("graphql") do
+  #     Rails.event.notify("user_created", { id: 123 })
+  #   end
+  #
+  #   # Emits event:
+  #   #  {
+  #   #    name: "user_created",
+  #   #    payload: { id: 123 },
+  #   #    tags: { graphql: true },
+  #   #    timestamp: 1738964843208679035,
+  #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+  #   #  }
+  #
+  # ==== Context Store
+  #
+  # You may want to attach metadata to every event emitted by the reporter. While tags
+  # provide domain-specific context for a series of events, context is scoped to the job / request
+  # and should be used for metadata associated with the execution context.
+  # Context can be set via the +set_context+ method:
+  #
+  #   Rails.event.set_context(request_id: "abcd123", user_agent: "TestAgent")
+  #   Rails.event.notify("user_created", { id: 123 })
+  #
+  #   # Emits event:
+  #   #  {
+  #   #    name: "user_created",
+  #   #    payload: { id: 123 },
+  #   #    context: { request_id: "abcd123", user_agent: TestAgent" },
+  #   #    timestamp: 1738964843208679035,
+  #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+  #   #  }
+  #
+  # Context is reset automatically before and after each request.
+  #
+  # A custom context store can be configured via +config.active_support.event_reporter_context_store+.
+  #
+  #     # config/application.rb
+  #     config.active_support.event_reporter_context_store = CustomContextStore
+  #
+  #     class CustomContextStore
+  #       class << self
+  #         def context
+  #           # Return the context.
+  #         end
+  #
+  #         def set_context(context_hash)
+  #           # Append context_hash to the existing context store.
+  #         end
+  #
+  #         def clear
+  #           # Delete the stored context.
+  #         end
+  #       end
+  #     end
+  #
+  # The Event Reporter standardizes on symbol keys for all payload data, tags, and context store entries.
+  # String keys are automatically converted to symbols for consistency.
+  #
+  #   Rails.event.notify("user.created", { "id" => 123 })
+  #   # Emits event:
+  #   #  {
+  #   #    name: "user.created",
+  #   #    payload: { id: 123 },
+  #   #  }
+  class EventReporter
+    attr_reader :subscribers
+    attr_accessor :raise_on_error
+
+    ENCODERS = {
+      json: Encoders::JSON,
+      msgpack: Encoders::MessagePack
+    }.freeze
+
+    class << self
+      attr_accessor :context_store # :nodoc:
+
+      # Lookup an encoder by name or symbol.
+      #
+      #   ActiveSupport::EventReporter.encoder(:json)
+      #   # => ActiveSupport::EventReporter::Encoders::JSON
+      #
+      #   ActiveSupport::EventReporter.encoder("msgpack")
+      #   # => ActiveSupport::EventReporter::Encoders::MessagePack
+      #
+      # ==== Arguments
+      #
+      # * +format+ - The encoder format as a symbol or string
+      #
+      # ==== Raises
+      #
+      # * +KeyError+ - If the encoder format is not found
+      def encoder(format)
+        ENCODERS.fetch(format.to_sym) do
+          raise KeyError, "Unknown encoder format: #{format.inspect}. Available formats: #{ENCODERS.keys.join(', ')}"
+        end
+      end
+    end
+
+    self.context_store = EventContext
+
+    def initialize(*subscribers, raise_on_error: false, tags: nil)
+      @subscribers = []
+      subscribers.each { |subscriber| subscribe(subscriber) }
+      @raise_on_error = raise_on_error
+    end
+
+    # Registers a new event subscriber. The subscriber must respond to
+    #
+    #   emit(event: Hash)
+    #
+    # The event hash will have the following keys:
+    #
+    #   name: String (The name of the event)
+    #   payload: Hash, Object (The payload of the event, or the event object itself)
+    #   tags: Hash (The tags of the event)
+    #   timestamp: Float (The timestamp of the event, in nanoseconds)
+    #   source_location: Hash (The source location of the event, containing the filepath, lineno, and label)
+    #
+    # An optional filter proc can be provided to only receive a subset of events:
+    #
+    #   Rails.event.subscribe(subscriber) { |event| event[:name].start_with?("user.") }
+    #   Rails.event.subscribe(subscriber) { |event| event[:payload].is_a?(UserEvent) }
+    #
+    def subscribe(subscriber, &filter)
+      unless subscriber.respond_to?(:emit)
+        raise ArgumentError, "Event subscriber #{subscriber.class.name} must respond to #emit"
+      end
+
+      @subscribers << { subscriber: subscriber, filter: filter }
+    end
+
+    # Reports an event to all registered subscribers. An event name and payload can be provided:
+    #
+    #     Rails.event.notify("user.created", { id: 123 })
+    #     # Emits event:
+    #     #  {
+    #     #    name: "user.created",
+    #     #    payload: { id: 123 },
+    #     #    tags: {},
+    #     #    timestamp: 1738964843208679035,
+    #     #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+    #     #  }
+    #
+    # Alternatively, an event object can be provided:
+    #
+    #   Rails.event.notify(UserCreatedEvent.new(id: 123))
+    #   # Emits event:
+    #   #  {
+    #   #    name: "UserCreatedEvent",
+    #   #    payload: #<UserCreatedEvent:0x111>,
+    #   #    tags: {},
+    #   #    timestamp: 1738964843208679035,
+    #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+    #   #  }
+    #
+    # ==== Arguments
+    #
+    # * +:payload+ - The event payload when using string/symbol event names.
+    #
+    # * +:caller_depth+ - The stack depth to use for source location (default: 1).
+    #
+    # * +:kwargs+ - Additional payload data when using string/symbol event names.
+    def notify(name_or_object, payload = nil, caller_depth: 1, **kwargs)
+      name = resolve_name(name_or_object)
+      payload = resolve_payload(name_or_object, payload, **kwargs)
+
+      event = {
+        name: name,
+        payload: payload,
+        tags: TagStack.tags,
+        context: context_store.context,
+        timestamp: Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond),
+      }
+
+      caller_location = caller_locations(caller_depth, 1)&.first
+
+      if caller_location
+        source_location = {
+          filepath: caller_location.path,
+          lineno: caller_location.lineno,
+          label: caller_location.label,
+        }
+        event[:source_location] = source_location
+      end
+
+      subscribers.each do |subscriber_entry|
+        subscriber = subscriber_entry[:subscriber]
+        filter = subscriber_entry[:filter]
+
+        next if filter && !filter.call(event)
+
+        subscriber.emit(event)
+      rescue => subscriber_error
+        if raise_on_error
+          raise
+        else
+          warn(<<~MESSAGE)
+            Event reporter subscriber #{subscriber.class.name} raised an error on #emit: #{subscriber_error.message}
+            #{subscriber_error.backtrace&.join("\n")}
+          MESSAGE
+        end
+      end
+    end
+
+    # Temporarily enables debug mode for the duration of the block.
+    # Calls to +debug+ will only be reported if debug mode is enabled.
+    #
+    #   Rails.event.with_debug do
+    #     Rails.event.debug("sql.query", { sql: "SELECT * FROM users" })
+    #   end
+    def with_debug
+      prior = Fiber[:event_reporter_debug_mode]
+      Fiber[:event_reporter_debug_mode] = true
+      yield
+    ensure
+      Fiber[:event_reporter_debug_mode] = prior
+    end
+
+    # Check if debug mode is currently enabled.
+    def debug_mode?
+      Fiber[:event_reporter_debug_mode]
+    end
+
+    # Report an event only when in debug mode. For example:
+    #
+    #   Rails.event.debug("sql.query", { sql: "SELECT * FROM users" })
+    #
+    # ==== Arguments
+    #
+    # * +:payload+ - The event payload when using string/symbol event names.
+    #
+    # * +:caller_depth+ - The stack depth to use for source location (default: 1).
+    #
+    # * +:kwargs+ - Additional payload data when using string/symbol event names.
+    def debug(name_or_object, payload = nil, caller_depth: 1, **kwargs)
+      if debug_mode?
+        if block_given?
+          notify(name_or_object, payload, caller_depth: caller_depth + 1, **kwargs.merge(yield))
+        else
+          notify(name_or_object, payload, caller_depth: caller_depth + 1, **kwargs)
+        end
+      end
+    end
+
+    # Add tags to events to supply additional context. Tags operate in a stack-oriented manner,
+    # so all events emitted within the block inherit the same set of tags. For example:
+    #
+    #   Rails.event.tagged("graphql") do
+    #     Rails.event.notify("user.created", { id: 123 })
+    #   end
+    #
+    #   # Emits event:
+    #   # {
+    #   #    name: "user.created",
+    #   #    payload: { id: 123 },
+    #   #    tags: { graphql: true },
+    #   #    timestamp: 1738964843208679035,
+    #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+    #   #  }
+    #
+    # Tags can be provided as arguments or as keyword arguments, and can be nested:
+    #
+    #   Rails.event.tagged("graphql") do
+    #   # Other code here...
+    #     Rails.event.tagged(section: "admin") do
+    #       Rails.event.notify("user.created", { id: 123 })
+    #     end
+    #   end
+    #
+    #   # Emits event:
+    #   #  {
+    #   #    name: "user.created",
+    #   #    payload: { id: 123 },
+    #   #    tags: { section: "admin", graphql: true },
+    #   #    timestamp: 1738964843208679035,
+    #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+    #   #  }
+    #
+    # The +tagged+ API can also receive a tag object:
+    #
+    #   graphql_tag = GraphqlTag.new(operation_name: "user_created", operation_type: "mutation")
+    #   Rails.event.tagged(graphql_tag) do
+    #     Rails.event.notify("user.created", { id: 123 })
+    #   end
+    #
+    #   # Emits event:
+    #   #  {
+    #   #    name: "user.created",
+    #   #    payload: { id: 123 },
+    #   #    tags: { "GraphqlTag": #<GraphqlTag:0x111> },
+    #   #    timestamp: 1738964843208679035,
+    #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
+    #   #  }
+    def tagged(*args, **kwargs, &block)
+      TagStack.with_tags(*args, **kwargs, &block)
+    end
+
+    # Sets context data that will be included with all events emitted by the reporter.
+    # Context data should be scoped to the job or request, and is reset automatically
+    # before and after each request and job.
+    #
+    #   Rails.event.set_context(user_agent: "TestAgent")
+    #   Rails.event.set_context(job_id: "abc123")
+    #   Rails.event.tagged("graphql") do
+    #     Rails.event.notify("user_created", { id: 123 })
+    #   end
+    #
+    #   # Emits event:
+    #   #  {
+    #   #    name: "user_created",
+    #   #    payload: { id: 123 },
+    #   #    tags: { graphql: true },
+    #   #    context: { user_agent: "TestAgent", job_id: "abc123" },
+    #   #    timestamp: 1738964843208679035
+    #   #  }
+    def set_context(context)
+      context_store.set_context(context)
+    end
+
+    # Clears all context data.
+    def clear_context
+      context_store.clear
+    end
+
+    # Returns the current context data.
+    def context
+      context_store.context
+    end
+
+    private
+      def context_store
+        self.class.context_store
+      end
+
+      def resolve_name(name_or_object)
+        case name_or_object
+        when String, Symbol
+          name_or_object.to_s
+        else
+          name_or_object.class.name
+        end
+      end
+
+      def resolve_payload(name_or_object, payload, **kwargs)
+        case name_or_object
+        when String, Symbol
+          handle_unexpected_args(name_or_object, payload, kwargs) if payload && kwargs.any?
+          if kwargs.any?
+            kwargs.transform_keys(&:to_sym)
+          elsif payload
+            payload.transform_keys(&:to_sym)
+          end
+        else
+          handle_unexpected_args(name_or_object, payload, kwargs) if payload || kwargs.any?
+          name_or_object
+        end
+      end
+
+      def handle_unexpected_args(name_or_object, payload, kwargs)
+        message = <<~MESSAGE
+          Rails.event.notify accepts either an event object, a payload hash, or keyword arguments.
+          Received: #{name_or_object.inspect}, #{payload.inspect}, #{kwargs.inspect}
+        MESSAGE
+
+        if raise_on_error
+          raise ArgumentError, message
+        else
+          warn(message)
+        end
+      end
+  end
+end

--- a/activesupport/lib/active_support/event_reporter/encoders.rb
+++ b/activesupport/lib/active_support/event_reporter/encoders.rb
@@ -1,0 +1,90 @@
+# typed: true
+# frozen_string_literal: true
+
+module ActiveSupport
+  class EventReporter
+    # = Event Encoders
+    #
+    # Default encoders for serializing structured events. These encoders can be used
+    # by subscribers to convert event data into various formats.
+    #
+    # Example usage in a subscriber:
+    #
+    #   class LogSubscriber
+    #     def emit(event)
+    #       encoded_data = ActiveSupport::EventReporter::Encoders::JSON.encode(event)
+    #       Rails.logger.info(encoded_data)
+    #     end
+    #   end
+    #
+    #   Rails.event.subscribe(LogSubscriber)
+    module Encoders
+      # Base encoder class that other encoders can inherit from.
+      class Base
+        # Encodes an event hash into a serialized format.
+        #
+        # @param event [Hash] The event hash containing name, payload, tags, context, timestamp, and source_location
+        # @return [String] The encoded event data
+        def self.encode(event)
+          raise NotImplementedError, "Subclasses must implement #encode"
+        end
+      end
+
+      # JSON encoder for serializing events to JSON format.
+      #
+      #   event = { name: "user_created", payload: { id: 123 }, tags: { api: true } }
+      #   ActiveSupport::EventReporter::Encoders::JSON.encode(event)
+      #   # => {
+      #   #      "name": "user_created",
+      #   #      "payload": {
+      #   #        "id": 123
+      #   #      },
+      #   #      "tags": {
+      #   #        "api": true
+      #   #      },
+      #   #      "context": {}
+      #   #    }
+      #
+      # Schematized events and tags MUST respond to #to_h to be serialized.
+      #
+      #   event = { name: "UserCreatedEvent", payload: #<UserCreatedEvent:0x111>, tags: { "GraphqlTag": #<GraphqlTag:0x111> } }
+      #   ActiveSupport::EventReporter::Encoders::JSON.encode(event)
+      #   # => {
+      #   #      "name": "UserCreatedEvent",
+      #   #      "payload": {
+      #   #        "id": 123
+      #   #      },
+      #   #      "tags": {
+      #   #        "GraphqlTag": {
+      #   #          "operation_name": "user_created",
+      #   #          "operation_type": "mutation"
+      #   #        }
+      #   #      },
+      #   #      "context": {}
+      #   #    }
+      class JSON < Base
+        def self.encode(event)
+          event[:payload] = event[:payload].to_h
+          event[:tags] = event[:tags].transform_values do |value|
+            value.respond_to?(:to_h) ? value.to_h : value
+          end
+          ::JSON.dump(event)
+        end
+      end
+
+      # EventReporter encoder for serializing events to MessagePack format.
+      class MessagePack < Base
+        def self.encode(event)
+          require "msgpack"
+          event[:payload] = event[:payload].to_h
+          event[:tags] = event[:tags].transform_values do |value|
+            value.respond_to?(:to_h) ? value.to_h : value
+          end
+          ::MessagePack.pack(event)
+        rescue LoadError
+          raise LoadError, "msgpack gem is required for MessagePack encoding. Add 'gem \"msgpack\"' to your Gemfile."
+        end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/event_reporter/test_helper.rb
+++ b/activesupport/lib/active_support/event_reporter/test_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ActiveSupport::EventReporter::TestHelper # :nodoc:
+  class EventSubscriber # :nodoc:
+    attr_reader :events
+
+    def initialize
+      @events = []
+    end
+
+    def emit(event)
+      @events << event
+    end
+  end
+
+  def event_matcher(name:, payload: nil, tags: {}, context: {}, source_location: nil)
+    ->(event) {
+      return false unless event[:name] == name
+      return false unless event[:payload] == payload
+      return false unless event[:tags] == tags
+      return false unless event[:context] == context
+
+      [:filepath, :lineno, :label].each do |key|
+        if source_location && source_location[key]
+          return false unless event[:source_location][key] == source_location[key]
+        end
+      end
+
+      true
+    }
+  end
+end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -38,10 +38,19 @@ module ActiveSupport
       end
     end
 
+    initializer "active_support.set_event_reporter_context_store" do |app|
+      config.after_initialize do
+        if klass = app.config.active_support.event_reporter_context_store
+          ActiveSupport.event_reporter.context_store = klass
+        end
+      end
+    end
+
     initializer "active_support.reset_execution_context" do |app|
       app.reloader.before_class_unload do
         ActiveSupport::CurrentAttributes.clear_all
         ActiveSupport::ExecutionContext.clear
+        ActiveSupport.event_reporter.clear_context
       end
 
       app.executor.to_run do
@@ -51,6 +60,7 @@ module ActiveSupport
       app.executor.to_complete do
         ActiveSupport::CurrentAttributes.clear_all
         ActiveSupport::ExecutionContext.pop
+        ActiveSupport.event_reporter.clear_context
       end
 
       ActiveSupport.on_load(:active_support_test_case) do

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -6,6 +6,7 @@ require "active_support/testing/setup_and_teardown"
 require "active_support/testing/tests_without_assertions"
 require "active_support/testing/assertions"
 require "active_support/testing/error_reporter_assertions"
+require "active_support/testing/event_reporter_assertions"
 require "active_support/testing/deprecation"
 require "active_support/testing/declarative"
 require "active_support/testing/isolation"
@@ -178,6 +179,7 @@ module ActiveSupport
     prepend ActiveSupport::Testing::TestsWithoutAssertions
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::ErrorReporterAssertions
+    include ActiveSupport::Testing::EventReporterAssertions
     include ActiveSupport::Testing::NotificationAssertions
     include ActiveSupport::Testing::Deprecation
     include ActiveSupport::Testing::ConstantStubbing

--- a/activesupport/lib/active_support/testing/event_reporter_assertions.rb
+++ b/activesupport/lib/active_support/testing/event_reporter_assertions.rb
@@ -1,0 +1,163 @@
+# typed: true
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Testing
+    # Provides test helpers for asserting on ActiveSupport::EventReporter events.
+    module EventReporterAssertions
+      module EventCollector # :nodoc:
+        @subscribed = false
+        @mutex = Mutex.new
+
+        class Event # :nodoc:
+          attr_reader :event_data
+
+          def initialize(event_data)
+            @event_data = event_data
+          end
+
+          def inspect
+            "#{event_data[:name]} (payload: #{event_data[:payload].inspect}, tags: #{event_data[:tags].inspect})"
+          end
+
+          def matches?(name, payload, tags)
+            return false unless name.to_s == event_data[:name]
+
+            if payload && payload.is_a?(Hash)
+              return false unless matches_hash?(payload, :payload)
+            end
+
+            return false unless matches_hash?(tags, :tags)
+            true
+          end
+
+          private
+            def matches_hash?(expected_hash, event_key)
+              expected_hash.all? do |k, v|
+                if v.is_a?(Regexp)
+                  event_data.dig(event_key, k).to_s.match?(v)
+                else
+                  event_data.dig(event_key, k) == v
+                end
+              end
+            end
+        end
+
+        class << self
+          def emit(event)
+            event_recorders&.each do |events|
+              events << Event.new(event)
+            end
+            true
+          end
+
+          def record
+            subscribe
+            events = []
+            event_recorders << events
+            begin
+              yield
+              events
+            ensure
+              event_recorders.delete_if { |r| events.equal?(r) }
+            end
+          end
+
+          private
+            def subscribe
+              return if @subscribed
+
+              @mutex.synchronize do
+                unless @subscribed
+                  if ActiveSupport.event_reporter
+                    ActiveSupport.event_reporter.subscribe(self)
+                    @subscribed = true
+                  else
+                    raise Minitest::Assertion, "No event reporter is configured"
+                  end
+                end
+              end
+            end
+
+            def event_recorders
+              ActiveSupport::IsolatedExecutionState[:active_support_event_reporter_assertions] ||= []
+            end
+        end
+      end
+
+      # Asserts that the block does not cause an event to be reported to +Rails.event+.
+      #
+      # If no name is provided, passes if evaluated code in the yielded block reports no events.
+      #
+      #   assert_no_event_reported do
+      #     service_that_does_not_report_events.perform
+      #   end
+      #
+      # If a name is provided, passes if evaluated code in the yielded block reports no events
+      # with that name.
+      #
+      #   assert_no_event_reported("user.created") do
+      #     service_that_does_not_report_events.perform
+      #   end
+      def assert_no_event_reported(name = nil, payload: {}, tags: {}, &block)
+        events = EventCollector.record(&block)
+
+        if name.nil?
+          assert_predicate(events, :empty?)
+        else
+          matching_event = events.find { |event| event.matches?(name, payload, tags) }
+          if matching_event
+            message = "Expected no '#{name}' event to be reported, but found:\n  " \
+              "#{matching_event.inspect}"
+            flunk(message)
+          end
+          assert(true)
+        end
+      end
+
+      # Asserts that the block causes an event with the given name to be reported
+      # to +Rails.event+.
+      #
+      # Passes if the evaluated code in the yielded block reports a matching event.
+      #
+      #   assert_event_reported("user.created") do
+      #     Rails.event.notify("user.created", { id: 123 })
+      #   end
+      #
+      # To test further details about the reported event, you can specify payload and tag matchers.
+      #
+      #   assert_event_reported("user.created",
+      #     payload: { id: 123, name: "John Doe" },
+      #     tags: { request_id: /[0-9]+/ }
+      #   ) do
+      #     Rails.event.tagged(request_id: "123") do
+      #       Rails.event.notify("user.created", { id: 123, name: "John Doe" })
+      #     end
+      #   end
+      #
+      # The matchers support partial matching - only the specified keys need to match.
+      #
+      #   assert_event_reported("user.created", payload: { id: 123 }) do
+      #     Rails.event.notify("user.created", { id: 123, name: "John Doe" })
+      #   end
+      def assert_event_reported(name, payload: nil, tags: {}, &block)
+        events = EventCollector.record(&block)
+
+        if events.empty?
+          flunk("Expected an event to be reported, but there were no events reported.")
+        elsif (event = events.find { |event| event.matches?(name, payload, tags) })
+          assert(true)
+          event.event_data
+        else
+          message = "Expected an event to be reported matching:\n  " \
+            "name: #{name}\n  " \
+            "payload: #{payload.inspect}\n  " \
+            "tags: #{tags.inspect}\n" \
+            "but none of the #{events.size} reported events matched:\n  " \
+            "#{events.map(&:inspect).join("\n  ")}"
+          flunk(message)
+        end
+      end
+    end
+  end
+end

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -1,0 +1,652 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/event_reporter/test_helper"
+require "json"
+
+module ActiveSupport
+  class EventReporterTest < ActiveSupport::TestCase
+    include EventReporter::TestHelper
+
+    setup do
+      @subscriber = EventReporter::TestHelper::EventSubscriber.new
+      @reporter = EventReporter.new(@subscriber, raise_on_error: true)
+    end
+
+    class TestEvent
+      def initialize(data)
+        @data = data
+      end
+    end
+
+    class HttpRequestTag
+      def initialize(http_method, http_status)
+        @http_method = http_method
+        @http_status = http_status
+      end
+    end
+
+    class LoggingAbstraction
+      def initialize(reporter)
+        @reporter = reporter
+      end
+
+      def a_log_method(message)
+        @reporter.notify(:custom_event, caller_depth: 2, message: message)
+      end
+
+      def a_debug_method(message)
+        @reporter.debug(:custom_event, caller_depth: 2, message: message)
+      end
+    end
+
+    class ErrorSubscriber
+      def emit(event)
+        raise StandardError.new("Uh oh!")
+      end
+    end
+
+    test "#subscribe" do
+      reporter = ActiveSupport::EventReporter.new
+      reporter.subscribe(@subscriber)
+      assert_equal([{ subscriber: @subscriber, filter: nil }], reporter.subscribers)
+    end
+
+    test "#subscribe with filter" do
+      reporter = ActiveSupport::EventReporter.new
+
+      filter = ->(event) { event[:name].start_with?("user.") }
+      reporter.subscribe(@subscriber, &filter)
+
+      assert_equal([{ subscriber: @subscriber, filter: filter }], reporter.subscribers)
+    end
+
+    test "#subscribe raises ArgumentError when sink doesn't respond to emit" do
+      invalid_subscriber = Object.new
+
+      error = assert_raises(ArgumentError) do
+        @reporter.subscribe(invalid_subscriber)
+      end
+
+      assert_equal "Event subscriber Object must respond to #emit", error.message
+    end
+
+    test "#notify with name" do
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event")
+      ]) do
+        @reporter.notify(:test_event)
+      end
+    end
+
+    test "#notify filters" do
+      reporter = ActiveSupport::EventReporter.new
+      reporter.subscribe(@subscriber) { |event| event[:name].start_with?("user_") }
+
+      assert_not_called(@subscriber, :emit) do
+        reporter.notify(:test_event)
+      end
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "user_event")
+      ]) do
+        reporter.notify(:user_event)
+      end
+    end
+
+    test "#notify with name and hash payload" do
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" })
+      ]) do
+        @reporter.notify(:test_event, { key: "value" })
+      end
+    end
+
+    test "#notify with name and kwargs" do
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" })
+      ]) do
+        @reporter.notify(:test_event, key: "value")
+      end
+    end
+
+    test "#notify symbolizes keys in hash payload" do
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" })
+      ]) do
+        @reporter.notify(:test_event, { "key" => "value" })
+      end
+    end
+
+    test "#notify with hash payload and kwargs raises" do
+      error = assert_raises(ArgumentError) do
+        @reporter.notify(:test_event, { key: "value" }, extra: "arg")
+      end
+
+      assert_match(
+        /Rails.event.notify accepts either an event object, a payload hash, or keyword arguments/,
+        error.message
+      )
+    end
+
+    test "#notify includes source location in event payload" do
+      filepath = __FILE__
+      lineno = __LINE__ + 4
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", source_location: { filepath:, lineno: })
+      ]) do
+        @reporter.notify("test_event")
+      end
+    end
+
+    test "#notify with caller depth option" do
+      logging_abstraction = LoggingAbstraction.new(@reporter)
+      filepath = __FILE__
+      lineno = __LINE__ + 4
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "custom_event", payload: { message: "hello" }, source_location: { filepath:, lineno: })
+      ]) do
+        logging_abstraction.a_log_method("hello")
+      end
+    end
+
+    test "#notify with event object" do
+      event = TestEvent.new("value")
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: TestEvent.name, payload: event)
+      ]) do
+        @reporter.notify(event)
+      end
+    end
+
+    test "#notify with event object and kwargs raises when raise_on_error is true" do
+      event = TestEvent.new("value")
+      error = assert_raises(ArgumentError) do
+        @reporter.notify(event, extra: "arg")
+      end
+
+      assert_match(
+        /Rails.event.notify accepts either an event object, a payload hash, or keyword arguments/,
+        error.message
+      )
+    end
+
+    test "#notify with event object and hash payload raises when raise_on_error is true" do
+      event = TestEvent.new("value")
+      error = assert_raises(ArgumentError) do
+        @reporter.notify(event, { extra: "arg" })
+      rescue RailsStrictWarnings::WarningError => _e
+        # Expected warning
+      end
+
+      assert_match(
+        /Rails.event.notify accepts either an event object, a payload hash, or keyword arguments/,
+        error.message
+      )
+    end
+
+    test "#notify with event object and kwargs warns when raise_on_error is false" do
+      previous_raise_on_error = @reporter.raise_on_error
+      @reporter.raise_on_error = false
+
+      event = TestEvent.new("value")
+
+      _out, err = capture_io do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: TestEvent.name, payload: event)
+        ]) do
+          @reporter.notify(event, extra: "arg")
+        rescue RailsStrictWarnings::WarningError => _e
+          # Expected warning
+        end
+      end
+
+      assert_match(/Rails.event.notify accepts either an event object, a payload hash, or keyword arguments/, err)
+    ensure
+      @reporter.raise_on_error = previous_raise_on_error
+    end
+
+    test "#notify warns about subscriber errors when raise_on_error is false" do
+      previous_raise_on_error = @reporter.raise_on_error
+      @reporter.raise_on_error = false
+
+      @reporter.subscribe(ErrorSubscriber.new)
+
+      _out, err = capture_io do
+        @reporter.notify(:test_event)
+      rescue RailsStrictWarnings::WarningError => _e
+        # Expected warning
+      end
+
+      assert_match(/Event reporter subscriber #{ErrorSubscriber.name} raised an error on #emit: Uh oh!/, err)
+    ensure
+      @reporter.raise_on_error = previous_raise_on_error
+    end
+
+    test "#notify raises subscriber errors when raise_on_error is true" do
+      @reporter.subscribe(ErrorSubscriber.new)
+
+      error = assert_raises(StandardError) do
+        @reporter.notify(:test_event)
+      end
+
+      assert_equal("Uh oh!", error.message)
+    end
+
+    test "#with_debug" do
+      @reporter.with_debug do
+        assert_predicate @reporter, :debug_mode?
+      end
+      assert_not_predicate @reporter, :debug_mode?
+    end
+
+    test "#with_debug works with nested calls" do
+      @reporter.with_debug do
+        assert_predicate @reporter, :debug_mode?
+
+        @reporter.with_debug do
+          assert_predicate @reporter, :debug_mode?
+        end
+
+        assert_predicate @reporter, :debug_mode?
+      end
+    end
+
+    test "#debug emits when in debug mode" do
+      @reporter.with_debug do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { key: "value" })
+        ]) do
+          @reporter.debug(:test_event, key: "value")
+        end
+      end
+    end
+
+    test "#debug with caller depth" do
+      logging_abstraction = LoggingAbstraction.new(@reporter)
+      filepath = __FILE__
+      lineno = __LINE__ + 4
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "custom_event", payload: { message: "hello" }, source_location: { filepath:, lineno: })
+      ]) do
+        @reporter.with_debug { logging_abstraction.a_debug_method("hello") }
+      end
+    end
+
+    test "#debug emits in debug mode with block" do
+      @reporter.with_debug do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { slow_to_compute: "value" })
+        ]) do
+          @reporter.debug(:test_event) do
+            { slow_to_compute: "value" }
+          end
+        end
+      end
+    end
+
+    test "#debug does not emit when not in debug mode" do
+      assert_not_called(@subscriber, :emit) do
+        @reporter.debug(:test_event, key: "value")
+      end
+    end
+
+    test "#debug with block merges kwargs" do
+      @reporter.with_debug do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { key: "value", slow_to_compute: "another_value" })
+        ]) do
+          @reporter.debug(:test_event, key: "value") do
+            { slow_to_compute: "another_value" }
+          end
+        end
+      end
+    end
+
+    test "#tagged adds tags to the emitted event" do
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" }, tags: { section: "admin" })
+      ]) do
+        @reporter.tagged(section: "admin") do
+          @reporter.notify(:test_event, key: "value")
+        end
+      end
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" }, tags: { section: "checkouts" })
+      ]) do
+        @reporter.tagged({ section: "checkouts" }) do
+          @reporter.notify(:test_event, key: "value")
+        end
+      end
+    end
+
+    test "#tagged with nested tags" do
+      @reporter.tagged(section: "admin") do
+        @reporter.tagged(nested: "tag") do
+          assert_called_with(@subscriber, :emit, [
+            event_matcher(name: "test_event", payload: { key: "value" }, tags: { section: "admin", nested: "tag" })
+          ]) do
+            @reporter.notify(:test_event, key: "value")
+          end
+        end
+        @reporter.tagged(hello: "world") do
+          assert_called_with(@subscriber, :emit, [
+            event_matcher(name: "test_event", payload: { key: "value" }, tags: { section: "admin", hello: "world" })
+          ]) do
+            @reporter.notify(:test_event, key: "value")
+          end
+        end
+      end
+    end
+
+    test "#tagged with boolean tags" do
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" }, tags: { is_for_testing: true })
+      ]) do
+        @reporter.tagged(:is_for_testing) do
+          @reporter.notify(:test_event, key: "value")
+        end
+      end
+    end
+
+    test "#tagged can overwrite values on collision" do
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" }, tags: { section: "checkouts" })
+      ]) do
+        @reporter.tagged(section: "admin") do
+          @reporter.tagged(section: "checkouts") do
+            @reporter.notify(:test_event, key: "value")
+          end
+        end
+      end
+    end
+
+    test "#tagged with tag object" do
+      http_tag = HttpRequestTag.new("GET", 200)
+
+      @reporter.tagged(http_tag) do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { key: "value" }, tags: { "#{HttpRequestTag.name}": http_tag })
+        ]) do
+          @reporter.notify(:test_event, key: "value")
+        end
+      end
+    end
+
+    test "#tagged with mixed tags" do
+      http_tag = HttpRequestTag.new("GET", 200)
+      @reporter.tagged("foobar", http_tag, shop_id: 123) do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { key: "value" }, tags: { foobar: true, "#{HttpRequestTag.name}": http_tag, shop_id: 123 })
+        ]) do
+          @reporter.notify(:test_event, key: "value")
+        end
+      end
+    end
+
+    test "#tagged copies tag stack from parent fiber without mutating parent's tag stack" do
+      @reporter.tagged(shop_id: 999) do
+        Fiber.new do
+          @reporter.tagged(shop_id: 123) do
+            assert_called_with(@subscriber, :emit, [
+              event_matcher(name: "test_event", payload: { key: "value" }, tags: { shop_id: 123 })
+            ]) do
+              @reporter.notify(:test_event, key: "value")
+            end
+          end
+        end.resume
+
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "parent_event", payload: { key: "parent" }, tags: { shop_id: 999 })
+        ]) do
+          @reporter.notify(:parent_event, key: "parent")
+        end
+      end
+    end
+
+    test "#tagged maintains isolation between concurrent fibers" do
+      @reporter.tagged(shop_id: 123) do
+        fiber = Fiber.new do
+          assert_called_with(@subscriber, :emit, [
+            event_matcher(name: "child_event", payload: { key: "value" }, tags: { shop_id: 123 })
+          ]) do
+            @reporter.notify(:child_event, key: "value")
+          end
+        end
+
+        @reporter.tagged(api_client_id: 456) do
+          fiber.resume
+
+          # Verify parent fiber has both tags
+          assert_called_with(@subscriber, :emit, [
+            event_matcher(name: "parent_event", payload: { key: "parent" }, tags: { shop_id: 123, api_client_id: 456 })
+          ]) do
+            @reporter.notify(:parent_event, key: "parent")
+          end
+        end
+      end
+    end
+  end
+
+  class ContextStoreTest < ActiveSupport::TestCase
+    include EventReporter::TestHelper
+
+    setup do
+      @subscriber = EventReporter::TestHelper::EventSubscriber.new
+      @reporter = EventReporter.new(@subscriber, raise_on_error: true)
+    end
+
+    teardown do
+      EventContext.clear
+    end
+
+    test "#context returns empty hash by default" do
+      assert_equal({}, @reporter.context)
+    end
+
+    test "#set_context sets context data" do
+      @reporter.set_context(shop_id: 123)
+      assert_equal({ shop_id: 123 }, @reporter.context)
+    end
+
+    test "#set_context merges with existing context" do
+      @reporter.set_context(shop_id: 123)
+      @reporter.set_context(user_id: 456)
+      assert_equal({ shop_id: 123, user_id: 456 }, @reporter.context)
+    end
+
+    test "#set_context overwrites existing keys" do
+      @reporter.set_context(shop_id: 123)
+      @reporter.set_context(shop_id: 456)
+      assert_equal({ shop_id: 456 }, @reporter.context)
+    end
+
+    test "#set_context with string keys converts them to symbols" do
+      @reporter.set_context("shop_id" => 123)
+      assert_equal({ shop_id: 123 }, @reporter.context)
+    end
+
+    test "#clear_context removes all context data" do
+      @reporter.set_context(shop_id: 123, user_id: 456)
+      @reporter.clear_context
+      assert_equal({}, @reporter.context)
+    end
+
+    test "#notify includes context in event" do
+      @reporter.set_context(shop_id: 123)
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value" }, tags: {}, context: { shop_id: 123 })
+      ]) do
+        @reporter.notify(:test_event, key: "value")
+      end
+    end
+
+    test "#context inherited by child fibers without mutating parent's context" do
+      @reporter.set_context(shop_id: 999)
+      Fiber.new do
+        @reporter.set_context(shop_id: 123)
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", context: { shop_id: 123 })
+        ]) do
+          @reporter.notify(:test_event)
+        end
+      end.resume
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "parent_event", payload: { key: "parent" }, context: { shop_id: 999 })
+      ]) do
+        @reporter.notify(:parent_event, key: "parent")
+      end
+    end
+
+    test "#context isolated between concurrent fibers" do
+      @reporter.set_context(shop_id: 123)
+      fiber = Fiber.new do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "child_event", context: { shop_id: 123 })
+        ]) do
+          @reporter.notify(:child_event)
+        end
+      end
+
+      @reporter.set_context(api_client_id: 456)
+      fiber.resume
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "parent_event", context: { shop_id: 123, api_client_id: 456 })
+      ]) do
+        @reporter.notify(:parent_event)
+      end
+    end
+
+    test "context is preserved when using #tagged" do
+      @reporter.set_context(shop_id: 123)
+
+      @reporter.tagged(request_id: "abc") do
+        assert_equal({ shop_id: 123 }, @reporter.context)
+
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { key: "value" }, tags: { request_id: "abc" }, context: { shop_id: 123 })
+        ]) do
+          @reporter.notify(:test_event, key: "value")
+        end
+      end
+    end
+  end
+
+  class EncodersTest < ActiveSupport::TestCase
+    class TestEvent
+      def initialize(data)
+        @data = data
+      end
+
+      def to_h
+        { data: @data }
+      end
+    end
+
+    class HttpRequestTag
+      def initialize(http_method, http_status)
+        @http_method = http_method
+        @http_status = http_status
+      end
+
+      def to_h
+        {
+          http_method: @http_method,
+          http_status: @http_status,
+        }
+      end
+    end
+
+    setup do
+      @event = {
+        name: "test_event",
+        payload: { id: 123, message: "hello" },
+        tags: { section: "admin" },
+        context: { user_id: 456 },
+        timestamp: 1738964843208679035,
+        source_location: { filepath: "/path/to/file.rb", lineno: 42, label: "test_method" }
+      }
+    end
+
+    test "looking up encoder by symbol" do
+      assert_equal EventReporter::Encoders::JSON, EventReporter.encoder(:json)
+      assert_equal EventReporter::Encoders::MessagePack, EventReporter.encoder(:msgpack)
+    end
+
+    test "looking up encoder by string" do
+      assert_equal EventReporter::Encoders::JSON, EventReporter.encoder("json")
+      assert_equal EventReporter::Encoders::MessagePack, EventReporter.encoder("msgpack")
+    end
+
+    test "looking up nonexistant encoder raises KeyError" do
+      error = assert_raises(KeyError) do
+        EventReporter.encoder(:unknown)
+      end
+      assert_equal "Unknown encoder format: :unknown. Available formats: json, msgpack", error.message
+    end
+
+    test "Base encoder raises NotImplementedError" do
+      assert_raises(NotImplementedError) do
+        EventReporter::Encoders::Base.encode(@event)
+      end
+    end
+
+    test "JSON encoder encodes event to JSON" do
+      json_string = EventReporter::Encoders::JSON.encode(@event)
+      parsed = ::JSON.parse(json_string)
+
+      assert_equal "test_event", parsed["name"]
+      assert_equal({ "id" => 123, "message" => "hello" }, parsed["payload"])
+      assert_equal({ "section" => "admin" }, parsed["tags"])
+      assert_equal({ "user_id" => 456 }, parsed["context"])
+      assert_equal 1738964843208679035, parsed["timestamp"]
+      assert_equal({ "filepath" => "/path/to/file.rb", "lineno" => 42, "label" => "test_method" }, parsed["source_location"])
+    end
+
+    test "JSON encoder serializes event objects and object tags as hashes" do
+      @event[:payload] = TestEvent.new("value")
+      @event[:tags] = { "HttpRequestTag": HttpRequestTag.new("GET", 200) }
+      json_string = EventReporter::Encoders::JSON.encode(@event)
+      parsed = ::JSON.parse(json_string)
+
+      assert_equal "value", parsed["payload"]["data"]
+      assert_equal "GET", parsed["tags"]["HttpRequestTag"]["http_method"]
+      assert_equal 200, parsed["tags"]["HttpRequestTag"]["http_status"]
+    end
+
+    test "MessagePack encoder encodes event to MessagePack" do
+      begin
+        require "msgpack"
+      rescue LoadError
+        skip "msgpack gem not available"
+      end
+
+      msgpack_data = EventReporter::Encoders::MessagePack.encode(@event)
+      parsed = ::MessagePack.unpack(msgpack_data)
+
+      assert_equal "test_event", parsed["name"]
+      assert_equal({ "id" => 123, "message" => "hello" }, parsed["payload"])
+      assert_equal({ "section" => "admin" }, parsed["tags"])
+      assert_equal({ "user_id" => 456 }, parsed["context"])
+      assert_equal 1738964843208679035, parsed["timestamp"]
+      assert_equal({ "filepath" => "/path/to/file.rb", "lineno" => 42, "label" => "test_method" }, parsed["source_location"])
+    end
+
+    test "MessagePack encoder serializes event objects and object tags as hashes" do
+      @event[:payload] = TestEvent.new("value")
+      @event[:tags] = { "HttpRequestTag": HttpRequestTag.new("GET", 200) }
+      msgpack_data = EventReporter::Encoders::MessagePack.encode(@event)
+      parsed = ::MessagePack.unpack(msgpack_data)
+
+      assert_equal "value", parsed["payload"]["data"]
+      assert_equal "GET", parsed["tags"]["HttpRequestTag"]["http_method"]
+      assert_equal 200, parsed["tags"]["HttpRequestTag"]["http_status"]
+    end
+  end
+end

--- a/activesupport/test/testing/event_reporter_assertions_test.rb
+++ b/activesupport/test/testing/event_reporter_assertions_test.rb
@@ -1,0 +1,125 @@
+# typed: true
+# frozen_string_literal: true
+
+require "active_support/test_case"
+
+module ActiveSupport
+  module Testing
+    class EventReporterAssertionsTest < ActiveSupport::TestCase
+      setup do
+        @reporter = ActiveSupport.event_reporter
+      end
+
+      test "#assert_event_reported" do
+        assert_event_reported("user.created") do
+          @reporter.notify("user.created", { id: 123, name: "John Doe" })
+        end
+      end
+
+      test "#assert_event_reported with payload" do
+        assert_event_reported("user.created", payload: { id: 123, name: "John Doe" }) do
+          @reporter.notify("user.created", { id: 123, name: "John Doe" })
+        end
+      end
+
+      test "#assert_event_reported with tags" do
+        assert_event_reported("user.created", tags: { graphql: true }) do
+          @reporter.tagged(:graphql) do
+            @reporter.notify("user.created", { id: 123, name: "John Doe" })
+          end
+        end
+      end
+
+      test "#assert_event_reported partial matching" do
+        assert_event_reported("user.created", payload: { id: 123 }, tags: { foo: :bar }) do
+          @reporter.tagged(foo: :bar, baz: :qux) do
+            @reporter.notify("user.created", { id: 123, name: "John Doe" })
+          end
+        end
+      end
+
+      test "#assert_event_reported with regex payload" do
+        assert_event_reported("user.created", payload: { id: /[0-9]+/ }) do
+          @reporter.notify("user.created", { id: 123, name: "John Doe" })
+        end
+      end
+
+      test "#assert_event_reported with regex tags" do
+        assert_event_reported("user.created", tags: { foo: /bar/ }) do
+          @reporter.tagged(foo: :bar, baz: :qux) do
+            @reporter.notify("user.created")
+          end
+        end
+      end
+
+      test "#assert_no_event_reported" do
+        assert_no_event_reported do
+          # No events are reported here
+        end
+      end
+
+      test "#assert_no_event_reported with provided name" do
+        assert_no_event_reported("user.created") do
+          @reporter.notify("another.event")
+        end
+      end
+
+      test "#assert_no_event_reported with payload" do
+        assert_no_event_reported("user.created", payload: { id: 123, name: "Sazz Pataki" }) do
+          @reporter.notify("user.created", { id: 123, name: "Mabel Mora" })
+        end
+
+        assert_no_event_reported("user.created", payload: { name: "Sazz Pataki" }) do
+          @reporter.notify("user.created")
+        end
+      end
+
+      test "#assert_no_event_reported with tags" do
+        assert_no_event_reported("user.created", tags: { api: true, zip_code: 10003 }) do
+          @reporter.tagged(api: false, zip_code: 10003) do
+            @reporter.notify("user.created")
+          end
+        end
+
+        assert_no_event_reported("user.created", tags: { api: true }) do
+          @reporter.notify("user.created")
+        end
+      end
+
+      test "#assert_event_reported fails when event is not reported" do
+        e = assert_raises(Minitest::Assertion) do
+          assert_event_reported("user.created") do
+            # No events are reported here
+          end
+        end
+
+        assert_equal "Expected an event to be reported, but there were no events reported.", e.message
+      end
+
+      test "#assert_event_reported fails when different event is reported" do
+        e = assert_raises(Minitest::Assertion) do
+          assert_event_reported("user.created", payload: { id: 123 }) do
+            @reporter.notify("another.event", { id: 123, name: "John Doe" })
+          end
+        end
+
+        assert_match(/Expected an event to be reported matching:/, e.message)
+        assert_match(/name: user\.created/, e.message)
+        assert_match(/but none of the 1 reported events matched:/, e.message)
+        assert_match(/another\.event/, e.message)
+      end
+
+      test "#assert_no_event_reported fails when event is reported" do
+        payload = { id: 123, name: "John Doe" }
+        e = assert_raises(Minitest::Assertion) do
+          assert_no_event_reported("user.created") do
+            @reporter.notify("user.created", payload)
+          end
+        end
+
+        assert_match(/Expected no 'user\.created' event to be reported, but found:/, e.message)
+        assert_match(/user\.created/, e.message)
+      end
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2952,6 +2952,37 @@ The default value depends on the `config.load_defaults` target version:
 [ActiveSupport::Cache::Store#fetch]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
 [ActiveSupport::Cache::Store#write]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-write
 
+#### `config.active_support.event_reporter_context_store`
+
+Configures a custom context store for the Event Reporter. The context store is used to manage metadata that should be attached to every event emitted by the reporter.
+
+By default, the Event Reporter uses `ActiveSupport::EventContext` which stores context in fiber-local storage.
+
+To use a custom context store, set this config to a class that implements the context store interface:
+
+```ruby
+# config/application.rb
+config.active_support.event_reporter_context_store = CustomContextStore
+
+class CustomContextStore
+  class << self
+    def context
+      # Return the context hash
+    end
+
+    def set_context(context_hash)
+      # Append context_hash to the existing context store
+    end
+
+    def clear
+      # Clear the stored context
+    end
+  end
+end
+```
+
+Defaults to `nil`, which means the default `ActiveSupport::EventContext` store is used.
+
 ### Configuring Active Job
 
 `config.active_job` provides the following configuration options:

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -93,6 +93,14 @@ module Rails
       ActiveSupport.error_reporter
     end
 
+    # Returns the ActiveSupport::EventReporter of the current \Rails project,
+    # otherwise it returns +nil+ if there is no project.
+    #
+    #   Rails.event.notify("my_event", { message: "Hello, world!" })
+    def event
+      ActiveSupport.event_reporter
+    end
+
     # Returns all \Rails groups for loading based on:
     #
     # * The \Rails environment;

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -73,6 +73,10 @@ module Rails
         end
       end
 
+      initializer :initialize_event_reporter, group: :all do
+        Rails.event.raise_on_error = config.consider_all_requests_local
+      end
+
       # Initialize cache early in the stack so railties can make use of it.
       initializer :initialize_cache, group: :all do
         cache_format_version = config.active_support.delete(:cache_format_version)


### PR DESCRIPTION
### Motivation / Background

Ref: https://github.com/rails/rails/issues/50452

This PR adds structured event reporting to Rails. The event reporter, accessible via `Rails.event`, allows you to report structured events to subscriber(s), and provides mechanisms for adding tags and context to events. While the existing `Rails.logger` is great for producing human-readable logs, the unstructured log lines it generates are difficult for modern data analytics / observability platforms to parse. We'd like to add first-class support for structured events, complementing the existing Rails logger. 

Note that events encompass "structured logs", but also "business events", as well as telemetry events such as metrics and logs. The Event Reporter is designed to be a single interface for producing any kind of event in a Rails application. 

This is the API we developed for structured logging at Shopify and are using in our monolith.

### Detail

#### Basic Event Reporting
```ruby
  # Simple event with payload
  Rails.event.notify("user_created", { id: 123, name: "John Doe" })

  # Event object (for schematized events)
  Rails.event.notify(UserCreatedEvent.new(id: 123, name: "John Doe"))
```
 
#### Event Structure

```ruby
# All events include standardized metadata:
  {
    name: "user_created",
    payload: { id: 123, name: "John Doe" },
    tags: { section: "admin" },
    context: { request_id: "abc123", user_agent: "Mozilla..." },
    timestamp: 1738964843208679035, # nanosecond precision
    source_location: {
      filepath: "app/services/user_service.rb",
      lineno: 45,
      label: "UserService#create"
    }
  }
```

#### Adding Tags / Context

```ruby
 # Tags - Domain-specific context that nests:
  Rails.event.tagged("graphql") do
    Rails.event.tagged(section: "admin") do
      Rails.event.notify("user_created", { id: 123 })
      # Event includes tags: { graphql: true, section: "admin" }
    end
  end

  # Context - Request/job-scoped metadata:
  Rails.event.set_context(request_id: "abc123", shop_id: 456)
  Rails.event.notify("user_created", { id: 123 })
  # All subsequent events in this request include the context
```

#### Debug Mode - Conditional event reporting:
  ```ruby
  Rails.event.with_debug do
    Rails.event.debug("sql_query", { sql: "SELECT * FROM users" })
    # Only reported when debug mode is active
  end
```

 #### Subscriber Interface

EDIT: I've amended this PR to provide some default encoders out of the box, and we may additionally want to provide a default subscriber that converts structured events into unstructured log lines.

We separate the emission of events from how these events reach end consumers; applications are expected to define their own subscribers, and the Event Reporter is responsible for emitting events to these subscribers.

```ruby
  class MySubscriber
    def emit(event)
      # Process the structured event hash
      # Serialize and export to logging pipeline
    end
  end

  Rails.event.subscribe(MySubscriber.new)
```

#### Testing Support
```ruby
  # Assert specific events are reported
  assert_event_reported("user.created", payload: { id: 123 }) do
    UserService.create_user(name: "John")
  end

  # Assert no events are reported
  assert_no_event_reported("user.deleted") do
    UserService.update_user(id: 123, name: "Jane")
  end
```

 ### Key Design Decisions

  1. Fiber-based Isolation: Tags and context are scoped per fiber. Child fibers / threads inherit context from the parent, but the context is copied on write so that changes do not propagate to the parent. 
  2. Structured Metadata: Every event includes consistent name, timestamp, source location, payload, tags, and context.
  3. Flexible Payloads: Supports both hash payloads and custom event objects for implicitly structured events and explicitly schematized events.
  4. Publisher-Subscriber: Decouples event emission from processing, allowing multiple subscribers and providing flexibility for applications to define how events reach consumers.

### Additional information

#### What is an event?

"Business Events", Traces, Spans, Metrics and Logs are all types of events. At Shopify, we built the Structured Event Reporter to be a unified solution for any and all of these use cases.

#### Why support arbitrarily structured payloads (hashes) and "event objects"?

It is important for the API to support both implicitly structured events (hashes) and explicitly typed events that comply with a schema. At Shopify, we're moving towards a future where all our events are schematized. The Event Reporter allows "event objects" to be passed to the Event Reporter, and these can have defined schemas. These objects are passed directly to subscribers in the `payload` field; we don't make any assumptions about how these should be serialized. The subscriber(s) need to handle encoding these appropriately.

#### Why no log levels?

Log levels are rather arbitrary. Different logging systems use different levels, and these are interpreted differently depending on the user / context and are generally used inconsistently. The primary use case for log levels is to distinguish:
> Things that developers care about when they are developing or debugging software.
> Things that users care about when using your software.

> Obviously these are debug and info levels, respectively.

(Source: https://dave.cheney.net/2015/11/05/lets-talk-about-logging)

As such, when designing this API, we opted to implicitly support "log levels" in the API via `Rails.event.notify` and `Rails.event.debug`. We don't require additional level parameters, nor do we expose different levels in the API.

#### How do the payload, tags, and context differ?

The **payload**, or event object, contains information about an event that occurred, typically specific to a given domain. **Tags** can be used to enrich an event with further context, and form a "stack"; all events within the block will include tags currently pushed onto the stack. Note that tags and the event payload may occupy logically different domains. The **context** is designed for request/job-level metadata that spans the entire execution context. Context should expand over the course of the unit of work, and will be attached to every event emitted by the event reporter.

#### Why are we not using `ActiveSupport::ExecutionContext` for the event context?

At Shopify, we specifically want to use Fiber storage as the underlying storage mechanism for storing event reporter context. We [explored making changes](https://github.com/rails/rails/pull/54788) to the existing execution context / isolated execution state singletons to allow this, but we decided it made more sense to handroll what we needed specifically for the event reporter, and then revisit folding this back into AS::EC / AS::ISE later.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
