### PR TITLE
Fix `HWIA#transform_keys!` removing defaults

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -278,9 +278,7 @@ module ActiveSupport
     #   hash[:a][:c] # => "c"
     #   dup[:a][:c]  # => "c"
     def dup
-      self.class.new(self).tap do |new_hash|
-        set_defaults(new_hash)
-      end
+      copy_defaults(self.class.new(self))
     end
 
     # This method has the same semantics of +update+, except it does not
@@ -368,12 +366,12 @@ module ActiveSupport
     def transform_keys!(hash = NOT_GIVEN, &block)
       if NOT_GIVEN.equal?(hash)
         if block_given?
-          replace(transform_keys(&block).tap { |h| set_defaults(h) })
+          replace(copy_defaults(transform_keys(&block)))
         else
           return to_enum(:transform_keys!)
         end
       else
-        replace(transform_keys(hash, &block).tap { |h| set_defaults(h) })
+        replace(copy_defaults(transform_keys(hash, &block)))
       end
 
       self
@@ -397,8 +395,7 @@ module ActiveSupport
     def to_hash
       copy = Hash[self]
       copy.transform_values! { |v| convert_value_to_hash(v) }
-      set_defaults(copy)
-      copy
+      copy_defaults(copy)
     end
 
     def to_proc
@@ -438,12 +435,13 @@ module ActiveSupport
       end
 
 
-      def set_defaults(target)
+      def copy_defaults(target)
         if default_proc
           target.default_proc = default_proc.dup
         else
           target.default = default
         end
+        target
       end
 
       def update_with_single_argument(other_hash, block)

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -368,12 +368,12 @@ module ActiveSupport
     def transform_keys!(hash = NOT_GIVEN, &block)
       if NOT_GIVEN.equal?(hash)
         if block_given?
-          replace(transform_keys(&block))
+          replace(transform_keys(&block).tap { |h| set_defaults(h) })
         else
           return to_enum(:transform_keys!)
         end
       else
-        replace(transform_keys(hash, &block))
+        replace(transform_keys(hash, &block).tap { |h| set_defaults(h) })
       end
 
       self

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -555,15 +555,20 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
 
     hash_with_default = Hash.new(:a)
     hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys!(&:to_s)
-    assert_equal hash_with_default.default, hash.default
+    assert_equal :a, hash.default
+    assert_equal :a, hash_with_default.default
+
     hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys! { |k| k.to_s }
-    assert_equal hash_with_default.default, hash.default
+    assert_equal :a, hash.default
+    assert_equal :a, hash_with_default.default
 
     hash_with_default_proc = Hash.new { |h, k| h[k] = :b }
+    default_proc = hash_with_default_proc.default_proc
+
     hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys!(&:to_s)
-    assert_equal hash_with_default_proc.default_proc, hash.default_proc
+    assert_equal default_proc, hash.default_proc
     hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys! { |k| k.to_s }
-    assert_equal hash_with_default_proc.default_proc, hash.default_proc
+    assert_equal default_proc, hash.default_proc
   end
 
   def test_indifferent_deep_transform_keys_bang

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -486,6 +486,18 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_raise TypeError do
       hash.transform_keys(nil)
     end
+
+    hash_with_default = Hash.new(:a)
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys(&:to_s)
+    assert_nil hash.default
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys { |k| k.to_s }
+    assert_nil hash.default
+
+    hash_with_default_proc = Hash.new { |h, k| h[k] = :b }
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys(&:to_s)
+    assert_nil hash.default_proc
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys { |k| k.to_s }
+    assert_nil hash.default_proc
   end
 
   def test_indifferent_deep_transform_keys
@@ -540,6 +552,18 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_raise TypeError do
       hash.transform_keys(nil)
     end
+
+    hash_with_default = Hash.new(:a)
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys!(&:to_s)
+    assert_equal hash_with_default.default, hash.default
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys! { |k| k.to_s }
+    assert_equal hash_with_default.default, hash.default
+
+    hash_with_default_proc = Hash.new { |h, k| h[k] = :b }
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys!(&:to_s)
+    assert_equal hash_with_default_proc.default_proc, hash.default_proc
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys! { |k| k.to_s }
+    assert_equal hash_with_default_proc.default_proc, hash.default_proc
   end
 
   def test_indifferent_deep_transform_keys_bang


### PR DESCRIPTION
Ref #55376 

A [previous change][1] fixed `HWIA#transform_keys!` from clobbering keys if they ended up transforming into another pre-transformed key. However, that change also resulted in `HWIA#transform_keys!` clearing the `default`/`default_proc`.

This commit fixes that issue and adds test coverage to both `#transform_keys` and `#transform_keys!` to ensure that their behavior with regard to `default`/`default_proc` is consistent with `Hash`.

```irb
irb(main):001> Hash.new(:a).transform_keys(&:to_s).default
=> nil
irb(main):002> Hash.new(:a).transform_keys!(&:to_s).default
=> :a
```

[1]: https://github.com/rails/rails/commit/f49d7a0d5a67eccb8d7017c38ac157a5244a7526

cc @byroot

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
