### PR TITLE
Turn off debug mode when calling `assert_no_event_reported`

### DIFF
--- a/activesupport/test/testing/event_reporter_assertions_test.rb
+++ b/activesupport/test/testing/event_reporter_assertions_test.rb
@@ -85,6 +85,16 @@ module ActiveSupport
         end
       end
 
+      test "#assert_no_event_reported ingores debug by default" do
+        original_debug_mode = @reporter.debug_mode?
+        @reporter.debug_mode = true
+        assert_no_event_reported do
+          @reporter.debug("user.created")
+        end
+      ensure
+        @reporter.debug_mode = original_debug_mode
+      end
+
       test "#assert_event_reported fails when event is not reported" do
         e = assert_raises(Minitest::Assertion) do
           assert_event_reported("user.created") do


### PR DESCRIPTION
### Motivation / Background

rails/rails@5cc95ee made debug mode the default in test. However, when calling `assert_no_event_reported` developers likely want to test production behaviour, so we should turn off debug mode when calling this assertion.

### Detail

Turn off debug mode within the `assert_no_event_reported` block, but give developers the ability to keep it on with the `debug_mode` param.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
