### PR TITLE
Allow getter and setter for `options[:namespace]` in `ActiveSupport::Cache::Store`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow getting and setting of `options[:namespace]` in `ActiveSupport::Cache::Store`
+    after initialize.
+
+    *Nick Schwaderer*
+
 *   Make the cache of `ActiveSupport::Cache::Strategy::LocalCache::Middleware` updatable.
 
     If the cache client at `Rails.cache` of a booted application changes, the corresponding

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -797,13 +797,13 @@ module ActiveSupport
       end
 
       # Get the current namespace
-      def get_namespace
+      def namespace
         @options[:namespace]
       end
 
       # Set the current namespace. Note, this will be ignored if custom
       # options are passed to cache wills with a namespace key.
-      def set_namespace(namespace)
+      def namespace=(namespace)
         @options[:namespace] = namespace
       end
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -796,6 +796,17 @@ module ActiveSupport
         raise NotImplementedError.new("#{self.class.name} does not support clear")
       end
 
+      # Get the current namespace
+      def get_namespace
+        @options[:namespace]
+      end
+
+      # Set the current namespace. Note, this will be ignored if custom
+      # options are passed to cache wills with a namespace key.
+      def set_namespace(namespace)
+        @options[:namespace] = namespace
+      end
+
       private
         def default_serializer
           case Cache.format_version

--- a/activesupport/test/cache/cache_key_test.rb
+++ b/activesupport/test/cache/cache_key_test.rb
@@ -78,6 +78,13 @@ class CacheKeyTest < ActiveSupport::TestCase
     assert_equal "foo/bar/baz", ActiveSupport::Cache.expand_cache_key(%w{foo bar baz}.to_enum)
   end
 
+  def test_set_and_get_namespace
+    cache = ActiveSupport::Cache::MemoryStore.new
+    assert_nil cache.get_namespace
+    cache.set_namespace("test")
+    assert_equal "test", cache.get_namespace
+  end
+
   private
     def with_env(kv)
       old_values = {}


### PR DESCRIPTION
In development or after initialization a user may want to inspect the current cache namespace. They may also wish to change it. This PR adds this functionality.

Note: custom namespaces passed in as options during the cache calls will override any previously set namespace value during that call.

Why:

To make parallel tests more resilient, we have found that it is better to reset the cache namespace between tests instead of clearing the cache.

This functionality can be used as follows:

```ruby
def randomize_namespace
  namespace = Rails.cache.namespace

  if namespace
    namespace = "#{SecureRandom.hex(6)}r:" + namespace.split("r:")[-1]
  else
    namespace = SecureRandom.hex(6)
  end

  Rails.cache.namespace = namespace
end
````

For reviewers: is `cache_key_test` the best home for these tests?
