### PR TITLE
Revert "Rails New: Only add browser restrictions when using importmap"

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -124,8 +124,4 @@
 
     *Petrik de Heus*
 
-*   Only add browser restrictions for a new Rails app when using importmap.
-
-    *Lucas Dohmen*
-
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
@@ -1,9 +1,11 @@
 class ApplicationController < ActionController::<%= options.api? ? "API" : "Base" %>
-<%- if using_importmap? -%>
+<%- unless options.api? -%>
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+<%- if using_importmap? -%>
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+<% end -%>
 <% end -%>
 end


### PR DESCRIPTION
Reverts rails/rails#55263