### PR TITLE
[ci skip] Correct `transform_keys!` example in 8.0.3 changelog

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -57,7 +57,7 @@
 
     ```ruby
     >> {a: 1, b: 2}.with_indifferent_access.transform_keys!(&:succ)
-    => {"c" => 1, "d" => 2}
+    => {"b" => 1, "c" => 2}
     ```
 
     *Jason T Johnson*, *Jean Boussier*


### PR DESCRIPTION
This is pretty minor, but while reading the 8.0.3 release notes today, I was brought up short by the example for `ActiveSupport::HashWithIndifferentAccess#tranform_keys!`. I couldn’t understand how it was supposed to work… until I tried it out and realized the example was wrong. This updates the example to match the actual behavior.

It would be nice if somebody would update [the release description on GitHub](https://github.com/rails/rails/releases/tag/v8.0.3), too. That way, people using Dependabot (like me!) or similar tools will see this corrected text.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* N/A Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
