### PR TITLE
Add prefix option to has_secure_token for improved token identification

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -14,14 +14,17 @@ module ActiveRecord
       #   # Schema: User(token:string, auth_token:string)
       #   class User < ActiveRecord::Base
       #     has_secure_token
-      #     has_secure_token :auth_token, length: 36
+      #     has_secure_token :invite_token, prefix: true
+      #     has_secure_token :auth_token, length: 36, prefix: "auth_"
       #   end
       #
       #   user = User.new
       #   user.save
       #   user.token # => "pX27zsMN2ViQKta1bGfLmVJE"
-      #   user.auth_token # => "tU9bLuZseefXQ4yQxQo8wjtBvsAfPc78os6R"
+      #   user.invite_token # => "invite_token_srUP2WWCb6yCtfy6CAKVdzxF"
+      #   user.auth_token # => "auth_tU9bLuZseefXQ4yQxQo8wjtBvsAfPc78os6R"
       #   user.regenerate_token # => true
+      #   user.regenerate_invite_token # => true
       #   user.regenerate_auth_token # => true
       #
       # +SecureRandom::base58+ is used to generate at minimum a 24-character unique token, so collisions are highly unlikely.
@@ -33,8 +36,7 @@ module ActiveRecord
       # ==== Options
       #
       # [+:length+]
-      #   Length of the Secure Random, with a minimum of 24 characters. It will
-      #   default to 24.
+      #   Length of the randomly generated token, with a minimum of 24 characters. Defaults to 24.
       #
       # [+:on+]
       #   The callback when the value is generated. When called with <tt>on:
@@ -43,17 +45,34 @@ module ActiveRecord
       #   in a <tt>before_</tt> callback. When not specified, +:on+ will use the value of
       #   <tt>config.active_record.generate_secure_token_on</tt>, which defaults to +:initialize+
       #   starting in \Rails 7.1.
-      def has_secure_token(attribute = :token, length: MINIMUM_TOKEN_LENGTH, on: ActiveRecord.generate_secure_token_on)
+      #
+      # [+:prefix+]
+      #   An optional string prepended to the generated token. Intended primarily for keys that
+      #   will be publicly visible (e.g. API keys, URLs, etc.) so that their purpose can be identified at a glance.
+      #   The prefix does not count toward +:length+.
+      def has_secure_token(attribute = :token, length: MINIMUM_TOKEN_LENGTH, on: ActiveRecord.generate_secure_token_on, prefix: nil)
         if length < MINIMUM_TOKEN_LENGTH
           raise MinimumLengthError, "Token requires a minimum length of #{MINIMUM_TOKEN_LENGTH} characters."
         end
 
+        prefix = "#{attribute}_" if prefix == true
+
+        if prefix
+          generate_token = -> do
+            token = self.generate_unique_secure_token(length: length)
+
+            "#{prefix}#{token}"
+          end
+        else
+          generate_token = -> { self.generate_unique_secure_token(length: length) }
+        end
+
         # Load securerandom only when has_secure_token is used.
         require "active_support/core_ext/securerandom"
-        define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token(length: length) }
+        define_method("regenerate_#{attribute}") { update! attribute => generate_token.call }
         set_callback on, on == :initialize ? :after : :before do
           if new_record? && !query_attribute(attribute)
-            send("#{attribute}=", self.class.generate_unique_secure_token(length: length))
+            send("#{attribute}=", generate_token.call)
           end
         end
       end

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -116,4 +116,18 @@ class SecureTokenTest < ActiveRecord::TestCase
 
     assert_equal "#{user.token}_modified", user.modified_token
   end
+
+  def test_token_with_prefix
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "users"
+      attribute :auth_token
+      has_secure_token prefix: true, on: :initialize
+      has_secure_token :auth_token, on: :initialize, prefix: "auth_"
+    end
+
+    user = model.new
+
+    assert_match(/^token_/, user.token)
+    assert_match(/^auth/, user.auth_token)
+  end
 end


### PR DESCRIPTION
Adds an optional :prefix paramer to has_secure_token that prepends a string to generated tokens, making token types immediately identifiable in logs, debugging sessions, and error messages.

Before:
  user.auth_token # => "pX27zsMN2ViQKta1bGfLmVJE"
  user.reset_token # => "tU9bLuZseefXQ4yQxQo8wjtB"

After:
  has_secure_token :auth_token, prefix: "auth_"
  has_secure_token :reset_token, prefix: true

  user.auth_token # => "auth_pX27zsMN2ViQKta1bGfLmVJE"
  user.reset_token # => "reset_token_tU9bLuZseefXQ4yQxQo8wjtB"

This enables better developer clarity without additional database columns or complex token parsing logic. Particularly valuable when analyzing application logs, supporting operations teams, and debugging authentication flows with multiple token types.

Anecdotally, I have dozens of classes that I override the #generate_unique_secure_token method, passing in a hardcoded prefix. It _feels_ far nicer to copy/paste a token with context to others than an string without any purpose encoded.

Notably, ~~the current implementation makes this a breaking change for anyone who has overriden the #generates_unique_secure_token like myself~~. This is no longer true with https://github.com/rails/rails/pull/55822/commits/38cad158e34a914fbf4e45ae2c0f89d8f4e40116

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
