### PR TITLE
Introduce `this_week?`, `this_month?`, and `this_year?` to Date/Time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Introduce `this_week?`, `this_month?`, and `this_year?` methods to Date/Time
+
+    Similar to `today?`, `tomorrow?`, and `yesterday?`, these methods are useful to
+    query time instances against the current period.
+
+    ```ruby
+    unless date.this_week?
+      link_to "See week recap", week_recap_path(date)
+    end
+    ```
+
+    *Matheus Richard*
+
 *   Removed the deprecated `ActiveSupport::Multibyte::Chars` class.
 
     As well as `String#mb_chars`

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -4,7 +4,7 @@
     query time instances against the current period.
 
     ```ruby
-    unless date.this_week?
+    unless post.created_at.this_week?
       link_to "See week recap", week_recap_path(date)
     end
     ```

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -63,6 +63,21 @@ module DateAndTime
       !WEEKEND_DAYS.include?(wday)
     end
 
+    # Returns true if the date/time falls within the current week.
+    def this_week?
+      ::Date.current.all_week.include?(to_date)
+    end
+
+    # Returns true if the date/time falls within the current month.
+    def this_month?
+      ::Date.current.all_month.include?(to_date)
+    end
+
+    # Returns true if the date/time falls within the current year.
+    def this_year?
+      ::Date.current.all_year.include?(to_date)
+    end
+
     # Returns true if the date/time falls before <tt>date_or_time</tt>.
     def before?(date_or_time)
       self < date_or_time

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -358,6 +358,33 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_this_week
+    Date.stub(:current, Date.new(2000, 1, 5)) do # Wed, 2000-01-05
+      assert_equal false, Time.utc(2000, 1, 2, 23, 59, 59).this_week?
+      assert_equal true,  Time.utc(2000, 1, 3, 0, 0, 0).this_week?
+      assert_equal true,  Time.utc(2000, 1, 9, 23, 59, 59).this_week?
+      assert_equal false, Time.utc(2000, 1, 10, 0, 0, 0).this_week?
+    end
+  end
+
+  def test_this_month
+    Date.stub(:current, Date.new(2000, 1, 15)) do
+      assert_equal false, Time.utc(1999, 12, 31, 23, 59, 59).this_month?
+      assert_equal true,  Time.utc(2000, 1, 1, 0, 0, 0).this_month?
+      assert_equal true,  Time.utc(2000, 1, 31, 23, 59, 59).this_month?
+      assert_equal false, Time.utc(2000, 2, 1, 0, 0, 0).this_month?
+    end
+  end
+
+  def test_this_year
+    Date.stub(:current, Date.new(2000, 6, 30)) do
+      assert_equal false, Time.utc(1999, 12, 31, 23, 59, 59).this_year?
+      assert_equal true,  Time.utc(2000, 1, 1, 0, 0, 0).this_year?
+      assert_equal true,  Time.utc(2000, 12, 31, 23, 59, 59).this_year?
+      assert_equal false, Time.utc(2001, 1, 1, 0, 0, 0).this_year?
+    end
+  end
+
   def test_current_returns_date_today_when_zone_is_not_set
     with_env_tz "US/Eastern" do
       Time.stub(:now, Time.local(1999, 12, 31, 23, 59, 59)) do


### PR DESCRIPTION
Similar to `today?`, `tomorrow?`, and `yesterday?`, these methods are useful to
query time instances against the current period.

```ruby
unless some_date.in_this_week?
  link_to "See week recap", week_recap_path(some_date)
end
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
