### PR TITLE
Optimise `ActionDispatch::Http::URL.build_host_url` when protocol in host

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Optimize `ActionDispatch::Http::URL.build_host_url` when protocol is included in host.
+
+    When using URL helpers with a host that includes the protocol (e.g., `{ host: "https://example.com" }`),
+    skip unnecessary protocol normalization and string duplication since the extracted protocol is already
+    in the correct format. This eliminates 2 string allocations per URL generation and provides a ~10%
+    performance improvement for this case.
+
+    *Joshua Young*, *Hartley McGuire*
+
 *   Allow `action_controller.logger` to be disabled by setting it to `nil` or `false` instead of always defaulting to `Rails.logger`.
 
     *Roberto Miranda*


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When using URL helpers with a host that includes the protocol (e.g., `{ host: "https://api.example.com" }`), we (@buildkite) found that the already-extracted protocol was being unnecessarily processed through `#normalize_protocol`, creating extra allocations and showing up as a hotspot in our production profiles.

Example local profile: [output.json.gz](https://github.com/user-attachments/files/22236956/output.json.gz) (viewable at https://vernier.prof, select allocations for data source)

### Detail

**Before:**
1. `HOST_REGEXP` extracts `"https://"` from host
2. `normalize_protocol` processes `"https://"` through `PROTOCOL_REGEXP` and creates new string
3. `protocol.dup` creates another allocation

**After:**
1. `HOST_REGEXP` extracts `"https://"` from host  
2. Skip `normalize_protocol` since it's already in correct format
3. Skip `dup` since regex capture groups are mutable

This optimization only applies when no explicit protocol option is provided and `HOST_REGEXP` successfully extracts a protocol. The `HOST_REGEXP` pattern ensures extracted protocols are always in the final `"protocol://"` format that `normalize_protocol` would return, making the normalization step redundant.

The change eliminates 2 string allocations per URL generation when protocol is included in the host, resulting in a ~10-12% performance improvement and ~16% reduction in total allocations for that case. Other cases remain unaffected with no performance regression.

<details>
<summary>Benchmarking</summary>

<br>

**Script:**
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "./"

  gem "benchmark-ips"
  gem "benchmark-memory"
end

require "action_controller/railtie"
require "minitest/autorun"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.root = __dir__
  config.eager_load = false
  config.hosts << "example.org"
  config.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
end
Rails.application.initialize!

Rails.application.routes.draw do
  get "/", to: proc { [200, {}, ["Home"]] }, as: :home
end

class TestHelperWithoutProtocol
  include Rails.application.routes.url_helpers

  def default_url_options
    { host: "example.org" }
  end
end

class TestHelperWithExplicitProtocol
  include Rails.application.routes.url_helpers

  def default_url_options
    { host: "example.org", protocol: "http://" }
  end
end

class TestHelperWithProtocolInHost
  include Rails.application.routes.url_helpers

  def default_url_options
    { host: "http://example.org" }
  end
end

class BugTest < ActiveSupport::TestCase
  def test_benchmark
    th1 = TestHelperWithoutProtocol.new
    th2 = TestHelperWithExplicitProtocol.new
    th3 = TestHelperWithProtocolInHost.new

    Benchmark.ips do |x|
      x.report("home_url ips without protocol") { th1.home_url }
      x.report("home_url ips with explicit protocol") { th2.home_url }
      x.report("home_url ips with protocol in host") { th3.home_url }
    end

    puts "\n"

    Benchmark.memory do |x|
      x.report("home_url allocations without protocol") { th1.home_url }
      x.report("home_url allocations with explicit protocol") { th2.home_url }
      x.report("home_url allocations with protocol in host") { th3.home_url }
    end

    assert true
  end
end
```

**Results:**
```
main (604e8e057020d3ae522f674e3fdcaf4dea160d31):

ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
home_url without protocol
                        24.470k i/100ms
home_url with explicit protocol
                        21.399k i/100ms
home_url with protocol in host
                        22.408k i/100ms
Calculating -------------------------------------
home_url without protocol
                        245.376k (± 2.8%) i/s    (4.08 μs/i) -      1.248M in   5.090068s
home_url with explicit protocol
                        220.910k (± 2.5%) i/s    (4.53 μs/i) -      1.113M in   5.040106s
home_url with protocol in host
                        227.877k (± 2.8%) i/s    (4.39 μs/i) -      1.143M in   5.019124s

Calculating -------------------------------------
home_url allocations without protocol
                         2.680k memsize (   360.000  retained)
                        26.000  objects (     3.000  retained)
                         4.000  strings (     1.000  retained)
home_url allocations with explicit protocol
                         2.928k memsize (   360.000  retained)
                        29.000  objects (     3.000  retained)
                         6.000  strings (     1.000  retained)
home_url allocations with protocol in host
                         3.008k memsize (   360.000  retained)
                        31.000  objects (     3.000  retained)
                         6.000  strings (     1.000  retained)


optimise-build-host-url-with-protocol-in-host rebased on main (604e8e057020d3ae522f674e3fdcaf4dea160d31):

ruby 3.4.5 (2025-07-16 revision 20cda200d3) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
home_url without protocol
                        24.536k i/100ms
home_url with explicit protocol
                        21.617k i/100ms
home_url with protocol in host
                        25.034k i/100ms
Calculating -------------------------------------
home_url without protocol
                        254.096k (± 2.5%) i/s    (3.94 μs/i) -      1.276M in   5.024416s
home_url with explicit protocol
                        230.278k (± 2.5%) i/s    (4.34 μs/i) -      1.167M in   5.072466s
home_url with protocol in host
                        254.472k (± 2.6%) i/s    (3.93 μs/i) -      1.277M in   5.020847s

Calculating -------------------------------------
home_url allocations without protocol
                         2.680k memsize (   360.000  retained)
                        26.000  objects (     3.000  retained)
                         4.000  strings (     1.000  retained)
home_url allocations with explicit protocol
                         2.928k memsize (   360.000  retained)
                        29.000  objects (     3.000  retained)
                         6.000  strings (     1.000  retained)
home_url allocations with protocol in host
                         2.680k memsize (   360.000  retained)
                        26.000  objects (     3.000  retained)
                         4.000  strings (     1.000  retained)
```

</details>

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.