### PR TITLE
Bump PostgreSQL client version to 18

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 			"version": "latest"
 		},
 		"ghcr.io/rails/devcontainer/features/postgres-client:1.1.3": {
-			"version": "17"
+			"version": "18"
 		}
 	},
 


### PR DESCRIPTION
### Motivation / Background

This pull request bumps the PostgreSQL client version to 18 in the devcontainer since the `postgres:latest` image now uses PostgreSQL 18.

https://github.com/docker-library/postgres/commit/22ca5c8d8e4b37bece4d38dbce1a060583b5308a

### Detail
- With this fix
```sql
vscode ➜ /workspaces/rails/activerecord (pg18-client-devcontainer) $ psql -d postgres
psql (18.0 (Debian 18.0-1.pgdg12+3))
Type "help" for help.

postgres=# select version();
                                                         version
--------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 18.0 (Debian 18.0-1.pgdg13+3) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit
(1 row)

postgres=#
```

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
