### PR TITLE
Add `case_sensitive:` option to `ComparisonValidator`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `case_sensitive:` option for `ActiveModel::Validations::ComparisonValidator` when using `:equal_to` or `:other_than` options.
+
+    ```ruby
+    validates :new_email, comparison: { other_than: :old_email, case_sensitive: false }
+    ```
+
+    *Ryan Townsend*
+
 *   Add `except_on:` option for validation callbacks.
 
     *Ben Sheldon*

--- a/activemodel/test/cases/validations/comparison_validation_test.rb
+++ b/activemodel/test/cases/validations/comparison_validation_test.rb
@@ -117,8 +117,15 @@ class ComparisonValidationTest < ActiveModel::TestCase
   def test_validates_comparison_with_equal_to_using_string
     Topic.validates_comparison_of :approved, equal_to: "cat"
 
-    assert_invalid_values(["dog", "whale"], "must be equal to cat")
+    assert_invalid_values(["dog", "whale", "Cat", "CAT"], "must be equal to cat")
     assert_valid_values(["cat"])
+  end
+
+  def test_validates_comparison_with_case_insensitive_equal_to_using_string
+    Topic.validates_comparison_of :approved, equal_to: "cat", case_sensitive: false
+
+    assert_invalid_values(["dog", "whale"], "must be equal to cat")
+    assert_valid_values(["cat", "Cat", "CAT"])
   end
 
   def test_validates_comparison_with_less_than_using_numeric
@@ -230,6 +237,13 @@ class ComparisonValidationTest < ActiveModel::TestCase
     Topic.validates_comparison_of :approved, other_than: "whale"
 
     assert_invalid_values(["whale"], "must be other than whale")
+    assert_valid_values(["ant", "cat", "dog", "Whale", "WHALE"])
+  end
+
+  def test_validates_comparison_with_case_insensitive_other_than_using_string
+    Topic.validates_comparison_of :approved, other_than: "whale", case_sensitive: false
+
+    assert_invalid_values(["whale", "Whale", "WHALE"], "must be other than whale")
     assert_valid_values(["ant", "cat", "dog"])
   end
 
@@ -309,6 +323,14 @@ class ComparisonValidationTest < ActiveModel::TestCase
       end
     assert_equal "Expected one of :greater_than, :greater_than_or_equal_to, :equal_to," \
                  " :less_than, :less_than_or_equal_to, or :other_than option to be supplied.", error.message
+  end
+
+  def test_validates_comparison_of_case_insensitive_for_non_equal_to_or_other_than_checks
+    [:greater_than, :greater_than_or_equal_to, :less_than, :less_than_or_equal_to].each do |option|
+      assert_raises(ArgumentError) do
+        Topic.validates_comparison_of(:approved, option => "cat", case_sensitive: false)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

I often find I need to compare strings in validation for either equality or 'other than', but I'm comparing to case-insensitive database columns (`citext` in PostgreSQL), but the comparison validator is case-sensitive so I end up having to write my own validation method – introducing a `case_sensitive: false` option means this custom logic can be avoided.

### Detail

This Pull Request changes `ActiveModel::Validations::ComparisonValidator` to allow `:case_sensitive` to be supplied as an option. This option effectively defaults to true, which means the current behaviour is retained unless explicitly opting-in, making it a non-breaking change for existing users of the validator.

An `ArgumentError` is raised when the option is supplied for comparisons other than `:equal_to` or `:other_than`. Technically, the option to perform case-insensitive string comparison with `:greater_than`, `:less_than` etc would be possible, but I don't personally have a use-case for this (and I'd imagine that's exceptionally rare) – happy to implement this in the PR if this is desirable though.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
