### PR TITLE
Fix Module#anonymous? to handle overridden name method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `Module#anonymous?` to handle overridden `name` methods.
+
+    The `anonymous?` method now uses `bind_call` to bypass any user-defined name method overrides and access the actual module name from Ruby's internal state. This ensures correct behavior when classes or modules override their `name`.
+
+    *Americo Duarte*
+
 *   Fix parallel tests hanging when worker processes die abruptly.
 
     Previously, if a worker process was killed (e.g., OOM killed, `kill -9`) during parallel

--- a/activesupport/lib/active_support/core_ext/module/anonymous.rb
+++ b/activesupport/lib/active_support/core_ext/module/anonymous.rb
@@ -25,6 +25,7 @@ class Module
   #   m.name         # => "M"
   #   m.anonymous?   # => false
   def anonymous?
-    name.nil?
+    # Use bind_call to bypass any overridden name method and get the actual module name
+    Module.instance_method(:name).bind_call(self).nil?
   end
 end

--- a/activesupport/test/core_ext/module/anonymous_test.rb
+++ b/activesupport/test/core_ext/module/anonymous_test.rb
@@ -13,4 +13,43 @@ class AnonymousTest < ActiveSupport::TestCase
     assert_not_predicate Kernel, :anonymous?
     assert_not_predicate Object, :anonymous?
   end
+
+  test "anonymous class or module remains anonymous despite overriding name method" do
+    anonymous_module = Module.new do
+      def self.name
+        "FakeName"
+      end
+    end
+    anonymous_class = Class.new do
+      def self.name
+        "FakeName"
+      end
+    end
+
+    assert_predicate anonymous_module, :anonymous?
+    assert_predicate anonymous_class, :anonymous?
+  end
+
+  test "overridden name method does not interfere with anonymous detection for constants" do
+    test_module = Module.new do
+      def self.name
+        raise NotImplementedError
+      end
+    end
+    test_class = Class.new do
+      def self.name
+        raise NotImplementedError
+      end
+    end
+
+    # Assign to constants to make them non-anonymous
+    self.class.const_set(:TestModule, test_module)
+    self.class.const_set(:TestClass, test_class)
+
+    assert_not_predicate self.class::TestModule, :anonymous?
+    assert_not_predicate self.class::TestClass, :anonymous?
+  ensure
+    self.class.send(:remove_const, :TestModule) if self.class.const_defined?(:TestModule)
+    self.class.send(:remove_const, :TestClass) if self.class.const_defined?(:TestClass)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

`Module#anonymous?` breaks when classes override the `name` method, causing exceptions during introspection. This affects frameworks and CI optimizations that rely on determining if a module is attached to a constant.

The current implementation assumes `name` is never overridden, but this happens in practice:

```ruby
class Parent
  def self.name
    raise NotImplementedError, "Children classes must implement #{__method__}"
  end
end

Parent.anonymous? # raises NotImplementedError instead of returning false
```

### Details

This Pull Request changes `Module#anonymous?` to use `bind_call` to access the original `Module#name` directly, bypassing user-defined overrides on class or module definitions. This ensures the method accurately reflects the true anonymous state based on constant assignment.

### Additional information

This issue could affect any code that uses `Module#anonymous?` for introspection, particularly in frameworks or libraries that need to determine if a class/module has been properly defined and assigned to a constant.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.