### PR TITLE
[7-2-stable] Pin mysql2 to 0.5.6 to fix CI  

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,7 @@ platforms :ruby, :windows do
 
   group :db do
     gem "pg", "~> 1.3"
-    gem "mysql2", "~> 0.5"
+    gem "mysql2", "~> 0.5", "< 0.5.7"
     gem "trilogy", ">= 2.7.0"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -716,7 +716,7 @@ DEPENDENCIES
   minitest-ci
   minitest-retry
   msgpack (>= 1.7.0)
-  mysql2 (~> 0.5)
+  mysql2 (~> 0.5, < 0.5.7)
   nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.3)
   prism


### PR DESCRIPTION
Backports a986a55 to `7-2-stable` to fix CI:
https://buildkite.com/rails/rails/builds/122182#01999bc5-d112-449c-81b1-09a04635067b

/cc @skipkayhil 