### PR TITLE
Make transaction isolation work smoothly with transactional tests

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -353,6 +353,22 @@ module ActiveRecord
       # isolation level.
       #  :args: (requires_new: nil, isolation: nil, &block)
       def transaction(requires_new: nil, isolation: nil, joinable: true, &block)
+        # If we're running inside the single, non-joinable transaction that
+        # ActiveRecord::TestFixtures starts around each example (depth == 1),
+        # an `isolation:` hint must be validated then ignored so that the
+        # adapter isn't asked to change the isolation level mid-transaction.
+        if isolation && !requires_new && open_transactions == 1 && !current_transaction.joinable?
+          iso = isolation.to_sym
+
+          unless transaction_isolation_levels.include?(iso)
+            raise ActiveRecord::TransactionIsolationError,
+                  "invalid transaction isolation level: #{iso.inspect}"
+          end
+
+          current_transaction.isolation = iso
+          isolation = nil
+        end
+
         if !requires_new && current_transaction.joinable?
           if isolation && current_transaction.isolation != isolation
             raise ActiveRecord::TransactionIsolationError, "cannot set isolation when joining a transaction"

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -436,13 +436,16 @@ module ActiveRecord
         end
       end
 
+      TRANSACTION_ISOLATION_LEVELS = {
+        read_uncommitted: "READ UNCOMMITTED",
+        read_committed:   "READ COMMITTED",
+        repeatable_read:  "REPEATABLE READ",
+        serializable:     "SERIALIZABLE"
+      }.freeze
+      private_constant :TRANSACTION_ISOLATION_LEVELS
+
       def transaction_isolation_levels
-        {
-          read_uncommitted: "READ UNCOMMITTED",
-          read_committed:   "READ COMMITTED",
-          repeatable_read:  "REPEATABLE READ",
-          serializable:     "SERIALIZABLE"
-        }
+        TRANSACTION_ISOLATION_LEVELS
       end
 
       # Begins the transaction with the isolation level set. Raises an error by

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -124,6 +124,7 @@ module ActiveRecord
       def after_commit; yield; end
       def after_rollback; end
       def user_transaction; ActiveRecord::Transaction::NULL_TRANSACTION; end
+      def isolation=(_); end
     end
 
     class Transaction # :nodoc:
@@ -154,6 +155,10 @@ module ActiveRecord
       # Returns the isolation level if it was explicitly set, nil otherwise
       def isolation
         @isolation_level
+      end
+
+      def isolation=(isolation) # :nodoc:
+        @isolation_level = isolation
       end
 
       def initialize(connection, isolation: nil, joinable: true, run_commit_callbacks: false)
@@ -424,6 +429,10 @@ module ActiveRecord
       # Delegates to parent transaction's isolation level
       def isolation
         @parent_transaction.isolation
+      end
+
+      def isolation=(isolation) # :nodoc:
+        @parent_transaction.isolation = isolation
       end
 
       def materialize!

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -302,3 +302,55 @@ class TransactionIsolationTest < ActiveRecord::TestCase
       end
   end
 end
+
+class TransactionIsolationWithTransactionalTestsTest < ActiveRecord::TestCase
+  if ActiveRecord::Base.lease_connection.supports_transaction_isolation? && !current_adapter?(:SQLite3Adapter)
+    class Tag < ActiveRecord::Base
+      self.table_name = "tags"
+    end
+
+    test "starting a transaction with isolation does not raise an error" do
+      assert_nothing_raised do
+        Tag.transaction(isolation: :read_committed) do
+          Tag.create!
+        end
+      end
+    end
+
+    test "starting a transaction with isolation sets the isolation level" do
+      Tag.transaction(isolation: :read_committed) do
+        assert_equal :read_committed, Tag.lease_connection.current_transaction.isolation
+      end
+    end
+
+    test "starting a transaction with a different isolation level raises an error" do
+      Tag.transaction(isolation: :read_committed) do
+        Tag.create!
+
+        assert_raises(ActiveRecord::TransactionIsolationError) do
+          Tag.transaction(isolation: :repeatable_read) do
+            Tag.create!
+          end
+        end
+      end
+    end
+
+    test "specifying the same isolation level does not raise an error" do
+      assert_nothing_raised do
+        Tag.transaction(isolation: :read_committed) do
+          Tag.create!
+
+          Tag.transaction(isolation: :read_committed) do
+            Tag.create!
+          end
+        end
+      end
+    end
+
+    test "invalid isolation level raises TransactionIsolationError" do
+      assert_raises(ActiveRecord::TransactionIsolationError) do
+        Tag.transaction(isolation: :unknown_level) { Tag.create! }
+      end
+    end
+  end
+end


### PR DESCRIPTION
When transactional fixtures are enabled, any code that specifies transaction isolation breaks in tests.

Here's an example:

```ruby
class ExampleTest < ActiveRecord::TestCase
  self.use_transactional_tests = true

  class Tag < ActiveRecord::Base
    self.table_name = "tags"
  end

  test "omglol" do
    Tag.transaction(isolation: :read_committed) do
      Tag.create!
    end
  end
end

# fails with:
ActiveRecord::TransactionIsolationError: cannot set transaction isolation in a nested transaction
    lib/active_record/connection_adapters/abstract/transaction.rb:418:in 'ActiveRecord::ConnectionAdapters::SavepointTransaction#initialize'
    lib/active_record/connection_adapters/abstract/transaction.rb:538:in 'Class#new'
    lib/active_record/connection_adapters/abstract/transaction.rb:538:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#begin_transaction'
    /Users/kirs/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in 'Thread.handle_interrupt'
    /Users/kirs/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in 'block in ActiveSupport::Concurrency::LoadInterlockAwareMonitorMixin#synchronize'
```

This error makes sense because the transaction is already open by the test framework and you cannot change isolation in the middle of transaction.

The workaround is having to check whether the test transaction has been open in every code path:

```ruby
isolation = if Tag.lease_connection.transaction.open?
  nil
else
  :read_committed
end
Tag.transaction(isolation: isolation) do
  ...
end
```

Similar to how transactional fixtures [mock the replica connection](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/test_fixtures.rb#L239-L262) so that you can smoothly test code that uses DB replicas, I think we can provide better DX and let you pass `isolation` in tests when `use_transactional_tests` is enabled.

This is achieved by accounting for the fact that in tests, the first transaction always comes from transactional fixtures, and mocking that.

I'm open to better ideas how to make this work, but I strongly believe that making it work seamlessly in transactional tests is a good DX.

@byroot @rafaelfranca @matthewd 