### PR TITLE
Revert "Merge pull request #53723 from fatkodima/preserve-duplicate-selected-columns"

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -85,7 +85,7 @@ module ActiveRecord
           return if other.select_values.empty?
 
           if other.model == relation.model
-            relation.select_values += other.select_values if relation.select_values != other.select_values
+            relation.select_values += other.select_values
           else
             relation.select_values += other.instance_eval do
               arel_columns(select_values)

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -85,9 +85,9 @@ module ActiveRecord
           return if other.select_values.empty?
 
           if other.model == relation.model
-            relation.select_values += other.select_values
+            relation.select_values |= other.select_values
           else
-            relation.select_values += other.instance_eval do
+            relation.select_values |= other.instance_eval do
               arel_columns(select_values)
             end
           end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -426,7 +426,7 @@ module ActiveRecord
     end
 
     def _select!(*fields) # :nodoc:
-      self.select_values += fields
+      self.select_values |= fields
       self
     end
 

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -115,14 +115,6 @@ module ActiveRecord
       assert_not_nil post.post_title
     end
 
-    def test_select_preserves_duplicate_columns
-      quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
-      quoted_posts = Regexp.escape(quote_table_name("posts"))
-      assert_queries_match(/SELECT #{quoted_posts_id}, #{quoted_posts_id} FROM #{quoted_posts}/i) do
-        Post.select(:id, :id).to_a
-      end
-    end
-
     def test_reselect
       expected = Post.select(:title).to_sql
       assert_equal expected, Post.select(:title, :body).reselect(:title).to_sql

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       }
       expected.default = [ Object.new ]
 
-      (Relation::MULTI_VALUE_METHODS - [:select]).each do |method|
+      Relation::MULTI_VALUE_METHODS.each do |method|
         getter, setter = "#{method}_values", "#{method}_values="
         values = expected[method]
         relation = Relation.new(FakeKlass)
@@ -291,15 +291,6 @@ module ActiveRecord
       relation = Post.joins(:comments).merge Comment.joins(:ratings)
 
       assert_equal 3, relation.where(id: post.id).pluck(:id).size
-    end
-
-    def test_merge_preserves_duplicate_columns
-      quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
-      quoted_posts = Regexp.escape(quote_table_name("posts"))
-      posts = Post.select(:id)
-      assert_queries_match(/SELECT #{quoted_posts_id}, #{quoted_posts_id} FROM #{quoted_posts}/i) do
-        posts.merge(posts).to_a
-      end
     end
 
     def test_merge_raises_with_invalid_argument

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -47,11 +47,10 @@ module ActiveRecord
         unscope:   [ :where ],
         extending: [ Module.new ],
         with:      [ foo: Post.all ],
-        select:    [ :id, :id ],
       }
       expected.default = [ Object.new ]
 
-      Relation::MULTI_VALUE_METHODS.each do |method|
+      (Relation::MULTI_VALUE_METHODS - [:select]).each do |method|
         getter, setter = "#{method}_values", "#{method}_values="
         values = expected[method]
         relation = Relation.new(FakeKlass)
@@ -292,6 +291,15 @@ module ActiveRecord
       relation = Post.joins(:comments).merge Comment.joins(:ratings)
 
       assert_equal 3, relation.where(id: post.id).pluck(:id).size
+    end
+
+    def test_merge_preserves_duplicate_columns
+      quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
+      quoted_posts = Regexp.escape(quote_table_name("posts"))
+      posts = Post.select(:id)
+      assert_queries_match(/SELECT #{quoted_posts_id}, #{quoted_posts_id} FROM #{quoted_posts}/i) do
+        posts.merge(posts).to_a
+      end
     end
 
     def test_merge_raises_with_invalid_argument


### PR DESCRIPTION
Since `ActiveRecord::Relation` is mainly used to build queries to assign to model objects, it doesn't make much sense to have duplicate column names, and the example at https://github.com/rails/rails/issues/53715#issuecomment-2495268538 can be solved by just specifying an alias.

```diff
diff --git a/activerecord/53715.rb b/activerecord/53715.rb
index 748d18aa29..5b8f858c43 100644
--- a/issues/53715.rb
+++ b/issues/53715.rb
@@ -83,7 +83,7 @@ def publish_all(notice_type, action_user, target)
       insert_into = im.to_sql
 
       recipients = User.notice_recipients(notice_type, action_user, target)
-      select_columns = [:id] + COLUMNS.map { |c| Arel::Nodes.build_quoted(base_attrs[c.to_s]) }
+      select_columns = [:id] + COLUMNS.map { |c| Arel::Nodes.build_quoted(base_attrs[c.to_s]).as(c.to_s) }
       select_from = recipients.select(select_columns).to_sql
 
       connection.execute("#{insert_into} #{select_from}")
```

I don't want to break existing code for a rare use case.

Fixes #55785.