### PR TITLE
Make `ActiveSupport::Gzip.compress` deterministic

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Make `ActiveSupport::Gzip.compress` deterministic based on input.
+
+    `ActiveSupport::Gzip.compress` used to include a timestamp in the output,
+    causing consecutive calls with the same input data to have different output
+    if called during different seconds. It now always sets the timestamp to `0`
+    so that the output is identical for any given input.
+
+    *Rob Brackett*
+
 *   Given an array of `Thread::Backtrace::Location` objects, the new method
     `ActiveSupport::BacktraceCleaner#clean_locations` returns an array with the
     clean ones:

--- a/activesupport/lib/active_support/gzip.rb
+++ b/activesupport/lib/active_support/gzip.rb
@@ -32,6 +32,7 @@ module ActiveSupport
     def self.compress(source, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY)
       output = Stream.new
       gz = Zlib::GzipWriter.new(output, level, strategy)
+      gz.mtime = 0
       gz.write(source)
       gz.close
       output.string

--- a/activesupport/test/gzip_test.rb
+++ b/activesupport/test/gzip_test.rb
@@ -42,4 +42,9 @@ class GzipTest < ActiveSupport::TestCase
       ActiveSupport::Gzip.decompress(compressed)
     end
   end
+
+  def test_sets_mtime_to_zero
+    compressed = ActiveSupport::Gzip.compress("Hello World")
+    assert_equal Time.at(0), Zlib::GzipReader.new(StringIO.new(compressed)).mtime
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This makes `ActiveSupport::Gzip.compress` always set the output gzipped data’s last modified timestamp to `0`.

I have some tests of code that uses `ActiveSupport::Gzip.compress` that have been flaky for a long time, and recently discovered this is because the output of that method includes the timestamp of when it was compressed. If two calls with the same input happen during different seconds, then you get different output (so, in my flaky tests, they fail to compare correctly).

One solution for those flaky tests is to decompress the result and assert that the result is what was expected, but it occurred to me that most folks might be like me and expect this helper to deterministically output the same thing for any given input, so that’s what I’ve done here. Not doing so might be subtly breaking various caching mechanisms for a lot of apps (for example, when investigating the issue, one of the first results I found on the web was [a post about someone encountering the same problem in Python](https://dramsch.net/today-i-learned/gzip/today-i-learned-about-deterministic-gzip-compression/)). Other parts of Rails itself have dealt with similar problems by doing the same thing internally (#49166).

### Detail

Since `ActiveSupport::Gzip.compress` is mainly meant as a simple shortcut for Rails users (it doesn’t seem to be used internally), I thought it would be appropriate to simply make it set the timestamp to `0`.

However, that *could* cause subtle breakage for users who are relying on the current timestamp behavior. **I’m happy to make this an option instead** (defaulting off if boolean or to the current time if a timestamp) if that’s a problem or if folks think that this should just be configurable in general.

(Relatedly, Gzip headers can also carry an optional filename — `orig_name` in Ruby Zlib. If `mtime` should be exposed as an option here, it might make sense to expose that, too.)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
