### PR TITLE
Log when rescue_from handles an exception

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Log when `rescue_from` handles an error.
+
+    During development it's useful to know when `a rescue_from` handler
+    rescues an exception; and where the exception was first raised. This
+    behaviour is similar to the existing log entry for "Filter chain halted as
+    :before_action rendered or redirected".
+
+    *Steven Webb*
+
 *   Make `ActiveSupport::Gzip.compress` deterministic based on input.
 
     `ActiveSupport::Gzip.compress` used to include a timestamp in the output,

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -92,6 +92,7 @@ module ActiveSupport
 
         if handler = handler_for_rescue(exception, object: object)
           handler.call exception
+          logger.info("rescue_from handled exception #{exception.class} (#{exception.message}) - #{exception.backtrace.first}")
           exception
         elsif exception
           if visited_exceptions.include?(exception.cause)

--- a/activesupport/test/rescuable_test.rb
+++ b/activesupport/test/rescuable_test.rb
@@ -107,6 +107,14 @@ class Stargate
   def sos_first
     @result = "sos_first"
   end
+
+  def self.logger_buffer
+    @buffer ||= StringIO.new
+  end
+
+  def self.logger
+    @logger ||= ActiveSupport::Logger.new(logger_buffer)
+  end
 end
 
 class CoolStargate < Stargate
@@ -172,5 +180,11 @@ class RescuableTest < ActiveSupport::TestCase
   def test_rescue_handles_loops_in_exception_cause_chain
     @stargate.dispatch :looped_crash
     assert_equal "unhandled", @stargate.result
+  end
+
+  def test_rescue_from_logs_info
+    Stargate.logger_buffer.truncate(0)
+    @stargate.dispatch :attack
+    assert_match(/rescue_from handled exception/, Stargate.logger_buffer.string)
   end
 end


### PR DESCRIPTION
### Motivation / Background

In development when a `before_action` renders or redirects this error message appears on the logs:

> Filter chain halted as :before_action rendered or redirected

I find this message very helpful. However, if a before_action raises an error that is handled by a rescue_from block, nothing is logged indicating an error occurred.

[Original proposal](https://discuss.rubyonrails.org/t/feature-proposal-log-when-before-action-raises-an-exception/89414)

### Detail

This PR adds a log message indicating an exception was rescued, and displays where it was originally raised. For example:

> rescue_from handled exception HomeController::MyError (Oh no!) -
>   /home/vscode/my-test-app/app/controllers/home_controller.rb:15:in
>   'HomeController#authenticate'

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
