### PR TITLE
fix: add conditional asset_path configuration for API apps to fix `kamal deploy`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Exclude `asset_path` configuration from Kamal `deploy.yml` for API applications.
+
+    API applications don't serve assets, so the `asset_path` configuration in `deploy.yml`
+    is not needed and can cause 404 errors on in-flight requests. The asset_path is now
+    only included for regular Rails applications that serve assets.
+
+    *Saiqul Haq*
+
 *   Reverted the incorrect default `config.public_file_server.headers` config.
 
     If you created a new application using Rails `8.1.0.beta1`, make sure to regenerate

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -80,10 +80,13 @@ volumes:
   - "<%= app_name %>_storage:/rails/storage"
 
 <% end -%>
+<% unless options.api? -%>
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
 asset_path: /rails/public/assets
+
+<% end -%>
 
 # Configure the image builder.
 builder:

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -140,6 +140,16 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "public/406-unsupported-browser.html"
   end
 
+  def test_kamal_deploy_yml_excludes_asset_path_for_api_apps
+    generator [destination_root], ["--api"]
+    run_generator_instance
+
+    assert_file "config/deploy.yml" do |content|
+      assert_no_match(/asset_path:/, content)
+      assert_no_match(/public\/assets/, content)
+    end
+  end
+
   private
     def default_files
       %w(.gitignore

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -775,6 +775,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_kamal_deploy_yml_includes_asset_path_for_regular_apps
+    generator [destination_root]
+    run_generator_instance
+
+    assert_file "config/deploy.yml" do |content|
+      assert_match(/asset_path: \/rails\/public\/assets/, content)
+    end
+  end
+
   def test_usage_read_from_file
     assert_called(File, :read, returns: "USAGE FROM FILE") do
       assert_equal "USAGE FROM FILE", Rails::Generators::AppGenerator.desc


### PR DESCRIPTION
### Motivation / Background
Currently, the Rails app generator always includes an `asset_path` setting in the generated `config/deploy.yml`. This is useful for regular Rails apps, where static assets need to be bridged across versions to avoid 404s during in-flight requests.  

However, in API-only applications, this configuration is not relevant because API apps typically do not serve assets. Having the unused `asset_path` in `deploy.yml` can create confusion and might lead to unnecessary configuration in API deployments.  

This Pull Request ensures that `asset_path` is only included for regular Rails applications and excluded from API-only apps.  

### Detail
- Updated `deploy.yml.tt` template to wrap the `asset_path` setting in an `unless options.api?` conditional.
- Added a test in `api_app_generator_test.rb` to verify `asset_path` is excluded in API apps.
- Added a test in `app_generator_test.rb` to verify `asset_path` is included for regular apps.

### Additional information
This change prevents accidental misconfiguration in API-only deployments while preserving the current behavior for full-stack applications. It ensures generated `deploy.yml` files remain accurate and minimal, tailored to the app type.  

### Checklist
* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added to confirm the new conditional behavior.
* [x] CHANGELOG entry will need to be added if Rails considers this a user-facing generator change.
