### PR TITLE
Restore initial condition around setting of time attributes when deserializing a job

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -167,8 +167,8 @@ module ActiveJob
       self.exception_executions = job_data["exception_executions"]
       self.locale               = job_data["locale"] || I18n.locale.to_s
       self.timezone             = job_data["timezone"] || Time.zone&.name
-      self.enqueued_at          = deserialize_time(job_data["enqueued_at"])
-      self.scheduled_at         = deserialize_time(job_data["scheduled_at"])
+      self.enqueued_at          = deserialize_time(job_data["enqueued_at"]) if job_data["enqueued_at"]
+      self.scheduled_at         = deserialize_time(job_data["scheduled_at"]) if job_data["scheduled_at"]
     end
 
     # Configures the job with the given options.
@@ -212,7 +212,7 @@ module ActiveJob
       def deserialize_time(time)
         if time.is_a?(Time)
           time
-        elsif time
+        else
           Time.iso8601(time)
         end
       end

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -41,6 +41,20 @@ class JobSerializationTest < ActiveSupport::TestCase
     end
   end
 
+  test "keeps scheduled_at around after deserialization if data doesnt include it" do
+    freeze_time
+
+    current_time = Time.now
+
+    job = HelloJob.new
+    serialized_job = job.serialize
+    job.set(wait_until: current_time)
+
+    job.deserialize(serialized_job)
+
+    assert_equal current_time, job.scheduled_at
+  end
+
   test "deserializes enqueued_at when ActiveSupport.parse_json_times is true" do
     freeze_time
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

After https://github.com/rails/rails/pull/55661 was merged a bug was reported that the behavior changed slightly. Moving the `if` into a method resulted in the enqueued_at and scheduled_at being set to nil if no data was passed. Instead to restore the prior behavior it should skip setting the attr if the data is missing in the job_data.


This Pull Request has been created because of a bug reported here: https://github.com/rails/rails/pull/55661#issuecomment-3299689673

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
