### PR TITLE
Fix `SCRIPT_NAME` handling in URL helpers for root-mounted engines

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   URL helpers for engines mounted at the application root handle `SCRIPT_NAME` correctly.
+
+    Fixed an issue where `SCRIPT_NAME` is not applied to paths generated for routes in an engine
+    mounted at "/".
+
+    *Mike Dalessio*
+
 *   Update `ActionController::Metal::RateLimiting` to support passing method names to `:by` and `:with`
 
     ```ruby

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -54,6 +54,7 @@ module ActionDispatch
       # dependent part.
       def merge_script_names(previous_script_name, new_script_name)
         return new_script_name unless previous_script_name
+        new_script_name = new_script_name.chomp("/")
 
         resolved_parts = new_script_name.count("/")
         previous_parts = previous_script_name.count("/")

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -47,6 +47,7 @@ module ApplicationTests
       @simple_plugin.write "config/routes.rb", <<-RUBY
         Weblog::Engine.routes.draw do
           get '/weblog' => "weblogs#index", as: 'weblogs'
+          get '/generate_weblog_route' => "weblogs#generate_weblog_route", as: 'weblog_generate_weblog_route'
         end
       RUBY
 
@@ -54,6 +55,10 @@ module ApplicationTests
         class WeblogsController < ActionController::Base
           def index
             render plain: request.url
+          end
+
+          def generate_weblog_route
+            render plain: weblog.weblogs_path
           end
         end
       RUBY
@@ -285,6 +290,14 @@ module ApplicationTests
       # test that the Active Storage direct upload URL is added to a file field that explicitly requires it within en engine's view code
       get "/someone/blog/file_field_with_direct_upload_path"
       assert_equal "<input type=\"file\" name=\"image\" id=\"image\" data-direct-upload-url=\"http://example.org/rails/active_storage/direct_uploads\" />", last_response.body
+
+      # test that correct path is generated in an engine mounted at root
+      get "/generate_weblog_route"
+      assert_equal "/weblog", last_response.body
+
+      # test that correct path is generated in an engine mounted at root with default_url_options
+      get "/generate_weblog_route", {}, { "SCRIPT_NAME" => "/1234" }
+      assert_equal "/1234/weblog", last_response.body
     end
 
     test "route path for controller action when engine is mounted at root" do


### PR DESCRIPTION
### Motivation / Background

When an engine is mounted at "/" and `SCRIPT_NAME` is being used, the URL helpers incorrectly drop the script name from the generated URLs.

### Detail

The issue is in the private method `ActionDispatch::Routing::RoutesProxy#merge_script_names` which doesn't handle the edge case of `new_script_name` being a sole slash "/" with no segment following it.

This bug does not manifest for non-root paths with trailing slashes (like "/bar/") because the paths are cleaned up by `Mapper::Mapping#normalize_path` in `Mapper::Resources.add_route`.

The fix I've adopted here is simply to remove any trailing "/" from the `new_script_name` variable. We could also just return `previous_script_name` if `new_script_name == "/"`, however I thought running the names through the existing logic would be preferable to a special-case guard clause.


### Additional information

I think this issue has been present since the changes introduced in #29898 in Rails v5.2.0. cc @deivid-rodriguez in case he has feedback! 🙏

I think this might fix https://github.com/rails/rails/issues/34023. cc @jeremy in case he remembers what was going on there.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
