### PR TITLE
Add Copy as Text button to error pages

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add "Copy as text" button to error pages
+
+    *Mikkel Malmberg*
+
 *   Add `scope:` option to `rate_limit` method.
 
     Previously, it was not possible to share a rate limit count between several controllers, since the count was by

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -127,6 +127,7 @@ module ActionDispatch
           trace_to_show: wrapper.trace_to_show,
           routes_inspector: routes_inspector(wrapper),
           source_extracts: wrapper.source_extracts,
+          exception_message_for_copy: compose_exception_message(wrapper).join("\n"),
         )
       end
 
@@ -140,6 +141,11 @@ module ActionDispatch
         return unless logger
         return if !log_rescued_responses?(request) && wrapper.rescue_response?
 
+        message = compose_exception_message(wrapper)
+        log_array(logger, message, request)
+      end
+
+      def compose_exception_message(wrapper)
         trace = wrapper.exception_trace
 
         message = []
@@ -168,7 +174,7 @@ module ActionDispatch
           end
         end
 
-        log_array(logger, message, request)
+        message
       end
 
       def log_array(logger, lines, request)

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_copy_button.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_copy_button.html.erb
@@ -1,0 +1,1 @@
+<button onclick="copyAsText.bind(this)()">Copy as text</button>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
@@ -1,4 +1,5 @@
 <header>
+  <%= render "rescues/copy_button" %>
   <h1>Blocked hosts: <%= @hosts.join(", ") %></h1>
 </header>
 <main role="main" id="container">

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -1,4 +1,5 @@
 <header>
+  <%= render "rescues/copy_button" %>
   <h1>
     <%= @exception_wrapper.exception_class_name %>
     <% if params_valid? && @request.parameters['controller'] %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
@@ -1,4 +1,5 @@
 <header role="banner">
+  <%= render "rescues/copy_button" %>
   <h1>
     <%= @exception.class.to_s %>
     <% if @request.parameters['controller'] %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -38,6 +38,22 @@
       padding: 0.5em 1.5em;
     }
 
+    header button {
+      appearance: none;
+      background-color: hsl(0 0% 0% / 0.2);
+      border: 0;
+      border-radius: 14px;
+      color: white;
+      float: right;
+      font-weight: 500;
+      height: 28px;
+      padding-inline: 14px;
+      margin: 0.35em 0;
+    }
+    header button:active {
+      background-color: hsl(0 0% 0% / 0.25);
+    }
+
     h1 {
       overflow-wrap: break-word;
       margin: 0.2em 0;
@@ -298,11 +314,21 @@
     var toggleEnvDump = function() {
       return toggle('env_dump');
     }
+    var copyAsText = function() {
+      const text = document.getElementById("exception-message-for-copy").textContent;
+
+      navigator.clipboard.writeText(text).then(() => {
+        const beforeText = this.innerText;
+        this.innerText = "Copied!"
+        setTimeout(() => this.innerText = beforeText, 1000)
+      })
+    }
   </script>
 </head>
 <body>
 
   <%= yield %>
+  <script type="text/plain" id="exception-message-for-copy"><%= raw @exception_message_for_copy %></script>
 
 </body>
 </html>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
@@ -1,4 +1,5 @@
 <header role="banner">
+  <%= render "rescues/copy_button" %>
   <h1>No view template for interactive request</h1>
 </header>
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
@@ -1,4 +1,5 @@
 <header role="banner">
+  <%= render "rescues/copy_button" %>
   <h1>Template is missing</h1>
 </header>
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
@@ -1,4 +1,5 @@
 <header role="banner">
+  <%= render "rescues/copy_button" %>
   <h1>Routing Error</h1>
 </header>
 <main role="main" id="container">

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
@@ -1,4 +1,5 @@
 <header role="banner">
+  <%= render "rescues/copy_button" %>
   <h1>
     <%= @exception_wrapper.exception_name %> in
     <%= @request.parameters["controller"].camelize if @request.parameters["controller"] %>#<%= @request.parameters["action"] %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
@@ -1,4 +1,5 @@
 <header role="banner">
+  <%= render "rescues/copy_button" %>
   <h1>Unknown action</h1>
 </header>
 <main role="main" id="container">


### PR DESCRIPTION
### Motivation / Background

Often when developing, you need to copy an error for pasting somewhere else. Be it searching the web, chatting with an LLM or sending to that co-worker to shame them for breaking production on a Friday.

This Pull Request adds a button to error page headers that, when clicked, copies a plain text version of the error to the user's clipboard.

For simplicity's sake, I'm reusing the already formatted log version. This is usually brief and to the point – and will also likely match any other copy-pasted versions others have put on the internet.

### Additional information

In action:

https://github.com/user-attachments/assets/81cf76db-0af1-4f10-be31-6b5283a8820d


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
