### PR TITLE
Document change to schema.rb ordering [ci skip]

### DIFF
--- a/guides/source/8_1_release_notes.md
+++ b/guides/source/8_1_release_notes.md
@@ -127,6 +127,8 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 ### Notable changes
 
+*   The table columns inside `schema.rb` are [now sorted alphabetically.](https://github.com/rails/rails/pull/53281)
+
 Active Storage
 --------------
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -82,6 +82,9 @@ Upgrading from Rails 8.0 to Rails 8.1
 
 For more information on changes made to Rails 8.1 please see the [release notes](8_1_release_notes.html).
 
+### The table columns inside `schema.rb` are now sorted alphabetically.
+
+ActiveRecord now alphabetically sorts table columns in schema.rb by default, so dumps are consistent across machines and don’t flip-flop with migration order -- meaning fewer noisy diffs. structure.sql can still be leveraged to preserve exact column order. [See #53281 for more details on alphabetizing schema changes.](https://github.com/rails/rails/pull/53281)
 
 Upgrading from Rails 7.2 to Rails 8.0
 -------------------------------------


### PR DESCRIPTION
### Motivation / Background

The move to an alphabetized `schema.rb` file will affect many applications and makes sense to call out as a notable change. Anyone running `bin/rails app:update` or any other command that dumps the schema will run into it.

### Additional information

PR with the change: https://github.com/rails/rails/pull/53281

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
