### PR TITLE
Remove references to jsons `quirks_mode`

### DIFF
--- a/activesupport/test/core_ext/object/json_gem_encoding_test.rb
+++ b/activesupport/test/core_ext/object/json_gem_encoding_test.rb
@@ -45,7 +45,7 @@ class JsonGemEncodingTest < ActiveSupport::TestCase
 
     def assert_same_with_or_without_active_support(subject)
       begin
-        expected = JSON.generate(subject, quirks_mode: true)
+        expected = JSON.generate(subject)
       rescue JSON::GeneratorError => e
         exception = e
       end
@@ -54,10 +54,10 @@ class JsonGemEncodingTest < ActiveSupport::TestCase
 
       if exception
         assert_raises JSON::GeneratorError, match: e.message do
-          JSON.generate(subject, quirks_mode: true)
+          JSON.generate(subject)
         end
       else
-        assert_equal expected, JSON.generate(subject, quirks_mode: true)
+        assert_equal expected, JSON.generate(subject)
       end
     end
 end


### PR DESCRIPTION
It was removed in https://github.com/ruby/json/commit/7d2ad6d6556da03300a5aeadeeacaec563435773 and does nothing now
