### PR TITLE
Merge pull request #55691 from kohder/rl-id-value-alias-fix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Don't add `id_value` attribute alias when attribute/column with that name already exists.
+
+    *Rob Lewis*
+
 *   Fix false positive change detection involving STI and polymorhic has one relationships.
 
     Polymorphic `has_one` relationships would always be considered changed when defined in a STI child

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -113,7 +113,7 @@ module ActiveRecord
           unless abstract_class?
             load_schema
             super(attribute_names)
-            alias_attribute :id_value, :id if _has_attribute?("id")
+            alias_attribute :id_value, :id if _has_attribute?("id") && !_has_attribute?("id_value")
           end
 
           generate_alias_attributes

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -15,11 +15,12 @@ require "models/contact"
 require "models/keyboard"
 require "models/numeric_data"
 require "models/cpk"
+require "models/book_identifier"
 
 class AttributeMethodsTest < ActiveRecord::TestCase
   include InTimeZone
 
-  fixtures :topics, :developers, :companies, :computers
+  fixtures :topics, :developers, :companies, :computers, :book_identifiers
 
   def setup
     @old_matchers = ActiveRecord::Base.send(:attribute_method_patterns).dup
@@ -42,6 +43,17 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_includes new_topic_model.attribute_aliases, "id_value"
   end
 
+  test "#id_value alias is not defined if id_value column exist" do
+    new_book_identifier_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "book_identifiers"
+    end
+
+    new_book_identifier_model.define_attribute_methods
+    assert_includes new_book_identifier_model.attribute_names, "id"
+    assert_includes new_book_identifier_model.attribute_names, "id_value"
+    assert_empty new_book_identifier_model.attribute_aliases
+  end
+
   test "aliasing `id` attribute allows reading the column value" do
     topic = Topic.create(id: 123_456, title: "title").becomes(TitlePrimaryKeyTopic)
 
@@ -61,6 +73,14 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     topic = Topic.find(1)
     assert_equal 1, topic.id_value
+  end
+
+  test "#id_value returns the value in the id_value column, when id_value column exists" do
+    book_identifier = BookIdentifier.new
+    assert_nil book_identifier.id_value
+
+    book_identifier = BookIdentifier.find(1)
+    assert_equal book_identifiers(:awdr_isbn13).id_value, book_identifier.id_value
   end
 
   test "#id_value alias is not defined if id column doesn't exist" do

--- a/activerecord/test/fixtures/book_identifiers.yml
+++ b/activerecord/test/fixtures/book_identifiers.yml
@@ -1,0 +1,11 @@
+awdr_isbn13:
+  book_id: 1
+  id: 1
+  id_type: "ISBN-13"
+  id_value: "979-8888651346"
+
+awdr_asin:
+  book_id: 1
+  id: 2
+  id_type: "ASIN"
+  id_value: "B0DXPFFXD9"

--- a/activerecord/test/models/book_identifier.rb
+++ b/activerecord/test/models/book_identifier.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class BookIdentifier < ActiveRecord::Base
+  belongs_to :book
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -159,6 +159,12 @@ ActiveRecord::Schema.define do
     t.date :updated_on
   end
 
+  create_table :book_identifiers, id: :integer, force: true do |t|
+    t.references :book
+    t.string :id_type, null: false
+    t.string :id_value, null: false
+  end
+
   create_table :encrypted_books, id: :integer, force: true do |t|
     t.references :author
     t.string :format


### PR DESCRIPTION
Backporting #55691 into 7-2-stable.

Don't add `id_value` attribute alias when `id_value` is present

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
