### PR TITLE
Add support for plain button rendering using button_to with form: false

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -411,6 +411,41 @@ class UrlHelperTest < ActiveSupport::TestCase
     end
   end
 
+  def test_button_to_with_form_false_sets_type_button
+    assert_dom_equal(
+      %(<button type="button">Click</button>),
+      button_to("Click", "/somewhere", form: false)
+    )
+  end
+
+  def test_button_to_with_form_false_renders_button_with_class
+    assert_dom_equal(
+      %(<button type="button" class="btn">Save</button>),
+      button_to("Save", "/save", form: false, class: "btn")
+    )
+  end
+
+  def test_button_to_with_form_false_and_method_raises
+    error = assert_raises(ArgumentError) do
+      button_to("Delete", "/delete", form: false, method: :delete)
+    end
+    assert_match "Cannot use :method option when form: false is passed", error.message
+  end
+
+  def test_button_to_with_form_false_and_submit_type_raises
+    error = assert_raises(ArgumentError) do
+      button_to("Click", "/nowhere", form: false, type: :submit)
+    end
+    assert_match "Cannot use type: 'submit' when form: false is passed", error.message
+  end
+
+  def test_button_to_with_form_false_and_submit_type_as_string_raises
+    error = assert_raises(ArgumentError) do
+      button_to("Click", "/nowhere", form: false, type: "submit")
+    end
+    assert_match "Cannot use type: 'submit' when form: false is passed", error.message
+  end
+
   class FakeParams
     def initialize(permitted = true)
       @permitted = permitted


### PR DESCRIPTION
## Summary

This PR adds support for passing `form: false` attribute in button_to to render a plain `<button>` without generating a form: 

`<%= button_to "Delete", "#", form: false %>`

## Motivation / Background

I ran into while working to convert my app to use [Shopify Polaris Web Components](https://shopify.dev/docs/api/app-home/using-polaris-components) inside a Rails application. Shopify’s UI system expects buttons to be rendered as plain `<button>` tags in certain places and their JavaScript APIs are designed to interact with button elements only in those areas.

While [button_tag](https://api.rubyonrails.org/v8.0/classes/ActionView/Helpers/FormTagHelper.html#method-i-button_tag) exists, replacing button_to with it often requires additional refactoring.

For example if i want to convert this code into a plain button:

`<%= button_to "Delete", post_path(post), method: :delete, data: { turbo_confirm: "Are you sure?" } %>`

with form false i could simply do 

`<%= button_to "Delete", form: false, post_path(post), method: :delete, data: { turbo_confirm: "Are you sure?" } %>`

But now using button tag i also need to add type: button:

`
<%= button_tag "Delete", type: "button", data: { action: "click->posts#destroy" } %>`

This makes the conversion more verbose and mechanical than it needs to be. Supporting `form: false` provides a more intuitive and streamlined way to disable form behavior while keeping the same button_to interface.

If I ever need to revert away from Polaris Web Components, I would otherwise have to refactor all button tags back to use button_to. With this approach, I can simply remove `form: false` and regain the original behavior without changing helpers or rewriting templates.

If this is perceived as a reasonable addition, it also makes sense for Rails to enforce some security-related constraints in this context. This PR proposes that when `form: false` is used, options like `method:,` `type: "submit"`, and any behavior that would generate hidden `<input>` tags (such as params: or authenticity tokens) are disallowed or ignored by default to prevent misuse and preserve the intent of the button_to helper.

## Checklist

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.