### PR TITLE
Move custom ActiveJob serializer deprecation into #index_serializers

### DIFF
--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -76,15 +76,7 @@ module ActiveJob
           @serializers_index.clear
           serializers.each do |s|
             if s.respond_to?(:klass)
-              begin
-                @serializers_index[s.klass] = s
-              rescue NotImplementedError => e
-                ActiveJob.deprecator.warn(
-                  <<~MSG.squish
-                    #{e.message}. This will raise an error in Rails 8.2.
-                  MSG
-                )
-              end
+              @serializers_index[s.klass] = s
             elsif s.respond_to?(:klass, true)
               klass = s.send(:klass)
               ActiveJob.deprecator.warn(<<~MSG.squish)
@@ -92,6 +84,13 @@ module ActiveJob
                 This will raise an error in Rails 8.2.
               MSG
               @serializers_index[klass] = s
+            else
+              ActiveJob.deprecator.warn(
+                <<~MSG.squish
+                  #{s.class.name} should implement a public #klass method.
+                  This will raise an error in Rails 8.2.
+                MSG
+              )
             end
           end
         end

--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -47,11 +47,6 @@ module ActiveJob
       def deserialize(hash)
         raise NotImplementedError, "#{self.class.name} should implement a public #deserialize(hash) method"
       end
-
-      # The class of the object that will be serialized.
-      def klass
-        raise NotImplementedError, "#{self.class.name} should implement a public #klass method"
-      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Follow-up to https://github.com/rails/rails/pull/55760 

tldr; upgrading to Rails 8.1 suddenly causes the app to raise and crash. The performance optimization makes sense and is super valuable, but it also makes sense to raise this as a deprecation instead of crash the app.

To avoid confusion, instead of a raise > rescue > warn, we are moving things so that this method will more directly handle the #klass reference in this deprecation cycle

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. _Note: the test from the previous PR also covers this_. 
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. _Note: the previous PR also covers this_
