### PR TITLE
Make all framework log subscribers API private

### DIFF
--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -3,11 +3,7 @@
 require "active_support/log_subscriber"
 
 module ActionMailer
-  # = Action Mailer \LogSubscriber
-  #
-  # Implements the ActiveSupport::LogSubscriber for logging notifications when
-  # email is delivered or received.
-  class LogSubscriber < ActiveSupport::LogSubscriber
+  class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
     # An email was delivered.
     def deliver(event)
       info do

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# :markup: markdown
-
 module ActionController
-  class LogSubscriber < ActiveSupport::LogSubscriber
+  class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
     INTERNAL_PARAMS = %w(controller action format _method only_path)
 
     def start_processing(event)

--- a/actionpack/lib/action_dispatch/log_subscriber.rb
+++ b/actionpack/lib/action_dispatch/log_subscriber.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# :markup: markdown
-
 module ActionDispatch
-  class LogSubscriber < ActiveSupport::LogSubscriber
+  class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
     def redirect(event)
       payload = event.payload
 

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -3,10 +3,7 @@
 require "active_support/log_subscriber"
 
 module ActionView
-  # = Action View Log Subscriber
-  #
-  # Provides functionality so that \Rails can output logs from Action View.
-  class LogSubscriber < ActiveSupport::LogSubscriber
+  class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
     VIEWS_PATTERN = /^app\/views\//
 
     def initialize

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  class LogSubscriber < ActiveSupport::LogSubscriber
+  class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
     IGNORE_PAYLOAD_NAMES = ["SCHEMA", "EXPLAIN"]
 
     class_attribute :backtrace_cleaner, default: ActiveSupport::BacktraceCleaner.new

--- a/activestorage/lib/active_storage/log_subscriber.rb
+++ b/activestorage/lib/active_storage/log_subscriber.rb
@@ -3,7 +3,7 @@
 require "active_support/log_subscriber"
 
 module ActiveStorage
-  class LogSubscriber < ActiveSupport::LogSubscriber
+  class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
     def service_upload(event)
       message = "Uploaded file to key: #{key_in(event)}"
       message += " (checksum: #{event.payload[:checksum]})" if event.payload[:checksum]


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because some log subscribers are currently public API and some aren't. I don't see any use of them being public, so let's just make them private.

### Detail

This Pull Request changes framework `LogSubscriber` classes to be nodoc private.

### Additional information

Since the introduction of structured event subscribers in https://github.com/rails/rails/pull/55690, we want to retire log subscribers in order to have one subscriber for each framework event instead of two (one currently emits a structured event and the other logs). We can't do this if some log subscribers are API public without a deprecation cycle. These event listeners are an implementation detail that don't need to be public anyway, so making them private seems appropriate.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
