### PR TITLE
Allow defining custom attributes on jobs

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -75,7 +75,7 @@ module ActiveJob
       end
     end
 
-    def deserialize_argument(argument)
+    def deserialize_argument(argument) # :nodoc:
       case argument
       when nil, true, false, String, Integer, Float
         argument

--- a/activejob/lib/active_job/attributes.rb
+++ b/activejob/lib/active_job/attributes.rb
@@ -47,7 +47,7 @@ module ActiveJob
           raise ArgumentError, "Attribute #{name} is already defined"
         end
 
-        attributes.add(name.to_s)
+        attributes.include?(name.to_s)
         attr_accessor name
       end
 

--- a/activejob/lib/active_job/attributes.rb
+++ b/activejob/lib/active_job/attributes.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  # = Active Job \Attributes
+  #
+  # Allows defining custom job attributes that will be serialized and deserialized along with
+  # the job arguments. Useful for cross-cutting concerns.
+  #
+  #   module ShardedJob
+  #     extend ActiveSupport::Concern
+  #
+  #     included do
+  #       attribute :shard
+  #       attribute :class_name
+  #
+  #       around_perform do |job, block|
+  #         klass = job.class_name&.constantize || ActiveRecord::Base
+  #         klass.connected_to(shard: job.shard.to_sym, &block)
+  #       end
+  #     end
+  #   end
+  #
+  #   class UserDeletionJob < ActiveJob::Base
+  #     include ShardedJob
+  #
+  #     # ...
+  #   end
+  #
+  # Once an attribute has been configured, it can be set on job instances with normal assignment
+  # _or_ it can be set via the +set+ method:
+  #
+  #   job = UserDeletionJob.new(user_id)
+  #   job.set(shard: shard_id)
+  #   job.enqueue
+  #
+  # This includes the various ways that +set+ can be called, e.g.
+  #
+  #   UserDeletionJob.set(shard: shard_id).new(user_id).enqueue
+  #   UserDeletionJob.new(user_id).enqueue(shard: shard_id)
+  #
+  module Attributes
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def attribute(name)
+        if respond_to?(name)
+          raise ArgumentError, "Attribute #{name} is already defined"
+        end
+
+        attributes.add(name.to_s)
+        attr_accessor name
+      end
+
+      # The attributes defined on the class, as well as their options.
+      #
+      # Will be inherited to subclasses.
+      def attributes
+        @attributes ||=
+          if superclass.respond_to?(:attributes)
+            superclass.attributes.dup
+          else
+            Set.new
+          end
+      end
+    end
+
+    def set(options = {})
+      options.each_key do |name|
+        if self.class.attributes.include?(name.to_s)
+          send("#{name}=", options.delete(name))
+        end
+      end
+
+      super
+    end
+
+    def serialize
+      data = super
+
+      self.class.attributes.each do |name|
+        data[name] = Arguments.serialize_argument(send(name))
+      end
+
+      data
+    end
+
+    def deserialize(job_data)
+      self.class.attributes.each do |attr|
+        send("#{attr}=", Arguments.deserialize_argument(job_data[attr]))
+      end
+
+      super
+    end
+  end
+end

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_job/core"
+require "active_job/attributes"
 require "active_job/queue_adapter"
 require "active_job/queue_name"
 require "active_job/queue_priority"
@@ -62,6 +63,7 @@ module ActiveJob # :nodoc:
   # * SerializationError - Error class for serialization errors.
   class Base
     include Core
+    include Attributes
     include QueueAdapter
     include QueueName
     include QueuePriority

--- a/activejob/test/cases/attributes_test.rb
+++ b/activejob/test/cases/attributes_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class AccountScopedJob < ActiveJob::Base
+  attribute :account_id
+  attribute :metadata
+
+  def perform
+    JobBuffer.add({ account_id:, metadata: })
+  end
+end
+
+class SubClassedJob < AccountScopedJob
+end
+
+class AttributesTest < ActiveSupport::TestCase
+  setup do
+    JobBuffer.clear
+  end
+
+  test "serializes and deserializes the defined attributes" do
+    job_data = AccountScopedJob.new.set(account_id: 42, metadata: { user_ids: [1, 2] }).serialize
+    job = AccountScopedJob.new
+    job.deserialize(job_data)
+
+    assert_equal 42, job.account_id
+    assert_equal({ user_ids: [1, 2] }, job.metadata)
+  end
+
+  test "integrates with #set" do
+    job = AccountScopedJob.new.set(account_id: 42)
+    assert_equal 42, job.account_id
+  end
+
+  test "defines attribute accessors" do
+    job = AccountScopedJob.new
+    job.account_id = 42
+    assert_equal 42, job.account_id
+  end
+
+  test "passes attributes to the job execution" do
+    AccountScopedJob.set(account_id: 42, metadata: { user_ids: [1, 2] }).perform_now
+    assert_equal({ account_id: 42, metadata: { user_ids: [1, 2] } }, JobBuffer.last_value)
+  end
+
+  test "defaults attributes to nil" do
+    AccountScopedJob.perform_now
+    assert_nil JobBuffer.last_value[:account_id]
+    assert_nil JobBuffer.last_value[:metadata]
+  end
+
+  test "raises when defining an existing attribute" do
+    assert_raises(ArgumentError) do
+      Class.new(ActiveJob::Base) do
+        attribute :queue_name
+      end
+    end
+  end
+
+  test "subclasses inherit the parent class attributes" do
+    job = SubClassedJob.new.set(account_id: 42)
+    assert_equal 42, job.account_id
+  end
+end


### PR DESCRIPTION
This allows attaching arbitrary attributes to jobs, including from included modules.


### Motivation / Background

The target use cases would be orthogonal to the specific jobs, e.g. consistent auditing metadata. My concrete use case is the ability to attach OTel [Span Links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) to the traces for job execution, linking back to the site where the job was enqueued. This allows going back and forth between traces in order to debug e.g. why specific arguments were set on a job. I'm using Datadog for this, but it's an OTel concept.

### Detail

This Pull Request changes Active Job and adds support for setting _attributes_.

For example:

```ruby
class ApplicationJob < ActiveJob::Base
  # Simplified example of adding tracing metadata
  attribute :trace_id
  around_perform { |job, block| Tracer.trace(parent_trace_id: job.trace_id, &block) }
end

# Subclasses of ShardedJob will be executed against a specific shard
class ShardedJob < ApplicationJob
  # This would also be useful for other domain-orthogonal concerns, e.g. sharding
  attribute :shard

  before_enqueue { |job| raise "you must set `shard`!" if job.shard.nil? }

  around_perform do |job, block|
    ActiveRecord::Base.connected_to(shard: job.shard.to_sym, &block)
  end
end
```

The attributes are made available as normal accessors, but are also integrated with `ActiveJob::Base#set`:

```ruby
UserDeletionJob.new(user_id).set(shard: account.shard).enqueue
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
