### PR TITLE
Removal of thread pool and use of `Thread.new` instead

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -301,9 +301,7 @@ module ActionController
               error = e
             end
           ensure
-            # Clear execution state to prevent memory leaks and state corruption
             ActiveSupport::IsolatedExecutionState.clear
-
             clean_up_thread_locals(locals, t2)
 
             @_response.commit!

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -282,7 +282,7 @@ module ActionController
           # Since we're processing the view in a different thread, copy the thread locals
           # from the main thread to the child thread. :'(
           locals.each { |k, v| t2[k] = v }
-          
+
           # NOTE: IsolatedExecutionState.share_with is needed for CurrentAttributes to work properly
           # The original issue was not with this call itself, but with database connection state corruption
           # that happened due to complex thread pool management. By using simple Thread.new and
@@ -309,7 +309,7 @@ module ActionController
             # Clear execution state to prevent memory leaks and state corruption
             # This is safe because we're using simple Thread.new instead of complex thread pool management
             ActiveSupport::IsolatedExecutionState.clear
-            
+
             clean_up_thread_locals(locals, t2)
 
             @_response.commit!


### PR DESCRIPTION
### Motivation / Background

[Closes ](https://github.com/rails/rails/issues/55132)

The Problem:
PR#52731 introduced execution state sharing between threads via `ActiveSupport::IsolatedExecutionState.share_with(t1)` and `ActiveSupport::IsolatedExecutionState.clear` This caused database connections to be shared between threads, leading to the crash found here:

```
def disconnect!
  @lock.synchronize do
    super
    @raw_connection&.close rescue nil # Crash here - double PG#close
    @raw_connection = nil
  end
end
```
### Detail

Removing code that allows execution state sharing between threads.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
