### PR TITLE
Emit a warning when `pg` gem < 1.6.0 is used with PostgreSQL 18+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Emit a warning for pg gem < 1.6.0 when using PostgreSQL 18+
+
+    *Yasuo Honda*
+
 *   Fix `#merge` with `#or` or `#and` and a mixture of attributes and SQL strings resulting in an incorrect query.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -666,6 +666,9 @@ module ActiveRecord
         if database_version < 9_03_00 # < 9.3
           raise "Your version of PostgreSQL (#{database_version}) is too old. Active Record supports PostgreSQL >= 9.3."
         end
+        if database_version >= 18_00_00 && Gem::Version.new(PG::VERSION) < Gem::Version.new("1.6.0")
+          warn "pg gem version #{PG::VERSION} is known to be incompatible with PostgreSQL 18+. Please upgrade to pg 1.6.0 or later."
+        end
       end
 
       class << self

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -181,6 +181,9 @@ module ActiveRecord
     end
 
     test "raises Interrupt when canceling statement via interrupt" do
+      if ActiveRecord::Base.lease_connection.database_version >= 18_00_00 && Gem::Version.new(PG::VERSION) < Gem::Version.new("1.6.0")
+        skip "pg gem version #{PG::VERSION} is known to be incompatible with PostgreSQL 18+. "
+      end
       start_time = Time.now
       thread = Thread.new do
         Sample.transaction do


### PR DESCRIPTION
Split from https://github.com/rails/rails/pull/55282

### Motivation / Background
This commit emits a warning when `pg` gem < 1.6.0 is used with PostgreSQL 18+ to prevent compatibility issues of PG::Connection#cancel.

### Detail
PostgreSQL 18 (scheduled for release around September/October 2025) changes the format of the cancel request key , which causes PG::Connection#cancel to fail with pg gem 1.5.9 and below. This issue is already addressed in https://github.com/ged/ruby-pg/pull/614 and the fix is included in pg gem v1.6.0 (currently released as v1.6.0.rc2).

Instead of requiring pg gem 1.6+ for all users when raising minimum supported PostgreSQL version to 10 discussed at https://github.com/rails/rails/pull/55282 , warnings are only shown to PostgreSQL 18+ + pg gem ≤ 1.5.9 users actually affected by the PG::Connection#cancel behavior.

### Additional information
Also skip the failing test if pg gem version < 1.6.0 and PostgreSQL version is 18+.

```ruby
$ bundle info pg
  * pg (1.5.9)
    Summary: Pg is the Ruby interface to the PostgreSQL RDBMS
    Homepage: https://github.com/ged/ruby-pg
    Documentation: http://deveiate.org/code/pg
    Source Code: https://github.com/ged/ruby-pg
    Changelog: https://github.com/ged/ruby-pg/blob/master/History.md
    Path: /home/yahonda/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/pg-1.5.9
    Reverse Dependencies:
        queue_classic (4.0.0) depends on pg (>= 1.1, < 2.0)
$
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/transaction_test.rb -n test_raises_Interrupt_when_canceling_statement_via_interrupt
Using postgresql
Run options: -n test_raises_Interrupt_when_canceling_statement_via_interrupt --seed 17678

F

Failure:
ActiveRecord::PostgresqlTransactionTest#test_raises_Interrupt_when_canceling_statement_via_interrupt [test/cases/adapters/postgresql/transaction_test.rb:199]:
Expected 10.014372003 to be < 5.

bin/test test/cases/adapters/postgresql/transaction_test.rb:183

Finished in 10.067954s, 0.0993 runs/s, 0.1987 assertions/s.
1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
