### PR TITLE
Add `cgi` gem to Gemfile until newer rouge gem is released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ group :doc do
   gem "redcarpet", "~> 3.6.1", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "rouge"
+  # Workaround until https://github.com/rouge-ruby/rouge/pull/2131 is merged and released
+  gem "cgi", require: false
   gem "rubyzip", "~> 2.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.0)
     chef-utils (18.6.2)
       concurrent-ruby
     childprocess (5.1.0)
@@ -752,6 +753,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara (>= 3.39)
+  cgi
   connection_pool
   cssbundling-rails
   dalli (>= 3.0.1)


### PR DESCRIPTION
### Motivation / Background

This pull request addresses this Rails CI Nightly failure below. https://buildkite.com/rails/rails-nightly/builds/2679#0198a53d-2b95-4767-95aa-e54f1297493d/1193-1197

### Detail

- Errors addressed by this commit

```ruby
$ ruby -v
ruby 3.5.0dev (2025-08-12T14:43:46Z master c5c894c6e4) +PRISM [x86_64-linux]
$ cd guides
$ bundle install
$ bundle exec rake guides:lint
... snip ...
Generating active_record_validations.md as active_record_validations.html
Generating 5_1_release_notes.md as 5_1_release_notes.html
Generating asset_pipeline.md as asset_pipeline.html
/home/yahonda/.local/share/mise/installs/ruby/trunk/lib/ruby/gems/3.5.0+2/gems/rouge-4.5.1/lib/rouge/lexer.rb:55:in 'Rouge::Lexer.lookup_fancy': undefined method 'parse' for class CGI (NoMethodError)

        opts = CGI.parse(opts || '').map do |k, vals|
                  ^^^^^^
	from /home/yahonda/.local/share/mise/installs/ruby/trunk/lib/ruby/gems/3.5.0+2/gems/rouge-4.5.1/lib/rouge/lexer.rb:95:in 'Rouge::Lexer.find_fancy'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/markdown/renderer.rb:35:in 'RailsGuides::Markdown::Renderer#block_code'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/markdown.rb:90:in 'Redcarpet::Markdown#render'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/markdown.rb:90:in 'RailsGuides::Markdown#generate_body'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/markdown.rb:28:in 'RailsGuides::Markdown#render'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/generator.rb:214:in 'RailsGuides::Generator#generate_guide'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/generator.rb:108:in 'block in RailsGuides::Generator#generate_guides'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/generator.rb:106:in 'Array#each'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/generator.rb:106:in 'RailsGuides::Generator#generate_guides'
	from /home/yahonda/src/github.com/rails/rails/guides/rails_guides/generator.rb:52:in 'RailsGuides::Generator#generate'
	from rails_guides.rb:31:in '<main>'
rake aborted!
Command failed with status (1): [/home/yahonda/.local/share/mise/installs/ruby/trunk/bin/ruby -Eutf-8:utf-8 rails_guides.rb]
/home/yahonda/src/github.com/rails/rails/guides/Rakefile:33:in 'block (3 levels) in <top (required)>'
/home/yahonda/.local/share/mise/installs/ruby/trunk/bin/bundle:25:in '<main>'
Tasks: TOP => guides:lint => guides:lint:check_links
(See full trace by running task with --trace)
$
```

### Additional information
This workaround commit can be reverted when newer version of rouge gem is relased including https://github.com/rouge-ruby/rouge/pull/2131

- Ruby 3.5 removes cgi by default https://bugs.ruby-lang.org/issues/21258
https://github.com/ruby/ruby/pull/13275

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
