### PR TITLE
Swallow error if libvips or ruby-vips gem are missing

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -12,7 +12,7 @@ begin
   gem "ruby-vips"
   require "ruby-vips"
 rescue LoadError => error
-  raise error unless error.message.include?("ruby-vips")
+  raise error unless error.message.match?(/libvips|ruby-vips/)
 end
 
 module ActiveStorage


### PR DESCRIPTION
Follow up to #55303

The previous behavior would be to raise an error only if the gem was missing, this would happen at Runtime before refactoring to startup.

But if trying to boot Rails without libvips installed, this will raise the following error:

```
/home/zzak/.rbenv/versions/3.5.0/lib/ruby/gems/3.5.0+4/gems/ffi-1.17.2/lib/ffi/dynamic_library.rb:94:in 'FFI::DynamicLibrary.load_library': Could not open library 'vips.so.42': vips.so.42: cannot open shared object file: No such file or directory. (LoadError)
Could not open library 'libvips.so.42': libvips.so.42: cannot open shared object file: No such file or directory.
Searched in <system library path>
        from /home/zzak/.rbenv/versions/3.5.0/lib/ruby/gems/3.5.0+4/gems/ffi-1.17.2/lib/ffi/library.rb:95:in 'block in FFI::Library#ffi_lib'
        from /home/zzak/.rbenv/versions/3.5.0/lib/ruby/gems/3.5.0+4/gems/ffi-1.17.2/lib/ffi/library.rb:94:in 'Array#map'
        from /home/zzak/.rbenv/versions/3.5.0/lib/ruby/gems/3.5.0+4/gems/ffi-1.17.2/lib/ffi/library.rb:94:in 'FFI::Library#ffi_lib'
        from /home/zzak/.rbenv/versions/3.5.0/lib/ruby/gems/3.5.0+4/gems/ruby-vips-2.2.5/lib/vips.rb:46:in '<module:Vips>'
        from /home/zzak/.rbenv/versions/3.5.0/lib/ruby/gems/3.5.0+4/gems/ruby-vips-2.2.5/lib/vips.rb:43:in '<top (required)>'
```

However, because this happens when loading the engine, I think the error was swallowed by Rails startup, and all of the other config setup at the start of loading the engine was not evaluated, so parts like:

```
config.active_storage.paths = ActiveSupport::OrderedOptions.new
config.active_storage.queues = ActiveSupport::InheritableOptions.new
```

Which meant when booting a new Rails app without libvips installed on the system, you actually got this error instead:

```
NoMethodError: undefined method 'analysis=' for nil (NoMethodError)

            active_storage.queues.analysis = :active_storage_analysis
```

If you did manage to boot the app, you could see the other defaults were not setup yet.

```
$ bin/rails c
Loading development environment (Rails 8.1.0.beta1)
>> ActiveStorage.variable_content_types
=> []
```

/cc @jeromedalbert @Earlopain 