### PR TITLE
[ci skip] Remove the scroll overflow on code blocks:

### DIFF
--- a/guides/assets/stylesrc/components/_code-container.scss
+++ b/guides/assets/stylesrc/components/_code-container.scss
@@ -2,7 +2,7 @@
 // Containers
 //
 // These are interstitial elements used throughout the guides, providing help,
-// context, more info, or warnings to readers. 
+// context, more info, or warnings to readers.
 // ----------------------------------------------------------------------------
 
 /* Same bottom margin for special boxes than for regular paragraphs, this way
@@ -49,7 +49,6 @@ dl dd .interstitial {
 
     pre {
       margin: 0;
-      overflow: scroll;
       white-space: pre;
     }
 


### PR DESCRIPTION
- We introduced a change in #54661 to prevent overflowing codeblocks into other elements.

  This change creates white scroll bars on MacOS (maybe other platfroms too) only when you connect a mouse, it's a behaviour of MacOS that it displays scroll bar on elements.

  This commit removes the overflow property without affecting overflow problem, that is because the PR linked above restrained the element to a 100% width.