### PR TITLE
Slightly speed up ActiveJob enqueueing with hashes/keyword arguments

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -64,7 +64,7 @@ module ActiveJob
         RUBY2_KEYWORDS_KEY, RUBY2_KEYWORDS_KEY.to_sym,
         OBJECT_SERIALIZER_KEY, OBJECT_SERIALIZER_KEY.to_sym,
         WITH_INDIFFERENT_ACCESS_KEY, WITH_INDIFFERENT_ACCESS_KEY.to_sym,
-      ]
+      ].to_set
       private_constant :RESERVED_KEYS, :GLOBALID_KEY,
         :SYMBOL_KEYS_KEY, :RUBY2_KEYWORDS_KEY, :WITH_INDIFFERENT_ACCESS_KEY
 
@@ -159,10 +159,12 @@ module ActiveJob
 
       def serialize_hash_key(key)
         case key
-        when *RESERVED_KEYS
+        when RESERVED_KEYS
           raise SerializationError.new("Can't serialize a Hash with reserved key #{key.inspect}")
-        when String, Symbol
-          key.to_s
+        when String
+          key
+        when Symbol
+          key.name
         else
           raise SerializationError.new("Only string and symbol hash keys may be serialized as job arguments, but #{key.inspect} is a #{key.class}")
         end

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -89,7 +89,10 @@ module ActiveJob
         when ActiveSupport::HashWithIndifferentAccess
           serialize_indifferent_hash(argument)
         when Hash
-          symbol_keys = argument.each_key.grep(Symbol).map!(&:to_s)
+          symbol_keys = argument.keys
+          symbol_keys.select! { |k| k.is_a?(Symbol) }
+          symbol_keys.map!(&:name)
+
           aj_hash_key = if Hash.ruby2_keywords_hash?(argument)
             RUBY2_KEYWORDS_KEY
           else

--- a/activejob/lib/active_job/serializers/symbol_serializer.rb
+++ b/activejob/lib/active_job/serializers/symbol_serializer.rb
@@ -4,7 +4,7 @@ module ActiveJob
   module Serializers
     class SymbolSerializer < ObjectSerializer # :nodoc:
       def serialize(argument)
-        super("value" => argument.to_s)
+        super("value" => argument.name)
       end
 
       def deserialize(argument)


### PR DESCRIPTION
### Motivation / Background

The splat in the case/when is not great since it allocates an array each time it is encountered.

This avoids the allocation, uses a set for the reserved keys, and avoids string allocations for symbol keys.

<details><summary>Benchmark</summary>
<p>

```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "../rails"
  gem "benchmark-ips"
end

require "active_job/railtie"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.secret_key_base = "secret_key_base"
  config.active_job.queue_adapter = :test

  config.logger = Logger.new(File::NULL)
end
Rails.application.initialize!

class MyJob < ActiveJob::Base
  def perform
    puts "performed"
  end
end

job_data = ("a".."z").to_h { [it, it] }
Benchmark.ips do |x|
  x.report("perform_later") do
    MyJob.perform_later(job_data)
  end
end
```

</p>
</details> 

Before:
```
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [x86_64-linux]
Warming up --------------------------------------
       perform_later     1.541k i/100ms
Calculating -------------------------------------
       perform_later     16.415k (±18.0%) i/s   (60.92 μs/i) -     78.591k in   5.031642s
```

After:
```
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [x86_64-linux]
Warming up --------------------------------------
       perform_later     1.834k i/100ms
Calculating -------------------------------------
       perform_later     19.456k (±20.3%) i/s   (51.40 μs/i) -     91.700k in   5.028421s
```

About 18% faster when the hash has many string keys. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
