### PR TITLE
Optimize ActiveJob ObjectSerializer

### DIFF
--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -28,6 +28,11 @@ module ActiveJob
         delegate :serialize?, :serialize, :deserialize, to: :instance
       end
 
+      def initialize
+        super
+        @template = { Arguments::OBJECT_SERIALIZER_KEY => self.class.name }.freeze
+      end
+
       # Determines if an argument should be serialized by a serializer.
       def serialize?(argument)
         argument.is_a?(klass)
@@ -35,7 +40,7 @@ module ActiveJob
 
       # Serializes an argument to a JSON primitive type.
       def serialize(hash)
-        { Arguments::OBJECT_SERIALIZER_KEY => self.class.name }.merge!(hash)
+        @template.merge(hash)
       end
 
       # Deserializes an argument from a JSON primitive type.


### PR DESCRIPTION
Same benchmark than in b6c472accd371de359f9ddd13c1f24e14e0d3019 / https://github.com/rails/rails/pull/55583

Since 1f8a0c06c163696618032d1001a0bdf9e2ac1ed1 had to be reverted as it changes the order of keys in the payload, the next bext thing we can do is to precompute the base hash.

The gain is modest but the patch is simple.

```
ruby 3.5.0dev (2025-08-27T10:41:07Z master 5257e1298c) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
aj-obj-serializer-template
                        23.500k i/100ms
Calculating -------------------------------------
aj-obj-serializer-template
                        234.683k (± 0.7%) i/s    (4.26 μs/i) -      1.175M in   5.007012s

Comparison:
aj-obj-serializer-template:   234682.8 i/s
     previous-commit:         223601.1 i/s - 1.05x  slower
```
