### PR TITLE
Optionally skip bundler-audit

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Optionally skip bundler-audit.
+
+    Skips adding the `bin/bundler-audit` & `config/bundler-audit.yml` if the gem is not installed when `bin/rails app:update` runs.
+
+    Passes an option to `--skip-bundler-audit` when new apps are generated & adds that same option to the `--minimal` generator flag.
+
+    *Jill Klang*
+
 *   Show engine routes in `/rails/info/routes` as well.
 
     *Petrik de Heus*

--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -73,6 +73,7 @@ module Rails
               skip_action_text:    !defined?(ActionText::Engine),
               skip_action_cable:   !defined?(ActionCable::Engine),
               skip_brakeman:       skip_gem?("brakeman"),
+              skip_bundler_audit:  skip_gem?("bundler-audit"),
               skip_rubocop:        skip_gem?("rubocop"),
               skip_thruster:       skip_gem?("thruster"),
               skip_test:           !defined?(Rails::TestUnitRailtie),

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -106,6 +106,9 @@ module Rails
         class_option :skip_brakeman,       type: :boolean, default: nil,
                                            desc: "Skip brakeman setup"
 
+        class_option :skip_bundler_audit,  type: :boolean, default: nil,
+                                           desc: "Skip bundler-audit setup"
+
         class_option :skip_ci,             type: :boolean, default: nil,
                                            desc: "Skip GitHub CI files"
 
@@ -398,6 +401,10 @@ module Rails
 
       def skip_brakeman?
         options[:skip_brakeman]
+      end
+
+      def skip_bundler_audit?
+        options[:skip_bundler_audit]
       end
 
       def skip_ci?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -109,7 +109,7 @@ module Rails
     end
 
     def bin
-      exclude_pattern = Regexp.union([(/thrust/ if skip_thruster?), (/rubocop/ if skip_rubocop?), (/brakeman/ if skip_brakeman?)].compact)
+      exclude_pattern = Regexp.union([(/thrust/ if skip_thruster?), (/rubocop/ if skip_rubocop?), (/brakeman/ if skip_brakeman?), (/bundler-audit/ if skip_bundler_audit?)].compact)
       directory "bin", { exclude_pattern: exclude_pattern } do |content|
         "#{shebang}\n" + content
       end
@@ -127,8 +127,8 @@ module Rails
         template "routes.rb" unless options[:update]
         template "application.rb"
         template "environment.rb"
-        template "bundler-audit.yml"
-        template "cable.yml" unless options[:update] || options[:skip_action_cable]
+        template "bundler-audit.yml" unless skip_bundler_audit?
+        template "cable.yml" unless options[:update] || skip_action_cable?
         template "ci.rb"
         template "puma.rb"
         template "storage.yml" unless options[:update] || skip_active_storage?
@@ -153,7 +153,7 @@ module Rails
 
       config
 
-      if !options[:skip_action_cable] && !action_cable_config_exist
+      if !skip_action_cable? && !action_cable_config_exist
         template "config/cable.yml"
       end
 
@@ -177,7 +177,7 @@ module Rails
         remove_file "config/initializers/cors.rb"
       end
 
-      if !bundle_audit_config_exist
+      if !skip_bundler_audit? && !bundle_audit_config_exist
         template "config/bundler-audit.yml"
       end
 
@@ -317,6 +317,7 @@ module Rails
             :skip_active_storage,
             :skip_bootsnap,
             :skip_brakeman,
+            :skip_bundler_audit,
             :skip_ci,
             :skip_dev_gems,
             :skip_docker,

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -54,9 +54,11 @@ gem "image_processing", "~> 1.2"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+<%- unless options.skip_bundler_audit? -%>
 
   # Audits gems for known security defects (use config/bundler-audit.yml to ignore issues)
   gem "bundler-audit", require: false
+<%- end -%>
 <%- unless options.skip_brakeman? -%>
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -6,7 +6,9 @@ CI.run do
   step "Style: Ruby", "bin/rubocop"
 <% end -%>
 
+<% unless options.skip_bundler_audit? -%>
   step "Security: Gem audit", "bin/bundler-audit"
+<% end -%>
 <% if using_node? -%>
   step "Security: Yarn vulnerability audit", "yarn audit"
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -6,7 +6,7 @@ on:
     branches: [ <%= user_default_branch %> ]
 
 jobs:
-<%- unless skip_brakeman? -%>
+<%- unless skip_brakeman? && skip_bundler_audit? -%>
   scan_ruby:
     runs-on: ubuntu-latest
 
@@ -19,11 +19,15 @@ jobs:
         with:
           bundler-cache: true
 
+      <%- unless skip_brakeman? %>
       - name: Scan for common Rails security vulnerabilities using static analysis
         run: bin/brakeman --no-pager
+      <% end %>
 
+      <%- unless skip_bundler_audit? -%>
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
+      <% end %>
 
 <% end -%>
 <%- if using_importmap? -%>

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -124,6 +124,7 @@ module Rails
       opts[:force] = force
       opts[:skip_thruster] = true
       opts[:skip_brakeman] = true
+      opts[:skip_bundler_audit] = true
       opts[:skip_bundle] = true
       opts[:skip_ci] = true
       opts[:skip_kamal] = true

--- a/railties/test/application/bin_ci_test.rb
+++ b/railties/test/application/bin_ci_test.rb
@@ -19,6 +19,7 @@ module ApplicationTests
         # Default steps
         assert_match(/bin\/rubocop/, content)
         assert_match(/bin\/brakeman/, content)
+        assert_match(/bin\/bundler-audit/, content)
         assert_match(/"bin\/rails test"$/, content)
         assert_match(/"bin\/rails test:system"$/, content)
         assert_match(/bin\/rails db:seed:replant/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -298,6 +298,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_preserves_skip_bundler_audit
+    run_generator [ destination_root, "--skip-bundler-audit" ]
+
+    FileUtils.cd(destination_root) do
+      assert_no_changes -> { File.exist?("bin/bundler-audit") } do
+        run_app_update
+      end
+    end
+  end
+
   def test_app_update_preserves_skip_rubocop
     run_generator [ destination_root, "--skip-rubocop" ]
 
@@ -653,6 +663,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_file "bin/rubocop"
     assert_no_file "bin/brakeman"
+  end
+
+  def test_inclusion_of_bundler_audit
+    run_generator
+    assert_gem "bundler-audit"
+  end
+
+  def test_bundler_audit_is_skipped_if_required
+    run_generator [destination_root, "--skip-bundler-audit"]
+
+    assert_no_gem "bundler-audit"
+    assert_no_file "bin/bundler-audit"
   end
 
   def test_inclusion_of_ci_files
@@ -1379,6 +1401,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_option :skip_active_storage
     assert_option :skip_bootsnap
     assert_option :skip_brakeman
+    assert_option :skip_bundler_audit
     assert_option :skip_ci
     assert_option :skip_dev_gems
     assert_option :skip_docker

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -39,7 +39,6 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/app/views/layouts/mailer.text.erb
   test/dummy/app/views/pwa/manifest.json.erb
   test/dummy/app/views/pwa/service-worker.js
-  test/dummy/bin/bundler-audit
   test/dummy/bin/ci
   test/dummy/bin/dev
   test/dummy/bin/rails
@@ -48,7 +47,6 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/config.ru
   test/dummy/config/application.rb
   test/dummy/config/boot.rb
-  test/dummy/config/bundler-audit.yml
   test/dummy/config/cable.yml
   test/dummy/config/ci.rb
   test/dummy/config/database.yml


### PR DESCRIPTION
### Motivation / Background

Was testing the 8.1 upgrade and noticed that bundler-audit files got added when running `bin/rails app:update`, regardless of whether that gem was included in the gemfile.

Since the new/update passes are tightly coupled, this also adds the option to `--skip-bundler-audit` when generating a new app. This flag was passed in to the `--minimal` generator option as well. 

### Additional information

Added automated testing for newly-generated apps and tested with an app I'm using to test the Rails 8.1 upgrade.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
