### PR TITLE
Set pipefail for rails-new-docker step

### DIFF
--- a/.github/workflows/rails-new-docker.yml
+++ b/.github/workflows/rails-new-docker.yml
@@ -24,6 +24,7 @@ jobs:
         bundler-cache: true
     - name: Generate --dev app
       run: |
+        set -euo pipefail
         bundle exec railties/exe/rails new $APP_PATH --dev
     - name: Build image
       run: |


### PR DESCRIPTION
This step was previously failing but still marked as green: https://github.com/rails/rails/actions/runs/17870596398/job/50823217427#step:5:200