### PR TITLE
Remove loading behaviour from interlock

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -236,12 +236,7 @@ module ActionController
 
       private
         def each_chunk(&block)
-          loop do
-            str = nil
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              str = @buf.pop
-            end
-            break unless str
+          while str = @buf.pop
             yield str
           end
         end
@@ -306,9 +301,7 @@ module ActionController
         end
       end
 
-      ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-        @_response.await_commit
-      end
+      @_response.await_commit
 
       raise error if error
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
@@ -129,9 +129,7 @@ module ActiveRecord
             t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             elapsed = 0
             loop do
-              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                @cond.wait(timeout - elapsed)
-              end
+              @cond.wait(timeout - elapsed)
 
               return remove if any?
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -568,9 +568,7 @@ module ActiveRecord
           type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds, async: async, allow_retry: allow_retry) do |notification_payload|
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-              result = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
-              end
+              result = perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
               handle_warnings(result, sql)
               result
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -5,6 +5,7 @@ require "active_record/connection_adapters/abstract/schema_dumper"
 require "active_record/connection_adapters/abstract/schema_creation"
 require "active_support/concurrency/null_lock"
 require "active_support/concurrency/load_interlock_aware_monitor"
+require "active_support/concurrency/thread_monitor"
 require "arel/collectors/bind"
 require "arel/collectors/composite"
 require "arel/collectors/sql_string"
@@ -190,9 +191,9 @@ module ActiveRecord
         @lock =
         case lock_thread
         when Thread
-          ActiveSupport::Concurrency::ThreadLoadInterlockAwareMonitor.new
+          ActiveSupport::Concurrency::ThreadMonitor.new
         when Fiber
-          ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
+          ::Monitor.new
         else
           ActiveSupport::Concurrency::NullLock
         end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -173,8 +173,10 @@ module ActiveRecord
             connection_latch.count_down
             load_interlock_latch.wait
 
-            ActiveSupport::Dependencies.interlock.loading do
-              able_to_load = true
+            assert_deprecated(/ActiveSupport::Dependencies::Interlock#loading is deprecated/, ActiveSupport.deprecator) do
+              ActiveSupport::Dependencies.interlock.loading do
+                able_to_load = true
+              end
             end
           end
         end

--- a/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb
+++ b/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb
@@ -4,69 +4,15 @@ require "monitor"
 
 module ActiveSupport
   module Concurrency
-    module LoadInterlockAwareMonitorMixin # :nodoc:
-      EXCEPTION_NEVER = { Exception => :never }.freeze
-      EXCEPTION_IMMEDIATE = { Exception => :immediate }.freeze
-      private_constant :EXCEPTION_NEVER, :EXCEPTION_IMMEDIATE
-
-      # Enters an exclusive section, but allows dependency loading while blocked
-      def mon_enter
-        mon_try_enter ||
-          ActiveSupport::Dependencies.interlock.permit_concurrent_loads { super }
-      end
-
-      def synchronize(&block)
-        Thread.handle_interrupt(EXCEPTION_NEVER) do
-          mon_enter
-
-          begin
-            Thread.handle_interrupt(EXCEPTION_IMMEDIATE, &block)
-          ensure
-            mon_exit
-          end
-        end
-      end
-    end
     # A monitor that will permit dependency loading while blocked waiting for
     # the lock.
-    class LoadInterlockAwareMonitor < Monitor
-      include LoadInterlockAwareMonitorMixin
-    end
-
-    class ThreadLoadInterlockAwareMonitor # :nodoc:
-      prepend LoadInterlockAwareMonitorMixin
-
-      def initialize
-        @owner = nil
-        @count = 0
-        @mutex = Mutex.new
-      end
-
-      private
-        def mon_try_enter
-          if @owner != Thread.current
-            return false unless @mutex.try_lock
-            @owner = Thread.current
-          end
-          @count += 1
-        end
-
-        def mon_enter
-          @mutex.lock if @owner != Thread.current
-          @owner = Thread.current
-          @count += 1
-        end
-
-        def mon_exit
-          unless @owner == Thread.current
-            raise ThreadError, "current thread not owner"
-          end
-
-          @count -= 1
-          return unless @count == 0
-          @owner = nil
-          @mutex.unlock
-        end
-    end
+    LoadInterlockAwareMonitor = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(
+      "ActiveSupport::Concurrency::LoadInterlockAwareMonitor",
+      "::Monitor",
+      ActiveSupport.deprecator,
+      message: "ActiveSupport::Concurrency::LoadInterlockAwareMonitor is deprecated and will be " \
+               "removed in Rails 9.0. Use Monitor directly instead, as the loading interlock is " \
+               "no longer used."
+    )
   end
 end

--- a/activesupport/lib/active_support/concurrency/thread_monitor.rb
+++ b/activesupport/lib/active_support/concurrency/thread_monitor.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Concurrency
+    class ThreadMonitor # :nodoc:
+      EXCEPTION_NEVER = { Exception => :never }.freeze
+      EXCEPTION_IMMEDIATE = { Exception => :immediate }.freeze
+      private_constant :EXCEPTION_NEVER, :EXCEPTION_IMMEDIATE
+
+      def initialize
+        @owner = nil
+        @count = 0
+        @mutex = Mutex.new
+      end
+
+      def synchronize(&block)
+        Thread.handle_interrupt(EXCEPTION_NEVER) do
+          mon_enter
+
+          begin
+            Thread.handle_interrupt(EXCEPTION_IMMEDIATE, &block)
+          ensure
+            mon_exit
+          end
+        end
+      end
+
+      private
+        def mon_try_enter
+          if @owner != Thread.current
+            return false unless @mutex.try_lock
+            @owner = Thread.current
+          end
+          @count += 1
+        end
+
+        def mon_enter
+          @mutex.lock if @owner != Thread.current
+          @owner = Thread.current
+          @count += 1
+        end
+
+        def mon_exit
+          unless @owner == Thread.current
+            raise ThreadError, "current thread not owner"
+          end
+
+          @count -= 1
+          return unless @count == 0
+          @owner = nil
+          @mutex.unlock
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -21,7 +21,12 @@ module ActiveSupport # :nodoc:
     # preventing any other thread from being inside a #run_interlock
     # block at the same time.
     def self.load_interlock(&block)
-      interlock.loading(&block)
+      ActiveSupport.deprecator.warn(
+        "ActiveSupport::Dependencies.load_interlock is deprecated and " \
+        "will be removed in Rails 9.0. The loading interlock is no longer " \
+        "used since Rails switched to Zeitwerk for autoloading."
+      )
+      yield if block
     end
 
     # Execute the supplied block while holding an exclusive lock,

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -10,19 +10,24 @@ module ActiveSupport # :nodoc:
       end
 
       def loading(&block)
-        @lock.exclusive(purpose: :load, compatible: [:load], after_compatible: [:load], &block)
+        ActiveSupport.deprecator.warn(
+          "ActiveSupport::Dependencies::Interlock#loading is deprecated and " \
+          "will be removed in Rails 9.0. The loading interlock is no longer " \
+          "used since Rails switched to Zeitwerk for autoloading."
+        )
+        yield if block
       end
 
       def unloading(&block)
-        @lock.exclusive(purpose: :unload, compatible: [:load, :unload], after_compatible: [:load, :unload], &block)
+        @lock.exclusive(purpose: :unload, compatible: [:unload], after_compatible: [:unload], &block)
       end
 
       def start_unloading
-        @lock.start_exclusive(purpose: :unload, compatible: [:load, :unload])
+        @lock.start_exclusive(purpose: :unload, compatible: [:unload])
       end
 
       def done_unloading
-        @lock.stop_exclusive(compatible: [:load, :unload])
+        @lock.stop_exclusive(compatible: [:unload])
       end
 
       def start_running
@@ -38,7 +43,8 @@ module ActiveSupport # :nodoc:
       end
 
       def permit_concurrent_loads(&block)
-        @lock.yield_shares(compatible: [:load], &block)
+        # Soft deprecated: no deprecation warning for now, but this is a no-op.
+        yield if block
       end
 
       def raw_state(&block) # :nodoc:

--- a/activesupport/test/concurrency/load_interlock_aware_monitor_test.rb
+++ b/activesupport/test/concurrency/load_interlock_aware_monitor_test.rb
@@ -1,76 +1,27 @@
 # frozen_string_literal: true
 
 require_relative "../abstract_unit"
-require "concurrent/atomic/count_down_latch"
 require "active_support/concurrency/load_interlock_aware_monitor"
 
 module ActiveSupport
   module Concurrency
-    module LoadInterlockAwareMonitorTests
-      def test_entering_with_no_blocking
-        assert @monitor.mon_enter
-      end
-
-      def test_entering_with_blocking
-        load_interlock_latch = Concurrent::CountDownLatch.new
-        monitor_latch = Concurrent::CountDownLatch.new
-
-        able_to_use_monitor = false
-        able_to_load = false
-
-        thread_with_load_interlock = Thread.new do
-          ActiveSupport::Dependencies.interlock.running do
-            load_interlock_latch.count_down
-            monitor_latch.wait
-
-            @monitor.synchronize do
-              able_to_use_monitor = true
-            end
-          end
-        end
-
-        thread_with_monitor_lock = Thread.new do
-          @monitor.synchronize do
-            monitor_latch.count_down
-            load_interlock_latch.wait
-
-            ActiveSupport::Dependencies.interlock.loading do
-              able_to_load = true
-            end
-          end
-        end
-
-        thread_with_load_interlock.join
-        thread_with_monitor_lock.join
-
-        assert able_to_use_monitor
-        assert able_to_load
-      end
-    end
-
     class LoadInterlockAwareMonitorTest < ActiveSupport::TestCase
-      include LoadInterlockAwareMonitorTests
-
-      def setup
-        @monitor = ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
-      end
-    end
-
-    class ThreadLoadInterlockAwareMonitorTest < ActiveSupport::TestCase
-      include LoadInterlockAwareMonitorTests
-
-      def setup
-        @monitor = ActiveSupport::Concurrency::ThreadLoadInterlockAwareMonitor.new
+      def test_deprecated_constant_resolves_to_monitor
+        monitor = nil
+        assert_deprecated(/ActiveSupport::Concurrency::LoadInterlockAwareMonitor is deprecated/, ActiveSupport.deprecator) do
+          monitor = LoadInterlockAwareMonitor.new
+        end
+        assert_instance_of ::Monitor, monitor
       end
 
-      def test_lock_owned_by_thread
-        @monitor.synchronize do
-          enumerator = Enumerator.new do |yielder|
-            @monitor.synchronize do
-              yielder.yield 42
-            end
+      def test_deprecated_constant_can_synchronize
+        assert_deprecated(/ActiveSupport::Concurrency::LoadInterlockAwareMonitor is deprecated/, ActiveSupport.deprecator) do
+          monitor = LoadInterlockAwareMonitor.new
+          result = nil
+          monitor.synchronize do
+            result = 42
           end
-          assert_equal 42, enumerator.next
+          assert_equal 42, result
         end
       end
     end

--- a/activesupport/test/concurrency/thread_monitor_test.rb
+++ b/activesupport/test/concurrency/thread_monitor_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "concurrent/atomic/count_down_latch"
+require "active_support/concurrency/thread_monitor"
+
+module ActiveSupport
+  module Concurrency
+    class ThreadMonitorTest < ActiveSupport::TestCase
+      def setup
+        @monitor = ThreadMonitor.new
+      end
+
+      def test_synchronize_blocks_other_threads
+        blocked = false
+        ready_latch = Concurrent::CountDownLatch.new
+        blocked_latch = Concurrent::CountDownLatch.new
+
+        thread1 = Thread.new do
+          @monitor.synchronize do
+            ready_latch.count_down
+            blocked_latch.wait
+            sleep 0.1
+          end
+        end
+
+        thread2 = Thread.new do
+          ready_latch.wait
+          @monitor.synchronize do
+            blocked = true
+          end
+        end
+
+        sleep 0.05 # Give thread2 time to try to acquire the lock
+        assert_not blocked, "Thread should be blocked waiting for monitor"
+
+        blocked_latch.count_down
+        thread1.join
+        thread2.join
+
+        assert blocked, "Thread should have acquired monitor after first thread released it"
+      end
+
+      def test_reentrant_locking
+        count = 0
+        @monitor.synchronize do
+          count += 1
+          @monitor.synchronize do
+            count += 1
+            @monitor.synchronize do
+              count += 1
+            end
+          end
+        end
+        assert_equal 3, count
+      end
+
+      def test_lock_owned_by_current_thread
+        @monitor.synchronize do
+          # Test that we can create an enumerator that also tries to acquire the lock
+          # This should work because the same thread already owns the lock
+          enumerator = Enumerator.new do |yielder|
+            @monitor.synchronize do
+              yielder.yield 42
+            end
+          end
+          assert_equal 42, enumerator.next
+        end
+      end
+
+      def test_exception_handling_releases_lock
+        exception_raised = false
+        subsequent_lock_acquired = false
+
+        begin
+          @monitor.synchronize do
+            raise StandardError, "test exception"
+          end
+        rescue StandardError
+          exception_raised = true
+        end
+
+        assert exception_raised
+
+        # Ensure the lock was properly released
+        @monitor.synchronize do
+          subsequent_lock_acquired = true
+        end
+
+        assert subsequent_lock_acquired
+      end
+
+      def test_thread_error_on_wrong_thread_unlock
+        @monitor.synchronize do
+          thread = Thread.new do
+            assert_raises(ThreadError) do
+              @monitor.send(:mon_exit)
+            end
+          end
+          thread.join
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The running/unloading interaction is still needed, but "loading" protection was only required for classic autoloading.

This eliminates the need for `permit_concurrent_loads` -- which is the main reason I didn't want to rush into it: once we've stopped recommending that wrapping, it would be very hard to put back again. But at this point I think it's pretty clear it can safely go away.

I've removed all references to `permit_concurrent_loads` from the guide, but kept the method as a silent no-op (no deprecation). We can eventually age it out via a future deprecation, but for now there's no need to bother every existing caller.

In contrast, there should be approximately zero external callers directly invoking "loading" mode on the interlock; those methods are deprecated here just in case, but _are immediately no-op with no locking applied_. Since the switch to Zeitwerk, they've already not been interacting with framework-level loading, so this should only create an observable change if someone was using our lock as if it was their own mutex.

I've also changed references to the "Load Interlock" in the guide to "Reloading Interlock"; it's a longer name, a different name, and breaks the in-page anchor... but it just seems confusing to keep the old name when it's (already!) not involved in Load, only Reload.