### PR TITLE
[ci skip] Wording correction for url_from documentation

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -241,7 +241,8 @@ module ActionController
     #     url_from("http://example.com/profile")  # => "http://example.com/profile"
     #     url_from("http://evil.com/profile")     # => nil
     #
-    # Subdomains are considered part of the host:
+    # Subdomains are included when comparing hosts. The hostname must match exactly
+    # for a redirect to be considered internal.
     #
     #     # If request.host is on https://example.com or https://app.example.com, you'd get:
     #     url_from("https://dev.example.com/profile") # => nil


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current wording for the subdomain handling of url_from implies that subdomains are considered safe but they are not. This is confusing and caused me to waste time debugging why my subdomains were raising a [UnsafeRedirectError](https://api.rubyonrails.org/classes/ActionController/Redirecting/UnsafeRedirectError.html)

### Detail

This Pull Request adds two words to the documentation to be more explicit about the behaviour shown in the example.

### Checklist

Before submitting the PR make sure the following are checked:

* [ x ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ x ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ x ] Tests are added or updated if you fix a bug or add a feature.
* [ x ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
