### PR TITLE
Rate Limiting: Add context to request and response

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Access rate limiting context from `ActionDispatch::Request` and `ActionDispatch::Response`
+
+    Add `ActionDispatch::Request#rate_limit` and `ActionDispatch::Response#retry_after`.
+
+    *Sean Doyle*
+
 *   Define `ActionController::Parameters#deconstruct_keys` to support pattern matching
 
     ```ruby

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -498,6 +498,16 @@ module ActionDispatch
       controller_instance.commit_csrf_token(self) if controller_instance.respond_to?(:commit_csrf_token)
     end
 
+    # Write the ActionController::RateLimit values collected during the request
+    def rate_limit=(value)
+      set_header "action_controller.rate_limit", value
+    end
+
+    # Read the ActionController::RateLimit values collected during the request
+    def rate_limit
+      get_header "action_controller.rate_limit"
+    end
+
     private
       def check_method(name)
         if name

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -396,6 +396,30 @@ module ActionDispatch # :nodoc:
       end
     end
 
+    # Write a Time to the Retry-After HTTP header.
+    #
+    # Expects a value formatted according to RFC 2616 or a non-negative
+    # integer indicating the seconds to delay after the response is received.
+    #
+    #     response.retry_after = 5.minutes.from_now.httpdate
+    #     response.retry_after = 300
+    #
+    # Date, Time, DateTime, and ActiveSupport::TimeWithZone instances will be
+    # coerced to a formatted string.
+    #
+    #     response.retry_after = 5.minutes.from_now
+    def retry_after=(value)
+      value = value.httpdate if value.respond_to?(:httpdate)
+      value = value.to_i unless value.is_a?(String)
+
+      set_header "Retry-After", value
+    end
+
+    # Read from the Retry-After HTTP header.
+    def retry_after
+      get_header "Retry-After"
+    end
+
     # Avoid having to pass an open file handle as the response body. Rack::Sendfile
     # will usually intercept the response and uses the path directly, so there is no
     # reason to open the file.


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, the default behavior for exceeding a rate limit involved responding with a status of [429 Too many requests][]. The only indication that a rate limit was exceeded was the `429` code. Custom controller code that responds to rate limited requests does not have access to rate limit contextual information.

### Detail

Add readers and writers for `ActionDispatch::Request#rate_limit` and This commit introduces the `ActionController::RateLimiting::RateLimit` class to access contextual information that pertains to the rate limited request, including:

* `limit`
* `count`
* `within`
* `by`
* `name`
* `scope`
* `cache_key`

Similarly, add readers and writers for
`ActionDispatch::Response#retry_after` to write the RFC 2616-formatted `within` value to the response's [Retry-After][] header.

[429 Too many requests]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429
[Retry-After]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
