### PR TITLE
Add ActiveRecord::ExclusionViolation error class for exclusion constraint violations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `ActiveRecord::ExclusionViolation` error class for exclusion constraint violations.
+
+    When an exclusion constraint is violated in PostgreSQL, the error will now be raised
+    as `ActiveRecord::ExclusionViolation` instead of the generic `ActiveRecord::StatementInvalid`,
+    making it easier to handle these specific constraint violations in application code.
+
+    This follows the same pattern as other constraint violation error classes like
+    `RecordNotUnique` for unique constraint violations and `InvalidForeignKey` for
+    foreign key constraint violations.
+
+    *Ryuta Kamizono*
+
 *   Attributes filtered by `filter_attributes` will now also be filtered by `filter_parameters`
     so sensitive information is not leaked.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -791,6 +791,7 @@ module ActiveRecord
         NOT_NULL_VIOLATION    = "23502"
         FOREIGN_KEY_VIOLATION = "23503"
         UNIQUE_VIOLATION      = "23505"
+        EXCLUSION_VIOLATION   = "23P01"
         SERIALIZATION_FAILURE = "40001"
         DEADLOCK_DETECTED     = "40P01"
         DUPLICATE_DATABASE    = "42P04"
@@ -822,6 +823,8 @@ module ActiveRecord
             RecordNotUnique.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when FOREIGN_KEY_VIOLATION
             InvalidForeignKey.new(message, sql: sql, binds: binds, connection_pool: @pool)
+          when EXCLUSION_VIOLATION
+            ExclusionViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when VALUE_LIMIT_VIOLATION
             ValueTooLong.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when NUMERIC_VALUE_OUT_OF_RANGE

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -292,6 +292,10 @@ module ActiveRecord
   class NotNullViolation < StatementInvalid
   end
 
+  # Raised when a record cannot be inserted or updated because it would violate an exclusion constraint.
+  class ExclusionViolation < StatementInvalid
+  end
+
   # Raised when a record cannot be inserted or updated because a value too long for a column type.
   class ValueTooLong < StatementInvalid
   end


### PR DESCRIPTION
When an exclusion constraint is violated in PostgreSQL, the error will now be raised as ActiveRecord::ExclusionViolation instead of the generic ActiveRecord::StatementInvalid, making it easier to handle these specific constraint violations in application code.

This follows the same pattern as other constraint violation error classes like RecordNotUnique for unique constraint violations and InvalidForeignKey for foreign key constraint violations.
