### PR TITLE
Fix ActiveRecord vs db_config schema_format

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -466,8 +466,7 @@ db_namespace = namespace :db do
 
     desc "Load a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`) into the database"
     task load: [:load_config, :check_protected_environments] do
-      schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
-      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(schema_format, ENV["SCHEMA"])
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(ENV["SCHEMA_FORMAT"], ENV["SCHEMA"])
     end
 
     namespace :dump do


### PR DESCRIPTION
Fix #55698

Inside `load_schema_current` is `format || db_config.schema_format` (and `db_config.schema_format` is `format || ActiveRecord.schema_format`). So the correct thing to do here is only pass in `SCHEMA_FORMAT` if given so that it can fallback to a `db_config.schema_format` and only then fallback to `ActiveRecord.schema_format`.
