### PR TITLE
Fix enum conflict message grammar.

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -383,7 +383,7 @@ module ActiveRecord
 
       ENUM_CONFLICT_MESSAGE = \
         "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
-        "this will generate a %{type} method \"%{method}\", which is already defined " \
+        "this will generate %{type} method \"%{method}\", which is already defined " \
         "by %{source}."
       private_constant :ENUM_CONFLICT_MESSAGE
 
@@ -405,10 +405,18 @@ module ActiveRecord
         raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
           enum: enum_name,
           klass: name,
-          type: type,
+          type: type_sentence(type),
           method: method_name,
           source: source
         }
+      end
+
+      def type_sentence(type)
+        case type
+        when "instance" then "an #{type}"
+        when "class"    then "a #{type}"
+        else "a"
+        end
       end
 
       def detect_negative_enum_conditions!(method_names)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -584,6 +584,22 @@ class EnumTest < ActiveRecord::TestCase
     end
   end
 
+  test "conflict message grammar" do
+    conflicts = {
+      column: /will generate a class method/,
+      logger: /will generate an instance method/,
+    }
+
+    conflicts.each do |name, pattern|
+      assert_raises(ArgumentError, match: pattern) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "books"
+          enum name, [:value]
+        end
+      end
+    end
+  end
+
   test "overriding enum method should not raise" do
     assert_nothing_raised do
       Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
Format the error message so that the correct article is used according to the method type (e.g. "an instance method", "a class method").

~Fallback to omitting the method type altogether if unknown, producing the generic wording "a method".~

Fixes #55364

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the grammar in the enum conflict message is slightly off.

### Detail

This Pull Request changes how the message is formatted to fix the grammar issue.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
