### PR TITLE
Update JSONGemCoderEncoder to handle non-String hash keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.14.0)
+    json (2.15.0)
     jwt (2.10.1)
       base64
     kamal (2.4.0)


### PR DESCRIPTION
Follow-up to a8a80e3396276a0c6a281f72b6776d17b2e9312b.
