### PR TITLE
Fix Action Cable compatibility with redis-rb 5.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,9 +473,9 @@ GEM
     rdoc (6.9.1)
       psych (>= 4.0.0)
     redcarpet (3.6.1)
-    redis (5.3.0)
+    redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.24.0)
+    redis-client (0.25.1)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/55355

Action Cable was depending on a bug of redis-rb, but the bug has now been fixed.

FYI: @yahonda 