### PR TITLE
Use frozen_string_literal by default in new apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,5 +1,10 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
+# Enable frozen string literals
+if defined?(RubyVM::InstructionSequence.compile_option=nil)
+  RubyVM::InstructionSequence.compile_option = { frozen_string_literal: true }
+end
+
 require "bundler/setup" # Set up gems listed in the Gemfile.
 <% if depend_on_bootsnap? -%>
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
After this morning's "Chat With Maintainers" at Rails World there was a discussion that we could maybe enable frozen string literal by default.

This does this by modifying `RubyVM::InstructionSequence.compile_option` in the generated boot.rb. This way new Rails applications will have frozen string literal enabled by default (no change to existing applications).

(I made an app and it seems to work 🤞 CI agrees)