### PR TITLE
Fix unresolvable RDoc references [ci-skip]

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -604,9 +604,8 @@ module ActionDispatch
   #         end
   #     end
   #
-  # See the [request helpers documentation]
-  # (rdoc-ref:ActionDispatch::Integration::RequestHelpers) for help
-  # on how to use `get`, etc.
+  # See the [request helpers documentation](rdoc-ref:ActionDispatch::Integration::RequestHelpers)
+  # for help on how to use `get`, etc.
   #
   # ### Changing the request encoding
   #

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -256,13 +256,13 @@ module ActiveRecord # :nodoc:
   # * AssociationTypeMismatch - The object assigned to the association wasn't of the type
   #   specified in the association definition.
   # * AttributeAssignmentError - An error occurred while doing a mass assignment through the
-  #   {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  #   {ActiveRecord::Base#attributes=}[rdoc-ref:ActiveModel::AttributeAssignment#attributes=] method.
   #   You can inspect the +attribute+ property of the exception object to determine which attribute
   #   triggered the error.
   # * ConnectionNotEstablished - No connection has been established.
   #   Use {ActiveRecord::Base.establish_connection}[rdoc-ref:ConnectionHandling#establish_connection] before querying.
   # * MultiparameterAssignmentErrors - Collection of errors that occurred during a mass assignment using the
-  #   {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  #   {ActiveRecord::Base#attributes=}[rdoc-ref:ActiveModel::AttributeAssignment#attributes=] method.
   #   The +errors+ property of this exception contains an array of
   #   AttributeAssignmentError
   #   objects that should be inspected to determine which attributes triggered the errors.

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
   # Raised when the single-table inheritance mechanism fails to locate the subclass
   # (for example due to improper usage of column that
-  # {ActiveRecord::Base.inheritance_column}[rdoc-ref:ModelSchema::ClassMethods#inheritance_column]
+  # {ActiveRecord::Base.inheritance_column}[rdoc-ref:ModelSchema.inheritance_column]
   # points to).
   class SubclassNotFound < ActiveRecordError
   end
@@ -451,7 +451,7 @@ module ActiveRecord
   UnknownAttributeError = ActiveModel::UnknownAttributeError
 
   # Raised when an error occurred while doing a mass assignment to an attribute through the
-  # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  # {ActiveRecord::Base#attributes=}[rdoc-ref:ActiveModel::AttributeAssignment#attributes=] method.
   # The exception has an +attribute+ property that is the name of the offending attribute.
   class AttributeAssignmentError < ActiveRecordError
     attr_reader :exception, :attribute
@@ -464,7 +464,7 @@ module ActiveRecord
   end
 
   # Raised when there are multiple errors while doing a mass assignment through the
-  # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=]
+  # {ActiveRecord::Base#attributes=}[rdoc-ref:ActiveModel::AttributeAssignment#attributes=]
   # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
   # objects, each corresponding to the error while assigning to an attribute.
   class MultiparameterAssignmentErrors < ActiveRecordError

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -307,7 +307,7 @@ module ActiveRecord
       end
     end
 
-    # Like #find_or_create_by, but calls {new}[rdoc-ref:Core#new]
+    # Like #find_or_create_by, but calls {new}[rdoc-ref:Core.new]
     # instead of {create}[rdoc-ref:Persistence::ClassMethods#create].
     def find_or_initialize_by(attributes, &block)
       find_by(attributes) || new(attributes, &block)


### PR DESCRIPTION
```
ActionDispatch/IntegrationTest.html: `rdoc-ref:ActionDispatch::Integration::RequestHelpers)` can't be resolved for `ActionDispatch::Integration::RequestHelpers)`
ActionDispatch/IntegrationTest.html: `rdoc-ref:ActionDispatch::Integration::RequestHelpers)` can't be resolved for `ActionDispatch::Integration::RequestHelpers)`
ActiveRecord/AttributeAssignmentError.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/AttributeAssignmentError.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/Base.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/Base.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/Base.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/Base.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/MultiparameterAssignmentErrors.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/MultiparameterAssignmentErrors.html: `rdoc-ref:AttributeAssignment#attributes=` can't be resolved for `ActiveRecord::Base#attributes=`
ActiveRecord/Relation.html: `rdoc-ref:Core#new` can't be resolved for `new`
ActiveRecord/SubclassNotFound.html: `rdoc-ref:ModelSchema::ClassMethods#inheritance_column` can't be resolved for `ActiveRecord::Base.inheritance_column`
ActiveRecord/SubclassNotFound.html: `rdoc-ref:ModelSchema::ClassMethods#inheritance_column` can't be resolved for `ActiveRecord::Base.inheritance_column`
```