### PR TITLE
Eager autoload ActiveRecord::Transaction

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -87,7 +87,6 @@ module ActiveRecord
   autoload :Timestamp
   autoload :TokenFor
   autoload :TouchLater
-  autoload :Transaction
   autoload :Transactions
   autoload :Translation
   autoload :Validations
@@ -109,6 +108,7 @@ module ActiveRecord
     autoload :Result
     autoload :StatementCache
     autoload :TableMetadata
+    autoload :Transaction
     autoload :Type
 
     autoload_under "relation" do


### PR DESCRIPTION
This class is not referenced until a transaction is opened, so it needs to be eager loaded to avoid autoloading at runtime.