### PR TITLE
Fix lease_connection to preserve pool state when checkout callbacks fail

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -344,8 +344,9 @@ module ActiveRecord
       # held in a cache keyed by a thread.
       def lease_connection
         lease = connection_lease
-        lease.sticky = true
         lease.connection ||= checkout
+        lease.sticky = true
+        lease.connection
       end
 
       def permanent_lease? # :nodoc:


### PR DESCRIPTION
### Motivation / Background

This Pull Request addresses a connection pool state issue that can cause `ActiveRecord::Base.connection` to return `nil`.

For example, in Rails console:

```
my-app(dev)> p = ->{raise "some error"}
=> #<Proc:0x000000011f6bab78 (blog-app):1 (lambda)>

my-app(dev)> ActiveRecord::ConnectionAdapters::SQLite3Adapter.set_callback(:checkout, :after, p)
=> [ActiveRecord::ConnectionAdapters::SQLite3Adapter]

my-app(dev)> ActiveRecord::Base.connection
(blog-app):1:in 'block in <main>': some error (RuntimeError)
	from (blog-app):3:in '<main>'

my-app(dev)> ActiveRecord::Base.connection
=> nil
```

This happens because `ConnectionHandling#connection` expects `active_connection` to return a usable connection when `pool.permanent_lease?` is false.

Ref: https://github.com/rails/rails/blob/4fcc1dd2e23e76a31a6f6b6f7bd5b0ebfa87e1fe/activerecord/lib/active_record/connection_handling.rb#L276-L294

The root cause is that `ConnectionPool#connection_lease` previously marked the lease as sticky before assigning `lease.connection`.
When a checkout callback raises an exception, `lease.connection` remains `nil` while `lease.sticky` is `true`.

This is considered a bug because `connection_lease` objects are not expected to have `sticky = true` while `connection = nil`.
This inconsistent state propagates to `active_connection`, causing `ActiveRecord::Base.connection` to unexpectedly return `nil`.

### Detail

This Pull Request changes `ConnectionPool#lease_connection` to assign the `sticky` flag after successfully checking out a connection.

Additionally, a test has been added to ensure that exceptions in checkout callbacks do not affect `permanent_lease?` or `active_connection?` state.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
