### PR TITLE
FormTagHelper: replace `#safe_concat` with `#content_tag`

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -1048,9 +1048,9 @@ module ActionView
         end
 
         def form_tag_with_body(html_options, content)
-          output = form_tag_html(html_options)
-          output << content.to_s if content
-          output.safe_concat("</form>")
+          extra_tags = extra_tags_for_form(html_options)
+          html = content_tag(:form, safe_join([extra_tags, content]), html_options)
+          prevent_content_exfiltration(html)
         end
 
         # see http://www.w3.org/TR/html4/types.html#type-name


### PR DESCRIPTION
### Motivation / Background

There are two private methods in the
`ActionView::Helpers::FormTagHelper` module that are used to render `<form>` element: `form_tag_html` and `form_tag_with_body`. The `form_tag_html` method renders an opening `<form>` tag with HTML attributes as its options, and the `form_tag_with_body` method renders an opening `<form>` tag, content, and then the closing `</form>` tag.

The implementation for `form_tag_with_body` closes the element by calling [ActiveSupport::SafeBuffer#safe_concat][] with `"</form>"`.

While this achieves the desired output, the
[ActionView::Helpers::TagHelper#content_tag] method can achieve the same output without needing to manage the closing tag.

### Detail

After this change, the `form_tag_html` and `form_tag_with_body` differ only slightly:

```diff
 extra_tags = extra_tags_for_form(html_options)
-html = tag(:form, html_options, true) + extra_tags
+html = content_tag(:form, safe_join([extra_tags, content]), html_options)
 prevent_content_exfiltration(html)
```

[ActiveSupport::SafeBuffer#safe_concat]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/SafeBuffer.html#method-i-safe_concat
[ActionView::Helpers::TagHelper#content_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
