### PR TITLE
Respect `schema_search_path` on `rails dbconsole` for Postgres

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Respect `schema_search_path` on `rails dbconsole` for PostgreSQL.
+
+    *Gabriel Sobrinho*
+
 *   Preserve IPv6 prefix when dumping PostgreSQL `cidr` / `inet` defaults to `schema.rb`.
 
     The schema dumper used to omit the prefix whenever it equaled `/32`, which

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -71,7 +71,7 @@ module ActiveRecord
         end
 
         def dbconsole(config, options = {})
-          pg_config = config.configuration_hash
+          pg_config = config.configuration_hash.deep_dup
 
           ENV["PGUSER"]         = pg_config[:username] if pg_config[:username]
           ENV["PGHOST"]         = pg_config[:host] if pg_config[:host]
@@ -81,6 +81,11 @@ module ActiveRecord
           ENV["PGSSLCERT"]      = pg_config[:sslcert].to_s if pg_config[:sslcert]
           ENV["PGSSLKEY"]       = pg_config[:sslkey].to_s if pg_config[:sslkey]
           ENV["PGSSLROOTCERT"]  = pg_config[:sslrootcert].to_s if pg_config[:sslrootcert]
+
+          if pg_config[:schema_search_path]
+            pg_config[:variables] ||= {}
+            pg_config[:variables][:search_path] ||= pg_config[:schema_search_path]
+          end
           if pg_config[:variables]
             ENV["PGOPTIONS"] = pg_config[:variables].filter_map do |name, value|
               "-c #{name}=#{value.to_s.gsub(/[ \\]/, '\\\\\0')}" unless value == ":default" || value == :default

--- a/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
@@ -82,6 +82,36 @@ module ActiveRecord
         assert_equal "-c search_path=my_schema,\\ default,\\ \\\\my_schema -c statement_timeout=5000", ENV["PGOPTIONS"]
       end
 
+      def test_postgresql_include_schema_search_path
+        config = make_db_config(adapter: "postgresql", database: "db", schema_search_path: "my_schema, default, \\my_schema")
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+
+        assert_equal "-c search_path=my_schema,\\ default,\\ \\\\my_schema", ENV["PGOPTIONS"]
+      end
+
+      def test_postgresql_include_variables_and_schema_search_path
+        config = make_db_config(adapter: "postgresql", database: "db", schema_search_path: "my_schema, default, \\my_schema", variables: { statement_timeout: 5000, lock_timeout: ":default" })
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+
+        assert_equal "-c statement_timeout=5000 -c search_path=my_schema,\\ default,\\ \\\\my_schema", ENV["PGOPTIONS"]
+      end
+
+      def test_postgresql_include_variables_search_path_override
+        config = make_db_config(adapter: "postgresql", database: "db", schema_search_path: "dummy", variables: { search_path: "my_schema, default, \\my_schema", statement_timeout: 5000, lock_timeout: ":default" })
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+
+        assert_equal "-c search_path=my_schema,\\ default,\\ \\\\my_schema -c statement_timeout=5000", ENV["PGOPTIONS"]
+      end
+
       def test_postgresql_can_use_alternative_cli
         ActiveRecord.database_cli[:postgresql] = "pgcli"
         config = make_db_config(adapter: "postgresql", database: "db")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I want `rails dbconsole` to respect the `schema_search_path` from `config/database.yml`.

### Detail

This Pull Request will add the `search_path` to `PGOPTIONS` when set before calling `psql`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
This will keep parity between the `psql` connection and the connection used by the rails app.

If you have a custom search path set to lets say `myschema`, the application will be running with that search path but `rails dbconsole` will open with search path as `$user,public` instead.

So to workaround you have to remember to call `SET search_path TO myschema` on the psql session to have the same connection configuration.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
