### PR TITLE
Update devcontainer to use Ruby 3.4.6

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3.4, 3.3, 3.2
-ARG VARIANT="3.4.5"
+ARG VARIANT="3.4.6"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
### Motivation / Background
This pull request updates the devcontainer to use Ruby 3.4.6

### Detail

- Ruby version installed with this commit:
```bash
vscode ➜ /workspaces/rails (use-ruby346-devcontainer) $ ruby -v
ruby 3.4.6 (2025-09-16 revision dbd83256b1) +PRISM [aarch64-linux]
```

### Additional information
Ruby 3.4.6 is available at:
https://github.com/rails/devcontainer/pkgs/container/devcontainer%2Fimages%2Fruby/516271395?tag=3.4.6 https://github.com/rails/devcontainer/commit/845288ce6ebc271909795019e3f7915e2b25f69c

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
