### PR TITLE
Add replicas to test database parallelization setup

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add replicas to test database parallelization setup.
+
+    Setup and configuration of databases for parallel testing now includes replicas.
+
+    This fixes an issue when using a replica database, database selector middleware,
+    and non-transactional tests, where integration tests running in parallel would select
+    the base test database, i.e. `db_test`, instead of the numbered parallel worker database,
+    i.e. `db_test_{n}`.
+
+    *Adam Maas*
+
 *   Optimize schema dumping to prevent duplicate file generation.
 
     `ActiveRecord::Tasks::DatabaseTasks.dump_all` now tracks which schema files

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -19,10 +19,12 @@ module ActiveRecord
     def self.create_and_load_schema(i, env_name:)
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 
-      ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
+      ActiveRecord::Base.configurations.configs_for(env_name: env_name, include_hidden: true).each do |db_config|
         db_config._database = "#{db_config.database}_#{i}"
 
-        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, nil)
+        if db_config.database_tasks?
+          ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, nil)
+        end
       end
     ensure
       ActiveRecord::Base.establish_connection

--- a/activerecord/test/cases/test_databases_test.rb
+++ b/activerecord/test/cases/test_databases_test.rb
@@ -101,5 +101,35 @@ class TestDatabasesTest < ActiveRecord::TestCase
       ActiveRecord::Base.establish_connection(:arunit)
       ENV["RAILS_ENV"] = previous_env
     end
+
+    def test_create_databases_after_fork_with_replica
+      previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit"
+      prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {
+        "arunit" => {
+          "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+          "replica" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3", "replica" => true }
+        }
+      }
+
+      idx = 42
+      primary_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      expected_primary_database = "#{primary_db_config.database}_#{idx}"
+      replica_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "replica", include_hidden: true)
+      expected_replica_database = "#{replica_db_config.database}_#{idx}"
+
+      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _) {
+        assert_equal expected_primary_database, db_config.database
+      }) do
+        ActiveSupport::Testing::Parallelization.after_fork_hooks.each { |cb| cb.call(idx) }
+      end
+
+      # Updates the database configuration
+      assert_equal expected_primary_database, ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").database
+      assert_equal expected_replica_database, ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "replica", include_hidden: true).database
+    ensure
+      ActiveRecord::Base.configurations = prev_configs
+      ActiveRecord::Base.establish_connection(:arunit)
+      ENV["RAILS_ENV"] = previous_env
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #55758

### Detail

This Pull Request makes a change so that setup and configuration of databases for parallel testing now includes replicas.
    
This fixes an issue when using a replica database, database selector middleware, and non-transactional tests, where integration tests running in parallel would select the base test database, i.e. `db_test`, instead of the numbered parallel worker database, i.e. `db_test_{n}`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

The main issue revolves around how transactional tests work, and how they affect database selection when using a replica database. When using transaction tests, which is default, the test is wrapped in a transaction, which will default the entire transaction to the primary (writer) database. Because of this transaction, the test will use the primary database for the entire test, and the issue does not happen.

When you disable transactional tests, `self.use_transactional_tests = false`, this transaction is not present, so there is no initial/inherent database selection. In an integration test, the test setup code will use the primary database, but the controller request (GET, specifically) will run through the [database selector middleware](https://api.rubyonrails.org/classes/ActiveRecord/Middleware/DatabaseSelector.html), since we have this enabled when using a replica. The middleware will select the replica, because the test setup does not go through the middleware when doing the initial writes.

This creates an issue when running your tests in parallel, because replica databases do not get configured with a parallel worker number, i.e. `test_db-{n}`. That is because [configs_for](https://github.com/rails/rails/blob/v8.0.3/activerecord/lib/active_record/test_databases.rb#L14-L15) hides replica database configs unless you pas the `include_hidden: true` flag.

With the integration test running in parallel, when the database selector middleware selects the replica during the GET request, it'll use the base test database, i.e. `test_db`, not the numbered version, `test_db-{n}`, since these were not configured to use a parallel worker database. This ends up raising an error because the test setup was written to the parallel numbered database `test_db-{n}`, while the request reads from the base replica database `test_db`.

i.e. 
```ruby
class TestsControllerTest < ActionDispatch::IntegrationTest
  self.use_transactional_tests = false
  test "should get show" do
    test = Test.create(name: "test") # Uses `test_db-{n}`
    get test_url(test)               # Uses `test_db`
    assert_response :success         # 404
  end
end
```

To fix this issue, I've included replica databases in the parallel testing setup by passing the `include_hidden: true` flag to `configs_for`. Additionally, I skip `reconstruct_from_schema` for replicas, since these will replicate to replicas if using replication.

More information about this can be found in the original issue:  #55758 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
