### PR TITLE
[Fix #55468] Update pgbouncer related docs

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3563,12 +3563,11 @@ development:
   pool: 5
 ```
 
-By default Active Record uses database features like prepared statements and advisory locks. You might need to disable those features if you're using an external connection pooler like PgBouncer:
+By default Active Record a database features called advisory locks. You might need to disable this feature if you're using an external connection pooler like PgBouncer:
 
 ```yaml
 production:
   adapter: postgresql
-  prepared_statements: false
   advisory_locks: false
 ```
 


### PR DESCRIPTION

### Motivation / Background
Following up on #55468, rails documentation currently contains some guidance related to pgbouncer that I believe is outdated. Specifically regarding prepared statements. .

Please note that I am a pgbouncer contributor but have not tested rails against pgbouncer and have no experience with rails/ruby so I cannot verify this guidance directly.

### Detail
Prepared statement support was added in pgbouncer v1.21.0 released on Oct 16, 2023 as an optional feature. Since then numerous bug fixes were implemented and it is now a default feature.

Please note there is also guidance about advisory locks. I am not sure if this advice is still warranted or not so I kept that in.

### Additional information
- https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_1_21_0

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
