### PR TITLE
Fix instability of mounted_helpers in `ActionDispatch::IntegrationTest`

### DIFF
--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -238,6 +238,12 @@ module TestGenerationPrefix
       verify_redirect "http://www.example.com/foo"
     end
 
+    test "[ENGINE] mounted_helpers doesn't use SCRIPT_NAME from request" do
+      get "/pure-awesomeness/blog/posts/1"
+      assert_equal "/", root_path
+      assert_equal "/", main_app.root_path
+    end
+
     # Inside Application
     test "[APP] generating engine's route includes prefix" do
       get "/generate"


### PR DESCRIPTION
### Motivation / Background

When using `ActionDispatch::IntegrationTest` with a mounted Engine, the `main_app` helpers could become unstable and return different results depending on the last request.

For example, after accessing an Engine route, `main_app.root_path` unexpectedly changes:

```ruby
main_app.root_path #=> "/"
get "/mounted_engine/posts/1"
main_app.root_path #=> "/mounted_engine/"
```

### Detail

This issue was caused by `url_options[:script_name]`, which varied depending on the last request.

-  `ActionDispatch::IntegrationTest::Session#url_options` uses the `url_options` of the last accessed controller. [code](https://github.com/rails/rails/blob/d18731bed119911867d55983e07b2c853805d7d2/actionpack/lib/action_dispatch/testing/integration.rb#L142)
-  mounted_helpers works through a `RoutesProxy` that replaces `_routes` when generating URLs. [code](https://github.com/rails/rails/blob/d18731bed119911867d55983e07b2c853805d7d2/actionpack/lib/action_dispatch/routing/routes_proxy.rb#L22)
-  This replacement should ensure that `script_name` generation switches correctly, producing the expected path. [code](https://github.com/rails/rails/blob/d18731bed119911867d55983e07b2c853805d7d2/actionpack/lib/action_controller/metal/url_for.rb#L45)
-  However, in `IntegrationTest`, the `_routes` replacement was missing, so the generated paths were incorrectly affected by the request history

This fix ensures that `_routes` replacement is also applied in `IntegrationTest`, making mounted_helpers behave consistently.

A new test was added to confirm that even after accessing an Engine route, `main_app.root_path` always returns `/`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
