### PR TITLE
Show engine routes in `/rails/info/routes` as well

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Show engine routes in `/rails/info/routes` as well.
+
+    *Petrik de Heus*
+
 *   Exclude `asset_path` configuration from Kamal `deploy.yml` for API applications.
 
     API applications don't serve assets, so the `asset_path` configuration in `deploy.yml`

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -27,7 +27,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
         fuzzy: matching_routes(query: query, exact_match: false)
       }
     else
-      @routes_inspector = ActionDispatch::Routing::RoutesInspector.new(_routes.routes)
+      @routes_inspector = ActionDispatch::Routing::RoutesInspector.new(Rails.application.routes.routes)
       @page_title = "Routes"
     end
   end
@@ -46,7 +46,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
       normalized_path = ("/" + query).squeeze("/")
       query_without_url_or_path_suffix = query.gsub(/(\w)(_path$)/, '\1').gsub(/(\w)(_url$)/, '\1')
 
-      _routes.routes.filter_map do |route|
+      Rails.application.routes.routes.filter_map do |route|
         route_wrapper = ActionDispatch::Routing::RouteWrapper.new(route)
 
         if exact_match


### PR DESCRIPTION
`_routes.routes` does not include engine routes, so engine routes don't show up in `/rails/routes`.

By using `Rails.application.routes.routes`, [similar to `Rails::Command::RoutesCommand`](https://github.com/rails/rails/blob/c6272da25fa823d26f8469ffef3a9dc7a1225d2c/railties/lib/rails/commands/routes/routes_command.rb#L33), the routes do show up.

### Detail

For a `Blog` engine the routes would look like this:

<img width="844" height="346" alt="image" src="https://github.com/user-attachments/assets/95a2b6f1-ee6c-4709-99ce-a28ebae60c3a" />


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
