### PR TITLE
Make TableMetadata#associated_with non-predicate

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -99,7 +99,7 @@ module ActiveRecord
           elsif value.is_a?(Hash) && !table.has_column?(key)
             table.associated_table(key, &block)
               .predicate_builder.expand_from_hash(value.stringify_keys)
-          elsif (associated_reflection = table.associated_with?(key))
+          elsif (associated_reflection = table.associated_with(key))
             # Find the foreign key when using queries such as:
             # Post.where(author: author)
             #

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       klass&.columns_hash&.key?(column_name)
     end
 
-    def associated_with?(table_name)
+    def associated_with(table_name)
       klass&._reflect_on_association(table_name)
     end
 


### PR DESCRIPTION
Since we're using its return value now (and not its truthiness), it doesn't make sense to be a predicate method.
