### PR TITLE
Dark mode support in the Welcome page

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -35,6 +35,14 @@
       text-align: center;
     }
 
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #1a1a1a;
+        background-image: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEwMjQiIHZpZXdCb3g9IjAgMCAxNDQwIDEwMjQiIHdpZHRoPSIxNDQwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Im0xNDQwIDUxMC4wMDA2NDh2LTUxMC4wMDA2NDhoLTE0NDB2Mzg0LjAwMDY0OGM0MTcuMzExOTM5IDEzMS4xNDIxNzkgODkxIDE3MS41MTMgMTQ0MCAxMjZ6IiBmaWxsPSIjMzMzIi8+PC9zdmc+);
+        color: #e0e0e0;
+      }
+    }
+
     nav {
       font-size: 0;
       height: 20vw;
@@ -56,6 +64,13 @@
 
     nav a:hover {
       background: #261B23;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      nav a {
+        background: #D30001;
+        filter: drop-shadow(0 20px 13px rgb(255 255 255 / 0.03)) drop-shadow(0 8px 5px rgb(255 255 255 / 0.08));
+      }
     }
 
     nav a img {


### PR DESCRIPTION
Hi 🙋‍♂️ First time committer :)

I recently went over to the dark side, and noticed the Welcome page didn't have dark mode styling :)

My apps are usually api-only, and my startup script always opens localhost:3000 in a browser tab, so I see the screen a lot :)

### Detail

- Adding dark-mode css rules for the Welcome screen

### Additional information

I looked at previously opened PRs for this file, and in general they were merged for cosmetic changes, like fixing the drop shadow in Safari, or improving the responsiveness.

### Result

<img width="1912" height="926" alt="SCR-20250823-upeg" src="https://github.com/user-attachments/assets/c8727458-5276-4cdd-bc75-7624964354ce" />

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
