### PR TITLE
Enable hooking LocalCache into Executor

### DIFF
--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -3,22 +3,25 @@
 module ActiveSupport
   module ExecutionContext # :nodoc:
     class Record
-      attr_reader :store, :current_attributes_instances
+      attr_reader :store, :current_attributes_instances, :local_cache_registry
 
       def initialize
         @store = {}
         @current_attributes_instances = {}
+        @local_cache_registry = {}
         @stack = []
       end
 
       def push
-        @stack << @store << @current_attributes_instances
+        @stack << @store << @current_attributes_instances << @local_cache_registry
         @store = {}
         @current_attributes_instances = {}
+        @local_cache_registry = {}
         self
       end
 
       def pop
+        @local_cache_registry = @stack.pop
         @current_attributes_instances = @stack.pop
         @store = @stack.pop
         self
@@ -99,6 +102,10 @@ module ActiveSupport
 
       def current_attributes_instances
         record.current_attributes_instances
+      end
+
+      def local_cache_registry
+        record.local_cache_registry
       end
 
       private

--- a/activesupport/test/cache/strategy/local_cache_test.rb
+++ b/activesupport/test/cache/strategy/local_cache_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/cache"
+require "active_support/core_ext/object/with"
+
+module ActiveSupport
+  module Cache
+    module Strategy
+      class LocalCacheTest < ActiveSupport::TestCase
+        test "sets and restores LocalCache when re-entering the executor" do
+          ActiveSupport::ExecutionContext.with(nestable: true) do
+            cache = Cache::NullStore.new
+
+            # simulate executor hooks from active_support/railtie.rb
+            executor = Class.new(ActiveSupport::Executor)
+            executor.to_run do
+              ActiveSupport::ExecutionContext.push
+            end
+            executor.to_complete do
+              ActiveSupport::ExecutionContext.pop
+            end
+            cache.install_executor_hooks(executor)
+
+            cache.write("dev null", 1)
+            assert_nil cache.read("dev null")
+
+            cache.with_local_cache do
+              assert_nil cache.read("dev null")
+
+              cache.write("cached locally", 2)
+              assert_equal 2, cache.read("cached locally")
+
+              executor.wrap do
+                assert_nil cache.read("cached locally")
+
+                cache.write("nested cache", 3)
+                assert_equal 3, cache.read("nested cache")
+              end
+
+              assert_nil cache.read("nested cache")
+              assert_equal 2, cache.read("cached locally")
+            end
+
+            assert_nil cache.read("cached locally")
+          end
+        end
+      end
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -65,6 +65,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_view.remove_hidden_field_autocomplete`](#config-action-view-remove-hidden-field-autocomplete): `true`
 - [`config.action_view.render_tracker`](#config-action-view-render-tracker): `:ruby`
 - [`config.active_record.raise_on_missing_required_finder_order_columns`](#config-active-record-raise-on-missing-required-finder-order-columns): `true`
+- [`config.local_cache_store_strategy`](#config-local-cache-store-strategy): `:executor`
 - [`config.yjit`](#config-yjit): `!Rails.env.local?`
 
 #### Default Values for Target Version 8.0
@@ -447,9 +448,20 @@ An app's configured `javascript_path` will be excluded from `autoload_paths`.
 
 #### `config.local_cache_store_strategy`
 
-Configures whether `ActiveSupport::Cache::Strategy::LocalCache` is added to the
-middleware stack if supported by `Rails.cache`. Set to `false` to disable the
-middleware.
+Configures whether `Rails.cache` will use `LocalCache`, if supported. Valid
+options are:
+
+- `:executor`, which enables `LocalCache` inside the application's `Executor`.
+- `:middleware`, which enables `LocalCache` with a Rack middleware.
+- `false`, to disable any automatic `LocalCache` behavior.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `:middleware`        |
+| 8.1                   | `:executor`          |
+
+[`Executor`]: https://api.rubyonrails.org/classes/ActionDispatch/Executor.html
+[`LocalCache`]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Strategy/LocalCache.html
 
 #### `config.log_file_size`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -444,6 +444,13 @@ attacks.
 Sets the path where your app's JavaScript lives relative to the `app` directory and the default value is `javascript`.
 An app's configured `javascript_path` will be excluded from `autoload_paths`.
 
+
+#### `config.local_cache_store_strategy`
+
+Configures whether `ActiveSupport::Cache::Strategy::LocalCache` is added to the
+middleware stack if supported by `Rails.cache`. Set to `false` to disable the
+middleware.
+
 #### `config.log_file_size`
 
 Defines the maximum size of the Rails log file in bytes. Defaults to `104_857_600` (100 MiB) in development and test, and unlimited in all other environments.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Enable hooking `LocalCache` into `Executor`.
+
+    Previously, `LocalCache` would automatically be enabled for requests using a
+    middleware (if supported by the `Rails.cache` store). Now, it can be
+    configured to use the `Executor` instead, meaning it'll be used in jobs,
+    tests, etc. This will be the default starting with `load_defaults 8.1`.
+
+    ```ruby
+    config.local_cache_store_strategy = :executor
+    ```
+
+    The same configuration can also be used to disable the `LocalCache`.
+
+    ```ruby
+    config.local_cache_store_strategy = false
+    ```
+
+    *Hartley McGuire*
+
 *   Add command `rails credentials:fetch PATH` to get the value of a credential from the credentials file.
 
     ```bash

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -81,16 +81,7 @@ module Rails
         cache_format_version = config.active_support.delete(:cache_format_version)
         ActiveSupport.cache_format_version = cache_format_version if cache_format_version
 
-        unless Rails.cache
-          Rails.cache = ActiveSupport::Cache.lookup_store(*config.cache_store)
-
-          case config.local_cache_store
-          when :middleware
-            if Rails.cache.respond_to?(:middleware)
-              config.middleware.insert_before(::Rack::Runtime, Rails.cache.middleware)
-            end
-          end
-        end
+        Rails.cache ||= ActiveSupport::Cache.lookup_store(*config.cache_store)
       end
 
       # We setup the once autoloader this early so that engines and applications

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -84,8 +84,11 @@ module Rails
         unless Rails.cache
           Rails.cache = ActiveSupport::Cache.lookup_store(*config.cache_store)
 
-          if Rails.cache.respond_to?(:middleware)
-            config.middleware.insert_before(::Rack::Runtime, Rails.cache.middleware)
+          case config.local_cache_store
+          when :middleware
+            if Rails.cache.respond_to?(:middleware)
+              config.middleware.insert_before(::Rack::Runtime, Rails.cache.middleware)
+            end
           end
         end
       end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -26,7 +26,7 @@ module Rails
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
                     :dom_testing_default_html_version, :yjit
 
-      attr_reader :encoding, :api_only, :loaded_config_version, :log_level
+      attr_reader :encoding, :api_only, :loaded_config_version, :local_cache_store_strategy, :log_level
 
       def initialize(*)
         super
@@ -56,6 +56,7 @@ module Rails
         @log_file_size                           = nil
         @generators                              = app_generators
         @cache_store                             = [ :file_store, "#{root}/tmp/cache/" ]
+        @local_cache_store_strategy              = :middleware
         @railties_order                          = [:all]
         @relative_url_root                       = ENV["RAILS_RELATIVE_URL_ROOT"]
         @reload_classes_only_on_change           = true
@@ -525,6 +526,14 @@ module Rails
       def colorize_logging=(val)
         ActiveSupport::LogSubscriber.colorize_logging = val
         generators.colorize_logging = val
+      end
+
+      def local_cache_store_strategy=(val)
+        if [false, :middleware].include? val
+          @local_cache_store_strategy = val
+        else
+          raise ArgumentError, "Invalid value for local_cache_store_strategy, #{val}. Must be `false` or `:middleware`"
+        end
       end
 
       def secret_key_base

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -357,6 +357,8 @@ module Rails
           # faster in these environments.
           self.yjit = !Rails.env.local?
 
+          self.local_cache_store_strategy = :executor
+
           if respond_to?(:action_controller)
             action_controller.escape_json_responses = false
             action_controller.action_on_path_relative_redirect = :raise

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -529,10 +529,10 @@ module Rails
       end
 
       def local_cache_store_strategy=(val)
-        if [false, :middleware].include? val
+        if [false, :middleware, :executor].include? val
           @local_cache_store_strategy = val
         else
-          raise ArgumentError, "Invalid value for local_cache_store_strategy, #{val}. Must be `false` or `:middleware`"
+          raise ArgumentError, "Invalid value for local_cache_store, #{val}. Must be `false`, `:middleware`, or `:executor`"
         end
       end
 

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -49,6 +49,9 @@ module Rails
           middleware.use ::ActionDispatch::Executor, app.executor
 
           middleware.use ::ActionDispatch::ServerTiming if config.server_timing
+
+          middleware.use Rails.cache.middleware if config.local_cache_store_strategy == :middleware && Rails.cache.respond_to?(:middleware)
+
           middleware.use ::Rack::Runtime
           middleware.use ::Rack::MethodOverride unless config.api_only
           middleware.use ::ActionDispatch::RequestId, header: config.action_dispatch.request_id_header

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -64,3 +64,8 @@
 # Applications that want to keep generating the `autocomplete` attribute for those tags can set it to `false`.
 #++
 # Rails.configuration.action_view.remove_hidden_field_autocomplete = true
+
+# Configures the Rails.cache LocalCache to use the application's executor
+# instead of a middleware (if the Rails.cache store supports it)
+#
+# Rails.configuration.local_cache_store_strategy = :executor

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4391,6 +4391,14 @@ module ApplicationTests
       assert_not(Rails.application.config.middleware.map(&:name).include?("ActiveSupport::Cache::Strategy::LocalCache"))
     end
 
+    test "LocalCache middleware can be removed via configuration" do
+      add_to_config "config.local_cache_store_strategy = false"
+
+      app "development"
+
+      assert_not_includes Rails.application.config.middleware.map(&:name), "ActiveSupport::Cache::Strategy::LocalCache"
+    end
+
     test "custom middleware with overridden names can be added, moved, or deleted" do
       app_file "config/initializers/add_custom_middleware.rb", <<~RUBY
         class CustomMiddlewareOne

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4340,6 +4340,8 @@ module ApplicationTests
     end
 
     test "app starts with LocalCache middleware" do
+      add_to_config "config.local_cache_store_strategy = :middleware"
+
       app "development"
 
       assert(Rails.application.config.middleware.map(&:name).include?("ActiveSupport::Cache::Strategy::LocalCache"))
@@ -4350,6 +4352,8 @@ module ApplicationTests
     end
 
     test "LocalCache middleware can be moved via app config" do
+      add_to_config "config.local_cache_store_strategy = :middleware"
+
       # you can't move Rails.cache.middleware as it doesn't exist yet
       add_to_config "config.middleware.move_after(Rails::Rack::Logger, ActiveSupport::Cache::Strategy::LocalCache)"
 
@@ -4361,6 +4365,8 @@ module ApplicationTests
     end
 
     test "LocalCache middleware can be moved via initializer" do
+      add_to_config "config.local_cache_store_strategy = :middleware"
+
       app_file "config/initializers/move_local_cache_middleware.rb", <<~RUBY
         Rails.application.config.middleware.move_after(Rails::Rack::Logger, Rails.cache.middleware)
       RUBY
@@ -4373,6 +4379,8 @@ module ApplicationTests
     end
 
     test "LocalCache middleware can be removed via app config" do
+      add_to_config "config.local_cache_store_strategy = :middleware"
+
       # you can't delete Rails.cache.middleware as it doesn't exist yet
       add_to_config "config.middleware.delete(ActiveSupport::Cache::Strategy::LocalCache)"
 
@@ -4382,6 +4390,8 @@ module ApplicationTests
     end
 
     test "LocalCache middleware can be removed via initializer" do
+      add_to_config "config.local_cache_store_strategy = :middleware"
+
       app_file "config/initializers/remove_local_cache_middleware.rb", <<~RUBY
         Rails.application.config.middleware.delete(Rails.cache.middleware)
       RUBY
@@ -4410,8 +4420,6 @@ module ApplicationTests
     end
 
     test "LocalCache executor hook can be enabled via configuration" do
-      add_to_config "config.local_cache_store_strategy = :executor"
-
       app "development"
 
       assert_not_includes Rails.application.config.middleware.map(&:name), "ActiveSupport::Cache::Strategy::LocalCache"
@@ -4424,6 +4432,8 @@ module ApplicationTests
     end
 
     test "LocalCache executor hook can be enabled via configuration in initializer" do
+      add_to_config "config.local_cache_store_strategy = :middleware"
+
       app_file "config/initializers/new_framework_defaults.rb", <<~RUBY
         Rails.configuration.local_cache_store_strategy = :executor
       RUBY

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4399,6 +4399,16 @@ module ApplicationTests
       assert_not_includes Rails.application.config.middleware.map(&:name), "ActiveSupport::Cache::Strategy::LocalCache"
     end
 
+    test "LocalCache middleware can be removed via configuration in initializer" do
+      app_file "config/initializers/remove_local_cache_middleware.rb", <<~RUBY
+        Rails.configuration.local_cache_store_strategy = false
+      RUBY
+
+      app "development"
+
+      assert_not_includes Rails.application.config.middleware.map(&:name), "ActiveSupport::Cache::Strategy::LocalCache"
+    end
+
     test "custom middleware with overridden names can be added, moved, or deleted" do
       app_file "config/initializers/add_custom_middleware.rb", <<~RUBY
         class CustomMiddlewareOne

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -31,7 +31,6 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
       "ActionDispatch::Static",
       "ActionDispatch::Executor",
       "ActionDispatch::ServerTiming",
-      "ActiveSupport::Cache::Strategy::LocalCache",
       "Rack::Runtime",
       "Rack::MethodOverride",
       "ActionDispatch::RequestId",
@@ -66,7 +65,6 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
       "ActionDispatch::Static",
       "ActionDispatch::Executor",
       "ActionDispatch::ServerTiming",
-      "ActiveSupport::Cache::Strategy::LocalCache",
       "Rack::Runtime",
       "Rack::MethodOverride",
       "ActionDispatch::RequestId",
@@ -99,7 +97,6 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
       "Rack::Sendfile",
       "ActionDispatch::Static",
       "ActionDispatch::Executor",
-      "ActiveSupport::Cache::Strategy::LocalCache",
       "Rack::Runtime",
       "ActionDispatch::RequestId",
       "ActionDispatch::RemoteIp",
@@ -319,6 +316,8 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
   end
 
   test "Rails.cache does respond to middleware" do
+    add_to_config "config.local_cache_store_strategy = :middleware"
+
     boot!
     assert_equal "ActiveSupport::Cache::Strategy::LocalCache", middleware[4]
     assert_equal "Rack::Runtime", middleware[5]


### PR DESCRIPTION
Previously, Rails would automatically add the `LocalCache::Middleware`
to the stack if `Rails.cache` is configured to use a `Store` that
supports `LocalCache` (currently, `MemCacheStore`, `RedisCacheStore`,
and `NullStore`).

This commit introduces an additional option to the configuration added
in a previous commit (`config.local_cache_store_strategy`), `:executor`. When
using this option, Rails will register `run` and `complete` hooks on the
application's executor instead of using a middleware.

While Rails automatically adds a middleware for requests to take
advantage of the `LocalCache`, there is no such built in mechanism for
Active Job. Similarly, regular `ActiveSupport::TestCase` tests will not
end up using the `LocalCache` even though they may be testing behavior
that _would_ go through the `LocalCache` during a real request. By using
the executor for configuring the `LocalCache`, requests, job, tests, and
any other application code wrapped in the executor will be able to take
advantage of it. This is also already the behavior of Active Record's
in-memory-cache, so this would align `Rails.cache`'s in-memory-cache
with it.

Finally, using the executor means we have one less middleware in the
request stack and one less BodyProxy allocated and wrapped around the
response, which makes me happy.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
