### PR TITLE
Extend `ActionMailer::TestCase` with multi-part assertions

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,2 +1,18 @@
+*   Add `assert_part` and `assert_no_part` to `ActionMailer::TestCase`
+
+    ```ruby
+    test "assert MyMailer.welcome HTML and text parts" do
+      mail = MyMailer.welcome("Hello, world")
+
+      assert_part :text, mail do |text|
+        assert_includes text, "Hello, world"
+      end
+      assert_part :html, mail do |html|
+        assert_dom html.root, "p", "Hello, world"
+      end
+    end
+    ```
+
+    *Sean Doyle*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/test/assert_select_email_test.rb
+++ b/actionmailer/test/assert_select_email_test.rb
@@ -10,14 +10,7 @@ class AssertSelectEmailTest < ActionMailer::TestCase
     end
   end
 
-  class AssertMultipartSelectMailer < ActionMailer::Base
-    def test(options)
-      mail subject: "Test e-mail", from: "test@test.host", to: "test <test@test.host>" do |format|
-        format.text { render plain: options[:text] }
-        format.html { render plain: options[:html] }
-      end
-    end
-  end
+  tests AssertSelectMailer
 
   #
   # Test assert_select_email
@@ -37,6 +30,63 @@ class AssertSelectEmailTest < ActionMailer::TestCase
     end
   end
 
+  def test_assert_part_last_mail_delivery
+    AssertSelectMailer.test("<div><p>foo</p><p>bar</p></div>").deliver_now
+
+    assert_part :html do |html|
+      assert_kind_of Rails::Dom::Testing.html_document, html
+
+      assert_dom html, "div" do
+        assert_dom "p:first-child", "foo"
+        assert_dom "p:last-child", "bar"
+      end
+    end
+  end
+
+  def test_assert_part_with_mail_argument
+    mail = AssertSelectMailer.test("<div><p>foo</p><p>bar</p></div>")
+
+    assert_part :html, mail do |html|
+      assert_kind_of Rails::Dom::Testing.html_document, html
+
+      assert_dom html, "div" do
+        assert_dom "p:first-child", "foo"
+        assert_dom "p:last-child", "bar"
+      end
+    end
+  end
+end
+
+class AssertMultipartSelectEmailTest < ActionMailer::TestCase
+  class AssertMultipartSelectMailer < ActionMailer::Base
+    def test(options)
+      mail subject: "Test e-mail", from: "test@test.host", to: "test <test@test.host>" do |format|
+        format.text { render plain: options[:text] } if options.key?(:text)
+        format.html { render plain: options[:html] } if options.key?(:html)
+      end
+    end
+  end
+
+  tests AssertMultipartSelectMailer
+
+  #
+  # Test assert_select_email
+  #
+
+  def test_assert_select_email
+    assert_raise ActiveSupport::TestCase::Assertion do
+      assert_select_email { }
+    end
+
+    AssertMultipartSelectMailer.test(html: "<div><p>foo</p><p>bar</p></div>", text: "foo bar").deliver_now
+    assert_select_email do
+      assert_select "div:root" do
+        assert_select "p:first-child", "foo"
+        assert_select "p:last-child", "bar"
+      end
+    end
+  end
+
   def test_assert_select_email_multipart
     AssertMultipartSelectMailer.test(html: "<div><p>foo</p><p>bar</p></div>", text: "foo bar").deliver_now
     assert_select_email do
@@ -44,6 +94,62 @@ class AssertSelectEmailTest < ActionMailer::TestCase
         assert_select "p:first-child", "foo"
         assert_select "p:last-child", "bar"
       end
+    end
+  end
+
+  def test_assert_part_last_mail_delivery
+    AssertMultipartSelectMailer.test(html: "<div><p>foo</p><p>bar</p></div>", text: "foo bar").deliver_now
+
+    assert_part :text do |text|
+      assert_includes text, "foo bar"
+    end
+    assert_part :html do |html|
+      assert_kind_of Rails::Dom::Testing.html_document, html
+
+      assert_dom html, "div" do
+        assert_dom "p:first-child", "foo"
+        assert_dom "p:last-child", "bar"
+      end
+    end
+  end
+
+  def test_assert_part_with_mail_argument
+    mail = AssertMultipartSelectMailer.test(html: "<div><p>foo</p><p>bar</p></div>", text: "foo bar")
+
+    assert_part :text, mail do |text|
+      assert_includes text, "foo bar"
+    end
+    assert_part :html, mail do |html|
+      assert_kind_of Rails::Dom::Testing.html_document, html
+
+      assert_dom html, "div" do
+        assert_dom "p:first-child", "foo"
+        assert_dom "p:last-child", "bar"
+      end
+    end
+  end
+
+  def test_assert_part_without_block
+    assert_part :html, AssertMultipartSelectMailer.test(html: "html")
+    assert_part :text, AssertMultipartSelectMailer.test(text: "text")
+
+    assert_raises Minitest::Assertion, match: "expected part matching text/html" do
+      assert_part :html, AssertMultipartSelectMailer.test(text: "text")
+    end
+    assert_raises Minitest::Assertion, match: "expected part matching text/plain" do
+      assert_part :text, AssertMultipartSelectMailer.test(html: "html")
+    end
+  end
+
+  def test_assert_no_part
+    assert_no_part :html, AssertMultipartSelectMailer.test(text: "text")
+    assert_no_part :text, AssertMultipartSelectMailer.test(html: "html")
+
+    assert_raises Minitest::Assertion, match: "expected no part matching text/html" do
+      assert_no_part :html, AssertMultipartSelectMailer.test(html: "html")
+    end
+    assert_raises Minitest::Assertion, match: "expected no part matching text/plain" do
+      assert_no_part :text, AssertMultipartSelectMailer.test(text: "text")
     end
   end
 end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -2208,6 +2208,36 @@ You have been invited.
 Cheers!
 ```
 
+When testing multi-part emails with both HTML *and* text parts, use the
+[`assert_part`](https://api.rubyonrails.org/classes/ActionMailer/TestCase/Behavior.html#method-i-assert_part)
+assertion. When testing emails with HTML parts, use the assertions provided by [Rails::Dom::Testing](https://github.com/rails/rails-dom-testing).
+
+```ruby
+require "test_helper"
+
+class UserMailerTest < ActionMailer::TestCase
+  test "invite" do
+    # Create the email and store it for further assertions
+    email = UserMailer.create_invite("me@example.com",
+                                     "friend@example.com", Time.now)
+
+    # Test the body of the sent email's text part
+    assert_part :text, email do |text|
+      assert_includes text, "Hi friend@example.com"
+      assert_includes text, "You have been invited."
+      assert_includes text, "Cheers!"
+    end
+
+    # Test the body of the sent email's HTML part
+    assert_part :html, email do |html|
+      assert_dom html, "h1", text: "Hi friend@example.com"
+      assert_dom html, "p", text: "You have been invited."
+      assert_dom html, "p", text: "Cheers!"
+    end
+  end
+end
+```
+
 #### Configuring the Delivery Method for Test
 
 The line `ActionMailer::Base.delivery_method = :test` in


### PR DESCRIPTION
The Problem
---

Prior to this change, testing the content of multi-part Action
Mailer-generated `Mail` instances involved parsing content derived from
each part into the appropriate type. For example, tests might read
`mail.body.raw_source` from `text/plain` bodies into `String` instances
and parse `text/html` bodies into HTML documents with Nokogiri.

The Proposal
---

This commit defines `assert_part` and `assert_no_part` as assertion
methods on `ActionMailer::TestCase`.

The `assert_part` method iterates over each available part, and asserts
that the multi-part email includes a part that corresponds to the
`content_type` argument.

```ruby
test "assert against the HTML and text parts of the last delivered MyMailer.welcome mailer" do
  MyMailer.welcome("Hello, world").deliver_now

  assert_part :text do |text|
    assert_includes text, "Hello, world"
  end
  assert_part :html do |html|
    assert_dom html.root, "h1", "Hello, world"
  end
  assert_no_part :xml
end

test "assert against the HTML and text parts of a MyMailer.welcome mail instance" do
  mail = MyMailer.welcome("Hello, world")

  assert_part :text, mail do |text|
    assert_includes text, "Hello, world"
  end
  assert_part :html, mail do |html|
    assert_dom html.root, "h1", "Hello, world"
  end
  assert_no_part :xml, mail
end
```

Additional details
---

While HTML assertion support is already baked-into the gem's railtie,
calls to `assert_part(:html)` make the fully-formed HTML
document (a `Nokogiri::HTML4::Document` or `Nokogiri::HTML5::Document`
instance) available to the block. The method also accepts a `Mail` instance directly.

By comparison, the [assert_dom_email][] method (and its
`assert_select_email` alias) provided by `Rails::Dom::Testing` yields an
HTML fragment, and cannot assert against any `Mail` instance except for
the last delivery.

[Rails::Dom::Testing]: https://github.com/rails/rails-dom-testing
[assert_dom_email]: https://github.com/rails/rails-dom-testing/blob/v2.3.0/lib/rails/dom/testing/assertions/selector_assertions.rb#L287-L317

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
