### PR TITLE
Optimize Active Job argument serialization by ~5x

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `ActiveJob::Serializers::ObjectSerializers#klass` method is now public.
+
+    Custom Active Job serializers must have a public `#klass` method too.
+    The returned class will be index allowing for faster serialization.
+
+    *Jean Boussier*
+
 *   Allow jobs to the interrupted and resumed with Continuations
 
     A job can use Continuations by including the `ActiveJob::Continuable`

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -31,8 +31,48 @@ module ActiveJob
     # serialized without mutation are returned as-is. Arrays/Hashes are
     # serialized element by element. All other types are serialized using
     # GlobalID.
-    def serialize(arguments)
-      arguments.map { |argument| serialize_argument(argument) }
+    def serialize(argument)
+      case argument
+      when nil, true, false, Integer, Float # Types that can hardly be subclassed
+        argument
+      when String
+        if argument.class == String
+          argument
+        else
+          begin
+            Serializers.serialize(argument)
+          rescue SerializationError
+            argument
+          end
+        end
+      when Symbol
+        { OBJECT_SERIALIZER_KEY => "ActiveJob::Serializers::SymbolSerializer", "value" => argument.name }
+      when GlobalID::Identification
+        convert_to_global_id_hash(argument)
+      when Array
+        argument.map { |arg| serialize(arg) }
+      when ActiveSupport::HashWithIndifferentAccess
+        serialize_indifferent_hash(argument)
+      when Hash
+        symbol_keys = argument.keys
+        symbol_keys.select! { |k| k.is_a?(Symbol) }
+        symbol_keys.map!(&:name)
+
+        aj_hash_key = if Hash.ruby2_keywords_hash?(argument)
+          RUBY2_KEYWORDS_KEY
+        else
+          SYMBOL_KEYS_KEY
+        end
+        result = serialize_hash(argument)
+        result[aj_hash_key] = symbol_keys
+        result
+      else
+        if argument.respond_to?(:permitted?) && argument.respond_to?(:to_h)
+          serialize_indifferent_hash(argument.to_h)
+        else
+          Serializers.serialize(argument)
+        end
+      end
     end
 
     # Deserializes a set of arguments. Intrinsic types that can safely be
@@ -68,50 +108,6 @@ module ActiveJob
       private_constant :RESERVED_KEYS, :GLOBALID_KEY,
         :SYMBOL_KEYS_KEY, :RUBY2_KEYWORDS_KEY, :WITH_INDIFFERENT_ACCESS_KEY
 
-      def serialize_argument(argument)
-        case argument
-        when nil, true, false, Integer, Float # Types that can hardly be subclassed
-          argument
-        when String
-          if argument.class == String
-            argument
-          else
-            begin
-              Serializers.serialize(argument)
-            rescue SerializationError
-              argument
-            end
-          end
-        when Symbol
-          { OBJECT_SERIALIZER_KEY => "ActiveJob::Serializers::SymbolSerializer", "value" => argument.name }
-        when GlobalID::Identification
-          convert_to_global_id_hash(argument)
-        when Array
-          argument.map { |arg| serialize_argument(arg) }
-        when ActiveSupport::HashWithIndifferentAccess
-          serialize_indifferent_hash(argument)
-        when Hash
-          symbol_keys = argument.keys
-          symbol_keys.select! { |k| k.is_a?(Symbol) }
-          symbol_keys.map!(&:name)
-
-          aj_hash_key = if Hash.ruby2_keywords_hash?(argument)
-            RUBY2_KEYWORDS_KEY
-          else
-            SYMBOL_KEYS_KEY
-          end
-          result = serialize_hash(argument)
-          result[aj_hash_key] = symbol_keys
-          result
-        else
-          if argument.respond_to?(:permitted?) && argument.respond_to?(:to_h)
-            serialize_indifferent_hash(argument.to_h)
-          else
-            Serializers.serialize(argument)
-          end
-        end
-      end
-
       def deserialize_argument(argument)
         case argument
         when nil, true, false, String, Integer, Float
@@ -145,7 +141,7 @@ module ActiveJob
 
       def serialize_hash(argument)
         argument.each_with_object({}) do |(key, value), hash|
-          hash[serialize_hash_key(key)] = serialize_argument(value)
+          hash[serialize_hash_key(key)] = serialize(value)
         end
       end
 

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -67,11 +67,7 @@ module ActiveJob
         result[aj_hash_key] = symbol_keys
         result
       else
-        if argument.respond_to?(:permitted?) && argument.respond_to?(:to_h)
-          serialize_indifferent_hash(argument.to_h)
-        else
-          Serializers.serialize(argument)
-        end
+        Serializers.serialize(argument)
       end
     end
 

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -82,6 +82,8 @@ module ActiveJob
               argument
             end
           end
+        when Symbol
+          { OBJECT_SERIALIZER_KEY => "ActiveJob::Serializers::SymbolSerializer", "value" => argument.name }
         when GlobalID::Identification
           convert_to_global_id_hash(argument)
         when Array

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -52,6 +52,14 @@ module ActiveJob
       end
     end
 
+    initializer "active_job.action_controller_parameters" do |app|
+      ActiveSupport.on_load(:active_job) do
+        ActiveSupport.on_load(:action_controller) do
+          ActiveJob::Serializers.add_serializers ActiveJob::Serializers::ActionControllerParametersSerializer
+        end
+      end
+    end
+
     initializer "active_job.set_configs" do |app|
       options = app.config.active_job
       options.queue_adapter ||= (Rails.env.test? ? :test : :async)

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -19,6 +19,7 @@ module ActiveJob
     autoload :ModuleSerializer
     autoload :RangeSerializer
     autoload :BigDecimalSerializer
+    autoload :ActionControllerParametersSerializer
 
     @serializers = Set.new
     @serializers_index = {}
@@ -57,6 +58,14 @@ module ActiveJob
       # Adds new serializers to a list of known serializers.
       def add_serializers(*new_serializers)
         new_serializers = new_serializers.flatten
+        new_serializers.map! do |s|
+          if s.is_a?(Class) && s < ObjectSerializer
+            s.instance
+          else
+            s
+          end
+        end
+
         @serializers += new_serializers
         index_serializers
         @serializers

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -20,15 +20,15 @@ module ActiveJob
     autoload :RangeSerializer
     autoload :BigDecimalSerializer
 
-    mattr_accessor :_additional_serializers
-    self._additional_serializers = Set.new
+    @serializers = Set.new
+    @serializers_index = {}
 
     class << self
       # Returns serialized representative of the passed object.
       # Will look up through all known serializers.
       # Raises ActiveJob::SerializationError if it can't find a proper serializer.
       def serialize(argument)
-        serializer = serializers.detect { |s| s.serialize?(argument) }
+        serializer = @serializers_index[argument.class] || serializers.find { |s| s.serialize?(argument) }
         raise SerializationError.new("Unsupported argument type: #{argument.class.name}") unless serializer
         serializer.serialize(argument)
       end
@@ -47,24 +47,45 @@ module ActiveJob
       end
 
       # Returns list of known serializers.
-      def serializers
-        self._additional_serializers
+      attr_reader :serializers
+
+      def serializers=(serializers)
+        @serializers = serializers
+        index_serializers
       end
 
       # Adds new serializers to a list of known serializers.
       def add_serializers(*new_serializers)
-        self._additional_serializers += new_serializers.flatten
+        new_serializers = new_serializers.flatten
+        @serializers += new_serializers
+        index_serializers
+        @serializers
       end
+
+      private
+        def index_serializers
+          @serializers_index.clear
+          serializers.each do |s|
+            if s.respond_to?(:klass)
+              @serializers_index[s.klass] = s
+            elsif s.respond_to?(:klass, true)
+              ActiveJob.deprecator.warn(<<~MSG.squish)
+                #{s.klass.name}#klass method should be public.
+              MSG
+              @serializers_index[s.send(:klass)] = s
+            end
+          end
+        end
     end
 
-    add_serializers SymbolSerializer,
-      DurationSerializer,
-      DateTimeSerializer,
-      DateSerializer,
-      TimeWithZoneSerializer,
-      TimeSerializer,
-      ModuleSerializer,
-      RangeSerializer,
-      BigDecimalSerializer
+    add_serializers SymbolSerializer.instance,
+      DurationSerializer.instance,
+      DateTimeSerializer.instance,
+      DateSerializer.instance,
+      TimeWithZoneSerializer.instance,
+      TimeSerializer.instance,
+      ModuleSerializer.instance,
+      RangeSerializer.instance,
+      BigDecimalSerializer.instance
   end
 end

--- a/activejob/lib/active_job/serializers/action_controller_parameters_serializer.rb
+++ b/activejob/lib/active_job/serializers/action_controller_parameters_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class ActionControllerParametersSerializer < ObjectSerializer
+      def serialize(argument)
+        Arguments.serialize(argument.to_h.with_indifferent_access)
+      end
+
+      def deserialize(hash)
+        raise NotImplementedError # Serialized as a HashWithIndifferentAccess
+      end
+
+      def serialize?(argument)
+        argument.respond_to?(:permitted?) && argument.respond_to?(:to_h)
+      end
+
+      def klass
+        if defined?(ActionController::Parameters)
+          ActionController::Parameters
+        end
+      end
+    end
+  end
+end

--- a/activejob/lib/active_job/serializers/big_decimal_serializer.rb
+++ b/activejob/lib/active_job/serializers/big_decimal_serializer.rb
@@ -13,10 +13,9 @@ module ActiveJob
         BigDecimal(hash["value"])
       end
 
-      private
-        def klass
-          BigDecimal
-        end
+      def klass
+        BigDecimal
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/date_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_serializer.rb
@@ -11,10 +11,9 @@ module ActiveJob
         Date.iso8601(hash["value"])
       end
 
-      private
-        def klass
-          Date
-        end
+      def klass
+        Date
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/date_time_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_time_serializer.rb
@@ -7,10 +7,9 @@ module ActiveJob
         DateTime.iso8601(hash["value"])
       end
 
-      private
-        def klass
-          DateTime
-        end
+      def klass
+        DateTime
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/duration_serializer.rb
+++ b/activejob/lib/active_job/serializers/duration_serializer.rb
@@ -6,12 +6,12 @@ module ActiveJob
       def serialize(duration)
         # Ideally duration.parts would be wrapped in an array before passing to Arguments.serialize,
         # but we continue passing the bare hash for backwards compatibility:
-        super("value" => duration.value, "parts" => Arguments.serialize(duration.parts))
+        super("value" => duration.value, "parts" => Arguments.serialize(duration.parts.to_a))
       end
 
       def deserialize(hash)
         value = hash["value"]
-        parts = Arguments.deserialize(hash["parts"])
+        parts = Arguments.deserialize(hash["parts"].to_h)
         # `parts` is originally a hash, but will have been flattened to an array by Arguments.serialize
         klass.new(value, parts.to_h)
       end

--- a/activejob/lib/active_job/serializers/duration_serializer.rb
+++ b/activejob/lib/active_job/serializers/duration_serializer.rb
@@ -16,10 +16,9 @@ module ActiveJob
         klass.new(value, parts.to_h)
       end
 
-      private
-        def klass
-          ActiveSupport::Duration
-        end
+      def klass
+        ActiveSupport::Duration
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/module_serializer.rb
+++ b/activejob/lib/active_job/serializers/module_serializer.rb
@@ -12,10 +12,9 @@ module ActiveJob
         hash["value"].constantize
       end
 
-      private
-        def klass
-          Module
-        end
+      def klass
+        Module
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -17,11 +17,9 @@ module ActiveJob
     #       Money.new(hash["amount"], hash["currency"])
     #     end
     #
-    #     private
-    #
-    #       def klass
-    #         Money
-    #       end
+    #     def klass
+    #       Money
+    #     end
     #   end
     class ObjectSerializer
       include Singleton
@@ -41,15 +39,14 @@ module ActiveJob
       end
 
       # Deserializes an argument from a JSON primitive type.
-      def deserialize(json)
-        raise NotImplementedError
+      def deserialize(hash)
+        raise NotImplementedError, "#{self.class.name} should implement a public #deserialize(hash) method"
       end
 
-      private
-        # The class of the object that will be serialized.
-        def klass # :doc:
-          raise NotImplementedError
-        end
+      # The class of the object that will be serialized.
+      def klass
+        raise NotImplementedError, "#{self.class.name} should implement a public #klass method"
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -35,7 +35,8 @@ module ActiveJob
 
       # Serializes an argument to a JSON primitive type.
       def serialize(hash)
-        { Arguments::OBJECT_SERIALIZER_KEY => self.class.name }.merge!(hash)
+        hash[Arguments::OBJECT_SERIALIZER_KEY] = self.class.name
+        hash
       end
 
       # Deserializes an argument from a JSON primitive type.

--- a/activejob/lib/active_job/serializers/range_serializer.rb
+++ b/activejob/lib/active_job/serializers/range_serializer.rb
@@ -14,10 +14,9 @@ module ActiveJob
         klass.new(*Arguments.deserialize(hash.values_at(*KEYS)))
       end
 
-      private
-        def klass
-          ::Range
-        end
+      def klass
+        ::Range
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/range_serializer.rb
+++ b/activejob/lib/active_job/serializers/range_serializer.rb
@@ -3,15 +3,16 @@
 module ActiveJob
   module Serializers
     class RangeSerializer < ObjectSerializer
-      KEYS = %w[begin end exclude_end].freeze
-
       def serialize(range)
-        args = Arguments.serialize([range.begin, range.end, range.exclude_end?])
-        super(KEYS.zip(args).to_h)
+        super(
+          "begin" => Arguments.serialize(range.begin),
+          "end" => Arguments.serialize(range.end),
+          "exclude_end" => range.exclude_end?, # Always boolean, no need to serialize
+        )
       end
 
       def deserialize(hash)
-        klass.new(*Arguments.deserialize(hash.values_at(*KEYS)))
+        Range.new(*Arguments.deserialize([hash["begin"], hash["end"]]), hash["exclude_end"])
       end
 
       def klass

--- a/activejob/lib/active_job/serializers/symbol_serializer.rb
+++ b/activejob/lib/active_job/serializers/symbol_serializer.rb
@@ -11,10 +11,9 @@ module ActiveJob
         argument["value"].to_sym
       end
 
-      private
-        def klass
-          Symbol
-        end
+      def klass
+        Symbol
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/time_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_serializer.rb
@@ -7,10 +7,9 @@ module ActiveJob
         Time.iso8601(hash["value"])
       end
 
-      private
-        def klass
-          Time
-        end
+      def klass
+        Time
+      end
     end
   end
 end

--- a/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -16,10 +16,9 @@ module ActiveJob
         Time.iso8601(hash["value"]).in_time_zone(hash["time_zone"] || Time.zone)
       end
 
-      private
-        def klass
-          ActiveSupport::TimeWithZone
-        end
+      def klass
+        ActiveSupport::TimeWithZone
+      end
     end
   end
 end

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -45,6 +45,11 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
 
   setup do
     @person = Person.find("5")
+    @original_serializers = ActiveJob::Serializers.serializers
+  end
+
+  teardown do
+    ActiveJob::Serializers.serializers = @original_serializers
   end
 
   [ nil, 1, 1.0, 1_000_000_000_000_000_000_000,
@@ -109,6 +114,8 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   test "serialize a ActionController::Parameters" do
+    ActiveJob::Serializers.add_serializers ActiveJob::Serializers::ActionControllerParametersSerializer
+
     parameters = Parameters.new(a: 1)
 
     assert_equal(

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -35,10 +35,9 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
       MyString.new(hash["value"])
     end
 
-    private
-      def klass
-        MyString
-      end
+    def klass
+      MyString
+    end
   end
 
   class StringWithoutSerializer < String
@@ -133,7 +132,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_instance_of MyString, deserialized
     assert_equal my_string, deserialized
   ensure
-    ActiveJob::Serializers._additional_serializers = original_serializers
+    ActiveJob::Serializers.serializers = original_serializers
   end
 
   test "serialize a String subclass object without a serializer" do

--- a/activejob/test/cases/serializers_test.rb
+++ b/activejob/test/cases/serializers_test.rb
@@ -25,10 +25,9 @@ class SerializersTest < ActiveSupport::TestCase
       DummyValueObject.new(hash["value"])
     end
 
-    private
-      def klass
-        DummyValueObject
-      end
+    def klass
+      DummyValueObject
+    end
   end
 
   setup do
@@ -37,7 +36,7 @@ class SerializersTest < ActiveSupport::TestCase
   end
 
   teardown do
-    ActiveJob::Serializers._additional_serializers = @original_serializers
+    ActiveJob::Serializers.serializers = @original_serializers
   end
 
   test "can't serialize unknown object" do
@@ -85,7 +84,7 @@ class SerializersTest < ActiveSupport::TestCase
 
   test "adds new serializer" do
     ActiveJob::Serializers.add_serializers DummySerializer
-    assert ActiveJob::Serializers.serializers.include?(DummySerializer)
+    assert ActiveJob::Serializers.serializers.include?(DummySerializer.instance)
   end
 
   test "can't add serializer with the same key twice" do

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -49,9 +49,15 @@ module ActiveSupport
     attr_reader :time_zone
 
     def initialize(utc_time, time_zone, local_time = nil, period = nil)
-      @utc = utc_time ? transfer_time_values_to_utc_constructor(utc_time) : nil
       @time_zone, @time = time_zone, local_time
-      @period = @utc ? period : get_period_and_ensure_valid_local_time(period)
+      if utc_time
+        @utc = transfer_time_values_to_utc_constructor(utc_time)
+        @period = period
+      else
+        @utc = nil
+        @period = get_period_and_ensure_valid_local_time(period)
+      end
+      @is_utc = zone == "UTC" || zone == "UCT"
     end
 
     # Returns a <tt>Time</tt> instance that represents the time in +time_zone+.
@@ -103,7 +109,7 @@ module ActiveSupport
     #   Time.zone = 'Eastern Time (US & Canada)'    # => 'Eastern Time (US & Canada)'
     #   Time.zone.now.utc?                          # => false
     def utc?
-      zone == "UTC" || zone == "UCT"
+      @is_utc
     end
     alias_method :gmt?, :utc?
 
@@ -146,7 +152,13 @@ module ActiveSupport
     #
     #   Time.zone.now.xmlschema  # => "2014-12-04T11:02:37-05:00"
     def xmlschema(fraction_digits = 0)
-      "#{time.strftime(PRECISIONS[fraction_digits.to_i])}#{formatted_offset(true, 'Z')}"
+      if @is_utc
+        utc.iso8601(fraction_digits || 0)
+      else
+        str = time.iso8601(fraction_digits || 0)
+        str[-1] = formatted_offset(true, "Z")
+        str
+      end
     end
     alias_method :iso8601, :xmlschema
     alias_method :rfc3339, :xmlschema
@@ -560,7 +572,9 @@ module ActiveSupport
       SECONDS_PER_DAY = 86400
 
       def incorporate_utc_offset(time, offset)
-        if time.kind_of?(Date)
+        if offset.zero?
+          time
+        elsif time.kind_of?(Date)
           time + Rational(offset, SECONDS_PER_DAY)
         else
           time + offset

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -736,12 +736,6 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal 500000000, twz.nsec
   end
 
-  def test_utc_to_local_conversion_saves_period_in_instance_variable
-    assert_nil @twz.instance_variable_get("@period")
-    @twz.time
-    assert_kind_of TZInfo::TimezonePeriod, @twz.instance_variable_get("@period")
-  end
-
   def test_instance_created_with_local_time_returns_correct_utc_time
     twz = ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(1999, 12, 31, 19))
     assert_equal Time.utc(2000), twz.utc

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3238,7 +3238,11 @@ module ApplicationTests
     end
 
     test "custom serializers should be able to set via config.active_job.custom_serializers in an initializer" do
-      class ::DummySerializer < ActiveJob::Serializers::ObjectSerializer; end
+      class ::DummySerializer < ActiveJob::Serializers::ObjectSerializer
+        def klass
+          nil
+        end
+      end
 
       app_file "config/initializers/custom_serializers.rb", <<-RUBY
       Rails.application.config.active_job.custom_serializers << DummySerializer
@@ -3246,7 +3250,7 @@ module ApplicationTests
 
       app "development"
 
-      assert_includes ActiveJob::Serializers.serializers, DummySerializer
+      assert_includes ActiveJob::Serializers.serializers, DummySerializer.instance
     end
 
     test "config.active_job.verbose_enqueue_logs defaults to true in development" do


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/55579 (FYI @camertron)

See individual commits for details.

Overall gains (benchmark source is in the first commit)

```
ruby 3.5.0dev (2025-08-27T10:41:07Z master 5257e1298c) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
opt-aj-serialize-index
                        26.282k i/100ms
Calculating -------------------------------------
opt-aj-serialize-index
                        268.003k (± 1.0%) i/s    (3.73 μs/i) -      1.340M in   5.001883s

Comparison:
                  main:    52026.7 i/s
opt-aj-serialize-index:   268003.4 i/s - 5.15x  faster
```

The benchmark is taken from https://github.com/rails/rails/pull/55579. I'm not convinced it's particularly representative of job arguments payloads out there, but it does test a wide range of serializers.

Some stones left unturned:

  - `DateTime` objects are serialized with `TimeSerializer` calling `DateTime#xmlschema` and somehow this is way slower than `Time#xmlschema`. `DateTime` objects are somewhat deprecated, but could be worth checking what's up.
  - The format itself is very inefficient, as discussed with @Earlopain in https://github.com/rails/rails/pull/55544, things like `_aj_symbol_keys` being an array of string is a waste if we assume most hash either have all or none of their keys are symbol. However this requires a schema change, so is a bit out of scope of this PR.
  - The `_aj_serialized` values being fully qualified class name is very wasteful. At least for the builtin ones we should have smaller names. The benchmark payload is `1.35kB` once serialized in JSON, that's a bit ridiculous. It could be shinked by 25% just by removing the namespace part from the serializers, or `~30%` by also using shorter keys.
