### PR TITLE
Creates `parallel_worker_id` helper for running parallel tests

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Create `parallel_worker_id` helper for running parallel tests. This allows users to
+    know which worker they are currently running in.
+
+    *Nick Schwaderer*
+    
 *   Make the cache of `ActiveSupport::Cache::Strategy::LocalCache::Middleware` updatable.
 
     If the cache client at `Rails.cache` of a booted application changes, the corresponding

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -23,7 +23,22 @@ module ActiveSupport
   class TestCase < ::Minitest::Test
     Assertion = Minitest::Assertion
 
+    # Class variable to store the parallel worker ID
+    @@parallel_worker_id = nil
+
     class << self
+      # Returns the current parallel worker ID if tests are running in parallel,
+      # nil otherwise.
+      #
+      #   ActiveSupport::TestCase.parallel_worker_id # => 2
+      def parallel_worker_id
+        @@parallel_worker_id
+      end
+
+      def parallel_worker_id=(value) # :nodoc:
+        @@parallel_worker_id = value
+      end
+
       # Sets the order in which test cases are run.
       #
       #   ActiveSupport::TestCase.test_order = :random # => :random
@@ -173,6 +188,11 @@ module ActiveSupport
     end
 
     alias_method :method_name, :name
+
+    # Returns the current parallel worker ID if tests are running in parallel
+    def parallel_worker_id
+      self.class.parallel_worker_id
+    end
 
     include ActiveSupport::Testing::TaggedLogging
     prepend ActiveSupport::Testing::SetupAndTeardown

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -78,6 +78,8 @@ module ActiveSupport
         end
 
         def after_fork
+          ActiveSupport::TestCase.parallel_worker_id = @number
+
           Parallelization.after_fork_hooks.each do |cb|
             cb.call(@number)
           end

--- a/activesupport/test/parallelization_test.rb
+++ b/activesupport/test/parallelization_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+class ParallelizationTest < ActiveSupport::TestCase
+  def setup
+    @original_worker_id = ActiveSupport::TestCase.parallel_worker_id
+  end
+
+  def teardown
+    ActiveSupport::TestCase.parallel_worker_id = @original_worker_id
+  end
+
+  test "parallel_worker_id is accessible as an attribute and method" do
+    ActiveSupport::TestCase.parallel_worker_id = nil
+    assert_nil ActiveSupport::TestCase.parallel_worker_id
+    assert_nil parallel_worker_id
+  end
+
+  test "parallel_worker_id is set and accessible from class and instance" do
+    ActiveSupport::TestCase.parallel_worker_id = 3
+
+    assert_equal 3, ActiveSupport::TestCase.parallel_worker_id
+    assert_equal 3, parallel_worker_id
+  end
+
+  test "parallel_worker_id persists across test subclasses" do
+    ActiveSupport::TestCase.parallel_worker_id = 5
+
+    subclass = Class.new(ActiveSupport::TestCase)
+    assert_equal 5, subclass.parallel_worker_id
+
+    instance = subclass.new("test")
+    assert_equal 5, instance.parallel_worker_id
+  end
+end


### PR DESCRIPTION
Right now the only opportunity to access the parallel worker id is to grab it in

```
parallelize_setup do |worker_id|
```

Where it must be assigned to a config by hand. This PR makes a helper `parallel_worker_id` available throughout. It is `nil` if not in parallel.