### PR TITLE
Optimize ActiveSupport::SafeBuffer

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -67,14 +67,13 @@ module ActiveSupport # :nodoc:
       original_concat(value)
     end
 
-    def initialize(str = "")
-      @html_safe = true
+    def initialize(_str = "")
       super
     end
 
     def initialize_copy(other)
       super
-      @html_safe = other.html_safe?
+      @html_unsafe = true unless other.html_safe?
     end
 
     def concat(value)
@@ -116,7 +115,9 @@ module ActiveSupport # :nodoc:
     def *(_)
       new_string = super
       new_safe_buffer = new_string.is_a?(SafeBuffer) ? new_string : SafeBuffer.new(new_string)
-      new_safe_buffer.instance_variable_set(:@html_safe, @html_safe)
+      if @html_unsafe
+        new_safe_buffer.instance_variable_set(:@html_unsafe, true)
+      end
       new_safe_buffer
     end
 
@@ -131,9 +132,9 @@ module ActiveSupport # :nodoc:
       self.class.new(super(escaped_args))
     end
 
-    attr_reader :html_safe
-    alias_method :html_safe?, :html_safe
-    remove_method :html_safe
+    def html_safe?
+      @html_unsafe.nil?
+    end
 
     def to_s
       self
@@ -159,7 +160,7 @@ module ActiveSupport # :nodoc:
           end                                       # end
 
           def #{unsafe_method}!(*args)              # def capitalize!(*args)
-            @html_safe = false                      #   @html_safe = false
+            @html_unsafe = true                     #   @html_unsafe = true
             super                                   #   super
           end                                       # end
         EOT
@@ -180,7 +181,7 @@ module ActiveSupport # :nodoc:
         end                                             # end
 
         def #{unsafe_method}!(*args, &block)            # def gsub!(*args, &block)
-          @html_safe = false                            #   @html_safe = false
+          @html_unsafe = true                           #   @html_unsafe = false
           if block                                      #   if block
             super(*args) { |*params|                    #     super(*args) { |*params|
               set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
@@ -214,7 +215,9 @@ module ActiveSupport # :nodoc:
 
       def string_into_safe_buffer(new_string, is_html_safe)
         new_safe_buffer = new_string.is_a?(SafeBuffer) ? new_string : SafeBuffer.new(new_string)
-        new_safe_buffer.instance_variable_set :@html_safe, is_html_safe
+        unless is_html_safe
+          new_safe_buffer.instance_variable_set :@html_unsafe, true
+        end
         new_safe_buffer
       end
   end


### PR DESCRIPTION
For normal objects, eagerly defining ivars is good to avoid trashing inline caches. But for subclasses of core types like String, ivars are stored in a global hash table, hence initializing and accessing them is rather costly. That cost is even higher if a ractor has been spawned, because looking up the table will require synchronizing the entire VM.

Based on the assumption that the overwhelming majority of `SafeBuffer` instances are never mutated, hence never end up unsafe, we can optimize by marking the unsafe status rather than the opposite.

This way we save on eagerly allocating the external buffer in the global ivar table, save from having to free it when the buffer is collected, and also save from having to lookup the table when accessing the ivar because the VM is smart enough to see the object has the default shape, hence doesn't have any ivar.

```ruby

require "bundler/inline"

gemfile do
  gem "rails", path: "."
  gem "benchmark-ips"
end

require "active_support/all"

Benchmark.ips do |x|
  x.report("String#html_safe") { "test".html_safe }
end
```

Before:

```
ruby 3.5.0dev (2025-07-17T14:01:57Z master a46309d19a) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
    String#html_safe   575.727k i/100ms
Calculating -------------------------------------
    String#html_safe      6.421M (± 1.6%) i/s  (155.75 ns/i) -     32.241M in   5.022802s
```

After:

```
ruby 3.5.0dev (2025-07-17T14:01:57Z master a46309d19a) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
    String#html_safe     1.070M i/100ms
Calculating -------------------------------------
    String#html_safe     12.470M (± 0.8%) i/s   (80.19 ns/i) -     63.140M in   5.063698s
```
