### PR TITLE
Remove TableMetadata -> Reflection delegation

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -99,24 +99,26 @@ module ActiveRecord
           elsif value.is_a?(Hash) && !table.has_column?(key)
             table.associated_table(key, &block)
               .predicate_builder.expand_from_hash(value.stringify_keys)
-          elsif table.associated_with?(key)
+          elsif (associated_reflection = table.associated_with?(key))
             # Find the foreign key when using queries such as:
             # Post.where(author: author)
             #
             # For polymorphic relationships, find the foreign key and type:
             # PriceEstimate.where(estimate_of: treasure)
-            associated_table = table.associated_table(key)
-            if associated_table.polymorphic_association?
+
+            if associated_reflection.polymorphic?
               value = [value] unless value.is_a?(Array)
               klass = PolymorphicArrayValue
-            elsif associated_table.through_association?
+            elsif associated_reflection.through_reflection?
+              associated_table = table.associated_table(key)
+
               next associated_table.predicate_builder.expand_from_hash(
                 associated_table.primary_key => value
               )
             end
 
             klass ||= AssociationQueryValue
-            queries = klass.new(associated_table, value).queries.map! do |query|
+            queries = klass.new(associated_reflection, value).queries.map! do |query|
               # If the query produced is identical to attributes don't go any deeper.
               # Prevents stack level too deep errors when association and foreign_key are identical.
               query == attributes ? self[key, value] : expand_from_hash(query)

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -3,24 +3,24 @@
 module ActiveRecord
   class PredicateBuilder
     class AssociationQueryValue # :nodoc:
-      def initialize(associated_table, value)
-        @associated_table = associated_table
+      def initialize(reflection, value)
+        @reflection = reflection
         @value = value
       end
 
       def queries
-        if associated_table.join_foreign_key.is_a?(Array)
+        if reflection.join_foreign_key.is_a?(Array)
           id_list = ids
           id_list = id_list.pluck(primary_key) if id_list.is_a?(Relation)
 
-          id_list.map { |ids_set| associated_table.join_foreign_key.zip(ids_set).to_h }
+          id_list.map { |ids_set| reflection.join_foreign_key.zip(ids_set).to_h }
         else
-          [ associated_table.join_foreign_key => ids ]
+          [ reflection.join_foreign_key => ids ]
         end
       end
 
       private
-        attr_reader :associated_table, :value
+        attr_reader :reflection, :value
 
         def ids
           case value
@@ -37,15 +37,15 @@ module ActiveRecord
         end
 
         def primary_key
-          associated_table.join_primary_key
+          reflection.join_primary_key
         end
 
         def primary_type
-          associated_table.join_primary_type
+          reflection.join_primary_type
         end
 
         def polymorphic_name
-          associated_table.polymorphic_name_association
+          reflection.polymorphic_name
         end
 
         def select_clause?

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -3,24 +3,24 @@
 module ActiveRecord
   class PredicateBuilder
     class PolymorphicArrayValue # :nodoc:
-      def initialize(associated_table, values)
-        @associated_table = associated_table
+      def initialize(reflection, values)
+        @reflection = reflection
         @values = values
       end
 
       def queries
-        return [ associated_table.join_foreign_key => values ] if values.empty?
+        return [ reflection.join_foreign_key => values ] if values.empty?
 
         type_to_ids_mapping.map do |type, ids|
           query = {}
-          query[associated_table.join_foreign_type] = type if type
-          query[associated_table.join_foreign_key] = ids
+          query[reflection.join_foreign_type] = type if type
+          query[reflection.join_foreign_key] = ids
           query
         end
       end
 
       private
-        attr_reader :associated_table, :values
+        attr_reader :reflection, :values
 
         def type_to_ids_mapping
           default_hash = Hash.new { |hsh, key| hsh[key] = [] }
@@ -30,7 +30,7 @@ module ActiveRecord
         end
 
         def primary_key(value)
-          associated_table.join_primary_key(klass(value))
+          reflection.join_primary_key(klass(value))
         end
 
         def klass(value)

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -2,12 +2,9 @@
 
 module ActiveRecord
   class TableMetadata # :nodoc:
-    delegate :join_primary_key, :join_primary_type, :join_foreign_key, :join_foreign_type, to: :reflection
-
-    def initialize(klass, arel_table, reflection = nil)
+    def initialize(klass, arel_table)
       @klass = klass
       @arel_table = arel_table
-      @reflection = reflection
     end
 
     def primary_key
@@ -42,24 +39,12 @@ module ActiveRecord
       if association_klass
         arel_table = association_klass.arel_table
         arel_table = arel_table.alias(table_name) if arel_table.name != table_name
-        TableMetadata.new(association_klass, arel_table, reflection)
+        TableMetadata.new(association_klass, arel_table)
       else
         type_caster = TypeCaster::Connection.new(klass, table_name)
         arel_table = Arel::Table.new(table_name, type_caster: type_caster)
-        TableMetadata.new(nil, arel_table, reflection)
+        TableMetadata.new(nil, arel_table)
       end
-    end
-
-    def polymorphic_association?
-      reflection&.polymorphic?
-    end
-
-    def polymorphic_name_association
-      reflection&.polymorphic_name
-    end
-
-    def through_association?
-      reflection&.through_reflection?
     end
 
     def reflect_on_aggregation(aggregation_name)
@@ -78,6 +63,6 @@ module ActiveRecord
     attr_reader :arel_table
 
     private
-      attr_reader :klass, :reflection
+      attr_reader :klass
   end
 end


### PR DESCRIPTION
The delegation is unnecessary since the reflection instance is already available where needed in the predicate builder.

Removing it simplifies TableMetadata (as well as the classes it was previously passed to only to delegate to a reflection), and prevents a TableMetadata allocation except when actually used (querying a through association).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
