### PR TITLE
Dedupe schema dumps and refactor test helpers

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Optimize schema dumping to prevent duplicate file generation.
+
+    `ActiveRecord::Tasks::DatabaseTasks.dump_all` now tracks which schema files
+    have already been dumped and skips dumping the same file multiple times.
+    This improves performance when multiple database configurations share the
+    same schema dump path.
+
+    *Mikey Gough*, *Hartley McGuire*
+
 *   Add structured events for Active Record:
     - `active_record.strict_loading_violation`
     - `active_record.sql`


### PR DESCRIPTION
### Motivation / Background

In working on a large application, @skipkayhil and I noticed that occasionally `db:schema:dump` will dump the same schema more than once. We can speed up `db:migrate` by first checking if a schema has already been dumped before dumping.

Testing these changes on a large application I noticed a roughly 40% improvement in running `bin/rails db:schema:dump`.

This Pull Request has been created because `db:schema:dump` is occasionally dumping the same schema more than once. We can increase performance by checking for duplicate schema dumps before dumping.

While adding test coverage I also noticed several copy-pasted function definitions to stub configurations. I refactored these into a single helper method inside the `DatabaseTasksHelper` module which can be included in the test classes that need it. That full refactoring is available [here](https://github.com/rails/rails/pull/55732) and should be shipped first. Then we can rebase this and ship the schema dump improvements.

### Detail

This Pull Request changes the `dump_all` method to first check if a schema has already been dumped before calling `dump_schema`.

### Additional information

In testing these changes against a large application, I noticed the following time differences in calling `db:schema:dump`. Please note that these performance gains will vary depending on the size of an application's schema.

#### No-deduplication
<img width="354" height="61" alt="no-deduplication" src="https://github.com/user-attachments/assets/9908b3ba-760f-436d-b601-badc454095c5" />

#### Deduplication
<img width="332" height="55" alt="deduplication" src="https://github.com/user-attachments/assets/6f0709b7-45be-438e-9eba-a2599782a6d4" />

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
