### PR TITLE
docs: document alias_attribute behavior change in Rails 7.2 upgrading guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -104,6 +104,60 @@ set the `queue_adapter` config to something other than `:test`, but written test
 
 If no config is provided, the `TestAdapter` will continue to be used.
 
+### `alias_attribute` now bypasses custom methods on the original attribute
+
+In Rails 7.2, `alias_attribute` now bypasses custom methods defined on the original attribute and directly accesses the underlying database value. This change was announced via deprecation warnings in Rails 7.1.
+
+**Before (Rails 7.1):**
+
+```ruby
+class User < ActiveRecord::Base
+  def email
+    "custom_#{super}"
+  end
+
+  alias_attribute :username, :email
+end
+
+user = User.create!(email: "test@example.com")
+user.username
+# => "custom_test@example.com"
+```
+
+**After (Rails 7.2):**
+
+```ruby
+user = User.create!(email: "test@example.com")
+user.username
+# => "test@example.com"  # Raw database value
+```
+
+If you received the deprecation warning "Since Rails 7.2 `#{method_name}` will not be calling `#{target_name}` anymore", you should manually define the alias method:
+
+```ruby
+class User < ActiveRecord::Base
+  def email
+    "custom_#{super}"
+  end
+
+  def username
+    email  # This will call the custom email method
+  end
+end
+```
+
+Alternatively, you can use `alias_method`:
+
+```ruby
+class User < ActiveRecord::Base
+  def email
+    "custom_#{super}"
+  end
+
+  alias_method :username, :email
+end
+```
+
 Upgrading from Rails 7.0 to Rails 7.1
 -------------------------------------
 


### PR DESCRIPTION
### Motivation / Background

Follow up from https://github.com/rails/rails/pull/55480#issuecomment-3180770021

I am upgrading an app from `7.0.8` to latest which is `8.0.2`. I have an existing logic that passes custom method in `alias_attribute` expecting custom method to trigger.  

The Rails 7.2 upgrading guide needs to be updated to properly document the `alias_attribute` behavior change that was introduced in Rails 7.2.

Currently, the documentation for the `alias_attribute` behavior change is missing from the upgrading guide, making it difficult for developers to understand what changed and how to handle the upgrade.

---

### Detail

* Updates the Rails 7.2 upgrading guide to clarify the `alias_attribute` behavior change

### Additional information

**Related PRs and commits that introduced related changes:**
* https://github.com/rails/rails/pull/48533
* https://github.com/rails/rails/pull/49624


---

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
