### PR TITLE
Allow logs and notifications for open redirects

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -13,6 +13,7 @@ module ActionController
   class Railtie < Rails::Railtie # :nodoc:
     config.action_controller = ActiveSupport::OrderedOptions.new
     config.action_controller.raise_on_open_redirects = false
+    config.action_controller.action_on_open_redirect = :log
     config.action_controller.action_on_path_relative_redirect = :log
     config.action_controller.log_query_tags_around_actions = true
     config.action_controller.wrap_parameters_by_default = false
@@ -99,6 +100,17 @@ module ActionController
       ActiveSupport.on_load(:action_controller_base) do
         if app.config.action_controller.default_protect_from_forgery
           protect_from_forgery with: :exception
+        end
+      end
+    end
+
+    initializer "action_controller.open_redirects" do |app|
+      ActiveSupport.on_load(:action_controller, run_once: true) do
+        if app.config.action_controller.raise_on_open_redirects != nil
+          ActiveSupport.deprecator.warn(<<~MSG.squish)
+            `raise_on_open_redirects` is deprecated and will be removed in a future Rails version.
+            Use `config.action_controller.action_on_open_redirect = :raise` instead.
+          MSG
         end
       end
     end

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -652,224 +652,182 @@ class RedirectTest < ActionController::TestCase
   end
 
   def test_redirect_to_path_relative_url_with_log
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :log
-
-    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    old_logger = ActionController::Base.logger
-    ActionController::Base.logger = logger
-
-    get :redirect_to_path_relative_url
-    assert_response :redirect
-    assert_equal "http://test.hostexample.com", redirect_to_url
-    assert_match(/Path relative URL redirect detected: "example.com"/, logger.logged(:warn).last)
-  ensure
-    ActionController::Base.logger = old_logger
-    ActionController::Base.action_on_path_relative_redirect = old_config
+    with_path_relative_redirect(:log) do
+      with_logger do |logger|
+        get :redirect_to_path_relative_url
+        assert_response :redirect
+        assert_equal "http://test.hostexample.com", redirect_to_url
+        assert_logged(/Path relative URL redirect detected: "example.com"/, logger)
+      end
+    end
   end
 
   def test_redirect_to_path_relative_url_starting_with_an_at_with_log
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :log
-
-    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    old_logger = ActionController::Base.logger
-    ActionController::Base.logger = logger
-
-    get :redirect_to_path_relative_url_starting_with_an_at
-    assert_response :redirect
-    assert_equal "http://test.host@example.com", redirect_to_url
-    assert_match(/Path relative URL redirect detected: "@example.com"/, logger.logged(:warn).last)
-  ensure
-    ActionController::Base.logger = old_logger
-    ActionController::Base.action_on_path_relative_redirect = old_config
+    with_path_relative_redirect(:log) do
+      with_logger do |logger|
+        get :redirect_to_path_relative_url_starting_with_an_at
+        assert_response :redirect
+        assert_equal "http://test.host@example.com", redirect_to_url
+        assert_logged(/Path relative URL redirect detected: "@example.com"/, logger)
+      end
+    end
   end
 
   def test_redirect_to_path_relative_url_starting_with_an_at_with_notify
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :notify
+    with_path_relative_redirect(:notify) do
+      events = []
+      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
 
-    events = []
-    ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-      events << ActiveSupport::Notifications::Event.new(*args)
+      get :redirect_to_path_relative_url_starting_with_an_at
+
+      assert_response :redirect
+      assert_equal "http://test.host@example.com", redirect_to_url
+
+      assert_equal 1, events.size
+      event = events.first
+      assert_equal "@example.com", event.payload[:url]
+      assert_equal 'Path relative URL redirect detected: "@example.com"', event.payload[:message]
+      assert_kind_of Array, event.payload[:stack_trace]
+      assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url_starting_with_an_at") }
+    ensure
+      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
     end
-
-    get :redirect_to_path_relative_url_starting_with_an_at
-
-    assert_response :redirect
-    assert_equal "http://test.host@example.com", redirect_to_url
-
-    assert_equal 1, events.size
-    event = events.first
-    assert_equal "@example.com", event.payload[:url]
-    assert_equal 'Path relative URL redirect detected: "@example.com"', event.payload[:message]
-    assert_kind_of Array, event.payload[:stack_trace]
-    assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url_starting_with_an_at") }
-  ensure
-    ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
-    ActionController::Base.action_on_path_relative_redirect = old_config
   end
 
   def test_redirect_to_path_relative_url_with_notify
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :notify
+    with_path_relative_redirect(:notify) do
+      events = []
+      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
 
-    events = []
-    ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-      events << ActiveSupport::Notifications::Event.new(*args)
+      get :redirect_to_path_relative_url
+
+      assert_response :redirect
+      assert_equal "http://test.hostexample.com", redirect_to_url
+
+      assert_equal 1, events.size
+      event = events.first
+      assert_equal "example.com", event.payload[:url]
+      assert_equal 'Path relative URL redirect detected: "example.com"', event.payload[:message]
+      assert_kind_of Array, event.payload[:stack_trace]
+      assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url") }
+    ensure
+      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
     end
-
-    get :redirect_to_path_relative_url
-
-    assert_response :redirect
-    assert_equal "http://test.hostexample.com", redirect_to_url
-
-    assert_equal 1, events.size
-    event = events.first
-    assert_equal "example.com", event.payload[:url]
-    assert_equal 'Path relative URL redirect detected: "example.com"', event.payload[:message]
-    assert_kind_of Array, event.payload[:stack_trace]
-    assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url") }
-  ensure
-    ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
-    ActionController::Base.action_on_path_relative_redirect = old_config
   end
 
   def test_redirect_to_path_relative_url_with_raise
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :raise
+    with_path_relative_redirect(:raise) do
+      error = assert_raise(ActionController::Redirecting::UnsafeRedirectError) do
+        get :redirect_to_path_relative_url
+      end
 
-    error = assert_raise(ActionController::Redirecting::UnsafeRedirectError) do
-      get :redirect_to_path_relative_url
+      assert_equal 'Path relative URL redirect detected: "example.com"', error.message
     end
-
-    assert_equal 'Path relative URL redirect detected: "example.com"', error.message
-  ensure
-    ActionController::Base.action_on_path_relative_redirect = old_config
   end
 
   def test_redirect_to_path_relative_url_starting_with_an_at_with_raise
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :raise
+    with_path_relative_redirect(:raise) do
+      error = assert_raise(ActionController::Redirecting::UnsafeRedirectError) do
+        get :redirect_to_path_relative_url_starting_with_an_at
+      end
 
-    error = assert_raise(ActionController::Redirecting::UnsafeRedirectError) do
-      get :redirect_to_path_relative_url_starting_with_an_at
+      assert_equal 'Path relative URL redirect detected: "@example.com"', error.message
     end
-
-    assert_equal 'Path relative URL redirect detected: "@example.com"', error.message
-  ensure
-    ActionController::Base.action_on_path_relative_redirect = old_config
   end
 
   def test_redirect_to_absolute_url_does_not_log
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :log
+    with_path_relative_redirect(:log) do
+      with_logger do |logger|
+        get :redirect_to_url
+        assert_response :redirect
+        assert_equal "http://www.rubyonrails.org/", redirect_to_url
+        assert_not_logged(/Path relative URL redirect detected/, logger)
+      end
 
-    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    old_logger = ActionController::Base.logger
-    ActionController::Base.logger = logger
-
-    get :redirect_to_url
-    assert_response :redirect
-    assert_equal "http://www.rubyonrails.org/", redirect_to_url
-    assert_empty logger.logged(:warn)
-
-    get :relative_url_redirect_with_status
-    assert_response :redirect
-    assert_equal "http://test.host/things/stuff", redirect_to_url
-    assert_empty logger.logged(:warn)
-  ensure
-    ActionController::Base.logger = old_logger
-    ActionController::Base.action_on_path_relative_redirect = old_config
+      with_logger do |logger|
+        get :relative_url_redirect_with_status
+        assert_response :redirect
+        assert_equal "http://test.host/things/stuff", redirect_to_url
+        assert_empty logger.logged(:warn)
+      end
+    end
   end
 
   def test_redirect_to_absolute_url_does_not_notify
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :notify
+    with_path_relative_redirect(:notify) do
+      events = []
+      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
 
-    events = []
-    ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-      events << ActiveSupport::Notifications::Event.new(*args)
+      get :redirect_to_url
+      assert_response :redirect
+      assert_equal "http://www.rubyonrails.org/", redirect_to_url
+      assert_empty events
+
+      get :relative_url_redirect_with_status
+      assert_response :redirect
+      assert_equal "http://test.host/things/stuff", redirect_to_url
+      assert_empty events
+    ensure
+      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
     end
-
-    get :redirect_to_url
-    assert_response :redirect
-    assert_equal "http://www.rubyonrails.org/", redirect_to_url
-    assert_empty events
-
-    get :relative_url_redirect_with_status
-    assert_response :redirect
-    assert_equal "http://test.host/things/stuff", redirect_to_url
-    assert_empty events
-  ensure
-    ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
-    ActionController::Base.action_on_path_relative_redirect = old_config
   end
 
   def test_redirect_to_absolute_url_does_not_raise
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :raise
+    with_path_relative_redirect(:raise) do
+      get :redirect_to_url
+      assert_response :redirect
+      assert_equal "http://www.rubyonrails.org/", redirect_to_url
 
-    get :redirect_to_url
-    assert_response :redirect
-    assert_equal "http://www.rubyonrails.org/", redirect_to_url
+      get :relative_url_redirect_with_status
+      assert_response :redirect
+      assert_equal "http://test.host/things/stuff", redirect_to_url
 
-    get :relative_url_redirect_with_status
-    assert_response :redirect
-    assert_equal "http://test.host/things/stuff", redirect_to_url
-
-    get :redirect_to_url_with_network_path_reference
-    assert_response :redirect
-    assert_equal "//www.rubyonrails.org/", redirect_to_url
-  ensure
-    ActionController::Base.action_on_path_relative_redirect = old_config
+      get :redirect_to_url_with_network_path_reference
+      assert_response :redirect
+      assert_equal "//www.rubyonrails.org/", redirect_to_url
+    end
   end
 
   def test_redirect_to_query_string_url_does_not_trigger_path_relative_warning_with_log
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :log
-
-    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    old_logger = ActionController::Base.logger
-    ActionController::Base.logger = logger
-
-    get :redirect_to_query_string_url
-    assert_response :redirect
-    assert_equal "http://test.host?foo=bar", redirect_to_url
-    assert_empty logger.logged(:warn)
-  ensure
-    ActionController::Base.logger = old_logger
-    ActionController::Base.action_on_path_relative_redirect = old_config
+    with_path_relative_redirect(:log) do
+      with_logger do |logger|
+        get :redirect_to_query_string_url
+        assert_response :redirect
+        assert_equal "http://test.host?foo=bar", redirect_to_url
+        assert_not_logged(/Path relative URL redirect detected/, logger)
+      end
+    end
   end
 
   def test_redirect_to_query_string_url_does_not_trigger_path_relative_warning_with_notify
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :notify
+    with_path_relative_redirect(:notify) do
+      events = []
+      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
 
-    events = []
-    ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-      events << ActiveSupport::Notifications::Event.new(*args)
+      get :redirect_to_query_string_url
+      assert_response :redirect
+      assert_equal "http://test.host?foo=bar", redirect_to_url
+
+      assert_empty events.select { |e| e.payload[:message]&.include?("Path relative URL redirect detected") }
+    ensure
+      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
     end
-
-    get :redirect_to_query_string_url
-    assert_response :redirect
-    assert_equal "http://test.host?foo=bar", redirect_to_url
-
-    assert_empty events.select { |e| e.payload[:message]&.include?("Path relative URL redirect detected") }
-  ensure
-    ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
-    ActionController::Base.action_on_path_relative_redirect = old_config
   end
 
   def test_redirect_to_query_string_url_does_not_trigger_path_relative_warning_with_raise
-    old_config = ActionController::Base.action_on_path_relative_redirect
-    ActionController::Base.action_on_path_relative_redirect = :raise
-
-    get :redirect_to_query_string_url
-    assert_response :redirect
-    assert_equal "http://test.host?foo=bar", redirect_to_url
-  ensure
-    ActionController::Base.action_on_path_relative_redirect = old_config
+    with_path_relative_redirect(:raise) do
+      get :redirect_to_query_string_url
+      assert_response :redirect
+      assert_equal "http://test.host?foo=bar", redirect_to_url
+    end
   end
 
   def test_redirect_with_allowed_redirect_hosts
@@ -893,6 +851,33 @@ class RedirectTest < ActionController::TestCase
   end
 
   private
+    def with_logger
+      logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
+      old_logger = ActionController::Base.logger
+      ActionController::Base.logger = logger
+      yield logger
+    ensure
+      ActionController::Base.logger = old_logger
+    end
+
+    def assert_logged(pattern, logger)
+      assert logger.logged(:warn).any? { |msg| msg.match?(pattern) },
+        "Expected to find log matching #{pattern.inspect} in: #{logger.logged(:warn).inspect}"
+    end
+
+    def assert_not_logged(pattern, logger)
+      assert logger.logged(:warn).none? { |msg| msg.match?(pattern) },
+        "Expected not to find log matching #{pattern.inspect} in: #{logger.logged(:warn).inspect}"
+    end
+
+    def with_path_relative_redirect(action)
+      old_config = ActionController::Base.action_on_path_relative_redirect
+      ActionController::Base.action_on_path_relative_redirect = action
+      yield
+    ensure
+      ActionController::Base.action_on_path_relative_redirect = old_config
+    end
+
     def with_raise_on_open_redirects
       old_raise_on_open_redirects = ActionController::Base.raise_on_open_redirects
       ActionController::Base.raise_on_open_redirects = true

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.1
 
+- [`config.action_controller.action_on_open_redirect`](#config-action-controller-action-on-open-redirect): `:raise`
 - [`config.action_controller.action_on_path_relative_redirect`](#config-action-controller-action-on-path-relative-redirect): `:raise`
 - [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`
 - [`config.action_view.remove_hidden_field_autocomplete`](#config-action-view-remove-hidden-field-autocomplete): `true`
@@ -1971,6 +1972,30 @@ The default value depends on the `config.load_defaults` target version:
 | 7.0                   | `true`               |
 
 [redirect_to]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
+
+#### `config.action_controller.action_on_open_redirect`
+
+Controls how Rails handles open redirect attempts (redirects to external hosts).
+
+**Note:** This configuration replaces the deprecated [`config.action_controller.raise_on_open_redirects`](#config-action-controller-raise-on-open-redirects)
+option, which will be removed in a future Rails version. The new configuration provides more
+flexible control over open redirect protection.
+
+When set to `:log`, Rails will log a warning when an open redirect is detected.
+When set to `:notify`, Rails will publish an `open_redirect.action_controller`
+notification event. When set to `:raise`, Rails will raise an
+`ActionController::Redirecting::UnsafeRedirectError`.
+
+If `raise_on_open_redirects` is set to `true`, it will take precedence
+over this configuration for backward compatibility, effectively forcing `:raise`
+behavior.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `:log`               |
+| 8.1                   | `:raise`             |
 
 #### `config.action_controller.action_on_path_relative_redirect`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -351,6 +351,10 @@ module Rails
         when "8.1"
           load_defaults "8.0"
 
+          if respond_to?(:action_controller)
+            action_controller.action_on_open_redirect = :raise
+          end
+
           # Development and test environments tend to reload code and
           # redefine methods (e.g. mocking), hence YJIT isn't generally
           # faster in these environments.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -53,6 +53,25 @@
 # Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
 
 ###
+# Controls how Rails handles open redirect vulnerabilities.
+# When set to `:raise`, Rails will raise an `ActionController::Redirecting::UnsafeRedirectError`
+# for redirects to external hosts, which helps prevent open redirect attacks.
+#
+# This configuration replaces the deprecated `raise_on_open_redirects` setting, providing
+# the ability for large codebases to safely turn on the protection (after monitoring it with :log/:notifications)
+#
+# Example:
+#   redirect_to params[:redirect_url]  # May raise UnsafeRedirectError if URL is external
+#   redirect_to "http://evil.com"      # Raises UnsafeRedirectError
+#   redirect_to "/safe/path"           # Works correctly (internal URL)
+#   redirect_to "http://evil.com", allow_other_host: true  # Works (explicitly allowed)
+#
+# Applications that want to allow these redirects can set the config to `:log` (previous default)
+# to only log warnings, or `:notify` to send ActiveSupport notifications for monitoring.
+#
+#++
+# Rails.configuration.action_controller.action_on_open_redirect = :raise
+###
 # Use a Ruby parser to track dependencies between Action View templates
 #++
 # Rails.configuration.action_view.render_tracker = :ruby


### PR DESCRIPTION
### Motivation / Background

Instead of only allowing to raise.

This is to aid large codebases to find all places that currently do open
redirects but are not called with `allow_other_host: true`.

`raise_on_open_redirects` is marked as deprecated and if set to true
will set `action_on_open_redirect` to `:raise`


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
