### PR TITLE
[ci skip][docs] Fixes rubydoc links

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1200,7 +1200,7 @@ the client. This section describes the purpose of some of the properties of the
 
 To get a full list of the available methods, refer to the [Rails API
 documentation](https://api.rubyonrails.org/classes/ActionDispatch/Request.html)
-and [Rack](https://www.rubydoc.info/github/rack/rack/Rack/Request)
+and [Rack](https://www.rubydoc.info/gems/rack/Rack/Request)
 documentation.
 
 | Property of `request`                     | Purpose                                                                          |
@@ -1271,4 +1271,4 @@ Here are some of the properties of the `response` object:
 To get a full list of the available methods, refer to the [Rails API
 documentation](https://api.rubyonrails.org/classes/ActionDispatch/Response.html)
 and [Rack
-Documentation](https://www.rubydoc.info/github/rack/rack/Rack/Response).
+Documentation](https://www.rubydoc.info/gems/rack/Rack/Response).

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1861,7 +1861,7 @@ documentation](https://github.com/rails/rails-dom-testing).
 In order to integrate with [rails-dom-testing][], tests that inherit from
 `ActionView::TestCase` declare a `document_root_element` method that returns the
 rendered content as an instance of a
-[Nokogiri::XML::Node](https://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Node):
+[Nokogiri::XML::Node](https://www.rubydoc.info/gems/nokogiri/Nokogiri/XML/Node):
 
 ```ruby
 test "renders a link to itself" do


### PR DESCRIPTION
## Motivation / Background
This PR addresses several broken Rubydoc links by updating them to their correct destinations.

## Detail
I used `git grep` to search for files containing "rubydoc" and then individually checked each link within those files to confirm its validity. As a result, I found the following three links were broken:

- [x] [./guides/source/action_controller_overview.md:1203](https://github.com/rails/rails/blob/6f912a5986cd9295e3fbb45b1ec22159e51ad65d/guides/source/action_controller_overview.md?plain=1#L1203)
  - ❌https://www.rubydoc.info/github/rack/rack/Rack/Request
  - ✅https://www.rubydoc.info/gems/rack/Rack/Request

- [x] [./guides/source/action_controller_overview.md:1274](https://github.com/rails/rails/blob/6f912a5986cd9295e3fbb45b1ec22159e51ad65d/guides/source/action_controller_overview.md?plain=1#L1274)
  - ❌https://www.rubydoc.info/github/rack/rack/Rack/Response
  - ✅https://www.rubydoc.info/gems/rack/Rack/Response

- [x] [./guides/source/testing.md:1864](https://github.com/rails/rails/blob/6f912a5986cd9295e3fbb45b1ec22159e51ad65d/guides/source/testing.md?plain=1#L1864)
  - ❌https://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Node
  - ✅https://www.rubydoc.info/gems/nokogiri/Nokogiri/XML/Node

### Additional Notes
Result of `git grep`

```
❯ git grep "rubydoc"
actionview/lib/action_view/helpers/translation_helper.rb:      # See https://www.rubydoc.info/gems/i18n/I18n/Backend/Base:localize
activerecord/lib/active_record/aggregations.rb:      # aggregated using the +NetAddr::CIDR+ value class (https://www.rubydoc.info/gems/netaddr/1.5.0/NetAddr/CIDR).
activestorage/README.md:Image files can furthermore be transformed using on-demand variants for quality, aspect ratio, size, or any other [MiniMagick](https://github.com/minimagick/minimagick) or [Vips](https://www.rubydoc.info/gems/ruby-vips/Vips/Image) supported transformation.
activestorage/app/models/active_storage/variant.rb:# * {ruby-vips reference}[http://www.rubydoc.info/gems/ruby-vips/Vips/Image]
guides/source/action_controller_overview.md:and [Rack](https://www.rubydoc.info/github/rack/rack/Rack/Request)
guides/source/action_controller_overview.md:Documentation](https://www.rubydoc.info/github/rack/rack/Rack/Response).
guides/source/active_storage_overview.md:[Vips]: https://www.rubydoc.info/gems/ruby-vips/Vips/Image
guides/source/api_app.md:documentation](https://www.rubydoc.info/gems/rack/Rack/Sendfile).
guides/source/caching_with_rails.md:See the [`Dalli::Client` documentation](https://www.rubydoc.info/gems/dalli/Dalli/Client#initialize-instance_method) for supported address types.
guides/source/generators.md:[`Thor::Actions`]: https://www.rubydoc.info/gems/thor/Thor/Actions
guides/source/generators.md:[`create_file`]: https://www.rubydoc.info/gems/thor/Thor/Actions#create_file-instance_method
guides/source/generators.md:[`desc`]: https://www.rubydoc.info/gems/thor/Thor#desc-class_method
guides/source/generators.md:[`copy_file`]: https://www.rubydoc.info/gems/thor/Thor/Actions#copy_file-instance_method
guides/source/generators.md:[`class_option`]: https://www.rubydoc.info/gems/thor/Thor/Base/ClassMethods#class_option-instance_method
guides/source/generators.md:[`options`]: https://www.rubydoc.info/gems/thor/Thor/Base#options-instance_method
guides/source/generators.md:documentation](https://www.rubydoc.info/gems/thor/Thor/Actions) for details.
guides/source/generators.md:There are also methods that allow you to interact with the user from the Ruby template, such as [`ask`][], [`yes`][], and [`no`][]. You can learn about all user interactivity methods in the [Thor Shell documentation](https://www.rubydoc.info/gems/thor/Thor/Shell/Basic). Let's see examples of using `ask`, `yes?` and `no?`:
guides/source/generators.md:[`gsub_file`]: https://www.rubydoc.info/gems/thor/Thor/Actions#gsub_file-instance_method
guides/source/generators.md:[`insert_into_file`]: https://www.rubydoc.info/gems/thor/Thor/Actions#insert_into_file-instance_method
guides/source/generators.md:[`inside`]: https://www.rubydoc.info/gems/thor/Thor/Actions#inside-instance_method
guides/source/generators.md:[`run`]: https://www.rubydoc.info/gems/thor/Thor/Actions#run-instance_method
guides/source/generators.md:[`copy_file`]: https://www.rubydoc.info/gems/thor/Thor/Actions#copy_file-instance_method
guides/source/generators.md:[`create_file`]: https://www.rubydoc.info/gems/thor/Thor/Actions#create_file-instance_method
guides/source/generators.md:[`ask`]: https://www.rubydoc.info/gems/thor/Thor/Shell/Basic#ask-instance_method
guides/source/generators.md:[`yes`]: https://www.rubydoc.info/gems/thor/Thor/Shell/Basic#yes%3F-instance_method
guides/source/generators.md:[`no`]: https://www.rubydoc.info/gems/thor/Thor/Shell/Basic#no%3F-instance_method
guides/source/testing.md:| [`assert_response(type, message = nil)`][] | Asserts that the response comes with a specific status code. You can specify `:success` to indicate 200-299, `:redirect` to indicate 300-399, `:missing` to indicate 404, or `:error` to match the 500-599 range. You can also pass an explicit status number or its symbolic equivalent. For more information, see [full list of status codes](https://rubydoc.info/gems/rack/Rack/Utils#HTTP_STATUS_CODES-constant) and how their [mapping](https://rubydoc.info/gems/rack/Rack/Utils#SYMBOL_TO_STATUS_CODE-constant) works.|
guides/source/testing.md:[Capybara](https://www.rubydoc.info/github/jnicklas/capybara) under the hood.
guides/source/testing.md:[`Capybara`](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions)
guides/source/testing.md:[Nokogiri::XML::Node](https://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Node):
guides/source/testing.md:Assertions](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions)
```

## Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: [Fix #issue-number]
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

