### PR TITLE
`#to_sql` support for calculation and finder methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Enhance `ActiveRecord::Relation#to_sql` to support calculation and finder methods.
+
+    `#to_sql` now returns a proxy object that supports calling calculation methods
+    (`count`, `sum`, `average`, `maximum`, `minimum`, `calculate`) and finder methods
+    (`first`, `last`, `take`, `find`, `find_by`, `exists?`, `pick`, `pluck`, `ids`)
+    to return the SQL string for the final query without executing it.
+
+    ```ruby
+    User.where(active: true).to_sql.count
+    # => "SELECT COUNT(*) FROM \"users\" WHERE \"users\".\"active\" = 1"
+
+    User.joins(:posts).to_sql.pluck(:name, :email)
+    # => "SELECT \"users\".\"name\", \"users\".\"email\" FROM \"users\" INNER JOIN \"posts\" ON \"posts\".\"user_id\" = \"users\".\"id\""
+
+    User.where(role: 'admin').to_sql.exists?
+    # => "SELECT 1 AS one FROM \"users\" WHERE \"users\".\"role\" = 'admin' LIMIT 1"
+    ```
+
+    Backward compatibility is maintained through method delegation. Existing code
+    that expects `#to_sql` to return a string continues to work unchanged.
+
+    Additionally, `ActiveRecord::Relation#explain` now supports the same calculation
+    and finder methods for consistency.
+
+    *Joshua Young*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -103,6 +103,7 @@ module ActiveRecord
     autoload :AutosaveAssociation
     autoload :ConnectionAdapters
     autoload :DisableJoinsAssociationRelation
+    autoload :ExplainProxy
     autoload :FutureResult
     autoload :LegacyYamlAdapter
     autoload :Promise
@@ -111,6 +112,7 @@ module ActiveRecord
     autoload :StatementCache
     autoload :TableMetadata
     autoload :Transaction
+    autoload :ToSQLProxy
     autoload :Type
 
     autoload_under "relation" do
@@ -121,6 +123,7 @@ module ActiveRecord
       autoload :PredicateBuilder
       autoload :QueryMethods
       autoload :SpawnMethods
+      autoload :ToSQL
     end
   end
 

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -3,10 +3,10 @@
 require "active_record/explain_registry"
 
 module ActiveRecord
-  module Explain
+  module Explain # :nodoc:
     # Executes the block with the collect flag enabled. Queries are collected
     # asynchronously by the subscriber and returned.
-    def collecting_queries_for_explain # :nodoc:
+    def collecting_queries_for_explain
       ExplainRegistry.start
       yield
       ExplainRegistry.queries
@@ -16,7 +16,7 @@ module ActiveRecord
 
     # Makes the adapter execute EXPLAIN for the tuples of queries and bindings.
     # Returns a formatted string ready to be logged.
-    def exec_explain(queries, options = []) # :nodoc:
+    def exec_explain(queries, options = [])
       str = with_connection do |c|
         queries.map do |sql, binds|
           msg = +"#{build_explain_clause(c, options)} #{sql}"

--- a/activerecord/lib/active_record/explain_proxy.rb
+++ b/activerecord/lib/active_record/explain_proxy.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  class ExplainProxy # :nodoc:
+    def initialize(relation, options)
+      @relation = relation
+      @options  = options
+    end
+
+    def inspect
+      exec_explain { @relation.send(:exec_queries) }
+    end
+
+    def average(...)
+      exec_explain { @relation.average(...) }
+    end
+
+    def calculate(...)
+      exec_explain { @relation.calculate(...) }
+    end
+
+    def count(...)
+      exec_explain { @relation.count(...) }
+    end
+
+    def exists?(...)
+      exec_explain { @relation.exists?(...) }
+    end
+
+    def find(...)
+      exec_explain { @relation.find(...) }
+    end
+
+    def find_by(...)
+      exec_explain { @relation.find_by(...) }
+    end
+
+    def first(...)
+      exec_explain { @relation.first(...) }
+    end
+
+    def ids(...)
+      exec_explain { @relation.ids(...) }
+    end
+
+    def last(...)
+      exec_explain { @relation.last(...) }
+    end
+
+    def maximum(...)
+      exec_explain { @relation.maximum(...) }
+    end
+
+    def minimum(...)
+      exec_explain { @relation.minimum(...) }
+    end
+
+    def pick(...)
+      exec_explain { @relation.pick(...) }
+    end
+
+    def pluck(...)
+      exec_explain { @relation.pluck(...) }
+    end
+
+    def sum(...)
+      exec_explain { @relation.sum(...) }
+    end
+
+    def take(...)
+      exec_explain { @relation.take(...) }
+    end
+
+    private
+      def exec_explain(&block)
+        @relation.exec_explain(@relation.collecting_queries_for_explain { block.call }, @options)
+      end
+  end
+end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -3,54 +3,6 @@
 module ActiveRecord
   # = Active Record \Relation
   class Relation
-    class ExplainProxy  # :nodoc:
-      def initialize(relation, options)
-        @relation = relation
-        @options  = options
-      end
-
-      def inspect
-        exec_explain { @relation.send(:exec_queries) }
-      end
-
-      def average(column_name)
-        exec_explain { @relation.average(column_name) }
-      end
-
-      def count(column_name = nil)
-        exec_explain { @relation.count(column_name) }
-      end
-
-      def first(limit = nil)
-        exec_explain { @relation.first(limit) }
-      end
-
-      def last(limit = nil)
-        exec_explain { @relation.last(limit) }
-      end
-
-      def maximum(column_name)
-        exec_explain { @relation.maximum(column_name) }
-      end
-
-      def minimum(column_name)
-        exec_explain { @relation.minimum(column_name) }
-      end
-
-      def pluck(*column_names)
-        exec_explain { @relation.pluck(*column_names) }
-      end
-
-      def sum(identity_or_column = nil)
-        exec_explain { @relation.sum(identity_or_column) }
-      end
-
-      private
-        def exec_explain(&block)
-          @relation.exec_explain(@relation.collecting_queries_for_explain { block.call }, @options)
-        end
-    end
-
     MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
                             :order, :default_order, :joins, :left_outer_joins,
                             :references, :extending, :unscope, :optimizer_hints,
@@ -66,10 +18,11 @@ module ActiveRecord
     VALUE_METHODS = (MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS + CLAUSE_METHODS).freeze
 
     include Enumerable
-    include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
+    include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, ToSQL, Delegation
     include SignedId::RelationMethods, TokenFor::RelationMethods
 
     attr_reader :table, :model, :loaded, :predicate_builder
+    attr_writer :to_sql # :nodoc:
     attr_accessor :skip_preloading_value
     alias :klass :model
     alias :loaded? :loaded
@@ -92,6 +45,7 @@ module ActiveRecord
       @future_result = nil
       @records = nil
       @async = false
+      @to_sql = false
       @none = false
     end
 
@@ -1220,7 +1174,7 @@ module ActiveRecord
       @future_result&.cancel
       @future_result = nil
       @delegate_to_model = false
-      @to_sql = @arel = @loaded = @should_eager_load = nil
+      @arel = @loaded = @should_eager_load = nil
       @offsets = @take = nil
       @cache_keys = nil
       @cache_versions = nil
@@ -1233,16 +1187,7 @@ module ActiveRecord
     #   User.where(name: 'Oscar').to_sql
     #   # SELECT "users".* FROM "users"  WHERE "users"."name" = 'Oscar'
     def to_sql
-      @to_sql ||= if eager_loading?
-        apply_join_dependency do |relation, join_dependency|
-          relation = join_dependency.apply_column_aliases(relation)
-          relation.to_sql
-        end
-      else
-        model.with_connection do |conn|
-          conn.unprepared_statement { conn.to_sql(arel) }
-        end
-      end
+      ToSQLProxy.new(self)
     end
 
     # Returns a hash of where conditions.
@@ -1426,6 +1371,8 @@ module ActiveRecord
       end
 
       def exec_queries(&block)
+        return to_sql if @to_sql
+
         if lock_value && model.current_preventing_writes
           raise ActiveRecord::ReadOnlyError, "Lock query attempted while in readonly mode"
         end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -216,7 +216,7 @@ module ActiveRecord
     def calculate(operation, column_name)
       operation = operation.to_s.downcase
 
-      if @none
+      if !@to_sql && @none
         case operation
         when "count", "sum"
           result = group_values.any? ? Hash.new : 0
@@ -293,7 +293,7 @@ module ActiveRecord
     #
     # See also #ids.
     def pluck(*column_names)
-      if @none
+      if !@to_sql && @none
         if @async
           return Promise::Complete.new([])
         else
@@ -301,7 +301,7 @@ module ActiveRecord
         end
       end
 
-      if loaded? && all_attributes?(column_names)
+      if !@to_sql && loaded? && all_attributes?(column_names)
         result = records.pluck(*column_names)
         if @async
           return Promise::Complete.new(result)
@@ -318,6 +318,8 @@ module ActiveRecord
         relation = spawn
         columns = relation.arel_columns(column_names)
         relation.select_values = columns
+        return relation.to_sql if @to_sql
+
         result = skip_query_cache_if_necessary do
           if where_clause.contradiction? && !possible_aggregation?(column_names)
             ActiveRecord::Result.empty(async: @async)
@@ -354,12 +356,17 @@ module ActiveRecord
     #   # SELECT people.name, people.email_address FROM people WHERE id = 1 LIMIT 1
     #   # => [ 'David', 'david@loudthinking.com' ]
     def pick(*column_names)
-      if loaded? && all_attributes?(column_names)
+      if !@to_sql && loaded? && all_attributes?(column_names)
         result = records.pick(*column_names)
         return @async ? Promise::Complete.new(result) : result
       end
 
-      limit(1).pluck(*column_names).then(&:first)
+      result = limit(1).pluck(*column_names)
+      if @to_sql
+        result
+      else
+        result.then(&:first)
+      end
     end
 
     # Same as #pick, but performs the query asynchronously and returns an
@@ -455,7 +462,7 @@ module ActiveRecord
       def execute_simple_calculation(operation, column_name, distinct) # :nodoc:
         if build_count_subquery?(operation, column_name, distinct)
           # Shortcut when limit is zero.
-          return @async ? Promise::Complete.new(0) : 0 if limit_value == 0
+          return @async ? Promise::Complete.new(0) : 0 if !@to_sql && limit_value == 0
 
           relation = self
           query_builder = build_count_subquery(spawn, column_name, distinct)
@@ -471,6 +478,7 @@ module ActiveRecord
 
           query_builder = relation.arel
         end
+        return relation.to_sql if @to_sql
 
         query_result = if relation.where_clause.contradiction?
           if @async
@@ -542,6 +550,7 @@ module ActiveRecord
 
           relation.group_values  = group_fields
           relation.select_values = select_values
+          return relation.to_sql if @to_sql
 
           result = skip_query_cache_if_necessary do
             connection.select_all(relation.arel, "#{model.name} #{operation.capitalize}", async: @async)

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -199,12 +199,18 @@ module ActiveRecord
     #
     #   [#<Person id:4>, #<Person id:3>, #<Person id:2>]
     def last(limit = nil)
-      return find_last(limit) if loaded? || has_limit_or_offset?
+      return find_last(limit) if (!@to_sql && loaded?) || has_limit_or_offset?
 
-      result = ordered_relation.limit(limit)
-      result = result.reverse_order!
+      relation = ordered_relation.limit(limit)
+      relation = relation.reverse_order!
 
-      limit ? result.reverse : result.first
+      if @to_sql && limit
+        relation.to_sql
+      elsif limit
+        relation.reverse
+      else
+        relation.first
+      end
     end
 
     # Same as #last but raises ActiveRecord::RecordNotFound if no record
@@ -355,7 +361,7 @@ module ActiveRecord
     #   Person.exists?
     #   Person.where(name: 'Spartacus', rating: 4).exists?
     def exists?(conditions = :none)
-      return false if @none
+      return false if !@to_sql && @none
 
       if Base === conditions
         raise ArgumentError, <<-MSG.squish
@@ -364,7 +370,7 @@ module ActiveRecord
         MSG
       end
 
-      return false if !conditions || limit_value == 0
+      return false if !@to_sql && (!conditions || limit_value == 0)
 
       if eager_loading?
         relation = apply_join_dependency(eager_loading: false)
@@ -372,6 +378,7 @@ module ActiveRecord
       end
 
       relation = construct_relation_for_exists(conditions)
+      return relation.to_sql if @to_sql
       return false if relation.where_clause.contradiction?
 
       skip_query_cache_if_necessary do
@@ -487,9 +494,9 @@ module ActiveRecord
         raise UnknownPrimaryKey.new(model) if primary_key.nil?
 
         first_item = ids.first
-        return [] if first_item.is_a?(Array) && first_item.empty?
+        return [] if !@to_sql && first_item.is_a?(Array) && first_item.empty?
 
-        expects_array = model.primary_key_definition.expects_multiple_ids?(first_item)
+        expects_array = !@to_sql && model.primary_key_definition.expects_multiple_ids?(first_item)
 
         ids = first_item if expects_array
 
@@ -519,11 +526,12 @@ module ActiveRecord
 
         relation = where(model.primary_key_definition.where_hash(id))
 
-        record = relation.take
+        result = relation.take
+        return result if @to_sql
 
-        raise_record_not_found_exception!(id, 0, 1) unless record
+        raise_record_not_found_exception!(id, 0, 1) unless result
 
-        record
+        result
       end
 
       def find_some(ids)
@@ -538,7 +546,7 @@ module ActiveRecord
 
         # 11 ids with limit 3, offset 9 should give 2 results.
         if offset_value
-          if ids.size <= offset_value
+          if !@to_sql && ids.size <= offset_value
             return []
           elsif ids.size - offset_value < expected_size
             expected_size = ids.size - offset_value
@@ -547,6 +555,8 @@ module ActiveRecord
 
         relation = where(primary_key => ids)
         relation = relation.select(table[primary_key]) unless select_values.empty?
+        return relation.to_sql if @to_sql
+
         result = relation.to_a
 
         if result.size == expected_size
@@ -577,15 +587,22 @@ module ActiveRecord
       end
 
       def find_take
-        if loaded?
+        if !@to_sql && loaded?
           records.first
         else
-          @take ||= limit(1).records.first
+          @take ||= begin
+            relation = limit(1)
+            if @to_sql
+              relation.to_sql
+            else
+              relation.records.first
+            end
+          end
         end
       end
 
       def find_take_with_limit(limit)
-        if loaded?
+        if !@to_sql && loaded?
           records.take(limit)
         else
           limit(limit).to_a
@@ -594,11 +611,18 @@ module ActiveRecord
 
       def find_nth(index)
         @offsets ||= {}
-        @offsets[index] ||= find_nth_with_limit(index, 1).first
+        @offsets[index] ||= begin
+          result = find_nth_with_limit(index, 1)
+          if @to_sql
+            result
+          else
+            result.first
+          end
+        end
       end
 
       def find_nth_with_limit(index, limit)
-        if loaded?
+        if !@to_sql && loaded?
           records[index, limit] || []
         else
           relation = ordered_relation
@@ -609,7 +633,13 @@ module ActiveRecord
 
           if limit > 0
             relation = relation.offset((offset_value || 0) + index) unless index.zero?
-            relation.limit(limit).to_a
+            relation = relation.limit(limit)
+          end
+
+          if @to_sql
+            relation.to_sql
+          elsif limit > 0
+            relation.to_a
           else
             []
           end
@@ -631,7 +661,13 @@ module ActiveRecord
       end
 
       def find_last(limit)
-        limit ? records.last(limit) : records.last
+        if @to_sql
+          to_sql
+        elsif limit
+          records.last(limit)
+        else
+          records.last
+        end
       end
 
       def ordered_relation

--- a/activerecord/lib/active_record/relation/to_sql.rb
+++ b/activerecord/lib/active_record/relation/to_sql.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  module ToSQL # :nodoc:
+    def exec_to_sql
+      relation = if eager_loading?
+        apply_join_dependency do |relation, join_dependency|
+          join_dependency.apply_column_aliases(relation)
+        end
+      else
+        self
+      end
+
+      with_connection do |conn|
+        conn.unprepared_statement do
+          conn.to_sql(relation.arel)
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -34,8 +34,9 @@ module ActiveRecord
         return nil if condition.blank?
 
         case condition
-        when Array; sanitize_sql_array(condition)
-        else        condition
+        when Array;      sanitize_sql_array(condition)
+        when ToSQLProxy; condition.to_s
+        else             condition
         end
       end
       alias :sanitize_sql :sanitize_sql_for_conditions

--- a/activerecord/lib/active_record/to_sql_proxy.rb
+++ b/activerecord/lib/active_record/to_sql_proxy.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  class ToSQLProxy # :nodoc:
+    def initialize(relation)
+      @relation = relation
+    end
+
+    delegate_missing_to :to_s
+
+    def to_s
+      @relation.exec_to_sql
+    end
+
+    def inspect
+      to_s.inspect
+    end
+
+    def eql?(other)
+      case other
+      when ToSQLProxy then to_s == other.to_s
+      else to_s == other
+      end
+    end
+    alias :== :eql?
+
+    def hash
+      to_s.hash
+    end
+
+    def average(...)
+      exec_to_sql { @relation.average(...) }
+    end
+
+    def calculate(...)
+      exec_to_sql { @relation.calculate(...) }
+    end
+
+    def count(...)
+      exec_to_sql { @relation.count(...) }
+    end
+
+    def exists?(...)
+      exec_to_sql { @relation.exists?(...) }
+    end
+
+    def find(...)
+      exec_to_sql { @relation.find(...) }
+    end
+
+    def find_by(...)
+      exec_to_sql { @relation.find_by(...) }
+    end
+
+    def first(...)
+      exec_to_sql { @relation.first(...) }
+    end
+
+    def ids(...)
+      exec_to_sql { @relation.ids(...) }
+    end
+
+    def last(...)
+      exec_to_sql { @relation.last(...) }
+    end
+
+    def maximum(...)
+      exec_to_sql { @relation.maximum(...) }
+    end
+
+    def minimum(...)
+      exec_to_sql { @relation.minimum(...) }
+    end
+
+    def pick(...)
+      exec_to_sql { @relation.pick(...) }
+    end
+
+    def pluck(...)
+      exec_to_sql { @relation.pluck(...) }
+    end
+
+    def sum(...)
+      exec_to_sql { @relation.sum(...) }
+    end
+
+    def take(...)
+      exec_to_sql { @relation.take(...) }
+    end
+
+    private
+      def exec_to_sql(&block)
+        @relation.to_sql = true
+        block.call
+      ensure
+        @relation.to_sql = false
+      end
+  end
+end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -35,13 +35,20 @@ if ActiveRecord::Base.lease_connection.supports_explain?
       end
     end
 
+    def test_relation_explain_with_calculate
+      expected_query = capture_sql {
+        Car.calculate(:count, :id)
+      }.first
+      message = Car.all.explain.calculate(:count, :id)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
     def test_relation_explain_with_average
       expected_query = capture_sql {
         Car.average(:id)
       }.first
       message = Car.all.explain.average(:id)
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_count
@@ -49,8 +56,7 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.count
       }.first
       message = Car.all.explain.count
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_count_and_argument
@@ -58,8 +64,7 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.count(:id)
       }.first
       message = Car.all.explain.count(:id)
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_minimum
@@ -67,8 +72,7 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.minimum(:id)
       }.first
       message = Car.all.explain.minimum(:id)
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_maximum
@@ -76,8 +80,7 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.maximum(:id)
       }.first
       message = Car.all.explain.maximum(:id)
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_sum
@@ -85,8 +88,23 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.sum(:id)
       }.first
       message = Car.all.explain.sum(:id)
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_exists
+      expected_query = capture_sql {
+        Car.all.exists?
+      }.first
+      message = Car.all.explain.exists?
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_exists_with_argument
+      expected_query = capture_sql {
+        Car.all.exists?(name: "JoshMobile")
+      }.first
+      message = Car.all.explain.exists?(name: "JoshMobile")
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_first
@@ -94,8 +112,15 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.all.first
       }.first
       message = Car.all.explain.first
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query.sub(/LIMIT.*/, ""), message)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_first_with_argument
+      expected_query = capture_sql {
+        Car.all.first(5)
+      }.first
+      message = Car.all.explain.first(5)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_last
@@ -103,8 +128,39 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.all.last
       }.first
       message = Car.all.explain.last
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query.sub(/LIMIT.*/, ""), message)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_last_with_argument
+      expected_query = capture_sql {
+        Car.all.last(5)
+      }.first
+      message = Car.all.explain.last(5)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_take
+      expected_query = capture_sql {
+        Car.all.take
+      }.first
+      message = Car.all.explain.take
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_take_with_argument
+      expected_query = capture_sql {
+        Car.all.take(5)
+      }.first
+      message = Car.all.explain.take(5)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_pick
+      expected_query = capture_sql {
+        Car.all.pick(:id, :name)
+      }.first
+      message = Car.all.explain.pick(:id, :name)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_pluck
@@ -112,8 +168,7 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.all.pluck
       }.first
       message = Car.all.explain.pluck
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_relation_explain_with_pluck_with_args
@@ -121,8 +176,31 @@ if ActiveRecord::Base.lease_connection.supports_explain?
         Car.all.pluck(:id, :name)
       }.first
       message = Car.all.explain.pluck(:id, :name)
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_ids
+      expected_query = capture_sql {
+        Car.all.ids
+      }.first
+      message = Car.all.explain.ids
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_find
+      expected_query = capture_sql {
+        Car.all.find(1)
+      }.first
+      message = Car.all.explain.find(1)
+      assert_match(normalize_expected_sql(expected_query), message)
+    end
+
+    def test_relation_explain_with_find_by
+      expected_query = capture_sql {
+        Car.all.find_by(id: 1)
+      }.first
+      message = Car.all.explain.find_by(id: 1)
+      assert_match(normalize_expected_sql(expected_query), message)
     end
 
     def test_exec_explain_with_no_binds
@@ -198,6 +276,19 @@ if ActiveRecord::Base.lease_connection.supports_explain?
 
       def bind_param(name, value)
         ActiveRecord::Relation::QueryAttribute.new(name, value, ActiveRecord::Type::Value.new)
+      end
+
+      def normalize_expected_sql(expected_sql)
+        if current_adapter?(:Mysql2Adapter) && ActiveRecord::Base.lease_connection.prepared_statements
+          # Convert ? placeholders to regex patterns that match actual values
+          # EXPLAIN queries show actual values, not placeholders
+          pattern = Regexp.escape(expected_sql)
+          pattern = pattern.gsub(/=\\ \\?/, "=\\ (?:\\d+|'[^']*')")
+          pattern = pattern.gsub(/LIMIT\\ \\?/, "LIMIT\\ \\d+")
+          Regexp.new("#{expected_explain_clause} #{pattern}")
+        else
+          "#{expected_explain_clause} #{expected_sql}"
+        end
       end
 
       def expected_explain_clause

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -345,6 +345,10 @@ module ActiveRecord
       ActiveRecord::Base.adapter_class.quote_table_name(name)
     end
 
+    def quote_column_name(name)
+      ActiveRecord::Base.adapter_class.quote_column_name(name)
+    end
+
     # Connect to the database
     ARTest.connect
     # Load database schema

--- a/activerecord/test/cases/to_sql_test.rb
+++ b/activerecord/test/cases/to_sql_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/car"
+
+class ToSQLTest < ActiveRecord::TestCase
+  fixtures :cars
+
+  def test_relation_to_sql
+    to_sql = assert_no_queries { Car.where(name: "honda").to_sql }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} WHERE #{quote_table_name('cars')}.#{quote_column_name('name')} = 'honda'", to_sql
+  end
+
+  def test_relation_to_sql_with_average
+    to_sql = assert_no_queries { Car.all.to_sql.average(:id) }
+    assert_equal "SELECT AVG(#{quote_table_name('cars')}.#{quote_column_name('id')}) FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_calculate
+    to_sql = assert_no_queries { Car.all.to_sql.calculate(:average, :id) }
+    assert_equal "SELECT AVG(#{quote_table_name('cars')}.#{quote_column_name('id')}) FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_count
+    to_sql = assert_no_queries { Car.all.to_sql.count }
+    assert_equal "SELECT COUNT(*) FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_count_and_argument
+    to_sql = assert_no_queries { Car.all.to_sql.count(:id) }
+    assert_equal "SELECT COUNT(#{quote_table_name('cars')}.#{quote_column_name('id')}) FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_exists
+    to_sql = assert_no_queries { Car.all.to_sql.exists? }
+    assert_equal "SELECT 1 AS one FROM #{quote_table_name('cars')} LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_exists_with_argument
+    to_sql = assert_no_queries { Car.all.to_sql.exists?(name: "JoshMobile") }
+    assert_equal "SELECT 1 AS one FROM #{quote_table_name('cars')} WHERE #{quote_table_name('cars')}.#{quote_column_name('name')} = 'JoshMobile' LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_find
+    to_sql = assert_no_queries { Car.all.to_sql.find(1) }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} WHERE #{quote_table_name('cars')}.#{quote_column_name('id')} = 1 LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_find_by
+    to_sql = assert_no_queries { Car.all.to_sql.find_by(id: 1) }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} WHERE #{quote_table_name('cars')}.#{quote_column_name('id')} = 1 LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_first
+    to_sql = assert_no_queries { Car.all.to_sql.first }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} ORDER BY #{quote_table_name('cars')}.#{quote_column_name('id')} ASC LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_first_with_argument
+    to_sql = assert_no_queries { Car.all.to_sql.first(5) }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} ORDER BY #{quote_table_name('cars')}.#{quote_column_name('id')} ASC LIMIT 5", to_sql
+  end
+
+  def test_relation_to_sql_with_ids
+    to_sql = assert_no_queries { Car.all.to_sql.ids }
+    assert_equal "SELECT #{quote_table_name('cars')}.#{quote_column_name('id')} FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_last
+    to_sql = assert_no_queries { Car.all.to_sql.last }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} ORDER BY #{quote_table_name('cars')}.#{quote_column_name('id')} DESC LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_last_with_argument
+    to_sql = assert_no_queries { Car.all.to_sql.last(5) }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} ORDER BY #{quote_table_name('cars')}.#{quote_column_name('id')} DESC LIMIT 5", to_sql
+  end
+
+  def test_relation_to_sql_with_maximum
+    to_sql = assert_no_queries { Car.all.to_sql.maximum(:id) }
+    assert_equal "SELECT MAX(#{quote_table_name('cars')}.#{quote_column_name('id')}) FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_minimum
+    to_sql = assert_no_queries { Car.all.to_sql.minimum(:id) }
+    assert_equal "SELECT MIN(#{quote_table_name('cars')}.#{quote_column_name('id')}) FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_pick
+    to_sql = assert_no_queries { Car.all.to_sql.pick(:id) }
+    assert_equal "SELECT #{quote_table_name('cars')}.#{quote_column_name('id')} FROM #{quote_table_name('cars')} LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_pluck
+    to_sql = assert_no_queries { Car.all.to_sql.pluck }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_pluck_with_args
+    to_sql = assert_no_queries { Car.all.to_sql.pluck(:id, :name) }
+    assert_equal "SELECT #{quote_table_name('cars')}.#{quote_column_name('id')}, #{quote_table_name('cars')}.#{quote_column_name('name')} FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_sum
+    to_sql = assert_no_queries { Car.all.to_sql.sum(:id) }
+    assert_equal "SELECT SUM(#{quote_table_name('cars')}.#{quote_column_name('id')}) FROM #{quote_table_name('cars')}", to_sql
+  end
+
+  def test_relation_to_sql_with_take
+    to_sql = assert_no_queries { Car.all.to_sql.take }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} LIMIT 1", to_sql
+  end
+
+  def test_relation_to_sql_with_take_with_argument
+    to_sql = assert_no_queries { Car.all.to_sql.take(5) }
+    assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} LIMIT 5", to_sql
+  end
+
+  def test_relation_to_sql_with_binds
+    to_sql = assert_no_queries { Car.all.where("id = ?", 1).to_sql }
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+      assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} WHERE (id = '1')", to_sql
+    else
+      assert_equal "SELECT #{quote_table_name('cars')}.* FROM #{quote_table_name('cars')} WHERE (id = 1)", to_sql
+    end
+  end
+
+  def test_relation_to_sql_with_binds_and_proxy_method
+    to_sql = assert_no_queries { Car.all.where("id = ?", 1).to_sql.pluck(:id) }
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+      assert_equal "SELECT #{quote_table_name('cars')}.#{quote_column_name('id')} FROM #{quote_table_name('cars')} WHERE (id = '1')", to_sql
+    else
+      assert_equal "SELECT #{quote_table_name('cars')}.#{quote_column_name('id')} FROM #{quote_table_name('cars')} WHERE (id = 1)", to_sql
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Implements this proposal: https://discuss.rubyonrails.org/t/feature-proposal-to-sql-support-for-calculation-and-finder-methods/89381

cc @byroot

### Detail

This PR enhances `ActiveRecord::Relation#to_sql` to support calculation and finder methods, allowing developers to inspect the SQL that would be generated for complex queries without executing them.

This PR enhances `ActiveRecord::Relation#to_sql` to support calculation and finder methods, allowing developers to inspect the SQL that would be generated for complex queries without executing them.

**Example new capabilities:**
```ruby
> User.where(active: true).to_sql.count
#=> "SELECT COUNT(*) FROM \"users\" WHERE \"users\".\"active\" = 1"

> User.joins(:posts).to_sql.pluck(:name, :email)
#=> "SELECT \"users\".\"name\", \"users\".\"email\" FROM \"users\" INNER JOIN \"posts\" ON \"posts\".\"user_id\" = \"users\".\"id\""

> User.where(role: 'admin').to_sql.exists?
#=> "SELECT 1 AS one FROM \"users\" WHERE \"users\".\"role\" = 'admin' LIMIT 1"
```

**Changes:**
1. Updates `ActiveRecord::Relation#to_sql` to return a proxy object similar to `#explain` so that `ActiveRecord::Calculations` and `ActiveRecord::FinderMethods` can be called on it to return the SQL string for the final query. Missing methods are delegated to the `#to_s` method on the proxy to avoid introducing breaking changes with current code which expects the method to return a `String`.
2. Extracts `ActiveRecord::Relation::ExplainProxy` into its own file, `ActiveRecord::ExplainProxy`.
3. Extends `ExplainProxy` to bring it to parity with `ToSQLProxy` so that both now support all calculation and almost all finder methods (excluding the additional order based methods, e.g. `#second`).

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

None.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
