### PR TITLE
Remove incorrect ActiveSupport changelog entry announced in the Rails 7.1.3

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -111,13 +111,6 @@
 
     *Eugene Kenny*
 
-*   Fix `ActiveSupport::JSON.encode` to prevent duplicate keys.
-
-    If the same key exist in both String and Symbol form it could
-    lead to the same key being emitted twice.
-
-    *Manish Sharma*
-
 *   Fix `ActiveSupport::Cache::Store#read_multi` when using a cache namespace
     and local cache strategy.
 


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because the ActiveSupport changelog contains an entry that refers to a change which was later reverted and is **not part of the `7-1-stable` branch**. The entry was mistakenly announced in the Rails **7.1.3** release notes, even though the change had already been reverted. Keeping it is misleading for developers upgrading to Rails 7.1, since they might expect the reverted feature/fix to be available.

### Detail
This Pull Request removes the incorrect changelog entry from `activesupport/CHANGELOG.md`.
No code is affected — this is purely a documentation cleanup.

### Additional information
The change was reverted in commit: https://github.com/rails/rails/commit/2ac84355ca8498c2b679cc85c1cfc1064e5a6537  
No tests are needed, as this PR only updates documentation.

### Checklist
Before submitting the PR make sure the following are checked:
* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.