### PR TITLE
Support integer shard keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add support for integer shard keys.
+    ```ruby
+    # Now accepts symbols as shard keys.
+    ActiveRecord::Base.connects_to(shards: {
+      1: { writing: :primary_shard_one, reading: :primary_shard_one },
+      2: { writing: :primary_shard_two, reading: :primary_shard_two},
+    })
+
+    ActiveRecord::Base.connected_to(shard: 1) do
+      # ..
+    end
+    ```
+
+    *Nony Dutton*
+
 *   Add `ActiveRecord::Base.only_columns`
 
     Similar in use case to `ignored_columns` but listing columns to consider rather than the ones

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -100,7 +100,8 @@ module ActiveRecord
           db_config = resolve_config_for_connection(database_key)
 
           self.connection_class = true
-          connections << connection_handler.establish_connection(db_config, owner_name: self, role: role, shard: shard.to_sym)
+          shard = shard.to_sym unless shard.is_a? Integer
+          connections << connection_handler.establish_connection(db_config, owner_name: self, role: role, shard: shard)
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

Currently, `.connects_to(shards: ...)` coerces all of the shard keys into symbols. Because an integer cannot be coerced into a symbol, attempting to identify a shard with an integer will raise an exception:

```ruby
1.to_sym
(irb):1:in '<main>': undefined method 'to_sym' for an instance of Integer (NoMethodError)
```

I think it would be useful to support integers as shard keys along with symbols. This would simplify shard switching when shards are identified by integer columns in a database.

As an example, if there is an `accounts` table with a `shard` integer column which identifies which shard that account's data lives on, this currently would not work:

```ruby
account = Account.first

ActiveRecord::Base.connected_to(shard: account.shard) do
  # ...
end
```

A workaround would be to first coerce or serialize the integer into a string but that's unideal:

```ruby
account = Account.first

ActiveRecord::Base.connected_to(shard: account.shard.to_s.to_sym) do
  # ...
end
```

### Detail

This makes a `.connects_to` change, coercing the shard key into a symbol _unless_ the key is an integer. From there, passing a symbol or integer to `connected_to(shard: ...)` should both work.

### Additional information

`connected_to` will no longer raise `NoMethodError` when you pass it shard keys as integers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
