### PR TITLE
Robustify routing parameters against objects that don't respond to empty?

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -249,7 +249,7 @@ module ActionDispatch
                 @arg_size.times { |i|
                   key = @required_parts[i]
                   value = args[i].to_param
-                  yield key if value.nil? || value.empty?
+                  yield key if value.nil? || (value.respond_to?(:empty?) && value.empty?)
                   params[key] = value
                 }
                 params

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -249,7 +249,7 @@ module ActionDispatch
                 @arg_size.times { |i|
                   key = @required_parts[i]
                   value = args[i].to_param
-                  yield key if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+                  yield key if value.nil? || value.blank?
                   params[key] = value
                 }
                 params

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3933,12 +3933,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       @app.routes.url_helpers.user_path(non_emptyable_object)
       assert true, "URL helper correctly handled object without empty? method"
     rescue NoMethodError => e
-      if e.message.include?("undefined method 'empty?'")
-        flunk "URL helper called empty? without checking respond_to?(:empty?) first. Fix needed in routing code."
-      else
-        # Re-raise if it's a different NoMethodError we weren't expecting
-        raise
-      end
+      flunk e.message
     end
   end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3922,16 +3922,25 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     # Create a class that doesn't respond to empty?
     non_emptyable_class = Class.new do
+      def initialize(id)
+        @id = id
+      end
+
       def to_param
         self  # Return self, not a string
       end
+
+      def to_s
+        "custom_object_#{@id}"
+      end
     end
 
-    non_emptyable_object = non_emptyable_class.new
+    non_emptyable_object = non_emptyable_class.new(212)
 
     begin
-      @app.routes.url_helpers.user_path(non_emptyable_object)
-      assert true, "URL helper correctly handled object without empty? method"
+      generated_path = @app.routes.url_helpers.user_path(non_emptyable_object)
+      assert_equal "/users/custom_object_212", generated_path,
+                   "URL helper should generate path with object's string representation"
     rescue NoMethodError => e
       flunk e.message
     end


### PR DESCRIPTION
The optimized URL helpers call `empty?` without checking `respond_to?(:empty?)` first, causing NoMethodError for objects that don't implement the method.

Includes a test that fails before this fix and succeeds after.

# Fix routing parameter `empty?` method bug

## Problem

The Rails routing system's optimized URL helpers have a bug where they call `empty?` on parameter objects without first checking if the object responds to that method. This causes `NoMethodError` exceptions when using objects that don't implement `empty?` as URL parameters.

## What This PR Does

This PR adds a test that demonstrates the bug by:
- Creating a test object that doesn't implement `empty?`
- Attempting to use it as a URL parameter
- Showing that the current code fails with `NoMethodError`

The test fails before this fix and succeeds after.

## Impact

This bug affects any application using custom objects as URL parameters where those objects don't implement `empty?`. The fix is backward compatible and doesn't change behavior for objects that do implement `empty?`.
