### PR TITLE
Remove unnecessary configuration mutation in Active Storage and Active Support railties

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -174,9 +174,9 @@ module ActiveStorage
       end
     end
 
-    initializer "active_storage.services" do
+    initializer "active_storage.services" do |app|
       ActiveSupport.on_load(:active_storage_blob) do
-        configs = Rails.configuration.active_storage.service_configurations ||=
+        configs = app.config.active_storage.service_configurations ||=
           begin
             config_file = Rails.root.join("config/storage/#{Rails.env}.yml")
             config_file = Rails.root.join("config/storage.yml") unless config_file.exist?
@@ -187,7 +187,7 @@ module ActiveStorage
 
         ActiveStorage::Blob.services = ActiveStorage::Service::Registry.new(configs)
 
-        if config_choice = Rails.configuration.active_storage.service
+        if config_choice = app.config.active_storage.service
           ActiveStorage::Blob.service = ActiveStorage::Blob.services.fetch(config_choice)
         end
       end
@@ -209,7 +209,7 @@ module ActiveStorage
     initializer "action_view.configuration" do
       config.after_initialize do |app|
         ActiveSupport.on_load(:action_view) do
-          multiple_file_field_include_hidden = app.config.active_storage.delete(:multiple_file_field_include_hidden)
+          multiple_file_field_include_hidden = app.config.active_storage.multiple_file_field_include_hidden
 
           unless multiple_file_field_include_hidden.nil?
             ActionView::Helpers::FormHelper.multiple_file_field_include_hidden = multiple_file_field_include_hidden

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -15,7 +15,7 @@ module ActiveSupport
 
     initializer "active_support.isolation_level" do |app|
       config.after_initialize do
-        if level = app.config.active_support.delete(:isolation_level)
+        if level = app.config.active_support.isolation_level
           ActiveSupport::IsolatedExecutionState.isolation_level = level
         end
       end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This is a follow-up to #55347, in which I'm removing a few other places where `delete` is used unnecessarily to mutate Rails configuration.

### Detail

Only two Rails components _need_ to mutate their configuration: Action View and Action Mailer. They must mutate their configuration because they both have a pattern where the configuration hash is mass-assigned to their `Base` objects, so any key without a matching setter on the class blows up.

In Action View:

https://github.com/rails/rails/blob/a9390062424dd77bd4542a6426fcfcfad2369cb4/actionview/lib/action_view/railtie.rb#L80-L86

In Action Mailer:

https://github.com/rails/rails/blob/a9390062424dd77bd4542a6426fcfcfad2369cb4/actionmailer/lib/action_mailer/railtie.rb#L62-L62

I'll speculate that contributors pattern-match against these files and so sometimes use `delete` to grab values from configuration even when it's unnecessary. And then that spreads around as a pattern.

I personally find this pattern of mutating configuration values to be surprising---this adventure is partially motivated by history with Action Mailer ("I swear I set that!"). So I'd love if valid setters were instead allow-listed and indexed from the config rather than non-setter values being deleted from the config. One step at a time.  

**AND** While looking at Active Storage's engine, I noticed it uses the global `Rails.configuration...` instead of the locally scoped `app.config...` so I tweaked that.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
