### PR TITLE
Improve performance of ActiveJob serializers

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Improve performance of ActiveJob serializers
+
+    Introduces a new `add_class_based_serializer` method on `ActiveJob::Serializers`
+    that allows specifying a custom class and serializer pair. These serializers are
+    used to serialize a specific class and, unlike existing serializers, do not consider
+    ancestors of the given class when determining if they can handle an object.
+    Class-based serializer lookups are much faster than regular serializer lookups, which
+    work by iterating over all serializers to find one that can handle the given object.
+
+    *Cameron Dutro*
+
 *   Allow jobs to the interrupted and resumed with Continuations
 
     A job can use Continuations by including the `ActiveJob::Continuable`

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -8,6 +8,7 @@ module ActiveJob
   module Serializers # :nodoc:
     extend ActiveSupport::Autoload
 
+    autoload :ClassBasedSerializer
     autoload :ObjectSerializer
     autoload :TimeObjectSerializer
     autoload :SymbolSerializer
@@ -55,16 +56,26 @@ module ActiveJob
       def add_serializers(*new_serializers)
         self._additional_serializers += new_serializers.flatten
       end
+
+      # Adds a new serializer that will be used to serialize a specific class. These serializers do not consider
+      # ancestors, and will only be used if the class matches exactly. Class-based serializer lookups are much faster
+      # than regular serializer lookups, which have to iterate through all serializers to find one that can handle the
+      # given object. Most regular serializers call the object's `#is_a?` method to determine if they can handle the
+      # object, which can incur a performance penalty.
+      def add_class_based_serializer(klass, serializer)
+        ClassBasedSerializer.add_serializer(klass, serializer)
+      end
     end
 
-    add_serializers SymbolSerializer,
-      DurationSerializer,
-      DateTimeSerializer,
-      DateSerializer,
-      TimeWithZoneSerializer,
-      TimeSerializer,
-      ModuleSerializer,
-      RangeSerializer,
-      BigDecimalSerializer
+    add_serializers ClassBasedSerializer.instance,
+      SymbolSerializer.instance,
+      DurationSerializer.instance,
+      DateTimeSerializer.instance,
+      DateSerializer.instance,
+      TimeWithZoneSerializer.instance,
+      TimeSerializer.instance,
+      ModuleSerializer.instance,
+      RangeSerializer.instance,
+      BigDecimalSerializer.instance
   end
 end

--- a/activejob/lib/active_job/serializers/big_decimal_serializer.rb
+++ b/activejob/lib/active_job/serializers/big_decimal_serializer.rb
@@ -13,10 +13,9 @@ module ActiveJob
         BigDecimal(hash["value"])
       end
 
-      private
-        def klass
-          BigDecimal
-        end
+      def klass
+        BigDecimal
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/class_based_serializer.rb
+++ b/activejob/lib/active_job/serializers/class_based_serializer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class ClassBasedSerializer < ObjectSerializer
+      mattr_accessor :serializers, default: {}
+
+      class << self
+        def add_serializer(klass, serializer)
+          self.serializers[klass] = serializer
+        end
+      end
+
+      [
+        SymbolSerializer.instance,
+        DurationSerializer.instance,
+        DateTimeSerializer.instance,
+        DateSerializer.instance,
+        TimeWithZoneSerializer.instance,
+        TimeSerializer.instance,
+        ModuleSerializer.instance,
+        RangeSerializer.instance,
+        BigDecimalSerializer.instance
+      ].each do |serializer|
+        add_serializer(serializer.klass, serializer)
+      end
+
+      def serialize?(argument)
+        self.class.serializers.include?(argument.class)
+      end
+
+      def serialize(argument)
+        serializer = self.class.serializers[argument.class]
+        raise SerializationError, "No serializer found for #{argument.class}" unless serializer
+        serializer.serialize(argument)
+      end
+
+      def deserialize(_hash)
+        raise NotImplementedError, "ClassBasedSerializer is a wrapper around an array of other serializers and cannot itself be deserialized."
+      end
+    end
+  end
+end

--- a/activejob/lib/active_job/serializers/date_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_serializer.rb
@@ -11,10 +11,9 @@ module ActiveJob
         Date.iso8601(hash["value"])
       end
 
-      private
-        def klass
-          Date
-        end
+      def klass
+        Date
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/date_time_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_time_serializer.rb
@@ -7,10 +7,9 @@ module ActiveJob
         DateTime.iso8601(hash["value"])
       end
 
-      private
-        def klass
-          DateTime
-        end
+      def klass
+        DateTime
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/duration_serializer.rb
+++ b/activejob/lib/active_job/serializers/duration_serializer.rb
@@ -16,10 +16,9 @@ module ActiveJob
         klass.new(value, parts.to_h)
       end
 
-      private
-        def klass
-          ActiveSupport::Duration
-        end
+      def klass
+        ActiveSupport::Duration
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/module_serializer.rb
+++ b/activejob/lib/active_job/serializers/module_serializer.rb
@@ -12,10 +12,9 @@ module ActiveJob
         hash["value"].constantize
       end
 
-      private
-        def klass
-          Module
-        end
+      def klass
+        Module
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/range_serializer.rb
+++ b/activejob/lib/active_job/serializers/range_serializer.rb
@@ -14,10 +14,9 @@ module ActiveJob
         klass.new(*Arguments.deserialize(hash.values_at(*KEYS)))
       end
 
-      private
-        def klass
-          ::Range
-        end
+      def klass
+        ::Range
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/symbol_serializer.rb
+++ b/activejob/lib/active_job/serializers/symbol_serializer.rb
@@ -11,10 +11,9 @@ module ActiveJob
         argument["value"].to_sym
       end
 
-      private
-        def klass
-          Symbol
-        end
+      def klass
+        Symbol
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/time_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_serializer.rb
@@ -7,10 +7,9 @@ module ActiveJob
         Time.iso8601(hash["value"])
       end
 
-      private
-        def klass
-          Time
-        end
+      def klass
+        Time
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -16,10 +16,9 @@ module ActiveJob
         Time.iso8601(hash["value"]).in_time_zone(hash["time_zone"] || Time.zone)
       end
 
-      private
-        def klass
-          ActiveSupport::TimeWithZone
-        end
+      def klass
+        ActiveSupport::TimeWithZone
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Hi there! 👋  Thanks for all you do to maintain Rails 😄 

I was looking at the interface for custom `ActiveJob::Serializers` and realized it requires a `serialize?` method that is called for potentially every serializer for every argument in the worst case. Because custom serializers are only considered after built-in serializers for complex types like `DateTime` and `Range` are considered, this behavior can lead to a fairly severe performance penalty for custom serializers. In fact, the more serializers you add, the worse performance becomes.

Currently, serializers are checked in this order:

1. SymbolSerializer
1. DurationSerializer
1. DateTimeSerializer
1. DateSerializer
1. TimeWithZoneSerializer
1. TimeSerializer
1. ModuleSerializer
1. RangeSerializer
1. BigDecimalSerializer
1. Any custom serializers

Benchmarking using [this script](https://gist.github.com/camertron/99a669ca4b20ad2ab7db4e1ab1e56630) produces the following chart showing the degradation in performance as additional custom serializers are added:

<img width="600" alt="custom" src="https://github.com/user-attachments/assets/13a7f597-f196-4a92-b077-c77f836cec5a" />

This is in addition to the performance penalty already incurred from needing to check all the built-in serializers from the list above.

This pull request makes several changes to ActiveJob serializers that lead to a roughly 2x performance improvement in the linked benchmark, although the actual improvement depends on how may custom serializers are configured and which are used in any particular serialization operation.

### Detail

This pull request makes the following changes:

1. Avoids the overhead of `delegate`d method calls on built-in serializers. This leads to a modest ~3% speed improvement.
1. Introduces the `ClassBasedSerializer` that uses a hash to map classes to their associated built-in serializer. This is where the majority of the performance improvement comes from, since the lookup changes from O(n) complexity to O(1)
1. Allows registration of custom "class-based" serializers via `ActiveJob::Serializers.add_class_based_serializer` that offers the same O(1) lookup performance characteristics.

#### Avoiding delegated method calls

Built-in serializers inherit from `ActiveJob::Serializers::ObjectSerializer`, which is a Ruby singleton. Each is registered by its class with `ActiveJob::Serializers`. This means methods like `serialize?`, `serialize`, etc are called on the class. The first change proposed in this PR registers the singleton instance instead, avoiding the delegated method call overhead. In other words, instead of this:

```ruby
ActiveJob::Serializers.add_serializers(RangeSerializer)
```

the proposed code does this:

```ruby
ActiveJob::Serializers.add_serializers(RangeSerializer.instance)
```

#### The class-based serializer

All the existing built-in serializers implement the `serialize?` method in terms of `Object#is_a?`. For example, `RangeSerializer#serialize?` returns `true` when passed a `Range` object because `argument.is_a?(Range)` returns `true`. This also means `RangeSerializer` will serialize objects that _inherit_ from `Range`, although that is very probably not the common case. The `ClassBasedSerializer` improves the performance of the common case by mapping exact classes to their associated serializer, meaning it will serialize `Range` objects but not objects that inherit from `Range`. This mapping allows   much faster serializer lookups than the existing series of `is_a?` checks.

Since we haven't actually changed `RangeSerializer`, it will continue to work as a fallback for the uncommon case as well.

#### Custom "class-based" serializers

Developers can add their own custom class-based serializers via `ActiveJob::Serializers.add_class_based_serializer(klass, serializer_klass)`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

With the two changes described above, we can see how the number of iterations per second for built-in and custom types improves across the board. `SymbolSerializer` is the first built-in serializer checked, so there is no improvement i.e. both the iterative and hash-based approaches contribute 50% of the total iterations per second.

However as the iterative approach has to check more and more serializers, we can see the hash-based approach performing better and better compared to the iterative approach.

<img width="1875" height="1094" alt="chart" src="https://github.com/user-attachments/assets/58740d9e-ffa9-41ca-a088-b8b493493393" />

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
