### PR TITLE
Add `relative_time_in_words` helper to ActionView

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Introduce `relative_time_in_words` helper
+
+    ```ruby
+    relative_time_in_words(3.minutes.from_now) # => "in 3 minutes"
+    relative_time_in_words(3.minutes.ago) # => "3 minutes ago"
+    relative_time_in_words(10.seconds.ago, include_seconds: true) # => "less than 10 seconds ago"
+    ```
+
+    *Matheus Richard*
+
 *   Make `nonce: false` remove the nonce attribute from `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`.
 
     *francktrouillez*

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -186,6 +186,23 @@ module ActionView
 
       alias_method :distance_of_time_in_words_to_now, :time_ago_in_words
 
+      # Like <tt>time_ago_in_words</tt>, but adds a prefix/suffix depending on whether the time is in the past or future.
+      # You can use the <tt>scope</tt> option to customize the translation scope. All other options
+      # are forwarded to <tt>time_ago_in_words</tt>.
+      #
+      #   relative_time_in_words(3.minutes.from_now) # => "in 3 minutes"
+      #   relative_time_in_words(3.minutes.ago) # => "3 minutes ago"
+      #   relative_time_in_words(10.seconds.ago, include_seconds: true) # => "less than 10 seconds ago"
+      #
+      # See also #time_ago_in_words
+      def relative_time_in_words(from_time, options = {})
+        now = Time.now
+        time = distance_of_time_in_words(from_time, now, options.except(:scope))
+        key = from_time > now ? :future : :past
+
+        I18n.t(key, time: time, scope: options.fetch(:scope, :'datetime.relative'), locale: options[:locale])
+      end
+
       # Returns a set of select tags (one for year, month, and day) pre-selected for accessing a specified date-based
       # attribute (identified by +method+) on an object assigned to the template (identified by +object+).
       #

--- a/actionview/lib/action_view/locale/en.yml
+++ b/actionview/lib/action_view/locale/en.yml
@@ -43,6 +43,9 @@
       hour:   "Hour"
       minute: "Minute"
       second: "Seconds"
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
 
   helpers:
     select:

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -203,6 +203,18 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "about 1 year", time_ago_in_words(1.year.ago - 1.day)
   end
 
+  def test_relative_time_when_time_is_in_the_past
+    assert_equal "3 minutes ago", relative_time_in_words(3.minutes.ago)
+  end
+
+  def test_relative_time_when_time_is_in_the_future
+    assert_equal "in 3 minutes", relative_time_in_words(3.minutes.from_now)
+  end
+
+  def test_relative_time_delegates_options_to_time_ago_in_words
+    assert_equal "less than 20 seconds ago", relative_time_in_words(10.seconds.ago, include_seconds: true)
+  end
+
   def test_select_day
     expected = +%(<select id="date_day" name="date[day]">\n)
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)


### PR DESCRIPTION
### Motivation / Background

A similar proposal was made in https://github.com/rails/rails/pull/52547. The need for the feature is here, but I proposed a new method not to complicate `time_ago_in_words` and also because returning `"in <future time>"` from a helper called `time_ago` doesn't make sense.

### Detail

This Pull Request adds a new helper `relative_time_in_words` to ActionView.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
