### PR TITLE
[skip ci] Fix typo GuestCleanupJob in Bulk Enqueuing section

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -747,24 +747,24 @@ jobs as arguments (note that this is different from `perform_later`).
 `perform_all_later` does call `perform` under the hood. The arguments passed to
 `new` will be passed on to `perform` when it's eventually called.
 
-Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
+Here is an example calling `perform_all_later` with `GuestsCleanupJob` instances:
 
 ```ruby
 # Create jobs to pass to `perform_all_later`.
 # The arguments to `new` are passed on to `perform`
-guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest) }
+cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest) }
 
-# Will enqueue a separate job for each instance of `GuestCleanupJob`
-ActiveJob.perform_all_later(guest_cleanup_jobs)
+# Will enqueue a separate job for each instance of `GuestsCleanupJob`
+ActiveJob.perform_all_later(cleanup_jobs)
 
 # Can also use `set` method to configure options before bulk enqueuing jobs.
-guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest).set(wait: 1.day) }
+cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest).set(wait: 1.day) }
 
-ActiveJob.perform_all_later(guest_cleanup_jobs)
+ActiveJob.perform_all_later(cleanup_jobs)
 ```
 
 `perform_all_later` logs the number of jobs successfully enqueued, for example
-if `Guest.all.map` above resulted in 3 `guest_cleanup_jobs`, it would log
+if `Guest.all.map` above resulted in 3 `cleanup_jobs`, it would log
 `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` (assuming all were enqueued).
 
 The return value of `perform_all_later` is `nil`. Note that this is different


### PR DESCRIPTION
The job name throughout the tutorial is with plural "Guests" not "Guest" so we make it consistent here. Also updates the variable names to just `cleanup_jobs` for readability and consistency.

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because there was a mismatch in the job name in the "Bulk Enqueuing" section of the "Active Job Basics" tutorial.

### Detail

This Pull Request changes an example in Active Job documentation to refer to the same job as the rest of the document.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
