### PR TITLE
Make reset token expiry configurable in has_secure_password

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `reset_token: { expires_in: ... }` option to `has_secure_password`.
+
+    Allows configuring the expiry duration of password reset tokens (default remains 15 minutes for backwards compatibility).
+
+    ```ruby
+    has_secure_password reset_token: { expires_in: 1.hour }
+    ```
+
+    *Jevin Sew*
+
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Add `except_on:` option for validation callbacks.

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/user"
 require "models/pilot"
+require "models/slow_pilot"
 require "models/visitor"
 
 class SecurePasswordTest < ActiveModel::TestCase
@@ -14,6 +15,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @user = User.new
     @visitor = Visitor.new
     @pilot = Pilot.new
+    @slow_pilot = SlowPilot.new
 
     # Simulate loading an existing user from the DB
     @existing_user = User.new
@@ -339,5 +341,10 @@ class SecurePasswordTest < ActiveModel::TestCase
 
     assert_equal "finding-for-password_reset-by-999", Pilot.find_by_password_reset_token("999")
     assert_equal "finding-for-password_reset-by-999!", Pilot.find_by_password_reset_token!("999")
+  end
+
+  test "password reset token duration" do
+    assert_equal "password_reset-token-3600", @slow_pilot.password_reset_token
+    assert_equal 1.hour, @slow_pilot.password_reset_token_expires_in
   end
 end

--- a/activemodel/test/models/slow_pilot.rb
+++ b/activemodel/test/models/slow_pilot.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SlowPilot
+  include ActiveModel::SecurePassword
+
+  def self.generates_token_for(purpose, expires_in: nil, &)
+    @@expires_in = expires_in
+  end
+
+  def generate_token_for(purpose)
+    "#{purpose}-token-#{@@expires_in}"
+  end
+
+  has_secure_password reset_token: { expires_in: 1.hour }
+end

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -145,6 +145,9 @@ the `/passwords/new` path and routes to the passwords controller. The `new`
 method of the `PasswordsController` class runs through the flow for sending a
 password reset email.
 
+The link is valid for 15 minutes by default, but this can be configured with
+`has_secure_password`.
+
 The mailers for *reset password* are also set up by the generator at
 `app/mailers/password_mailer.rb` and render the following email to send to the
 user:

--- a/railties/lib/rails/generators/rails/authentication/templates/app/views/passwords_mailer/reset.html.erb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/views/passwords_mailer/reset.html.erb.tt
@@ -1,4 +1,6 @@
 <p>
-  You can reset your password within the next 15 minutes on
+  You can reset your password on
   <%%= link_to "this password reset page", edit_password_url(@user.password_reset_token) %>.
+
+  This link will expire in <%%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.
 </p>

--- a/railties/lib/rails/generators/rails/authentication/templates/app/views/passwords_mailer/reset.text.erb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/views/passwords_mailer/reset.text.erb.tt
@@ -1,2 +1,4 @@
-You can reset your password within the next 15 minutes on this password reset page:
+You can reset your password on
 <%%= edit_password_url(@user.password_reset_token) %>
+
+This link will expire in <%%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.


### PR DESCRIPTION
### Motivation / Background

In the current authentication flow, password reset tokens are valid for 15 minutes. This is not configurable and can be an issue for a lot of users. This PR allows to modify this expiration time.

The PR does not break the current logic. It keeps the 15 minute default.

Modifying the expiration time can be done like this:
```
has_secure_password reset_token: { expires_in: 1.hour }
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
