### PR TITLE
Fix EventReporter heading level for Security [ci skip]

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -263,7 +263,7 @@ module ActiveSupport
   #   #    payload: { id: 123 },
   #   #  }
   #
-  # ==== Security
+  # === Security
   #
   # When reporting events, Hash-based payloads are automatically filtered to remove sensitive data based on {Rails.application.filter_parameters}[https://guides.rubyonrails.org/configuring.html#config-filter-parameters].
   #


### PR DESCRIPTION
4de4e6e changed the heading levels and the PR for filtering parameters was not updated, this brings that last heading into alignment.

Before:

<img width="263" height="328" alt="Screenshot from 2025-09-07 11-31-54" src="https://github.com/user-attachments/assets/81c495b4-0699-482c-a364-c366958cb862" />

After:

<img width="263" height="328" alt="Screenshot from 2025-09-07 11-34-04" src="https://github.com/user-attachments/assets/59d57ccc-0643-417e-a934-bb9645ee5ec7" />
