### PR TITLE
If a serialized job is decoded when ActiveSupport.parse_json_times is true, use the parsed Time object

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -167,8 +167,8 @@ module ActiveJob
       self.exception_executions = job_data["exception_executions"]
       self.locale               = job_data["locale"] || I18n.locale.to_s
       self.timezone             = job_data["timezone"] || Time.zone&.name
-      self.enqueued_at          = Time.iso8601(job_data["enqueued_at"]) if job_data["enqueued_at"]
-      self.scheduled_at         = Time.iso8601(job_data["scheduled_at"]) if job_data["scheduled_at"]
+      self.enqueued_at          = deserialize_time(job_data["enqueued_at"])
+      self.scheduled_at         = deserialize_time(job_data["scheduled_at"])
     end
 
     # Configures the job with the given options.
@@ -207,6 +207,14 @@ module ActiveJob
 
       def arguments_serialized?
         @serialized_arguments
+      end
+
+      def deserialize_time(time)
+        if time.is_a?(Time)
+          time
+        elsif time
+          Time.iso8601(time)
+        end
       end
   end
 end

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -5,6 +5,7 @@ require "jobs/gid_job"
 require "jobs/hello_job"
 require "models/person"
 require "json"
+require "active_support/json"
 
 class JobSerializationTest < ActiveSupport::TestCase
   setup do
@@ -37,6 +38,45 @@ class JobSerializationTest < ActiveSupport::TestCase
       assert_equal "es", new_job.serialize["locale"]
     ensure
       I18n.available_locales = old_locales
+    end
+  end
+
+  test "deserializes enqueued_at when ActiveSupport.parse_json_times is true" do
+    freeze_time
+
+    Time.use_zone "US/Eastern" do
+      with_parse_json_times(true) do
+        current_time = Time.now
+
+        job = HelloJob.new
+        serialized_job = job.serialize
+        payload = ActiveSupport::JSON.decode(serialized_job.to_json)
+
+        new_job = HelloJob.new
+        new_job.deserialize(payload)
+
+        assert_equal current_time, new_job.enqueued_at
+      end
+    end
+  end
+
+  test "deserializes scheduled_at when ActiveSupport.parse_json_times is true" do
+    freeze_time
+
+    Time.use_zone "US/Eastern" do
+      with_parse_json_times(true) do
+        current_time = Time.now
+
+        job = HelloJob.new
+        job.scheduled_at = current_time
+        serialized_job = job.serialize
+        payload = ActiveSupport::JSON.decode(serialized_job.to_json)
+
+        new_job = HelloJob.new
+        new_job.deserialize(payload)
+
+        assert_equal current_time, new_job.scheduled_at
+      end
     end
   end
 
@@ -122,4 +162,13 @@ class JobSerializationTest < ActiveSupport::TestCase
 
     assert_equal job.serialize, deserialized_job.serialize
   end
+
+  private
+    def with_parse_json_times(value)
+      old_value = ActiveSupport.parse_json_times
+      ActiveSupport.parse_json_times = value
+      yield
+    ensure
+      ActiveSupport.parse_json_times = old_value
+    end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In SolidQueue the main Job model looks like this:
```ruby
module SolidQueue
  class Job < Record
    class EnqueueError < StandardError; end

    include Executable, Clearable, Recurrable

    serialize :arguments, coder: JSON
```

`arguments` is what stores the serialized data of the job. `coder: JSON` ends up using `ActiveSupport::JSON` for encoding and decoding the data to/from the database.

If `ActiveSupport.parse_json_times` is set to true, the enqueued_at and scheduled_at keys get parsed as Time objects when instantiating the model. But when the job is deserialized those are expected to be strings. This results in an exception being raised because Time.iso8601 expects a string to be passed.

This change checks the type  to see if it's already a Time object and to skip parsing trying to parse it. ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
