### PR TITLE
Replace America/Godthab with America/Nuuk

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -64,7 +64,7 @@ module ActiveSupport
       "Montevideo"                   => "America/Montevideo",
       "Georgetown"                   => "America/Guyana",
       "Puerto Rico"                  => "America/Puerto_Rico",
-      "Greenland"                    => "America/Godthab",
+      "Greenland"                    => "America/Nuuk",
       "Mid-Atlantic"                 => "Atlantic/South_Georgia",
       "Azores"                       => "Atlantic/Azores",
       "Cape Verde Is."               => "Atlantic/Cape_Verde",


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
This PR has been opened because according to IANA, `America/Godthab` is just a link to `America/Godthab` and not a canonical timezone.

This has already been covered in Debian Trixie where `America/Godthab` cannot be found as a timezone anymore in `/usr/loca/zoneinfo/America` (which is used by the [tzinfo gem](https://github.com/tzinfo/tzinfo)).

**Sources**
- https://data.iana.org/time-zones/data/backward
- https://data.iana.org/time-zones/tzdb/zone.tab
- https://packages.debian.org/bookworm/all/tzdata/filelist
- https://packages.debian.org/trixie/all/tzdata/filelist


<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The change in Debian already leads to unwanted side-effects in ActiveSupport (see Additional information below).

Calling `ActiveSupport::TimeZone.find_tzinfo('Greenland')` in Debian Trixie results in the following error:
```
/usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:321:in 'TZInfo::DataSource#validate_timezone_identifier': Invalid identifier: America/Godthab (TZInfo::InvalidTimezoneIdentifier)
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_sources/zoneinfo_data_source.rb:307:in 'TZInfo::DataSources::ZoneinfoDataSource#load_timezone_info'
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:195:in 'TZInfo::DataSource#get_timezone_info'
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/timezone.rb:128:in 'TZInfo::Timezone.get'
        from /usr/local/bundle/gems/activesupport-8.0.2.1/lib/active_support/values/time_zone.rb:208:in 'ActiveSupport::TimeZone.find_tzinfo'
        from (irb):3:in '<main>'
        from <internal:kernel>:168:in 'Kernel#loop'
        from /usr/local/lib/ruby/gems/3.4.0/gems/irb-1.14.3/exe/irb:9:in '<top (required)>'
        from /usr/local/bin/irb:25:in 'Kernel#load'
        from /usr/local/bin/irb:25:in '<main>'
```
This PR could possibly fix that problem.

### Detail

This PR changes internal tzinfo data from "America/Godthab" to "America/Nuuk" for `ActiveSupport::TimeZone`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

The effect of the latest Debian changes on ActiveSupport can be reproduced easily. Below are two examples that demonstrate ActiveSupport behavior in Debian Bookworm vs. Trixie.

Debian Bookworm:
```
docker run --rm -it --entrypoint=bash ruby:3.4.5-slim-bookworm
root@c5ba1c648821:/# gem install activesupport
Fetching activesupport-8.0.2.1.gem
Fetching tzinfo-2.0.6.gem
Fetching concurrent-ruby-1.3.5.gem
Fetching i18n-1.14.7.gem
Fetching connection_pool-2.5.3.gem
Successfully installed concurrent-ruby-1.3.5
Successfully installed tzinfo-2.0.6
Successfully installed i18n-1.14.7
Successfully installed connection_pool-2.5.3
Successfully installed activesupport-8.0.2.1
5 gems installed

A new release of RubyGems is available: 3.6.9 → 3.7.1!
Run `gem update --system 3.7.1` to update your installation.

root@c5ba1c648821:/# irb
irb(main):001> require 'active_support/time'
=> true
irb(main):002> ActiveSupport::TimeZone::MAPPING.fetch('Greenland')
=> "America/Godthab"
irb(main):003> ActiveSupport::TimeZone.find_tzinfo('Greenland')
=> #<TZInfo::DataTimezone: America/Godthab>
irb(main):004> TZInfo::Timezone.get('America/Godthab')
=> #<TZInfo::DataTimezone: America/Godthab>
irb(main):005> TZInfo::Timezone.get('America/Nuuk')
=> #<TZInfo::DataTimezone: America/Nuuk>
irb(main):006> quit
root@c5ba1c648821:/# ls /usr/share/zoneinfo/America/
Adak            Belem          Cayman         Dawson_Creek  Goose_Bay     Iqaluit        Managua      Monterrey     Pangnirtung     Resolute       St_Kitts       Whitehorse
Anchorage       Belize         Chicago        Denver        Grand_Turk    Jamaica        Manaus       Montevideo    Paramaribo      Rio_Branco     St_Lucia       Winnipeg
Anguilla        Blanc-Sablon   Chihuahua      Detroit       Grenada       Jujuy          Marigot      Montreal      Phoenix         Rosario        St_Thomas      Yakutat
Antigua         Boa_Vista      Ciudad_Juarez  Dominica      Guadeloupe    Juneau         Martinique   Montserrat    Port-au-Prince  Santa_Isabel   St_Vincent     Yellowknife
Araguaina       Bogota         Coral_Harbour  Edmonton      Guatemala     Kentucky       Matamoros    Nassau        Port_of_Spain   Santarem       Swift_Current
Argentina       Boise          Cordoba        Eirunepe      Guayaquil     Knox_IN        Mazatlan     New_York      Porto_Acre      Santiago       Tegucigalpa
Aruba           Buenos_Aires   Costa_Rica     El_Salvador   Guyana        Kralendijk     Mendoza      Nipigon       Porto_Velho     Santo_Domingo  Thule
Asuncion        Cambridge_Bay  Coyhaique      Ensenada      Halifax       La_Paz         Menominee    Nome          Puerto_Rico     Sao_Paulo      Thunder_Bay
Atikokan        Campo_Grande   Creston        Fort_Nelson   Havana        Lima           Merida       Noronha       Punta_Arenas    Scoresbysund   Tijuana
Atka            Cancun         Cuiaba         Fort_Wayne    Hermosillo    Los_Angeles    Metlakatla   North_Dakota  Rainy_River     Shiprock       Toronto
Bahia           Caracas        Curacao        Fortaleza     Indiana       Louisville     Mexico_City  Nuuk          Rankin_Inlet    Sitka          Tortola
Bahia_Banderas  Catamarca      Danmarkshavn   Glace_Bay     Indianapolis  Lower_Princes  Miquelon     Ojinaga       Recife          St_Barthelemy  Vancouver
Barbados        Cayenne        Dawson         Godthab       Inuvik        Maceio         Moncton      Panama        Regina          St_Johns       Virgin
```

Debian Trixie:
```
> docker run --rm -it --entrypoint=bash ruby:3.4.5-slim
root@fa559769cb70:/# gem install activesupport
Fetching activesupport-8.0.2.1.gem
Fetching tzinfo-2.0.6.gem
Fetching i18n-1.14.7.gem
Fetching concurrent-ruby-1.3.5.gem
Fetching connection_pool-2.5.3.gem
Successfully installed concurrent-ruby-1.3.5
Successfully installed tzinfo-2.0.6
Successfully installed i18n-1.14.7
Successfully installed connection_pool-2.5.3
Successfully installed activesupport-8.0.2.1
5 gems installed

A new release of RubyGems is available: 3.6.9 → 3.7.1!
Run `gem update --system 3.7.1` to update your installation.

root@fa559769cb70:/# irb
irb(main):001> require 'active_support/time'
=> true
irb(main):002> ActiveSupport::TimeZone::MAPPING.fetch('Greenland')
=> "America/Godthab"
irb(main):003> ActiveSupport::TimeZone.find_tzinfo('Greenland')
/usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:321:in 'TZInfo::DataSource#validate_timezone_identifier': Invalid identifier: America/Godthab (TZInfo::InvalidTimezoneIdentifier)
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_sources/zoneinfo_data_source.rb:307:in 'TZInfo::DataSources::ZoneinfoDataSource#load_timezone_info'
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:195:in 'TZInfo::DataSource#get_timezone_info'
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/timezone.rb:128:in 'TZInfo::Timezone.get'
        from /usr/local/bundle/gems/activesupport-8.0.2.1/lib/active_support/values/time_zone.rb:208:in 'ActiveSupport::TimeZone.find_tzinfo'
        from (irb):3:in '<main>'
        from <internal:kernel>:168:in 'Kernel#loop'
        from /usr/local/lib/ruby/gems/3.4.0/gems/irb-1.14.3/exe/irb:9:in '<top (required)>'
        from /usr/local/bin/irb:25:in 'Kernel#load'
        from /usr/local/bin/irb:25:in '<main>'
irb(main):004> TZInfo::Timezone.get('America/Godthab')
/usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:321:in 'TZInfo::DataSource#validate_timezone_identifier': Invalid identifier: America/Godthab (TZInfo::InvalidTimezoneIdentifier)
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_sources/zoneinfo_data_source.rb:307:in 'TZInfo::DataSources::ZoneinfoDataSource#load_timezone_info'
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:195:in 'TZInfo::DataSource#get_timezone_info'
        from /usr/local/bundle/gems/tzinfo-2.0.6/lib/tzinfo/timezone.rb:128:in 'TZInfo::Timezone.get'
        from (irb):4:in '<main>'
        from <internal:kernel>:168:in 'Kernel#loop'
        from /usr/local/lib/ruby/gems/3.4.0/gems/irb-1.14.3/exe/irb:9:in '<top (required)>'
        from /usr/local/bin/irb:25:in 'Kernel#load'
        from /usr/local/bin/irb:25:in '<main>'
irb(main):005> TZInfo::Timezone.get('America/Nuuk')
=> #<TZInfo::DataTimezone: America/Nuuk>
irb(main):006> quit
root@fa559769cb70:/# ls /usr/share/zoneinfo/America/
Adak       Bahia_Banderas  Caracas        Curacao       Fort_Nelson  Havana      Los_Angeles    Metlakatla   Nome            Porto_Acre    Santarem       St_Thomas      Whitehorse
Anchorage  Barbados        Cayenne        Danmarkshavn  Fortaleza    Hermosillo  Lower_Princes  Mexico_City  Noronha         Porto_Velho   Santiago       St_Vincent     Winnipeg
Anguilla   Belem           Cayman         Dawson        Glace_Bay    Indiana     Maceio         Miquelon     North_Dakota    Puerto_Rico   Santo_Domingo  Swift_Current  Yakutat
Antigua    Belize          Chicago        Dawson_Creek  Goose_Bay    Inuvik      Managua        Moncton      Nuuk            Punta_Arenas  Sao_Paulo      Tegucigalpa    Yellowknife
Araguaina  Blanc-Sablon    Chihuahua      Denver        Grand_Turk   Iqaluit     Manaus         Monterrey    Ojinaga         Rainy_River   Scoresbysund   Thule
Argentina  Boa_Vista       Ciudad_Juarez  Detroit       Grenada      Jamaica     Marigot        Montevideo   Panama          Rankin_Inlet  Shiprock       Thunder_Bay
Aruba      Bogota          Coral_Harbour  Dominica      Guadeloupe   Juneau      Martinique     Montreal     Pangnirtung     Recife        Sitka          Tijuana
Asuncion   Boise           Costa_Rica     Edmonton      Guatemala    Kentucky    Matamoros      Montserrat   Paramaribo      Regina        St_Barthelemy  Toronto
Atikokan   Cambridge_Bay   Coyhaique      Eirunepe      Guayaquil    Kralendijk  Mazatlan       Nassau       Phoenix         Resolute      St_Johns       Tortola
Atka       Campo_Grande    Creston        El_Salvador   Guyana       La_Paz      Menominee      New_York     Port-au-Prince  Rio_Branco    St_Kitts       Vancouver
Bahia      Cancun          Cuiaba         Ensenada      Halifax      Lima        Merida         Nipigon      Port_of_Spain   Santa_Isabel  St_Lucia       Virgin
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
