### PR TITLE
Ensure rack.response_finished callback handles receiving arguments

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -13,7 +13,7 @@ module ActionDispatch
     def call(env)
       state = @executor.run!(reset: true)
       if response_finished = env["rack.response_finished"]
-        response_finished << -> { state.complete! }
+        response_finished << proc { state.complete! }
       end
 
       begin

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -180,7 +180,7 @@ class ExecutorTest < ActiveSupport::TestCase
     assert_not completed
 
     assert_equal 1, env["rack.response_finished"].size
-    env["rack.response_finished"].first.call
+    env["rack.response_finished"].first.call({}, 200, {}, nil)
 
     assert completed
   end
@@ -199,7 +199,7 @@ class ExecutorTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, env["rack.response_finished"].size
-    env["rack.response_finished"].first.call
+    env["rack.response_finished"].first.call({}, 200, {}, nil)
 
     assert_equal 1, completed_count
   end


### PR DESCRIPTION
### Motivation / Background

Follow up to https://github.com/rails/rails/pull/55425, which was not compliant with the Rack SPEC. I missed the fact that `rack.response_finished` callables are invoked with arguments 🤦‍♀️ Thank you @ioquatix for kindly pointing this out ❤️ 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.

cc @eileencodes 