### PR TITLE
[7-2-stable] Allow installing ruby platform gems for sass-embedded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "cssbundling-rails"
 gem "importmap-rails", ">= 1.2.3"
 gem "tailwindcss-rails"
 gem "dartsass-rails"
+gem "sass-embedded", "< 1.77"
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)
 # being dependent on a binary library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,11 +510,14 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.9.1)
       fugit (~> 1.1, >= 1.1.6)
-    sass-embedded (1.77.4-aarch64-linux-gnu)
+    sass-embedded (1.76.0)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.4-arm64-darwin)
+      rake (>= 13.0.0)
+    sass-embedded (1.76.0-aarch64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.4-x86_64-linux-gnu)
+    sass-embedded (1.76.0-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.76.0-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
     sdoc (2.6.1)
       rdoc (>= 5.0)
@@ -629,6 +632,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-24
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -692,6 +696,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rails-omakase
   rubyzip (~> 2.0)
+  sass-embedded (< 1.77)
   sdoc
   selenium-webdriver (>= 4.20.0)
   sidekiq


### PR DESCRIPTION
In sass-contrib/sass-embedded-host-ruby@2c14553 support for Ruby < 3.2 was ended for native linux platform gem installs, because it has some issues.

```
Installing sass-embedded 1.78.0 (was 1.76.0) with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/sass-embedded-1.78.0/ext/sass
/home/zzak/.rbenv/versions/3.1.7/bin/ruby -I/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0 -rrubygems
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/rake-13.3.0/exe/rake
RUBYARCHDIR\=/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/sass-embedded-1.78.0
RUBYLIBDIR\=/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/sass-embedded-1.78.0
gem install --force --install-dir /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/sass-embedded-1.78.0/ext/sass/ruby
--no-document --ignore-dependencies --platform x86_64-linux-gnu --version 1.78.0 sass-embedded
rake aborted!
NameError: uninitialized constant JSON::Fragment
<internal:/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:96:in `require'
<internal:/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:96:in `require'
<internal:/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require'
<internal:/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require'
<internal:/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require'
<internal:/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require'

Caused by:
NoMethodError: undefined method `parse' for #<Psych::Parser:0x00007f813b85ead0
@handler=#<Psych::Handlers::DocumentStream:0x00007f813b85ebe8 @stack=[], @last=nil, @root=nil, @start_line=nil,
@start_column=nil, @end_line=nil, @end_column=nil, @block=#<Proc:0x00007f813b85eb20
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/psych.rb:399>>, @external_encoding=0>

      parser.parse yaml, filename
            ^^^^^^

Tasks: TOP => default => install => cli.rb => dart-sass
(See full trace by running task with --trace)
rm -rf /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/sass-embedded-1.78.0/ext/sass/ruby

rake failed, exit code 1

Gem files will remain installed in /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/sass-embedded-1.78.0 for
inspection.
Results logged to
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/sass-embedded-1.78.0/gem_make.out

  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/ext/builder.rb:102:in `run'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/ext/rake_builder.rb:28:in `build'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/ext/builder.rb:171:in `build_extension'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/ext/builder.rb:205:in `block in build_extensions'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/ext/builder.rb:202:in `each'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/ext/builder.rb:202:in `build_extensions'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/3.1.0/rubygems/installer.rb:843:in `build_extensions'
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/rubygems_gem_installer.rb:76:in
`build_extensions'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/source/rubygems.rb:205:in `install'
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/installer/gem_installer.rb:54:in
`install'
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/installer/parallel_installer.rb:132:in
`do_install'
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/installer/parallel_installer.rb:123:in
`block in worker_pool'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/worker.rb:62:in `apply_func'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/worker.rb:57:in `block in process_queue'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/worker.rb:54:in `loop'
  /home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/worker.rb:54:in `process_queue'
/home/zzak/.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/worker.rb:90:in `block (2 levels) in
create_threads'

An error occurred while installing sass-embedded (1.78.0), and Bundler cannot continue.

In Gemfile:
  dartsass-rails was resolved to 0.5.0, which depends on
    sass-embedded
```

[[ref](https://buildkite.com/rails/rails/builds/121746#01996166-e6f2-4fc0-b224-a57d848d343b/141-614)]