### PR TITLE
Allow `Called deprecated method `upload_stream` of Aws::S3::Object.` warning tentatively

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,16 +126,19 @@ GEM
     ast (2.4.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.1037.0)
-    aws-sdk-core (3.215.1)
+    aws-sdk-core (3.230.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
+      logger
     aws-sdk-kms (1.96.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.177.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-s3 (1.197.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sdk-sns (1.92.0)

--- a/tools/strict_warnings.rb
+++ b/tools/strict_warnings.rb
@@ -13,6 +13,7 @@ module RailsStrictWarnings # :nodoc:
     # Expected non-verbose warning emitted by Rails.
     /Ignoring .*\.yml because it has expired/,
     /Failed to validate the schema cache because/,
+    /Called deprecated method `upload_stream` of Aws::S3::Object. Use `Aws::S3::TransferManager#upload_stream` instead./,
   )
 
   SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
### Motivation / Background

This commit workarounds #55525 since it starts failing at CI against Ruby released versions like https://buildkite.com/rails/rails/builds/120993#0198db92-0c60-4fe1-b142-e72dc2e44b5c/1310-1373

Also it bumps the `aws-sdk-s3` gem version to reproduce this issue.

### Detail

- With this commit
```ruby
$ RAILS_STRICT_WARNINGS=1 bin/test test/service/s3_service_test.rb -n test_compose
... snip ...
Run options: -n test_compose --seed 23764

Called deprecated method `upload_stream` of Aws::S3::Object. Use `Aws::S3::TransferManager#upload_stream` instead.
Method `upload_stream` will be removed in next major version.
/home/yahonda/src/github.com/rails/rails/activestorage/lib/active_storage/service/s3_service.rb:103:in 'ActiveStorage::Service::S3Service#compose'
/home/yahonda/src/github.com/rails/rails/activestorage/test/service/shared_service_tests.rb:156:in 'block (2 levels) in <module:SharedServiceTests>'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest/test.rb:94:in 'block (2 levels) in Minitest::Test#run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest/test.rb:190:in 'Minitest::Test#capture_exceptions'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest/test.rb:89:in 'block in Minitest::Test#run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:368:in 'Minitest::Runnable#time_it'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest/test.rb:88:in 'Minitest::Test#run'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/executor/test_helper.rb:5:in 'block in ActiveSupport::Executor::TestHelper#run'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/execution_wrapper.rb:104:in 'ActiveSupport::ExecutionWrapper.perform'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/executor/test_helper.rb:5:in 'ActiveSupport::Executor::TestHelper#run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:1208:in 'Minitest.run_one_method'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:447:in 'Minitest::Runnable.run_one_method'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:434:in 'block (2 levels) in Minitest::Runnable.run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:430:in 'Array#each'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:430:in 'block in Minitest::Runnable.run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:472:in 'Minitest::Runnable.on_signal'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:459:in 'Minitest::Runnable.with_info_handler'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:429:in 'Minitest::Runnable.run'
/home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in 'Rails::LineFiltering#run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:332:in 'block in Minitest.__run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:332:in 'Array#map'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:332:in 'Minitest.__run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:288:in 'Minitest.run'
/home/yahonda/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/minitest-5.25.5/lib/minitest.rb:86:in 'block in Minitest.autorun'
.

Finished in 6.596386s, 0.1516 runs/s, 0.1516 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
$
```

### Additional information
It can be reverted once #55541 is merged.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
