### PR TITLE
Allow a CSRF strategy to handle a cross origin request:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Rails now call `handle_cross_origin_request` when a cross origin request is detected.
+
+    Previously, when a cross origin request was detected, Rails would log an error and
+    raise a `ActionController::InvalidCrossOriginRequest` (which would get turned
+    into a 422 response).
+    Now, a custom strategy can implement the `handle_cross_origin_request` method to perform
+    the logic they want, similar to the existent `handle_unverified_request`.
+
+    Applications using Rails built-in strategies such as `:exception`, `:null_session` or
+    `:reset_sesssion` will get the same behaviour as before.
+
+    Applications using a custom strategy will get the same behaviour as before but
+    a deprecation warning in the event where they haven't implemented `handle_cross_origin_request`.
+
+    *Edouard Chin*
+
 *   URL helpers for engines mounted at the application root handle `SCRIPT_NAME` correctly.
 
     Fixed an issue where `SCRIPT_NAME` is not applied to paths generated for routes in an engine


### PR DESCRIPTION
### Motivation / Background

We are trying to flip the switch and enable all controllers to be CSRF protected by default (this is the default since ec4a836919c021c0a5cf9ebeebb4db5e02104a55).

Before we can do this in a safe way, we have a custom CSRF strategy that only logs when a CSRF violation is triggered. This strategy is only called when a bad/no CSRF token is sent, but it doesn't account for when a Cross-Origin request happens, and Rails will raise an error, which we don't want yet.

### Detail

One of our controller didn't emit any log WRT to CSRF violation, so we flipped the "raise" switch for that controller, but ultimately realized it was used for serving javascript assets.

E.g. some html files we don't control were calling this endpoint `<script src="/our-controller"></script>`

This ended up creating an incident on our end.

#### Solution

I'd like to be able to implement the `handle_cross_origin_request` method in our strategy which will get called whenever a cross origin request happens (similar to when a bad CSRF token is sent).

This change is backward compatible, application using the Rails builtin strategies (null_session, exception, reset_session) will continue to emit a log and return a 422 when a Cross Origin is detected.

Custom strategies that don't implement `handle_cross_origin_request` will also continue behaving the same way but will get a deprecation warning.

cc/ @that-jill

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
