### PR TITLE
fix/hardcoded-postgres

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -5,6 +5,7 @@ require "tempfile"
 module ActiveRecord
   module Tasks # :nodoc:
     class PostgreSQLDatabaseTasks # :nodoc:
+      PG_DATABASE = ENV["PG_DATABASE"] || "postgres"
       DEFAULT_ENCODING = ENV["CHARSET"] || "utf8"
       ON_ERROR_STOP_1 = "ON_ERROR_STOP=1"
       SQL_COMMENT_BEGIN = "--"
@@ -100,7 +101,7 @@ module ActiveRecord
         end
 
         def public_schema_config
-          configuration_hash.merge(database: "postgres", schema_search_path: "public")
+          configuration_hash.merge(database: PG_DATABASE, schema_search_path: "public")
         end
 
         def psql_env


### PR DESCRIPTION
### Motivation / Background
Fixes #48236

This Pull Request has been created because users are not always in control of the name of their default postgresql database's name.  For example, Digital Ocean automatically names it "defaultdb" and does not allow renaming.

My team had found a workaround by setting this value on the primary database in config/database.yml, but this had to be done and undone between production vs development branches as our development environments run locally and thus DO use the common "postgres" name.

### Detail
This Pull Request changes `activerecord/lib/active_record/tasks/postgresql_database_tasks.rb` to allow the name of the default postgresql database to be set via environment variable.

It adds one line:
`PG_DATABASE = ENV["PG_DATABASE"] || "postgres"`
And changes one line (to replace the single instance of hardcoded `"postgres"` with `PG_DATABASE`)

With these changes, we are able to perform database management operations such as `RAILS_ENV=production PG_DATABASE=defaultdb DATABASE_URL=<...> bin/rails db:{drop,create,migrate,seed}` on our remote postgresql deployment from the comfort of our own terminals.