### PR TITLE
[Docs] Improve `ActiveSupport::EventReporter` documentation on `Subscribers`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -50,7 +50,19 @@
     ```
 
     Events are emitted to subscribers. Applications register subscribers to
-    control how events are serialized and emitted.
+    control how events are serialized and emitted. Subscribers must implement
+    an `#emit` method, which receives the event hash:
+
+    ```ruby
+    class LogSubscriber
+      def emit(event)
+        payload = event[:payload].map { |key, value| "#{key}=#{value}" }.join(" ")
+        source_location = event[:source_location]
+        log = "[#{event[:name]}] #{payload} at #{source_location[:filepath]}:#{source_location[:lineno]}"
+        Rails.logger.info(log)
+      end
+    end
+    ```
 
     *Adrianna Chang*
 


### PR DESCRIPTION
### Motivation / Background

Ref: https://github.com/rails/rails/pull/55515/files#r2286958305

We removed the default encoders from the Event Reporter, but with it lost any documented examples of how to write a subscriber. This PR makes the interface requirements (`#emit)` for subscribers more apparent, and provides some examples.

cc @zzak
