### PR TITLE
[rail_inspector] Fix linting defaults post-release

### DIFF
--- a/tools/rail_inspector/lib/rail_inspector/configuring.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring.rb
@@ -67,10 +67,7 @@ module RailInspector
         Check::FrameworkDefaults.new(
           self,
           framework_defaults_by_version,
-          doc
-            .versioned_defaults
-            .slice_before { |line| line.start_with?("####") }
-            .to_a,
+          doc.versioned_defaults,
         ),
         Check::NewFrameworkDefaultsFile.new(
           self,

--- a/tools/rail_inspector/lib/rail_inspector/configuring.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring.rb
@@ -6,21 +6,42 @@ require_relative "./configuring/check/framework_defaults"
 
 module RailInspector
   class Configuring
-    class CachedParser
-      def initialize
-        @cache = {}
+    class Files
+      class Proxy
+        def initialize(pathname)
+          @pathname = pathname
+        end
+
+        def parse
+          @parse ||= Prism.parse_file(@pathname.to_s).value
+        end
+
+        def read
+          @pathname.read
+        end
+
+        def write(string)
+          @pathname.write(string)
+        end
+
+        def to_s
+          @pathname.to_s
+        end
       end
 
-      def call(path)
-        @cache[path] ||= Prism.parse_file(path.to_s).value
+      def initialize(root)
+        @root = Pathname.new(root)
+        @files = {}
+      end
+
+      def []=(name, path)
+        @files[name] = Proxy.new(@root.join(path))
+      end
+
+      def method_missing(name, ...)
+        @files[name] || super
       end
     end
-
-    DOC_PATH = "guides/source/configuring.md"
-    APPLICATION_CONFIGURATION_PATH =
-      "railties/lib/rails/application/configuration.rb"
-    NEW_FRAMEWORK_DEFAULTS_PATH =
-      "railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_%{version}.rb.tt"
 
     class Doc
       attr_accessor :general_config, :versioned_defaults
@@ -45,12 +66,19 @@ module RailInspector
       end
     end
 
-    attr_reader :errors, :parser
+    attr_reader :errors, :files
 
     def initialize(rails_path)
       @errors = []
-      @parser = CachedParser.new
-      @rails_path = Pathname.new(rails_path)
+      @files = Files.new(rails_path)
+
+      @files[:application_configuration] = "railties/lib/rails/application/configuration.rb"
+      @files[:doc_path] = "guides/source/configuring.md"
+      @files[:rails_version] = "RAILS_VERSION"
+
+      @files[:new_framework_defaults] = "railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_%{version}.rb.tt" % {
+        version: rails_version.tr(".", "_")
+      }
     end
 
     def check
@@ -60,27 +88,15 @@ module RailInspector
     end
 
     def doc
-      @doc ||=
-        begin
-          content = File.read(doc_path)
-          Configuring::Doc.new(content)
-        end
-    end
-
-    def parse(relative_path)
-      parser.call(@rails_path.join(relative_path))
-    end
-
-    def read(relative_path)
-      File.read(@rails_path.join(relative_path))
+      @doc ||= Configuring::Doc.new(files.doc_path.read)
     end
 
     def rails_version
-      @rails_version ||= File.read(@rails_path.join("RAILS_VERSION")).to_f.to_s
+      @rails_version ||= files.rails_version.read.to_f.to_s
     end
 
     def write!
-      File.write(doc_path, doc.to_s)
+      files.doc_path.write(doc.to_s)
     end
 
     def error_message
@@ -90,10 +106,5 @@ module RailInspector
         "Make sure new configurations are added to configuring.md#rails-general-configuration in alphabetical order.\n" +
         "Errors may be autocorrectable with the --autocorrect flag"
     end
-
-    private
-      def doc_path
-        @rails_path.join(DOC_PATH)
-      end
   end
 end

--- a/tools/rail_inspector/lib/rail_inspector/configuring.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring.rb
@@ -3,6 +3,7 @@
 require "pathname"
 require_relative "./configuring/check/general_configuration"
 require_relative "./configuring/check/framework_defaults"
+require_relative "./configuring/document"
 
 module RailInspector
   class Configuring
@@ -43,29 +44,6 @@ module RailInspector
       end
     end
 
-    class Doc
-      attr_accessor :general_config, :versioned_defaults
-
-      def initialize(content)
-        @before, @versioned_defaults, @general_config, @after =
-          content
-            .split("\n")
-            .slice_before do |line|
-              [
-                "### Versioned Default Values",
-                "### Rails General Configuration",
-                "### Configuring Assets"
-              ].include?(line)
-            end
-            .to_a
-      end
-
-      def to_s
-        (@before + @versioned_defaults + @general_config + @after).join("\n") +
-          "\n"
-      end
-    end
-
     attr_reader :errors, :files
 
     def initialize(rails_path)
@@ -88,7 +66,7 @@ module RailInspector
     end
 
     def doc
-      @doc ||= Configuring::Doc.new(files.doc_path.read)
+      @doc ||= Configuring::Document.parse(files.doc_path.read)
     end
 
     def rails_version

--- a/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
@@ -8,12 +8,14 @@ module RailInspector
       class FrameworkDefaults
         attr_reader :checker
 
-        def initialize(checker)
+        def initialize(checker, defaults_by_version, documented_defaults)
           @checker = checker
+          @defaults_by_version = defaults_by_version
+          @documented_defaults = documented_defaults
         end
 
         def check
-          header, *defaults_by_version = documented_defaults
+          header, *defaults_by_version = @documented_defaults
 
           checker.doc.versioned_defaults =
             header +
@@ -30,7 +32,7 @@ module RailInspector
             version = header.match(/\d\.\d/)[0]
 
             generated_doc =
-              checker.framework_defaults_by_version[version]
+              @defaults_by_version[version]
                 .map do |config, value|
                   full_config =
                     case config
@@ -67,14 +69,6 @@ module RailInspector
             MESSAGE
 
             [header, "", *generated_doc, ""]
-          end
-
-          def documented_defaults
-            checker
-              .doc
-              .versioned_defaults
-              .slice_before { |line| line.start_with?("####") }
-              .to_a
           end
       end
     end

--- a/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
@@ -37,12 +37,7 @@ module RailInspector
             end
 
             def defaults_file_content
-              @defaults_file_content ||= checker.read(new_framework_defaults_path)
-            end
-
-            def new_framework_defaults_path
-              NEW_FRAMEWORK_DEFAULTS_PATH %
-                { version: checker.rails_version.tr(".", "_") }
+              @defaults_file_content ||= checker.files.new_framework_defaults.read
             end
         end
 
@@ -66,7 +61,7 @@ module RailInspector
 
         private
           def app_config_tree
-            checker.parse(APPLICATION_CONFIGURATION_PATH)
+            checker.files.application_configuration.parse
           end
 
           def check_defaults(defaults)
@@ -106,7 +101,7 @@ module RailInspector
               end
 
             checker.errors << <<~MESSAGE unless config_diff.empty?
-              #{APPLICATION_CONFIGURATION_PATH}: Incorrect load_defaults docs
+              #{checker.files.application_configuration}: Incorrect load_defaults docs
               --- Expected
               +++ Actual
               #{config_diff.split("\n")[5..].join("\n")}

--- a/tools/rail_inspector/lib/rail_inspector/configuring/check/general_configuration.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/check/general_configuration.rb
@@ -21,7 +21,7 @@ module RailInspector
             APP_CONFIG_CONST = "Rails::Application::Configuration"
 
             def app_config_tree
-              @checker.parse(APPLICATION_CONFIGURATION_PATH)
+              @checker.files.application_configuration.parse
             end
         end
 

--- a/tools/rail_inspector/lib/rail_inspector/configuring/check/new_framework_defaults_file.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/check/new_framework_defaults_file.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RailInspector
+  class Configuring
+    module Check
+      class NewFrameworkDefaultsFile
+        attr_reader :checker, :visitor
+
+        # Defaults are strings like:
+        #   self.yjit
+        #   action_controller.escape_json_responses
+        def initialize(checker, defaults, file_content)
+          @checker = checker
+          @defaults = defaults
+          @file_content = file_content
+        end
+
+        def check
+          @defaults.each do |config|
+            if config.start_with? "self"
+              next if @file_content.include? config.gsub(/^self/, "config")
+              next if @file_content.include? config.gsub(/^self/, "configuration")
+            end
+
+            next if @file_content.include? config
+
+            next if config == "self.yjit"
+
+            checker.errors << <<~MESSAGE
+              #{checker.files.new_framework_defaults}: Missing new default
+              #{config}
+
+            MESSAGE
+          end
+        end
+      end
+    end
+  end
+end

--- a/tools/rail_inspector/lib/rail_inspector/configuring/document.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/document.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RailInspector
+  class Configuring
+    class Document
+      class << self
+        def parse(text)
+          before, versioned_defaults, general_config, after =
+            text
+              .split("\n")
+              .slice_before do |line|
+                [
+                  "### Versioned Default Values",
+                  "### Rails General Configuration",
+                  "### Configuring Assets"
+                ].include?(line)
+              end
+              .to_a
+
+          new(before, versioned_defaults, general_config, after)
+        end
+      end
+
+      attr_accessor :general_config, :versioned_defaults
+
+      def initialize(before, versioned_defaults, general_config, after)
+        @before, @versioned_defaults, @general_config, @after =
+          before, versioned_defaults, general_config, after
+      end
+
+      def to_s
+        (@before + @versioned_defaults + @general_config + @after).join("\n") +
+          "\n"
+      end
+    end
+  end
+end

--- a/tools/rail_inspector/lib/rail_inspector/configuring/document.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/document.rb
@@ -5,19 +5,19 @@ module RailInspector
     class Document
       class << self
         def parse(text)
-          before, versioned_defaults, general_config, after =
+          before, *versioned_defaults, general_config, after =
             text
               .split("\n")
               .slice_before do |line|
                 [
-                  "### Versioned Default Values",
+                  "#### Default Values for Target Version",
                   "### Rails General Configuration",
                   "### Configuring Assets"
-                ].include?(line)
+                ].any? { |s| line.start_with?(s) }
               end
               .to_a
 
-          new(before, versioned_defaults, general_config, after)
+          new(before, versioned_defaults.flatten.join("\n"), general_config, after)
         end
       end
 
@@ -29,7 +29,7 @@ module RailInspector
       end
 
       def to_s
-        (@before + @versioned_defaults + @general_config + @after).join("\n") +
+        (@before + [@versioned_defaults] + @general_config + @after).join("\n") +
           "\n"
       end
     end

--- a/tools/rail_inspector/test/rail_inspector/configuring/check/framework_defaults_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/configuring/check/framework_defaults_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rail_inspector/configuring"
+
+class FrameworkDefaultsTest < ActiveSupport::TestCase
+  def test_identifies_self_when_file_uses_config
+    defaults = {
+      "8.0" => {
+        "action_dispatch.strict_freshness" => "true",
+        "Regexp.timeout" => "1"
+      },
+      "8.1" => {
+        "self.yjit" => "!Rails.env.local?",
+        "action_controller.escape_json_responses" => "false",
+      }
+    }
+
+    doc = [
+      ["### Versioned Default Values"],
+      [
+        "#### Default Values for Target Version 8.1",
+        "",
+        "- [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`",
+        "- [`config.yjit`](#config-yjit): `!Rails.env.local?`",
+        "",
+      ],
+      [
+        "#### Default Values for Target Version 8.0",
+        "",
+        "- [`Regexp.timeout`](#regexp-timeout): `1`",
+        "- [`config.action_dispatch.strict_freshness`](#config-action-dispatch-strict-freshness): `true`",
+        "",
+      ],
+    ]
+
+    check(defaults, doc).check
+
+    assert_empty checker.errors
+  end
+
+  private
+    def check(defaults, doc)
+      @check ||= RailInspector::Configuring::Check::FrameworkDefaults.new(checker, defaults, doc)
+    end
+
+    def checker
+      @checker ||= RailInspector::Configuring.new("../..")
+    end
+end

--- a/tools/rail_inspector/test/rail_inspector/configuring/check/framework_defaults_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/configuring/check/framework_defaults_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rail_inspector/configuring"
+
+class TestFrameworkDefaults < ActiveSupport::TestCase
+  def test_identifies_self_when_file_uses_config
+    defaults = ["self.log_file_size"]
+
+    check(defaults, <<~FILE).check
+    ###
+    # You must apply this in config/application.rb
+    # config.log_file_size = 100 * 1024 * 1024
+    FILE
+
+    assert_empty checker.errors
+  end
+
+  def test_identifies_self_when_file_uses_configuration
+    defaults = ["self.log_file_size"]
+
+    check(defaults, <<~FILE).check
+    ###
+    # You must apply this in config/application.rb
+    # Rails.configuration.log_file_size = 100 * 1024 * 1024
+    FILE
+
+    assert_empty checker.errors
+  end
+
+  private
+    def check(defaults, file_content)
+      @check ||= RailInspector::Configuring::Check::FrameworkDefaults::NewFrameworkDefaultsFile.new(checker, defaults, file_content)
+    end
+
+    def checker
+      @checker ||= RailInspector::Configuring.new("../..")
+    end
+end

--- a/tools/rail_inspector/test/rail_inspector/configuring/check/framework_defaults_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/configuring/check/framework_defaults_test.rb
@@ -16,25 +16,36 @@ class FrameworkDefaultsTest < ActiveSupport::TestCase
       }
     }
 
-    doc = [
-      ["### Versioned Default Values"],
-      [
-        "#### Default Values for Target Version 8.1",
-        "",
-        "- [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`",
-        "- [`config.yjit`](#config-yjit): `!Rails.env.local?`",
-        "",
-      ],
-      [
-        "#### Default Values for Target Version 8.0",
-        "",
-        "- [`Regexp.timeout`](#regexp-timeout): `1`",
-        "- [`config.action_dispatch.strict_freshness`](#config-action-dispatch-strict-freshness): `true`",
-        "",
-      ],
-    ]
+    check(defaults, <<~DOC).check
+      #### Default Values for Target Version 8.1
 
-    check(defaults, doc).check
+      - [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`
+      - [`config.yjit`](#config-yjit): `!Rails.env.local?`
+
+      #### Default Values for Target Version 8.0
+
+      - [`Regexp.timeout`](#regexp-timeout): `1`
+      - [`config.action_dispatch.strict_freshness`](#config-action-dispatch-strict-freshness): `true`
+    DOC
+
+    assert_empty checker.errors
+  end
+
+  def test_post_release
+    defaults = {
+      "8.0" => {
+        "Regexp.timeout" => "1"
+      },
+      "8.1" => {},
+    }
+
+    check(defaults, <<~DOC).check
+      #### Default Values for Target Version 8.1
+
+      #### Default Values for Target Version 8.0
+
+      - [`Regexp.timeout`](#regexp-timeout): `1`
+    DOC
 
     assert_empty checker.errors
   end

--- a/tools/rail_inspector/test/rail_inspector/configuring/check/new_framework_defaults_file_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/configuring/check/new_framework_defaults_file_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 require "rail_inspector/configuring"
 
-class TestFrameworkDefaults < ActiveSupport::TestCase
+class NewFrameworkDefaultsFileTest < ActiveSupport::TestCase
   def test_identifies_self_when_file_uses_config
     defaults = ["self.log_file_size"]
 
@@ -30,7 +30,7 @@ class TestFrameworkDefaults < ActiveSupport::TestCase
 
   private
     def check(defaults, file_content)
-      @check ||= RailInspector::Configuring::Check::FrameworkDefaults::NewFrameworkDefaultsFile.new(checker, defaults, file_content)
+      @check ||= RailInspector::Configuring::Check::NewFrameworkDefaultsFile.new(checker, defaults, file_content)
     end
 
     def checker

--- a/tools/rail_inspector/test/rail_inspector/visitor/framework_default_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/visitor/framework_default_test.rb
@@ -113,6 +113,18 @@ class FrameworkDefaultTest < Minitest::Test
     assert_equal("1", config["8.0"]["Regexp.timeout"])
   end
 
+  def test_post_release
+    config = config_for_defaults <<~RUBY
+      case target_version.to_s
+      when "8.1"
+        load_defaults "8.0"
+      end
+    RUBY
+
+    assert_includes config, "8.1"
+    assert_equal({}, config["8.1"])
+  end
+
   private
     def wrapped_defaults(defaults)
       <<~RUBY


### PR DESCRIPTION
Based on #55446
Replaces #50408

Previously, the linter would not validate that all versions with
defaults were documented, just that documented versions were correct.
This lead to no validation of defaults for a new version until the new
version's header was added.

Additionally, the header couldn't be added until the first default for
that version was added because the linter would raise an error if a
version header was present with no defaults.

This commit fixes both of those problems. It now more strictly compares
the _actual_ versioned defaults with the documented defaults so that it
will never miss any based on which are currently documented.
Additionally, it won't error if a header is present without any defaults
(and due to the more strict comparison, this state is expected).