### PR TITLE
Clarifies action of `db:migate:reset` in Rails 8.0 release notes [ci skip]

### DIFF
--- a/guides/source/8_0_release_notes.md
+++ b/guides/source/8_0_release_notes.md
@@ -186,7 +186,10 @@ Please refer to the [Changelog][active-record] for detailed changes.
 ### Notable changes
 
 *   Running `db:migrate` on a fresh database now loads the schema before running
-    migrations. (The previous behavior is available as `db:migrate:reset`)
+    migrations. Subsequent calls will run pending migrations.
+    (If you need the previous behavior of running migrations from scratch instead of loading the 
+    schema file, this can be done by running `db:migrate:reset` which 
+    _will drop and recreate the database before running migrations_)
 
 Active Storage
 --------------


### PR DESCRIPTION
### Motivation / Background

The `db:migrate:reset` rake task is described in the Rails 8.0 release notes as `the previous behavior`. This is not entirely true as it destructively recreates the databases first and then runs the previous behavior. This can lead to unexpected data loss. There are several recent issues that show this is causing confusion

### Change

This PR expands on the release notes to clarify that 

closes rails/rails#55499


