### PR TITLE
Restore support to analyze image blobs with `image_magick`

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
@@ -11,6 +11,10 @@ module ActiveStorage
   # This analyzer relies on the third-party {MiniMagick}[https://github.com/minimagick/minimagick] gem. MiniMagick requires
   # the {ImageMagick}[http://www.imagemagick.org] system library.
   class Analyzer::ImageAnalyzer::ImageMagick < Analyzer::ImageAnalyzer
+    def self.accept?(blob)
+      super && ActiveStorage.variant_processor == :mini_magick
+    end
+
     private
       def read_image
         download_blob_to_tempfile do |file|

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -19,6 +19,10 @@ module ActiveStorage
   # This analyzer relies on the third-party {ruby-vips}[https://github.com/libvips/ruby-vips] gem. Ruby-vips requires
   # the {libvips}[https://libvips.github.io/libvips/] system library.
   class Analyzer::ImageAnalyzer::Vips < Analyzer::ImageAnalyzer
+    def self.accept?(blob)
+      super && ActiveStorage.variant_processor == :vips
+    end
+
     private
       def read_image
         download_blob_to_tempfile do |file|

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -60,12 +60,12 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
 
   private
     def analyze_with_vips
-      previous_analyzers, ActiveStorage.analyzers = ActiveStorage.analyzers, [ActiveStorage::Analyzer::ImageAnalyzer::Vips]
+      previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, :vips
 
       yield
     rescue LoadError
       ENV["BUILDKITE"] ? raise : skip("Variant processor vips is not installed")
     ensure
-      ActiveStorage.analyzers = previous_analyzers
+      ActiveStorage.variant_processor = previous_processor
     end
 end


### PR DESCRIPTION
### Motivation / Background

Since https://github.com/rails/rails/commit/93c00a8c74c24a3da40d30b6d0c3c667b8ebe9ba, `config.active_storage.analyzers` contains both vips and image magick analyzers. However, they both inherit from `Analyzer::ImageAnalyzer`, which means they just check for `blob.image?` to check if they should accept the image.

That means that even if the user explicitly does `variant_processor = :mini_magick`, vips gets called first (because it comes first in the array), and image magick never gets a chance to do anything.

Before that commit it worked because the analyzers were conditionally added to the array, so there was only ever one or the other present.

This fixes this by once again implementing custom `accept?`, which was previously removed in https://github.com/rails/rails/commit/e978ef011f11102771c5b302f25d9ab7895316cb

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
