### PR TITLE
Make local cache middleware updatable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Make the cache of `ActiveSupport::Cache::Strategy::LocalCache::Middleware` updatable.
+
+    If the cache client at `Rails.cache` of a booted application changes, the corresponding
+    mounted middleware needs to update in order for request-local caches to be setup properly.
+    Otherwise, redundant cache operations will erroneously hit the datastore.
+
+    *Gannon McGibbon*
+
 *   Add `assert_events_reported` test helper for `ActiveSupport::EventReporter`.
 
     This new assertion allows testing multiple events in a single block, regardless of order:

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -68,12 +68,25 @@ module ActiveSupport
           use_temporary_local_cache(LocalStore.new, &block)
         end
 
+        # Set a new local cache.
+        def new_local_cache
+          LocalCacheRegistry.set_cache_for(local_cache_key, LocalStore.new)
+        end
+
+        # Unset the current local cache.
+        def unset_local_cache
+          LocalCacheRegistry.set_cache_for(local_cache_key, nil)
+        end
+
+        # The current local cache.
+        def local_cache
+          LocalCacheRegistry.cache_for(local_cache_key)
+        end
+
         # Middleware class can be inserted as a Rack handler to be local cache for the
         # duration of request.
         def middleware
-          @middleware ||= Middleware.new(
-            "ActiveSupport::Cache::Strategy::LocalCache",
-            local_cache_key)
+          @middleware ||= Middleware.new("ActiveSupport::Cache::Strategy::LocalCache", self)
         end
 
         def clear(options = nil) # :nodoc:
@@ -212,10 +225,6 @@ module ActiveSupport
 
           def local_cache_key
             @local_cache_key ||= "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
-          end
-
-          def local_cache
-            LocalCacheRegistry.cache_for(local_cache_key)
           end
 
           def bypass_local_cache(&block)

--- a/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
@@ -11,7 +11,8 @@ module ActiveSupport
         # This class wraps up local storage for middlewares. Only the middleware method should
         # construct them.
         class Middleware # :nodoc:
-          attr_reader :name, :cache
+          attr_reader :name
+          attr_accessor :cache
 
           def initialize(name, cache)
             @name = name

--- a/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb
@@ -11,11 +11,11 @@ module ActiveSupport
         # This class wraps up local storage for middlewares. Only the middleware method should
         # construct them.
         class Middleware # :nodoc:
-          attr_reader :name, :local_cache_key
+          attr_reader :name, :cache
 
-          def initialize(name, local_cache_key)
+          def initialize(name, cache)
             @name = name
-            @local_cache_key = local_cache_key
+            @cache = cache
             @app = nil
           end
 
@@ -25,18 +25,17 @@ module ActiveSupport
           end
 
           def call(env)
-            LocalCacheRegistry.set_cache_for(local_cache_key, LocalStore.new)
+            cache.new_local_cache
             response = @app.call(env)
             response[2] = ::Rack::BodyProxy.new(response[2]) do
-              LocalCacheRegistry.set_cache_for(local_cache_key, nil)
+              cache.unset_local_cache
             end
             cleanup_on_body_close = true
             response
           rescue Rack::Utils::InvalidParameterError
             [400, {}, []]
           ensure
-            LocalCacheRegistry.set_cache_for(local_cache_key, nil) unless
-              cleanup_on_body_close
+            cache.unset_local_cache unless cleanup_on_body_close
           end
         end
       end

--- a/activesupport/test/cache/local_cache_middleware_test.rb
+++ b/activesupport/test/cache/local_cache_middleware_test.rb
@@ -8,53 +8,57 @@ module ActiveSupport
     module Strategy
       module LocalCache
         class MiddlewareTest < ActiveSupport::TestCase
+          class Cache
+            include LocalCache
+          end
+
           def test_local_cache_cleared_on_close
-            key = "super awesome key"
-            assert_nil LocalCacheRegistry.cache_for key
-            middleware = Middleware.new("<3", key).new(->(env) {
-              assert LocalCacheRegistry.cache_for(key), "should have a cache"
+            cache = Cache.new
+            assert_nil cache.local_cache
+            middleware = Middleware.new("<3", cache).new(->(env) {
+              assert cache.local_cache, "should have a cache"
               [200, {}, []]
             })
             _, _, body = middleware.call({})
-            assert LocalCacheRegistry.cache_for(key), "should still have a cache"
+            assert cache.local_cache, "should still have a cache"
             body.each { }
-            assert LocalCacheRegistry.cache_for(key), "should still have a cache"
+            assert cache.local_cache, "should still have a cache"
             body.close
-            assert_nil LocalCacheRegistry.cache_for(key)
+            assert_nil cache.local_cache
           end
 
           def test_local_cache_cleared_and_response_should_be_present_on_invalid_parameters_error
-            key = "super awesome key"
-            assert_nil LocalCacheRegistry.cache_for key
-            middleware = Middleware.new("<3", key).new(->(env) {
-              assert LocalCacheRegistry.cache_for(key), "should have a cache"
+            cache = Cache.new
+            assert_nil cache.local_cache
+            middleware = Middleware.new("<3", cache).new(->(env) {
+              assert cache.local_cache, "should have a cache"
               raise Rack::Utils::InvalidParameterError
             })
             response = middleware.call({})
             assert response, "response should exist"
-            assert_nil LocalCacheRegistry.cache_for(key)
+            assert_nil cache.local_cache
           end
 
           def test_local_cache_cleared_on_exception
-            key = "super awesome key"
-            assert_nil LocalCacheRegistry.cache_for key
-            middleware = Middleware.new("<3", key).new(->(env) {
-              assert LocalCacheRegistry.cache_for(key), "should have a cache"
+            cache = Cache.new
+            assert_nil cache.local_cache
+            middleware = Middleware.new("<3", cache).new(->(env) {
+              assert cache.local_cache, "should have a cache"
               raise
             })
             assert_raises(RuntimeError) { middleware.call({}) }
-            assert_nil LocalCacheRegistry.cache_for(key)
+            assert_nil cache.local_cache
           end
 
           def test_local_cache_cleared_on_throw
-            key = "super awesome key"
-            assert_nil LocalCacheRegistry.cache_for key
-            middleware = Middleware.new("<3", key).new(->(env) {
-              assert LocalCacheRegistry.cache_for(key), "should have a cache"
+            cache = Cache.new
+            assert_nil cache.local_cache
+            middleware = Middleware.new("<3", cache).new(->(env) {
+              assert cache.local_cache, "should have a cache"
               throw :warden
             })
             assert_throws(:warden) { middleware.call({}) }
-            assert_nil LocalCacheRegistry.cache_for(key)
+            assert_nil cache.local_cache
           end
         end
       end

--- a/activesupport/test/cache/local_cache_middleware_test.rb
+++ b/activesupport/test/cache/local_cache_middleware_test.rb
@@ -60,6 +60,18 @@ module ActiveSupport
             assert_throws(:warden) { middleware.call({}) }
             assert_nil cache.local_cache
           end
+
+          def test_local_cache_middlewre_can_reassign_cache
+            cache = Cache.new
+            new_cache = Cache.new
+            middleware = Middleware.new("<3", cache).new(->(env) {
+              assert cache.local_cache, "should have a cache"
+              throw :warden
+            })
+            middleware.cache = new_cache
+
+            assert_same(new_cache, middleware.cache)
+          end
         end
       end
     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it is currently impossible to update local cache middleware for Rails.cache once the application is booted. If the cache client needs to change for any reason post-boot, mounted middleware will point to the wrong cache key and redundant cache operations will hit the datastore.

### Detail

This Pull Request changes `ActiveSupport::Cache::Strategy::LocalCache::Middleware` to keep reference of the cache instead of the generated cache key (which uses the cache's object ID), and then makes the cache reader an accessor. While I was in the area, I added public local cache resetting methods so that tests and middleware don't need to reach into internals.

### Additional information

Without this patch, there's no way to cleanly update local cache middleware if `Rails.cache` changes. This is a niche use-case, but for cases like forked parallel test workers, it is useful.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
