### PR TITLE
Fix excerpt helper with non-whitespace separator

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -260,7 +260,14 @@ module ActionView
         prefix, first_part   = cut_excerpt_part(:first, first_part, separator, options)
         postfix, second_part = cut_excerpt_part(:second, second_part, separator, options)
 
-        affix = [first_part, separator, phrase, separator, second_part].join.strip
+        affix = [
+          first_part,
+          !first_part.empty? ? separator : "",
+          phrase,
+          !second_part.empty? ? separator : "",
+          second_part
+        ].join.strip
+
         [prefix, affix, postfix].join
       end
 

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -359,6 +359,9 @@ class TextHelperTest < ActionView::TestCase
     options = { separator: "\n", radius: 1 }
     assert_equal("...very\nvery long\nstring", excerpt("my very\nvery\nvery long\nstring", "long", options))
 
+    options = { separator: "_" }
+    assert_equal("foo", excerpt("foo", "foo", options))
+
     assert_equal excerpt("This is a beautiful morning", "a"),
                  excerpt("This is a beautiful morning", "a", separator: nil)
   end


### PR DESCRIPTION
Prior to this commit, the `excerpt` helper would always prepend and append a non-whitespace separator:

  ```ruby
  excerpt("foo", "foo", separator: "_")
  # => "_foo_"
  ```

This commit fixes `excerpt` to handle non-whitespace separators the same as whitespace separators:

  ```ruby
  excerpt("foo", "foo", separator: "_")
  # => "foo"
  ```
