### PR TITLE
Remove the ability to set email_address value via query parameters

### DIFF
--- a/railties/lib/rails/generators/erb/authentication/templates/app/views/passwords/new.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/app/views/passwords/new.html.erb
@@ -3,6 +3,6 @@
 <%%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
 
 <%%= form_with url: passwords_path do |form| %>
-  <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
+  <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address" %><br>
   <%%= form.submit "Email reset instructions" %>
 <%% end %>

--- a/railties/lib/rails/generators/erb/authentication/templates/app/views/sessions/new.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/app/views/sessions/new.html.erb
@@ -2,7 +2,7 @@
 <%%= tag.div(flash[:notice], style: "color:green") if flash[:notice] %>
 
 <%%= form_with url: session_path do |form| %>
-  <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
+  <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address" %><br>
   <%%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %><br>
   <%%= form.submit "Sign in" %>
 <%% end %>


### PR DESCRIPTION
The authentication generator form templates allow setting the email_address form field value with query parameters. This is not used in any existing functionality or test.

Fixes #55168

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
