### PR TITLE
Remove ActiveSupport::Subscriber#publish_event in favor of call

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -149,12 +149,6 @@ module ActiveSupport
       log_exception(event.name, e)
     end
 
-    def publish_event(event)
-      super if logger
-    rescue => e
-      log_exception(event.name, e)
-    end
-
     attr_writer :event_levels # :nodoc:
 
   private

--- a/activesupport/lib/active_support/structured_event_subscriber.rb
+++ b/activesupport/lib/active_support/structured_event_subscriber.rb
@@ -91,12 +91,6 @@ module ActiveSupport
       handle_event_error(event.name, e)
     end
 
-    def publish_event(event)
-      super
-    rescue => e
-      handle_event_error(event.name, e)
-    end
-
     private
       def handle_event_error(name, error)
         ActiveSupport.error_reporter.report(error, source: name)

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -137,10 +137,5 @@ module ActiveSupport
       method = event.name[0, event.name.index(".")]
       send(method, event)
     end
-
-    def publish_event(event) # :nodoc:
-      method = event.name[0, event.name.index(".")]
-      send(method, event)
-    end
   end
 end

--- a/activesupport/test/structured_event_subscriber_test.rb
+++ b/activesupport/test/structured_event_subscriber_test.rb
@@ -78,18 +78,6 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
     assert_equal "error_event.test", error_report.source
   end
 
-  def test_publish_event_handles_errors
-    ActiveSupport::StructuredEventSubscriber.attach_to :test, @subscriber
-
-    event = ActiveSupport::Notifications::Event.new("error_event.test", Time.current, Time.current, "123", {})
-
-    error_report = assert_error_reported(NoMethodError) do
-      @subscriber.publish_event(event)
-    end
-    assert_match(/undefined method (`|')error_event'/, error_report.error.message)
-    assert_equal "error_event.test", error_report.source
-  end
-
   def test_debug_only_methods
     ActiveSupport::StructuredEventSubscriber.attach_to :test, @subscriber
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveSupport::Subscriber` and subclasses have duplicated methods. One can be removed because it is not documented.

### Detail

This Pull Request changes `ActiveSupport::Subscriber` by removing the `#publish_event` method. Developers can use the documented `#call` method instead. This is private API so no changelog is needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
