### PR TITLE
Remove `cgi` from the gemfile again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,8 +66,6 @@ group :doc do
   gem "redcarpet", "~> 3.6.1", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "rouge"
-  # Workaround until https://github.com/rouge-ruby/rouge/pull/2131 is merged and released
-  gem "cgi", require: false
   gem "rubyzip", "~> 2.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.5.0)
     chef-utils (18.6.2)
       concurrent-ruby
     childprocess (5.1.0)
@@ -517,7 +516,7 @@ GEM
       rufus-scheduler (~> 3.2, != 3.3)
     retriable (3.1.2)
     rexml (3.4.0)
-    rouge (4.6.0)
+    rouge (4.6.1)
     rubocop (1.79.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -758,7 +757,6 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara (>= 3.39)
-  cgi
   connection_pool
   cssbundling-rails
   dalli (>= 3.0.1)


### PR DESCRIPTION
This reverts commit fc6608728d00331237237113e310da0b0c37b648 (https://github.com/rails/rails/pull/55493), reversing changes made to 5ed40765abcba701196b44c893fde871cae02cdc.

rouge 4.6.1 has been released. https://github.com/rouge-ruby/rouge/releases/tag/v4.6.1

cc @yahonda
