### PR TITLE
Add custom active job serializers in a load hook

### DIFF
--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -19,7 +19,7 @@ module ActiveJob
     end
 
     initializer "active_job.custom_serializers" do |app|
-      config.after_initialize do
+      ActiveSupport.on_load(:active_job) do
         custom_serializers = app.config.active_job.custom_serializers
         ActiveJob::Serializers.add_serializers custom_serializers
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3250,6 +3250,10 @@ module ApplicationTests
 
       app "development"
 
+      assert_nothing_raised do
+        ActiveJob::Base
+      end
+
       assert_includes ActiveJob::Serializers.serializers, DummySerializer.instance
     end
 
@@ -3268,7 +3272,7 @@ module ApplicationTests
     end
 
     test "config.active_job.enqueue_after_transaction_commit is deprecated" do
-      app_file "config/initializers/custom_serializers.rb", <<-RUBY
+      app_file "config/initializers/enqueue_after_transaction_commit.rb", <<-RUBY
       Rails.application.config.active_job.enqueue_after_transaction_commit = :always
       RUBY
 


### PR DESCRIPTION
### Motivation / Background

rails/rails@b6c472a optimized looking up active job serializes by indexing them by their klass when they are added.

Calling klass could load autoloaded code. Currently custom serializers are added in an after_initialize hook, meaning we will load autoloaded code at boot time in development and test. Instead, let's add them within an active job load hook to defer adding them until we load a job.

### Detail

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
