### PR TITLE
Backport 55419 to 8-0-stable

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -262,9 +262,7 @@ module ActiveSupport
     #   hash[:a][:c] # => "c"
     #   dup[:a][:c]  # => "c"
     def dup
-      self.class.new(self).tap do |new_hash|
-        set_defaults(new_hash)
-      end
+      copy_defaults(self.class.new(self))
     end
 
     # This method has the same semantics of +update+, except it does not
@@ -352,12 +350,12 @@ module ActiveSupport
     def transform_keys!(hash = NOT_GIVEN, &block)
       if NOT_GIVEN.equal?(hash)
         if block_given?
-          replace(transform_keys(&block))
+          replace(copy_defaults(transform_keys(&block)))
         else
           return to_enum(:transform_keys!)
         end
       else
-        replace(transform_keys(hash, &block))
+        replace(copy_defaults(transform_keys(hash, &block)))
       end
 
       self
@@ -381,8 +379,7 @@ module ActiveSupport
     def to_hash
       copy = Hash[self]
       copy.transform_values! { |v| convert_value_to_hash(v) }
-      set_defaults(copy)
-      copy
+      copy_defaults(copy)
     end
 
     def to_proc
@@ -418,12 +415,13 @@ module ActiveSupport
       end
 
 
-      def set_defaults(target)
+      def copy_defaults(target)
         if default_proc
           target.default_proc = default_proc.dup
         else
           target.default = default
         end
+        target
       end
 
       def update_with_single_argument(other_hash, block)

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -476,6 +476,18 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_raise TypeError do
       hash.transform_keys(nil)
     end
+
+    hash_with_default = Hash.new(:a)
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys(&:to_s)
+    assert_nil hash.default
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys { |k| k.to_s }
+    assert_nil hash.default
+
+    hash_with_default_proc = Hash.new { |h, k| h[k] = :b }
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys(&:to_s)
+    assert_nil hash.default_proc
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys { |k| k.to_s }
+    assert_nil hash.default_proc
   end
 
   def test_indifferent_deep_transform_keys
@@ -530,6 +542,23 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_raise TypeError do
       hash.transform_keys(nil)
     end
+
+    hash_with_default = Hash.new(:a)
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys!(&:to_s)
+    assert_equal :a, hash.default
+    assert_equal :a, hash_with_default.default
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default).transform_keys! { |k| k.to_s }
+    assert_equal :a, hash.default
+    assert_equal :a, hash_with_default.default
+
+    hash_with_default_proc = Hash.new { |h, k| h[k] = :b }
+    default_proc = hash_with_default_proc.default_proc
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys!(&:to_s)
+    assert_equal default_proc, hash.default_proc
+    hash = ActiveSupport::HashWithIndifferentAccess.new(hash_with_default_proc).transform_keys! { |k| k.to_s }
+    assert_equal default_proc, hash.default_proc
   end
 
   def test_indifferent_deep_transform_keys_bang


### PR DESCRIPTION
Backport #55419 to `8-0-stable` to fix #55376 