### PR TITLE
Introduce Hash#deep_compact to core_ext

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_compact.rb
@@ -1,6 +1,10 @@
 class Hash
-  def deep_compact(remove_blank: false)
-    dup.deep_compact!(remove_blank: remove_blank)
+  def deep_compact
+    dup.deep_compact!
+  end
+
+  def deep_compact_blank
+    dup.deep_compact!(remove_blank: true)
   end
 
   def deep_compact!(remove_blank: false)

--- a/activesupport/lib/active_support/core_ext/hash/deep_compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_compact.rb
@@ -1,0 +1,49 @@
+class Hash
+  def deep_compact(blank: false)
+    dup.deep_compact!(blank: blank)
+  end
+
+  def deep_compact!(blank: false)
+    each_key do |k|
+      v = self[k]
+
+      case v
+      when Hash
+        v.deep_compact!(blank: blank)
+        delete(k) if blank ? v.blank? : v.nil?
+      when Array
+        v.map! do |elem|
+          if elem.is_a?(Hash)
+            elem.deep_compact!(blank: blank)
+            elem
+          elsif elem.is_a?(Array)
+            deep_compact_array(elem, blank)
+          else
+            elem
+          end
+        end
+        v.reject! { |elem| blank ? elem.blank? : elem.nil? }
+        delete(k) if blank ? v.blank? : v.nil?
+      else
+        delete(k) if blank ? v.blank? : v.nil?
+      end
+    end
+    self
+  end
+
+  private
+
+  def deep_compact_array(arr, blank)
+    arr.map! do |elem|
+      if elem.is_a?(Hash)
+        elem.deep_compact!(blank: blank)
+      elsif elem.is_a?(Array)
+        deep_compact_array(elem, blank)
+      else
+        elem
+      end
+    end
+    arr.reject! { |elem| blank ? elem.blank? : elem.nil? }
+    arr
+  end
+end

--- a/activesupport/test/deep_compact_test.rb
+++ b/activesupport/test/deep_compact_test.rb
@@ -8,7 +8,6 @@ class DeepCompactTest < ActiveSupport::TestCase
     h = { a: 1, b: nil, c: { d: nil, e: 2 }, f: [1, nil, { g: nil, h: 3 }] }
     expected = { a: 1, c: { e: 2 }, f: [1, { h: 3 }] }
     assert_equal expected, h.deep_compact
-    # original unchanged
     assert h.key?(:b)
   end
 
@@ -20,7 +19,7 @@ class DeepCompactTest < ActiveSupport::TestCase
 
   test "blank: true removes blank values" do
     h = { a: "", b: " ", c: [], d: {}, e: 0 }
-    assert_equal({ e: 0 }, h.deep_compact(blank: true))
+    assert_equal({ e: 0 }, h.deep_compact(remove_blank: true))
   end
 
   test "handles nested arrays of arrays" do

--- a/activesupport/test/deep_compact_test.rb
+++ b/activesupport/test/deep_compact_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/core_ext/hash/deep_compact"
+
+class DeepCompactTest < ActiveSupport::TestCase
+  test "removes nils recursively" do
+    h = { a: 1, b: nil, c: { d: nil, e: 2 }, f: [1, nil, { g: nil, h: 3 }] }
+    expected = { a: 1, c: { e: 2 }, f: [1, { h: 3 }] }
+    assert_equal expected, h.deep_compact
+    # original unchanged
+    assert h.key?(:b)
+  end
+
+  test "bang version mutates" do
+    h = { a: nil, b: { c: nil, d: 1 } }
+    h.deep_compact!
+    assert_equal({ b: { d: 1 } }, h)
+  end
+
+  test "blank: true removes blank values" do
+    h = { a: "", b: " ", c: [], d: {}, e: 0 }
+    assert_equal({ e: 0 }, h.deep_compact(blank: true))
+  end
+
+  test "handles nested arrays of arrays" do
+    h = { x: [[nil, 1], [nil, [2, nil]]] }
+    assert_equal({ x: [[1], [ [2] ]] }, h.deep_compact)
+  end
+
+  test "leaves empty collections (decision)" do
+    h = { x: { y: nil } }
+    assert_equal({ x: {} }, h.deep_compact)
+  end
+end

--- a/activesupport/test/deep_compact_test.rb
+++ b/activesupport/test/deep_compact_test.rb
@@ -19,7 +19,7 @@ class DeepCompactTest < ActiveSupport::TestCase
 
   test "blank: true removes blank values" do
     h = { a: "", b: " ", c: [], d: {}, e: 0 }
-    assert_equal({ e: 0 }, h.deep_compact(remove_blank: true))
+    assert_equal({ e: 0 }, h.deep_compact_blank)
   end
 
   test "handles nested arrays of arrays" do


### PR DESCRIPTION
### Summary

Introduce `Hash#deep_compact` (non‑destructive) and `Hash#deep_compact!` (destructive) to recursively remove nil (and optionally blank) values from nested hashes and arrays.

Usage
```ruby
h = { a: 1, b: nil, c: { d: nil, e: 2 }, f: [1, nil, { g: nil, h: 3 }] }
h.deep_compact
# => { a: 1, c: { e: 2 }, f: [1, { h: 3 }] }

h.deep_compact(blank: true)
# removes blank? values (""/[], {}) as well
```

API
```ruby
Hash#deep_compact(blank: false)  -> new_hash
Hash#deep_compact!(blank: false) -> self
```


Motivation

- Common need when preparing JSON/API payloads or normalizing params.
- Rails ships Hash#compact, but not a recursive variant; everyone rewrites this.
- Aligns with other deep helpers (deep_transform_keys, deep_merge) in ActiveSupport.
