### PR TITLE
Correct irb inspection class [ci skip]

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -287,7 +287,7 @@ $ bin/rails console
 
 ```irb
 irb> 10.requests_per_hour
-=> #<struct ApiBoost::RateLimit requests=10, per=:hour>
+=> #<data ApiBoost::RateLimit requests=10, per=:hour>
 ```
 
 The dummy application automatically loads your plugin, so any extensions you add


### PR DESCRIPTION
Just a quick fix in the irb output example. The example uses `Data.define`, but the irb output used a `Struct`. Verified the correction in my own irb:

```rb
irb(main):015> 10.requests_per_hour
=> #<data ApiBoost::RateLimit requests=10, per=:hour>
```
