### PR TITLE
Re-add `Range#overlap?` documentation

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/overlap.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlap.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Range
-  # Compare two ranges and see if they overlap each other
-  #  (1..5).overlap?(4..6) # => true
-  #  (1..5).overlap?(7..9) # => false
   unless Range.method_defined?(:overlap?) # Ruby 3.3+
+    # Compare two ranges and see if they overlap each other
+    #  (1..5).overlap?(4..6) # => true
+    #  (1..5).overlap?(7..9) # => false
     def overlap?(other)
       raise TypeError unless other.is_a? Range
 


### PR DESCRIPTION
When `Range#overlap?` started being defined only when Ruby itself doesn't define it, the documentation wasn't wrapped in the conditional, making RDoc not link the documentation to the defined method.

This commit fixes it by moving the documentation inside the conditional.

[ci skip]