### PR TITLE
Raise explicit error on null byte in SQLite string quoting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -64,6 +64,9 @@ module ActiveRecord
         end
 
         def quote_string(s)
+          if s.include?("\x00")
+            raise ArgumentError, "string contains null byte"
+          end
           ::SQLite3::Database.quote(s)
         end
 

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -14,6 +14,13 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
     assert_equal "''", @conn.quote_string("'")
   end
 
+  def test_quote_string_with_null_byte_raises
+    error = assert_raises(ArgumentError) do
+      @conn.quote_string("foo\x00bar")
+    end
+    assert_match(/null byte/, error.message)
+  end
+
   def test_quote_column_name
     [@conn, @conn.class].each do |adapter|
       assert_equal '"foo"', adapter.quote_column_name("foo")


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes a long-standing bug in the SQLite adapter where inserting strings containing a NUL (`\0`) byte would result in a confusing SQL error like:

SQLite3::SQLException: unrecognized token: "'jes"

The underlying issue was that SQLite does not support NUL bytes in quoted strings, and Rails did not validate this before generating SQL.

Fixes [#947](https://github.com/rails/rails/issues/947) (original issue that was closed)  
Closes [#55373](https://github.com/rails/rails/issues/55373) (new issue created)

---

### Detail

This PR updates `quote_string` in the SQLite3 adapter to raise an explicit `ArgumentError` if a string contains a null byte (`\x00`), avoiding a confusing syntax error at the database level.

A regression test was added in `activerecord/test/cases/adapters/sqlite3/quoting_test.rb` to ensure this behavior is maintained.

Example now raises:

```ruby
3.4.5 :001 > TestModel.create!(foo:"jes\0test")
(jestest):1:in '<main>': string contains null byte (ArgumentError)

            raise ArgumentError, "string contains null byte"
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Detail
This Pull Request changes the `quote_string` method in the SQLite3 adapter to explicitly raise an `ArgumentError` when a null byte (`\x00`) is present in a string. This prevents SQLite from attempting to parse an invalid query and raising a vague `unrecognized token` error.

A corresponding regression test has been added in `quoting_test.rb` to ensure this behavior remains enforced.

### Additional information
This behavior aligns with how Rails already handles other invalid string inputs, such as bad UTF-8 sequences. By failing fast with an `ArgumentError`, it improves developer experience and avoids low-level, cryptic SQLite errors.

This issue was previously discussed in [#947](https://github.com/rails/rails/issues/947), but could not be reopened. A new issue has been created and linked (see #50507). This change ensures better consistency across adapters in how invalid data is handled before reaching the database.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
