### PR TITLE
Avoid dynamic encrypting in generated fixtures

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Generate static BCrypt password digests in fixtures instead of dynamic ERB expressions.
+
+    Previously, fixtures with password digest attributes used `<%= BCrypt::Password.create("secret") %>`,
+    which regenerated the hash on each test run. Now generates a static hash with a comment
+    showing how to recreate it.
+
+    *Nate Smith*, *Cassia Scheffer*
+
 *   Broaden the `.gitignore` entry when adding a credentials key to ignore all key files.
 
     *Greg Molnar*

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
@@ -4,7 +4,7 @@
 <%= name %>:
 <% attributes.each do |attribute| -%>
   <%- if attribute.password_digest? -%>
-  password_digest: <%%= BCrypt::Password.create("secret") %>
+  password_digest: <%= BCrypt::Password.create("secret") %>  # Generated with BCrypt::Password.create("secret")
   <%- elsif attribute.reference? -%>
   <%= yaml_key_value(attribute.column_name.delete_suffix("_id"), attribute.default || name) %>
   <%- elsif !attribute.virtual? -%>

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -3,6 +3,7 @@
 require "plugin_helpers"
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
+require "bcrypt"
 
 class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include PluginHelpers
@@ -564,7 +565,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "test/fixtures/users.yml" do |content|
-      assert_match(/password_digest: <%= BCrypt::Password.create\("secret"\) %>/, content)
+      assert_match(/password_digest: (.+)$/, content)
+      digest = content.match(/password_digest: ([^#\s]+)/)[1].strip
+      assert BCrypt::Password.new(digest) == "secret"
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

The current fixture generation for password attributes uses dynamic BCrypt encryption with ERB tags (`<%= BCrypt::Password.create("secret") %>`), which causes fixtures to regenerate different encrypted values each time they're loaded. 

### Detail

This Pull Request changes the fixture generation template to:
- Generate the BCrypt password hash once at fixture creation time instead of dynamically during each test run
- Add a comment showing how the encrypted value was generated (`# Generated with BCrypt::Password.create("secret")`)
- Update the corresponding test to verify that the generated fixture contains a valid BCrypt hash

### Additional information

The change affects the Rails generator template for model fixtures when using `has_secure_password` or similar password digest attributes. This is a minor improvement to the developer experience and test performance.

### Checklist

Before submitting the PR, make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
