### PR TITLE
Array#duplicates?

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `Array#duplicates?` method to easily determine whether arrays contain duplicate elements.
+
+    ```ruby
+    [ 1, 2, 2 ].duplicates? # => true
+    ```
+
+    *Daniel Pepper*
+
 *   Fix `Enumerable#sole` to return the full tuple instead of just the first element of the tuple.
 
     *Olivier Bellone*

--- a/activesupport/lib/active_support/core_ext/array.rb
+++ b/activesupport/lib/active_support/core_ext/array.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/array/access"
 require "active_support/core_ext/array/conversions"
+require "active_support/core_ext/array/duplicates"
 require "active_support/core_ext/array/extract"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/array/grouping"

--- a/activesupport/lib/active_support/core_ext/array/duplicates.rb
+++ b/activesupport/lib/active_support/core_ext/array/duplicates.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Array
+  # Returns true if the array contains any duplicate elements.
+  #   [1, 2, 3].duplicates?    # => false
+  #   [1, 2, 3, 1].duplicates? # => true
+  def duplicates?
+    seen = Set.new
+    each do |e|
+      return true if seen.add?(e).nil?
+    end
+
+    false
+  end
+end

--- a/activesupport/test/core_ext/array/duplicates_test.rb
+++ b/activesupport/test/core_ext/array/duplicates_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/array"
+
+class DuplicatesTest < ActiveSupport::TestCase
+  def test_integers
+    ary = [1, 2, 3]
+    assert_equal false, ary.duplicates?
+  end
+
+  def test_integers_duplicates
+    ary = [1, 2, 3, 1]
+    assert_equal true, ary.duplicates?
+  end
+
+  def test_strings
+    ary = %w(foo bar)
+    assert_equal false, ary.duplicates?
+  end
+
+  def test_strings_duplicates
+    ary = %w(foo bar foo foo)
+    assert_equal true, ary.duplicates?
+  end
+
+  def test_symbols
+    ary = [:foo, :bar]
+    assert_equal false, ary.duplicates?
+  end
+
+  def test_symbols_duplicates
+    ary = [:foo, :bar, :foo, :bar]
+    assert_equal true, ary.duplicates?
+  end
+
+  def test_empty
+    assert_equal false, [].duplicates?
+  end
+
+  def test_nil
+    ary = [nil, nil]
+    assert_equal true, ary.duplicates?
+  end
+
+  def test_single_element
+    ary = [42]
+    assert_equal false, ary.duplicates?
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I recently had to determine whether an array contained duplicates and was surprised Rails didn't have a helper to make this trivial.  Given all the threads on stack overflow regarding this subject, it seems like a common need.


### Detail

This Pull Request changes Array to add a `.duplicates?` method, which determines if the array contains duplicate elements.


### Additional information

common, although less efficient alternatives that iterate through the entire array instead of short circuiting:
```ruby
arr = [1, 2, 3, 2, 4]

arr.uniq.length != arr.length

arr.group_by(&:itself).select { |_k, v| v.size > 1 }.any?
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
