### PR TITLE
Automatically isolate cache namespaces in tests

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Automatically isolate cache namespaces in tests.
+
+    Each test now automatically gets a unique cache namespace via `Rails.cache`
+    to prevent cache key collisions. This eliminates the need for manual cache clearing
+    in teardown blocks for cache stores that support namespaces. It also greatly helps
+    parallel tests working together.
+
+    *Nick Schwaderer*
+
 *   Add `ActiveSupport::Cache::Store#namespace=` and `#namespace`.
 
     Can be used as an alternative to `Store#clear` in some situations such as parallel

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -17,6 +17,7 @@ require "active_support/testing/file_fixtures"
 require "active_support/testing/parallelization"
 require "active_support/testing/parallelize_executor"
 require "active_support/testing/notification_assertions"
+require "active_support/testing/cache_isolation"
 require "concurrent/utility/processor_counter"
 
 module ActiveSupport
@@ -197,6 +198,7 @@ module ActiveSupport
     include ActiveSupport::Testing::TaggedLogging
     prepend ActiveSupport::Testing::SetupAndTeardown
     prepend ActiveSupport::Testing::TestsWithoutAssertions
+    prepend ActiveSupport::Testing::CacheIsolation
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::ErrorReporterAssertions
     include ActiveSupport::Testing::EventReporterAssertions

--- a/activesupport/lib/active_support/testing/cache_isolation.rb
+++ b/activesupport/lib/active_support/testing/cache_isolation.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module ActiveSupport
+  module Testing
+    # Cache Isolation
+    #
+    # Automatically randomizes cache namespaces for each test to ensure proper
+    # isolation. This prevents cache key collisions and removes the need for
+    # explicit cache clearing in teardown.
+    #
+    # This module is automatically included in ActiveSupport::TestCase.
+    module CacheIsolation
+      def self.prepended(klass)
+        klass.set_callback(:setup, :before, :isolate_cache_namespace)
+      end
+
+      private
+        def isolate_cache_namespace
+          return unless defined?(Rails) && Rails.respond_to?(:cache)
+
+          store = Rails.cache
+          return unless store.is_a?(ActiveSupport::Cache::Store)
+          return unless store.respond_to?(:namespace=)
+
+          original_namespace = store.namespace
+
+          isolated_namespace = if original_namespace
+            if original_namespace.include?("r:")
+              "#{SecureRandom.hex(6)}r:" + original_namespace.split("r:", 2)[-1]
+            else
+              "#{SecureRandom.hex(6)}r:#{original_namespace}"
+            end
+          else
+            "#{SecureRandom.hex(6)}r:"
+          end
+
+          store.namespace = isolated_namespace
+        end
+    end
+  end
+end

--- a/activesupport/test/cache/cache_isolation_test.rb
+++ b/activesupport/test/cache/cache_isolation_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/cache"
+require "active_support/testing/cache_isolation"
+
+# Mock Rails.cache for testing
+module Rails
+  class << self
+    attr_accessor :cache
+  end
+end
+
+class CacheIsolationTest < ActiveSupport::TestCase
+  def setup
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new(namespace: "test_app")
+    @original_namespace = Rails.cache.namespace
+  end
+
+  test "isolate_cache_namespace randomizes Rails.cache namespace" do
+    # Manually call the private method
+    send(:isolate_cache_namespace)
+
+    assert_not_equal @original_namespace, Rails.cache.namespace
+    assert_match(/^[a-f0-9]{12}r:test_app$/, Rails.cache.namespace)
+  end
+
+  test "multiple calls replace the random prefix" do
+    send(:isolate_cache_namespace)
+    first_namespace = Rails.cache.namespace
+
+    send(:isolate_cache_namespace)
+    second_namespace = Rails.cache.namespace
+
+    assert_not_equal first_namespace, second_namespace
+    assert first_namespace.end_with?("r:test_app")
+    assert second_namespace.end_with?("r:test_app")
+  end
+
+  test "isolation works with complex namespaces" do
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new(namespace: "app:v1:production")
+
+    send(:isolate_cache_namespace)
+
+    assert_match(/^[a-f0-9]{12}r:app:v1:production$/, Rails.cache.namespace)
+  end
+
+  test "isolation skips non-ActiveSupport cache stores" do
+    Rails.cache = Object.new
+    original = Rails.cache
+
+    send(:isolate_cache_namespace)
+
+    assert_equal original, Rails.cache
+  end
+
+  test "isolation skips cache stores without namespace support" do
+    mock_cache = Object.new
+    def mock_cache.is_a?(klass)
+      klass == ActiveSupport::Cache::Store
+    end
+    Rails.cache = mock_cache
+    original = Rails.cache
+
+    send(:isolate_cache_namespace)
+
+    assert_equal original, Rails.cache
+  end
+end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -566,7 +566,7 @@ class SetupAndTeardownTest < ActiveSupport::TestCase
   teardown :foo, :sentinel
 
   def test_inherited_setup_callbacks
-    assert_equal [:reset_callback_record, :foo], self.class._setup_callbacks.map(&:filter)
+    assert_equal [:isolate_cache_namespace, :reset_callback_record, :foo], self.class._setup_callbacks.map(&:filter)
     assert_equal [:foo], @called_back
     assert_equal [:foo, :sentinel], self.class._teardown_callbacks.map(&:filter)
   end
@@ -596,7 +596,7 @@ class SubclassSetupAndTeardownTest < SetupAndTeardownTest
   teardown :bar
 
   def test_inherited_setup_callbacks
-    assert_equal [:reset_callback_record, :foo, :bar], self.class._setup_callbacks.map(&:filter)
+    assert_equal [:isolate_cache_namespace, :reset_callback_record, :foo, :bar], self.class._setup_callbacks.map(&:filter)
     assert_equal [:foo, :bar], @called_back
     assert_equal [:foo, :sentinel, :bar], self.class._teardown_callbacks.map(&:filter)
   end


### PR DESCRIPTION
Fixes: #48341
Ref: #55580

This change helps parallel tests avoid collisions with a shared cache store. It also helps existing test suites by removing the need to run `Rails.cache.clear` in setup or teardown.

With an existing namespace, `puts`'ing out the value during tests with `Rails.cache.namespace` should look like:

```
# Running: 

3eaf68e053car:my-existing-namespace
.704a79c87589r:my-existing-namespace
.8a10fc7d6c2cr:my-existing-namespace
.299e8dbfec5dr:my-existing-namespace
```

Without an existing namespace, it should look like:

```
# Running: 

ab9e605d3e56r:
.860de9cd1f47r:
.c0074cd994aer:
.a440598e8420r:
```
