### PR TITLE
RateLimiting: raise `ActionController::TooManyRequests` error

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Raise `ActionController::TooManyRequests` error from `ActionController::RateLimiting`
+
+    Requests that exceed the rate limit raise an `ActionController::TooManyRequests` error.
+    By default, Action Dispatch rescues the error and responds with a `429 Too Many Requests` status.
+
+    *Sean Doyle*
+
 *   Add .md/.markdown as Markdown extensions and add a default `markdown:` renderer:
 
     ```ruby

--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -103,4 +103,9 @@ module ActionController
       super(message)
     end
   end
+
+  # Raised when a Rate Limit is exceeded by too many requests within a period of
+  # time.
+  class TooManyRequests < ActionControllerError
+  end
 end

--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -22,8 +22,9 @@ module ActionController # :nodoc:
       # share rate limits across multiple controllers, you can provide your own scope,
       # by passing value in the `scope:` parameter.
       #
-      # Requests that exceed the rate limit are refused with a `429 Too Many Requests`
-      # response. You can specialize this by passing a callable in the `with:`
+      # Requests that exceed the rate limit will raise an `ActionController::TooManyRequests`
+      # error. By default, Action Dispatch will rescue from the error and refuse the request
+      # with a `429 Too Many Requests` response. You can specialize this by passing a callable in the `with:`
       # parameter. It's evaluated within the context of the controller processing the
       # request.
       #
@@ -57,7 +58,7 @@ module ActionController # :nodoc:
       #       rate_limit to: 3, within: 2.seconds, name: "short-term"
       #       rate_limit to: 10, within: 5.minutes, name: "long-term"
       #     end
-      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { head :too_many_requests }, store: cache_store, name: nil, scope: nil, **options)
+      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { raise TooManyRequests }, store: cache_store, name: nil, scope: nil, **options)
         before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store, name: name, scope: scope || controller_path) }, **options
       end
     end

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -23,6 +23,7 @@ module ActionDispatch
       "ActionDispatch::Http::Parameters::ParseError"       => :bad_request,
       "ActionController::BadRequest"                       => :bad_request,
       "ActionController::ParameterMissing"                 => :bad_request,
+      "ActionController::TooManyRequests"                  => :too_many_requests,
       "Rack::QueryParser::ParameterTypeError"              => :bad_request,
       "Rack::QueryParser::InvalidParameterError"           => :bad_request
     )

--- a/actionpack/test/controller/api/rate_limiting_test.rb
+++ b/actionpack/test/controller/api/rate_limiting_test.rb
@@ -23,8 +23,9 @@ class ApiRateLimitingTest < ActionController::TestCase
     get :limited_to_two
     assert_response :ok
 
-    get :limited_to_two
-    assert_response :too_many_requests
+    assert_raises ActionController::TooManyRequests do
+      get :limited_to_two
+    end
   end
 
   test "limit resets after time" do

--- a/actionpack/test/controller/rate_limiting_test.rb
+++ b/actionpack/test/controller/rate_limiting_test.rb
@@ -66,8 +66,9 @@ class RateLimitingTest < ActionController::TestCase
     get :limited
     assert_response :ok
 
-    get :limited
-    assert_response :too_many_requests
+    assert_raises ActionController::TooManyRequests do
+      get :limited
+    end
   end
 
   test "notification on limit action" do
@@ -80,25 +81,27 @@ class RateLimitingTest < ActionController::TestCase
         within: 2.seconds,
         name: nil,
         by: request.remote_ip) do
-      get :limited
+      assert_raises ActionController::TooManyRequests do
+        get :limited
+      end
     end
   end
 
   test "multiple rate limits" do
+    freeze_time
     get :limited
     get :limited
     assert_response :ok
 
-    travel_to 3.seconds.from_now do
-      get :limited
-      get :limited
-      assert_response :ok
-    end
+    travel 3.seconds
+    get :limited
+    get :limited
+    assert_response :ok
 
-    travel_to 3.seconds.from_now do
+    travel 3.seconds
+    get :limited
+    assert_raises ActionController::TooManyRequests do
       get :limited
-      get :limited
-      assert_response :too_many_requests
     end
   end
 
@@ -140,13 +143,15 @@ class RateLimitingTest < ActionController::TestCase
 
     @controller = RateLimitedSharedTwoController.new
 
-    get :limited_shared_two
-    assert_response :too_many_requests
+    assert_raises ActionController::TooManyRequests do
+      get :limited_shared_two
+    end
 
     @controller = RateLimitedSharedOneController.new
 
-    get :limited_shared_one
-    assert_response :too_many_requests
+    assert_raises ActionController::TooManyRequests do
+      get :limited_shared_one
+    end
   ensure
     RateLimitedBaseController.cache_store.clear
   end
@@ -166,8 +171,9 @@ class RateLimitingTest < ActionController::TestCase
 
     @controller = RateLimitedSharedThreeController.new
 
-    get :limited_shared_three
-    assert_response :too_many_requests
+    assert_raises ActionController::TooManyRequests do
+      get :limited_shared_three
+    end
   ensure
     RateLimitedSharedController.cache_store.clear
   end


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, the default behavior for exceeding a rate limit involved responding with a status of [429 Too many requests][]. The only indication that a rate limit was exceeded was the `429` code.

### Detail

This commit changes the default behavior from a `head :too_many_requests` call to instead raise a new `ActionController::TooManyRequests` error. This change adheres more closely to precedent established by other status codes like `ActionController::BadRequest` to a `:bad_request` (`400 Bad Request`) status, or `ActiveRecord::RecordNotFound` to a `:not_found` (`404 Not Found`) status.

Application-side controllers can be configured to `rescue_from` that exception, or they can rely on a new
`ActionController::TooManyRequests`-to-`429 Too many requests` status mapping entry in the `ActionDispatch/Middleware/ExceptionWrapper` error-to-status mapping.

[429 Too many requests]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429

### Additional information

**This PR was extracted from https://github.com/rails/rails/pull/53146, which was approved**.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
