### PR TITLE
Log when rescue_from handles an exception

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Produce a log when `rescue_from` is invoked.
+
+    *Steven Webb*, *Jean Boussier*
+
 *   Allow hosts redirects from `hosts` Rails configuration
 
     ```ruby

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -49,6 +49,13 @@ module ActionController
     end
     subscribe_log_level :halted_callback, :info
 
+    # Manually subscribed below
+    def rescue_from_callback(event)
+      exception = event.payload[:exception]
+      info { "rescue_from handled #{exception.class} (#{exception.message}) - #{exception.backtrace.first.delete_prefix("#{Rails.root}/")}" }
+    end
+    subscribe_log_level :rescue_from_callback, :info
+
     def send_file(event)
       info { "Sent file #{event.payload[:path]} (#{event.duration.round(1)}ms)" }
     end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -77,11 +77,11 @@ module Another
     end
 
     def with_exception
-      raise Exception
+      raise Exception, "Oopsie"
     end
 
     def with_rescued_exception
-      raise SpecialException
+      raise SpecialException, "Oops"
     end
 
     def with_action_not_found
@@ -152,6 +152,13 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
     assert_equal 4, logs.size
     assert_equal "Filter chain halted as :redirector rendered or redirected", logs.third
+  end
+
+  def test_rescue_from_callback
+    get :with_rescued_exception
+    wait
+    assert_equal 3, logs.size
+    assert_match "rescue_from handled Another::LogSubscribersController::SpecialException", logs.second
   end
 
   def test_process_action
@@ -406,7 +413,7 @@ class ACLogSubscriberTest < ActionController::TestCase
     get :with_rescued_exception
     wait
 
-    assert_equal 2, logs.size
+    assert_equal 3, logs.size
     assert_match(/Completed 406/, logs.last)
   end
 

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -92,6 +92,7 @@ module ActiveSupport
 
         if handler = handler_for_rescue(exception, object: object)
           handler.call exception
+          ActiveSupport::Notifications.instrument("rescue_from_callback.action_controller", exception: exception)
           exception
         elsif exception
           if visited_exceptions.include?(exception.cause)


### PR DESCRIPTION
### Motivation / Background

In development when a before_action renders or redirects this error message appears on the logs:

> Filter chain halted as :before_action rendered or redirected

I find this message very helpful. However, if a before_action raises an error that is handled by a rescue_from block, nothing is logged indicating an error occurred.

### Detail

This PR adds a log message indicating an exception was rescued, and displays where it was originally raised. For example:

> rescue_from handled BaseController::YourError (Oh no!) -
>   app/controllers/home_controller.rb:9:in 'HomeController#authenticate'

### Additional information

This is my second attempt at this feature. I accidentally [closed the first attempt](https://github.com/rails/rails/pull/55389) and Github won't let me re-open it.

Following [@byroot's suggestion](https://github.com/rails/rails/pull/55389#discussion_r2225854980) I switched to using ActiveSupport::Notification; however, I'm still not sure I'm on the right track so wanted to get feedback before writing tests, etc.

Initially I used "rescue_from_callback.action_controller" for the notification name in `activesupport/lib/active_support/rescuable.rb`. However, it didn't feel right to name it "...action_controller" when it was actually instrumented in active_support. I switched to naming it "...active_support"; however, that required manually subscribing to the notification in `actionpack/lib/action_controller/log_subscriber.rb` which feels better but I'm not sure if it's quite right. I considered creating a new log subscriber in active_support (maybe `ActiveSupport::Rescuable::LogSubscriber`); however, that felt like I was deviating too far from @byroot's suggestion so I thought it best to stop here and ask for feedback. Any advice is appreciated.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
