### PR TITLE
Introduce ActiveRecord.validate_enums_by_default config option

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Introduce `ActiveRecord.validate_enums_by_default` to control `enum` validation.
+    Set any value acceptable by the enum validate option. `false` by default.
+
+    ```ruby
+    config.active_record.validate_enums_by_default = true
+    config.active_record.validate_enums_by_default = false
+    config.active_record.validate_enums_by_default = {allow_nil: true}
+    ```
+
+    *Julien Bourdeau*
+
 *   Fix upsert_all when using repeated timestamp attributes.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -476,6 +476,13 @@ module ActiveRecord
   singleton_class.attr_accessor :generate_secure_token_on
   self.generate_secure_token_on = :create
 
+  ##
+  # :singleton-method: validate_enums_by_default
+  # Controls whether to automatically validate <tt>enum</tt> attributes.
+  # Defaults to <tt>false</tt>.
+  singleton_class.attr_accessor :validate_enums_by_default
+  self.validate_enums_by_default = false
+
   def self.deprecated_associations_options=(options)
     raise ArgumentError, "deprecated_associations_options must be a hash" unless options.is_a?(Hash)
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -220,7 +220,7 @@ module ActiveRecord
     end
 
     private
-      def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
+      def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: ActiveRecord.validate_enums_by_default, **options)
         values = assert_valid_enum_definition_values(values)
         assert_valid_enum_options(options)
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -41,6 +41,7 @@ module ActiveRecord
     config.active_record.generate_secure_token_on = :create
     config.active_record.use_legacy_signed_id_verifier = :generate_and_verify
     config.active_record.deprecated_associations_options = { mode: :warn, backtrace: false }
+    config.active_record.validate_enums_by_default = false
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -339,6 +339,42 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_predicate invalid_book, :valid?
   end
 
+  test "validation with config.validate_enums_by_default = true" do
+    ActiveRecord.validate_enums_by_default = true
+    klass = Class.new(ActiveRecord::Base) do
+    def self.name; "Book"; end
+    enum :status, [:proposed]
+  end
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: "unknown")
+    assert_not_predicate invalid_book, :valid?
+
+    invalid_book = klass.new(status: nil)
+    assert_not_predicate invalid_book, :valid?
+  end
+
+  test "validation with config.validate_enums_by_default = {allow_nil: true}" do
+    ActiveRecord.validate_enums_by_default = { allow_nil: true }
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; "Book"; end
+      enum :status, [:proposed]
+    end
+
+    valid_book = klass.new(status: nil)
+    assert_predicate valid_book, :valid?
+  end
+
+  test "validation with config.validate_enums_by_default = false" do
+    ActiveRecord.validate_enums_by_default = false
+    e = assert_raises(ArgumentError) do
+      @book.status = :unknown
+    end
+    assert_equal "'unknown' is not a valid status", e.message
+  end
+
   test "validation with 'validate: hash' option" do
     klass = Class.new(ActiveRecord::Base) do
       def self.name; "Book"; end


### PR DESCRIPTION
### Motivation / Background

In ActiveRecord model, passing an invalid value to an`enum` attribute will raise `ArgumentError`.
@mechnicov introduce a way to make enum attribute validate like any other attribute, raising `ActiveRecord::InvalidRecord` in https://github.com/rails/rails/pull/49100

We end up adding `validate: true` to all enum. This PR adds a new ActiveRecord configuration key to control the default behavior.

~~Ideally, I'd love this to part of 8.1 with `false` by default. I know we're already in beta, so it might be too late.
Then, even default to `true` in the next major.~~


### Detail

- Introduce `ActiveRecord.validate_enums_by_default` config
- `false` by default for backward compatibility, even if I believe `true` makes more sense.
- Update `_enum` method to read config instead of using hardcoded `false` value

I'm open to any better param name of course.

### Additional information

Reminder about enum

```rb
class Book < ApplicationRecord
  enum :status, %i[proposed accepted], validate: false # or `enum :status, %i[proposed accepted]` without validate option
end

Book.create(status: :unknown) # will raise ArgumentError

book = Book.new(status: :proposed)
book.status = :unknown # will raise ArgumentError
```

```rb
class Book < ApplicationRecord
  enum :status, %i[proposed accepted], validate: true
end

Book.create!(status: :unknown) # will raise ActiveRecord::InvalidRecord

book = Book.new(status: :unknown)
book.valid? # false ; book.errors[:status] is set to ["value_is_invalid"]

book = Book.new(status: :invalid)
book.status = :unknown # nothing happens until validation
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
