### PR TITLE
Fix typo in Sign Up and Settings Guide [ci skip]

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -1901,7 +1901,7 @@ end
 
 test "regular user cannot access /store/users" do
   sign_in_as users(:one)
-  get store_products_path
+  get store_users_path
   assert_response :redirect
   assert_equal "You aren't allowed to do that.", flash[:alert]
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is a typo in a path in the settings integration test for the [Sign Up and Settings](https://edgeguides.rubyonrails.org/sign_up_and_settings.html#testing-settings) tutorial.

### Detail

This Pull Request changes `get store_products_path` to `get_store_users_path` for the `test "regular user cannot access /store/users" do` test.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
