### PR TITLE
Use PG::Connection#close_prepared when available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,13 @@ GEM
       ast (~> 2.4.1)
       racc
     path_expander (1.1.3)
-    pg (1.5.9)
+    pg (1.6.2)
+    pg (1.6.2-aarch64-linux)
+    pg (1.6.2-aarch64-linux-musl)
+    pg (1.6.2-arm64-darwin)
+    pg (1.6.2-x86_64-darwin)
+    pg (1.6.2-x86_64-linux)
+    pg (1.6.2-x86_64-linux-musl)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Use `PG::Connection#close_prepared` (protocol level Close) to deallocate
+    prepared statements when available.
+
+    To enable its use, you must have pg >= 1.6.0, libpq >= 17, and a PostgreSQL
+    database version >= 17.
+
+    *Hartley McGuire*, *Andrew Jackson*
+
 *   Fix query cache for pinned connections in multi threaded transactional tests
 
     When a pinned connection is used across separate threads, they now use a separate cache store


### PR DESCRIPTION
Fix #55653

pgbouncer does not support "DEALLOCATE #{key}", but it does support "protocol level Close" (#close_prepared) starting in version 1.21.

This commit changes the PostgreSQL adapter to use #close_prepared (when available) to better support pgbouncer.