### PR TITLE
[ci skip] Document Optimistic Locking vs. ActiveStorage edge case

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -49,6 +49,11 @@ module ActiveRecord
     #     self.locking_column = :lock_person
     #   end
     #
+    # Note: When using +has_rich_text+ together with optimistic locking, background
+    # analysis of attachments (e.g. +ActiveStorage::AnalyzeJob+) increments +lock_version+.
+    # This can trigger a +StaleObjectError+ even without conflicting
+    # user edits. Applications that auto-save frequently are more likely to observe this.
+    #
     module Optimistic
       extend ActiveSupport::Concern
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I don't believe there's a framework-level solution to #55764, but this edge case should be documented. 

### Detail

This Pull Request add a note in `ActiveRecord::Locking::Optimistic` describing an possible interference with ActionText/ActiveStorage

### Additional info

Here's a relevant screenshot of the preview: 
<img width="1443" height="1476" alt="image" src="https://github.com/user-attachments/assets/89a4baeb-4d2d-4200-968f-dcd2d44e7566" />
 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* n/a Tests are added or updated if you fix a bug or add a feature.
* n/a CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
