### PR TITLE
Upgrade devcontainer from Ruby 3.4.4 to 3.4.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3.4, 3.3, 3.2
-ARG VARIANT="3.4.4"
+ARG VARIANT="3.4.5"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION


### Motivation / Background

Simply bumping devcontainer from Ruby 3.4.4 to 3.4.5.

- https://www.ruby-lang.org/en/news/2025/07/15/ruby-3-4-5-released/
- https://github.com/ruby/ruby/releases/tag/v3_4_5

### Detail

See above.

### Additional information

See above.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
