### PR TITLE
rate_limit notification instrumentation to include more payload

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `rate_limit.action_controller` notification has additional payload
+
+    additonal values: count, to, within, by, name, cache_key
+
+    *Jonathan Rochkind*
+
 *   Add JSON support to the built-in health controller.
 
     The health controller now responds to JSON requests with a structured response

--- a/actionpack/test/controller/rate_limiting_test.rb
+++ b/actionpack/test/controller/rate_limiting_test.rb
@@ -33,6 +33,20 @@ class RateLimitingTest < ActionController::TestCase
     assert_response :too_many_requests
   end
 
+  test "notification on limit action" do
+    get :limited
+    get :limited
+
+    assert_notification("rate_limit.action_controller",
+        count: 3,
+        to: 2,
+        within: 2.seconds,
+        name: nil,
+        by: request.remote_ip) do
+      get :limited
+    end
+  end
+
   test "multiple rate limits" do
     get :limited
     get :limited


### PR DESCRIPTION
### Motivation / Background

When trying to move some code over from the third-party [rack-attack](https://github.com/rack/rack-attack) to the built-in [rate_limit](https://api.rubyonrails.org/classes/ActionController/RateLimiting/ClassMethods.html#method-i-rate_limit) function, there were a lot of use cases that I would be able to accomplish with these added payload, but could not without. 

rack-attack itself sends a notification that only includes request in payload -- but all of these values are available in `request.env` in rack-attack, because of how it stores things in rack env. In Rails rate_limit, they are not, and are otherwise lost unless included in payload like this. 

I don't believe there's any way to access these values in the `with` closure either. If they are to be avail to app code as a result of invocation of limit, I think they need to be in event payload?

### Detail

Just added some payload values, very simple!

### Additional information

There were no tests of rate_limit instrumentation previously. I added one. That also tests for payload. 

it does not test for specific values that were not easy to test for with existing instrumentation, `request` and `cache_key`. But leaving better than I found it I think. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
