### PR TITLE
Fix incorrect statement about object destruction [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1325,7 +1325,7 @@ objects.
 ```
 
 The [`collection.destroy`][] method removes one or more objects from the
-collection by deleting records in the join table. This does not destroy the
+collection by deleting records in the join table. This destroys the
 objects.
 
 ```ruby


### PR DESCRIPTION
Replace the incorrect statement "This does not destroy the objects" with "This destroys the objects" to match the API Docs.

### Motivation / Background

This Pull Request has been created because the Rails guides had a factual error in  [Active Record Associations Section #2.6.1.1](https://guides.rubyonrails.org/association_basics.html#methods-added-by-has-and-belongs-to-many-managing-the-collection). 


### Detail
The guides originally state that [`collection.destroy`](https://api.rubyonrails.org/v8.0.2/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-destroy) does NOT destroy the  objects. According to the [API Docs](https://api.rubyonrails.org/v8.0.2/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-destroy), it does destroy the objects.


This Pull Request changes the incorrect statement "This does not destroy the objects" to "This destroys the objects" in order to match the API Docs.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
