### PR TITLE
Allow `postgres` as an alias for `postgresql` in rails generators

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
+*   Allow `postgres` as an alias for `postgresql` in rails generators
+
+    *Ali Ismayilov*
+
 *   Add command `rails credentials:fetch PATH` to get the value of a credential from the credentials file.
 
     ```bash

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -286,7 +286,7 @@ module Rails
 
         gem_name, gem_version = database.gem
         GemfileEntry.version gem_name, gem_version,
-          "Use #{options[:database]} as the database for Active Record"
+          "Use #{database.adapter} as the database for Active Record"
       end
 
       def web_server_gemfile_entry # :doc:
@@ -353,7 +353,7 @@ module Rails
       end
 
       def sqlite3? # :doc:
-        !skip_active_record? && options[:database] == "sqlite3"
+        !skip_active_record? && database.adapter == "sqlite3"
       end
 
       def skip_active_record? # :doc:

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -3,10 +3,14 @@
 module Rails
   module Generators
     class Database
-      DATABASES = %w( mysql trilogy postgresql sqlite3 mariadb-mysql mariadb-trilogy )
+      DATABASES = %w( mysql trilogy postgresql postgres sqlite3 mariadb-mysql mariadb-trilogy )
 
       module MySQL
         def name
+          "mysql"
+        end
+
+        def adapter
           "mysql"
         end
 
@@ -51,6 +55,10 @@ module Rails
           "mariadb"
         end
 
+        def adapter
+          "mariadb-mysql"
+        end
+
         def port
           3306
         end
@@ -72,7 +80,7 @@ module Rails
         def build(database_name)
           case database_name
           when "mysql" then MySQL2.new
-          when "postgresql" then PostgreSQL.new
+          when "postgresql", "postgres" then PostgreSQL.new
           when "trilogy" then Trilogy.new
           when "sqlite3" then SQLite3.new
           when "mariadb-mysql" then MariaDBMySQL2.new
@@ -93,6 +101,10 @@ module Rails
       end
 
       def name
+        raise NotImplementedError
+      end
+
+      def adapter
         raise NotImplementedError
       end
 
@@ -168,6 +180,10 @@ module Rails
           "postgres"
         end
 
+        def adapter
+          "postgresql"
+        end
+
         def template
           "config/databases/postgresql.yml"
         end
@@ -209,6 +225,10 @@ module Rails
       class Trilogy < Database
         include MySQL
 
+        def adapter
+          "trilogy"
+        end
+
         def template
           "config/databases/trilogy.yml"
         end
@@ -232,6 +252,10 @@ module Rails
 
       class SQLite3 < Database
         def name
+          "sqlite3"
+        end
+
+        def adapter
           "sqlite3"
         end
 
@@ -266,14 +290,23 @@ module Rails
 
       class MariaDBMySQL2 < MySQL2
         include MariaDB
+
+        def adapter
+          "mariadb-mysql"
+        end
       end
 
       class MariaDBTrilogy < Trilogy
         include MariaDB
+
+        def adapter
+          "mariadb-trilogy"
+        end
       end
 
       class Null < Database
         def name; end
+        def adapter; end
         def template; end
         def service; end
         def port; end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -275,7 +275,7 @@ module Rails
 
     def devcontainer
       devcontainer_options = {
-        database: options[:database],
+        database: database.adapter,
         redis: options[:skip_solid] && !(options[:skip_action_cable] && options[:skip_active_job]),
         kamal: !options[:skip_kamal],
         system_test: depends_on_system_test?,

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -75,7 +75,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    <%- if options[:database] == "sqlite3" -%>
+    <%- if database.adapter == "sqlite3" -%>
     # services:
     #  redis:
     #    image: valkey/valkey:8
@@ -84,7 +84,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     <%- else -%>
     services:
-      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      <%- if database.adapter == "mysql" || database.adapter == "trilogy" -%>
       mysql:
         image: mysql
         env:
@@ -92,7 +92,7 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- elsif options[:database] == "postgresql" -%>
+      <%- elsif database.adapter == "postgresql" -%>
       postgres:
         image: postgres
         env:
@@ -133,11 +133,11 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-          <%- if options[:database] == "mysql" -%>
+          <%- if database.adapter == "mysql" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306
-          <%- elsif options[:database] == "trilogy" -%>
+          <%- elsif database.adapter == "trilogy" -%>
           DATABASE_URL: trilogy://127.0.0.1:3306
-          <%- elsif options[:database] == "postgresql" -%>
+          <%- elsif database.adapter == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
@@ -148,7 +148,7 @@ jobs:
   system-test:
     runs-on: ubuntu-latest
 
-    <%- if options[:database] == "sqlite3" -%>
+    <%- if database.adapter == "sqlite3" -%>
     # services:
     #  redis:
     #    image: valkey/valkey:8
@@ -157,7 +157,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     <%- else -%>
     services:
-      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      <%- if database.adapter == "mysql" || database.adapter == "trilogy" -%>
       mysql:
         image: mysql
         env:
@@ -165,7 +165,7 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- elsif options[:database] == "postgresql" -%>
+      <%- elsif database.adapter == "postgresql" -%>
       postgres:
         image: postgres
         env:
@@ -206,11 +206,11 @@ jobs:
       - name: Run System Tests
         env:
           RAILS_ENV: test
-          <%- if options[:database] == "mysql" -%>
+          <%- if database.adapter == "mysql" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306
-          <%- elsif options[:database] == "trilogy" -%>
+          <%- elsif database.adapter == "trilogy" -%>
           DATABASE_URL: trilogy://127.0.0.1:3306
-          <%- elsif options[:database] == "postgresql" -%>
+          <%- elsif database.adapter == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}

--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -53,9 +53,9 @@ module Rails
 
       def update_database_yml
         # Only postgresql has devcontainer specific configuration, so only update database.yml if we are using postgres
-        return unless options[:database] == "postgresql"
+        return unless database.adapter == "postgresql"
 
-        template("config/databases/#{options[:database]}.yml", "config/database.yml")
+        template("config/databases/#{database.adapter}.yml", "config/database.yml")
       end
 
       private

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -40,7 +40,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    <%- if options[:database] == "sqlite3" -%>
+    <%- if database.adapter == "sqlite3" -%>
     # services:
     #  redis:
     #    image: valkey/valkey:8
@@ -49,7 +49,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     <%- else -%>
     services:
-      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      <%- if database.adapter == "mysql" || database.adapter == "trilogy" -%>
       mysql:
         image: mysql
         env:
@@ -57,7 +57,7 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- elsif options[:database] == "postgresql" -%>
+      <%- elsif database.adapter == "postgresql" -%>
       postgres:
         image: postgres
         env:
@@ -94,11 +94,11 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-          <%- if options[:database] == "mysql" -%>
+          <%- if database.adapter == "mysql" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306
-          <%- elsif options[:database] == "trilogy" -%>
+          <%- elsif database.adapter == "trilogy" -%>
           DATABASE_URL: trilogy://127.0.0.1:3306
-          <%- elsif options[:database] == "postgresql" -%>
+          <%- elsif database.adapter == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}

--- a/railties/test/commands/db_system_change_test.rb
+++ b/railties/test/commands/db_system_change_test.rb
@@ -25,12 +25,19 @@ class Rails::Command::DbSystemChangeTest < ActiveSupport::TestCase
     assert_match <<~MSG.squish, output
       Invalid value for --to option.
       Supported preconfigurations are:
-      mysql, trilogy, postgresql, sqlite3, mariadb-mysql, mariadb-trilogy.
+      mysql, trilogy, postgresql, postgres, sqlite3, mariadb-mysql, mariadb-trilogy.
     MSG
   end
 
   test "change to postgresql" do
     output = change_database(to: "postgresql")
+
+    assert_match "force  config/database.yml", output
+    assert_match "gsub  Gemfile", output
+  end
+
+  test "change to postgres" do
+    output = change_database(to: "postgres")
 
     assert_match "force  config/database.yml", output
     assert_match "gsub  Gemfile", output

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -28,7 +28,7 @@ module Rails
             assert_match <<~MSG.squish, output
               Invalid value for --to option.
               Supported preconfigurations are:
-              mysql, trilogy, postgresql, sqlite3, mariadb-mysql, mariadb-trilogy.
+              mysql, trilogy, postgresql, postgres, sqlite3, mariadb-mysql, mariadb-trilogy.
             MSG
           end
 


### PR DESCRIPTION
### Motivation / Background

Recently, I was starting a new project and got the familiar error:
```sh
$ rails new blog --database=postgres
Expected '--database' to be one of mysql, trilogy, postgresql, sqlite3, mariadb-mysql, mariadb-trilogy; got postgres
```

This time instead of cursing at the screen, I took a note to come back to this and submit a PR. It's a small PR, but in the spirit of Ruby it should contribute to the developer happiness.

### Detail

This Pull Request allows `postgres` as an alias for `postgresql` in rails generators.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
