### PR TITLE
Don't trigger action on path relative redirects starting with ?

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -199,7 +199,7 @@ module ActionController
       when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i
         options.to_str
       when String
-        if !options.start_with?("/") && !options.empty?
+        if !options.start_with?("/") && !options.start_with?("?") && !options.empty?
           _handle_path_relative_redirect(options)
         end
 

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -199,7 +199,7 @@ module ActionController
       when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i
         options.to_str
       when String
-        if !options.start_with?("/") && !options.start_with?("?") && !options.empty?
+        if !options.start_with?("/", "?") && !options.empty?
           _handle_path_relative_redirect(options)
         end
 


### PR DESCRIPTION
### Motivation / Background

This is an extension to the [ability to react to path relative redirects](https://github.com/rails/rails/pull/55308).
We realized that I missed the case where the redirect url starts with an `?`
If this is run on `https://www.example.com` you'd end up on e.g. `https://www.example.com?foo=bar`.

### Detail

This PR implements this change and the accompanying test cases

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
