### PR TITLE
Backwards compatibility in migrations with remove_foreign_key syntax

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1122,6 +1122,8 @@ module ActiveRecord
     # Uses the Active Record object's own table_name, or pre/suffix from the
     # options passed in.
     def proper_table_name(name, options = {})
+      return if name.nil?
+
       if name.respond_to? :table_name
         name.table_name
       else

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -863,6 +863,11 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal "prefix_table_suffix", migration.proper_table_name(:table, migration.table_name_options)
   end
 
+  def test_proper_table_name_with_nil
+    migration = ActiveRecord::Migration.new
+    assert_nil migration.proper_table_name(nil)
+  end
+
   def test_rename_table_with_prefix_and_suffix
     assert_not_predicate Thing, :table_exists?
     ActiveRecord::Base.table_name_prefix = "p_"


### PR DESCRIPTION
### Motivation / Background

When upgrading to Rails 8.1.0.beta1, older migrations were failing.

### Detail

There are several different ways to remove foreign keys in migrations:

```ruby
def up
  change_table(:sub_testings) do |t|
    t.remove_foreign_key :testings, column: "testing_id"
  end
end
```

also

```ruby
def up
  remove_foreign_key :sub_testings, column: "testing_id"
end
```

in the last syntax the to_table variable is not defined. The error we were seeing is that this was getting passed into rails as a nil and then transformed into an empty string, and then failing when the migration ran:

```
Caused by:
ArgumentError: Table '<table_name>' has no foreign key for  (ArgumentError)

            raise(ArgumentError, "Table '#{from_table}' has no foreign key for #{to_table || options}")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Additional information

#proper_table_name has been around for a long time. I can't think of any reason why we'd ever want to return an empty string instead of a nil if we don't pass in a name, but there may be a use case. None of the tests failed when I made this change. 

I added a test with a migration for `remove_foreign_key` versioned to Rails 7.0 because that's where I saw this migration originally fail. However, if I version that migration to 8.0, it fails as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
