### PR TITLE
[ci skip] Updated Getting Started Guide to have reference to query_attribute (attribute?) method

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2130,7 +2130,7 @@ following:
   <% end %>
 <% end %>
 ```
-You may be asking, "what is `inventory_count?` doing? Where is this method even coming from?" When following Rails conventions, many such methods are automatically defined for you. In this case, this is the `query_attribute` method. In addition to checking if an attribute (inventory in this case) is `false` or `nil`, this method is also checking if the attribute is 0 or an empty string.
+You may be asking, "what is `inventory_count?` doing? Where is this method even coming from?" When following Rails conventions, many such methods are automatically defined for you. In this case, this is the `query_attribute` method, which is aliased to `attribute?`. In addition to checking if an attribute (inventory in this case) is `false` or `nil`, this method is also checking if the attribute is 0 or an empty string.
 
 This can be seen [here](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activerecord/lib/active_record/attribute_methods/query.rb#L13) in the Rails source code itself or in the [Rails API manual](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Query.html#method-i-query_attribute). Tracking these methods down may seem tricky at first, but using the class the object is under and learning more about Rails conventions will make this an easier process.
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2132,7 +2132,7 @@ following:
 ```
 You may be asking, "what is `inventory_count?` doing? Where is this method even coming from?" When following Rails conventions, many such methods are automatically defined for you. In this case, this is the `query_attribute` method, which is aliased to `attribute?`. In addition to checking if an attribute (inventory in this case) is `false` or `nil`, this method is also checking if the attribute is 0 or an empty string.
 
-This can be seen [here](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activerecord/lib/active_record/attribute_methods/query.rb#L13) in the Rails source code itself or in the [Rails API manual](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Query.html#method-i-query_attribute). Tracking these methods down may seem tricky at first, but using the class the object is under and learning more about Rails conventions will make this an easier process.
+NOTE: `inventory_count?` is query method created by Active Record. Active Record adds query methods for all attributes. For numeric attributes these methods  return `true` for all non-zero number, and `false` otherwise.
 
 Next update `app/views/products/show.html.erb` to render this partial after the
 `cache` block.

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2130,7 +2130,6 @@ following:
   <% end %>
 <% end %>
 ```
-You may be asking, "what is `inventory_count?` doing? Where is this method even coming from?" When following Rails conventions, many such methods are automatically defined for you. In this case, this is the `query_attribute` method, which is aliased to `attribute?`. In addition to checking if an attribute (inventory in this case) is `false` or `nil`, this method is also checking if the attribute is 0 or an empty string.
 
 NOTE: `inventory_count?` is query method created by Active Record. Active Record adds query methods for all attributes. For numeric attributes these methods  return `true` for all non-zero number, and `false` otherwise.
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2131,6 +2131,7 @@ following:
 <% end %>
 ```
 You may be asking, "what is `inventory_count?` doing? Where is this method even coming from?" When following Rails conventions, many such methods are automatically defined for you. In this case, this is the `query_attribute` method. In addition to checking if an attribute (inventory in this case) is `false` or `nil`, this method is also checking if the attribute is 0 or an empty string.
+
 This can be seen [here](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activerecord/lib/active_record/attribute_methods/query.rb#L13) in the Rails source code itself or in the [Rails API manual](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Query.html#method-i-query_attribute). Tracking these methods down may seem tricky at first, but using the class the object is under and learning more about Rails conventions will make this an easier process.
 
 Next update `app/views/products/show.html.erb` to render this partial after the

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2130,8 +2130,10 @@ following:
   <% end %>
 <% end %>
 ```
+You may be asking, "what is `inventory_count?` doing? Where is this method even coming from?" When following Rails conventions, many such methods are automatically defined for you. In this case, this is the `query_attribute` method. In addition to checking if an attribute (inventory in this case) is `false` or `nil`, this method is also checking if the attribute is 0 or an empty string.
+This can be seen [here](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activerecord/lib/active_record/attribute_methods/query.rb#L13) in the Rails source code itself or in the [Rails API manual](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Query.html#method-i-query_attribute). Tracking these methods down may seem tricky at first, but using the class the object is under and learning more about Rails conventions will make this an easier process.
 
-Then update `app/views/products/show.html.erb` to render this partial after the
+Next update `app/views/products/show.html.erb` to render this partial after the
 `cache` block.
 
 ```erb


### PR DESCRIPTION
### Motivation / Background

I have made a minor update to the Getting Started Guide as ultimately as someone very new to Rails the convention of `inventory_count?` confused me. I know by Ruby conventions this provides a true or false result and I know in Ruby on `false` and `nil` are falsey.

I figured this was doing something like making the value 0 return false, but I had no real way to figure out how to even search for this. Someone on the Ruby Discord gave me a link to the source for this and I was able to dig a bit further from there. I double checked the Getting Started guide and the word attribute wasn't ever brought up.

This Pull Request has been created because as someone new to Rails, I found this confusing and was unsure how to even begin to find his beyond poking around in the ActiveRecord class source.

### Detail

This Pull Request adds a brief explanation of how to understand how the `inventory_count?` method call is working and gives someone their first look at how they may track down something in the source/API.

### Additional information

One alternative solution would be a new guide that gives a bit more background on the terminology or finding stuff in source. This could be touched on elsewhere  in the guides, I haven't gotten through all of them yet. Additionally, maybe this is in a note box instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [ X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

