### PR TITLE
hidde backtrace when parallel tests get interrupted

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -25,6 +25,8 @@ module ActiveSupport
             rescue => @setup_exception; end
 
             work_from_queue
+          rescue Interrupt
+            @queue.interrupt
           ensure
             set_process_title("(stopping)")
 
@@ -69,9 +71,6 @@ module ActiveSupport
               Minitest::UnexpectedError.new(error)
             end
             @queue.record(reporter, result)
-          rescue Interrupt
-            @queue.interrupt
-            raise
           end
 
           set_process_title("(idle)")

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -861,7 +861,7 @@ module ApplicationTests
 
       matches = @test_output.match(/(\d+) runs, (\d+) assertions, (\d+) failures/)
 
-      assert_match %r{Interrupt}, @error_output
+      assert_empty @error_output
       assert_equal 1, matches[3].to_i
       assert_operator matches[1].to_i, :<, 11
     end


### PR DESCRIPTION
### Motivation / Background

Right now, if one presses CONTROL+C during the parallel test run, one gets a very long backtrace that is very annoying.

### Additional information

The same problem was solved 11 years ago for the non parallel tests here:

* https://github.com/minitest/minitest/commit/b6ec36d086ac28e47e4e2dc7ffd995f462543f94
* https://github.com/minitest/minitest/issues/503

The reason why the 11 years old fix does not work for the parallel test is, that the rescue happens before the shutdown method gets executed. The shutdown method is where things get executed. In my opinion, this is wrong, but my guess is, that it was done so, because doing it otherwise would probably require changes in the Minitest gem itself.

NOTE: this is my first PR on the rails gem, so I apologize if I made something wrong. Also, there is a big probability that there is a better solution or that I miss some edge case that I am missing because of lack of knowledge.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
  - Not sure if this should go into the changelog.
