### PR TITLE
Don't add id_value attribute alias when id_value is present

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,6 +4,10 @@
 
     *Yasuo Honda*, *Lars Kanis*
 
+*   Don't add `id_value` attribute alias when attribute/column with that name already exists.
+
+    *Rob Lewis*
+
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Remove deprecated `:unsigned_float` and `:unsigned_decimal` column methods for MySQL.

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -113,7 +113,7 @@ module ActiveRecord
           unless abstract_class?
             load_schema
             super(attribute_names)
-            alias_attribute :id_value, :id if _has_attribute?("id")
+            alias_attribute :id_value, :id if _has_attribute?("id") && !_has_attribute?("id_value")
           end
 
           generate_alias_attributes

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -15,6 +15,7 @@ require "models/contact"
 require "models/keyboard"
 require "models/numeric_data"
 require "models/cpk"
+require "models/book_identifier"
 
 class AttributeMethodsTest < ActiveRecord::TestCase
   include InTimeZone
@@ -31,7 +32,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   ActiveRecord::Type.register(:epoch_timestamp, EpochTimestamp)
 
-  fixtures :topics, :developers, :companies, :computers
+  fixtures :topics, :developers, :companies, :computers, :book_identifiers
 
   def setup
     @old_matchers = ActiveRecord::Base.send(:attribute_method_patterns).dup
@@ -54,6 +55,17 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_includes new_topic_model.attribute_aliases, "id_value"
   end
 
+  test "#id_value alias is not defined if id_value column exist" do
+    new_book_identifier_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "book_identifiers"
+    end
+
+    new_book_identifier_model.define_attribute_methods
+    assert_includes new_book_identifier_model.attribute_names, "id"
+    assert_includes new_book_identifier_model.attribute_names, "id_value"
+    assert_empty new_book_identifier_model.attribute_aliases
+  end
+
   test "aliasing `id` attribute allows reading the column value" do
     topic = Topic.create(id: 123_456, title: "title").becomes(TitlePrimaryKeyTopic)
 
@@ -73,6 +85,14 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     topic = Topic.find(1)
     assert_equal 1, topic.id_value
+  end
+
+  test "#id_value returns the value in the id_value column, when id_value column exists" do
+    book_identifier = BookIdentifier.new
+    assert_nil book_identifier.id_value
+
+    book_identifier = BookIdentifier.find(1)
+    assert_equal book_identifiers(:awdr_isbn13).id_value, book_identifier.id_value
   end
 
   test "#id_value alias is not defined if id column doesn't exist" do

--- a/activerecord/test/fixtures/book_identifiers.yml
+++ b/activerecord/test/fixtures/book_identifiers.yml
@@ -1,0 +1,11 @@
+awdr_isbn13:
+  book_id: 1
+  id: 1
+  id_type: "ISBN-13"
+  id_value: "979-8888651346"
+
+awdr_asin:
+  book_id: 1
+  id: 2
+  id_type: "ASIN"
+  id_value: "B0DXPFFXD9"

--- a/activerecord/test/models/book_identifier.rb
+++ b/activerecord/test/models/book_identifier.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class BookIdentifier < ActiveRecord::Base
+  belongs_to :book
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -155,6 +155,12 @@ ActiveRecord::Schema.define do
     t.date :updated_on
   end
 
+  create_table :book_identifiers, id: :integer, force: true do |t|
+    t.references :book
+    t.string :id_type, null: false
+    t.string :id_value, null: false
+  end
+
   create_table :encrypted_books, id: :integer, force: true do |t|
     t.references :author
     t.string :format


### PR DESCRIPTION
Our company has a rather large Rails project with at least 4 tables/models with a pair of columns named `id_type` and `id_value`. This is colliding with the new special `id_value` attribute alias added in Rails 7.1. This change skips adding the alias on models that already have `id_value`. Obviously this means we couldn't also have compound key support on the same table but I think that's ok since this is likely only happening on legacy models.

### Detail

This Pull Request changes `ActiveRecord::AttributeMethods#define_attribute_methods` to skip `alias_attribute :id_value` for cases where `id_value` columns exist.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
