### PR TITLE
Optimize `#pluralize`

### DIFF
--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -30,6 +30,7 @@ module ActiveSupport
     # before any of the rules that may already have been loaded.
     class Inflections
       @__instance__ = Concurrent::Map.new
+      @__en_instance__ = nil
 
       class Uncountables # :nodoc:
         include Enumerable
@@ -74,10 +75,14 @@ module ActiveSupport
       end
 
       def self.instance(locale = :en)
+        return @__en_instance__ ||= new if locale == :en
+
         @__instance__[locale] ||= new
       end
 
       def self.instance_or_fallback(locale)
+        return @__en_instance__ ||= new if locale == :en
+
         I18n.fallbacks[locale].each do |k|
           return @__instance__[k] if @__instance__.key?(k)
         end

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -38,18 +38,18 @@ module ActiveSupport
 
         def initialize
           @members = []
-          @regex_array = []
+          @pattern = nil
         end
 
         def delete(entry)
           @members.delete(entry)
-          @regex_array.delete(to_regex(entry))
+          @pattern = nil
         end
 
         def <<(word)
           word = word.downcase
           @members << word
-          @regex_array << to_regex(word)
+          @pattern = nil
           self
         end
 
@@ -60,18 +60,17 @@ module ActiveSupport
         def add(words)
           words = words.flatten.map(&:downcase)
           @members.concat(words)
-          @regex_array += words.map { |word| to_regex(word) }
+          @pattern = nil
           self
         end
 
         def uncountable?(str)
-          @regex_array.any? { |regex| regex.match? str }
-        end
-
-        private
-          def to_regex(string)
-            /\b#{::Regexp.escape(string)}\Z/i
+          if @pattern.nil?
+            members_pattern = Regexp.union(@members.map { |w| /#{Regexp.escape(w)}/i })
+            @pattern = /\b#{members_pattern}\Z/i
           end
+          @pattern.match?(str)
+        end
       end
 
       def self.instance(locale = :en)

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -16,12 +16,16 @@ class InflectorTest < ActiveSupport::TestCase
     # This helper is implemented by setting @__instance__ because in some tests
     # there are module functions that access ActiveSupport::Inflector.inflections,
     # so we need to replace the singleton itself.
-    @original_inflections = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)[:en]
-    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, en: @original_inflections.dup)
+    @original_inflections = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__instance__)
+    @original_inflection_en = ActiveSupport::Inflector::Inflections.instance_variable_get(:@__en_instance__)
+
+    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, {})
+    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__en_instance__, @original_inflection_en.dup)
   end
 
   def teardown
-    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, en: @original_inflections)
+    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__instance__, @original_inflections)
+    ActiveSupport::Inflector::Inflections.instance_variable_set(:@__en_instance__, @original_inflection_en)
   end
 
   def test_pluralize_plurals

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -623,7 +623,7 @@ class InflectorTest < ActiveSupport::TestCase
 
         assert_equal [], inflect.singulars
         assert_equal [], inflect.plurals
-        assert_equal [], inflect.uncountables
+        assert_equal [], inflect.uncountables.to_a
 
         # restore all the inflections
         singulars.reverse_each { |singular| inflect.singular(*singular) }


### PR DESCRIPTION
Several different optimization, see each commit message for details.

Before:

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +YJIT +PRISM [arm64-darwin24]
Calculating -------------------------------------
             regular    252.175k (± 0.3%) i/s    (3.97 μs/i) -      1.275M in   5.054643s
           irregular    851.502k (± 1.0%) i/s    (1.17 μs/i) -      4.316M in   5.069125s
         uncountable      1.487M (± 0.7%) i/s  (672.56 ns/i) -      7.578M in   5.097231s
```

After:

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +YJIT +PRISM [arm64-darwin24]
Calculating -------------------------------------
             regular    298.382k (± 0.5%) i/s    (3.35 μs/i) -      1.515M in   5.076864s
           irregular      1.943M (± 0.4%) i/s  (514.77 ns/i) -      9.758M in   5.023349s
         uncountable      6.008M (± 0.4%) i/s  (166.45 ns/i) -     30.366M in   5.054350s
```

Benchmark:

```ruby
# frozen_string_literal: true
require "bundler/inline"

gemfile do
  gem "rails", path: "."
  gem "benchmark-ips"
end

Benchmark.ips do |x|
  x.report("regular") { ActiveSupport::Inflector.pluralize("test") }
  x.report("irregular") { ActiveSupport::Inflector.pluralize("zombie") }
  x.report("uncountable") { ActiveSupport::Inflector.pluralize("sheep") }
end
```