### PR TITLE
Don't output deprecated message in newly generated applications

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,7 +60,6 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.1
 
-- [`config.action_controller.action_on_open_redirect`](#config-action-controller-action-on-open-redirect): `:raise`
 - [`config.action_controller.action_on_path_relative_redirect`](#config-action-controller-action-on-path-relative-redirect): `:raise`
 - [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`
 - [`config.action_view.remove_hidden_field_autocomplete`](#config-action-view-remove-hidden-field-autocomplete): `true`
@@ -110,7 +109,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 7.0
 
-- [`config.action_controller.raise_on_open_redirects`](#config-action-controller-raise-on-open-redirects): `true`
+- [`config.action_controller.action_on_open_redirect`](#config-action-controller-action-on-open-redirect): `:raise`
 - [`config.action_controller.wrap_parameters_by_default`](#config-action-controller-wrap-parameters-by-default): `true`
 - [`config.action_dispatch.cookies_serializer`](#config-action-dispatch-cookies-serializer): `:json`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-XSS-Protection" => "0", "X-Content-Type-Options" => "nosniff", "X-Download-Options" => "noopen", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
@@ -1964,12 +1963,9 @@ with an external host is passed to [redirect_to][]. If an open redirect should
 be allowed, then `allow_other_host: true` can be added to the call to
 `redirect_to`.
 
-The default value depends on the `config.load_defaults` target version:
-
 | Starting with version | The default value is |
 | --------------------- | -------------------- |
 | (original)            | `false`              |
-| 7.0                   | `true`               |
 
 [redirect_to]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
 
@@ -1995,7 +1991,7 @@ The default value depends on the `config.load_defaults` target version:
 | Starting with version | The default value is |
 | --------------------- | -------------------- |
 | (original)            | `:log`               |
-| 8.1                   | `:raise`             |
+| 7.0                   | `:raise`             |
 
 #### `config.action_controller.action_on_path_relative_redirect`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -267,7 +267,7 @@ module Rails
           end
 
           if respond_to?(:action_controller)
-            action_controller.raise_on_open_redirects = true
+            action_controller.action_on_open_redirect = :raise
             action_controller.wrap_parameters_by_default = true
           end
         when "7.1"
@@ -350,10 +350,6 @@ module Rails
           Regexp.timeout ||= 1 if Regexp.respond_to?(:timeout=)
         when "8.1"
           load_defaults "8.0"
-
-          if respond_to?(:action_controller)
-            action_controller.action_on_open_redirect = :raise
-          end
 
           # Development and test environments tend to reload code and
           # redefine methods (e.g. mocking), hence YJIT isn't generally

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1580,12 +1580,6 @@ module ApplicationTests
       assert_equal "https://foo.example.com:9001/bar/posts", posts_url
     end
 
-    test "ActionController::Base.raise_on_open_redirects is true by default for new apps" do
-      app "development"
-
-      assert_equal true, ActionController::Base.raise_on_open_redirects
-    end
-
     test "ActionController::Base.raise_on_open_redirects is false by default for upgraded apps" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "6.1"'
@@ -1604,6 +1598,19 @@ module ApplicationTests
       app "development"
 
       assert_equal true, ActionController::Base.raise_on_open_redirects
+    end
+
+    test "ActionController::Base.action_on_open_redirect is :raise by default for new apps" do
+      app "development"
+
+      assert_equal :raise, ActionController::Base.action_on_open_redirect
+    end
+
+    test "ActionController::Base.action_on_open_redirect is :log when raise_on_open_redirects is false" do
+      add_to_config "config.action_controller.raise_on_open_redirects = false"
+      app "development"
+
+      assert_equal :log, ActionController::Base.action_on_open_redirect
     end
 
     test "config.action_dispatch.show_exceptions is sent in env" do


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because since #55496, the depreciation message about `raise_on_open _redirects` is shown in newly generated applications.

This is because the deprecations is shown when `raise_on_open_redirects` is not null, but the default value of it is `false`. https://github.com/rails/rails/blob/ec4337aae7d358e9d8ae3fc539347a2618b8fbe0/actionpack/lib/action_controller/railtie.rb#L110 https://github.com/rails/rails/blob/ec4337aae7d358e9d8ae3fc539347a2618b8fbe0/actionpack/lib/action_controller/railtie.rb#L15

In addition that, we set the value in `load_defaults`. https://github.com/rails/rails/blob/ec4337aae7d358e9d8ae3fc539347a2618b8fbe0/railties/lib/rails/application/configuration.rb#L270

### Detail

This Pull Request removed config key and checked the key existence for the condition of deprecation message to avoid the deprecation message in newly generated applications.

Fixes #55772.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
