### PR TITLE
Fix key collision bug in HashWithIndifferentAccess#transform_keys

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -360,17 +360,17 @@ module ActiveSupport
 
     def transform_keys!(hash = NOT_GIVEN, &block)
       return to_enum(:transform_keys!) if NOT_GIVEN.equal?(hash) && !block_given?
+      return super if hash.nil?
 
-      if hash.nil?
-        super
-      elsif NOT_GIVEN.equal?(hash)
-        keys.each { |key| self[yield(key)] = delete(key) }
-      elsif block_given?
-        keys.each { |key| self[hash[key] || yield(key)] = delete(key) }
-      else
-        keys.each { |key| self[hash[key] || key] = delete(key) }
-      end
-
+      new_keys =
+        if NOT_GIVEN.equal?(hash)
+          keys.map(&block)
+        elsif block_given?
+          keys.map { |key| hash[key] || yield(key) }
+        else
+          keys.map { |key| hash[key] || key }
+        end
+      replace(new_keys.zip(values).to_h)
       self
     end
 

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -473,6 +473,16 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal(["A", "bbb"], hash.keys) # asserting that order of keys is unchanged
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
 
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@integers).transform_keys { |k| k + 1 }
+
+    assert_equal([1, 2], hash.keys)
+
+    repeating_strings = { "a" => 1, "aa" => 2, "aaa" => 3 }
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(repeating_strings).transform_keys { |k| "#{k}a" }
+
+    assert_equal(%w[aa aaa aaaa], hash.keys)
+
     assert_raise TypeError do
       hash.transform_keys(nil)
     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `HashWithIndifferentAccess#transform_keys` contains a bug that can cause key collisions.

### Detail

This Pull Request changes the implementation of `HashWithIndifferentAccess#transform_keys` to transform all keys in one atomic action instead of altering each one per-iteration.

### Additional information

#### Example with Symbol Keys:

Where Hash will give you this:

```ruby
sym_hash = { a: "one", aa: "two", aaa: "three", aaaa: "four" }
sym_hash.transform_keys { |k| "#{k}a".to_sym }
  #=> {:aa=>"one", :aaa=>"two", :aaaa=>"three", :aaaaa=>"four"}
```

Whereas, HashWithIndifferentAccess was returning this:

```ruby
sym_hwia.transform_keys { |k| "#{k}a".to_sym }
  #=> {"aaaaa"=>"one"}
```

#### Example with Integer Keys:

Where Hash will give you this:

```ruby
int_hash = {2=>"A", 3=>"B", 4=>"C", 5=>"D"}
int_hash.transform_keys { |k| k + 1 }
  #=> {3=>"A", 4=>"B", 5=>"C", 6=>"D"}
```

Whereas, HashWithIndifferentAccess was returning this:

```ruby
int_hwia.transform_keys { |k| k + 1 }
  #=> {6=>"A"}
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.