### PR TITLE
Remove unnecessary calls to the GCP metadata server

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Remove unnecessary calls to the GCP metadata server.
+
+    Calling Google::Auth.get_application_default triggers an explicit call to
+    the metadata server - given it was being called for significant number of
+    file operations, it can lead to considerable tail latencies and even metadata
+    server overloads. Instead, it's preferable (and significantly more efficient)
+    that applications use:
+
+    ```ruby
+    Google::Apis::RequestOptions.default.authorization = Google::Auth.get_application_default(...)
+    ```
+
+    In the cases applications do not set that, the GCP libraries automatically determine credentials.
+
+    This also enables using credentials other than those of the associated GCP
+    service account like when using impersonation.
+
+    *Alex Coomans*
+
 *   Direct upload progress accounts for server processing time.
 
     *Jeremy Daer*


### PR DESCRIPTION
Calling Google::Auth.get_application_default triggers an explicit call to the metadata server - given it was being called for significant number of file operations, it can lead to considerable tail latencies and even metadata server overloads. Instead, it's preferable (and significantly more efficient) that applications use:

```ruby
Google::Apis::RequestOptions.default.authorization = Google::Auth.get_application_default(...)
```

In the cases applications do not set that, the GCP libraries automatically determine credentials.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
