### PR TITLE
[Fix #55513] parallel tests hanging when worker processes die abruptly

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix parallel tests hanging when worker processes die abruptly.
+
+    Previously, if a worker process was killed (e.g., OOM killed, `kill -9`) during parallel
+    test execution, the test suite would hang forever waiting for the dead worker.
+
+    *Joshua Young*
+
 *   Add `config.active_support.escape_js_separators_in_json`.
 
     Introduce a new framework default to skip escaping LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) in JSON.

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -18,7 +18,7 @@ module ActiveSupport
             DRb.stop_service
 
             @queue = DRbObject.new_with_uri(@url)
-            @queue.start_worker(@id)
+            @queue.start_worker(@id, Process.pid)
 
             begin
               after_fork
@@ -29,7 +29,7 @@ module ActiveSupport
             set_process_title("(stopping)")
 
             run_cleanup
-            @queue.stop_worker(@id)
+            @queue.stop_worker(@id, Process.pid)
           end
         end
 

--- a/activesupport/test/parallelization_test.rb
+++ b/activesupport/test/parallelization_test.rb
@@ -33,4 +33,21 @@ class ParallelizationTest < ActiveSupport::TestCase
     instance = subclass.new("test")
     assert_equal 5, instance.parallel_worker_id
   end
+
+  test "shutdown handles dead workers gracefully" do
+    parallelization = ActiveSupport::Testing::Parallelization.new(1)
+    parallelization.start
+
+    sleep 0.25
+
+    server = parallelization.instance_variable_get(:@queue_server)
+    assert server.active_workers?
+
+    worker_pids = parallelization.instance_variable_get(:@worker_pool)
+    Process.kill("KILL", worker_pids.first)
+    sleep 0.25
+
+    Timeout.timeout(2.5, Minitest::Assertion, "Expected shutdown to not hang") { parallelization.shutdown }
+    assert_not server.active_workers?
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Closes https://github.com/rails/rails/issues/55513.

### Detail

When parallel tests are running and a worker process dies abruptly (e.g., OOM killed, `kill -9`), the test suite would hang forever waiting for the dead worker to call `stop_worker`, which it never could.

The fix detects dead workers during shutdown by using `Process.waitpid` with `WNOHANG` to check which processes have exited, then removes them from the server's active worker list before waiting for remaining workers to finish. The server now tracks PIDs alongside worker IDs, allowing it to map dead processes back to their worker entries for cleanup.

<!-- ### Additional information -->

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
