### PR TITLE
Emit structured debug events in development only

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -73,7 +73,7 @@ module Rails
 
       initializer :initialize_event_reporter, group: :all do
         Rails.event.raise_on_error = config.consider_all_requests_local
-        Rails.event.debug_mode = config.consider_all_requests_local
+        Rails.event.debug_mode = Rails.env.development?
       end
 
       # Initialize cache early in the stack so railties can make use of it.


### PR DESCRIPTION
### Motivation / Background

Ref: https://github.com/rails/rails/pull/55566

Shopify's local Event Reporter emitted debug events in local environments (test and development), so I ported the change over to Rails. However, after further discussion with the team, we decided it's strange to emit debug events in test; this causes extra noise, and tests typically want to verify production behaviour, so emitting debug events by default causes a divergence.

This PR enables debug events in development only. Tests can verify debug events by enabling debug mode explicitly, e.g.
```ruby
def test_debug
  assert_event_reported("test") do
    Rails.event.with_debug do
      something_that_emits_a_debug_event()
    end
  end
end
```

cc @skipkayhil @Edouard-chin 

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I haven't added a CHANGELOG entry because the prior behaviour technically wasn't documented. 

We could also opt to make this configurable (and document the option), but not sure whether we want to encourage globally enabling / disabling it vs encouraging use of `with_debug` .