### PR TITLE
Extract (nestable) Execution from ExecutionContext

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -68,6 +68,7 @@ module ActiveSupport
     autoload :Deprecation
     autoload :Delegation
     autoload :Digest
+    autoload :Execution
     autoload :ExecutionContext
     autoload :Gzip
     autoload :Inflector

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -166,7 +166,7 @@ module ActiveSupport
         end
 
         def current_instances
-          ExecutionContext.current_attributes_instances
+          Execution[:active_support_current_attributes_instances] ||= {}
         end
 
         def current_instances_key

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/callbacks"
-require "active_support/execution_context"
 require "active_support/core_ext/object/with"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/delegation"

--- a/activesupport/lib/active_support/execution.rb
+++ b/activesupport/lib/active_support/execution.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Execution # :nodoc:
+    # Nesting should only legitimately happen during test because the test case
+    # itself is wrapped in an executor, and it might call into a controller or
+    # job which should be executed with their own fresh context. However in
+    # production this should never happen, and for extra safety we make sure to
+    # fully clear the state at the end of the request or job cycle.
+    @nestable = false
+
+    class << self
+      attr_accessor :nestable
+
+      def [](key)
+        current[key]
+      end
+
+      def []=(key, value)
+        current[key] = value
+      end
+
+      def push
+        if @nestable
+          state << {}
+        else
+          clear
+        end
+        self
+      end
+
+      def pop
+        if @nestable
+          state.pop
+        else
+          clear
+        end
+        self
+      end
+
+      def clear
+        IsolatedExecutionState[:active_support_execution] = nil
+      end
+
+      private
+        def state
+          IsolatedExecutionState[:active_support_execution] ||= []
+        end
+
+        def current
+          state.last || (state << {}).last
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -2,41 +2,9 @@
 
 module ActiveSupport
   module ExecutionContext # :nodoc:
-    class Record
-      attr_reader :store, :current_attributes_instances
-
-      def initialize
-        @store = {}
-        @current_attributes_instances = {}
-        @stack = []
-      end
-
-      def push
-        @stack << @store << @current_attributes_instances
-        @store = {}
-        @current_attributes_instances = {}
-        self
-      end
-
-      def pop
-        @current_attributes_instances = @stack.pop
-        @store = @stack.pop
-        self
-      end
-    end
-
     @after_change_callbacks = []
 
-    # Execution context nesting should only legitimately happen during test
-    # because the test case itself is wrapped in an executor, and it might call
-    # into a controller or job which should be executed with their own fresh context.
-    # However in production this should never happen, and for extra safety we make sure to
-    # fully clear the state at the end of the request or job cycle.
-    @nestable = false
-
     class << self
-      attr_accessor :nestable
-
       def after_change(&block)
         @after_change_callbacks << block
       end
@@ -46,8 +14,6 @@ module ActiveSupport
       def set(**options)
         options.symbolize_keys!
         keys = options.keys
-
-        store = record.store
 
         previous_context = if block_given?
           keys.zip(store.values_at(*keys)).to_h
@@ -67,43 +33,21 @@ module ActiveSupport
       end
 
       def []=(key, value)
-        record.store[key.to_sym] = value
+        store[key.to_sym] = value
         @after_change_callbacks.each(&:call)
       end
 
       def to_h
-        record.store.dup
-      end
-
-      def push
-        if @nestable
-          record.push
-        else
-          clear
-        end
-        self
-      end
-
-      def pop
-        if @nestable
-          record.pop
-        else
-          clear
-        end
-        self
+        store.dup
       end
 
       def clear
-        IsolatedExecutionState[:active_support_execution_context] = nil
-      end
-
-      def current_attributes_instances
-        record.current_attributes_instances
+        Execution[:active_support_execution_context] = nil
       end
 
       private
-        def record
-          IsolatedExecutionState[:active_support_execution_context] ||= Record.new
+        def store
+          Execution[:active_support_execution_context] ||= {}
         end
     end
   end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -40,7 +40,6 @@ module ActiveSupport
 
     initializer "active_support.reset_execution_context" do |app|
       app.reloader.before_class_unload do
-        ActiveSupport::CurrentAttributes.clear_all
         ActiveSupport::ExecutionContext.clear
       end
 
@@ -49,7 +48,6 @@ module ActiveSupport
       end
 
       app.executor.to_complete do
-        ActiveSupport::CurrentAttributes.clear_all
         ActiveSupport::ExecutionContext.pop
       end
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -40,20 +40,20 @@ module ActiveSupport
 
     initializer "active_support.reset_execution_context" do |app|
       app.reloader.before_class_unload do
-        ActiveSupport::ExecutionContext.clear
+        ActiveSupport::Execution.clear
       end
 
       app.executor.to_run do
-        ActiveSupport::ExecutionContext.push
+        ActiveSupport::Execution.push
       end
 
       app.executor.to_complete do
-        ActiveSupport::ExecutionContext.pop
+        ActiveSupport::Execution.pop
       end
 
       ActiveSupport.on_load(:active_support_test_case) do
         if app.config.active_support.executor_around_test_case
-          ActiveSupport::ExecutionContext.nestable = true
+          ActiveSupport::Execution.nestable = true
 
           require "active_support/executor/test_helper"
           include ActiveSupport::Executor::TestHelper

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -315,7 +315,6 @@ class CurrentAttributesTest < ActiveSupport::TestCase
       end
 
       executor.to_complete do
-        ActiveSupport::CurrentAttributes.clear_all
         ActiveSupport::ExecutionContext.pop
       end
 

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -305,17 +305,16 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     assert_equal [[:req, :value]], current.method(:attr=).parameters
   end
 
-
   test "set and restore attributes when re-entering the executor" do
-    ActiveSupport::ExecutionContext.with(nestable: true) do
+    ActiveSupport::Execution.with(nestable: true) do
       # simulate executor hooks from active_support/railtie.rb
       executor = Class.new(ActiveSupport::Executor)
       executor.to_run do
-        ActiveSupport::ExecutionContext.push
+        ActiveSupport::Execution.push
       end
 
       executor.to_complete do
-        ActiveSupport::ExecutionContext.pop
+        ActiveSupport::Execution.pop
       end
 
       Current.world = "world/1"


### PR DESCRIPTION
This extraction separates the two things that the ExecutionContext deals
with: per-request/job/etc. Context and the ability to restore
per-request/job/etc. state when nested in test environments.

This makes it simpler to give additional state the ability to work with
nested Executors in the test environment. This commit demonstrates what
that change looks like for the two states (Context and
CurrentAttributes).