### PR TITLE
Replace "Sprockets" with "Propshaft" in Engines Guide

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1316,7 +1316,7 @@ that only exists for your engine. In this case, the host application doesn't
 need to require `admin.css` or `admin.js`. Only the gem's admin layout needs
 these assets. It doesn't make sense for the host app to include
 `"blorgh/admin.css"` in its stylesheets. In this situation, you should
-explicitly define these assets for precompilation.  This tells Sprockets to add
+explicitly define these assets for precompilation.  This tells Propshaft to add
 your engine assets when `bin/rails assets:precompile` is triggered.
 
 You can define assets for precompilation in `engine.rb`:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to reduce possible confusion that someone might have when reading this Engines Guide

### Detail

This PR changes the one mention of  "Sprockets" to "Propshaft" in Engines Guide 

### Additional information

@rails/propshaft has been the default asset pipeline since Rails 8.0:

https://rubyonrails.org/2024/5/31/this-week-in-rails

AFAIK, changing this mention of "Sprockets" to "Propshaft" doesn't change any of the meaning or accuracy of text around it in this guide


---

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
