### PR TITLE
ActionText: Improved heading and table plain text

### DIFF
--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -41,7 +41,7 @@ module ActionText
         "#{remove_trailing_newlines(plain_text_for_child_values(child_values))}\n\n"
       end
 
-      %i[ h1 p ].each do |element|
+      %i[ h1 h2 h3 h4 h5 h6 p table ].each do |element|
         alias_method :"plain_text_for_#{element}_node", :plain_text_for_block
       end
 
@@ -121,6 +121,18 @@ module ActionText
         else
           text
         end
+      end
+
+      def plain_text_for_tr_node(node, child_values)
+        "#{plain_text_for_child_values(child_values).strip}\n"
+      end
+
+      def plain_text_for_table_cell(node, child_values)
+        "#{plain_text_for_child_values(child_values).strip} "
+      end
+
+      %i[ th td ].each do |element|
+        alias_method :"plain_text_for_#{element}_node", :plain_text_for_table_cell
       end
 
       class BottomUpReducer # :nodoc:

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -168,6 +168,20 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "tables are formatted" do
+    assert_converted_to(
+      "Greeting Greeted\nHello World\nHey You",
+      "<table><th>Greeting</th><th>Greeted</th><tr><td>Hello</td><td>World</td></tr><tr><td>Hey</td><td>You</td></tr></table>"
+    )
+  end
+
+  test "headings are formatted" do
+    assert_converted_to(
+      "HELLO!!!\n\nHELLO!\n\nHello!\n\nHey\n\nhey\n\nhi",
+      "<h1>HELLO!!!</h1><h2>HELLO!</h2><h3>Hello!</h3><h4>Hey</h4><h5>hey</h5><h6>hi</h6>"
+    )
+  end
+
   private
     def assert_converted_to(plain_text, html)
       assert_equal plain_text, ActionText::Content.new(html).to_plain_text


### PR DESCRIPTION
### Motivation / Background

Table formatting in the ActionText plaintext conversions.

### Detail

- Treat all heading tags (`<h1>-<h6>`) as blocks, not just `<h1>`.
- Format tables - line per row, and a space between cells.

This is a minor formatting improvement and likely does not require a CHANGELOG entry, but I can add one if needed.