### PR TITLE
Add conflicting record ID to `validates_uniqueness_of` error details

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Include record ID in error when uniqueness validation fails
+
+    When a uniqueness validation fails, the `errors.details` hash for the attribute
+    now includes an `:existing_id` key, holding the ID of the record that caused
+    the conflict.
+
+    ```ruby
+    # Before
+    errors.details[:name]
+    # => [{error: :taken, value: "John Doe"}]
+
+    # After
+    errors.details[:name]
+    # => [{error: :taken, value: "John Doe", existing_id: 123}]
+    ```
+
+    *Bruno Vicenzo*
+
 *   Bump the minimum PostgreSQL version to 10.0.
 
     As part of this change, `supports_pgcrypto_uuid?` is deprecated because

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -51,7 +51,8 @@ class I18nValidationTest < ActiveRecord::TestCase
     test "validates_uniqueness_of on generated message #{name}" do
       Topic.validates_uniqueness_of :title, validation_options
       @topic.title = unique_topic.title
-      assert_called_with(ActiveModel::Error, :generate_message, [:title, :taken, @topic, generate_message_options.merge(value: "unique!")]) do
+      error_options = generate_message_options.merge(value: "unique!", existing_id: unique_topic.id)
+      assert_called_with(ActiveModel::Error, :generate_message, [:title, :taken, @topic, error_options]) do
         @topic.valid?
         @topic.errors.messages
       end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -101,6 +101,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_not t2.valid?, "Shouldn't be valid"
     assert_not t2.save, "Shouldn't save t2 as unique"
     assert_equal ["has already been taken"], t2.errors[:title]
+    assert_includes t2.errors.details[:title], { error: :taken, value: "I'm uniqué!", existing_id: t.id }
 
     t2.title = "Now I am really also unique"
     assert t2.save, "Should now save t2 as unique"
@@ -577,6 +578,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     key2.key_number = 10
     assert_not_predicate key2, :valid?
+    assert_includes key2.errors.details[:key_number], { error: :taken, value: 10, existing_id: 10 }
   end
 
   def test_validate_uniqueness_without_primary_key
@@ -590,7 +592,9 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     abc = klass.create!(dashboard_id: "abc")
     assert_predicate klass.new(dashboard_id: "xyz"), :valid?
-    assert_not_predicate klass.new(dashboard_id: "abc"), :valid?
+    abc2 = klass.new(dashboard_id: "abc")
+    assert_not_predicate abc2, :valid?
+    assert_includes abc2.errors.details[:dashboard_id], { error: :taken, value: "abc" }
 
     abc.dashboard_id = "def"
 
@@ -641,6 +645,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_not_predicate item2, :valid?
 
     assert_equal(["has already been taken"], item2.errors[:id])
+    assert_includes item2.errors.details[:id], { error: :taken, value: item.id, existing_id: item.id }
   end
 end
 


### PR DESCRIPTION
### Motivation and Background

Currently, when a `validates_uniqueness_of` validation fails, the `errors.details` hash only provides `{ error: :taken, ... }`. This indicates that a conflict exists but offers no information about *which* record is causing the conflict.

This lack of context can be challenging in scenarios like building JSON APIs, where it would be highly beneficial to return a link or an ID to the conflicting resource.

This PR enhances the uniqueness validator to include the primary key of the conflicting record in the error details, providing developers with more actionable information.

This change was proposed and received positive feedback in the following Rails Discuss thread:
[https://discuss.rubyonrails.org/t/proposal-include-existing-record-id-in-uniqueness-validation-error-details/89810](https://discuss.rubyonrails.org/t/proposal-include-existing-record-id-in-uniqueness-validation-error-details/89810)

### Implementation

The core of this change is in `ActiveRecord::Validations::UniquenessValidator`. The existing database check, which used `.exists?`, has been replaced with a call to `.pick(klass.primary_key)`.

If a conflicting record is found, its ID is now added to the `errors.details` hash under the new key `:existing_id`.

**Before this change:**
```ruby
topic.errors.details[:title]
# => [{error: :taken, value: "Existing Topic"}]
```

**After this change:**
```ruby
topic.errors.details[:title]
# => [{error: :taken, value: "Existing Topic", existing_id: 1}]
```

This change applies to both simple and scoped uniqueness validations.
<details>
<summary>Click to see the benchmark script used</summary>

```ruby
#!/usr/bin/env ruby

require "bundler/setup"
require "benchmark/ips"
require "active_record"
require "sqlite3"

# --- 1. Minimal Setup ---
puts "Setting up test environment..."

# In-memory database connection
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

# Cleanly create a test table
ActiveRecord::Schema.define do
  create_table :topics, force: true do |t|
    t.string :title
  end
end

# Define the model
class Topic < ActiveRecord::Base
end

# Create a single record to be found by the queries
Topic.create!(title: "Hello World")

puts "Environment ready. Starting benchmark..."
puts "---"
puts "Ruby: #{RUBY_VERSION}"
puts "ActiveRecord: #{ActiveRecord::VERSION::STRING}"
puts

# --- 2. The Benchmark ---
Benchmark.ips do |x|
  # CHANGED: Increased time to 60 seconds (1 minute) for a more stable result.
  # Warmup is also slightly increased to 5 seconds.
  x.config(time: 60, warmup: 5)

  # Scenario A: The old approach
  # Generated SQL (approximate): SELECT 1 AS one FROM "topics" WHERE "topics"."title" = ? LIMIT 1
  x.report("using .exists?") do
    Topic.where(title: "Hello World").exists?
  end

  # Scenario B: Your new approach
  # Generated SQL (approximate): SELECT "topics"."id" FROM "topics" WHERE "topics"."title" = ? LIMIT 1
  x.report("using .pick(:id)") do
    Topic.where(title: "Hello World").pick(:id)
  end

  # Compares the two scenarios
  x.compare!
end
```

</details>

```
Setting up test environment...
-- create_table(:topics, {force: true})
   -> 0.0146s
Environment ready. Starting benchmark...
---
Ruby: 3.4.6
ActiveRecord: 8.1.0.beta1

ruby 3.4.6 (2025-09-16 revision dbd83256b1) +PRISM [x86_64-linux]
Warming up --------------------------------------
      using .exists?   693.000 i/100ms
    using .pick(:id)   831.000 i/100ms
Calculating -------------------------------------
      using .exists?      9.623k (±10.7%) i/s  (103.92 μs/i) -    566.181k in  60.003322s
    using .pick(:id)      9.750k (±10.6%) i/s  (102.56 μs/i) -    574.221k in  60.031766s

Comparison:
    using .pick(:id):     9750.1 i/s
      using .exists?:     9623.2 i/s - same-ish: difference falls within error
```

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
