### PR TITLE
Enable debug mode for events in local environments

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -265,15 +265,18 @@ module ActiveSupport
     # event emission, or when unexpected arguments are passed to +notify+.
     attr_writer :raise_on_error
 
+    attr_writer :debug_mode # :nodoc:
+
     class << self
       attr_accessor :context_store # :nodoc:
     end
 
     self.context_store = EventContext
 
-    def initialize(*subscribers, raise_on_error: false, tags: nil)
+    def initialize(*subscribers, raise_on_error: false)
       @subscribers = []
       subscribers.each { |subscriber| subscribe(subscriber) }
+      @debug_mode = false
       @raise_on_error = raise_on_error
     end
 
@@ -400,9 +403,10 @@ module ActiveSupport
       Fiber[:event_reporter_debug_mode] = prior
     end
 
-    # Check if debug mode is currently enabled.
+    # Check if debug mode is currently enabled. Debug mode is enabled on the reporter
+    # via +with_debug+, and in local environments.
     def debug_mode?
-      Fiber[:event_reporter_debug_mode]
+      @debug_mode || Fiber[:event_reporter_debug_mode]
     end
 
     # Report an event only when in debug mode. For example:

--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -387,6 +387,8 @@ module ActiveSupport
           ActiveSupport.error_reporter.report(subscriber_error, handled: true)
         end
       end
+
+      nil
     end
 
     # Temporarily enables debug mode for the duration of the block.

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -248,6 +248,11 @@ module ActiveSupport
       assert_not_predicate @reporter, :debug_mode?
     end
 
+    test "#debug_mode? returns true when debug_mode=true is set" do
+      @reporter.debug_mode = true
+      assert_predicate @reporter, :debug_mode?
+    end
+
     test "#with_debug works with nested calls" do
       @reporter.with_debug do
         assert_predicate @reporter, :debug_mode?

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -73,6 +73,7 @@ module Rails
 
       initializer :initialize_event_reporter, group: :all do
         Rails.event.raise_on_error = config.consider_all_requests_local
+        Rails.event.debug_mode = config.consider_all_requests_local
       end
 
       # Initialize cache early in the stack so railties can make use of it.


### PR DESCRIPTION
### Motivation / Background

Emit debug events by default in local environments. It would be good for devs to be able to see debug events when working locally, and it's also a bit of a pain to have to wrap tests in `Rails.event.with_debug` any time we want to assert that a debug event was emitted.

### Detail

Sets a new option on the Event Reporter, `debug_mode`, which will force the event reporter into debug mode. When bootstrapping the app, we configure that value based on `config.consider_all_requests_local`.

Also two small cleanups -- removed an unused `tags` kwarg from the constructor, and ensured `#notify` returns `nil`.

### Additional information

I considered combining `debug_mode` with `raise_on_error`, but decided it was clearer to keep them separate. We set both of them for local requests, but they don't mean the same thing. The former is enabling the emission of all debug events, and the latter defines behaviour if we encounter an error during event emission / in the subscriber code. 

I've also opted to no'doc `debug_mode`, I don't think apps should set this directly.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
