### PR TITLE
Fix ActiveSupport::Rescuable not to be coupled with ActionController

### DIFF
--- a/actionpack/lib/action_controller/metal/rescue.rb
+++ b/actionpack/lib/action_controller/metal/rescue.rb
@@ -13,6 +13,15 @@ module ActionController # :nodoc:
     extend ActiveSupport::Concern
     include ActiveSupport::Rescuable
 
+    module ClassMethods
+      def handler_for_rescue(exception, ...) # :nodoc:
+        if handler = super
+          ActiveSupport::Notifications.instrument("rescue_from_callback.action_controller", exception: exception)
+          handler
+        end
+      end
+    end
+
     # Override this method if you want to customize when detailed exceptions must be
     # shown. This method is only called when `consider_all_requests_local` is
     # `false`. By default, it returns `false`, but someone may set it to

--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -92,7 +92,6 @@ module ActiveSupport
 
         if handler = handler_for_rescue(exception, object: object)
           handler.call exception
-          ActiveSupport::Notifications.instrument("rescue_from_callback.action_controller", exception: exception)
           exception
         elsif exception
           if visited_exceptions.include?(exception.cause)


### PR DESCRIPTION
Followup on https://github.com/rails/rails/pull/55424

I mistakenly added an Action Controller event in the middle of Active Support.

Instead we can decorate the necessary method.

In addition, we can trigger the event before invoking the handler.
