### PR TITLE
[Fix #55379] Default branch in github ci templates

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -529,8 +529,13 @@ module Rails
         using_js_runtime? && %w[bun].include?(options[:javascript])
       end
 
-      def capture_command(command, pattern)
-        `#{command}`[pattern]
+      def capture_command(command, pattern = nil)
+        output = `#{command}`
+        if pattern
+          output[pattern]
+        else
+          output
+        end
       rescue SystemCallError
         nil
       end
@@ -760,11 +765,13 @@ module Rails
       end
 
       def user_default_branch
-        @user_default_branch ||= `git config init.defaultbranch`
+        @user_default_branch ||= capture_command("git config init.defaultbranch").strip.presence || "main"
       end
 
       def git_init_command
-        return "git init" if user_default_branch.strip.present?
+        if capture_command("git config init.defaultbranch").present?
+          return "git init"
+        end
 
         git_version = `git --version`[/\d+\.\d+\.\d+/]
 

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ <%= user_default_branch %> ]
 
 jobs:
 <%- unless skip_brakeman? -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ <%= user_default_branch %> ]
 
 jobs:
 <%- unless skip_rubocop? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1150,6 +1150,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     run_generator [destination_root]
     assert_file ".git/HEAD", /main/
+    assert_file ".github/workflows/ci.yml", /branches: \[ main \]/
   ensure
     if !current_default_branch.strip.empty?
       `git config --global init.defaultBranch #{current_default_branch}`
@@ -1165,6 +1166,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     run_generator [destination_root]
     assert_file ".git/HEAD", /master/
+    assert_file ".github/workflows/ci.yml", /branches: \[ master \]/
   ensure
     if current_default_branch && current_default_branch.strip.empty?
       `git config --global --unset init.defaultBranch`

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -145,6 +145,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
     run_generator
     assert_file ".git/HEAD", /main/
+    assert_file ".github/workflows/ci.yml", /branches: \[ main \]/
   ensure
     if !current_default_branch.strip.empty?
       `git config --global init.defaultBranch #{current_default_branch}`
@@ -160,6 +161,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
     run_generator
     assert_file ".git/HEAD", /master/
+    assert_file ".github/workflows/ci.yml", /branches: \[ master \]/
   ensure
     if current_default_branch && current_default_branch.strip.empty?
       `git config --global --unset init.defaultBranch`


### PR DESCRIPTION
### Motivation / Background

Fixes #55379

When generating a new rails app or a plugin, the config templates for GitHub workflow CI contain hardcoded "main" branch name.
Instead, they should take the default branch name from the `git config init.defaultbranch` if it is specified.

### Detail

1. I used the existing method `user_default_branch` inside template files to fetch the name of the default git branch.
2. The `user_default_branch` method was modified so that it uses `capture_command` inside. This way it does not crash on an error (if, for example, git is not installed) and there is no need to call `.strip` on each usage.
3. I changed the existing tests `test_version_control_initializes_git_repo_with_user_default_branch` to also verify the branch name in the generated CI config files.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
