### PR TITLE
`ERB::Util.html_escape`: stop trying to tidy bytes

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -402,7 +402,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       "action_dispatch.parameter_filter" => [:foo] }
     assert_response 500
 
-    assert_match(CGI.escape_html({ "foo" => "[FILTERED]" }.inspect[1..-2]), body)
+    assert_match(ERB::Util.html_escape({ "foo" => "[FILTERED]" }.inspect[1..-2]), body)
   end
 
   test "show registered original exception if the last exception is TemplateError" do
@@ -466,7 +466,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     })
     assert_response 500
 
-    assert_includes(body, CGI.escapeHTML(PP.pp(params, +"", 200)))
+    assert_includes(body, ERB::Util.html_escape(PP.pp(params, +"", 200)))
   end
 
   test "sets the HTTP charset parameter" do

--- a/actionview/lib/action_view/buffers.rb
+++ b/actionview/lib/action_view/buffers.rb
@@ -45,7 +45,7 @@ module ActionView
         @raw_buffer << if value.html_safe?
           value
         else
-          CGI.escapeHTML(value)
+          ERB::Util.unwrapped_html_escape(value)
         end
       end
       self

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "cgi/escape"
-require "cgi/util" if RUBY_VERSION < "3.5"
 require "action_view/helpers/date_helper"
 require "action_view/helpers/url_helper"
 require "action_view/helpers/form_tag_helper"

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "cgi/escape"
-require "cgi/util" if RUBY_VERSION < "3.5"
 require "erb"
 require "active_support/core_ext/string/output_safety"
 require "active_support/core_ext/array/extract_options"

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "cgi/escape"
-require "cgi/util" if RUBY_VERSION < "3.5"
 require "action_view/helpers/content_exfiltration_prevention_helper"
 require "action_view/helpers/url_helper"
 require "action_view/helpers/text_helper"

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -581,7 +581,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_text_field_tag_with_ac_parameters
     actual = text_field_tag "title", ActionController::Parameters.new(key: "value")
-    value = CGI.escapeHTML({ "key" => "value" }.inspect)
+    value = ERB::Util.html_escape({ "key" => "value" }.inspect)
     expected = %(<input id="title" name="title" type="text" value="#{value}" />)
     assert_dom_equal expected, actual
   end

--- a/activesupport/lib/active_support/core_ext/erb/util.rb
+++ b/activesupport/lib/active_support/core_ext/erb/util.rb
@@ -12,7 +12,7 @@ module ActiveSupport
         if s.html_safe?
           s
         else
-          super(ActiveSupport::Multibyte::Unicode.tidy_bytes(s))
+          super(s)
         end
       end
       alias :unwrapped_html_escape :html_escape # :nodoc:
@@ -61,7 +61,7 @@ class ERB
     #   html_escape_once('&lt;&lt; Accept & Checkout')
     #   # => "&lt;&lt; Accept &amp; Checkout"
     def html_escape_once(s)
-      ActiveSupport::Multibyte::Unicode.tidy_bytes(s.to_s).gsub(HTML_ESCAPE_ONCE_REGEXP, HTML_ESCAPE).html_safe
+      s.to_s.gsub(HTML_ESCAPE_ONCE_REGEXP, HTML_ESCAPE).html_safe
     end
 
     module_function :html_escape_once

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -196,14 +196,14 @@ module ActiveSupport # :nodoc:
 
     private
       def explicit_html_escape_interpolated_argument(arg)
-        (!html_safe? || arg.html_safe?) ? arg : CGI.escapeHTML(arg.to_s)
+        (!html_safe? || arg.html_safe?) ? arg : ERB::Util.unwrapped_html_escape(arg)
       end
 
       def implicit_html_escape_interpolated_argument(arg)
         if !html_safe? || arg.html_safe?
           arg
         else
-          CGI.escapeHTML(arg.to_str)
+          ERB::Util.unwrapped_html_escape(arg.to_str)
         end
       end
 

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -1102,12 +1102,6 @@ class OutputSafetyTest < ActiveSupport::TestCase
     assert_equal expected, ERB::Util.html_escape(string)
   end
 
-  test "ERB::Util.html_escape should correctly handle invalid UTF-8 strings" do
-    string = "\251 <"
-    expected = "© &lt;"
-    assert_equal expected, ERB::Util.html_escape(string)
-  end
-
   test "ERB::Util.html_escape should not escape safe strings" do
     string = "<b>hello</b>".html_safe
     assert_equal string, ERB::Util.html_escape(string)
@@ -1119,12 +1113,6 @@ class OutputSafetyTest < ActiveSupport::TestCase
 
     assert_equal escaped_string, ERB::Util.html_escape_once(string)
     assert_equal escaped_string, ERB::Util.html_escape_once(escaped_string)
-  end
-
-  test "ERB::Util.html_escape_once should correctly handle invalid UTF-8 strings" do
-    string = "\251 <"
-    expected = "© &lt;"
-    assert_equal expected, ERB::Util.html_escape_once(string)
   end
 
   test "ERB::Util.xml_name_escape should escape unsafe characters for XML names" do

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "cgi/escape"
-require "cgi/util" if RUBY_VERSION < "3.5"
+require "active_support/core_ext/erb/util"
 
 module Rails
   # This module helps build the runtime properties that are displayed in
@@ -44,11 +43,11 @@ module Rails
       def to_html
         (+"<table>").tap do |table|
           properties.each do |(name, value)|
-            table << %(<tr><td class="name">#{CGI.escapeHTML(name.to_s)}</td>)
+            table << %(<tr><td class="name">#{ERB::Util.html_escape(name.to_s)}</td>)
             formatted_value = if value.kind_of?(Array)
-              "<ul>" + value.map { |v| "<li>#{CGI.escapeHTML(v.to_s)}</li>" }.join + "</ul>"
+              "<ul>" + value.map { |v| "<li>#{ERB::Util.html_escape(v.to_s)}</li>" }.join + "</ul>"
             else
-              CGI.escapeHTML(value.to_s)
+              ERB::Util.html_escape(value.to_s)
             end
             table << %(<td class="value">#{formatted_value}</td></tr>)
           end

--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -39,7 +39,7 @@ class InfoTest < ActiveSupport::TestCase
     html = Rails::Info.to_html
     assert_includes html, '<tr><td class="name">Middleware</td>'
     properties.value_for("Middleware").each do |value|
-      assert_includes html, "<li>#{CGI.escapeHTML(value)}</li>"
+      assert_includes html, "<li>#{ERB::Util.html_escape(value)}</li>"
     end
   end
 

--- a/tools/preview_docs.rb
+++ b/tools/preview_docs.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "erb"
-require "cgi/escape"
-require "cgi/util" if RUBY_VERSION < "3.5"
+require "active_support/core_ext/string/output_safety"
 
 # How to test:
 #
@@ -41,9 +39,10 @@ class PreviewDocs
     "<a href=\"#{escape(url)}\">#{escape(name)}</a>"
   end
 
-  def escape(str)
-    CGI.escapeHTML(str)
-  end
+  private
+    def escape(str)
+      ERB::Util.html_escape(str)
+    end
 end
 
 module EnvVars


### PR DESCRIPTION
This call to `Unicode.tidy_bytes` has been introduced 10 years ago in https://github.com/rails/rails/pull/19992 but this pull request has been merged by mistake and was supposed to be reverted.

Semantically it makes no sense to deal with invalid strings at that layer, and performance wise it impose a massive overhead.

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
             current   504.509k i/100ms
             no_tidy     1.749M i/100ms
Calculating -------------------------------------
             current      5.607M (± 1.0%) i/s  (178.34 ns/i) -     28.253M in   5.038946s
             no_tidy     21.792M (± 0.6%) i/s   (45.89 ns/i) -    110.211M in   5.057658s

Comparison:
             current:  5607354.4 i/s
             no_tidy: 21791597.8 i/s - 3.89x  faster

ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
             current   261.902k i/100ms
             no_tidy   518.277k i/100ms
Calculating -------------------------------------
             current      2.795M (± 1.3%) i/s  (357.72 ns/i) -     14.143M in   5.060105s
             no_tidy      5.508M (± 0.2%) i/s  (181.55 ns/i) -     27.987M in   5.081000s

Comparison:
             current:  2795448.7 i/s
             no_tidy:  5508171.9 i/s - 1.97x  faster
```

```ruby
require "bundler/inline"

gemfile do
  gem "rails"
  gem "benchmark-ips"
end

require "active_support/all"
require "active_support/core_ext/erb/util"

module ERB::Util
  def self.html_escape_no_tidy(s) # :nodoc:
    s = s.to_s
    if s.html_safe?
      s
    else
      unwrapped_html_escape(s)
    end
  end
end

Benchmark.ips do |x|
  s = "Hello World"
  x.report("current") { ERB::Util.html_escape(s) }
  x.report("no_tidy") { ERB::Util.html_escape_no_tidy(s) }
  x.compare!(order: :baseline)
end

Benchmark.ips do |x|
  s = "Hello World" * 20
  x.report("current") { ERB::Util.html_escape(s) }
  x.report("no_tidy") { ERB::Util.html_escape_no_tidy(s) }
  x.compare!(order: :baseline)
end
```