### PR TITLE
Provide a method to check current transaction's isolation level

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Add `connection.current_transaction.isolation` API to check current transaction's isolation level.
+
+    Returns the isolation level if it was explicitly set via the `isolation:` parameter
+    or through `ActiveRecord.with_transaction_isolation_level`, otherwise returns `nil`.
+    Nested transactions return the parent transaction's isolation level.
+
+    ```ruby
+    # Returns nil when no transaction
+    User.connection.current_transaction.isolation # => nil
+
+    # Returns explicitly set isolation level
+    User.transaction(isolation: :serializable) do
+      User.connection.current_transaction.isolation # => :serializable
+    end
+
+    # Returns nil when isolation not explicitly set
+    User.transaction do
+      User.connection.current_transaction.isolation # => nil
+    end
+
+    # Nested transactions inherit parent's isolation
+    User.transaction(isolation: :read_committed) do
+      User.transaction do
+        User.connection.current_transaction.isolation # => :read_committed
+      end
+    end
+    ```
+
+    *Kir Shatrov*
+
 *   Emit a warning for pg gem < 1.6.0 when using PostgreSQL 18+
 
     *Yasuo Honda*

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -112,6 +112,7 @@ module ActiveRecord
       def closed?; true; end
       def open?; false; end
       def joinable?; false; end
+      def isolation; nil; end
       def add_record(record, _ = true); end
       def restartable?; false; end
       def dirty?; false; end
@@ -149,6 +150,11 @@ module ActiveRecord
       attr_accessor :written
 
       delegate :invalidate!, :invalidated?, to: :@state
+
+      # Returns the isolation level if it was explicitly set, nil otherwise
+      def isolation
+        @isolation_level
+      end
 
       def initialize(connection, isolation: nil, joinable: true, run_commit_callbacks: false)
         super()
@@ -386,7 +392,7 @@ module ActiveRecord
         @parent.state.add_child(@state)
       end
 
-      delegate :materialize!, :materialized?, :restart, to: :@parent
+      delegate :materialize!, :materialized?, :restart, :isolation, to: :@parent
 
       def rollback
         @state.rollback!
@@ -405,6 +411,7 @@ module ActiveRecord
       def initialize(connection, savepoint_name, parent_transaction, **options)
         super(connection, **options)
 
+        @parent_transaction = parent_transaction
         parent_transaction.state.add_child(@state)
 
         if isolation_level
@@ -412,6 +419,11 @@ module ActiveRecord
         end
 
         @savepoint_name = savepoint_name
+      end
+
+      # Delegates to parent transaction's isolation level
+      def isolation
+        @parent_transaction.isolation
       end
 
       def materialize!


### PR DESCRIPTION
This is somewhat related to https://github.com/rails/rails/pull/54836 and https://github.com/rails/rails/pull/55176.

For some code in the Shopify monolith, we want to be able to check whether the isolation has been set to a desired one in a parent transaction, and report if not.

This information is already available, we just need to set it to an instance variable and provide an accessor.

cc @eileencodes @byroot 