### PR TITLE
[8-0-stable] Lock RDoc to 6.9 until sdoc is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 
 group :doc do
   gem "sdoc"
-  gem "rdoc", "~> 6.7"
+  gem "rdoc", "< 6.10"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "rouge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,6 @@ GEM
     dotenv (3.1.8)
     drb (2.2.3)
     ed25519 (1.4.0)
-    erb (5.0.2)
     erubi (1.13.1)
     et-orbi (1.3.0)
       tzinfo
@@ -474,8 +473,7 @@ GEM
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rbtree (0.4.6)
-    rdoc (6.14.2)
-      erb
+    rdoc (6.9.1)
       psych (>= 4.0.0)
     redcarpet (3.2.3)
     redis (5.4.1)
@@ -751,7 +749,7 @@ DEPENDENCIES
   rack-cache (~> 1.2)
   rails!
   rake (>= 13)
-  rdoc (~> 6.7)
+  rdoc (< 6.10)
   redcarpet (~> 3.2.3)
   redis (>= 4.0.1)
   redis-namespace


### PR DESCRIPTION
Backports c0958cd to `8-0-stable` to fix `docs-preview` CI job.

https://buildkite.com/rails/docs-preview/builds/12411#019921e0-8eb0-4632-8d94-6aea9d50a417/141-674