### PR TITLE
Fix javascript_include_tag `type:` option to accept symbols

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -121,7 +121,7 @@ module ActionView
         crossorigin = options.delete("crossorigin")
         crossorigin = "anonymous" if crossorigin == true
         integrity = options["integrity"]
-        rel = options["type"] == "module" ? "modulepreload" : "preload"
+        rel = options["type"] == "module" || options["type"] == :module ? "modulepreload" : "preload"
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
@@ -370,7 +370,7 @@ module ActionView
         integrity = options[:integrity]
         fetchpriority = options.delete(:fetchpriority)
         nopush = options.delete(:nopush) || false
-        rel = mime_type == "module" ? "modulepreload" : "preload"
+        rel = mime_type == "module" || mime_type == :module ? "modulepreload" : "preload"
         add_nonce = content_security_policy_nonce &&
           respond_to?(:request) &&
           request.content_security_policy_nonce_directives&.include?("#{as_type}-src")

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -337,6 +337,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
   PreloadLinkToTag = {
     %(preload_link_tag '/application.js', type: 'module') => %(<link rel="modulepreload" href="/application.js" as="script" type="module" >),
+    %(preload_link_tag '/application.js', type: :module) => %(<link rel="modulepreload" href="/application.js" as="script" type="module" >),
     %(preload_link_tag '/styles/custom_theme.css') => %(<link rel="preload" href="/styles/custom_theme.css" as="style" type="text/css" />),
     %(preload_link_tag '/videos/video.webm') => %(<link rel="preload" href="/videos/video.webm" as="video" type="video/webm" />),
     %(preload_link_tag '/posts.json', as: 'fetch') => %(<link rel="preload" href="/posts.json" as="fetch" type="application/json" />),


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/55706

`javascript_include_tag "application", type: :module` now behaves
the same as `javascript_include_tag "application", type: "module"`
