### PR TITLE
[8-0-stable] Fix routes being cleared when using `reload_routes!`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `Rails.application.reload_routes!` from clearing almost all routes.
+
+    When calling `Rails.application.reload_routes!` inside a middleware of
+    a Rake task, it was possible under certain conditions that all routes would be cleared.
+    If ran inside a middleware, this would result in getting a 404 on most page you visit.
+    This issue was only happening in development.
+
+    *Edouard Chin*
+
 *   Address `rack 3.2` deprecations warnings.
 
     ```

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -158,7 +158,11 @@ module Rails
 
     # Reload application routes regardless if they changed or not.
     def reload_routes!
-      routes_reloader.reload!
+      if routes_reloader.execute_unless_loaded
+        routes_reloader.loaded = false
+      else
+        routes_reloader.reload!
+      end
     end
 
     def reload_routes_unless_loaded # :nodoc:

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -9,7 +9,7 @@ module Rails
 
       attr_reader :route_sets, :paths, :external_routes, :loaded
       attr_accessor :eager_load
-      attr_writer :run_after_load_paths # :nodoc:
+      attr_writer :run_after_load_paths, :loaded # :nodoc:
       delegate :execute_if_updated, :updated?, to: :updater
 
       def initialize

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -185,6 +185,26 @@ module ApplicationTests
       assert_match(/Code LOC: \d+\s+Test LOC: \d+\s+ Code to Test Ratio: 1:\w+/, rails("stats"))
     end
 
+    def test_reload_routes
+      add_to_config <<-RUBY
+        rake_tasks do
+          task do_something: :environment do
+            Rails.application.reload_routes!
+            puts Rails.application.routes.named_routes.to_h.keys.join(" ")
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get "foo", to: "foo#bar", as: :my_great_route
+        end
+      RUBY
+
+      output = Dir.chdir(app_path) { `bin/rails do_something` }
+      assert_includes(output.lines.first, "my_great_route")
+    end
+
     def test_loading_specific_fixtures
       rails "generate", "model", "user", "username:string", "password:string"
       rails "generate", "model", "product", "name:string"


### PR DESCRIPTION
Backports #54306 to `8-0-stable` branch.

Closes #55607

/cc @Edouard-chin @gmcgibbon 