### PR TITLE
Report json parse errors during json deserialization

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/json_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/json_test.rb
@@ -27,6 +27,20 @@ class SQLite3JSONTest < ActiveRecord::SQLite3TestCase
     assert_equal '{"list":[]}', klass.new.with_defaults_before_type_cast
   end
 
+  def test_invalid_json_can_be_updated
+    model = klass.create!
+    @connection.execute("UPDATE #{klass.table_name} SET payload = '---'")
+
+    model.reload
+    assert_equal "---", model.payload_before_type_cast
+    assert_error_reported(JSON::ParserError) do
+      assert_nil model.payload
+    end
+
+    model.update(payload: "no longer invalid")
+    assert_equal("no longer invalid", model.payload)
+  end
+
   private
     def column_type
       :json

--- a/activerecord/test/cases/json_attribute_test.rb
+++ b/activerecord/test/cases/json_attribute_test.rb
@@ -25,6 +25,20 @@ class JsonAttributeTest < ActiveRecord::TestCase
     end
   end
 
+  def test_invalid_json_can_be_updated
+    model = klass.create!
+    @connection.execute("UPDATE #{klass.table_name} SET payload = '---'")
+
+    model.reload
+    assert_equal "---", model.payload_before_type_cast
+    assert_error_reported(JSON::ParserError) do
+      assert_nil model.payload
+    end
+
+    model.update(payload: "no longer invalid")
+    assert_equal("no longer invalid", model.payload)
+  end
+
   private
     def column_type
       :string


### PR DESCRIPTION
Since `json` [v2.13.0](https://github.com/ruby/json/releases/tag/v2.13.0), duplicate keys are warned during parsing with the goal of raising in 3.0.0

For rails, I encountered this with json column types that merge into themselves. On rails below 8.1, this shows the warning message from the json gem. On main however, the output is silent since https://github.com/rails/rails/pull/54748

```rb
require "bundler/inline"
gemfile(true) do
  source "https://rubygems.org"
  gem "rails", "~> 8.0.0"
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.json :payload
  end
end

class Post < ActiveRecord::Base
end

class BugTest < ActiveSupport::TestCase
  def test_association_stuff
    post = Post.create!(payload: { foo: "bar" })
    [1, 2].each do |i|
      assert_silent do
        post.update(payload: post.payload.merge(state: i))
      end
    end

    assert_equal({ "foo" => "bar", "state" => 2 }, post.payload)
  end
end
```

If rails switches back to its behaviour on 8.0 with json 3.0, then for duplicate keys `nil` will be returned and no error from the json gem will be shown. I looked at the history on why it rescues and found this:
* https://github.com/rails/rails/commit/e8460f8bbe73537897f2162d1cccda943d8c0f4a added the rescue so that assigning a string to a json column does not leave the object in a broken state
* https://github.com/rails/rails/commit/efaa6e4f79d457c2cdd08cbc56d63bc972a6993c allowed json primitive types, removing the test from the previous commit

So perhaps the rescue can simply be removed.

As for writing a test, I have no idea how. This seems like it should work:

```rb
  def test_json_allow_duplicate_key_false_doesnt_raise_for_symbol_string_keys
    Topic.serialize :content, coder: ActiveRecord::Coders::JSON.new(allow_duplicate_key: false)

    t = Topic.create!(content: { foo: "bar" })
    [1, 2].each do |i|
      t.update(content: t.content.merge(state: i))
    end

    assert_equal({ "foo" => "bar", "state" => 2 }, t.content)
  end
```

But the warning goes away when options are specified: https://github.com/rails/rails/blob/1f9ca6c901bb5fc9b80857808dc1c52f1c5bf0bc/activesupport/lib/active_support/json/encoding.rb#L80-L82

That's also why the PR I mentioned above changed behaviour, `escape` is also an option so that codepath is now taken.
