### PR TITLE
Add support for `rack.response_finished` callbacks in `ActionDispatch::Executor`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add support for `rack.response_finished` callbacks in ActionDispatch::Executor.
+
+    The executor middleware now supports deferring completion callbacks to later
+    in the request lifecycle by utilizing Rack's `rack.response_finished` mechanism,
+    when available. This enables applications to define `rack.response_finished` callbacks
+    that may rely on state that would be cleaned up by the executor's completion callbacks.
+
+    *Adrianna Chang*, *Hartley McGuire*
+
 *   Produce a log when `rescue_from` is invoked.
 
     *Steven Webb*, *Jean Boussier*

--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -12,6 +12,10 @@ module ActionDispatch
 
     def call(env)
       state = @executor.run!(reset: true)
+      if response_finished = env["rack.response_finished"]
+        response_finished << -> { state.complete! }
+      end
+
       begin
         response = @app.call(env)
 
@@ -20,7 +24,11 @@ module ActionDispatch
           @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
         end
 
-        returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
+        unless response_finished
+          response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
+        end
+        returned = true
+        response
       rescue Exception => error
         request = ActionDispatch::Request.new env
         backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
@@ -28,7 +36,9 @@ module ActionDispatch
         @executor.error_reporter.report(wrapper.unwrapped_exception, handled: false, source: "application.action_dispatch")
         raise
       ensure
-        state.complete! unless returned
+        if !returned && !response_finished
+          state.complete!
+        end
       end
     end
   end

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -170,10 +170,44 @@ class ExecutorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_complete_callbacks_are_called_on_rack_response_finished
+    completed = false
+    executor.to_complete { completed = true }
+
+    env = { "rack.response_finished" => [] }
+    call_and_return_body(env)
+
+    assert_not completed
+
+    assert_equal 1, env["rack.response_finished"].size
+    env["rack.response_finished"].first.call
+
+    assert completed
+  end
+
+  def test_complete_callbacks_are_called_once_on_rack_response_finished_when_exception_is_raised
+    completed_count = 0
+    executor.to_complete { completed_count += 1 }
+
+    env = { "rack.response_finished" => [] }
+
+    begin
+      call_and_return_body(env) do
+        raise "error"
+      end
+    rescue
+    end
+
+    assert_equal 1, env["rack.response_finished"].size
+    env["rack.response_finished"].first.call
+
+    assert_equal 1, completed_count
+  end
+
   private
-    def call_and_return_body(&block)
+    def call_and_return_body(env = {}, &block)
       app = block || proc { [200, {}, []] }
-      env = Rack::MockRequest.env_for("", {})
+      env = Rack::MockRequest.env_for("", env)
       _, _, body = middleware(app).call(env)
       body
     end


### PR DESCRIPTION
### Motivation / Background

The executor middleware now supports deferring completion callbacks to later in the request lifecycle by utilizing Rack's `rack.response_finished` mechanism, when available. This enables applications to define `rack.response_finished` callbacks that may rely on state that would be cleaned up by the executor's completion callbacks.

This came up in the context of https://github.com/rails/rails/pull/55334#discussion_r2236757794 -- we want to use `to_complete` hooks to handle clearing context for the Event Reporter, but Shopify's application code wants to use said context in a `rack.response_finished` callback in order to produce a request summary log.

By moving the `to_complete` callbacks to `rack.response_finished` when available instead of `Rack::BodyProxy`, applications are able to define their own `rack.response_finished` callbacks that may rely on state that would be cleaned up (e.g. `ExecutionContext`, `CurrentAttributes`, and eventually the `EventReporter` context).

### Detail

- If `rack.response_finished` is set, we assume the webserver supports it. If there isn't support for it, we continue to use `Rack::BodyProxy`.
- We push the `state.complete!` to the array of callables; we do this _before_ we call the app, because we want it to run _after_ any application `rack.response_finished` callbacks run (and callbacks are executed in reverse order).
- We only run `state.complete!` in the `ensure` block if we're using `BodyProxy`; `rack.response_finished` ["should not raise any errors"](https://github.com/rack/rack/blob/main/SPEC.rdoc#rackresponse_finished-) and are run from an `ensure` block, so even if something went awry we'd invoke the complete callbacks. We don't want to invoke them twice.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
