### PR TITLE
Fix incorrect cache store comment in production.rb template [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -62,7 +62,7 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
+  # Replace the default file cache store with a durable alternative.
   # config.cache_store = :mem_cache_store
 
   <%- unless options[:skip_active_job] -%>


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the comment in the production.rb template incorrectly describes
the default cache store. The comment states the default is "in-process memory cache store" when it's
actually "file cache store" (as defined in [railties/lib/rails/application/configuration.rb](https://github.com/gongo/rails/blob/092c3e92efa8e762e3d2e32506ef894702f0702d/railties/lib/rails/application/configuration.rb#L58)).

### Detail

This Pull Request changes the comment.

### Additional information

> #### `config.cache_store`
> Configures which cache store to use for Rails caching. (snip). Defaults to `:file_store`.
>
> [guides/source/configuring.md](https://github.com/gongo/rails/blob/092c3e92efa8e762e3d2e32506ef894702f0702d/guides/source/configuring.md#configcache_store)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
