### PR TITLE
Introduce `Object#absence`, complementary to `Object#presence`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Introduce `Object#absence`, complementary to `Object#presence`.
+
+    Returns `true` if the receiver is blank, otherwise `nil`. This is
+    equivalent to:
+
+    ```ruby
+    object.blank? ? true : nil
+    ```
+
+    This can be useful when you want to return a value when a variable is blank,
+    or nil otherwise:
+
+    ```ruby
+    processed = false
+    {
+      processed_at: processed.presence && Time.current,
+      process_at: processed.absence && Time.current
+    }
+    # => { processed_at: nil, process_at: Mon, 14 Jul 2025 ... }
+    ```
+
+    *Petrik de Heus*
+
 *   Given an array of `Thread::Backtrace::Location` objects, the new method
     `ActiveSupport::BacktraceCleaner#clean_locations` returns an array with the
     clean ones:

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -26,7 +26,29 @@ class Object
     !blank?
   end
 
-  # Returns the receiver if it's present otherwise returns +nil+.
+  # Returns +true+ if the receiver is blank, otherwise returns +nil+.
+  # <tt>object.absence</tt> is equivalent to
+  #
+  #    object.blank? ? true : nil
+  #
+  # For example, something like
+  #
+  #   {
+  #     process_at: params[:processed].blank? ? Time.current : nil
+  #   }
+  #
+  # becomes
+  #
+  #   {
+  #     process_at: params[:processed].absence && Time.current
+  #   }
+  #
+  # @return [true, nil]
+  def absence
+    true if blank?
+  end
+
+  # Returns the receiver if it's present, otherwise returns +nil+.
   # <tt>object.presence</tt> is equivalent to
   #
   #    object.present? ? object : nil

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -36,6 +36,11 @@ class BlankTest < ActiveSupport::TestCase
     NOT.each   { |v| assert_equal true, v.present?,  "#{v.inspect} should be present" }
   end
 
+  def test_absence
+    BLANK.each { |v| assert_equal true, v.absence, "#{v.inspect}.absence should return true" }
+    NOT.each   { |v| assert_nil v.absence, "#{v.inspect}.absence should return nil" }
+  end
+
   def test_presence
     BLANK.each { |v| assert_nil v.presence, "#{v.inspect}.presence should return nil" }
     NOT.each   { |v| assert_equal v,   v.presence, "#{v.inspect}.presence should return self" }


### PR DESCRIPTION
### Motivation / Background

Sometimes you want to return a value when a variable is blank, or nil otherwise.

`Object#absence` returns `true` if the receiver is blank, otherwise `nil`. This is equivalent to:

```ruby
object.blank? ? true : nil
```

For example, when defining a Hash where:
* `:processed_at` should be set to `Time.current` if `processed` is `true`, otherwise set it to `nil`.
* `:process_at` should be set to `Time.current` if `processed` is `false`, otherwise set it to `nil`.

This could be defined as:
```ruby
  processed = false
  {
    processed_at: processed.present? ? Time.current : nil,
    process_at: processed.blank? ? Time.current : nil
  }
  # => { processed_at: nil, process_at: Mon, 14 Jul 2025 ... }
```

Using `presence` and `absence` this could be defined as:

```ruby
  {
    processed_at: processed.presence && Time.current,
    process_at: processed.absence && Time.current
  }
  # => { processed_at: nil, process_at: Mon, 14 Jul 2025 ... }
```

Another use-case would be setting a class on an HTML element if a variable is false/blank:

```erb
<div class="<%= enabled.blank? ? "disabled" : "" %>">...
```

With `absence` this could be changed to:

```erb
<div class="<%= enabled.absence && "disabled" %>">...
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
