### PR TITLE
[Getting Started Tutorial] Add note on default string type for `email` column for Subscriber and explain the resulting migration file [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2031,19 +2031,36 @@ of these subscribers.
 Let's generate a model called Subscriber to store these email addresses and
 associate them with the respective product.
 
+NOTE: Here we are not specifying a type for `email` as rails automatically defaults to a `string` when a type is not given for migrations.
+
 ```bash
 $ bin/rails generate model Subscriber product:belongs_to email
 ```
+
+By including `product:belongs_to` above, we told Rails that subscribers and products have a one-to-many relationship, meaning a Subscriber "belongs to" a single Product instance.
+
+Next, open the generated migration (`db/migrate/<timestamp>_create_subscribers.rb`) like we did for Product.
+
+```ruby#4-5
+class CreateSubscribers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :subscribers do |t|
+      t.belongs_to :product, null: false, foreign_key: true
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end
+```
+
+This looks quite similar to the migration for `Product`, the main new thing is `belongs_to` which adds a `product_id` foreign key column.
 
 Then run the new migration:
 
 ```bash
 $ bin/rails db:migrate
 ```
-
-By including `product:belongs_to` above, we told Rails that subscribers and
-products have a one-to-many relationship, meaning a Subscriber "belongs to" a
-single Product instance.
 
 A Product, however, can have many subscribers, so we then add
 `has_many :subscribers, dependent: :destroy` to our Product model to add the


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

When I was doing the tutorial, I noticed that the `email` column was not specified with a type yet it defaulted to a string. This confused me, so I wanted to add more detail about it. 

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

I added a note for the default with showing the generated migration file.

### Additional information

I tried looking for documentation on this, but didn't find anything. When I tried it in a few different projects, this did work. I did find the relevant code in `railties/lib/rails/generators/generated_attribute.rb` where
```ruby
def initialize(name, type = nil, index_type = false, attr_options = {})
  @name           = name
  @type           = type || :string
```

In the tutorial I don't want to link to the actual codebase, but I think there's a few more pages that I can add a note too.
* https://guides.rubyonrails.org/active_record_migrations.html
* https://guides.rubyonrails.org/command_line.html
* https://guides.rubyonrails.org/active_record_basics.html

Not sure if there's any other API specifc pages I can add a note to. If I do add these, should this be in this PR or a separate one?

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. - N/A
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. - N/A
