### PR TITLE
[Activejob] Enable enqueue_after_transaction_commit by default with ActiveRecord and validate invalid configurations

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Jobs are now enqueued after transaction commit.
+
+    This fixes that jobs would surprisingly run against uncommitted and
+    rolled-back records.
+
+    New Rails 8.2 apps (and apps upgrading to `config.load_defaults "8.2"`)
+    default `ActiveJob::Base.enqueue_after_transaction_commit` to true.
+    Uncomment the setting in `config/initializers/new_framework_defaults_8_2.rb`
+    to opt in.
+
+    *mugitti9*
+
 *   Deprecate built-in `sneakers` adapter.
 
     *Dino Maric*

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -4,11 +4,18 @@
     rolled-back records.
 
     New Rails 8.2 apps (and apps upgrading to `config.load_defaults "8.2"`)
-    default `ActiveJob::Base.enqueue_after_transaction_commit` to true.
+    have `config.active_job.enqueue_after_transaction_commit = true` by default.
     Uncomment the setting in `config/initializers/new_framework_defaults_8_2.rb`
     to opt in.
 
     *mugitti9*
+
+*   Un-deprecate the global `config.active_job.enqueue_after_transaction_commit`
+    toggle for app-wide overrides. It was deprecated in Rails 8.0 (when the
+    symbol values were removed) and made non-functional in 8.1. It now works
+    as a boolean config again.
+
+    *Jeremy Daer*
 
 *   Deprecate built-in `sneakers` adapter.
 

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -39,6 +39,14 @@ module ActiveJob
 
   module Enqueuing
     extend ActiveSupport::Concern
+    module ValidateEnqueueAfterTransactionCommit
+      def enqueue_after_transaction_commit=(value)
+        if value && !defined?(ActiveRecord)
+          raise ArgumentError, "enqueue_after_transaction_commit must be false when ActiveRecord is not available"
+        end
+        super
+      end
+    end
 
     included do
       ##
@@ -51,6 +59,8 @@ module ActiveJob
       #  - true forces the job to be deferred.
       #  - false forces the job to be queued immediately.
       class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: !!defined?(ActiveRecord)
+
+      singleton_class.prepend ValidateEnqueueAfterTransactionCommit
     end
 
     # Includes the +perform_later+ method for job initialization.

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -50,7 +50,7 @@ module ActiveJob
       # It can be set on a per job basis:
       #  - true forces the job to be deferred.
       #  - false forces the job to be queued immediately.
-      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: false
+      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: !!defined?(ActiveRecord)
     end
 
     # Includes the +perform_later+ method for job initialization.

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -39,14 +39,6 @@ module ActiveJob
 
   module Enqueuing
     extend ActiveSupport::Concern
-    module ValidateEnqueueAfterTransactionCommit
-      def enqueue_after_transaction_commit=(value)
-        if value && !defined?(ActiveRecord)
-          raise ArgumentError, "enqueue_after_transaction_commit must be false when ActiveRecord is not available"
-        end
-        super
-      end
-    end
 
     included do
       ##
@@ -58,9 +50,7 @@ module ActiveJob
       # It can be set on a per job basis:
       #  - true forces the job to be deferred.
       #  - false forces the job to be queued immediately.
-      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: !!defined?(ActiveRecord)
-
-      singleton_class.prepend ValidateEnqueueAfterTransactionCommit
+      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: false
     end
 
     # Includes the +perform_later+ method for job initialization.

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -31,9 +31,9 @@ module ActiveJob
         ActiveSupport.on_load(:active_record) do
           ActiveJob::Base.include EnqueueAfterTransactionCommit
 
-          config_version = app.config.loaded_config_version
-          if config_version && Gem::Version.new(config_version.to_s) >= Gem::Version.new("8.2")
-            ActiveJob::Base.enqueue_after_transaction_commit = true
+          if app.config.active_job.key?(:enqueue_after_transaction_commit)
+            ActiveJob::Base.enqueue_after_transaction_commit =
+              app.config.active_job.enqueue_after_transaction_commit
           end
         end
       end
@@ -64,7 +64,9 @@ module ActiveJob
         # Configs used in other initializers
         options = options.except(
           :log_query_tags_around_perform,
-          :custom_serializers
+          :custom_serializers,
+          # This config can't be applied globally, so we need to remove otherwise it will be applied to `ActiveJob::Base`.
+          :enqueue_after_transaction_commit
         )
 
         options.each do |k, v|

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -30,6 +30,11 @@ module ActiveJob
       ActiveSupport.on_load(:active_job) do
         ActiveSupport.on_load(:active_record) do
           ActiveJob::Base.include EnqueueAfterTransactionCommit
+
+          config_version = app.config.loaded_config_version
+          if config_version && Gem::Version.new(config_version.to_s) >= Gem::Version.new("8.2")
+            ActiveJob::Base.enqueue_after_transaction_commit = true
+          end
         end
       end
     end
@@ -59,9 +64,7 @@ module ActiveJob
         # Configs used in other initializers
         options = options.except(
           :log_query_tags_around_perform,
-          :custom_serializers,
-          # This config can't be applied globally, so we need to remove otherwise it will be applied to `ActiveJob::Base`.
-          :enqueue_after_transaction_commit
+          :custom_serializers
         )
 
         options.each do |k, v|

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -36,15 +36,13 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
   end
 
-  class EnqueueAfterCommitJob < ActiveJob::Base
-    self.enqueue_after_transaction_commit = true
-
+  class TestJob < ActiveJob::Base
     def perform
       # noop
     end
   end
 
-  class ErrorEnqueueAfterCommitJob < EnqueueErrorJob
+  class ErrorTestJob < EnqueueErrorJob
     class EnqueueErrorAdapter
       def enqueue(...)
         raise ActiveJob::EnqueueError, "There was an error enqueuing the job"
@@ -56,16 +54,13 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
 
     self.queue_adapter = EnqueueErrorAdapter.new
-    self.enqueue_after_transaction_commit = true
 
     def perform
       # noop
     end
   end
 
-  class EnqueueAfterCommitCallbackJob < ActiveJob::Base
-    self.enqueue_after_transaction_commit = true
-
+  class CallbackTestJob < ActiveJob::Base
     attr_reader :around_enqueue_called
 
     around_enqueue do |job, block|
@@ -81,8 +76,10 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   test "#perform_later wait for transactions to complete before enqueuing the job" do
     fake_active_record = FakeActiveRecord.new
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
+      TestJob.enqueue_after_transaction_commit = true
+
       assert_difference -> { fake_active_record.calls }, +1 do
-        EnqueueAfterCommitJob.perform_later
+        TestJob.perform_later
       end
     end
   end
@@ -90,8 +87,10 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   test "#perform_later returns the Job instance even if it's delayed by `after_all_transactions_commit`" do
     fake_active_record = FakeActiveRecord.new(false)
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
-      job = EnqueueAfterCommitJob.perform_later
-      assert_instance_of EnqueueAfterCommitJob, job
+      TestJob.enqueue_after_transaction_commit = true
+
+      job = TestJob.perform_later
+      assert_instance_of TestJob, job
       assert_predicate job, :successfully_enqueued?
     end
   end
@@ -99,13 +98,15 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   test "#perform_later yields the enqueued Job instance even if it's delayed by `after_all_transactions_commit`" do
     fake_active_record = FakeActiveRecord.new(false)
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
+      TestJob.enqueue_after_transaction_commit = true
+
       called = false
-      job = EnqueueAfterCommitJob.perform_later do |yielded_job|
+      job = TestJob.perform_later do |yielded_job|
         called = true
-        assert_instance_of EnqueueAfterCommitJob, yielded_job
+        assert_instance_of TestJob, yielded_job
       end
       assert called, "#perform_later yielded the job"
-      assert_instance_of EnqueueAfterCommitJob, job
+      assert_instance_of TestJob, job
       assert_predicate job, :successfully_enqueued?
     end
   end
@@ -113,8 +114,10 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   test "#perform_later assumes successful enqueue, but update status later" do
     fake_active_record = FakeActiveRecord.new(false)
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
-      job = ErrorEnqueueAfterCommitJob.perform_later
-      assert_instance_of ErrorEnqueueAfterCommitJob, job
+      ErrorTestJob.enqueue_after_transaction_commit = true
+
+      job = ErrorTestJob.perform_later
+      assert_instance_of ErrorTestJob, job
       assert_predicate job, :successfully_enqueued?
 
       fake_active_record.run_after_commit_callbacks
@@ -125,7 +128,9 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   test "#perform_later defers enqueue callbacks until after commit" do
     fake_active_record = FakeActiveRecord.new(false)
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
-      job = EnqueueAfterCommitCallbackJob.perform_later
+      CallbackTestJob.enqueue_after_transaction_commit = true
+
+      job = CallbackTestJob.perform_later
       assert_not_predicate job, :around_enqueue_called
       fake_active_record.run_after_commit_callbacks
       assert_predicate job, :around_enqueue_called
@@ -135,8 +140,10 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   test "ActiveJob.perform_all_later waits for transactions to complete before enqueuing jobs with `enqueue_after_transaction_commit`" do
     fake_active_record = FakeActiveRecord.new
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
+      TestJob.enqueue_after_transaction_commit = true
+
       assert_difference -> { fake_active_record.calls }, +1 do
-        ActiveJob.perform_all_later(EnqueueAfterCommitJob.new, EnqueueAfterCommitJob.new)
+        ActiveJob.perform_all_later(TestJob.new, TestJob.new)
       end
     end
   end
@@ -144,9 +151,11 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   test "ActiveJob.perform_all_later handles mixed jobs with and without `enqueue_after_transaction_commit`" do
     fake_active_record = FakeActiveRecord.new(false)
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
+      TestJob.enqueue_after_transaction_commit = true
+
       # Mix of jobs with and without enqueue_after_transaction_commit
       immediate_job = ImmediateJob.new
-      deferred_job = EnqueueAfterCommitJob.new
+      deferred_job = TestJob.new
 
       assert_notification("enqueue_all.active_job", jobs: [immediate_job], enqueued_count: 1) do
         ActiveJob.perform_all_later([immediate_job, deferred_job])
@@ -175,5 +184,11 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
 
     assert_equal false, job_class.enqueue_after_transaction_commit
+  end
+
+  test "raises error when setting to true without ActiveRecord" do
+    assert_raises(ArgumentError, "enqueue_after_transaction_commit must be false when ActiveRecord is not available") do
+      TestJob.enqueue_after_transaction_commit = true
+    end
   end
 end

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -167,18 +167,7 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
   end
 
-  test "default value is true when ActiveRecord is available" do
-    fake_active_record = FakeActiveRecord.new
-    stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
-      job_class = Class.new do
-        include ActiveJob::Enqueuing
-      end
-
-      assert_equal true, job_class.enqueue_after_transaction_commit
-    end
-  end
-
-  test "default value is false when ActiveRecord is not available" do
+  test "default value is false by default" do
     job_class = Class.new do
       include ActiveJob::Enqueuing
     end
@@ -186,9 +175,24 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     assert_equal false, job_class.enqueue_after_transaction_commit
   end
 
-  test "raises error when setting to true without ActiveRecord" do
-    assert_raises(ArgumentError, "enqueue_after_transaction_commit must be false when ActiveRecord is not available") do
+  test "can set enqueue_after_transaction_commit without ActiveRecord" do
+    original = TestJob.enqueue_after_transaction_commit
+
+    assert_nothing_raised do
       TestJob.enqueue_after_transaction_commit = true
     end
+  ensure
+    TestJob.enqueue_after_transaction_commit = original
+  end
+
+  test "base setting applies to existing subclasses" do
+    original = ActiveJob::Base.enqueue_after_transaction_commit
+    job_class = Class.new(ActiveJob::Base)
+
+    ActiveJob::Base.enqueue_after_transaction_commit = true
+
+    assert_equal true, job_class.enqueue_after_transaction_commit
+  ensure
+    ActiveJob::Base.enqueue_after_transaction_commit = original
   end
 end

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -157,4 +157,23 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "default value is true when ActiveRecord is available" do
+    fake_active_record = FakeActiveRecord.new
+    stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
+      job_class = Class.new do
+        include ActiveJob::Enqueuing
+      end
+
+      assert_equal true, job_class.enqueue_after_transaction_commit
+    end
+  end
+
+  test "default value is false when ActiveRecord is not available" do
+    job_class = Class.new do
+      include ActiveJob::Enqueuing
+    end
+
+    assert_equal false, job_class.enqueue_after_transaction_commit
+  end
 end

--- a/guides/source/8_2_release_notes.md
+++ b/guides/source/8_2_release_notes.md
@@ -131,6 +131,8 @@ Please refer to the [Changelog][active-job] for detailed changes.
 
 ### Notable changes
 
+*   Default `enqueue_after_transaction_commit` to true for new applications.
+
 Action Text
 ----------
 

--- a/guides/source/8_2_release_notes.md
+++ b/guides/source/8_2_release_notes.md
@@ -131,7 +131,9 @@ Please refer to the [Changelog][active-job] for detailed changes.
 
 ### Notable changes
 
-*   Default `enqueue_after_transaction_commit` to true for new applications.
+*   Un-deprecate `config.active_job.enqueue_after_transaction_commit` and default
+    it to `true` for new applications. This setting was deprecated in 8.0 and
+    non-functional in 8.1; it now works as a boolean config.
 
 Action Text
 ----------

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -61,6 +61,7 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 8.2
 
 - [`config.action_controller.forgery_protection_verification_strategy`](#config-action-controller-forgery-protection-verification-strategy): `:header_only`
+- [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `true`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 - [`config.active_storage.analyze`](#config-active-storage-analyze): `:immediately`
@@ -3206,6 +3207,25 @@ Accepts a logger conforming to the interface of Log4r or the default Ruby Logger
 #### `config.active_job.custom_serializers`
 
 Allows to set custom argument serializers. Defaults to `[]`.
+
+#### `config.active_job.enqueue_after_transaction_commit`
+
+Controls whether jobs enqueued inside an Active Record transaction are deferred
+until after the transaction commits. When false, jobs are enqueued immediately.
+Individual jobs can override the global setting:
+
+```ruby
+class NotificationJob < ApplicationJob
+  self.enqueue_after_transaction_commit = false
+end
+```
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 8.2                   | `true`               |
 
 #### `config.active_job.log_arguments`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -383,6 +383,10 @@ module Rails
           if respond_to?(:active_storage)
             active_storage.analyze = :immediately
           end
+
+          if respond_to?(:active_job)
+            active_job.enqueue_after_transaction_commit = true
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -18,9 +18,7 @@
 # commits before being dispatched to the queue. This prevents jobs from
 # operating on rolled-back data.
 #++
-# ActiveSupport.on_load(:active_job) do
-#   ActiveJob::Base.enqueue_after_transaction_commit = true
-# end
+# Rails.application.config.active_job.enqueue_after_transaction_commit = true
 
 ###
 # Use Sec-Fetch-Site header for CSRF protection instead of tokens.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -9,6 +9,19 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
+# Active Job
+
+###
+# Defer job enqueueing until after the database transaction commits.
+#
+# When enabled, jobs enqueued inside a transaction wait until the transaction
+# commits before being dispatched to the queue. This prevents jobs from
+# operating on rolled-back data.
+#++
+# ActiveSupport.on_load(:active_job) do
+#   ActiveJob::Base.enqueue_after_transaction_commit = true
+# end
+
 ###
 # Use Sec-Fetch-Site header for CSRF protection instead of tokens.
 #

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3337,7 +3337,7 @@ module ApplicationTests
         ActiveRecord::Base
       end
 
-      assert_equal false, ActiveJob::Base.enqueue_after_transaction_commit
+      assert_equal true, ActiveJob::Base.enqueue_after_transaction_commit
     end
 
     test "active record job queue is set" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3326,7 +3326,7 @@ module ApplicationTests
       assert_not ActiveJob.verbose_enqueue_logs
     end
 
-    test "enqueue_after_transaction_commit defaults to true for new apps" do
+    test "config.active_job.enqueue_after_transaction_commit defaults to true for new apps" do
       build_app
       app "production"
 
@@ -3334,13 +3334,11 @@ module ApplicationTests
       assert_equal true, ActiveJob::Base.enqueue_after_transaction_commit
     end
 
-    test "enqueue_after_transaction_commit can be set to false for new apps" do
+    test "config.active_job.enqueue_after_transaction_commit can be set to false for new apps" do
       build_app
 
       app_file "config/initializers/enqueue_after_transaction_commit.rb", <<-RUBY
-        ActiveSupport.on_load(:active_record) do
-          ActiveJob::Base.enqueue_after_transaction_commit = false
-        end
+        Rails.application.config.active_job.enqueue_after_transaction_commit = false
       RUBY
 
       app "production"
@@ -3349,13 +3347,26 @@ module ApplicationTests
       assert_equal false, ActiveJob::Base.enqueue_after_transaction_commit
     end
 
-    test "enqueue_after_transaction_commit defaults to false for upgraded apps" do
+    test "config.active_job.enqueue_after_transaction_commit defaults to false for upgraded apps" do
       remove_from_config '.*config\.load_defaults.*\n'
 
       app "production"
 
       assert ActiveRecord::Base
       assert_equal false, ActiveJob::Base.enqueue_after_transaction_commit
+    end
+
+    test "config.active_job.enqueue_after_transaction_commit can be set to true for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/enqueue_after_transaction_commit.rb", <<-RUBY
+        Rails.application.config.active_job.enqueue_after_transaction_commit = true
+      RUBY
+
+      app "production"
+
+      assert ActiveRecord::Base
+      assert_equal true, ActiveJob::Base.enqueue_after_transaction_commit
     end
 
     test "active record job queue is set" do


### PR DESCRIPTION
### Motivation / Background
Until now, the default value of ```enqueue_after_transaction_commit``` has been false.

This meant that jobs enqueued inside a transaction were dispatched to the queue immediately and could still run even if the transaction was rolled back. In practice, this is not a rare edge case—jobs that depend on uncommitted data often end up running prematurely, breaking application consistency.

With this change, the default is switched to true only when ActiveRecord is defined. This ensures that jobs are enqueued only after the surrounding transaction has successfully committed, preventing jobs tied to rolled-back work from being executed unnecessarily.


As DHH also stated in [#53375](https://github.com/rails/rails/pull/53375#issuecomment-2555694252)
```Yes, by default, all jobs should enqueue after the commit.``` 
I strongly agree with this position. At the same time, this change does not remove flexibility: if immediate enqueueing is still desired, it can be explicitly enabled by setting ```self.enqueue_after_transaction_commit = false``` on a per-job basis.

### Detail

- The default value of ```enqueue_after_transaction_commit``` is now set to true only when ActiveRecord is available.
- A validation has been added: attempting to set ```enqueue_after_transaction_commit = true``` when ActiveRecord is not defined will now raise an error, since such a configuration would not have meaningful semantics without transaction hooks.

### Why this change is needed (what problem it solves)
With the current behavior on main, jobs can be enqueued before the surrounding database transaction has successfully committed. For example:

```rb
ActiveRecord::Base.transaction do
  user = User.create!(name: "James")
  UserCreationNotifyJob.perform_later(user:)
end
```

In this case, UserCreationNotifyJob may be enqueued while the user record is still uncommitted. If the transaction is rolled back, the job can still run and attempt to operate on data that does not actually exist. This leads to subtle and easily overlooked inconsistencies.

Until Rails 7.2, most adapters—Sidekiq, Resque, and Solid Queue—effectively behaved as if enqueue_after_transaction_commit = true by default. As a result, many applications implicitly relied on jobs being enqueued only after the transaction had fully committed. With the current default on main, however, jobs may run earlier than expected, and this can introduce hard-to-debug issues.

In our application, we currently mitigate this by explicitly setting enqueue_after_transaction_commit = true on almost all jobs. But this shifts responsibility for a fundamental safety guarantee from the framework to individual applications, increases boilerplate, and risks inconsistencies when someone forgets to set it.

This issue is not theoretical or rare. For example, at a recent Ruby/Rails conference in Japan ("Kaigi on Rails"), there was a well-received talk titled “Never enqueue async jobs inside a transaction—seriously, never!”, which highlighted exactly this class of problems. The talk resonated widely, which shows how many developers have been impacted by premature job execution.

### Additional information

When ActiveRecord is not defined, transaction callbacks are not available, and therefore enabling ```enqueue_after_transaction_commit``` would result in misleading or inconsistent behavior. Explicit validation has been added to surface this misuse early and clearly.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.