### PR TITLE
Stop escaping JS separators in JSON by default

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `config.active_support.escape_js_separators_in_json`.
+
+    Introduce a new framework default to skip escaping LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) in JSON.
+
+    Historically these characters were not valid inside JavaScript literal strings but that changed in ECMAScript 2019.
+    As such it's no longer a concern in modern browsers: https://caniuse.com/mdn-javascript_builtins_json_json_superset.
+
+    *Étienne Barrié*, *Jean Boussier*
+
 *   Fix `NameError` when `class_attribute` is defined on instance singleton classes.
 
     Previously, calling `class_attribute` on an instance's singleton class would raise

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -8,6 +8,7 @@ module ActiveSupport
     delegate :use_standard_json_time_format, :use_standard_json_time_format=,
       :time_precision, :time_precision=,
       :escape_html_entities_in_json, :escape_html_entities_in_json=,
+      :escape_js_separators_in_json, :escape_js_separators_in_json=,
       :json_encoder, :json_encoder=,
       to: :'ActiveSupport::JSON::Encoding'
   end
@@ -67,8 +68,9 @@ module ActiveSupport
         "&".b => '\u0026'.b,
       }
 
-      ESCAPE_REGEX_WITH_HTML_ENTITIES = Regexp.union(*ESCAPED_CHARS.keys)
-      ESCAPE_REGEX_WITHOUT_HTML_ENTITIES = Regexp.union(U2028, U2029)
+      HTML_ENTITIES_REGEX = Regexp.union(*(ESCAPED_CHARS.keys - [U2028, U2029]))
+      FULL_ESCAPE_REGEX = Regexp.union(*ESCAPED_CHARS.keys)
+      JS_SEPARATORS_REGEX = Regexp.union(U2028, U2029)
 
       class JSONGemEncoder # :nodoc:
         attr_reader :options
@@ -86,14 +88,15 @@ module ActiveSupport
 
           return json unless @options.fetch(:escape, true)
 
-          # Rails does more escaping than the JSON gem natively does (we
-          # escape \u2028 and \u2029 and optionally >, <, & to work around
-          # certain browser problems).
           json.force_encoding(::Encoding::BINARY)
           if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
-            json.gsub!(ESCAPE_REGEX_WITH_HTML_ENTITIES, ESCAPED_CHARS)
-          else
-            json.gsub!(ESCAPE_REGEX_WITHOUT_HTML_ENTITIES, ESCAPED_CHARS)
+            if Encoding.escape_js_separators_in_json
+              json.gsub!(FULL_ESCAPE_REGEX, ESCAPED_CHARS)
+            else
+              json.gsub!(HTML_ENTITIES_REGEX, ESCAPED_CHARS)
+            end
+          elsif Encoding.escape_js_separators_in_json
+            json.gsub!(JS_SEPARATORS_REGEX, ESCAPED_CHARS)
           end
           json.force_encoding(::Encoding::UTF_8)
         end
@@ -184,14 +187,15 @@ module ActiveSupport
 
             return json unless @escape
 
-            # Rails does more escaping than the JSON gem natively does (we
-            # escape \u2028 and \u2029 and optionally >, <, & to work around
-            # certain browser problems).
             json.force_encoding(::Encoding::BINARY)
             if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
-              json.gsub!(ESCAPE_REGEX_WITH_HTML_ENTITIES, ESCAPED_CHARS)
-            else
-              json.gsub!(ESCAPE_REGEX_WITHOUT_HTML_ENTITIES, ESCAPED_CHARS)
+              if Encoding.escape_js_separators_in_json
+                json.gsub!(FULL_ESCAPE_REGEX, ESCAPED_CHARS)
+              else
+                json.gsub!(HTML_ENTITIES_REGEX, ESCAPED_CHARS)
+              end
+            elsif Encoding.escape_js_separators_in_json
+              json.gsub!(JS_SEPARATORS_REGEX, ESCAPED_CHARS)
             end
             json.force_encoding(::Encoding::UTF_8)
           end
@@ -206,6 +210,13 @@ module ActiveSupport
         # If true, encode >, <, & as escaped unicode sequences (e.g. > as \u003e)
         # as a safety measure.
         attr_accessor :escape_html_entities_in_json
+
+        # If true, encode LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029)
+        # as escaped unicode sequences ('\u2028' and '\u2029').
+        # Historically these characters were not valid inside JavaScript strings
+        # but that changed in ECMAScript 2019. As such it's no longer a concern in
+        # modern browsers: https://caniuse.com/mdn-javascript_builtins_json_json_superset.
+        attr_accessor :escape_js_separators_in_json
 
         # Sets the precision of encoded time values.
         # Defaults to 3 (equivalent to millisecond precision)
@@ -232,6 +243,7 @@ module ActiveSupport
 
       self.use_standard_json_time_format = true
       self.escape_html_entities_in_json  = true
+      self.escape_js_separators_in_json = true
       self.json_encoder =
         if defined?(JSONGemCoderEncoder)
           JSONGemCoderEncoder

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -3,6 +3,7 @@
 require "securerandom"
 require_relative "../abstract_unit"
 require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/object/with"
 require "active_support/json"
 require "active_support/time"
 require_relative "../time_zone_test_helpers"
@@ -55,6 +56,9 @@ class TestJSONEncoding < ActiveSupport::TestCase
   def test_unicode_escape
     assert_equal %{{"\\u2028":"\\u2029"}}, ActiveSupport::JSON.encode("\u2028" => "\u2029")
     assert_equal %{{"\u2028":"\u2029"}}, ActiveSupport::JSON.encode({ "\u2028" => "\u2029" }, escape: false)
+    ActiveSupport::JSON::Encoding.with(escape_js_separators_in_json: false) do
+      assert_equal %{{"\u2028":"\u2029"}}, ActiveSupport::JSON.encode({ "\u2028" => "\u2029" })
+    end
   end
 
   def test_hash_keys_encoding

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -65,6 +65,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_view.remove_hidden_field_autocomplete`](#config-action-view-remove-hidden-field-autocomplete): `true`
 - [`config.action_view.render_tracker`](#config-action-view-render-tracker): `:ruby`
 - [`config.active_record.raise_on_missing_required_finder_order_columns`](#config-active-record-raise-on-missing-required-finder-order-columns): `true`
+- [`config.active_support.escape_js_separators_in_json`](#config-active-support-escape-js-separators-in-json): `false`
 - [`config.yjit`](#config-yjit): `!Rails.env.local?`
 
 #### Default Values for Target Version 8.0
@@ -3019,6 +3020,20 @@ end
 ```
 
 Defaults to `nil`, which means the default `ActiveSupport::EventContext` store is used.
+
+#### `config.active_support.escape_js_separators_in_json`
+
+Specifies whether LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) are escaped when generating JSON.
+
+Historically these characters were not valid inside JavaScript literal strings but that changed in ECMAScript 2019.
+As such it's no longer a concern in modern browsers: https://caniuse.com/mdn-javascript_builtins_json_json_superset.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 8.1                   | `false`              |
 
 ### Configuring Active Job
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -365,6 +365,10 @@ module Rails
             active_record.raise_on_missing_required_finder_order_columns = true
           end
 
+          if respond_to?(:active_support)
+            active_support.escape_js_separators_in_json = false
+          end
+
           if respond_to?(:action_view)
             action_view.render_tracker = :ruby
           end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -28,6 +28,14 @@
 # Rails.configuration.action_controller.escape_json_responses = false
 
 ###
+# Skips escaping LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) in JSON.
+#
+# Historically these characters were not valid inside JavaScript literal strings but that changed in ECMAScript 2019.
+# As such it's no longer a concern in modern browsers: https://caniuse.com/mdn-javascript_builtins_json_json_superset.
+#++
+# Rails.configuration.active_support.escape_js_separators_in_json = false
+
+###
 # Raises an error when order dependent finder methods (e.g. `#first`, `#second`) are called without `order` values
 # on the relation, and the model does not have any order columns (`implicit_order_column`, `query_constraints`, or
 # `primary_key`) to fall back on.


### PR DESCRIPTION
Introduce a new framework default to skip escaping LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) in JSON.
