### PR TITLE
Fix stale state for polymorphic relationship

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -162,9 +162,15 @@ module ActiveRecord
         end
 
         def stale_state
-          Array(reflection.foreign_key).filter_map do |fk|
-            owner._read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
-          end.presence
+          foreign_key = reflection.foreign_key
+          if foreign_key.is_a?(Array)
+            attributes = foreign_key.map do |fk|
+              owner._read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
+            end
+            attributes if attributes.any?
+          else
+            owner._read_attribute(foreign_key) { |n| owner.send(:missing_attribute, n, caller) }
+          end
         end
     end
   end

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -162,9 +162,9 @@ module ActiveRecord
         end
 
         def stale_state
-          Array(reflection.foreign_key).map do |fk|
+          Array(reflection.foreign_key).filter_map do |fk|
             owner._read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
-          end
+          end.presence
         end
     end
   end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "support/deprecated_associations_test_helpers"
+require "models/attachment"
 require "models/developer"
 require "models/project"
 require "models/company"
@@ -1451,6 +1452,20 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal touch_time, car.reload.wheels_owned_at
+  end
+
+  def test_polymorphic_stale_state_handles_nil_foreign_keys_correctly
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "records"
+
+      has_one :attachment, as: :record
+
+      def self.polymorphic_name
+        "Blob"
+      end
+    end
+
+    assert_nothing_raised { Attachment.create!(record: klass.build, record_type: "Document") }
   end
 
   def test_build_with_conditions


### PR DESCRIPTION
### Motivation / Background

While working on updating to the latest version of rails `8-0-stable` we had some tests failing. After investigation we managed to track down the culprit to this [PR](https://github.com/rails/rails/pull/50297).

In some cases
https://github.com/rails/rails/blob/41f4e981ded1c0d8c2b3bc5bff5fb2af38da04ed/activerecord/lib/active_record/associations/belongs_to_association.rb#L164 
is now returning `[nil]`. 

Making this condition https://github.com/rails/rails/blob/41f4e981ded1c0d8c2b3bc5bff5fb2af38da04ed/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb#L44
being always truthy.

### Detail

Aligning the code with this one https://github.com/rails/rails/blob/41f4e981ded1c0d8c2b3bc5bff5fb2af38da04ed/activerecord/lib/active_record/associations/through_association.rb#L84

### Additional information

Unfortunately, we weren't able to come up with a minimalist reproductible case. It only happens on very specific cases on our side. Therefore we also had an hard time coming up with a good test to add.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
