### PR TITLE
Remove unused IsolatedExecutionState#unique_id

### DIFF
--- a/activesupport/lib/active_support/isolated_execution_state.rb
+++ b/activesupport/lib/active_support/isolated_execution_state.rb
@@ -28,10 +28,6 @@ module ActiveSupport
         @isolation_level = level
       end
 
-      def unique_id
-        self[:__id__] ||= Object.new
-      end
-
       def [](key)
         if state = @scope.current.active_support_execution_state
           state[key]


### PR DESCRIPTION
This was [replaced][1] with `ExecutionWrapper#active_key` and is no longer used.

[1]: https://github.com/rails/rails/commit/10c64a472f2f19a5e485bdac7d5106a76aeb29a5
