### PR TITLE
Rate limiting calls `cache_key` on `by:` if the object responds to it

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Rate limiting calls `cache_key` on `by:` if the object responds to it.
+
+    ```ruby
+    class CommentsController < ApplicationController
+      # Cache key in the store would be `rate-limit:comments:user/1`
+      rate_limit to: 2, within: 2.seconds, by: -> { current_user }
+    end
+    ```
+
+    *Daniel Sabourin*
+
 *   Add a configuration for `ActionDispatch::ExceptionWrapper.silent_exceptions` at `config.action_dispatch.silent_exceptions`.
 
     Exceptions on this list do not fall back to framework-level backtraces when there is no application backtrace.

--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -20,7 +20,9 @@ module ActionController # :nodoc:
       # Rate limits are by default unique to the ip address making the request, but
       # you can provide your own identity function by passing a callable in the `by:`
       # parameter. It's evaluated within the context of the controller processing the
-      # request.
+      # request. If the callable returns an object that responds to `cache_key`, its
+      # value will be used as the cache key. This is useful if you want the rate limit
+      # to be scoped by an individual user, instead of their ip address.
       #
       # By default, rate limits are scoped to the controller's path. If you want to
       # share rate limits across multiple controllers, you can provide your own scope,
@@ -89,6 +91,7 @@ module ActionController # :nodoc:
     private
       def rate_limiting(to:, within:, by:, with:, store:, name:, scope:)
         by = by.is_a?(Symbol) ? send(by) : instance_exec(&by)
+        by = by.cache_key if by.respond_to?(:cache_key)
         to = to.is_a?(Symbol) ? send(to) : (to.respond_to?(:call) ? instance_exec(&to) : to)
         within = within.is_a?(Symbol) ? send(within) : (within.respond_to?(:call) ? instance_exec(&within) : within)
 

--- a/actionpack/test/controller/rate_limiting_test.rb
+++ b/actionpack/test/controller/rate_limiting_test.rb
@@ -3,6 +3,8 @@
 require "abstract_unit"
 
 class RateLimitedController < ActionController::Base
+  ModelWithKey = Struct.new(:cache_key)
+
   self.cache_store = ActiveSupport::Cache::MemoryStore.new
   rate_limit to: 2, within: 2.seconds, only: :limited
   rate_limit to: 5, within: 1.minute, name: "long-term", only: :limited
@@ -28,6 +30,11 @@ class RateLimitedController < ActionController::Base
 
   rate_limit to: -> { params[:max_requests]&.to_i || 2 }, within: -> { params[:time_window]&.to_i&.seconds || 2.seconds }, only: :limited_with_callable_to_within
   def limited_with_callable_to_within
+    head :ok
+  end
+
+  rate_limit to: 2, within: 2.seconds, by: -> { ModelWithKey.new(params[:rate_limit_key]) }, only: :limited_with_key
+  def limited_with_key
     head :ok
   end
 
@@ -224,6 +231,19 @@ class RateLimitingTest < ActionController::TestCase
     assert_raises ActionController::TooManyRequests do
       get :limited_with_callable_to_within, params: { max_requests: 3, time_window: 5 }
     end
+  end
+
+  test "limit by object with cache_key" do
+    get :limited_with_key, params: { rate_limit_key: "user/1" }
+    get :limited_with_key, params: { rate_limit_key: "user/1" }
+    assert_response :ok
+
+    assert_raises ActionController::TooManyRequests do
+      get :limited_with_key, params: { rate_limit_key: "user/1" }
+    end
+
+    get :limited_with_key, params: { rate_limit_key: "user/2" }
+    assert_response :ok
   end
 
   test "cross-controller rate limit" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the default configuration of rate limiting by the `remote_ip` doesn't quite work for our use case. There are times where we have an authenticated user that we want to apply the rate limit to, but we don't want to restrict the entire IP incase there's multiple users on the same home/work network. By applying the rate limit to the user itself, each user has their own rate limit.

### Detail

This Pull Request changes the `rate_limit` `to:` argument to allow any kind of object to be returned. If the object responds to `cache_key` (like ActiveRecord objects do), the rate limit will call that method when constructing the cache key. 

```ruby
class CommentsController < ActionController::API
  # Cache key in the store would be `rate-limit:comments:user/1`
  rate_limit to: 2, within: 2.seconds, by: { current_user }

  private

  # Substitute however you load your user object (potentially using Devise)
  def current_user
    User.find(1)
  end
end
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
One might argue that it's not a huge deal to just call the `cache_key` method directly in `to:`, but to me this is a sensible enough default to warrant a change instead of letting the setting propagate the codebase if you have multiple user-centric rate limits.

```ruby
# how it's done now
class CommentsController < ActionController::API
  # Cache key in the store would be `rate-limit:comments:user/1`
  rate_limit to: 2, within: 2.seconds, by: { current_user.cache_key }
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
