### PR TITLE
 Skip calling PG::Connection#cancel when using libpq >= 18 with pg < 1.6.0

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Skip calling `PG::Connection#cancel` in `cancel_any_running_query`
+    when using libpq >= 18 with pg < 1.6.0, due to incompatibility.
+    Rollback still runs, but may take longer.
+
+    *Yasuo Honda*, *Lars Kanis*
+
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Remove deprecated `:unsigned_float` and `:unsigned_decimal` column methods for MySQL.
@@ -70,10 +76,6 @@
     ```
 
     *Kir Shatrov*
-
-*   Emit a warning for pg gem < 1.6.0 when using PostgreSQL 18+
-
-    *Yasuo Honda*
 
 *   Fix `#merge` with `#or` or `#and` and a mixture of attributes and SQL strings resulting in an incorrect query.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -666,9 +666,6 @@ module ActiveRecord
         if database_version < 9_03_00 # < 9.3
           raise "Your version of PostgreSQL (#{database_version}) is too old. Active Record supports PostgreSQL >= 9.3."
         end
-        if database_version >= 18_00_00 && Gem::Version.new(PG::VERSION) < Gem::Version.new("1.6.0")
-          warn "pg gem version #{PG::VERSION} is known to be incompatible with PostgreSQL 18+. Please upgrade to pg 1.6.0 or later."
-        end
       end
 
       class << self

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -181,8 +181,8 @@ module ActiveRecord
     end
 
     test "raises Interrupt when canceling statement via interrupt" do
-      if ActiveRecord::Base.lease_connection.database_version >= 18_00_00 && Gem::Version.new(PG::VERSION) < Gem::Version.new("1.6.0")
-        skip "pg gem version #{PG::VERSION} is known to be incompatible with PostgreSQL 18+. "
+      if PG.library_version >= 18_00_00 && Gem::Version.new(PG::VERSION) < Gem::Version.new("1.6.0")
+        skip "PG::Connection#cancel should not run when libpq of PostgreSQL #{PG.library_version / 10000} with pg gem version #{PG::VERSION}"
       end
       start_time = Time.now
       thread = Thread.new do


### PR DESCRIPTION
### Motivation / Background

PostgreSQL 18 changes the length of the cancel request key. With libpq 18 or newer the call to PG::Connection#cancel fails when the pg gem is older than 1.6.0. Rails calls PG::Connection#cancel from cancel_any_running_query, so this mismatch leads to runtime errors.

### Detail
Before this change pull request #55368 checked the PostgreSQL server version inside check_version. That was not correct. The incompatibility is between the pg gem version and the client library version (libpq), as discussed in #55368.

### Additional information
Refer to:
https://github.com/ged/ruby-pg/pull/614
https://github.com/rails/rails/pull/55368
https://github.com/rails/rails/pull/55413

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
