### PR TITLE
Add `success_callback` to Action Cable's `stream_from` and `stream_to`

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `stream_from` and `stream_to` now accept a `success_callback` that is
+    called when the stream subscription is established.
+
+    *Ben Sheldon*
+
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Allow passing composite channels to `ActionCable::Channel#stream_for` – e.g. `stream_for [ group, group.owner ]`


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Action Cable channels have a `success_callback` that is used in the implementation of `stream_from` and `stream_to`, which is used to ensure that streams subscriptions are established before the channel subscription confirmation is sent to the client.

👉🏻 This changes `stream_from` and `stream_to` to expose their own `success_callback` too. This callback can be used in Channels to defer behavior until the stream subscription is established. 

For example, a channel might want to ensure there aren't any missed updates between when a record is fetched and rendered for the frontend, and when an Action Cable stream subscription is ultimately established:

```ruby
class ReliableChannel < ActionCable::Base
  include Turbo::Streams::ActionHelper
  include ActionView::RecordIdentifier

  def subscribed
    resource = GlobalId::Locator.locate_signed params[:resource]
    rendered_at = Time.parse params[:rendered_at]
  
    #                    👇 👇 👇 👇 👇 👇
    stream_for(resource, success_callback: (lambda do
      resource.reload
      if resource.updated_at > rendered_at
        transmit turbo_stream_action_tag(
          :update, 
          target: dom_id(resource), 
          template: ApplicationController.render(resource, format: :html)
        )
      end
    end)
  end
end
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

I think this is conceptually a good change because it better aligns Stream subscription lifecycle options with Channel subscription lifecycle options.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
