### PR TITLE
Allow nested transaction with the same isolation level

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -354,7 +354,7 @@ module ActiveRecord
       #  :args: (requires_new: nil, isolation: nil, &block)
       def transaction(requires_new: nil, isolation: nil, joinable: true, &block)
         if !requires_new && current_transaction.joinable?
-          if isolation
+          if isolation && current_transaction.isolation != isolation
             raise ActiveRecord::TransactionIsolationError, "cannot set isolation when joining a transaction"
           end
           yield current_transaction.user_transaction

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -211,6 +211,18 @@ class TransactionIsolationTest < ActiveRecord::TestCase
       assert_begin_isolation_level_event(events, isolation: "REPEATABLE READ")
     end
 
+    test "specifying the same isolation level should not raise an error" do
+      assert_nothing_raised do
+        Tag.transaction(isolation: :read_committed) do
+          Tag.create!
+
+          Tag.transaction(isolation: :read_committed) do
+            Tag.create!
+          end
+        end
+      end
+    end
+
     # We are testing that a nonrepeatable read does not happen
     if ActiveRecord::Base.lease_connection.transaction_isolation_levels.include?(:repeatable_read)
       test "repeatable read" do


### PR DESCRIPTION
With `isolation` accessor I've added in https://github.com/rails/rails/pull/55407, we should allow code like this:

```ruby
def create_something
  # this method does not know if parent transaction exists and tries to starts its own read_committed tx:
  Tag.transaction(isolation: :read_committed) do
    Tag.create!
  end
end

Tag.transaction(isolation: :read_committed) do
  # some DB operations
  create_something
end
```

Without this patch, we have to make `create_something` check for parent transaction each time:

```ruby
def create_something
  transaction = Tag.lease_connection.transaction
  isolation = if transaction.open? && transaction.isolation == :read_committed
    nil
  else
    :read_committed
  end
  Tag.transaction(isolation: isolation) do
    Tag.create!
  end
end
```

@byroot @matthewd @rafaelfranca 