### PR TITLE
[Fix #55776] `class_attribute` on instance singleton class raises `NameError`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix `NameError` when `class_attribute` is defined on instance singleton classes.
+
+    Previously, calling `class_attribute` on an instance's singleton class would raise
+    a `NameError` when accessing the attribute through the instance.
+
+    ```ruby
+    object = MyClass.new
+    object.singleton_class.class_attribute :foo, default: "bar"
+    object.foo # previously raised NameError, now returns "bar"
+    ```
+
+    *Joshua Young*
+
 *   Introduce `ActiveSupport::Testing::EventReporterAssertions#with_debug_event_reporting`
     to enable event reporter debug mode in tests.
 

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -116,7 +116,7 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_equal "plop", @klass.setting
   end
 
-  test "when defined in a class's singleton" do
+  test "when defined in a class's singleton class" do
     @klass = Class.new do
       class << self
         class_attribute :__callbacks, default: 1
@@ -130,6 +130,26 @@ class ClassAttributeTest < ActiveSupport::TestCase
     @klass.__callbacks = 4
     assert_equal 1, @klass.__callbacks
     assert_equal 1, @klass.singleton_class.__callbacks
+
+    @klass.singleton_class.__callbacks = 4
+    assert_equal 4, @klass.__callbacks
+    assert_equal 4, @klass.singleton_class.__callbacks
+  end
+
+  test "when defined on an instance's singleton class" do
+    object = @klass.new
+
+    object.singleton_class.class_attribute :external_attr, default: "default_value"
+    assert_equal "default_value", object.external_attr
+    assert_equal "default_value", object.singleton_class.external_attr
+
+    object.external_attr = "new_value"
+    assert_equal "default_value", object.external_attr
+    assert_equal "default_value", object.singleton_class.external_attr
+
+    object.singleton_class.external_attr = "another_value"
+    assert_equal "another_value", object.external_attr
+    assert_equal "another_value", object.singleton_class.external_attr
   end
 
   test "works well with module singleton classes" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Closes #55776.

### Detail

When `class_attribute` is defined on an instance's singleton class (e.g., `object.singleton_class.class_attribute :foo`), accessing the attribute through the instance (`object.foo`) raises a `NameError` because the generated instance method tries to call `__class_attr_foo` as an instance method, but this method only exists as a private class method on the singleton class.

This fix changes the singleton class instance reader generation from `"def #{name}; #{namespaced_name}; end"` to `"def #{name}; self.singleton_class.#{name}; end"`, which properly delegates to the singleton class's public interface. The change preserves all existing behavior (including when `class_attribute` is defined on a class's singleton class) while fixing the `NameError` for instance singleton class attributes.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Also see https://github.com/rails/rails/issues/55776#issuecomment-3341321483.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.