### PR TITLE
Remove `ActiveJob::ConfiguredJob#perform_all_later` method

### DIFF
--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -19,9 +19,5 @@ module ActiveJob
 
       enqueue_result
     end
-
-    def perform_all_later(multi_args)
-      @job_class.perform_all_later(multi_args, options: @options)
-    end
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/46603 (cc @Mangara)

The removed method is currently broken and raises an error
```
undefined method 'perform_all_later' for class TestJob (NoMethodError)

      @job_class.perform_all_later(multi_args, options: @options)
                ^^^^^^^^^^^^^^^^^^
Did you mean?  perform_later
```

The intention of that method was probably to use it like this:
```ruby
TestJob.set(wait: 1.hour).perform_all_later([[job1_arg], [job2_arg]])
```

But then the syntax for `TestJob.perform_all_later([[job1_arg], [job2_arg]])` (note the job name usage instead of `ActiveJob`) should be implemented too, for consistency. 

But I think, this is really not needed, because existing syntax (`ActiveJob.perform_all_later(job1, job2)`) is flexible enough to handle both cases.