### PR TITLE
[ci skip] Document safe usage of `rescue_from`

### DIFF
--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -31,20 +31,28 @@ module ActiveSupport
       # which <tt>exception.is_a?(klass)</tt> holds true is the one invoked, if
       # any.
       #
+      # When used on an <tt>ActionController::Base</tt> subclass, handlers
+      # should usually create a fresh response object by calling
+      # <tt>set_response! self.class.make_response! request</tt>. This avoids
+      # inheriting headers that were set during request handling.
+      #
       #   class ApplicationController < ActionController::Base
       #     rescue_from User::NotAuthorized, with: :deny_access
       #     rescue_from ActiveRecord::RecordInvalid, with: :show_record_errors
       #
       #     rescue_from "MyApp::BaseError" do |exception|
+      #       set_response! self.class.make_response! request
       #       redirect_to root_url, alert: exception.message
       #     end
       #
       #     private
       #       def deny_access
+      #         set_response! self.class.make_response! request
       #         head :forbidden
       #       end
       #
       #       def show_record_errors(exception)
+      #         set_response! self.class.make_response! request
       #         redirect_back_or_to root_url, alert: exception.record.errors.full_messages.to_sentence
       #       end
       #   end

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Document safe usage of `rescue_from` by creating a fresh response object
+    before actually responding with an HTTP error.
+
+    *Rob Brackett*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -608,6 +608,7 @@ class ApplicationController < ActionController::Base
 
   private
     def record_not_found
+      set_response! self.class.make_response! request
       render plain: "Record Not Found", status: 404
     end
 end
@@ -652,6 +653,12 @@ end
 WARNING: Using `rescue_from` with `Exception` or `StandardError` would cause
 serious side-effects as it prevents Rails from handling exceptions properly. As
 such, it is not recommended to do so unless there is a strong reason.
+
+WARNING: If you use `rescue_from` to respond with a non-2xx response, you
+should *usually* create a fresh response object by calling
+`set_response! self.class.make_response! request`. This ensures the error
+response does not inherit cookies, caching information, or other headers that
+were set as part of your application’s normal request handling.
 
 NOTE: Certain exceptions are only rescuable from the `ApplicationController`
 class, as they are raised before the controller gets initialized, and the action


### PR DESCRIPTION
### Motivation / Background

When responding with a non-2xx HTTP response, `ActionController::Base#rescue_from` handlers should usually create a fresh response object in order to avoid inheriting cookies, caching info, or other headers that were set during normal request handling. In most cases, these headers won’t be relevant to an error and can cause problems if they are added to an error response (for example, you probably don’t want an error to get cached by a CDN or other proxy). The guides and API docs never mention that, though.

I ran into this issue when using `if stale?` ([the recommended way to do conditional GET](https://guides.rubyonrails.org/caching_with_rails.html#conditional-get-support)) on a controller. Not realizing I needed to use a fresh response or clear the headers led to intermittent caching problems I didn’t know about and left unaddressed for a long time!


### Detail

This adds a warning and updates examples in the Rails Guides and API docs about this issue. It suggests always creating a fresh response object by calling `set_response! self.class.make_response! request`, which AFAICT is the most correct approach. I’m happy to change this if there is a better way!

The behavior change I suggested for `stale?` in #54808 doesn’t seem to have much interest, so I’m attempting to document things so fewer people hit this problem. I suspect there are probably other controller methods with similar issues, so this documentation update is probably a good idea anyway.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
