### PR TITLE
Allow getter and setter for `options[:namespace]` in `ActiveSupport::Cache::Store`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `ActiveSupport::Cache::Store#namespace=` and `#namespace`.
+
+    Can be used as an alternative to `Store#clear` in some situations such as parallel
+    testing.
+
+    *Nick Schwaderer*
+
 *   Create `parallel_worker_id` helper for running parallel tests. This allows users to
     know which worker they are currently running in.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -796,6 +796,17 @@ module ActiveSupport
         raise NotImplementedError.new("#{self.class.name} does not support clear")
       end
 
+      # Get the current namespace
+      def namespace
+        @options[:namespace]
+      end
+
+      # Set the current namespace. Note, this will be ignored if custom
+      # options are passed to cache wills with a namespace key.
+      def namespace=(namespace)
+        @options[:namespace] = namespace
+      end
+
       private
         def default_serializer
           case Cache.format_version

--- a/activesupport/test/cache/cache_key_test.rb
+++ b/activesupport/test/cache/cache_key_test.rb
@@ -78,6 +78,16 @@ class CacheKeyTest < ActiveSupport::TestCase
     assert_equal "foo/bar/baz", ActiveSupport::Cache.expand_cache_key(%w{foo bar baz}.to_enum)
   end
 
+  def test_set_and_get_namespace
+    cache = ActiveSupport::Cache::MemoryStore.new
+    assert_nil cache.namespace
+    cache.namespace = "test"
+    assert_equal "test", cache.namespace
+
+    cache.namespace = "test2"
+    assert_equal "test2", cache.namespace
+  end
+
   private
     def with_env(kv)
       old_values = {}


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/55573 (Had to reopen because Shopify doesn't allow maintainers to edit PRs).

In development or after initialization a user may want to inspect the current cache namespace. They may also wish to change it. This PR adds this functionality.

Note: custom namespaces passed in as options during the cache calls will override any previously set namespace value during that call.

Why:

To make parallel tests more resilient, we have found that it is better to reset the cache namespace between tests instead of clearing the cache.

This functionality can be used as follows:

```ruby
def randomize_namespace
  @store = Rails.cache.store
  namespace = @store.namespace

  if namespace
    namespace = "#{SecureRandom.hex(6)}r:" + namespace.split("r:")[-1]
  else
    namespace = SecureRandom.hex(6)
  end

  @store.namespace = namespace
end
````
