### PR TITLE
Add optional setting to `SchemaDumper` to disable sorting of table columns

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -175,6 +175,19 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_equal %w[account_id client_of description firm_id firm_name name rating status type], column_names
   end
 
+  def test_table_columns_unsorted
+    original_value = ActiveRecord::SchemaDumper.sort_table_columns
+    ActiveRecord::SchemaDumper.sort_table_columns = false
+
+    column_names = column_definition_lines(dump_table_schema("companies")).flatten.filter_map do |line|
+      $1 if line !~ /t\.index/ && line.match(/t\..*"(\w+)"/)
+    end
+
+    assert_equal %w[type firm_id firm_name name client_of rating account_id description status], column_names
+  ensure
+    ActiveRecord::SchemaDumper.sort_table_columns = original_value
+  end
+
   def test_schema_dumps_index_columns_in_right_order
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_index/).first.strip
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1824,6 +1824,10 @@ whether a foreign key's name should be dumped to db/schema.rb or not. By
 default, foreign key names starting with `fk_rails_` are not exported to the
 database schema dump. Defaults to `/^fk_rails_[0-9a-f]{10}$/`.
 
+#### `ActiveRecord::SchemaDumper.sort_table_columns`
+
+When `true`, table columns are sorted alphabetically in the generated schema file. When `false`, the columns are listed in the same order as in the database. Defaults to `true`.
+
 #### `config.active_record.encryption.support_unencrypted_data`
 
 When `true`, unencrypted data can be read normally. When `false`, it will raise errors. Default: `false`.


### PR DESCRIPTION
### Motivation / Background

Pull request https://github.com/rails/rails/pull/53281, merged in January, has changed the behavior of `ActiveRecord::SchemaDumper` to print table columns inside a `create_table` block in `schema.db` sorted alphabetically by name, instead of the actual order in the database.

The rationale was that when multiple people are adding migrations to the same table in parallel, they can end up with different order of the columns in their local databases, which then generate different versions of the schema, causing confusing diffs or merge conflicts. Putting columns in alphabetical order makes the order deterministic.

That is true, but it's also true that the order is now deterministically *different* than the actual order in the database… and sometimes, the order of the columns matters to some degree (otherwise, why have an `:after` / `:before` options in migrations at all?).

This PR intends to add a way to restore the behavior present in AR 8.0 and earlier, while keeping the new behavior as a default.

### Detail

The PR adds a class field `sort_table_columns` in `ActiveRecord::SchemaDumper`, defaulting to true. If set to false, the table columns are printed in original order instead of sorted by name.

### Additional information

I've added one additional test and checked the tests with `rake test:sqlite3`.

Alternative name I've considered was `sort_columns_by_name`, so we could go with that if you prefer.
