### PR TITLE
Add load-hooks for Active Model autoloaded constants referenced in initializers

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -204,4 +204,6 @@ module ActiveModel
         [@base, @attribute, @raw_type, @options.except(*CALLBACKS_OPTIONS)]
       end
   end
+
+  ActiveSupport.run_load_hooks(:active_model_error, Error)
 end

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -14,11 +14,15 @@ module ActiveModel
     end
 
     initializer "active_model.secure_password" do
-      ActiveModel::SecurePassword.min_cost = Rails.env.test?
+      ActiveSupport.on_load(:active_model_secure_password) do
+        ActiveModel::SecurePassword.min_cost = Rails.env.test?
+      end
     end
 
-    initializer "active_model.i18n_customize_full_message" do
-      ActiveModel::Error.i18n_customize_full_message = config.active_model.delete(:i18n_customize_full_message) || false
+    initializer "active_model.i18n_customize_full_message" do |app|
+      ActiveSupport.on_load(:active_model_error) do
+        ActiveModel::Error.i18n_customize_full_message = app.config.active_model.i18n_customize_full_message || false
+      end
     end
   end
 end

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -228,4 +228,6 @@ module ActiveModel
       end
     end
   end
+
+  ActiveSupport.run_load_hooks(:active_model_secure_password, SecurePassword)
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I noticed that there are 2 autoloaded constants referenced in the Active Model initializer that are not wrapped with load hooks. This means that the autoloaded constants will be loaded immediately during boot rather than deferred.

Additionally, I noticed that the Active Model configuration is mutated with a `delete` unnecessarily and I removed the `delete`. afaict, configuration is only necessarily mutated when configuration is mass-assigned against another interface. For example, Action View does a lot of `config.action_view.delete` in its Railtie because it later does this:

https://github.com/rails/rails/blob/5d8c81c2c0985dbb1c99d16b08e272b05a1dd176/actionview/lib/action_view/railtie.rb#L80-L86

(I say "afaict" because I'm pretty sure the `delete` pattern is not intended to signal consumption in the theme of #44996 ... though there are a few other seemingly unnecessary imo usages in the codebase... Happy to clean those up if given the signal) 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~ didn't seem to warrant it
