### PR TITLE
Improve active job serializer #klass deprecation message

### DIFF
--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -80,7 +80,7 @@ module ActiveJob
             elsif s.respond_to?(:klass, true)
               klass = s.send(:klass)
               ActiveJob.deprecator.warn(<<~MSG.squish)
-                #{klass.name}#klass method should be public.
+                #{s.class.name}#klass method should be public.
               MSG
               @serializers_index[klass] = s
             end


### PR DESCRIPTION
### Motivation / Background

A deprecation was added in rails/rails@b6c472a to require a serializers #klass method to be public.

I was upgrading my app and noticed the deprecation method is slightly confusing. For

```
class MyModelSerializer
  private

  def klass
    MyModel
  end
end
```

We get `MyModel#klass method should be public.`. But `klass` is defined on the serializer not the model so it should be `MyModelSerializer#klass method should be public.`.


### Detail

Update the message to include the name of the serializer.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
