### PR TITLE
Add retryable option to Arel.sql with bind parameter support

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add retryable option to `Arel.sql` with bind parameter support.
+
+    ```ruby
+    User.where(Arel.sql('name LIKE ?', search_term, retryable: true))
+    Post.where(Arel.sql('id = :id', retryable: true), { id: 1 })
+    ```
+
+    *euglena1215*
+
 *   Add replicas to test database parallelization setup.
 
     Setup and configuration of databases for parallel testing now includes replicas.

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -55,7 +55,7 @@ module Arel
     elsif positional_binds.empty? && named_binds.empty?
       Arel::Nodes::SqlLiteral.new(sql_string, retryable: retryable)
     else
-      Arel::Nodes::BoundSqlLiteral.new sql_string, positional_binds, named_binds
+      Arel::Nodes::BoundSqlLiteral.new sql_string, positional_binds, named_binds, retryable: retryable
     end
   end
 

--- a/activerecord/lib/arel/nodes/bound_sql_literal.rb
+++ b/activerecord/lib/arel/nodes/bound_sql_literal.rb
@@ -3,9 +3,9 @@
 module Arel # :nodoc: all
   module Nodes
     class BoundSqlLiteral < NodeExpression
-      attr_reader :sql_with_placeholders, :positional_binds, :named_binds
+      attr_reader :sql_with_placeholders, :positional_binds, :named_binds, :retryable
 
-      def initialize(sql_with_placeholders, positional_binds, named_binds)
+      def initialize(sql_with_placeholders, positional_binds, named_binds, retryable: false)
         has_positional = !(positional_binds.nil? || positional_binds.empty?)
         has_named = !(named_binds.nil? || named_binds.empty?)
 
@@ -30,6 +30,7 @@ module Arel # :nodoc: all
         end
 
         @sql_with_placeholders = sql_with_placeholders
+        @retryable = retryable
         if has_positional
           @positional_binds = positional_binds
           @named_binds = nil

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -758,7 +758,7 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_BoundSqlLiteral(o, collector)
-          collector.retryable = false
+          collector.retryable &&= o.retryable
           bind_index = 0
 
           new_bind = lambda do |value|

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -724,6 +724,8 @@ module ActiveRecord
           assert (a = Author.first)
           assert Post.where(id: [1, 2]).first
           assert Post.where(Arel.sql("id IN (1,2)", retryable: true)).first
+          assert Post.where(Arel.sql("id > ?", 0, retryable: true)).first
+          assert Post.where(Arel.sql("id = :id", retryable: true), { id: 1 }).first
           assert Post.find(1)
           assert Post.find_by(title: "Welcome to the weblog")
           assert_predicate Post, :exists?
@@ -732,7 +734,7 @@ module ActiveRecord
           Author.group(:name).count
         end.select { |n| n.payload[:name] != "SCHEMA" }
 
-        assert_equal 9, notifications.length
+        assert_equal 11, notifications.length
 
         notifications.each do |n|
           assert n.payload[:allow_retry], "#{n.payload[:sql]} was not retryable"
@@ -746,6 +748,8 @@ module ActiveRecord
           assert_not_nil (a = Author.first)
           assert_not_nil Post.where(id: [1, 2]).first
           assert Post.where(Arel.sql("id IN (1,2)", retryable: true)).first
+          assert Post.where(Arel.sql("id > ?", 0, retryable: true)).first
+          assert Post.where(Arel.sql("id = :id", retryable: true), { id: 1 }).first
           assert_not_nil Post.find(1)
           assert_not_nil Post.find_by(title: "Welcome to the weblog")
           assert_predicate Post, :exists?
@@ -754,7 +758,7 @@ module ActiveRecord
           Author.group(:name).count
         end.select { |n| n.payload[:name] != "SCHEMA" }
 
-        assert_equal 9, notifications.length
+        assert_equal 11, notifications.length
 
         notifications.each do |n|
           assert n.payload[:allow_retry], "#{n.payload[:sql]} was not retryable"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In our Rails 7 application, we occasionally encountered transient `ConnectionFailed` errors during database migrations and queries. When Rails 8 introduced the `allow_retry` functionality, we upgraded expecting it to resolve these issues.

After upgrading to Rails 8, we did see a reduction in connection errors. However, we still encountered `ConnectionFailed` errors in queries that use bind parameters, such as `where("name LIKE ?", "%foo%")`.
These parameterized queries were not benefiting from the retry mechanism because they couldn't be marked as retryable.

This PR extends the retryable functionality introduced in #54951 by adding support for bind parameters in `Arel.sql`. Now developers can create retryable bound SQL literals for parameterized queries:

```ruby
# Before: Not retryable
User.where("name LIKE ?", search_term)

# After: Retryable with bind parameters
User.where(Arel.sql('name LIKE ?', search_term, retryable: true))
```

This enhancement allows our application (and others facing similar connection stability issues) to leverage the retry mechanism for a broader range of queries, leading to improved database connection resilience.

### Detail

This builds upon the retryable SqlLiteral support introduced in #54951 by extending Arel.sql to accept a retryable option with bind parameters. Previously, only plain SqlLiterals could be marked as retryable, but now developers can create retryable bound SQL literals for parameterized queries.

The retryable option works with both positional (?) and named (:name) bind parameters and integrates with ActiveRecord's existing retry infrastructure.

Example usage:

```rb
User.where(Arel.sql('name LIKE ?', search_term, retryable: true))
Post.where(Arel.sql('id = :id', retryable: true), { id: 1 })
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
