### PR TITLE
Preserve one space between elements when converting to plaintext

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Preserve one space between elements when converting to plain text.
+
+    Line breaks between text and inline elements (like `<a>` tags) are now
+    squeezed to a single space instead of being removed, ensuring proper
+    spacing in the plaintext output.
+
+    *Steve Hoeksema*
+
 *   Attachment upload progress accounts for server processing time.
 
     *Jeremy Daer*

--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -57,8 +57,22 @@ module ActionText
         "\n"
       end
 
+      # If this text node has trailing whitespace and a next sibling that's an element,
+      # convert trailing whitespace (including multiple newlines) to a single space
+      # to preserve spacing between inline elements.
+      # But only if the previous sibling doesn't exist (first child) or is not skippable.
       def plain_text_for_text_node(node, index)
-        remove_trailing_newlines(node.text)
+        text = node.text
+        if text.match?(/\s+\z/) && node.next_sibling && !node.next_sibling.text?
+          prev_sibling = node.previous_sibling
+          if !prev_sibling || !skippable?(prev_sibling)
+            text.sub(/\s+\z/, " ")
+          else
+            remove_trailing_newlines(text)
+          end
+        else
+          remove_trailing_newlines(text)
+        end
       end
 
       def plain_text_for_div_node(node, index)

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -137,6 +137,17 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "squeezes line breaks and other whitespace to a single space between inline elements" do
+    assert_converted_to(
+      "Visit my website at example.com",
+      <<~HTML
+        Visit my website at
+
+        <a href="example.com">example.com</a>
+      HTML
+    )
+  end
+
   test "preserves trailing linebreaks after text" do
     assert_converted_to(
       "Hello\nHow are you?",


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because inline elements on multiple lines were smooshed together when converted to plain text.

### Detail

An HTML fragment like

    Visit my website at
    <a href="example.com">example.com</a>

will now be converted to

    Visit my website at example.com

instead of

    Visit my website atexample.com

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
