### PR TITLE
Fix a typo in ActiveRecord::ConnectionHandling#with_connection doc [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -301,7 +301,7 @@ module ActiveRecord
 
     # Checkouts a connection from the pool, yield it and then check it back in.
     # If a connection was already leased via #lease_connection or a parent call to
-    # #with_connection, that same connection is yieled.
+    # #with_connection, that same connection is yielded.
     # If #lease_connection is called inside the block, the connection won't be checked
     # back in.
     # If #connection is called inside the block, the connection won't be checked back in


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is a typo in `ActiveRecord::ConnectionHandling#with_connection` docstring.

### Detail

This Pull Request fixes a typo: `yieled` -> `yielded`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
