### PR TITLE
Fix query cache for pinned connections in multi threaded transactional tests

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix query cache for pinned connections in multi threaded transactional tests
+
+    When a pinned connection is used across separate threads, they now use a separate cache store
+    for each thread.
+
+    This improve accuracy of system tests, and any test using multiple threads.
+
+    *Heinrich Lee Yu*, *Jean Boussier*
+
 *   Fix time attribute dirty tracking with timezone conversions.
 
     Time-only attributes now maintain a fixed date of 2000-01-01 during timezone conversions,

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -31,6 +31,7 @@ module ActiveRecord
       end
 
       def schema_cache; end
+      def query_cache; end
       def connection_descriptor; end
       def checkin(_); end
       def remove(_); end
@@ -362,6 +363,7 @@ module ActiveRecord
         end
 
         @pinned_connection.lock_thread = ActiveSupport::IsolatedExecutionState.context if lock_thread
+        @pinned_connection.pinned = true
         @pinned_connection.verify! # eagerly validate the connection
         @pinned_connection.begin_transaction joinable: false, _lazy: false
       end
@@ -384,6 +386,7 @@ module ActiveRecord
           end
 
           if @pinned_connection.nil?
+            connection.pinned = false
             connection.steal!
             connection.lock_thread = nil
             checkin(connection)

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -209,15 +209,26 @@ module ActiveRecord
         end
       end
 
-      attr_accessor :query_cache
-
       def initialize(*)
         super
         @query_cache = nil
       end
 
+      attr_writer :query_cache
+
+      def query_cache
+        if @pinned && @owner != ActiveSupport::IsolatedExecutionState.context
+          # With transactional tests, if the connection is pinned, any thread
+          # other than the one that pinned the connection need to go through the
+          # query cache pool, so each thread get a different cache.
+          pool.query_cache
+        else
+          @query_cache
+        end
+      end
+
       def query_cache_enabled
-        @query_cache&.enabled?
+        query_cache&.enabled?
       end
 
       # Enable the query cache within the block.
@@ -256,7 +267,7 @@ module ActiveRecord
 
         # If arel is locked this is a SELECT ... FOR UPDATE or somesuch.
         # Such queries should not be cached.
-        if @query_cache&.enabled? && !(arel.respond_to?(:locked) && arel.locked)
+        if query_cache_enabled && !(arel.respond_to?(:locked) && arel.locked)
           sql, binds, preparable, allow_retry = to_sql_and_binds(arel, binds, preparable, allow_retry)
 
           if async
@@ -280,7 +291,7 @@ module ActiveRecord
 
           result = nil
           @lock.synchronize do
-            result = @query_cache[key]
+            result = query_cache[key]
           end
 
           if result
@@ -299,7 +310,7 @@ module ActiveRecord
           hit = true
 
           @lock.synchronize do
-            result = @query_cache.compute_if_absent(key) do
+            result = query_cache.compute_if_absent(key) do
               hit = false
               yield
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -43,6 +43,7 @@ module ActiveRecord
       attr_reader :pool
       attr_reader :visitor, :owner, :logger, :lock
       attr_accessor :allow_preconnect
+      attr_accessor :pinned # :nodoc:
       alias :in_use? :owner
 
       def pool=(value)
@@ -153,6 +154,7 @@ module ActiveRecord
         end
 
         @owner = nil
+        @pinned = false
         @pool = ActiveRecord::ConnectionAdapters::NullPool.new
         @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @allow_preconnect = true

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -729,16 +729,28 @@ class QueryCacheTest < ActiveRecord::TestCase
       ActiveRecord::Base.lease_connection.enable_query_cache!
       assert_cache :clean
 
+      main_thread_cache = ActiveRecord::Base.lease_connection.query_cache
+      assert_same main_thread_cache, ActiveRecord::Base.lease_connection.query_cache
+
       thread_a = Thread.new do
         middleware { |env|
           assert_cache :clean
+
+          # In a background thread, the cache instance must stay consistent but be different from the main
+          # thread.
+          background_thread_cache = ActiveRecord::Base.lease_connection.query_cache
+          assert_same background_thread_cache, ActiveRecord::Base.lease_connection.query_cache
+          assert_not_same main_thread_cache, ActiveRecord::Base.lease_connection.query_cache
           [200, {}, nil]
         }.call({})
       end
 
       thread_a.join
+
+      assert_same main_thread_cache, ActiveRecord::Base.lease_connection.query_cache
     ensure
       ActiveRecord::Base.connection_pool.unpin_connection!
+      assert_same main_thread_cache, ActiveRecord::Base.lease_connection.query_cache
     end
   end
 
@@ -755,7 +767,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
       thread_a = Thread.new do
         middleware { |env|
-          assert_cache :dirty # The cache is shared with the main thread
+          assert_cache :clean
 
           Post.first
           assert_cache :dirty
@@ -845,10 +857,12 @@ class QueryCacheTest < ActiveRecord::TestCase
         end
       when :clean
         assert connection.query_cache_enabled, "cache should be on"
+        assert_not_nil connection.query_cache
         assert_predicate connection.query_cache, :empty?, "cache should be empty"
       when :dirty
         assert connection.query_cache_enabled, "cache should be on"
-        assert_not connection.query_cache.empty?, "cache should be dirty"
+        assert_not_nil connection.query_cache
+        assert_not_predicate connection.query_cache, :empty?, "cache should be dirty"
       else
         raise "unknown state"
       end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/55689
Fix: https://github.com/rails/rails/pull/55696

When a pinned connection is used across separate threads, each thread should have its own query cache store.

@engwan
