### PR TITLE
Make engine routes filterable in bin/rails routes, improve engine formatting

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Add engine route filtering and better formatting in `bin/rails routes`.
+
+    Allow engine routes to be filterable in the routing inspector, and
+    improve formatting of engine routing output.
+
+    Before:
+    ```
+    > bin/rails routes -e engine_only
+    No routes were found for this grep pattern.
+    For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.
+    ```
+
+    After:
+    ```
+    > bin/rails routes -e engine_only
+    Routes for application:
+    No routes were found for this grep pattern.
+    For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.
+
+    Routes for Test::Engine:
+    Prefix Verb URI Pattern       Controller#Action
+    engine GET  /engine_only(.:format) a#b
+    ```
+
+    *Dennis Paagman*, *Gannon McGibbon*
+
 *   Add structured events for Action Pack and Action Dispatch:
     - `action_dispatch.redirect`
     - `action_controller.request_started`

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -64,6 +64,14 @@ module ActionDispatch
       def engine?
         app.engine?
       end
+
+      def to_h
+        { name: name,
+          verb: verb,
+          path: path,
+          reqs: reqs,
+          source_location: source_location }
+      end
     end
 
     ##
@@ -72,33 +80,51 @@ module ActionDispatch
     # not use this class.
     class RoutesInspector # :nodoc:
       def initialize(routes)
-        @engines = {}
-        @routes = routes
+        @routes = wrap_routes(routes)
+        @engines = load_engines_routes
       end
 
       def format(formatter, filter = {})
-        routes_to_display = filter_routes(normalize_filter(filter))
-        routes = collect_routes(routes_to_display)
-        if routes.none?
-          formatter.no_routes(collect_routes(@routes), filter)
-          return formatter.result
-        end
+        all_routes = { nil => @routes }.merge(@engines)
 
-        formatter.header routes
-        formatter.section routes
-
-        @engines.each do |name, engine_routes|
-          formatter.section_title "Routes for #{name}"
-          if engine_routes.any?
-            formatter.header engine_routes
-            formatter.section engine_routes
-          end
+        all_routes.each do |engine_name, routes|
+          format_routes(formatter, filter, engine_name, routes)
         end
 
         formatter.result
       end
 
       private
+        def format_routes(formatter, filter, engine_name, routes)
+          routes = filter_routes(routes, normalize_filter(filter)).map(&:to_h)
+
+          formatter.section_title "Routes for #{engine_name || "application"}" if @engines.any?
+          if routes.any?
+            formatter.header routes
+            formatter.section routes
+          else
+            formatter.no_routes engine_name, routes, filter
+          end
+          formatter.footer routes
+        end
+
+        def wrap_routes(routes)
+          routes.routes.map { |route| RouteWrapper.new(route) }.reject(&:internal?)
+        end
+
+        def load_engines_routes
+          engine_routes = @routes.select(&:engine?)
+
+          engines = engine_routes.to_h do |engine_route|
+            engine_app_routes = engine_route.rack_app.routes
+            engine_app_routes = engine_app_routes.routes if engine_app_routes.is_a?(ActionDispatch::Routing::RouteSet)
+
+            [engine_route.endpoint, wrap_routes(engine_app_routes)]
+          end
+
+          engines
+        end
+
         def normalize_filter(filter)
           if filter[:controller]
             { controller: /#{filter[:controller].underscore.sub(/_?controller\z/, "")}/ }
@@ -118,39 +144,13 @@ module ActionDispatch
           end
         end
 
-        def filter_routes(filter)
+        def filter_routes(routes, filter)
           if filter
-            @routes.select do |route|
-              route_wrapper = RouteWrapper.new(route)
-              filter.any? { |filter_type, value| route_wrapper.matches_filter?(filter_type, value) }
+            routes.select do |route|
+              filter.any? { |filter_type, value| route.matches_filter?(filter_type, value) }
             end
           else
-            @routes
-          end
-        end
-
-        def collect_routes(routes)
-          routes.collect do |route|
-            RouteWrapper.new(route)
-          end.reject(&:internal?).collect do |route|
-            collect_engine_routes(route)
-
-            { name: route.name,
-              verb: route.verb,
-              path: route.path,
-              reqs: route.reqs,
-              source_location: route.source_location }
-          end
-        end
-
-        def collect_engine_routes(route)
-          name = route.endpoint
-          return unless route.engine?
-          return if @engines[name]
-
-          routes = route.rack_app.routes
-          if routes.is_a?(ActionDispatch::Routing::RouteSet)
-            @engines[name] = collect_routes(routes.routes)
+            routes
           end
         end
     end
@@ -174,27 +174,36 @@ module ActionDispatch
         def header(routes)
         end
 
-        def no_routes(routes, filter)
-          @buffer <<
-            if routes.none?
-              <<~MESSAGE
-                You don't have any routes defined!
+        def footer(routes)
+        end
 
-                Please add some routes in config/routes.rb.
-              MESSAGE
-            elsif filter.key?(:controller)
+        def no_routes(engine, routes, filter)
+          @buffer <<
+            if filter.key?(:controller)
               "No routes were found for this controller."
             elsif filter.key?(:grep)
               "No routes were found for this grep pattern."
+            elsif routes.none?
+              if engine
+                "No routes defined."
+              else
+                <<~MESSAGE
+                  You don't have any routes defined!
+
+                  Please add some routes in config/routes.rb.
+                MESSAGE
+              end
             end
 
-          @buffer << "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html."
+          unless engine
+            @buffer << "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html."
+          end
         end
       end
 
       class Sheet < Base
         def section_title(title)
-          @buffer << "\n#{title}:"
+          @buffer << "#{title}:"
         end
 
         def section(routes)
@@ -203,6 +212,10 @@ module ActionDispatch
 
         def header(routes)
           @buffer << draw_header(routes)
+        end
+
+        def footer(routes)
+          @buffer << ""
         end
 
         private
@@ -235,11 +248,15 @@ module ActionDispatch
         end
 
         def section_title(title)
-          @buffer << "\n#{"[ #{title} ]"}"
+          @buffer << "#{"[ #{title} ]"}"
         end
 
         def section(routes)
           @buffer << draw_expanded_section(routes)
+        end
+
+        def footer(routes)
+          @buffer << ""
         end
 
         private
@@ -272,7 +289,7 @@ module ActionDispatch
           super
         end
 
-        def no_routes(routes, filter)
+        def no_routes(engine, routes, filter)
           @buffer <<
             if filter.none?
               "No unused routes found."
@@ -301,6 +318,9 @@ module ActionDispatch
 
       # The header is part of the HTML page, so we don't construct it here.
       def header(routes)
+      end
+
+      def footer(routes)
       end
 
       def no_routes(*)

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -36,6 +36,7 @@ module ActionDispatch
         end
 
         assert_equal [
+          "Routes for application:",
           "       Prefix Verb URI Pattern              Controller#Action",
           "custom_assets GET  /custom/assets(.:format) custom_assets#show",
           "         blog      /blog                    Blog::Engine",
@@ -60,10 +61,12 @@ module ActionDispatch
         end
 
         assert_equal [
+          "Routes for application:",
           "Prefix Verb URI Pattern Controller#Action",
           "  blog      /blog       Blog::Engine",
           "",
-          "Routes for Blog::Engine:"
+          "Routes for Blog::Engine:",
+          "No routes defined.",
         ], output
       end
 
@@ -336,7 +339,8 @@ module ActionDispatch
           mount engine => "/blog", :as => "blog"
         end
 
-        expected = ["--[ Route 1 ]----------",
+        expected = [ "[ Routes for application ]",
+                     "--[ Route 1 ]----------",
                      "Prefix            | custom_assets",
                      "Verb              | GET",
                      "URI               | /custom/assets(.:format)",
@@ -380,7 +384,7 @@ module ActionDispatch
       end
 
       def test_not_routes_when_expanded
-        output = draw(grep: "rails/dummy", formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new) { }
+        output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new) { }
 
         assert_equal [
           "You don't have any routes defined!",
@@ -444,7 +448,7 @@ module ActionDispatch
       end
 
       def test_no_routes_were_defined
-        output = draw(grep: "Rails::DummyController") { }
+        output = draw { }
 
         assert_equal [
           "You don't have any routes defined!",
@@ -485,6 +489,57 @@ module ActionDispatch
         assert_equal [
           "Prefix Verb URI Pattern       Controller#Action",
           "health GET  /health(.:format) Inline handler (Proc/Lambda)"
+        ], output
+      end
+
+      def test_displaying_routes_for_engines_with_filter
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = draw(grep: "cart") do
+          get "/custom/assets", to: "custom_assets#show"
+          mount engine => "/blog", :as => "blog"
+        end
+
+        assert_equal [
+          "Routes for application:",
+          "No routes were found for this grep pattern.",
+          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.",
+          "",
+          "Routes for Blog::Engine:",
+          "Prefix Verb URI Pattern     Controller#Action",
+          "  cart GET  /cart(.:format) cart#show"
+        ], output
+      end
+
+      def test_displaying_routes_for_engines_with_filter_not_matched
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = draw(grep: "dummy") do
+          get "/custom/assets", to: "custom_assets#show"
+          mount engine => "/blog", :as => "blog"
+        end
+
+        assert_equal [
+          "Routes for application:",
+          "No routes were found for this grep pattern.",
+          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.",
+          "",
+          "Routes for Blog::Engine:",
+          "No routes were found for this grep pattern.",
         ], output
       end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because as mentioned in https://github.com/rails/rails/pull/54573, the output of `bin/rails routes` doesn't filter engine routes properly.

Closes https://github.com/rails/rails/pull/54573

### Detail

This Pull Request changes the routing inspect to do the following:
- Always unfurl engine routes so that all routes of an application can be filtered as needed
- Improve heading, messaging, and formatting of the inspector to denote app routes, when engines have no routes, spacing between engines, etc.
- Only adds additional formatting on applications using engines

### Additional information

Since we rewrote how routes are collected and printed, I did a quick `time` benchmark on a large app to make sure we're not slowing things down:

Before:
```
bin/rails routes  4.73s user 3.26s system 84% cpu 9.513 total
bin/rails routes -g filter  4.75s user 3.14s system 90% cpu 8.766 total
```

After:
```
bin/rails routes  4.44s user 2.68s system 75% cpu 9.431 total
bin/rails routes -g filter  4.88s user 3.19s system 90% cpu 8.889 total
```

Same-ish to a bit faster on a full print. Applying a filter is slightly slower, but that's expected because it iterates through all routes (app and engine) now instead of lazy unfurling that previously missed embedded routes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
