### PR TITLE
Documentation small change: Add clarification to Concern's save location

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2354,7 +2354,9 @@ subscribers and how notifications are sent.
 
 Extracting code into concerns also helps make features reusable. For example, we
 could introduce a new model that also needs subscriber notifications. This
-module could be used in multiple models to provide the same functionality.
+module could be used in multiple models to provide the same functionality. 
+In this case, we would save the concern under `app/models/concerns/` instead of
+`app/models/product/`.
 
 ### Unsubscribe Links
 


### PR DESCRIPTION
As I was going through the guide I wondered how concerns would be used on multiple models without hurting DRY. 

The guide tells you to create the concern in a model specific folder called products and the sub chapter ends with saying concerns can be used by multiple models.  

I added a short explanation where to put the concerns in this case.
