### PR TITLE
Do not issue `Benchmark.ms` deprecation when method exists in the gem

### DIFF
--- a/activesupport/lib/active_support/core_ext/benchmark.rb
+++ b/activesupport/lib/active_support/core_ext/benchmark.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "benchmark"
+return if Benchmark.respond_to?(:ms)
 
 class << Benchmark
   def ms(&block) # :nodoc


### PR DESCRIPTION
`benchmark` gem is going to have `ms` method natively in the next version - https://github.com/ruby/benchmark/pull/38
So Rails doesn't need to issue a deprecation since there will be no breaking change for applications using `Benchmark.ms` 