### PR TITLE
Fix wrong changelog code sample

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   Add command `rails credentials:fetch PATH` to get the value of a credential from the credentials file.
 
     ```bash
-    $ bin/rails credentials:fetch kamal_registry/password
+    $ bin/rails credentials:fetch kamal_registry.password
     ```
 
     *Matthew Nguyen*, *Jean Boussier*


### PR DESCRIPTION
I was testing the new feature of fetching the credentials from the command line and found out the code sample was wrong. Initially [the PR](https://github.com/rails/rails/pull/53119) was using `/` to navigate the credentials hierarchy but then @byroot changed it to use `.` instead.
