### PR TITLE
Store destroy dependent record message on reflection name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Store destroy dependent record message on reflection name
+
+    Store the error from a `has_many :companies, dependent: :restrict_with_error` association
+    on the `companies` attribute and not `base` as before.
+
+    Please change your translations accordingly if you have customized the message.
+
+    *Thomas von Deyen*
+
 *   Add replicas to test database parallelization setup.
 
     Setup and configuration of databases for parallel testing now includes replicas.

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -18,8 +18,11 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = owner.class.human_attribute_name(reflection.name).downcase
-            owner.errors.add(:base, :'restrict_dependent_destroy.has_many', record: record)
+            record = owner.class.human_attribute_name(reflection.name)
+            default_translation = I18n.t(:'restrict_dependent_destroy.has_many',
+              scope: :"activerecord.errors.messages",
+              record: record.downcase)
+            owner.errors.add(reflection.name, :'restrict_dependent_destroy.has_many', message: default_translation)
             throw(:abort)
           end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2001,14 +2001,29 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_empty firm.errors
 
-    assert_equal "Cannot delete record because dependent companies exist", firm.errors[:base].first
+    assert_equal "Cannot delete record because dependent companies exist", firm.errors[:companies].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert firm.companies.exists?(name: "child")
   end
 
   def test_restrict_with_error_with_locale
     I18n.backend = I18n::Backend::Simple.new
-    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { companies: "client companies" } } }
+    I18n.backend.store_translations "en",
+      activerecord: {
+        errors: {
+          models: {
+            restricted_with_error_firm: {
+              attributes: {
+                companies: {
+                  restrict_dependent_destroy: {
+                    has_many: "Cannot delete record because Companies still exist"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     firm = RestrictedWithErrorFirm.create!(name: "restrict")
     firm.companies.create(name: "child")
 
@@ -2018,7 +2033,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_empty firm.errors
 
-    assert_equal "Cannot delete record because dependent client companies exist", firm.errors[:base].first
+    assert_equal "Cannot delete record because Companies still exist", firm.errors[:companies].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert firm.companies.exists?(name: "child")
   ensure


### PR DESCRIPTION
Currently we store the error on the `base` attribute which does not allow to translate individual error messages per assocation.

Furthermore the record name was downcased not allowing to have a capitalized record, which makes the error message hard to use in places where the associated record is not an english word.

Fixes #53448

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
