### PR TITLE
Fix typo and improve grammar in Erubi Template Handler comment

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -18,7 +18,7 @@ module ActionView
             properties[:preamble]   ||= ""
             properties[:postamble]  ||= "#{properties[:bufvar]}"
 
-            # Tell Eruby that whether template will be compiled with `frozen_string_literal: true`
+            # Tell Erubi whether the template will be compiled with `frozen_string_literal: true`
             properties[:freeze_template_literals] = !Template.frozen_string_literal
 
             properties[:escapefunc] = ""


### PR DESCRIPTION
### Motivation / Background

This pull request fixes a typo in `actionview/lib/action_view/template/handlers/erb/erubi.rb` I noticed while reading the source. It also slightly improves the flow of the comment so it reads more naturally.

### Detail

\-

### Additional information

\-

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.