### PR TITLE
Only use JSON::Coder with `json >= 2.15`.

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -146,7 +146,7 @@ module ActiveSupport
       end
 
       # ruby/json 2.14.x yields non-String keys but doesn't let us know it's a key
-      if defined?(::JSON::Coder) && !::JSON::VERSION.start_with?("2.14.")
+      if defined?(::JSON::Coder) && Gem::Version.new(::JSON::VERSION) >= Gem::Version.new("2.15")
         class JSONGemCoderEncoder # :nodoc:
           JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
           CODER = ::JSON::Coder.new do |value, is_key|


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/55726#issuecomment-3349478548 (cc @ghiculescu)

Older versions are harder to support, so it's not worth it.
