### PR TITLE
[RF-DOCS] Fix tutorials link in Sign Up & Settings Guide

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -2007,4 +2007,4 @@ Here are a few ideas to build on to this:
 
 Happy building!
 
-[Return to all tutorials](tutorials.html)
+[Return to all tutorials](https://rubyonrails.org/docs/tutorials)


### PR DESCRIPTION
This should link to the rubyonrails.org website directly instead of staying on the subdomain.

cc @AmandaPerino 