### PR TITLE
Simplify limit validation, move to call time

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Move `LIMIT` validation from query generation to when `limit()` is called.
+
+    *Hartley McGuire*, *Shuyang*
+
 *   Add `ActiveRecord::CheckViolation` error class for check constraint violations.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -53,7 +53,7 @@ module ActiveRecord
               end
             end
 
-            arel = scope.arel(aliases: alias_tracker.aliases)
+            arel = scope.arel(alias_tracker.aliases)
             nodes = arel.constraints.first
 
             if nodes.is_a?(Arel::Nodes::And)

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -502,20 +502,6 @@ module ActiveRecord
         "DEFAULT VALUES"
       end
 
-      # Sanitizes the given LIMIT parameter in order to prevent SQL injection.
-      #
-      # The +limit+ may be anything that can evaluate to a string via #to_s. It
-      # should look like an integer, or an Arel SQL literal.
-      #
-      # Returns Integer and Arel::Nodes::SqlLiteral limits as is.
-      def sanitize_limit(limit)
-        if limit.is_a?(Integer) || limit.is_a?(Arel::Nodes::SqlLiteral)
-          limit
-        else
-          Integer(limit)
-        end
-      end
-
       # Fixture value is quoted by Arel, however scalar values
       # are not quotable. In this case we want to convert
       # the column value to YAML.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -625,7 +625,7 @@ module ActiveRecord
       end
 
       model.with_connection do |c|
-        arel = eager_loading? ? apply_join_dependency.arel : arel(c)
+        arel = eager_loading? ? apply_join_dependency.arel : arel()
         arel.source.left = table
 
         key = if model.composite_primary_key?
@@ -1040,7 +1040,7 @@ module ActiveRecord
       end
 
       model.with_connection do |c|
-        arel = eager_loading? ? apply_join_dependency.arel : arel(c)
+        arel = eager_loading? ? apply_join_dependency.arel : arel()
         arel.source.left = table
 
         key = if model.composite_primary_key?
@@ -1233,7 +1233,7 @@ module ActiveRecord
         end
       else
         model.with_connection do |conn|
-          conn.unprepared_statement { conn.to_sql(arel(conn)) }
+          conn.unprepared_statement { conn.to_sql(arel) }
         end
       end
     end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1592,12 +1592,8 @@ module ActiveRecord
     end
 
     # Returns the Arel object associated with the relation.
-    def arel(conn = nil, aliases: nil) # :nodoc:
-      @arel ||= if conn
-        build_arel(conn, aliases)
-      else
-        with_connection { |c| build_arel(c, aliases) }
-      end
+    def arel(aliases = nil) # :nodoc:
+      @arel ||= build_arel(aliases)
     end
 
     def construct_join_dependency(associations, join_type) # :nodoc:
@@ -1751,7 +1747,7 @@ module ActiveRecord
         raise UnmodifiableRelation if @loaded || @arel
       end
 
-      def build_arel(connection, aliases = nil)
+      def build_arel(aliases)
         arel = Arel::SelectManager.new(table)
 
         build_joins(arel.join_sources, aliases)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1213,6 +1213,7 @@ module ActiveRecord
     end
 
     def limit!(value) # :nodoc:
+      value = Integer(value) unless value.nil?
       self.limit_value = value
       self
     end
@@ -1757,7 +1758,7 @@ module ActiveRecord
 
         arel.where(where_clause.ast) unless where_clause.empty?
         arel.having(having_clause.ast) unless having_clause.empty?
-        arel.take(build_cast_value("LIMIT", connection.sanitize_limit(limit_value))) if limit_value
+        arel.take(build_cast_value("LIMIT", limit_value)) if limit_value
         arel.skip(build_cast_value("OFFSET", offset_value.to_i)) if offset_value
         arel.group(*arel_columns(group_values)) unless group_values.empty?
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -192,19 +192,19 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_invalid_limit
     assert_raises(ArgumentError) do
-      Topic.limit("asdfadf").to_a
+      Topic.limit("asdfadf")
     end
   end
 
   def test_limit_should_sanitize_sql_injection_for_limit_without_commas
     assert_raises(ArgumentError) do
-      Topic.limit("1 select * from schema").to_a
+      Topic.limit("1 select * from schema")
     end
   end
 
   def test_limit_should_sanitize_sql_injection_for_limit_with_commas
     assert_raises(ArgumentError) do
-      Topic.limit("1, 7 procedure help()").to_a
+      Topic.limit("1, 7 procedure help()")
     end
   end
 

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -52,7 +52,12 @@ module ActiveRecord
       assert_equal [], relation.extending_values
     end
 
-    (Relation::SINGLE_VALUE_METHODS - [:lock, :reordering, :reverse_order, :create_with, :skip_query_cache, :strict_loading]).each do |method|
+    test "#limit!" do
+      assert relation.limit!(5).equal?(relation)
+      assert_equal 5, relation.limit_value
+    end
+
+    (Relation::SINGLE_VALUE_METHODS - [:limit, :lock, :reordering, :reverse_order, :create_with, :skip_query_cache, :strict_loading]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal :foo, relation.public_send("#{method}_value")


### PR DESCRIPTION
Fixes #44489
Closes #44699 

Previously, limit values were validated while building the Arel tree,
which can make it difficult to find the source of an invalid limit.

This commit moves the validation to `limit!` (where its actually set) so
that developers can more easily find the source of an invalid limit.

This also has the additional benefit of removing the need for a
connection in `build_arel` (which will be removed in a followup commit).

`sanitize_limit` currently ensures that limit values are either a
SqlLiteral or coerceable to an Integer. However, limits [use bind
params][1] and so end up quoted when compiled into queries:

```ruby
Topic.limit(Arel.sql("1, 1")).to_sql
# => SELECT "topics".* FROM "topics" LIMIT '1, 1'
```

Since SqlLiterals are quoted, you can actually only use SqlLiterals that
end up being a single value anyways (eg. `Arel.sql("1")`). Therefore,
instead of just inlining sanitize_limit into `limit!` it can be replaced
with a simple `Integer()` wrapper.

[1]: https://github.com/rails/rails/commit/574f255629a45cd67babcfb9bb8e163e091a53b8

---

[Remove unused connection arg from {build_,}arel](https://github.com/rails/rails/commit/ed6a2d76580bb5151e6591dd4a0de8ee4ec15419)

Partially revert https://github.com/rails/rails/commit/6ff9e82e4774d494298d6bfca2ceebe92aec64a1 because the
argument is no longer used. Since `aliases` is the only argument again,
I changed it back to be positional (which is what it was before the
connection argument was added in mentioned commit).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
