### PR TITLE
Bump RuboCop to fix some transient failures in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "prism"
 group :rubocop do
   # Rubocop has to be locked in the Gemfile because CI ignores Gemfile.lock
   # We don't want rubocop to start failing whenever rubocop makes a new release.
-  gem "rubocop", "< 1.73", require: false
+  gem "rubocop", "1.79.2", require: false
   gem "rubocop-minitest", require: false
   gem "rubocop-packaging", require: false
   gem "rubocop-performance", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,7 +423,7 @@ GEM
     os (1.1.4)
     ostruct (0.6.1)
     parallel (1.26.3)
-    parser (3.3.6.0)
+    parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
     path_expander (1.1.3)
@@ -431,7 +431,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.3.0)
+    prism (1.4.0)
     propshaft (1.2.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -512,7 +512,7 @@ GEM
     retriable (3.1.2)
     rexml (3.4.0)
     rouge (4.5.1)
-    rubocop (1.72.2)
+    rubocop (1.79.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -520,12 +520,13 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.1)
-      parser (>= 3.3.1.0)
-    rubocop-md (2.0.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-md (2.0.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
     rubocop-minitest (0.37.1)
@@ -793,7 +794,7 @@ DEPENDENCIES
   resque-scheduler
   rexml
   rouge
-  rubocop (< 1.73)
+  rubocop (= 1.79.2)
   rubocop-md
   rubocop-minitest
   rubocop-packaging

--- a/Rakefile
+++ b/Rakefile
@@ -174,7 +174,7 @@ task :smoke, [:frameworks, :isolated] do |task, args|
     frameworks = Releaser::FRAMEWORKS
   end
 
-  isolated = args[:isolated].nil? ? true : args[:isolated] == "true"
+  isolated = args[:isolated].nil? || args[:isolated] == "true"
   test_task = isolated ? "test:isolated" : "test"
 
   (frameworks - ["activerecord"]).each do |project|

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -29,7 +29,7 @@ module ActionMailbox
     initializer "action_mailbox.config" do
       config.after_initialize do |app|
         ActionMailbox.logger = app.config.action_mailbox.logger || Rails.logger
-        ActionMailbox.incinerate = app.config.action_mailbox.incinerate.nil? ? true : app.config.action_mailbox.incinerate
+        ActionMailbox.incinerate = app.config.action_mailbox.incinerate.nil? || app.config.action_mailbox.incinerate
         ActionMailbox.incinerate_after = app.config.action_mailbox.incinerate_after || 30.days
         ActionMailbox.queues = app.config.action_mailbox.queues || {}
         ActionMailbox.ingress = app.config.action_mailbox.ingress

--- a/actionpack/test/dispatch/test_response_test.rb
+++ b/actionpack/test/dispatch/test_response_test.rb
@@ -62,7 +62,7 @@ class TestResponseTest < ActiveSupport::TestCase
     HTML
     html = response.parsed_body
 
-    html.at("main") => {name:, content:}
+    html.at("main") => { name:, content: }
     assert_equal "main", name
     assert_equal "Some main content", content
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -117,7 +117,7 @@ module ActionView
         path_options = options.extract!("protocol", "extname", "host", "skip_pipeline").symbolize_keys
         preload_links = []
         use_preload_links_header = options["preload_links_header"].nil? ? preload_links_header : options.delete("preload_links_header")
-        nopush = options["nopush"].nil? ? true : options.delete("nopush")
+        nopush = options["nopush"].nil? || options.delete("nopush")
         crossorigin = options.delete("crossorigin")
         crossorigin = "anonymous" if crossorigin == true
         integrity = options["integrity"]
@@ -211,7 +211,7 @@ module ActionView
         preload_links = []
         crossorigin = options.delete("crossorigin")
         crossorigin = "anonymous" if crossorigin == true
-        nopush = options["nopush"].nil? ? true : options.delete("nopush")
+        nopush = options["nopush"].nil? || options.delete("nopush")
         integrity = options["integrity"]
 
         sources_tags = sources.uniq.map { |source|

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -859,7 +859,7 @@ end
 
 class PessimisticLockingWhilePreventingWritesTest < ActiveRecord::TestCase
   CUSTOM_LOCK = if current_adapter?(:SQLite3Adapter)
-    true # no-op
+    "FOR UPDATE" # no-op
   else
     "FOR SHARE"
   end


### PR DESCRIPTION
```
rubocop --parallel
Error: `Rails` cops have been extracted to the `rubocop-rails` gem.
(obsolete configuration found in .rubocop.yml, please update it)
````

Like here:
* https://buildkite.com/rails/rails/builds/120729/steps/canvas?sid=0198a576-b57c-485b-803a-150b40ee41df
* https://buildkite.com/rails/rails/builds/120724/steps/canvas?sid=0198a53d-2d42-49b2-8b35-97c2395f01b2

This is fixed since RuboCop 1.74 with https://github.com/rubocop/rubocop/pull/13954 but I can't tell why it would start only now.

`rubocop-md` needs a bump as well to silence some deprecation about a renamed cop.

Other changes are what rubocop now wants.