### PR TITLE
Refactor railties tests to not rely on generic route

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4090,7 +4090,6 @@ module ApplicationTests
       output = rails("routes", "-g", "active_storage")
       assert_equal <<~MESSAGE, output
                                Prefix Verb URI Pattern                                                                        Controller#Action
-                                           /:controller(/:action(/:id))(.:format)                                             :controller#:action
                    rails_service_blob GET  /files/blobs/redirect/:signed_id/*filename(.:format)                               active_storage/blobs/redirect#show
              rails_service_blob_proxy GET  /files/blobs/proxy/:signed_id/*filename(.:format)                                  active_storage/blobs/proxy#show
                                       GET  /files/blobs/:signed_id/*filename(.:format)                                        active_storage/blobs/redirect#show

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -17,7 +17,10 @@ module ApplicationTests
     end
 
     test "show exceptions middleware filter backtrace before logging" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
             raise 'oops'
@@ -35,7 +38,10 @@ module ApplicationTests
     end
 
     test "renders active record exceptions as 404" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
             raise ActiveRecord::RecordNotFound
@@ -53,10 +59,7 @@ module ApplicationTests
     end
 
     test "renders unknown http methods as 405 when routes are used as the custom exceptions app" do
-      app_file "config/routes.rb", <<-RUBY
-        Rails.application.routes.draw do
-        end
-      RUBY
+      routes ""
 
       add_to_config "config.exceptions_app = self.routes"
 
@@ -67,7 +70,7 @@ module ApplicationTests
     end
 
     test "renders unknown http formats as 406 when routes are used as the custom exceptions app" do
-      controller :foo, <<-RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
             render plain: "rendering index!"
@@ -79,12 +82,10 @@ module ApplicationTests
         end
       RUBY
 
-      app_file "config/routes.rb", <<-RUBY
-        Rails.application.routes.draw do
-          get "/foo", to: "foo#index"
-          post "/foo", to: "foo#index"
-          match "/406", to: "foo#not_acceptable", via: :all
-        end
+      routes <<~'RUBY'
+        get "/foo", to: "foo#index"
+        post "/foo", to: "foo#index"
+        match "/406", to: "foo#not_acceptable", via: :all
       RUBY
 
       add_to_config "config.exceptions_app = self.routes"
@@ -109,7 +110,7 @@ module ApplicationTests
     end
 
     test "uses custom exceptions app" do
-      add_to_config <<-RUBY
+      add_to_config <<~'RUBY'
         config.exceptions_app = lambda do |env|
           [404, { "Content-Type" => "text/plain" }, ["YOU FAILED"]]
         end
@@ -123,7 +124,10 @@ module ApplicationTests
     end
 
     test "URL generation error when action_dispatch.show_exceptions is set raises an exception" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
             raise ActionController::UrlGenerationError
@@ -141,7 +145,7 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :none
 
       assert_raise(ActionController::RoutingError) do
-        get("/foo", {}, "HTTPS" => "on")
+        get("/does-not-exist", {}, "HTTPS" => "on")
       end
     end
 
@@ -165,10 +169,8 @@ module ApplicationTests
     end
 
     test "routing to a nonexistent controller when action_dispatch.show_exceptions and consider_all_requests_local are set shows diagnostics" do
-      app_file "config/routes.rb", <<-RUBY
-        Rails.application.routes.draw do
-          resources :articles
-        end
+      routes <<~'RUBY'
+        resources :articles
       RUBY
 
       app.config.action_dispatch.show_exceptions = :all
@@ -179,7 +181,10 @@ module ApplicationTests
     end
 
     test "displays diagnostics message when exception raised in template that contains UTF-8" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
           end
@@ -200,7 +205,11 @@ module ApplicationTests
     end
 
     test "displays diagnostics message when malformed query parameters are provided" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
           end
@@ -216,7 +225,10 @@ module ApplicationTests
     end
 
     test "displays diagnostics message when too deep query parameters are provided" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
           end
@@ -235,7 +247,10 @@ module ApplicationTests
     end
 
     test "displays statement invalid template correctly" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
             raise ActiveRecord::StatementInvalid
@@ -258,7 +273,10 @@ module ApplicationTests
     end
 
     test "show_exceptions :rescuable with a rescuable error" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
             raise AbstractController::ActionNotFound
@@ -273,7 +291,10 @@ module ApplicationTests
     end
 
     test "show_exceptions :rescuable with a non-rescuable error" do
-      controller :foo, <<-RUBY
+      routes <<~'RUBY'
+        get "/foo" => "foo#index"
+      RUBY
+      controller :foo, <<~'RUBY'
         class FooController < ActionController::Base
           def index
             raise 'oops'

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -66,6 +66,9 @@ module ApplicationTests
     end
 
     test "integration test" do
+      routes <<~'RUBY'
+        get "/posts" => "posts#index"
+      RUBY
       controller "posts", <<-RUBY
         class PostsController < ActionController::Base
         end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -121,13 +121,6 @@ module TestHelpers
         end
       end
 
-      routes = File.read("#{app_path}/config/routes.rb")
-      if routes =~ /(\n\s*end\s*)\z/
-        File.open("#{app_path}/config/routes.rb", "w") do |f|
-          f.puts $` + "\nActionDispatch.deprecator.silence { match ':controller(/:action(/:id))(.:format)', via: :all }\n" + $1
-        end
-      end
-
       File.open("#{app_path}/config/database.yml", "w") do |f|
         if options[:multi_db]
           f.puts multi_db_database_configs
@@ -481,6 +474,14 @@ module TestHelpers
 
     def controller(name, contents)
       app_file("app/controllers/#{name}_controller.rb", contents)
+    end
+
+    def routes(routes)
+      app_file("config/routes.rb", <<~RUBY)
+        Rails.application.routes.draw do
+          #{routes}
+        end
+      RUBY
     end
 
     def use_frameworks(arr)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/53964

Having a generic route automatically defined make it hard to remove that deprecated feature.
