### PR TITLE
Prefer changed_for_autosave? [Fix #55771]

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -374,7 +374,7 @@ module ActiveRecord
         context = validation_context if custom_validation_context?
         return true if record.valid?(context)
 
-        if record.changed? || record.new_record? || context
+        if context || record.changed_for_autosave?
           associated_errors = record.errors.objects
         else
           # If there are existing invalid records in the DB, we should still be able to reference them.

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -2443,3 +2443,58 @@ class TestAutosaveAssociationOnABelongsToAssociationDefinedAsRecord < ActiveReco
     end
   end
 end
+
+class TestAutosaveAssociationWithNestedAttributes < ActiveRecord::TestCase
+  class Part < ActiveRecord::Base
+    self.table_name = "ship_parts"
+  end
+
+  class Ship < ActiveRecord::Base
+    self.table_name = "ships"
+    has_many :parts, class_name: Part.name
+    accepts_nested_attributes_for :parts, allow_destroy: true
+
+    validate :has_at_least_two_parts
+    def has_at_least_two_parts
+      current_parts = parts.select { |p| !p.marked_for_destruction? }
+      errors.add(:parts, "must have at least two parts") if current_parts.size < 2
+    end
+  end
+
+  class Pirate < ActiveRecord::Base
+    self.table_name = "pirates"
+    has_many :ships, class_name: Ship.name
+    accepts_nested_attributes_for :ships, allow_destroy: true
+  end
+
+  def test_should_be_invalid_when_nested_attributes_deletion_breaks_validation
+    pirate = Pirate.create!
+    ship = pirate.ships.new
+    2.times do |i|
+      ship.parts.build
+    end
+    part = ship.parts.first
+    ship.save!
+
+    deletion_params = {
+      "ships_attributes" => {
+        "0" => {
+          "id" => ship.id,
+          "parts_attributes" => {
+            "0" => {
+              "id" => part.id,
+              "_destroy" => "1",
+            },
+          }
+        }
+      }
+    }
+
+    assert_not pirate.update(deletion_params)
+    assert_nothing_raised do
+      part.reload
+    end
+    assert_includes pirate.errors[:"ships.parts"], "must have at least two parts"
+    assert_includes ship.errors[:parts], "must have at least two parts"
+  end
+end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/55771

- The original code intends to avoid already persisted invalid records
  from preventing new associated records from being saved.
- Issue #55771 documents that this could lead to previously valid data
  being saved and becoming invalid.
- The code originated in https://github.com/rails/rails/pull/53951
- And was updated in https://github.com/rails/rails/pull/54273
- The solution suggested by @axlekb in https://github.com/rails/rails/pull/53951#pullrequestreview-3272124308

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because 8.0.2 introduced a regression where previously valid models could become invalid through autosave when a distantly related record was deleted via nested attributes.

Bug reported in

- #55771 

### Detail

This Pull Request changes `changed?` to `changed_for_autosave?` at suggestion of @axlekb in discussion with @byroot.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
