### PR TITLE
Generalize `:rich_text_area` Capybara selector

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Generalize `:rich_text_area` Capybara selector
+
+    Prepare for more Action Text-capable WYSIWYG editors by making
+    `:rich_text_area` rely on the presence of `[role="textbox"]` and
+    `[contenteditable]` HTML attributes rather than a `<trix-editor>` element.
+
+    *Sean Doyle*
+
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Forward `fill_in_rich_text_area` options to Capybara

--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -35,7 +35,13 @@ module ActionText
     #     # <trix-editor input="trix_input_1"></trix-editor>
     #     fill_in_rich_textarea "message[content]", with: "Hello <em>world!</em>"
     def fill_in_rich_textarea(locator = nil, with:, **)
-      find(:rich_textarea, locator, **).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
+      find(:rich_textarea, locator, **).execute_script(<<~JS, with.to_s)
+        if ("value" in this) {
+          this.value = arguments[0]
+        } else {
+          this.editor.loadHTML(arguments[0])
+        }
+      JS
     end
     alias_method :fill_in_rich_text_area, :fill_in_rich_textarea
   end
@@ -45,13 +51,18 @@ end
   Capybara.add_selector rich_textarea do
     label "rich-text area"
     xpath do |locator|
+      xpath = XPath.descendant[[
+        XPath.attribute(:role) == "textbox",
+        (XPath.attribute(:contenteditable) == "") | (XPath.attribute(:contenteditable) == "true")
+      ].reduce(:&)]
+
       if locator.nil?
-        XPath.descendant(:"trix-editor")
+        xpath
       else
         input_located_by_name = XPath.anywhere(:input).where(XPath.attr(:name) == locator).attr(:id)
         input_located_by_label = XPath.anywhere(:label).where(XPath.string.n.is(locator)).attr(:for)
 
-        XPath.descendant(:"trix-editor").where \
+        xpath.where \
           XPath.attr(:id).equals(locator) |
           XPath.attr(:placeholder).equals(locator) |
           XPath.attr(:"aria-label").equals(locator) |

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -10,35 +10,48 @@ class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
   test "filling in a rich-text area by ID" do
     assert_selector :element, "trix-editor", id: "message_content"
     fill_in_rich_textarea "message_content", with: "Hello world!"
+    assert_selector :rich_text_area, "message_content", text: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by placeholder" do
     assert_selector :element, "trix-editor", placeholder: "Your message here"
     fill_in_rich_textarea "Your message here", with: "Hello world!"
+    assert_selector :rich_text_area, "Your message here", text: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by aria-label" do
     assert_selector :element, "trix-editor", "aria-label": "Message content aria-label"
     fill_in_rich_textarea "Message content aria-label", with: "Hello world!"
+    assert_selector :rich_text_area, "Message content aria-label", text: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by label" do
     assert_selector :label, "Message content label", for: "message_content"
     fill_in_rich_textarea "Message content label", id: "message_content", with: "Hello world!"
+    assert_selector :rich_text_area, "Message content label", text: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by input name" do
     assert_selector :element, "trix-editor", input: true
     fill_in_rich_textarea "message[content]", with: "Hello world!"
+    assert_selector :rich_text_area, "message[content]", text: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in the only rich-text area" do
     fill_in_rich_textarea with: "Hello world!"
+    assert_selector :rich_text_area, text: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
+  end
+
+  test "filling in a rich-text area with nil" do
+    fill_in_rich_textarea "message_content", with: nil
+    assert_selector :rich_text_area do |rich_text_area|
+      assert_empty rich_text_area.text
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Prepare for more Action Text-capable WYSIWYG editors by making `:rich_text_area` rely on the presence of [role="textbox"][] and [contenteditable][] HTML attributes rather than a `<trix-editor>` element. The `<trix-editor>` element will [set both of these HTML attributes when it connects to the document][connectedCallback].

### Detail

In addition, modify the JavaScript executed by the `fill_in_rich_textarea` system test helper to first check for the presence of the `.value` property on the `<trix-editor>` element (available since [trix@v2.1.7][]) before falling back to calling `this.editor.loadHTML(arguments[0])`.


### Additional information

Related to [basecamp/lexxy#193][]

[basecamp/lexxy#193]: https://github.com/basecamp/lexxy/issues/193#issuecomment-3286323679
[role="textbox"]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/textbox_role
[contenteditable]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable
[connectedCallback]: https://github.com/basecamp/trix/blob/v2.1.15/src/trix/elements/trix_editor_element.js#L485-L486
[trix@v2.1.7]: https://github.com/basecamp/trix/releases/tag/v2.1.7

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
