### PR TITLE
Removing the string option for validations

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -147,14 +147,14 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>except: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
-      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
+      # * <tt>:if</tt> - Specifies a method or proc to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
-      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
-      #   proc or string should return or evaluate to a +true+ or +false+ value.
-      # * <tt>:unless</tt> - Specifies a method, proc, or string to call to
+      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method or
+      #   proc should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:unless</tt> - Specifies a method or proc to call to
       #   determine if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
       #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
-      #   method, proc, or string should return or evaluate to a +true+ or +false+
+      #   method or proc should return or evaluate to a +true+ or +false+
       #   value.
       #
       # NOTE: Calling +validate+ multiple times on the same method will overwrite previous definitions.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because in Rails 5.2 the option of passing a string to :if and :unless was removed and causes now:  Passing string to be evaluated in :if and :unless conditional options is not supported. Pass a symbol for an instance method, or a lambda, proc or block, instead. (ArgumentError)

### Detail

This Pull Request changes the documentation for validations.

### Additional information

The commit in which it was removed was https://github.com/rails/rails/commit/c792354adcbf8c966f274915c605c6713b840548

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
