### PR TITLE
Restore latest sidekiq gem for tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem "useragent", require: false
 group :job do
   gem "resque", require: false
   gem "resque-scheduler", require: false
-  gem "sidekiq", "!= 8.0.3", require: false
+  gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "queue_classic", ">= 4.0.0", require: false, platforms: :ruby
   gem "sneakers", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,7 +592,7 @@ GEM
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     set (1.1.2)
-    sidekiq (8.0.2)
+    sidekiq (8.0.7)
       connection_pool (>= 2.5.0)
       json (>= 2.9.0)
       logger (>= 1.6.2)
@@ -809,7 +809,7 @@ DEPENDENCIES
   rubyzip (~> 2.0)
   sdoc!
   selenium-webdriver (>= 4.20.0)
-  sidekiq (!= 8.0.3)
+  sidekiq
   sneakers
   solid_cable
   solid_cache

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -35,7 +35,7 @@ class QueuingTest < ActiveSupport::TestCase
       Sidekiq::Testing.fake! do
         ::HelloJob.perform_later
         hash = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.jobs.first
-        assert_equal "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper", hash["class"]
+        assert_equal "Sidekiq::ActiveJob::Wrapper", hash["class"]
         assert_equal "HelloJob", hash["wrapped"]
       end
     end


### PR DESCRIPTION
First, this failure was fixed in Sidekiq 8.0.5:
https://github.com/sidekiq/sidekiq/blob/main/Changes.md#805

Fixes #55146.

```
$ AJ_INTEGRATION_TESTS=1 \
  AJ_ADAPTER=sidekiq \
  bin/test test/integration/queuing_test.rb \
    -n test_should_interrupt_jobs

Using sidekiq

INFO  2025-08-29T01:39:43.257Z pid=1413670 tid=ucva:
  Sidekiq 8.0.2 connecting to Redis with options {size: 10, pool_name: "internal", url: "redis://redis:6379/1"}

Run options: -n test_should_interrupt_jobs --seed 56399

Failure:
QueuingTest#test_should_interrupt_jobs [test/integration/queuing_test.rb:61]:
Expected false to be truthy.

bin/test test/integration/queuing_test.rb:50
```

Second, this failure was originally introduced in Sidekiq 8.0.3.

Fixes #54972.

```
$ bundle exec rake test:integration:sidekiq
 # ruby -w -I"lib:test" /home/zzak/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/rake-13.3.0/lib/rake/rake_test_loader.rb "test/integration/queuing_test.rb"

Using sidekiq

INFO  2025-08-29T01:41:28.604Z pid=1444128 tid=uxfc:
  Sidekiq 8.0.7 connecting to Redis with options {size: 10, pool_name: "internal", url: "redis://redis:6379/1"}

Run options: --seed 54098

Failure:
QueuingTest#test_should_supply_a_wrapped_class_name_to_Sidekiq [test/integration/queuing_test.rb:38]:
--- expected
+++ actual
@@ -1 +1 @@
-"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+"Sidekiq::ActiveJob::Wrapper"

bin/rails test activejob/test/integration/queuing_test.rb:34
```

This is because when the Sidekiq gem is loaded with Rails, it replaces the native Active Job adapter with it's own. When enqueuing jobs, the `"class"` attribute is set to `Sidekiq::ActiveJob::Wrapper`.

https://github.com/sidekiq/sidekiq/blob/205df02327a2402f4c844df07324d8ac3da80ffb/lib/active_job/queue_adapters/sidekiq_adapter.rb#L79

That is the source of both of these problems.

We should allow the gem to control the adapter as it will be deprecated and removed internally from Rails in the future.

This change is intended to be backported to other stable branches to ensure the Sidekiq adapter remains supported.

Closes #54991, #55148
