### PR TITLE
Catch when msgpack gem is missing and warn

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -235,8 +235,8 @@ module ActiveSupport
     attr_accessor :raise_on_error
 
     ENCODERS = {
-      json: Encoders::JSON,
-      msgpack: Encoders::MessagePack
+      json: "Encoders::JSON",
+      msgpack: "Encoders::MessagePack"
     }.freeze
 
     class << self
@@ -258,9 +258,10 @@ module ActiveSupport
       #
       # * +KeyError+ - If the encoder format is not found
       def encoder(format)
-        ENCODERS.fetch(format.to_sym) do
+        coder = ENCODERS.fetch(format.to_sym) do
           raise KeyError, "Unknown encoder format: #{format.inspect}. Available formats: #{ENCODERS.keys.join(', ')}"
         end
+        self.const_get(coder)
       end
     end
 

--- a/activesupport/lib/active_support/event_reporter/encoders.rb
+++ b/activesupport/lib/active_support/event_reporter/encoders.rb
@@ -30,61 +30,9 @@ module ActiveSupport
         end
       end
 
-      # JSON encoder for serializing events to JSON format.
-      #
-      #   event = { name: "user_created", payload: { id: 123 }, tags: { api: true } }
-      #   ActiveSupport::EventReporter::Encoders::JSON.encode(event)
-      #   # => {
-      #   #      "name": "user_created",
-      #   #      "payload": {
-      #   #        "id": 123
-      #   #      },
-      #   #      "tags": {
-      #   #        "api": true
-      #   #      },
-      #   #      "context": {}
-      #   #    }
-      #
-      # Schematized events and tags MUST respond to #to_h to be serialized.
-      #
-      #   event = { name: "UserCreatedEvent", payload: #<UserCreatedEvent:0x111>, tags: { "GraphqlTag": #<GraphqlTag:0x111> } }
-      #   ActiveSupport::EventReporter::Encoders::JSON.encode(event)
-      #   # => {
-      #   #      "name": "UserCreatedEvent",
-      #   #      "payload": {
-      #   #        "id": 123
-      #   #      },
-      #   #      "tags": {
-      #   #        "GraphqlTag": {
-      #   #          "operation_name": "user_created",
-      #   #          "operation_type": "mutation"
-      #   #        }
-      #   #      },
-      #   #      "context": {}
-      #   #    }
-      class JSON < Base
-        def self.encode(event)
-          event[:payload] = event[:payload].to_h
-          event[:tags] = event[:tags].transform_values do |value|
-            value.respond_to?(:to_h) ? value.to_h : value
-          end
-          ::JSON.dump(event)
-        end
-      end
-
-      # EventReporter encoder for serializing events to MessagePack format.
-      class MessagePack < Base
-        def self.encode(event)
-          require "msgpack"
-          event[:payload] = event[:payload].to_h
-          event[:tags] = event[:tags].transform_values do |value|
-            value.respond_to?(:to_h) ? value.to_h : value
-          end
-          ::MessagePack.pack(event)
-        rescue LoadError
-          raise LoadError, "msgpack gem is required for MessagePack encoding. Add 'gem \"msgpack\"' to your Gemfile."
-        end
-      end
+      extend ActiveSupport::Autoload
+      autoload :JSON
+      autoload :MessagePack
     end
   end
 end

--- a/activesupport/lib/active_support/event_reporter/encoders/json.rb
+++ b/activesupport/lib/active_support/event_reporter/encoders/json.rb
@@ -1,0 +1,50 @@
+# typed: true
+# frozen_string_literal: true
+
+module ActiveSupport
+  class EventReporter
+    module Encoders
+      # JSON encoder for serializing events to JSON format.
+      #
+      #   event = { name: "user_created", payload: { id: 123 }, tags: { api: true } }
+      #   ActiveSupport::EventReporter::Encoders::JSON.encode(event)
+      #   # => {
+      #   #      "name": "user_created",
+      #   #      "payload": {
+      #   #        "id": 123
+      #   #      },
+      #   #      "tags": {
+      #   #        "api": true
+      #   #      },
+      #   #      "context": {}
+      #   #    }
+      #
+      # Schematized events and tags MUST respond to #to_h to be serialized.
+      #
+      #   event = { name: "UserCreatedEvent", payload: #<UserCreatedEvent:0x111>, tags: { "GraphqlTag": #<GraphqlTag:0x111> } }
+      #   ActiveSupport::EventReporter::Encoders::JSON.encode(event)
+      #   # => {
+      #   #      "name": "UserCreatedEvent",
+      #   #      "payload": {
+      #   #        "id": 123
+      #   #      },
+      #   #      "tags": {
+      #   #        "GraphqlTag": {
+      #   #          "operation_name": "user_created",
+      #   #          "operation_type": "mutation"
+      #   #        }
+      #   #      },
+      #   #      "context": {}
+      #   #    }
+      class JSON < Base
+        def self.encode(event)
+          event[:payload] = event[:payload].to_h
+          event[:tags] = event[:tags].transform_values do |value|
+            value.respond_to?(:to_h) ? value.to_h : value
+          end
+          ::JSON.dump(event)
+        end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/event_reporter/encoders/message_pack.rb
+++ b/activesupport/lib/active_support/event_reporter/encoders/message_pack.rb
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+begin
+  gem "msgpack"
+  require "msgpack"
+rescue LoadError => error
+  warn <<~MSG
+    ActiveSupport::ErrorReporter::Encoders::MessagePack requires the msgpack gem.
+    Please add it to your Gemfile: `gem "msgpack"`
+  MSG
+  raise error
+end
+
+module ActiveSupport
+  class EventReporter
+    module Encoders
+      # EventReporter encoder for serializing events to MessagePack format.
+      class MessagePack < Base
+        def self.encode(event)
+          event[:payload] = event[:payload].to_h
+          event[:tags] = event[:tags].transform_values do |value|
+            value.respond_to?(:to_h) ? value.to_h : value
+          end
+          ::MessagePack.pack(event)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When `ActiveSupport::EventReporter.encoder(:msgpack)` is called, typically during boot, we can catch when the user forgot to add the gem and give them a warning.

This is similar to how `ActiveSupport::Messages::SerializerWithFallback.[](format)` works

See:
https://github.com/rails/rails/blob/6f912a5986cd9295e3fbb45b1ec22159e51ad65d/activesupport/lib/active_support/messages/serializer_with_fallback.rb#L9-L14

Also `ActiveSupport::MessagePack`:
https://github.com/rails/rails/blob/2ca26346a563a375277e97a09d879df33682df55/activesupport/lib/active_support/message_pack.rb#L3-L10

Context:
https://github.com/rails/rails/pull/55334#discussion_r2226708177