### PR TITLE
Disable bootsnap parallel precompilation to workaround QEMU bug

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+p [:load_test_case]
+puts caller
+
 require "minitest"
 require "active_support/testing/tagged_logging"
 require "active_support/testing/setup_and_teardown"

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -65,7 +65,8 @@ COPY Gemfile Gemfile.lock vendor ./
 
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
-    bundle exec bootsnap precompile --gemfile<% end %>
+    # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495
+    bundle exec bootsnap precompile -j 1 --gemfile<% end %>
 
 <% if using_node? -%>
 # Install node modules
@@ -83,8 +84,9 @@ RUN bun install --frozen-lockfile
 COPY . .
 
 <% if depend_on_bootsnap? -%>
-# Precompile bootsnap code for faster boot times
-RUN bundle exec bootsnap precompile app/ lib/
+# Precompile bootsnap code for faster boot times.
+# -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495
+RUN bundle exec bootsnap precompile -j 1 app/ lib/
 
 <% end -%>
 <% unless dockerfile_binfile_fixups.empty? -%>

--- a/railties/test/fixtures/Dockerfile.test
+++ b/railties/test/fixtures/Dockerfile.test
@@ -27,13 +27,14 @@ RUN apt-get install --no-install-recommends -y build-essential git pkg-config
 COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
-    bundle exec bootsnap precompile --gemfile
+    # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495
+    bundle exec bootsnap precompile -j 1 --gemfile
 
 # Copy application code
 COPY . .
 
-# Precompile bootsnap code for faster boot times
-RUN bundle exec bootsnap precompile app/ lib/
+# Precompile bootsnap code for faster boot times (single-threaded to mitigate Buildx/QEMU hang)
+RUN bundle exec bootsnap precompile -j 1 app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1120,6 +1120,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_dockerfile_bootsnap_precompile_is_single_threaded
+    skip "bootsnap not included on JRuby" if defined?(JRUBY_VERSION)
+    run_generator [destination_root, "--no-skip-bootsnap"]
+    assert_gem "bootsnap"
+    assert_file "Dockerfile" do |content|
+      assert_match(/bootsnap precompile -j 1 --gemfile/, content)
+      assert_match(/bootsnap precompile -j 1 app\/ lib\//, content)
+    end
+  end
+
   def test_inclusion_of_ruby_version
     run_generator
 


### PR DESCRIPTION
### Motivation / Background

Ref: https://github.com/rails/bootsnap/issues/495

Fixes #54039. Cross-arch Docker Buildx (QEMU) builds occasionally hang during parallel Bootsnap precompile. Single-threading avoids the deadlock.

### Detail

https://github.com/rails/bootsnap/issues/495#issuecomment-2657541922
> For those who are investigating, here are my attempts:
> ...
> `-j 0` takes around 350 seconds for a small Rails project on my machine, which is not bad compared to the time taken before the hang. (supposedly the time taken if `Process.fork` works correctly.)
>  ...
> The `-j 0` option is still the best contender for small projects, IMO.

https://github.com/rails/bootsnap/pull/501
> Try to detect QEMU fork bug

### Additional information

Lightweight safeguard; no Docker integration test (would be slow/flaky). Can be reverted if upstream issue is fully resolved.

### Checklist

* [x] Single focused change.
* [x] Commit message explains rationale and references issue.
* [x] Tests added.
* [ ] CHANGELOG (railties) entry to add if deemed user-visible.