### PR TITLE
Strip port numbers from `X-Forwarded-For` IP addresses

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Strip port numbers from X-Forwarded-For IP addresses in RemoteIp middleware.
+
+    Per RFC 7239 section 5.2, forwarded IP addresses may include port information
+    (e.g., "192.168.1.1:8080"). The RemoteIp middleware now removes port numbers
+    before validating IP addresses, preventing these IPs from being rejected as invalid.
+
+    *Adam Daniels*
+
 *   Add `action_dispatch.verbose_redirect_logs` setting that logs where redirects were called from.
 
     Similar to `active_record.verbose_query_logs` and `active_job.verbose_enqueue_logs`, this adds a line in your logs that shows where a redirect was called from.

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -177,6 +177,19 @@ module ActionDispatch
         return [] unless header
         # Split the comma-separated list into an array of strings.
         ips = header.strip.split(/[,\s]+/)
+        ips.map! do |ip|
+          # Remove port number if present, per RFC 7239 section 5.2.
+          case ip
+          when /\A\[(.+)\]:(\d+)\z/ # [IPv6]:port
+            $1
+          when /\A\[(.+)\]\z/       # [IPv6] without port
+            $1
+          when /\A([^:]+):(\d+)\z/  # IPv4:port (no other colons)
+            $1
+          else                      # Plain IP without port
+            ip
+          end
+        end
         ips.select! do |ip|
           # Only return IPs that are valid according to the IPAddr#new method.
           range = IPAddr.new(ip).to_range

--- a/railties/test/application/middleware/remote_ip_test.rb
+++ b/railties/test/application/middleware/remote_ip_test.rb
@@ -61,6 +61,24 @@ module ApplicationTests
     test "remote_ip works with HTTP_X_FORWARDED_FOR" do
       make_basic_app
       assert_equal "4.2.42.42", remote_ip("REMOTE_ADDR" => "1.1.1.1", "HTTP_X_FORWARDED_FOR" => "4.2.42.42")
+      assert_equal "4.2.42.42", remote_ip("REMOTE_ADDR" => "1.1.1.1", "HTTP_X_FORWARDED_FOR" => "4.2.42.42:56778")
+    end
+
+    test "remote_ip strips port from IPv4 addresses" do
+      make_basic_app
+      assert_equal "192.168.1.100", remote_ip("HTTP_X_FORWARDED_FOR" => "192.168.1.100:8080")
+    end
+
+    test "remote_ip strips port from IPv6 addresses in bracket notation" do
+      make_basic_app
+      assert_equal "::1", remote_ip("HTTP_X_FORWARDED_FOR" => "[::1]:8080")
+      assert_equal "2001:db8::1", remote_ip("HTTP_X_FORWARDED_FOR" => "[2001:db8::1]:8080")
+    end
+
+    test "remote_ip handles IPv6 addresses without ports" do
+      make_basic_app
+      assert_equal "::1", remote_ip("HTTP_X_FORWARDED_FOR" => "::1")
+      assert_equal "2001:db8::1", remote_ip("HTTP_X_FORWARDED_FOR" => "2001:db8::1")
     end
 
     test "the user can set trusted proxies with an enumerable of case equality comparable values" do


### PR DESCRIPTION
### Motivation / Background

RFC 7239 section 5.2 specifies that forwarded IP addresses in proxy headers may include port information (e.g., `192.168.1.1:8080`). Some proxies and clients include this port information when forwarding requests, but the `RemoteIp` middleware currently rejects these IP addresses as invalid during IPAddr parsing.

This causes legitimate forwarded IP addresses to be ignored.

### Details

I've seen this in the wild for an application deployed to Azure Web Apps.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
