### PR TITLE
Freeze database types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -878,7 +878,7 @@ module ActiveRecord
         def register_class_with_precision(mapping, key, klass, **kwargs) # :nodoc:
           mapping.register_type(key) do |*args|
             precision = extract_precision(args.last)
-            klass.new(precision: precision, **kwargs)
+            klass.new(precision: precision, **kwargs).freeze
           end
         end
 
@@ -913,7 +913,7 @@ module ActiveRecord
             m.alias_type %r(number)i,    "decimal"
             m.alias_type %r(double)i,    "float"
 
-            m.register_type %r(^json)i, Type::Json.new
+            m.register_type %r(^json)i, Type::Json.new.freeze
 
             m.register_type(%r(decimal)i) do |sql_type|
               scale = extract_scale(sql_type)
@@ -921,9 +921,9 @@ module ActiveRecord
 
               if scale == 0
                 # FIXME: Remove this class as well
-                Type::DecimalWithoutScale.new(precision: precision)
+                Type::DecimalWithoutScale.new(precision: precision).freeze
               else
-                Type::Decimal.new(precision: precision, scale: scale)
+                Type::Decimal.new(precision: precision, scale: scale).freeze
               end
             end
           end
@@ -931,7 +931,7 @@ module ActiveRecord
           def register_class_with_limit(mapping, key, klass)
             mapping.register_type(key) do |*args|
               limit = extract_limit(args.last)
-              klass.new(limit: limit)
+              klass.new(limit: limit).freeze
             end
           end
 


### PR DESCRIPTION
This commit freezes database type objects.  These objects are cached in globals, and this commit will get us closer to Ractor shareability