### PR TITLE
Fix badly anchored regular expression

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -40,7 +40,7 @@ class Module
   #   Current.new.user # => NoMethodError
   def thread_mattr_reader(*syms, instance_reader: true, instance_accessor: true, default: nil) # :nodoc:
     syms.each do |sym|
-      raise NameError.new("invalid attribute name: #{sym}") unless /^[_A-Za-z]\w*$/.match?(sym)
+      raise NameError.new("invalid attribute name: #{sym}") unless /\A[_A-Za-z]\w*\z/.match?(sym)
 
       # The following generated method concatenates `object_id` because we want
       # subclasses to maintain independent values.


### PR DESCRIPTION
https://github.com/rails/rails/blob/add5a73b26e78d6b13945525874749ae40af21c7/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb#L43-L43


fix the problem, the regular expression used to validate the attribute name should use the `\A` and `\z` anchors instead of `^` and `$`. This ensures that the entire string is matched, not just a single line. The change should be made on line 43 of `activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb`, replacing `/^[_A-Za-z]\w*$/` with `/\A[_A-Za-z]\w*\z/`. No additional imports or method definitions are needed.

### References
Ruby documentation: [Anchors](https://ruby-doc.org/3.2.0/Regexp.html#class-Regexp-label-Anchors)
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
