### PR TITLE
Remove the scroll overflow on code blocks:

### DIFF
--- a/guides/assets/stylesrc/components/_code-container.scss
+++ b/guides/assets/stylesrc/components/_code-container.scss
@@ -2,7 +2,7 @@
 // Containers
 //
 // These are interstitial elements used throughout the guides, providing help,
-// context, more info, or warnings to readers. 
+// context, more info, or warnings to readers.
 // ----------------------------------------------------------------------------
 
 /* Same bottom margin for special boxes than for regular paragraphs, this way
@@ -49,7 +49,6 @@ dl dd .interstitial {
 
     pre {
       margin: 0;
-      overflow: scroll;
       white-space: pre;
     }
 


### PR DESCRIPTION
### Motivation / Background

Fixes #55781

We introduced a change in #54661 to prevent overflowing codeblocks into other elements.

This change creates white scroll bars on MacOS (maybe other platfroms too) only when you connect a mouse, it's a behaviour of MacOS that it displays scroll bar on elements.

This commit removes the overflow property without affecting overflow problem, that is because the PR linked above restrained the element to a 100% width.

### Additional information

### Before

<img width="949" height="787" alt="image" src="https://github.com/user-attachments/assets/e58045a1-0bbf-4ffa-b04b-94a06f1bad32" />


### After

<img width="1346" height="606" alt="image" src="https://github.com/user-attachments/assets/e0b86bc9-6a52-41b7-abd3-7fc5d69c16a6" />

### After on small screens

<img width="531" height="857" alt="image" src="https://github.com/user-attachments/assets/230c700a-abaa-419a-b88b-c288ab55b0c1" />


Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
