### PR TITLE
Introduce `with_debug_event_reporting` to enable event reporter debug mode

### DIFF
--- a/actionmailer/test/structured_event_subscriber_test.rb
+++ b/actionmailer/test/structured_event_subscriber_test.rb
@@ -19,7 +19,7 @@ module ActionMailer
     end
 
     def run(*)
-      ActiveSupport.event_reporter.with_debug do
+      with_debug_event_reporting do
         super
       end
     end

--- a/actionpack/test/controller/structured_event_subscriber_test.rb
+++ b/actionpack/test/controller/structured_event_subscriber_test.rb
@@ -129,7 +129,7 @@ module ActionController
     end
 
     def test_unpermitted_parameters
-      ActiveSupport.event_reporter.with_debug do
+      with_debug_event_reporting do
         assert_event_reported("action_controller.unpermitted_parameters", payload: {
           controller: Another::StructuredEventSubscribersController.name,
           action: "unpermitted_parameters",

--- a/actionview/test/template/structured_event_subscriber_test.rb
+++ b/actionview/test/template/structured_event_subscriber_test.rb
@@ -35,7 +35,7 @@ module ActionView
 
     def test_render_template
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb", layout: nil }) do
             event = assert_event_reported("action_view.render_template", payload: { identifier: "test/hello_world.erb", layout: nil }) do
               @view.render(template: "test/hello_world")
@@ -50,7 +50,7 @@ module ActionView
 
     def test_render_template_with_layout
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           payload = { identifier: "test/hello_world.erb", layout: "layouts/yield" }
           assert_event_reported("action_view.render_start", payload:) do
             event = assert_event_reported("action_view.render_template", payload:) do
@@ -66,7 +66,7 @@ module ActionView
 
     def test_render_file_template
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb", layout: nil }) do
             event = assert_event_reported("action_view.render_template", payload: { identifier: "test/hello_world.erb", layout: nil }) do
               @view.render(file: "#{FIXTURE_LOAD_PATH}/test/hello_world.erb")
@@ -81,7 +81,7 @@ module ActionView
 
     def test_render_text_template
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           assert_event_reported("action_view.render_start", payload: { identifier: "text template", layout: nil }) do
             event = assert_event_reported("action_view.render_template", payload: { identifier: "text template", layout: nil }) do
               @view.render(plain: "TEXT")
@@ -96,7 +96,7 @@ module ActionView
 
     def test_render_inline_template
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           assert_event_reported("action_view.render_start", payload: { identifier: "inline template", layout: nil }) do
             event = assert_event_reported("action_view.render_template", payload: { identifier: "inline template", layout: nil }) do
               @view.render(inline: "<%= 'TEXT' %>")
@@ -111,7 +111,7 @@ module ActionView
 
     def test_render_partial_with_implicit_path
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           payload = { identifier: "customers/_customer.html.erb", layout: nil, cache_hit: nil }
           event = assert_event_reported("action_view.render_partial", payload:) do
             @view.render(Customer.new("david"), greeting: "hi")
@@ -128,7 +128,7 @@ module ActionView
         set_view_cache_dependencies
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }
           event = assert_event_reported("action_view.render_partial", payload:) do
             @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
@@ -147,7 +147,7 @@ module ActionView
 
         @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :hit }
           event = assert_event_reported("action_view.render_partial", payload:) do
             # Second render should hit cache.
@@ -165,7 +165,7 @@ module ActionView
         set_view_cache_dependencies
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           event = assert_event_reported("action_view.render_partial", payload: { identifier: "layouts/_yield_only.erb", layout: nil }) do
             @view.render(layout: "layouts/yield_only") { "hello" }
           end
@@ -181,7 +181,7 @@ module ActionView
         set_view_cache_dependencies
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           payload = { identifier: "test/_partial.html.erb", layout: "layouts/_yield_only" }
           event = assert_event_reported("action_view.render_partial", payload:) do
             @view.render(partial: "partial", layout: "layouts/yield_only")
@@ -198,7 +198,7 @@ module ActionView
         set_view_cache_dependencies
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           event = assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
             @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
           end
@@ -223,7 +223,7 @@ module ActionView
         set_view_cache_dependencies
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
             assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_nested_cached_customer.erb", layout: nil, cache_hit: :miss }) do
               @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
@@ -245,7 +245,7 @@ module ActionView
         set_view_cache_dependencies
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }) do
             @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
           end
@@ -264,7 +264,7 @@ module ActionView
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           event = assert_event_reported("action_view.render_collection", payload: { identifier: "test/_customer.erb", layout: nil, cache_hits: nil, count: 2 }) do
             @view.render(partial: "test/customer", collection: [ Customer.new("david"), Customer.new("mary") ])
           end
@@ -279,7 +279,7 @@ module ActionView
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           event = assert_event_reported("action_view.render_collection", payload: { identifier: "test/_customer.erb", layout: "layouts/_yield_only", cache_hits: nil, count: 2 }) do
             @view.render(partial: "test/customer", layout: "layouts/yield_only", collection: [ Customer.new("david"), Customer.new("mary") ])
           end
@@ -294,7 +294,7 @@ module ActionView
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           event = assert_event_reported("action_view.render_collection", payload: { identifier: "customers/_customer.html.erb", layout: nil, cache_hits: nil, count: 2 }) do
             @view.render([ Customer.new("david"), Customer.new("mary") ], greeting: "hi")
           end
@@ -309,7 +309,7 @@ module ActionView
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           event = assert_event_reported("action_view.render_collection", payload: { identifier: "templates", layout: nil, cache_hits: nil, count: 2 }) do
             @view.render([ GoodCustomer.new("david"), Customer.new("mary") ], greeting: "hi")
           end
@@ -325,7 +325,7 @@ module ActionView
         set_view_cache_dependencies
         set_cache_controller
 
-        ActiveSupport.event_reporter.with_debug do
+        with_debug_event_reporting do
           event = assert_event_reported("action_view.render_collection", payload: { identifier: "customers/_customer.html.erb", layout: nil, cache_hits: 0, count: 2 }) do
             @view.render(partial: "customers/customer", collection: [ Customer.new("david"), Customer.new("mary") ], cached: true,
               locals: { greeting: "hi" })

--- a/activerecord/test/cases/structured_event_subscriber_test.rb
+++ b/activerecord/test/cases/structured_event_subscriber_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     Event = Struct.new(:duration, :payload)
 
     def run(*)
-      ActiveSupport.event_reporter.with_debug do
+      with_debug_event_reporting do
         super
       end
     end

--- a/activestorage/test/structured_event_subscriber_test.rb
+++ b/activestorage/test/structured_event_subscriber_test.rb
@@ -64,7 +64,7 @@ module ActiveStorage
       blob = create_blob(filename: "avatar.jpg")
       user = User.create!(name: "Test", avatar: blob)
 
-      ActiveSupport.event_reporter.with_debug do
+      with_debug_event_reporting do
         assert_event_reported("active_storage.service_exist", payload: { key: /.*/, exist: true }) do
           user.avatar.service.exist? user.avatar.key
         end
@@ -75,7 +75,7 @@ module ActiveStorage
       blob = create_blob(filename: "avatar.jpg")
       user = User.create!(name: "Test", avatar: blob)
 
-      ActiveSupport.event_reporter.with_debug do
+      with_debug_event_reporting do
         assert_event_reported("active_storage.service_url", payload: { key: /.*/, url: /.*/ }) do
           user.avatar.url
         end
@@ -98,7 +98,7 @@ module ActiveStorage
       service = ActiveStorage::Service.configure :mirror, config
       service.upload blob.key, StringIO.new(blob.download), checksum: blob.checksum
 
-      ActiveSupport.event_reporter.with_debug do
+      with_debug_event_reporting do
         assert_event_reported("active_storage.service_mirror", payload: { key: /.*/, url: /.*/ }) do
           service.mirror blob.key, checksum: blob.checksum
         end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Introduce `ActiveSupport::Testing::EventReporterAssertions#with_debug_event_reporting`
+    to enable event reporter debug mode in tests.
+
+    The previous way to enable debug mode is by using `#with_debug` on the
+    event reporter itself, which is too verbose. This new helper will help
+    clear up any confusion on how to test debug events.
+
+    *Gannon McGibbon*
+
 *   Add `ActiveSupport::StructuredEventSubscriber` for consuming notifications and
     emitting structured event logs. Events may be emitted with the `#emit_event`
     or `#emit_debug_event` methods.

--- a/activesupport/lib/active_support/testing/event_reporter_assertions.rb
+++ b/activesupport/lib/active_support/testing/event_reporter_assertions.rb
@@ -212,6 +212,16 @@ module ActiveSupport
 
         assert(true)
       end
+
+      # Allows debug events to be reported to +Rails.event+ for the duration of a given block.
+      #
+      #   with_debug_event_reporting do
+      #     service_that_reports_debug_events.perform
+      #   end
+      #
+      def with_debug_event_reporting(&block)
+        ActiveSupport.event_reporter.with_debug(&block)
+      end
     end
   end
 end

--- a/activesupport/test/structured_event_subscriber_test.rb
+++ b/activesupport/test/structured_event_subscriber_test.rb
@@ -39,7 +39,7 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_emit_debug_event_calls_event_reporter_debug
-    ActiveSupport.event_reporter.with_debug do
+    with_debug_event_reporting do
       assert_event_reported("test.debug", payload: { debug: "info" }) do
         @subscriber.emit_debug_event("test.debug", { debug: "info" })
       end
@@ -89,7 +89,7 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
     end
 
     assert_error_reported(TestSubscriber::DebugOnlyError) do
-      ActiveSupport.event_reporter.with_debug do
+      with_debug_event_reporting do
         ActiveSupport::Notifications.instrument("debug_only_event.test")
       end
     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because debug event testing ergonomics are a little off in my opinion. I think we need a helper now that https://github.com/rails/rails/pull/55657 is merged which enables debug in development only. This became noticeable to me after testing structured event subscribers in https://github.com/rails/rails/pull/55690.

### Detail

This Pull Request changes `ActiveSupport::Testing::EventReporterAssertions` by adding `#with_debug_event_reporting` to enable event reporter debug mode in tests.

The previous way to enable debug mode is by using `#with_debug` on the event reporter itself, which is too verbose. This new helper will help clear up any confusion on how to test debug events.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
