### PR TITLE
Add headers to engine route inspection command

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add headers to engine routes inspection command
+
+    *Petrik de Heus*
+
 *   Add "Copy as text" button to error pages
 
     *Mikkel Malmberg*

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -89,7 +89,10 @@ module ActionDispatch
 
         @engines.each do |name, engine_routes|
           formatter.section_title "Routes for #{name}"
-          formatter.section engine_routes
+          if engine_routes.any?
+            formatter.header engine_routes
+            formatter.section engine_routes
+          end
         end
 
         formatter.result

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -41,6 +41,7 @@ module ActionDispatch
           "         blog      /blog                    Blog::Engine",
           "",
           "Routes for Blog::Engine:",
+          "Prefix Verb URI Pattern     Controller#Action",
           "  cart GET  /cart(.:format) cart#show"
         ], output
       end


### PR DESCRIPTION
When running `rails routes`, the routes of engines are shown in a separate block. This block currently doesn't show the headers for the engine routes. 

The existing headers for all the routes will typically not align as the indentation differs.
By outputting the headers for the engine the routes become easier to read.

Before:

```
Routes for Blorgh::Engine:
    articles GET    /articles(.:format)          blorgh/articles#index
...
```

After:

```
Routes for Blorgh::Engine:
      Prefix Verb   URI Pattern                  Controller#Action
    articles GET    /articles(.:format)          blorgh/articles#index
...
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
