### PR TITLE
[Fix #55177] Put conditions into where clause instead of join constraints

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -633,4 +633,26 @@
 
     *Kazuma Watanabe*
 
+*   Fix conditions from associations being incorrectly put into join constraints when using left outer join
+
+    ```ruby
+    has_many :hello_posts, -> { where "posts.body = 'hello'" }, class_name: "Post"
+    # ...
+    puts Author.left_outer_joins(:hello_posts).to_sql
+    ```
+
+    Before
+
+    ```SQL
+    SELECT `authors`.* FROM `authors` LEFT OUTER JOIN `posts` ON `posts`.`author_id` = `authors`.`id` AND (posts.body = 'hello')
+    ```
+
+    After
+
+    ```SQL
+    SELECT `authors`.* FROM `authors` LEFT OUTER JOIN `posts` ON `posts`.`author_id` = `authors`.`id` WHERE (posts.body = 'hello')
+    ```
+
+    *endenis*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1494,7 +1494,7 @@ module ActiveRecord
       end
 
       def references_eager_loaded_tables?
-        joined_tables = build_joins([]).flat_map do |join|
+        joined_tables = build_joins.flat_map do |join|
           if join.is_a?(Arel::Nodes::StringJoin)
             tables_in_string(join.left)
           else

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1753,7 +1753,7 @@ module ActiveRecord
       def build_arel(connection, aliases = nil)
         arel = Arel::SelectManager.new(table)
 
-        build_joins(arel.join_sources, aliases)
+        build_joins(arel, aliases)
 
         arel.where(where_clause.ast) unless where_clause.empty?
         arel.having(having_clause.ast) unless having_clause.empty?
@@ -1876,7 +1876,9 @@ module ActiveRecord
         return buckets, Arel::Nodes::InnerJoin
       end
 
-      def build_joins(join_sources, aliases = nil)
+      def build_joins(arel = nil, aliases = nil)
+        join_sources = arel&.join_sources || []
+
         return join_sources if joins_values.empty? && left_outer_joins_values.empty?
 
         buckets, join_type = build_join_buckets
@@ -1891,7 +1893,14 @@ module ActiveRecord
         unless named_joins.empty? && stashed_joins.empty?
           alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)
           join_dependency = construct_join_dependency(named_joins, join_type)
-          join_sources.concat(join_dependency.join_constraints(stashed_joins, alias_tracker, references_values))
+
+          join_dependency.join_constraints(stashed_joins, alias_tracker, references_values).each do |join_data|
+            join_sources.concat(join_data[:joins]) unless join_data[:joins].empty?
+
+            join_data[:where_conditions].each do |where_condition|
+              arel&.where(where_condition) unless where_condition.blank?
+            end
+          end
         end
 
         join_sources.concat(join_nodes) unless join_nodes.empty?

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -101,6 +101,12 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
     assert queries.none? { |sql| /WHERE/i.match?(sql) }
   end
 
+  def test_join_where_conditions_added_to_where_clause
+    queries = capture_sql { Author.left_outer_joins(:hello_posts).to_a }
+    assert queries.any? { |sql| /WHERE.+posts\.body = 'hello'/i.match?(sql) }
+    assert queries.none? { |sql| /posts\.body = 'hello'.+WHERE/i.match?(sql) }
+  end
+
   def test_find_with_sti_join
     scope = Post.left_outer_joins(:special_comments).where(id: posts(:sti_comments).id)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #55177

Right now when using left outer join with associations that have conditions these conditions are incorrectly put into join constraints instead of being put into a where-clause. This can cause wrong results.

Here is an example:

```ruby
class Author  < ActiveRecord::Base
  has_many :hello_posts, -> { where "posts.body = 'hello'" }, class_name: "Post"
end

puts Author.left_outer_joins(:hello_posts).to_sql
```

Before

```SQL
SELECT `authors`.* FROM `authors` LEFT OUTER JOIN `posts` ON `posts`.`author_id` = `authors`.`id` AND (posts.body = 'hello')
```

After

```SQL
SELECT `authors`.* FROM `authors` LEFT OUTER JOIN `posts` ON `posts`.`author_id` = `authors`.`id` WHERE (posts.body = 'hello')
```

### Detail

I have changed the logic of the `join_constraints` method in the `JoinAssociation` class.
It now returns a hash with `{ joins:, where_conditions: }`. This change allows to correctly put conditions into a where-clause.

### Additional information

I've included a changelog entry because this fix changes the behavior a little bit. I can remove it if needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
