### PR TITLE
Add nodoc to MySQL::IndexDefinition

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -48,7 +48,7 @@ module ActiveRecord
       end
 
       # = Active Record MySQL Adapter \Index Definition
-      class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition
+      class IndexDefinition < ActiveRecord::ConnectionAdapters::IndexDefinition # :nodoc:
         attr_accessor :enabled
 
         def initialize(*args, **kwargs)


### PR DESCRIPTION
Since its superclass, IndexDefinition, is nodoc, this probably should be too.

