### PR TITLE
[ci skip]Fix a broken link to ActiveStorage::Blob#url in the documentation

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -74,7 +74,7 @@ class ActiveStorage::Variant
     "variants/#{blob.key}/#{OpenSSL::Digest::SHA256.hexdigest(variation.key)}"
   end
 
-  # Returns the URL of the blob variant on the service. See {ActiveStorage::Blob#url} for details.
+  # Returns the URL of the blob variant on the service. See ActiveStorage::Blob#url for details.
   #
   # Use <tt>url_for(variant)</tt> (or the implied form, like <tt>link_to variant</tt> or <tt>redirect_to variant</tt>) to get the stable URL
   # for a variant that points to the ActiveStorage::RepresentationsController, which in turn will use this +service_call+ method


### PR DESCRIPTION
ref: https://edgeapi.rubyonrails.org/classes/ActiveStorage/Variant.html#method-i-url

## before
<img width="963" height="261" alt="image" src="https://github.com/user-attachments/assets/b947e12f-263a-4ac8-a717-5f2b87e8f4d9" />

## after
<img width="937" height="252" alt="image" src="https://github.com/user-attachments/assets/6e159938-d439-45b2-9327-726d2c3e8333" />
