### PR TITLE
[7-2-stable] Backport "Restore latest sidekiq gem for tests"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "useragent", require: false
 group :job do
   gem "resque", require: false
   gem "resque-scheduler", require: false
-  gem "sidekiq", "!= 8.0.3", require: false
+  gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false
   gem "queue_classic", ">= 4.0.0", require: false, platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,12 +527,12 @@ GEM
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     set (1.1.2)
-    sidekiq (7.3.9)
-      base64
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+    sidekiq (8.0.7)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
     sigdump (0.2.5)
     signet (0.19.0)
       addressable (~> 2.8)
@@ -693,7 +693,7 @@ DEPENDENCIES
   rubyzip (~> 2.0)
   sdoc
   selenium-webdriver (>= 4.20.0)
-  sidekiq (!= 8.0.3)
+  sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
   sqlite3 (>= 1.6.6)

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -33,7 +33,7 @@ class QueuingTest < ActiveSupport::TestCase
       Sidekiq::Testing.fake! do
         ::HelloJob.perform_later
         hash = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.jobs.first
-        assert_equal "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper", hash["class"]
+        assert_equal "Sidekiq::ActiveJob::Wrapper", hash["class"]
         assert_equal "HelloJob", hash["wrapped"]
       end
     end


### PR DESCRIPTION
Backports 80c048a to `7-2-stable`.