### PR TITLE
Remove unused AbstractPool module

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -8,12 +8,7 @@ require "active_record/connection_adapters/abstract/connection_pool/reaper"
 
 module ActiveRecord
   module ConnectionAdapters
-    module AbstractPool # :nodoc:
-    end
-
     class NullPool # :nodoc:
-      include ConnectionAdapters::AbstractPool
-
       class NullConfig
         def method_missing(...)
           nil
@@ -229,7 +224,6 @@ module ActiveRecord
 
       include MonitorMixin
       prepend QueryCache::ConnectionPoolConfiguration
-      include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
       attr_reader :db_config, :max_connections, :min_connections, :max_age, :keepalive, :reaper, :pool_config, :async_executor, :role, :shard


### PR DESCRIPTION
It was originally [introduced][1] when moving schema caches from the connections to pools to share logic between the real ConnectionPool and the NullPool.

However, the AbstractPool's implementation was later [removed][2] when refactoring SchemaCache to use pools instead of connections.

[1]: https://github.com/rails/rails/commit/49b6b211a922f73d0b083e7e4d2f0a91bd44da90
[2]: https://github.com/rails/rails/commit/b36f9186b0516ef17a6d29e13d2d0e736af43ef2