### PR TITLE
Persist search query across page reloads on routes

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -195,6 +195,20 @@
         checkNoMatch(fuzzySection, noFuzzyMatch);
       })
     })
+
+    // Persist the search query in query field across page reloads
+    if (window.sessionStorage) {
+      searchElem.value = sessionStorage.getItem('query');
+      window.oninput = function(event){
+        if (event.target === searchElem) {
+          sessionStorage.setItem('query', searchElem.value);
+        }
+      }
+
+      if (searchElem.value.length > 0) {
+        searchElem.onkeyup();
+      }
+    }
   }
 
   // Enables functionality to toggle between `_path` and `_url` helper suffixes

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Persist the search query in `/rails/info/routes` across page reloads.
+
+    *Aleksandr Borisov*
+
 *   Show engine routes in `/rails/info/routes` as well.
 
     *Petrik de Heus*


### PR DESCRIPTION
`/rails/info/routes` does not preserve search query across page reloads. This patch fixes this issue.

The use case is:

1. search for routes subset with `/rails/info/routes`
2. update routes config
3. reload the page to get updated search results

I thought it would be nice to persist a search query for the case.


https://github.com/user-attachments/assets/e3253365-0f39-4cdc-8e77-0f940a646548



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~~Tests are added or updated if you fix a bug or add a feature.~~ not applicable
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
