### PR TITLE
Deprecate usage of custom ActiveJob serializers without public #klass methods

### DIFF
--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -76,11 +76,20 @@ module ActiveJob
           @serializers_index.clear
           serializers.each do |s|
             if s.respond_to?(:klass)
-              @serializers_index[s.klass] = s
+              begin
+                @serializers_index[s.klass] = s
+              rescue NotImplementedError => e
+                ActiveJob.deprecator.warn(
+                  <<~MSG.squish
+                    #{e.message}. This will raise an error in Rails 8.2.
+                  MSG
+                )
+              end
             elsif s.respond_to?(:klass, true)
               klass = s.send(:klass)
               ActiveJob.deprecator.warn(<<~MSG.squish)
                 #{s.class.name}#klass method should be public.
+                This will raise an error in Rails 8.2.
               MSG
               @serializers_index[klass] = s
             end

--- a/activejob/test/cases/serializers_test.rb
+++ b/activejob/test/cases/serializers_test.rb
@@ -30,6 +30,8 @@ class SerializersTest < ActiveSupport::TestCase
     end
   end
 
+  class TestSerializerWithoutKlass < ActiveJob::Serializers::ObjectSerializer; end
+
   setup do
     @value_object = DummyValueObject.new 123
     @original_serializers = ActiveJob::Serializers.serializers
@@ -91,6 +93,14 @@ class SerializersTest < ActiveSupport::TestCase
     ActiveJob::Serializers.add_serializers DummySerializer
     assert_no_difference(-> { ActiveJob::Serializers.serializers.size }) do
       ActiveJob::Serializers.add_serializers DummySerializer
+    end
+  end
+
+  test "raises a deprecation warning if the klass method doesn't exist" do
+    expected_message = "TestSerializerWithoutKlass should implement a public #klass method. This will raise an error in Rails 8.2"
+
+    assert_deprecated(expected_message, ActiveJob.deprecator) do
+      ActiveJob::Serializers.add_serializers TestSerializerWithoutKlass
     end
   end
 end

--- a/guides/source/8_1_release_notes.md
+++ b/guides/source/8_1_release_notes.md
@@ -179,6 +179,8 @@ Please refer to the [Changelog][active-job] for detailed changes.
 
 ### Deprecations
 
+*   Custom Active Job serializers must have a public `#klass` method.
+
 ### Notable changes
 
 Action Text


### PR DESCRIPTION
### Motivation / Background

The performance gains from https://github.com/rails/rails/pull/55583 meant that, when testing upgrades from 8.0 to 8.1, suddenly the app crashed and stopped evaluating due to the raised `NotImplementedError` in the parent class:

<img width="955" height="605" alt="Screenshot 2025-09-24 at 5 04 16 PM" src="https://github.com/user-attachments/assets/43288c01-6ba4-44ed-9196-e2475870fcd1" />

[`index_serializers` checks if the class responds to `:klass`](https://github.com/rails/rails/blob/main/activejob/lib/active_job/serializers.rb#L78)

but in the case of custom serializers, it will also do, even if it doesn't have an implemented method because [it inherits from the ObjectSerializer, which raises the `NotImplementedError`.](https://github.com/rails/rails/blob/main/activejob/lib/active_job/serializers/object_serializer.rb#L52)

Which is what was causing things to raise, tests to fail, etc.

 This indexer isn't strictly required (there's a fallback), so it feels appropriate to do a proper deprecation cycle and then remove this behavior in a later version.

### Detail

This Pull Request catches the NotImplementedError in this method and instead reports the deprecation. When that happens, the indexer will fall back to the lookup, so they don't get the performance gains, but their app will continue to run until the deprecation is addressed.

I also added some clarity to the deprecations so people will know what to expect.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. _Note: no changelog is included because the notes from https://github.com/rails/rails/pull/55583 feel sufficient to me_
