### PR TITLE
Correct ActiveSupport changelog for JSON.encode fix and revert

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -111,6 +111,13 @@
 
     *Eugene Kenny*
 
+*   Fix `ActiveSupport::JSON.encode` to prevent duplicate keys.
+
+    If the same key exist in both String and Symbol form it could
+    lead to the same key being emitted twice.
+
+    *Manish Sharma*
+
 *   Fix `ActiveSupport::Cache::Store#read_multi` when using a cache namespace
     and local cache strategy.
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -116,6 +116,18 @@
     If the same key exist in both String and Symbol form it could
     lead to the same key being emitted twice.
 
+    ActiveSupport 7.1.2
+    ```ruby
+    {a: 1, "a" => 2}.to_json
+    # gives: "{\"a\":1,\"a\":2}"
+    ```
+    
+    ActiveSupport 7.1.3
+    ```ruby
+    {a: 1, "a" => 2}.to_json
+    # gives: "{\"a\":2}"
+    ```
+
     *Manish Sharma*
 
 *   Fix `ActiveSupport::Cache::Store#read_multi` when using a cache namespace

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -84,6 +84,25 @@
 
     *Jean Boussier*
 
+*   Revert "Fix `ActiveSupport::JSON.encode` to prevent duplicate keys." introduced in 7.1.3
+
+    If the same key exist in both String and Symbol form, json encoder
+    again emits the same key twice. [Reaseon](https://github.com/rails/rails/pull/50489#issuecomment-2123881327)
+
+    ActiveSupport 7.1.3
+    ```ruby
+    {a: 1, "a" => 2}.to_json
+    # gives: "{\"a\":2}"
+    ```
+
+    ActiveSupport 7.1.4
+    ```ruby
+    {a: 1, "a" => 2}.to_json
+    # gives: "{\"a\":1,\"a\":2}"
+    ```
+    
+    *Rafael Mendonça França*
+
 
 ## Rails 7.1.3.4 (June 04, 2024) ##
 


### PR DESCRIPTION
### Motivation / Background

In my [previous PR](https://github.com/rails/rails/pull/55735), I stated that this `JSON.encode` fix had been reverted before the 7.1.3 release, and I removed the corresponding ActiveSupport 7.1.3 changelog entry.
In fact, the fix was actually included in 7.1.3 and then reverted in 7.1.4, which was never documented in the changelog.

### Detail

This PR restores the removed ActiveSupport 7.1.3 changelog entry and adds a note about its reversion in ActiveSupport 7.1.4. It also adds code samples for clarity.

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
