### PR TITLE
feat: Add `:allow_nil` keyword to `#sole`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add optional `:allow_nil` flag to `#sole` method with defaults to `false`.
+    When `allow_nil: true` no exception will raise if collection has no records.
+    ```ruby
+    topics = Topic.where(title: "Title Does Not Exist")
+
+    topics.count                  # => 0
+    topics.sole                   # => raise RecordNotFound
+    topics.sole(allow_nil: false) # => raise RecordNotFound
+    topics.sole(allow_nil: true)  # => nil
+
+    topics = Topic.where(title: "The First Topic")
+
+    topics.count                  # => 1
+    topics.sole                   # => #<Topic ...>
+    topics.sole(allow_nil: false) # => #<Topic ...>
+    topics.sole(allow_nil: true)  # => #<Topic ...>
+
+    topics = Topic.all
+
+    topics.count                  # => 2+
+    topics.sole                   # => raise SoleRecordExceeded
+    topics.sole(allow_nil: false) # => raise SoleRecordExceeded
+    topics.sole(allow_nil: true)  # => raise SoleRecordExceeded
+    ```
+
+    *Alexey Zapparov*
+
 *   Add support for integer shard keys.
     ```ruby
     # Now accepts symbols as shard keys.

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -139,12 +139,28 @@ module ActiveRecord
     # record is found. Raises ActiveRecord::SoleRecordExceeded if more than one
     # record is found.
     #
-    #   Product.where(["price = %?", price]).sole
-    def sole
+    #   Product.where(["price = %?", price]).count                  # => 0
+    #   Product.where(["price = %?", price]).sole                   # => raise RecordNotFound
+    #   Product.where(["price = %?", price]).sole(allow_nil: true)  # => nil
+    #
+    #   Product.where(["price = %?", price]).count                  # => 1
+    #   Product.where(["price = %?", price]).sole                   # => #<Product ...>
+    #   Product.where(["price = %?", price]).sole(allow_nil: true)  # => #<Product ...>
+    #
+    #   Product.where(["price = %?", price]).count                  # => 2+
+    #   Product.where(["price = %?", price]).sole                   # => raise SoleRecordExceeded
+    #   Product.where(["price = %?", price]).sole(allow_nil: true)  # => raise SoleRecordExceeded
+    #
+    # ==== Options
+    #
+    # [+:allow_nil+]
+    #   Whether to return `nil` or raise ActiveRecord::RecordNotFound,
+    #   if no record is found. Defaults to false.
+    def sole(allow_nil: false)
       found, undesired = take(2)
 
       if found.nil?
-        raise_record_not_found_exception!
+        raise_record_not_found_exception! unless allow_nil
       elsif undesired.nil?
         found
       else

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add optional `:allow_nil` flag to `#sole` method with defaults to `false`.
+    When `allow_nil: true` no exception will raise if enumerable has no items.
+    ```ruby
+    [].sole                       # => raise SoleItemExpectedError
+    [].sole(allow_nil: false)     # => raise SoleItemExpectedError
+    [].sole(allow_nil: true)      # => nil
+
+    [1].sole                      # => 1
+    [1].sole(allow_nil: false)    # => 1
+    [1].sole(allow_nil: true)     # => 1
+
+    [1, 2].sole                   # => raise SoleItemExpectedError
+    [1, 2].sole(allow_nil: false) # => raise SoleItemExpectedError
+    [1, 2].sole(allow_nil: true)  # => raise SoleItemExpectedError
+    ```
+
+    *Alexey Zapparov*
+
 *   `ActiveSupport::FileUpdateChecker` does not depend on `Time.now` to prevent unecessary reloads with time travel test helpers
 
     *Jan Grodowski*

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -205,10 +205,20 @@ module Enumerable
   # Returns the sole item in the enumerable. If there are no items, or more
   # than one item, raises Enumerable::SoleItemExpectedError.
   #
-  #   ["x"].sole          # => "x"
-  #   Set.new.sole        # => Enumerable::SoleItemExpectedError: no item found
-  #   { a: 1, b: 2 }.sole # => Enumerable::SoleItemExpectedError: multiple items found
-  def sole
+  #   ["x"].sole                            # => "x"
+  #   Set.new.sole                          # => Enumerable::SoleItemExpectedError: no item found
+  #   { a: 1, b: 2 }.sole                   # => Enumerable::SoleItemExpectedError: multiple items found
+  #
+  #   ["x"].sole(allow_nil: true)           # => "x"
+  #   Set.new.sole(allow_nil: true)         # => nil
+  #   { a: 1, b: 2 }.sole(allow_nilw: true) # => Enumerable::SoleItemExpectedError: multiple items found
+  #
+  # ==== Options
+  #
+  # [+:allow_nil+]
+  #   Whether to return `nil` or raise Enumerable::SoleItemExpectedError,
+  #   when there are no items. Defaults to false.
+  def sole(allow_nil: false)
     result = nil
     found = false
 
@@ -224,7 +234,7 @@ module Enumerable
     if found
       result
     else
-      raise SoleItemExpectedError, "no item found"
+      raise SoleItemExpectedError, "no item found" unless allow_nil
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/range/sole.rb
+++ b/activesupport/lib/active_support/core_ext/range/sole.rb
@@ -7,7 +7,17 @@ class Range
   #   (1..1).sole   # => 1
   #   (2..1).sole   # => Enumerable::SoleItemExpectedError: no item found
   #   (..1).sole    # => Enumerable::SoleItemExpectedError: infinite range cannot represent a sole item
-  def sole
+  #
+  #   (1..1).sole(allow_nil: true) # => 1
+  #   (2..1).sole(allow_nil: true) # => nil
+  #   (..1).sole(allow_nil: true)  # => Enumerable::SoleItemExpectedError: infinite range cannot represent a sole item
+  #
+  # ==== Options
+  #
+  # [+:allow_nil+]
+  #   Whether to return `nil` or raise Enumerable::SoleItemExpectedError,
+  #   when there are no items. Defaults to false.
+  def sole(...)
     if self.begin.nil? || self.end.nil?
       raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "infinite range '#{inspect}' cannot represent a sole item"
     end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -395,10 +395,24 @@ class EnumerableTests < ActiveSupport::TestCase
     expected_raise = Enumerable::SoleItemExpectedError
 
     assert_raise(expected_raise) { GenericEnumerable.new([]).sole }
+    assert_raise(expected_raise) { GenericEnumerable.new([]).sole(allow_nil: false) }
+    assert_nil GenericEnumerable.new([]).sole(allow_nil: true)
+
     assert_equal 1, GenericEnumerable.new([1]).sole
+    assert_equal 1, GenericEnumerable.new([1]).sole(allow_nil: false)
+    assert_equal 1, GenericEnumerable.new([1]).sole(allow_nil: true)
+
     assert_raise(expected_raise) { GenericEnumerable.new([1, 2]).sole }
+    assert_raise(expected_raise) { GenericEnumerable.new([1, 2]).sole(allow_nil: false) }
+    assert_raise(expected_raise) { GenericEnumerable.new([1, 2]).sole(allow_nil: true) }
+
     assert_raise(expected_raise) { GenericEnumerable.new([1, nil]).sole }
+    assert_raise(expected_raise) { GenericEnumerable.new([1, nil]).sole(allow_nil: false) }
+    assert_raise(expected_raise) { GenericEnumerable.new([1, nil]).sole(allow_nil: true) }
+
     assert_raise(expected_raise) { GenericEnumerable.new(1..).sole }
+    assert_raise(expected_raise) { GenericEnumerable.new(1..).sole(allow_nil: false) }
+    assert_raise(expected_raise) { GenericEnumerable.new(1..).sole(allow_nil: true) }
   end
 
   def test_doesnt_bust_constant_cache

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -290,13 +290,25 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_sole
     assert_equal 1, (1..1).sole
+    assert_equal 1, (1..1).sole(allow_nil: false)
+    assert_equal 1, (1..1).sole(allow_nil: true)
 
     assert_raises(Enumerable::SoleItemExpectedError, match: "no item found") do
       (2..1).sole
     end
+    assert_raises(Enumerable::SoleItemExpectedError, match: "no item found") do
+      (2..1).sole(allow_nil: false)
+    end
+    assert_nil (2..1).sole(allow_nil: true)
 
     assert_raises(Enumerable::SoleItemExpectedError, match: "infinite range '..1' cannot represent a sole item") do
       (..1).sole
+    end
+    assert_raises(Enumerable::SoleItemExpectedError, match: "infinite range '..1' cannot represent a sole item") do
+      (..1).sole(allow_nil: false)
+    end
+    assert_raises(Enumerable::SoleItemExpectedError, match: "infinite range '..1' cannot represent a sole item") do
+      (..1).sole(allow_nil: true)
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Currently, the `#sole` method enforces uniqueness strictly by raising an error if no or multiple items are found. However, there are scenarios where it is desirable for `#sole` to return `nil` instead of raising an error when there are no matching records, for example:

* When application-level uniqueness is guaranteed, and zero results should be a silent, non-exceptional case.
* When validations or database uniqueness constraints are either insufficient or too costly (for performance reasons).
* To simplify flows where distinguishing between "not found" and "multiple found" is important, without always needing custom error handling.

To address these cases, this change introduces an optional `:allow_nil` keyword argument to #sole, defaulting to `false`. When set to `true`, the method returns `nil` instead of raising an error if no items are found.


### Detail

* Default behavior of `#sole` is unchanged -- it raises an error if zero or more than one item is found.
* With `allow_nil: true`, the method returns `nil` if no records/items exist. If more than one is found, it still raises the relevant error.


#### Example: Enumerable

```ruby
[].sole                       # => raise SoleItemExpectedError
[].sole(allow_nil: false)     # => raise SoleItemExpectedError
[].sole(allow_nil: true)      # => nil

[1].sole                      # => 1
[1].sole(allow_nil: false)    # => 1
[1].sole(allow_nil: true)     # => 1

[1, 2].sole                   # => raise SoleItemExpectedError
[1, 2].sole(allow_nil: false) # => raise SoleItemExpectedError
[1, 2].sole(allow_nil: true)  # => raise SoleItemExpectedError
```


#### Example: ActiveRecord

```ruby
topics = Topic.where(title: "Title Does Not Exist")

topics.count                    # => 0
topics.sole                     # => raise RecordNotFound
topics.sole(allow_nil: false)   # => raise RecordNotFound
topics.sole(allow_nil: true)    # => nil

topics = Topic.where(title: "The First Topic")

topics.count                    # => 1
topics.sole                     # => #<Topic ...>
topics.sole(allow_nil: false)   # => #<Topic ...>
topics.sole(allow_nil: true)    # => #<Topic ...>

topics = Topic.all

topics.count                    # => 2+
topics.sole                     # => raise SoleRecordExceeded
topics.sole(allow_nil: false)   # => raise SoleRecordExceeded
topics.sole(allow_nil: true)    # => raise SoleRecordExceeded
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
