### PR TITLE
Avoid clearing isolated state in live tests

### DIFF
--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -684,6 +684,14 @@ module ActionController
 
       assert_equal "aaron", Thread.current[:setting]
     end
+
+    def test_isolated_state_does_not_get_reset_in_test_environment
+      ActiveSupport::IsolatedExecutionState[:setting] = "aaron"
+
+      get :greet
+
+      assert_equal "aaron", ActiveSupport::IsolatedExecutionState[:setting]
+    end
   end
 
   class BufferTest < ActionController::TestCase

--- a/activesupport/lib/active_support/isolated_execution_state.rb
+++ b/activesupport/lib/active_support/isolated_execution_state.rb
@@ -55,11 +55,14 @@ module ActiveSupport
         scope.current
       end
 
-      def share_with(other)
+      def share_with(other, &block)
         # Action Controller streaming spawns a new thread and copy thread locals.
         # We do the same here for backward compatibility, but this is very much a hack
         # and streaming should be rethought.
-        context.active_support_execution_state = other.active_support_execution_state.dup
+        old_state, context.active_support_execution_state = context.active_support_execution_state, other.active_support_execution_state.dup
+        block.call
+      ensure
+        context.active_support_execution_state = old_state
       end
     end
 


### PR DESCRIPTION
When testing live streaming, we don't create a new thread and we patch the `Live` module to ensure that the thread locals are not cleared afterwards.

We were however always calling `ActiveSupport::IsolatedExecutionState.clear` so we were losing that state in tests.

Additionally since https://github.com/rails/rails/pull/55247 calling `ActiveSupport::IsolatedExecutionState.clear` is unsafe in test code, because we are in an execution context (for the test) and the call wipes that out.

This fix is not perfect as `share_with` does a shallow copy so changes from within the test streaming "thread" can leak out - I think that's a fundamental flaw in how the `Live` module and thread state interact.
