### PR TITLE
[ci skip] Warn against using arbitrary user supplied image transformations

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -968,6 +968,12 @@ location.
 <%= image_tag user.avatar.variant(resize_to_limit: [100, 100]) %>
 ```
 
+WARNING: It should be considered unsafe to provide arbitrary user supplied
+transformations or parameters to variant processors. This can potentially
+enable command injection vulnerabilities in your app. It is also recommended
+to implement a strict [ImageMagick security policy](https://imagemagick.org/script/security-policy.php)
+when MiniMagick is the variant processor of choice.
+
 If a variant is requested, Active Storage will automatically apply
 transformations depending on the image's format:
 


### PR DESCRIPTION
### Motivation / Background

In solving for the image transformation issue in the [latest security release](https://discuss.rubyonrails.org/t/cve-2025-24293-active-storage-allowed-transformation-methods-potentially-unsafe/89670), we came to the conclusion that although we make an attempt to de-risk accepting arbitrary user-supplied image transformation methods / parameters, this behavior should not be considered officially supported.


### Detail

This pull request updates the related ActiveStorage guide to note that this behavior should be considered unsafe.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
