### PR TITLE
[ci skip] Fix typo in Actionpack Changelog

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 *   `rate_limit.action_controller` notification has additional payload
 
-    additonal values: count, to, within, by, name, cache_key
+    additional values: count, to, within, by, name, cache_key
 
     *Jonathan Rochkind*
 


### PR DESCRIPTION
### Detail

This Pull Request changes a small typo to the CHANGELOG https://github.com/rails/rails/pull/55418
```diff
-- additonal
++ additional
```

CC @MatheusRich @jrochkind 