### PR TITLE
[Fix #55708] Respect the file_watcher config in the routes reloader

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `Rails::Application::RoutesReloader` uses the configured `Rails.application.config.file_watcher`
+
+    *Jan Grodowski*
+
 *   Add structured event for Rails deprecations, when `config.active_support.deprecation` is set to `:notify`.
 
     *zzak*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -419,7 +419,7 @@ module Rails
     end
 
     def routes_reloader # :nodoc:
-      @routes_reloader ||= RoutesReloader.new
+      @routes_reloader ||= RoutesReloader.new(file_watcher: config.file_watcher)
     end
 
     # Returns an array of file paths appended with a hash of

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -11,12 +11,13 @@ module Rails
       attr_writer :run_after_load_paths, :loaded # :nodoc:
       delegate :execute_if_updated, :updated?, to: :updater
 
-      def initialize
+      def initialize(file_watcher: ActiveSupport::FileUpdateChecker)
         @paths      = []
         @route_sets = []
         @external_routes = []
         @eager_load = false
         @loaded = false
+        @file_watcher = file_watcher
       end
 
       def reload!
@@ -48,7 +49,7 @@ module Rails
             hash[dir.to_s] = %w(rb)
           end
 
-          ActiveSupport::FileUpdateChecker.new(paths, dirs) { reload! }
+          @file_watcher.new(paths, dirs) { reload! }
         end
       end
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -191,11 +191,8 @@ class LoadingTest < ActiveSupport::TestCase
   test "does not reload constants on development if custom file watcher always returns false" do
     add_to_config <<-RUBY
       config.enable_reloading = true
-      config.file_watcher = Class.new do
-        def initialize(*); end
+      config.file_watcher = Class.new(ActiveSupport::FileUpdateChecker) do
         def updated?; false; end
-        def execute; end
-        def execute_if_updated; false; end
       end
     RUBY
 

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -815,5 +815,15 @@ module ApplicationTests
       get "/"
       assert_equal 200, last_response.status
     end
+
+    test "routes reloader uses configured file_watcher" do
+      add_to_config <<-RUBY
+        config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+      RUBY
+
+      app "development"
+
+      assert_instance_of ActiveSupport::EventedFileUpdateChecker, Rails.application.routes_reloader.send(:updater)
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #55708, where using `EventedFileUpdateChecker` also proved to be a possible workaround, but we found out that it's hardcoded inside `RoutesReloader`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
