### PR TITLE
Default to fiber isolation from Rails 8.1+.

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -63,6 +63,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_controller.action_on_path_relative_redirect`](#config-action-controller-action-on-path-relative-redirect): `:raise`
 - [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`
 - [`config.active_record.raise_on_missing_required_finder_order_columns`](#config-active-record-raise-on-missing-required-finder-order-columns): `true`
+- [`config.active_support.isolation_level`](#config-active-support-isolation-level): `:fiber`
 - [`config.yjit`](#config-yjit): `!Rails.env.local?`
 
 #### Default Values for Target Version 8.0

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Set `config.active_support.isolation_level = :fiber` as the default for Rails 8.1 applications.
+
+    This provides better support for fiber-based servers and modern concurrency patterns.
+    Existing applications upgrading to Rails 8.1 will maintain thread-based isolation
+    unless they update their `config.load_defaults` version.
+
+    *Samuel Williams*
+
 *   Generate static BCrypt password digests in fixtures instead of dynamic ERB expressions.
 
     Previously, fixtures with password digest attributes used `<%= BCrypt::Password.create("secret") %>`,

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -364,6 +364,10 @@ module Rails
           if respond_to?(:active_record)
             active_record.raise_on_missing_required_finder_order_columns = true
           end
+
+          if respond_to?(:active_support)
+            active_support.isolation_level = :fiber
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -10,6 +10,19 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 ###
+# Changes Rails internal state locality from thread-based to fiber-based.
+# This provides better support for fiber-based servers (e.g., Falcon) and 
+# modern fiber concurrency patterns, and is unlikely to cause issues for
+# most applications.
+#
+# However, applications that explicitly depend on Active Record connections 
+# being shared into fibers (e.g. enumerators) may need to review their code. 
+# If you encounter issues, you can revert to thread-based isolation by 
+# setting this to `:thread`.
+#++
+# Rails.configuration.active_support.isolation_level = :fiber
+
+###
 # Skips escaping HTML entities and line separators. When set to `false`, the
 # JSON renderer no longer escapes these to improve performance.
 #

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4529,7 +4529,14 @@ module ApplicationTests
       assert_equal true, ActionController::Base.raise_on_missing_callback_actions
     end
 
-    test "isolation_level is :thread by default" do
+    test "isolation_level is :fiber by default for Rails 8.1+" do
+      app "development"
+      assert_equal :fiber, ActiveSupport::IsolatedExecutionState.isolation_level
+    end
+
+    test "isolation_level is :thread by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
       app "development"
       assert_equal :thread, ActiveSupport::IsolatedExecutionState.isolation_level
     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Rails should adopt fiber isolation mode as the default for new applications in Rails 8.1 to better support modern fiber-based servers and concurrency patterns.

Currently, Rails defaults to thread-based isolation (`isolation_level = :thread`), but fiber-based isolation (`isolation_level = :fiber`) provides better support for:
- Fiber-based web servers like Falcon.
- Modern Ruby concurrency patterns using fibers.
- Better isolation of execution state in fiber-concurrent scenarios.

As Ruby's fiber support continues to mature and more applications adopt fiber-based architectures, Rails should provide sensible defaults that support these patterns out of the box.

### Detail

This Pull Request changes the default `config.active_support.isolation_level` from `:thread` to `:fiber` for newly generated Rails 8.1 applications by:

- Adding `active_support.isolation_level = :fiber` to the Rails 8.1 defaults in `load_defaults "8.1"`.
- Updating tests to reflect the new default while maintaining backward compatibility tests.
- Updating the configuration guide documentation to list the new default.

The change maintains full backward compatibility - existing applications that upgrade to Rails 8.1 but keep `config.load_defaults "8.0"` (or earlier) will continue using thread-based isolation. Only newly generated Rails 8.1 applications will get fiber isolation by default.

### Additional information

- Fiber isolation mode has been available since Rails 7.0 and is well-tested.
- The change follows Rails' established pattern for version-specific configuration defaults.
- Applications can still explicitly override the default by setting `config.active_support.isolation_level = :thread` if needed.
- This change aligns Rails with the direction of modern Ruby concurrency patterns.
- In the vast majority of cases, there shouldn't be any compatibility issues.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.