### PR TITLE
`ActionController::Parameters#deconstruct_keys` for pattern matching

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Define `ActionController::Parameters#deconstruct_keys` to support pattern matching
+
+    ```ruby
+    if params in { search:, page: }
+      Article.search(search).limit(page)
+    else
+      …
+    end
+
+    case (value = params[:string_or_hash_with_nested_key])
+    in String
+      # do something with a String `value`…
+    in { nested_key: }
+      # do something with `nested_key` or `value`
+    else
+      # …
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Submit test requests using `as: :html` with `Content-Type: x-www-form-urlencoded`
 
     *Sean Doyle*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -316,6 +316,10 @@ module ActionController
       [self.class, @parameters, @permitted].hash
     end
 
+    def deconstruct_keys(keys)
+      slice(*keys).each.with_object({}) { |(key, value), hash| hash.merge!(key.to_sym => value) }
+    end
+
     # Returns a safe ActiveSupport::HashWithIndifferentAccess representation of the
     # parameters with all unpermitted keys removed.
     #

--- a/actionpack/test/controller/parameters/equality_test.rb
+++ b/actionpack/test/controller/parameters/equality_test.rb
@@ -57,4 +57,17 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     params = ActionController::Parameters.new(foo: { bar: "baz" })
     assert params.has_value?(ActionController::Parameters.new("bar" => "baz"))
   end
+
+  test "deconstruct_keys works with parameters" do
+    assert_pattern { @params => { person: { age: "32" } } }
+    refute_pattern { @params => { person: { addresses: ["does not match"] } } }
+  end
+
+  test "deconstruct_keys returns instances of ActionController::Parameters for nested values" do
+    @params => { person: }
+    person => { addresses: }
+
+    assert_kind_of ActionController::Parameters, person
+    assert_kind_of ActionController::Parameters, addresses.first
+  end
 end


### PR DESCRIPTION
Related to [#48429][]

### Motivation / Background

Define `ActionController::Parameters#deconstruct_keys` in a `Hash`-like way, so that `params` can integrate with [pattern matching][] (for statements like `case … in`, `if … in`, and `params => { … }`).

### Detail

To do so, declare the [#deconstruct_keys][] method in way that loops over the specified keys and returns a
`ActiveSupport::HashWithIndifferentAccess` instance with only the root-level keys. Any primitives will remain primitives, and any `ActionController::Parameters` values below the first level of nesting will remain `ActionController::Parameters` instances.

### Additional information

This integration can be useful for controller parameters (either at the root level or nested within) that are to be passed to objects that don't expect attributes or keyword arguments:

```ruby
if params in { search:, page: }
  Model.search(search).limit(page)
else
  …
end

case (value = params[:primitive_or_nested])
in String
  # do something with a String `value`…
in { nested_key: }
  # do something with `nested_key` or `value`
else
  # …
end
```

[#48429]: https://github.com/rails/rails/issues/48429
[pattern matching]: https://docs.ruby-lang.org/en/master/syntax/pattern_matching_rdoc.html
[#deconstruct_keys]: https://docs.ruby-lang.org/en/master/syntax/pattern_matching_rdoc.html#label-Matching+non-primitive+objects-3A+deconstruct+and+deconstruct_keys

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
