### PR TITLE
Structured event subscriber cleanup

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,7 +1,5 @@
 *   Add structured events for Action Mailer:
-    - `action_mailer.delivery_error`
     - `action_mailer.delivered`
-    - `action_mailer.delivery_skipped`
     - `action_mailer.processed`
 
     *Gannon McGibbon*

--- a/actionmailer/test/structured_event_subscriber_test.rb
+++ b/actionmailer/test/structured_event_subscriber_test.rb
@@ -25,7 +25,7 @@ module ActionMailer
     end
 
     def test_deliver_is_notified
-      event = assert_event_reported("action_mailer.delivered", payload: { message_id: "123@abc", mail: /.*/ }) do
+      event = assert_event_reported("action_mailer.delivered", payload: { message_id: "123@abc", mail: /.*/, perform_deliveries: true }) do
         BaseMailer.welcome(message_id: "123@abc").deliver_now
       end
 
@@ -35,7 +35,7 @@ module ActionMailer
     end
 
     def test_deliver_message_when_perform_deliveries_is_false
-      assert_event_reported("action_mailer.delivery_skipped", payload: { message_id: "123@abc", mail: /.*/ }) do
+      assert_event_reported("action_mailer.delivered", payload: { message_id: "123@abc", mail: /.*/, perform_deliveries: false }) do
         BaseMailer.welcome_without_deliveries(message_id: "123@abc").deliver_now
       end
     ensure
@@ -47,7 +47,7 @@ module ActionMailer
       BaseMailer.delivery_method = BogusDelivery
       payload = { message_id: "123@abc", mail: /.*/, exception_class: "RuntimeError", exception_message: "failed" }
 
-      assert_event_reported("action_mailer.delivery_error", payload:) do
+      assert_event_reported("action_mailer.delivered", payload:) do
         assert_raises(RuntimeError) { BaseMailer.welcome(message_id: "123@abc").deliver_now }
       end
     ensure

--- a/actionpack/lib/action_controller/structured_event_subscriber.rb
+++ b/actionpack/lib/action_controller/structured_event_subscriber.rb
@@ -82,22 +82,34 @@ module ActionController
     end
     debug_only :unpermitted_parameters
 
-    %w(write_fragment read_fragment exist_fragment? expire_fragment).each do |method|
-      class_eval <<-METHOD, __FILE__, __LINE__ + 1
-        # frozen_string_literal: true
-        def #{method}(event)
-          return unless ActionController::Base.enable_fragment_cache_logging
-
-          key = ActiveSupport::Cache.expand_cache_key(event.payload[:key] || event.payload[:path])
-
-          emit_event("action_controller.fragment_cache",
-            method: "#{method}",
-            key: key,
-            duration_ms: event.duration.round(1)
-          )
-        end
-      METHOD
+    def write_fragment(event)
+      fragment_cache(__method__, event)
     end
+
+    def read_fragment(event)
+      fragment_cache(__method__, event)
+    end
+
+    def exist_fragment?(event)
+      fragment_cache(__method__, event)
+    end
+
+    def expire_fragment(event)
+      fragment_cache(__method__, event)
+    end
+
+    private
+      def fragment_cache(method_name, event)
+        return unless ActionController::Base.enable_fragment_cache_logging
+
+        key = ActiveSupport::Cache.expand_cache_key(event.payload[:key] || event.payload[:path])
+
+        emit_event("action_controller.fragment_cache",
+          method: "#{method_name}",
+          key: key,
+          duration_ms: event.duration.round(1)
+        )
+      end
   end
 end
 

--- a/actionview/lib/action_view/structured_event_subscriber.rb
+++ b/actionview/lib/action_view/structured_event_subscriber.rb
@@ -15,8 +15,8 @@ module ActionView
       emit_debug_event("action_view.render_template",
         identifier: from_rails_root(event.payload[:identifier]),
         layout: from_rails_root(event.payload[:layout]),
-        duration: event.duration.round(1),
-        gc: event.gc_time.round(1),
+        duration: event.duration.round(2),
+        gc: event.gc_time.round(2),
       )
     end
     debug_only :render_template
@@ -25,8 +25,8 @@ module ActionView
       emit_debug_event("action_view.render_partial",
         identifier: from_rails_root(event.payload[:identifier]),
         layout: from_rails_root(event.payload[:layout]),
-        duration: event.duration.round(1),
-        gc: event.gc_time.round(1),
+        duration: event.duration.round(2),
+        gc: event.gc_time.round(2),
         cache_hit: event.payload[:cache_hit],
       )
     end
@@ -35,8 +35,8 @@ module ActionView
     def render_layout(event)
       emit_event("action_view.render_layout",
         identifier: from_rails_root(event.payload[:identifier]),
-        duration: event.duration.round(1),
-        gc: event.gc_time.round(1),
+        duration: event.duration.round(2),
+        gc: event.gc_time.round(2),
       )
     end
     debug_only :render_layout
@@ -45,8 +45,8 @@ module ActionView
       emit_debug_event("action_view.render_collection",
         identifier: from_rails_root(event.payload[:identifier] || "templates"),
         layout: from_rails_root(event.payload[:layout]),
-        duration: event.duration.round(1),
-        gc: event.gc_time.round(1),
+        duration: event.duration.round(2),
+        gc: event.gc_time.round(2),
         cache_hits: event.payload[:cache_hits],
         count: event.payload[:count],
       )

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,11 +1,7 @@
 *   Add structured events for Active Job:
-    - `active_job.enqueue_failed`
-    - `active_job.enqueue_aborted`
     - `active_job.enqueued`
     - `active_job.bulk_enqueued`
     - `active_job.started`
-    - `active_job.failed`
-    - `active_job.aborted`
     - `active_job.completed`
     - `active_job.retry_scheduled`
     - `active_job.retry_stopped`
@@ -13,10 +9,7 @@
     - `active_job.interrupt`
     - `active_job.resume`
     - `active_job.step_skipped`
-    - `active_job.step_resumed`
     - `active_job.step_started`
-    - `active_job.step_interrupted`
-    - `active_job.step_errored`
     - `active_job.step`
 
     *Adrianna Chang*


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created as followup on https://github.com/rails/rails/pull/55690 to clean up some implementation details and event behaviour.

### Detail

This Pull Request changes Action Mailer and Active Job to emit one event per listener with variable payloads, instead of multiple named events.

### Additional information

Recorded durations are also now rounded to the same precision and all named the same.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
