### PR TITLE
Do not add seed step to config/ci if active record is skipped

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -22,7 +22,9 @@ CI.run do
   step "Tests: Rails", "bin/rails test"
   step "Tests: System", "bin/rails test:system"
 <% end -%>
+<% unless options.skip_active_record?  -%>
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+<% end -%>
 
   # Optional: set a green GitHub commit status to unblock PR merge.
   # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -669,6 +669,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_config_ci_includes_seed_step_by_default
+    run_generator [destination_root]
+
+    assert_file "config/ci.rb" do |content|
+      assert_match(/step "Tests: Seeds", "env RAILS_ENV=test bin\/rails db:seed:replant"/, content)
+    end
+  end
+
+  def test_config_ci_does_not_include_seed_step_when_skip_active_record_is_given
+    run_generator [destination_root, "--skip-active-record"]
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/step "Tests: Seeds"/, content)
+      assert_no_match(/bin\/rails db:seed:replant/, content)
+    end
+  end
+
   def test_ci_workflow_includes_db_test_prepare_by_default
     run_generator
     assert_file ".github/workflows/ci.yml" do |content|


### PR DESCRIPTION
### Motivation / Background

bin/ci fails on a newly generated app with `--skip-active-record` the binary fails with `Unrecognized command "db:seed:replant"`

<img width="680" height="533" alt="image" src="https://github.com/user-attachments/assets/1fb7d650-83af-4986-9849-fe01473c3870" />


### Detail

This Pull Request :
- updates `ci.tt` to check if `--skip-active-record` was used and sets the "Tests: Seeds" step accordingly in `config/ci.rb`

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

This relates/extension to #55643 