### PR TITLE
fix delegation visibility when using `...` in Ruby 3.4.0–3.4.2

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
+*   Fix issue with method visibility being ignored when delegating methods with arguments using `...` in Ruby versions 3.4.0 to 3.4.2.
+
+    Add explicit behavior for these Ruby versions:
+
+    ```ruby
+      RUBY_VERSION >= "3.4.0" && RUBY_VERSION <= "3.4.2" ? "*args, **kwargs, &block" : "..."
+    ```
+
+    In the old implementation, it was possible to call private methods of another class through delegation.
+
+    *Georgiy Melnikov*
+
 *   Add `ActiveSupport::Cache::Store#namespace=` and `#namespace`.
 
     Can be used as an alternative to `Store#clear` in some situations such as parallel

--- a/activesupport/lib/active_support/delegation.rb
+++ b/activesupport/lib/active_support/delegation.rb
@@ -93,14 +93,14 @@ module ActiveSupport
                 parameters = method_object.parameters
 
                 if parameters.map(&:first).intersect?([:opt, :rest, :keyreq, :key, :keyrest])
-                  "..."
+                  RUBY_VERSION >= "3.4.0" && RUBY_VERSION <= "3.4.2" ? "*args, **kwargs, &block" : "..."
                 else
                   defn = parameters.filter_map { |type, arg| arg if type == :req }
                   defn << "&"
                   defn.join(", ")
                 end
               else
-                "..."
+                RUBY_VERSION >= "3.4.0" && RUBY_VERSION <= "3.4.2" ? "*args, **kwargs, &block" : "..."
               end
             end
 


### PR DESCRIPTION
### Motivation / Background

Method delegation with the `...` argument allows calling private methods on another object, bypassing their visibility (relevant for Ruby versions 3.4.0–3.4.2, see: https://bugs.ruby-lang.org/issues/21196)

### Detail

Fix delegation visibility issue in Ruby 3.4.0–3.4.2.

In these Ruby versions, using `...` to forward arguments ignores method visibility, allowing private methods to be called. To work around this, delegation now explicitly expands arguments with `*args, **kwargs, &block` instead of `...`:

```ruby
RUBY_VERSION >= "3.4.0" && RUBY_VERSION <= "3.4.2" ? "*args, **kwargs, &block" : "
```
This ensures consistent and expected behavior across all Ruby versions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
