### PR TITLE
Setting max_connections to nil means no limit

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -112,6 +112,7 @@ module ActiveRecord
     # * +max_age+: number of seconds the pool will allow the connection to
     #   exist before retiring it at next checkin. (default Float::INFINITY).
     # * +max_connections+: maximum number of connections the pool may manage (default 5).
+    #   Set to +nil+ or -1 for unlimited connections.
     # * +min_connections+: minimum number of connections the pool will open and maintain (default 0).
     # * +pool_jitter+: maximum reduction factor to apply to +max_age+ and
     #   +keepalive+ intervals (default 0.2; range 0.0-1.0).
@@ -1223,7 +1224,7 @@ module ActiveRecord
           do_checkout = synchronize do
             return if self.discarded?
 
-            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_connections && (!block_given? || yield)
+            if @threads_blocking_new_connections.zero? && (@max_connections.nil? || (@connections.size + @now_connecting) < @max_connections) && (!block_given? || yield)
               if @connections.size > 0 || @original_context != ActiveSupport::IsolatedExecutionState.context
                 @activated = true
               end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -71,7 +71,10 @@ module ActiveRecord
       end
 
       def max_connections
-        (configuration_hash[:max_connections] || configuration_hash[:pool] || 5).to_i
+        max_connections = configuration_hash.fetch(:max_connections) {
+          configuration_hash.fetch(:pool, 5)
+        }&.to_i
+        max_connections if max_connections && max_connections >= 0
       end
 
       def min_connections
@@ -86,7 +89,7 @@ module ActiveRecord
       end
 
       def max_threads
-        (configuration_hash[:max_threads] || max_connections).to_i
+        (configuration_hash[:max_threads] || (max_connections || 5).clamp(0, 5)).to_i
       end
 
       def max_age

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1498,6 +1498,69 @@ module ActiveRecord
         ActiveRecord::ConnectionAdapters::AbstractAdapter.skip_callback(:checkout, :after, proc_to_raise)
       end
 
+      def test_unlimited_connections_with_nil
+        pool = new_pool_with_options(max_connections: nil)
+
+        assert_nil pool.max_connections
+        assert_nil pool.size
+
+        # Should be able to create many connections without hitting a limit
+        connections = []
+        10.times do
+          connections << pool.checkout
+        end
+
+        assert_equal 10, connections.size
+        connections.each { |conn| pool.checkin(conn) }
+      ensure
+        pool&.disconnect!
+      end
+
+      def test_unlimited_connections_with_negative_one
+        pool = new_pool_with_options(max_connections: -1)
+
+        assert_nil pool.max_connections
+        assert_nil pool.size
+
+        # Should be able to create many connections without hitting a limit
+        connections = []
+        10.times do
+          connections << pool.checkout
+        end
+
+        assert_equal 10, connections.size
+        connections.each { |conn| pool.checkin(conn) }
+      ensure
+        pool&.disconnect!
+      end
+
+      def test_zero_connections_means_zero_limit
+        pool = new_pool_with_options(max_connections: 0)
+
+        assert_equal 0, pool.max_connections
+        assert_equal 0, pool.size
+
+        # Should not be able to create any connections
+        error = assert_raises(ActiveRecord::ConnectionTimeoutError) do
+          pool.checkout
+        end
+        assert_match(/could not obtain a connection from the pool/, error.message)
+      ensure
+        pool&.disconnect!
+      end
+
+      def test_unlimited_connections_stat_reports_nil_size
+        pool = new_pool_with_options(max_connections: nil)
+
+        stat = pool.stat
+        assert_nil stat[:size]
+        assert_equal 0, stat[:connections]
+        assert_equal 0, stat[:busy]
+        assert_equal 0, stat[:idle]
+      ensure
+        pool&.disconnect!
+      end
+
       private
         def active_connections(pool)
           pool.connections.find_all(&:in_use?)

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -64,19 +64,39 @@ module ActiveRecord
         assert_equal 600, config.keepalive
       end
 
-      def test_max_connections_default_when_nil
+      def test_max_connections_unlimited_when_nil
         config = HashConfig.new("default_env", "primary", max_connections: nil, adapter: "abstract")
-        assert_equal 5, config.max_connections
+        assert_nil config.max_connections
+      end
+
+      def test_max_connections_unlimited_when_negative_one
+        config = HashConfig.new("default_env", "primary", max_connections: "-1", adapter: "abstract")
+        assert_nil config.max_connections
+      end
+
+      def test_max_connections_zero_means_zero
+        config = HashConfig.new("default_env", "primary", max_connections: "0", adapter: "abstract")
+        assert_equal 0, config.max_connections
       end
 
       def test_max_connections_overrides_with_value
-        config = HashConfig.new("default_env", "primary", max_connections: "0", adapter: "abstract")
-        assert_equal 0, config.max_connections
+        config = HashConfig.new("default_env", "primary", max_connections: "10", adapter: "abstract")
+        assert_equal 10, config.max_connections
       end
 
       def test_when_no_max_connections_uses_default
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
         assert_equal 5, config.max_connections
+      end
+
+      def test_max_threads_fallback_when_unlimited_connections
+        config = HashConfig.new("default_env", "primary", max_connections: nil, adapter: "abstract")
+        assert_equal 5, config.max_threads
+      end
+
+      def test_max_threads_fallback_when_negative_connections
+        config = HashConfig.new("default_env", "primary", max_connections: -1, adapter: "abstract")
+        assert_equal 5, config.max_threads
       end
 
       def test_min_connections_default_when_nil


### PR DESCRIPTION
We intend to make this the default: instead of users needing to do maths to choose a pool size based on the number of worker threads they have (in Puma etc.), we can just stop enforcing any limit. Under normal usage, actual consumption will be naturally limited by the number of threads that request a connection. (This natural limiting doesn't apply to code that uses explicit `checkout` calls instead of the standard connection-leasing model: such applications may still benefit from choosing a hard limit.)

In this PR, however, I am _not_ changing the default `max_connections` value from its current **5** -- just making sure there is a way to explicitly specify "unlimited" instead of needing to use an arbitrary large number.

