### PR TITLE
Fix for unsubscribing from event reporter using class

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -314,7 +314,7 @@ module ActiveSupport
     #   # or
     #   Rails.event.unsubscribe(MyEventSubscriber)
     def unsubscribe(subscriber)
-      @subscribers.delete_if { |s| s[:subscriber] === subscriber }
+      @subscribers.delete_if { |s| subscriber === s[:subscriber] }
     end
 
     # Reports an event to all registered subscribers. An event name and payload can be provided:

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -72,7 +72,9 @@ module ActiveSupport
     end
 
     test "#unsubscribe" do
+      first_subscriber = @subscriber
       second_subscriber = EventSubscriber.new
+
       @reporter.subscribe(second_subscriber)
       @reporter.notify(:test_event, key: "value")
 
@@ -86,7 +88,12 @@ module ActiveSupport
         @reporter.notify(:another_event, key: "value")
       end
 
+      assert event_matcher(name: "another_event", payload: { key: "value" }).call(first_subscriber.events.last)
+
+      @reporter.unsubscribe(EventSubscriber)
       @reporter.notify(:last_event, key: "value")
+
+      assert_empty first_subscriber.events.select(&event_matcher(name: "last_event", payload: { key: "value" }))
       assert_empty second_subscriber.events.select(&event_matcher(name: "last_event", payload: { key: "value" }))
     end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR fixes a small issue with unsubscribing using a class in the Event Reporter, which was introduced by https://github.com/rails/rails/pull/55487

The arguments of `===` were in the wrong order which prevented instances of a class being unsubscribed. 

```ruby
Rails.event.unsubscribe(MyEventSubscriber)
```

CC: @zzak 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
