### PR TITLE
Handle counter cache registration for associations with unloaded classes

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -38,7 +38,11 @@ module ActiveRecord::Associations::Builder # :nodoc:
       }
 
       klass = reflection.class_name.safe_constantize
-      klass._counter_cache_columns |= [cache_column] if klass && klass.respond_to?(:_counter_cache_columns)
+      if klass && klass.respond_to?(:_counter_cache_columns)
+        klass._counter_cache_columns |= [cache_column]
+      else
+        ActiveRecord::Associations::CounterCacheRegistry.register(reflection.class_name, cache_column)
+      end
       model.counter_cached_association_names |= [reflection.name]
     end
 

--- a/activerecord/lib/active_record/associations/counter_cache_registration.rb
+++ b/activerecord/lib/active_record/associations/counter_cache_registration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "active_record/associations/counter_cache_registry"
+
+module ActiveRecord
+  module Associations
+    # = Active Record Counter Cache Registration
+    #
+    # This module extends the inherited hook in ActiveRecord::Base to process
+    # pending counter cache registrations when a new model class is defined.
+    module CounterCacheRegistration
+      extend ActiveSupport::Concern
+
+      included do
+        class << self
+          alias_method :inherited_without_counter_cache_registration, :inherited
+
+          def inherited(subclass)
+            inherited_without_counter_cache_registration(subclass)
+
+            CounterCacheRegistry.process_pending(subclass)
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/associations/counter_cache_registry.rb
+++ b/activerecord/lib/active_record/associations/counter_cache_registry.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "concurrent/map"
+
+module ActiveRecord
+  module Associations
+    # = Active Record Counter Cache Registry
+    #
+    # This module provides a registry for counter cache columns that need to be
+    # added to a class that hasn't been loaded yet. When a belongs_to association
+    # with counter_cache: true is defined, and the associated class hasn't been
+    # loaded yet, the counter cache column is registered here. When the associated
+    # class is loaded, the pending counter cache columns are added to it.
+    module CounterCacheRegistry
+      extend self
+
+      def registry
+        @registry ||= Concurrent::Map.new
+      end
+
+      # Register a counter cache column for a class that hasn't been loaded yet.
+      # @param class_name [String] The name of the class to register the counter cache column for.
+      # @param cache_column [String] The name of the counter cache column.
+      def register(class_name, cache_column)
+        registry.compute_if_absent(class_name) { [] }
+        registry[class_name] << cache_column
+      end
+
+      # Process pending counter cache columns for a class that has just been loaded.
+      # @param klass [Class] The class to process pending counter cache columns for.
+      def process_pending(klass)
+        class_name = klass.name
+        return unless class_name && registry.key?(class_name)
+
+        cache_columns = registry.delete(class_name)
+        return if cache_columns.empty?
+
+        klass._counter_cache_columns |= cache_columns if klass.respond_to?(:_counter_cache_columns)
+      end
+
+      def clear
+        registry.clear
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -11,6 +11,7 @@ require "active_record/relation/delegation"
 require "active_record/attributes"
 require "active_record/type_caster"
 require "active_record/database_configurations"
+require "active_record/associations/counter_cache_registration"
 
 module ActiveRecord # :nodoc:
   # = Active Record
@@ -315,6 +316,7 @@ module ActiveRecord # :nodoc:
     include Callbacks
     include Timestamp
     include Associations
+    include Associations::CounterCacheRegistration
     include SecurePassword
     include AutosaveAssociation
     include NestedAttributes

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -101,6 +101,14 @@ module ActiveRecord
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end
 
+    initializer "active_record.clear_counter_cache_registry_on_reload" do |app|
+      app.config.to_prepare do
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Associations::CounterCacheRegistry.clear
+        end
+      end
+    end
+
     initializer "active_record.backtrace_cleaner" do
       ActiveSupport.on_load(:active_record) { LogSubscriber.backtrace_cleaner = ::Rails.backtrace_cleaner }
     end

--- a/activerecord/test/cases/counter_cache_load_order_test.rb
+++ b/activerecord/test/cases/counter_cache_load_order_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_record/associations/counter_cache_registry"
+
+module CounterCacheLoadOrderTestClasses; end
+
+class CounterCacheLoadOrderTest < ActiveRecord::TestCase
+  def setup
+    ActiveRecord::Associations::CounterCacheRegistry.clear
+  end
+
+  def teardown
+    CounterCacheLoadOrderTestClasses.send(:remove_const, :TestComment) if defined?(CounterCacheLoadOrderTestClasses::TestComment)
+    CounterCacheLoadOrderTestClasses.send(:remove_const, :TestPost) if defined?(CounterCacheLoadOrderTestClasses::TestPost)
+  end
+
+  test "counter cache works when associated class is loaded after the model with belongs_to" do
+    class CounterCacheLoadOrderTestClasses::TestComment < ActiveRecord::Base
+      self.table_name = "comments"
+      belongs_to :post, counter_cache: true, class_name: "CounterCacheLoadOrderTestClasses::TestPost"
+    end
+
+    class CounterCacheLoadOrderTestClasses::TestPost < ActiveRecord::Base
+      self.table_name = "posts"
+    end
+
+    assert CounterCacheLoadOrderTestClasses::TestPost.counter_cache_column?("test_comments_count")
+  end
+
+  test "counter cache works with custom counter cache column name" do
+    class CounterCacheLoadOrderTestClasses::TestComment < ActiveRecord::Base
+      self.table_name = "comments"
+      belongs_to :post, counter_cache: :custom_comments_count, class_name: "CounterCacheLoadOrderTestClasses::TestPost"
+    end
+
+    class CounterCacheLoadOrderTestClasses::TestPost < ActiveRecord::Base
+      self.table_name = "posts"
+    end
+
+    assert CounterCacheLoadOrderTestClasses::TestPost.counter_cache_column?("custom_comments_count")
+  end
+end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #55133 

This commit addresses an issue with ActiveRecord's counter cache feature that occurred when the associated class was loaded after the class defining the association. `belongs_to`.

Previously, for a counter cache to be correctly registered, the associated class needed to be loaded first. As pointed out in the issue this PR fixes: This may happen, for example, in scripts using Active Record directly without autoloading.

This commit introduces a that stores pending counter cache registrations. When a class is defined, this registry is checked, and any pending counter caches for that class are applied. `CounterCacheRegistry`



### Additional information

This PR's approach was heavily inspired on `ActiveRecord::Base.descendants` implementation since it also keeps track of records of classes and solve load-order issues. However, since `DescendantsTracker` is focused on inheritance, it wouldn't have worked in this case


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
