### PR TITLE
Allow non-hash sessions in Connection::TestCase

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -216,6 +216,9 @@ module ActionCable
         private
           def build_test_request(path, params: nil, headers: {}, session: {}, env: {})
             wrapped_headers = ActionDispatch::Http::Headers.from_hash(headers)
+            if session.respond_to?(:with_indifferent_access)
+              session = session.with_indifferent_access
+            end
 
             uri = URI.parse(path)
 
@@ -231,7 +234,7 @@ module ActionCable
             end
 
             TestRequest.create(request_env).tap do |request|
-              request.session = session.with_indifferent_access
+              request.session = session
               request.cookie_jar = cookies
             end
           end

--- a/actioncable/test/connection/test_case_test.rb
+++ b/actioncable/test/connection/test_case_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "rack/test"
 
 class SimpleConnection < ActionCable::Connection::Base
   identified_by :user_id
@@ -65,6 +66,11 @@ class ConnectionSimpleTest < ActionCable::Connection::TestCase
     disconnect
 
     assert_equal "456", SimpleConnection.disconnected_user_id
+  end
+
+  def test_non_hash_session
+    session = Rack::MockSession.new("non-hash session")
+    assert_nothing_raised { connect session: session }
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

We're passing an `ActionController::TestSession` in our tests because we rely on session specific methods, but it raises an error because it doesn't respond to `with_indifferent_access`.

### Detail

This updates `ActionCable::Connection::TestCase` to only call `#with_indifferent_access` when the passed session responds to it.

### Additional information

I was considering importing `ActionController::TestSession` into `Connection::TestCase`, but thought this might be crossing package boundaries that shouldn't be crossed.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
