### PR TITLE
Improve documentation for except and only methods [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -52,18 +52,18 @@ module ActiveRecord
       end
     end
 
-    # Removes from the query the condition(s) specified in +skips+.
+    # Removes the condition(s) specified in +skips+ from the query.
     #
-    #   Post.order('id asc').except(:order)                  # discards the order condition
-    #   Post.where('id > 10').order('id asc').except(:where) # discards the where condition but keeps the order
+    #   Post.order('id asc').except(:order)                  # removes the order condition
+    #   Post.where('id > 10').order('id asc').except(:where) # removes the where condition but keeps the order
     def except(*skips)
       relation_with values.except(*skips)
     end
 
-    # Removes any condition from the query other than the one(s) specified in +onlies+.
+    # Keeps only the condition(s) specified in +onlies+ in the query, removing all others.
     #
-    #   Post.order('id asc').only(:where)         # discards the order condition
-    #   Post.order('id asc').only(:where, :order) # uses the specified order
+    #   Post.order('id asc').only(:where)         # keeps only the where condition, removes the order
+    #   Post.order('id asc').only(:where, :order) # keeps only the where and order conditions
     def only(*onlies)
       relation_with values.slice(*onlies)
     end


### PR DESCRIPTION
Make the method descriptions clearer and more consistent [ci skip]

### Motivation / Background

This Pull Request has been created because the documentation for the `except` and `only` methods in `ActiveRecord::SpawnMethods` was inconsistent and used unclear language. The current docs use different terminology ("discards" vs "removes") and the `only` method description was confusing with phrases like "removes any condition from the query other than".

This change improves the RDoc comments in the source code to make the API documentation clearer and more consistent.

### Detail

This Pull Request changes the RDoc documentation comments for both methods to:
- Use consistent language ("removes" instead of "discards")
- Make the `only` method description more straightforward ("keeps only the condition(s) specified")
- Update the example comments to be clearer and more descriptive
- Improve overall readability for developers using these methods

### Additional information

This is a documentation-only change that improves the API reference documentation. The changes make the API docs more beginner-friendly and consistent, following the API Documentation Guidelines.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.