### PR TITLE
Filter event reporter payloads

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -114,6 +114,8 @@ module ActiveSupport
   @event_reporter = ActiveSupport::EventReporter.new
   singleton_class.attr_accessor :event_reporter # :nodoc:
 
+  cattr_accessor :filter_parameters, default: [] # :nodoc:
+
   def self.cache_format_version
     Cache.format_version
   end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -79,6 +79,12 @@ module ActiveSupport
       end
     end
 
+    initializer "active_support.set_filter_parameters" do |app|
+      config.after_initialize do
+        ActiveSupport.filter_parameters += Rails.application.config.filter_parameters
+      end
+    end
+
     initializer "active_support.deprecation_behavior" do |app|
       if app.config.active_support.report_deprecations == false
         app.deprecators.silenced = true

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -222,6 +222,17 @@ module ActiveSupport
       assert_equal("Uh oh!", error.message)
     end
 
+    test "#notify with filtered payloads" do
+      filter = ActiveSupport::ParameterFilter.new([:zomg], mask: "[FILTERED]")
+      @reporter.stub(:payload_filter, filter) do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { key: "value", zomg: "[FILTERED]" })
+        ]) do
+          @reporter.notify(:test_event, { key: "value", zomg: "secret" })
+        end
+      end
+    end
+
     test "#with_debug" do
       @reporter.with_debug do
         assert_predicate @reporter, :debug_mode?


### PR DESCRIPTION
For event payloads that are a hash, filter the data before emitting the event.

Since we want to filter any sensitive data as early as possible.

However, custom objects are not resolved until later, so we can't filter those.

---

Based on Shopify/rails#37 and Shopify/rails#38.

Originally discussed here:
https://github.com/rails/rails/pull/55334#discussion_r2212329630