### PR TITLE
Add callable support for public_file_server headers

### DIFF
--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -251,7 +251,8 @@ class StaticTest < ActiveSupport::TestCase
     headers = {
       "access-control-allow-origin" => "http://rubyonrails.org",
       "cache-control"               => "public, max-age=60",
-      "x-custom-header"             => "I'm a teapot"
+      "x-custom-header"             => "I'm a teapot",
+      "x-callable-header"           => lambda { |request| request.path }
     }
 
     @app = build_app(DummyApp, @root, headers: headers)
@@ -261,6 +262,7 @@ class StaticTest < ActiveSupport::TestCase
     assert_equal "http://rubyonrails.org", response.headers["access-control-allow-origin"]
     assert_equal "public, max-age=60",     response.headers["cache-control"]
     assert_equal "I'm a teapot",           response.headers["x-custom-header"]
+    assert_equal "/foo/bar.html",          response.headers["x-callable-header"]
   end
 
   def test_ignores_unknown_http_methods

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -17,8 +17,20 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
   <%- end -%>
 
-  # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  # Cache digest stamped assets for far-future expiry.
+  # Short cache for others: robots.txt, sitemap.xml, 404.html, etc.
+  config.public_file_server.headers = {
+    "cache-control" => lambda do |request|
+      if request.path.start_with?("/assets/")
+        # Files in /assets/ are expected to be fully immutable.
+        # If the content change the URL too.
+        "public, immutable, max-age=#{1.year.to_i}"
+      else
+        # For anything else we cache for 1 minute.
+        "public, max-age=#{1.minute.to_i}, stale-while-revalidate=#{5.minutes.to_i}"
+      end
+    end
+  }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
### Motivation / Background

As noted in #55617, there is no support for procs in the public file server. There was a test missing, so this probably went unnoticed. I'd took a stab at adding the functionality and wrote a basic test.

### Detail

This PR allows setting public file server headers with everything that responds to `:call`. In contrast to the original example configuration, I pass a single `Rack::Request` parameter directly instead of `path` and `_`.


### Additional information

If someone is using `ActionDispatch::FileHandler#call` directly and attempt is falsy, we're missing the headers. I think the cleanest way would be to add this to `Rack::Files` directly as well. Maybe I'm missing something, but I'm not sure if there are actual usages of `FileHandler#call` and if it's intended to be public api.