### PR TITLE
Restore exact behavior of AJ Arguments.serialize

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -31,7 +31,11 @@ module ActiveJob
     # serialized without mutation are returned as-is. Arrays/Hashes are
     # serialized element by element. All other types are serialized using
     # GlobalID.
-    def serialize(argument)
+    def serialize(arguments)
+      arguments.map { |argument| serialize_argument(argument) }
+    end
+
+    def serialize_argument(argument) # :nodoc:
       case argument
       when nil, true, false, Integer, Float # Types that can hardly be subclassed
         argument
@@ -50,7 +54,7 @@ module ActiveJob
       when GlobalID::Identification
         convert_to_global_id_hash(argument)
       when Array
-        argument.map { |arg| serialize(arg) }
+        argument.map { |arg| serialize_argument(arg) }
       when ActiveSupport::HashWithIndifferentAccess
         serialize_indifferent_hash(argument)
       when Hash
@@ -137,7 +141,7 @@ module ActiveJob
 
       def serialize_hash(argument)
         argument.each_with_object({}) do |(key, value), hash|
-          hash[serialize_hash_key(key)] = serialize(value)
+          hash[serialize_hash_key(key)] = serialize_argument(value)
         end
       end
 

--- a/activejob/lib/active_job/serializers/action_controller_parameters_serializer.rb
+++ b/activejob/lib/active_job/serializers/action_controller_parameters_serializer.rb
@@ -4,7 +4,7 @@ module ActiveJob
   module Serializers
     class ActionControllerParametersSerializer < ObjectSerializer
       def serialize(argument)
-        Arguments.serialize(argument.to_h.with_indifferent_access)
+        Arguments.serialize_argument(argument.to_h.with_indifferent_access)
       end
 
       def deserialize(hash)

--- a/activejob/lib/active_job/serializers/range_serializer.rb
+++ b/activejob/lib/active_job/serializers/range_serializer.rb
@@ -5,8 +5,8 @@ module ActiveJob
     class RangeSerializer < ObjectSerializer
       def serialize(range)
         super(
-          "begin" => Arguments.serialize(range.begin),
-          "end" => Arguments.serialize(range.end),
+          "begin" => Arguments.serialize_argument(range.begin),
+          "end" => Arguments.serialize_argument(range.end),
           "exclude_end" => range.exclude_end?, # Always boolean, no need to serialize
         )
       end


### PR DESCRIPTION
In 21fac8d8eeb147bb7ff4ec25b01e0007a04462a4 / https://github.com/rails/rails/pull/55583 I allowed `serialize` to accept all types, not just arrays to simplify some serializers, however that changed the behavior for objects other than arrays that respond to `#map`.

The same effect can be achieved by calling `serialize_argument` directly instead.

Since it used to be private, I marked it nodoc.


cc @composerinteralia 