### PR TITLE
Add #assert_events_reported test helper

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `assert_events_reported` test helper for `ActiveSupport::EventReporter`.
+
+    This new assertion allows testing multiple events in a single block, regardless of order:
+
+    ```ruby
+    assert_events_reported([
+      { name: "user.created", payload: { id: 123 } },
+      { name: "email.sent", payload: { to: "user@example.com" } }
+    ]) do
+      create_user_and_send_welcome_email
+    end
+    ```
+
+    *George Ma*
+
 *   Add `ActiveSupport::TimeZone#standard_name` method.
 
     ``` ruby


### PR DESCRIPTION
Add #assert_events_reported test helper

The addition of a `#assert_events_reported` helper which was developed with the Rails principles

  -  Optimizes for developer happiness - order doesn't matter, just presence
  - [ErrorReporter's `capture_error_reports`](https://edgeapi.rubyonrails.org/classes/ActiveSupport/Testing/ErrorReporterAssertions.html#method-i-capture_error_reports) similarity - focuses on "did these events get reported?"

You can imagine a stream of logs

```
"checkout.start"
"event-x"
"event-y"
"event-z"
"checkout.end"
```

we can either develop the `assert_events_reported` helper to be
1. Very strict in order (checkout.start must come first, then event-x, event-y, etc)
- but this would make it so if a test _only_ cared about `event-x` and `event-z` for example, you would still have to include the other three events in your `assert_events_reported` block
2. Flexible but strict order (events just have to be ordered in the same way they're sent)
- This would allow for `event-x` and `event-z` to be `assert_events_reported` asserted as long as they're passed into the assertion in the right order

```ruby
        assert_events_reported([
          {
            event: "event-x",
          },
          {
            event: "event-y",
          },
        ])
```

3. No ordering (just a count for whether the provided events occur in the block provided)
I went with this option as it was the most developer friendly and matches the [ErrorReporter](https://edgeapi.rubyonrails.org/classes/ActiveSupport/Testing/ErrorReporterAssertions.html#method-i-capture_error_reports)'s flexibility
