### PR TITLE
Remove unnecessary comment lines "HELPER METHODS"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -209,8 +209,6 @@ module ActiveRecord
         }
       end
 
-      # HELPER METHODS ===========================================
-
       # Must return the MySQL error number from the exception, if the exception has an
       # error number.
       def error_number(exception) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -92,8 +92,6 @@ module ActiveRecord
         true
       end
 
-      # HELPER METHODS ===========================================
-
       def error_number(exception)
         exception.error_number if exception.respond_to?(:error_number)
       end


### PR DESCRIPTION
### Motivation / Background

This comment was added via https://github.com/rails/rails/commit/5766539342426e956980bf6f54ef99600cbfc33e , at that time there were other methods as "HELPER METHODS", but now there is only one method `error_number`.

This "HELPER METHODS" comment appears at https://edgeapi.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Mysql2Adapter.html#method-i-error_number That does not help users to understand the method.

### Detail

This Pull Request changes [REPLACE ME]

### Additional information
Fix #55754

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
