### PR TITLE
[Docs] Fix some of the API docs for the Event Reporter.

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -98,19 +98,19 @@ module ActiveSupport
   # If an event object is passed to the +notify+ API, it will be passed through to subscribers as-is, and the name of the
   # object's class will be used as the event name.
   #
-  # class UserCreatedEvent
-  #   def initialize(id:, name:)
-  #     @id = id
-  #     @name = name
-  #   end
+  #   class UserCreatedEvent
+  #     def initialize(id:, name:)
+  #       @id = id
+  #       @name = name
+  #     end
   #
-  #   def to_h
-  #     {
-  #       id: @id,
-  #       name: @name
-  #     }
+  #     def to_h
+  #       {
+  #         id: @id,
+  #         name: @name
+  #       }
+  #     end
   #   end
-  # end
   #
   #   Rails.event.notify(UserCreatedEvent.new(id: 123, name: "John Doe"))
   #   # Emits event:
@@ -172,6 +172,7 @@ module ActiveSupport
   #   #    name: "user_created",
   #   #    payload: { id: 123 },
   #   #    tags: { graphql: true },
+  #   #    context: {},
   #   #    timestamp: 1738964843208679035,
   #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
   #   #  }
@@ -190,6 +191,7 @@ module ActiveSupport
   #   #  {
   #   #    name: "user_created",
   #   #    payload: { id: 123 },
+  #   #    tags: {},
   #   #    context: { request_id: "abcd123", user_agent: TestAgent" },
   #   #    timestamp: 1738964843208679035,
   #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
@@ -257,6 +259,7 @@ module ActiveSupport
     #   name: String (The name of the event)
     #   payload: Hash, Object (The payload of the event, or the event object itself)
     #   tags: Hash (The tags of the event)
+    #   context: Hash (The context of the event)
     #   timestamp: Float (The timestamp of the event, in nanoseconds)
     #   source_location: Hash (The source location of the event, containing the filepath, lineno, and label)
     #
@@ -281,6 +284,7 @@ module ActiveSupport
     #     #    name: "user.created",
     #     #    payload: { id: 123 },
     #     #    tags: {},
+    #     #    context: {},
     #     #    timestamp: 1738964843208679035,
     #     #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
     #     #  }
@@ -293,6 +297,7 @@ module ActiveSupport
     #   #    name: "UserCreatedEvent",
     #   #    payload: #<UserCreatedEvent:0x111>,
     #   #    tags: {},
+    #   #    context: {},
     #   #    timestamp: 1738964843208679035,
     #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
     #   #  }
@@ -395,6 +400,7 @@ module ActiveSupport
     #   #    name: "user.created",
     #   #    payload: { id: 123 },
     #   #    tags: { graphql: true },
+    #   #    context: {},
     #   #    timestamp: 1738964843208679035,
     #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
     #   #  }
@@ -413,6 +419,7 @@ module ActiveSupport
     #   #    name: "user.created",
     #   #    payload: { id: 123 },
     #   #    tags: { section: "admin", graphql: true },
+    #   #    context: {},
     #   #    timestamp: 1738964843208679035,
     #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
     #   #  }
@@ -429,6 +436,7 @@ module ActiveSupport
     #   #    name: "user.created",
     #   #    payload: { id: 123 },
     #   #    tags: { "GraphqlTag": #<GraphqlTag:0x111> },
+    #   #    context: {},
     #   #    timestamp: 1738964843208679035,
     #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
     #   #  }
@@ -453,6 +461,7 @@ module ActiveSupport
     #   #    tags: { graphql: true },
     #   #    context: { user_agent: "TestAgent", job_id: "abc123" },
     #   #    timestamp: 1738964843208679035
+    #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
     #   #  }
     def set_context(context)
       context_store.set_context(context)


### PR DESCRIPTION
### Detail

Indentation on one of the code examples was incorrect, and we forgot to add `context` to the expected fields in the `Event` hash.