### PR TITLE
Add ActiveRecord::SchemaDumper.ignore_extensions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActiveRecord::SchemaDumper.ignore_extensions` functionality.
+
+    *jonathan schatz*
+
+    Add the ability to filter extensions that are dumped to `schema.rb` analogous to the existing `ignore_tables` functionality.
+
 *   Fix `#merge` with `#or` or `#and` and a mixture of attributes and SQL strings resulting in an incorrect query.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -23,7 +23,8 @@ module ActiveRecord
           end
 
           def extensions(stream)
-            extensions = @connection.extensions
+            ignore_extensions = ActiveRecord::SchemaDumper.ignore_extensions
+            extensions = @connection.extensions.reject { |extension| ignore_extensions.any? { |pattern| pattern === extension } }
             if extensions.any?
               stream.puts "  # These are extensions that must be enabled in order to support this database"
               extensions.sort.each do |extension|

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -18,6 +18,12 @@ module ActiveRecord
 
     ##
     # :singleton-method:
+    # A list of extensions which should not be dumped to the schema.
+    # Acceptable values are strings and regexps.
+    cattr_accessor :ignore_extensions, default: []
+
+    ##
+    # :singleton-method:
     # Specify a custom regular expression matching foreign keys which name
     # should not be dumped to db/schema.rb.
     cattr_accessor :fk_ignore_pattern, default: /^fk_rails_[0-9a-f]{10}$/

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -420,6 +420,49 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
     end
 
+    def test_schema_dump_with_string_ignored_extension
+      original_schema_dumper_ignore_extensions = ActiveRecord::SchemaDumper.ignore_extensions
+      ActiveRecord::SchemaDumper.ignore_extensions = ["hstore"]
+
+      connection = ActiveRecord::Base.lease_connection
+
+      connection.stub(:extensions, ["hstore"]) do
+        output = dump_all_table_schema(/./)
+        assert_no_match "# These are extensions that must be enabled", output
+        assert_no_match %r{enable_extension "hstore"}, output
+      end
+
+      connection.stub(:extensions, []) do
+        output = dump_all_table_schema(/./)
+        assert_no_match "# These are extensions that must be enabled", output
+        assert_no_match %r{enable_extension}, output
+      end
+    ensure
+      ActiveRecord::SchemaDumper.ignore_extensions = original_schema_dumper_ignore_extensions
+    end
+
+    def test_schema_dump_with_regexp_ignored_extension
+      original_schema_dumper_ignore_extensions = ActiveRecord::SchemaDumper.ignore_extensions
+      ActiveRecord::SchemaDumper.ignore_extensions = [/hstore/]
+
+      connection = ActiveRecord::Base.lease_connection
+
+      connection.stub(:extensions, ["hstore"]) do
+        output = dump_all_table_schema(/./)
+        assert_no_match "# These are extensions that must be enabled", output
+        assert_no_match %r{enable_extension "hstore"}, output
+      end
+
+      connection.stub(:extensions, []) do
+        output = dump_all_table_schema(/./)
+        assert_no_match "# These are extensions that must be enabled", output
+        assert_no_match %r{enable_extension}, output
+      end
+    ensure
+      ActiveRecord::SchemaDumper.ignore_extensions = original_schema_dumper_ignore_extensions
+    end
+
+
     def test_schema_dump_includes_extensions_in_alphabetic_order
       connection = ActiveRecord::Base.lease_connection
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1741,7 +1741,11 @@ You should run `bin/rails db:migrate` to rebuild your schema.rb if you change th
 
 #### `ActiveRecord::SchemaDumper.ignore_tables`
 
-Accepts an array of tables that should _not_ be included in any generated schema file.
+Accepts an array of tables that should _not_ be included in any generated schema file. Tables to ignore can be specified as Strings or Regexps.
+
+#### `ActiveRecord::SchemaDumper.ignore_extensions`
+
+Accepts an array of extensions that should _not_ be included in any generated schema file. Extensions to ignore can be specified as Strings or Regexps.
 
 #### `ActiveRecord::SchemaDumper.fk_ignore_pattern`
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

there are times when we want to have postgresql extensions running in production but _not_  in development or test. examples are `pg_partman` and `pg_cron` - both of these are useful in production environments but having them listed in `db/schema.rb` causes issues in development (because developers _must_ install them and reconfigure postresql) and in test when running in ci (because we now have to build a custom docker image to run postgresql with these extensions since they don't ship in the standard postgresql docker images). 

we also have this issue when we pull in copies of our production data locally.  we run our production databases in aws aurora and by default it includes extensions that are vendor specific (eg `rds_tools`) which cannot be loaded or run in local environments. if we're running locally with a copy of our production database these extensions will show up in `db/schema.rb`.



### Detail

This Pull Request adds a new `ActiveRecord::SchemaDumper.ignore_extensions` configuration value which is analogous to the existing `ActiveRecord::SchemaDumper.ignore_tables` functionality.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
