### PR TITLE
Remove unused `dispatcher_class` override from `MapperTest::FakeSet`

### DIFF
--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -14,10 +14,6 @@ module ActionDispatch
           ActionDispatch::Request
         end
 
-        def dispatcher_class
-          RouteSet::Dispatcher
-        end
-
         def defaults
           routes.map(&:defaults)
         end


### PR DESCRIPTION
There is no `dispatcher_class` reader in `RouteSet` since https://github.com/rails/rails/commit/31cc4d621f57f35356b3395cf78d7cf043d6795c
so this override isn't necessary