### PR TITLE
Add `image_processing` to the gemfile by default for active_storage

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -47,18 +47,6 @@ module ActionText
           "app/views/layouts/action_text/contents/_content.html.erb"
       end
 
-      def enable_image_processing_gem
-        if (gemfile_path = Pathname(destination_root).join("Gemfile")).exist?
-          say "Ensure image_processing gem has been enabled so image uploads will work (remember to bundle!)"
-          image_processing_regex = /gem ["']image_processing["']/
-          if File.readlines(gemfile_path).grep(image_processing_regex).any?
-            uncomment_lines gemfile_path, image_processing_regex
-          else
-            run "bundle add --skip-install image_processing"
-          end
-        end
-      end
-
       def create_migrations
         rails_command "railties:install:migrations FROM=active_storage,action_text", inline: true
       end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -112,7 +112,8 @@ module ActiveStorage
           when /image_processing/
             ActiveStorage.logger.warn <<~WARNING.squish
               Generating image variants require the image_processing gem.
-              Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.
+              Please add `gem "image_processing", "~> 1.2"` to your Gemfile
+              or set `config.active_storage.variant_processor = :disabled`.
             WARNING
           else
             raise

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -41,12 +41,6 @@ will not install, and must be installed separately:
 * [ffmpeg](http://ffmpeg.org/) v3.4+ for video previews and ffprobe for video/audio analysis
 * [poppler](https://poppler.freedesktop.org/) or [muPDF](https://mupdf.com/) for PDF previews
 
-Image analysis and transformations also require the `image_processing` gem. Uncomment it in your `Gemfile`, or add it if necessary:
-
-```ruby
-gem "image_processing", ">= 1.2"
-```
-
 TIP: Compared to libvips, ImageMagick is better known and more widely available. However, libvips can be [up to 10x faster and consume 1/10 the memory](https://github.com/libvips/libvips/wiki/Speed-and-memory-use). For JPEG files, this can be further improved by replacing `libjpeg-dev` with `libjpeg-turbo-dev`, which is [2-7x faster](https://libjpeg-turbo.org/About/Performance).
 
 WARNING: Before you install and use third-party software, make sure you understand the licensing implications of doing so. MuPDF, in particular, is licensed under AGPL and requires a commercial license for some use.

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -42,7 +42,7 @@ gem "thruster", require: false
 <% unless skip_active_storage? -%>
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 <% end -%>
 <%- if options.api? -%>
 

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -37,7 +37,7 @@ module ApplicationTests
     def test_default_transformer_missing_gem_warning
       output = run_command("puts ActiveStorage.variant_transformer")
 
-      assert_includes(output, "Generating image variants require the image_processing gem. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+      assert_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile')
     end
 
     def test_default_transformer_with_gem_no_warning
@@ -49,16 +49,16 @@ module ApplicationTests
 
       output = run_command("puts ActiveStorage.variant_transformer")
 
-      assert_not_includes(output, "Generating image variants require the image_processing gem. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+      assert_not_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile')
       assert_includes(output, "ActiveStorage::Transformers::Vips")
     end
 
-    def test_disabled_transformer_no_warning
+    def test_disabled_transformer_missing_gem_no_warning
       add_to_config "config.active_storage.variant_processor = :disabled"
 
       output = run_command("puts ActiveStorage.variant_transformer")
 
-      assert_not_includes(output, "Generating image variants require the image_processing gem. Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.")
+      assert_not_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile')
       assert_includes(output, "ActiveStorage::Transformers::NullTransformer")
     end
 

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -74,18 +74,6 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/create_action_text_tables.action_text.rb"
   end
 
-  test "uncomments image_processing gem" do
-    gemfile = Pathname("Gemfile").expand_path(destination_root)
-    gemfile.dirname.mkpath
-    gemfile.write(%(# gem "image_processing"))
-
-    run_generator_instance
-
-    assert_file gemfile do |content|
-      assert_equal %(gem "image_processing"), content
-    end
-  end
-
   private
     def run_generator_instance
       @run_commands = []

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1743,7 +1743,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     def assert_gem_for_active_storage
-      assert_file "Gemfile", /^# gem "image_processing"/
+      assert_gem "image_processing"
     end
 
     def assert_frameworks_are_not_required_when_active_storage_is_skipped


### PR DESCRIPTION
### Motivation / Background

Right now, a new rails app emits a warning because this gem is eagerly loaded. This prevents that,
and also shows how to opt out of using it alltogether.

See https://github.com/rails/rails/pull/55303 and its trail for more context.

What do you think @zzak?

### Additional information

ActionText wants this gem present. Since it now starts out uncommented, that logic is no longer needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
