### PR TITLE
[8-0-stable] Backport "Restore latest sidekiq gem for tests"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem "useragent", require: false
 group :job do
   gem "resque", require: false
   gem "resque-scheduler", require: false
-  gem "sidekiq", "!= 8.0.3", require: false
+  gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false
   gem "queue_classic", ">= 4.0.0", require: false, platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,7 +563,7 @@ GEM
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     set (1.1.2)
-    sidekiq (8.0.2)
+    sidekiq (8.0.7)
       connection_pool (>= 2.5.0)
       json (>= 2.9.0)
       logger (>= 1.6.2)
@@ -763,7 +763,7 @@ DEPENDENCIES
   rubyzip (~> 2.0)
   sdoc
   selenium-webdriver (>= 4.20.0)
-  sidekiq (!= 8.0.3)
+  sidekiq
   sneakers
   solid_cable
   solid_cache

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -33,7 +33,7 @@ class QueuingTest < ActiveSupport::TestCase
       Sidekiq::Testing.fake! do
         ::HelloJob.perform_later
         hash = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.jobs.first
-        assert_equal "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper", hash["class"]
+        assert_equal "Sidekiq::ActiveJob::Wrapper", hash["class"]
         assert_equal "HelloJob", hash["wrapped"]
       end
     end


### PR DESCRIPTION
Backports 80c048a to `8-0-stable`.