### PR TITLE
[ci skip] docs: Fix out of date docs on cache.namespace

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -184,7 +184,7 @@ module ActiveSupport
     # is a Proc, it will be invoked when each key is evaluated so that you can
     # use application logic to invalidate keys.
     #
-    #   cache.namespace = -> { @last_mod_time }  # Set the namespace to a variable
+    #   cache.options[:namespace] = -> { @last_mod_time }  # Set the namespace to a variable
     #   @last_mod_time = Time.now  # Invalidate the entire cache by changing namespace
     #
     class Store


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I was trying to use cache namespaces and they didn't work as intended. Following the documentation and creating an initializer similar to the documented:

```ruby
Rails.cache.namespace = -> { @last_mod_time }
```

caused the application to crash.

### Detail

This Pull Request updates the documented example on how to set the namespace for an already initialized cache store instance.