### PR TITLE
Fix Action Cable `after_subscribe` callback to call after deferred subscription confirmation transmit

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixes the `after_subscribe` callback to call after the subscription confirmation
+    is transmitted or final-rejected, even when deferred for stream subscriptions.
+
+    *Ben Sheldon*
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Allow passing composite channels to `ActionCable::Channel#stream_for` – e.g. `stream_for [ group, group.owner ]`

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -245,9 +245,11 @@ module ActionCable
         end
 
         def ensure_confirmation_sent # :doc:
-          return if subscription_rejected?
           @defer_subscription_confirmation_counter.decrement
-          transmit_subscription_confirmation unless defer_subscription_confirmation?
+          unless defer_subscription_confirmation?
+            transmit_subscription_confirmation unless subscription_rejected?
+            run_callbacks :after_subscribe
+          end
         end
 
         def defer_subscription_confirmation! # :doc:

--- a/actioncable/lib/action_cable/channel/callbacks.rb
+++ b/actioncable/lib/action_cable/channel/callbacks.rb
@@ -41,6 +41,7 @@ module ActionCable
 
       included do
         define_callbacks :subscribe
+        define_callbacks :after_subscribe
         define_callbacks :unsubscribe
       end
 
@@ -58,7 +59,7 @@ module ActionCable
         #     after_subscribe :my_method, unless: :subscription_rejected?
         #
         def after_subscribe(*methods, &block)
-          set_callback(:subscribe, :after, *methods, &block)
+          set_callback(:after_subscribe, *methods, &block)
         end
         alias_method :on_subscribe, :after_subscribe
 


### PR DESCRIPTION
Related to #26547, fixes #25333. Follow-up/related to #55824. 



<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When subscribing to Action Cable Streams during Channel subscription, Action Cable defers transmitting the subscription confirmation until the Streams are subscribed. This meant that `after_subscribe` callbacks would be called _before_ the Channel Subscription confirmation is transmitted. This PR defers the `after_subscribe` callback until after the subscription confirmation is transmitted.

⚠️ This does change the authorization lifecycle. Previously it was possible to `reject` a subscription in the `after_subscribe` callback because that callback was _always_ invoked before the channel subscription confirmation was transmitted. 

https://github.com/rails/rails/blob/dac26fdf22498d79fe78501c55fdbf386f20590a/actioncable/lib/action_cable/channel/base.rb#L194-L201


That seems unintentional because the callback docs imply rejection should happen before:

```ruby
# This callback will be triggered after the Base#subscribed method is called,
# even if the subscription was rejected with the Base#reject method.
#
# To trigger the callback only on successful subscriptions, use the
# Base#subscription_rejected? method:
#
#     after_subscribe :my_method, unless: :subscription_rejected?
#
def after_subscribe(*methods, &block)
```

I didn't find any [visible source evidence](https://github.com/search?type=code&q=path%3Aapp%2Fchannels+%22after_subscribe%22+%22reject%22) of `reject` being used in an `after_subscribe`, but it's possible.

If that seems like a dealbreaker, we can introduce a new callback (`after_confirm`) to perform this role instead. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
