### PR TITLE
Fix `Enumerable#sole` when element is a tuple

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `Enumerable#sole` to return the full tuple instead of just the first element of the tuple.
+
+    *Olivier Bellone*
+
 *   Fix parallel tests hanging when worker processes die abruptly.
 
     Previously, if a worker process was killed (e.g., OOM killed, `kill -9`) during parallel

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -212,12 +212,12 @@ module Enumerable
     result = nil
     found = false
 
-    each do |element|
+    each do |*element|
       if found
         raise SoleItemExpectedError, "multiple items found"
       end
 
-      result = element
+      result = element.size == 1 ? element[0] : element
       found = true
     end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -401,6 +401,26 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_raise(expected_raise) { GenericEnumerable.new(1..).sole }
   end
 
+  def test_sole_returns_same_value_as_first_for_tuples
+    enum = Enumerator.new(1) { |yielder| yielder.yield(1, "one") }
+    assert_equal [1, "one"], enum.sole
+    assert_equal enum.first, enum.sole
+  end
+
+  class KeywordYielder
+    include Enumerable
+
+    def each
+      yield 1, two: 3
+    end
+  end
+
+  def test_sole_keyword_arguments
+    yielder = KeywordYielder.new
+    assert_equal [1, { two: 3 }], yielder.sole
+    assert_equal yielder.first, yielder.sole
+  end
+
   def test_doesnt_bust_constant_cache
     skip "Only applies to MRI" unless defined?(RubyVM.stat)
 


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because #54341 introduced a behavior change for `Enumerable#sole` when the sole element is a tuple.

Previously, `Enumerable#sole` would return the full tuple (same as `Enumerable#first`). #54341 changed the behavior so that `Enumerable#sole` only returns the first element of the tuple.

Fixes #55807.

### Detail

This Pull Request changes `Enumerable#sole` to return the full tuple, i.e. the same value as `Enumerable#first`.

### Additional information

-

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
