### PR TITLE
Do not inline process mailers when calling deliver_all_later

### DIFF
--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -20,7 +20,7 @@ module ActionMailer
 
     private
       def _deliver_all_later(delivery_method, *deliveries, **options)
-        deliveries.flatten!
+        deliveries = deliveries.first if deliveries.first.is_a?(Array)
 
         jobs = deliveries.map do |delivery|
           mailer_class = delivery.mailer_class

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -160,6 +160,16 @@ class MessageDeliveryTest < ActiveSupport::TestCase
     end
   end
 
+  test "deliver_all_later does not inline process the mailers" do
+    mail1 = DelayedMailer.test_message(1)
+    mail2 = DelayedMailer.test_message(2)
+
+    ActionMailer.deliver_all_later(mail1, mail2)
+
+    assert_not mail1.processed?
+    assert_not mail2.processed?
+  end
+
   test "deliver_all_later enqueues multiple deliveries with correct jobs" do
     old_delivery_job = BaseMailer.delivery_job
     BaseMailer.delivery_job = DummyJob


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix https://github.com/rails/rails/issues/55658

### Detail

In our application we store each email attempt/delivery inside a table for tracking purposes, and I was surprised that `deliver_all_later` was taking a lot of time to send around 2000 emails. after looking at the logs i figured that all mailers were processed as if i was calling `deliver_now` 

### Additional information

@fatkodima I still don't know why by looking at this caller stack, but it seems `flatten!` eager load the mails by trying to delegate a method which triggers the inline processing here:
https://github.com/rails/rails/blob/aedfc4af7625312bfdec087a0d03e5ad5da80027/actionmailer/lib/action_mailer/message_delivery.rb#L65-L67

<details>
<summary> Here is the `callers` output </summary>
```
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/sentry-rails-5.26.0/lib/sentry/rails/tracing.rb:56:in 'Sentry::Rails::Tracing::SentryNotificationExtension#instrument'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/activesupport/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/base.rb:651:in 'ActionMailer::Base#process'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:170:in 'block in ActionMailer::MessageDelivery#processed_mailer'",
"<internal:kernel>:91:in 'Kernel#tap'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:169:in 'ActionMailer::MessageDelivery#processed_mailer'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:66:in 'ActionMailer::MessageDelivery#__getobj__'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/3.4.0/delegate.rb:101:in 'Delegator#respond_to_missing?'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:23:in 'respond_to?'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:23:in 'Array#flatten!'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:23:in 'ActionMailer._deliver_all_later'",
"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:10:in 'ActionMailer.deliver_all_later'",

```

</details>

I can't figure out how this line is called `"/Users/user/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/rails-d18731bed119/actionmailer/lib/action_mailer/message_delivery.rb:23:in 'respond_to?'"`

when calling `flatten!` at line 23, it tries to call `respond_to?`


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
