### PR TITLE
Fix exec_{insert,update,delete} + query cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -10,9 +10,9 @@ module ActiveRecord
 
       class << self
         def included(base) # :nodoc:
-          dirties_query_cache base, :exec_query, :execute, :create, :insert, :update, :delete, :truncate,
+          dirties_query_cache base, :exec_query, :execute, :truncate,
             :truncate_tables, :rollback_to_savepoint, :rollback_db_transaction, :restart_db_transaction,
-            :exec_insert_all
+            :exec_insert, :exec_insert_all, :exec_delete, :exec_update
 
           base.set_callback :checkin, :after, :unset_query_cache!
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
       class << self
         def included(base) # :nodoc:
-          dirties_query_cache base, :exec_query, :execute, :truncate,
+          dirties_query_cache base, :exec_query, :execute,
             :truncate_tables, :rollback_to_savepoint, :rollback_db_transaction, :restart_db_transaction,
             :exec_insert, :exec_insert_all, :exec_delete, :exec_update
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -1141,6 +1141,18 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
   end
 end
 
+class NonTransactionalQueryCacheExpiryTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def test_truncate
+    Task.cache do
+      assert_called(ActiveRecord::Base.connection_pool.query_cache, :clear, times: 1) do
+        Task.with_connection { |c| c.truncate(Task.table_name) }
+      end
+    end
+  end
+end
+
 class TransactionInCachedSqlActiveRecordPayloadTest < ActiveRecord::TestCase
   # We need current_transaction to return the null transaction.
   self.use_transactional_tests = false


### PR DESCRIPTION
[Fix exec_{insert,update,delete} + query cache](https://github.com/rails/rails/commit/80924268dc39bf89b0241841ac28d1d308c1a608)

Previously, these three methods did not clear the query cache even
though execute, exec_query, insert, update, and delete did.

This commit makes the exec_ prefixed methods consistent with their
non-prefixed counterparts: the query_cache clearing is moved to the
exec_ version so that both versions clear the query cache.

(create is also removed as a delegation target because its an alias of
insert, which now clears the query cache with exec_insert)

---

[Fix truncate clearing query cache twice](https://github.com/rails/rails/commit/ee2f027ef697fc2396e4b9eaed32dedcad9d8d75)

Since truncate calls execute and both of those methods are intercepted
to clear the query cache, it unecessarily clears the cache twice.

This commit removes the truncate delegation so that the cache only gets
cleared once (with execute). A test is added to ensure that this doesn't
regress if the implementation of truncate were to be changed in the
future.