### PR TITLE
Action Text: change tag helpers to accept optional blocks

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Capture block content for form helper methods
+
+    ```erb
+    <%= rich_textarea_tag :content, nil do %>
+      <h1>hello world</h1>
+    <% end %>
+    <!-- <input type="hidden" name="content" id="trix_input_1" value="&lt;h1&gt;hello world&lt;/h1&gt;"/><trix-editor … -->
+
+    <%= rich_textarea :message, :content, input: "trix_input_1" do %>
+      <h1>hello world</h1>
+    <% end %>
+    <!-- <input type="hidden" name="message[content]" id="trix_input_1" value="&lt;h1&gt;hello world&lt;/h1&gt;"/><trix-editor … -->
+
+    <%= form_with model: Message.new do |form| %>
+      <%= form.rich_textarea :content do %>
+        <h1>hello world</h1>
+      <% end %>
+    <% end %>
+    <!-- <form action="/messages" accept-charset="UTF-8" method="post"><input type="hidden" name="message[content]" id="message_content_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;"/><trix-editor … -->
+    ```
+
+    *Sean Doyle*
+
 *   Generalize `:rich_text_area` Capybara selector
 
     Prepare for more Action Text-capable WYSIWYG editors by making

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -27,7 +27,14 @@ module ActionText
     #     rich_textarea_tag "content", message.content
     #     # <input type="hidden" name="content" id="trix_input_post_1">
     #     # <trix-editor id="content" input="trix_input_post_1" class="trix-content" ...></trix-editor>
-    def rich_textarea_tag(name, value = nil, options = {})
+    #
+    #     rich_textarea_tag "content", nil do
+    #       "<h1>Default content</h1>"
+    #     end
+    #     # <input type="hidden" name="content" id="trix_input_post_1" value="&lt;h1&gt;Default content&lt;/h1&gt;">
+    #     # <trix-editor id="content" input="trix_input_post_1" class="trix-content" ...></trix-editor>
+    def rich_textarea_tag(name, value = nil, options = {}, &block)
+      value = capture(&block) if value.nil? && block_given?
       options = options.symbolize_keys
       form = options.delete(:form)
 
@@ -53,11 +60,11 @@ module ActionView::Helpers
 
     delegate :dom_id, to: ActionView::RecordIdentifier
 
-    def render
+    def render(&block)
       options = @options.stringify_keys
       add_default_name_and_field(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
-      html_tag = @template_object.rich_textarea_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"))
+      html_tag = @template_object.rich_textarea_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"), &block)
       error_wrapping(html_tag)
     end
   end
@@ -82,10 +89,16 @@ module ActionView::Helpers
     #     # <trix-editor id="content" input="message_content_trix_input_message_1" class="trix-content" ...></trix-editor>
     #
     #     rich_textarea :message, :content, value: "<h1>Default message</h1>"
-    #     # <input type="hidden" name="message[content]" id="message_content_trix_input_message_1" value="<h1>Default message</h1>">
+    #     # <input type="hidden" name="message[content]" id="message_content_trix_input_message_1" value="&lt;h1&gt;Default message&lt;/h1&gt;">
     #     # <trix-editor id="content" input="message_content_trix_input_message_1" class="trix-content" ...></trix-editor>
-    def rich_textarea(object_name, method, options = {})
-      Tags::ActionText.new(object_name, method, self, options).render
+    #
+    #     rich_textarea :message, :content do
+    #       "<h1>Default message</h1>"
+    #     end
+    #     # <input type="hidden" name="message[content]" id="message_content_trix_input_message_1" value="&lt;h1&gt;Default message&lt;/h1&gt;">
+    #     # <trix-editor id="content" input="message_content_trix_input_message_1" class="trix-content" ...></trix-editor>
+    def rich_textarea(object_name, method, options = {}, &block)
+      Tags::ActionText.new(object_name, method, self, options).render(&block)
     end
     alias_method :rich_text_area, :rich_textarea
   end
@@ -98,8 +111,8 @@ module ActionView::Helpers
     #     <% end %>
     #
     # Please refer to the documentation of the base helper for details.
-    def rich_textarea(method, options = {})
-      @template.rich_textarea(@object_name, method, objectify_options(options))
+    def rich_textarea(method, options = {}, &block)
+      @template.rich_textarea(@object_name, method, objectify_options(options), &block)
     end
     alias_method :rich_text_area, :rich_textarea
   end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -37,11 +37,39 @@ class ActionText::FormHelperTest < ActionView::TestCase
     HTML
   end
 
+  test "#rich_textarea_tag helper with block" do
+    concat(
+      rich_textarea_tag(:content, nil, { input: "trix_input_1" }) do
+        concat "<h1>hello world</h1>"
+      end
+    )
+
+    assert_dom_equal(<<~HTML, output_buffer)
+      <input type="hidden" name="content" id="trix_input_1" value="&lt;h1&gt;hello world&lt;/h1&gt;"/>
+      <trix-editor input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
+      </trix-editor>
+    HTML
+  end
+
   test "#rich_textarea helper" do
     concat rich_textarea :message, :content, input: "trix_input_1"
 
     assert_dom_equal(<<~HTML, output_buffer)
       <input type="hidden" name="message[content]" id="trix_input_1" />
+      <trix-editor id="message_content" input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
+      </trix-editor>
+    HTML
+  end
+
+  test "#rich_textarea helper with block" do
+    concat(
+      rich_textarea(:message, :content, input: "trix_input_1") do
+        concat "<h1>hello world</h1>"
+      end
+    )
+
+    assert_dom_equal(<<~HTML, output_buffer)
+      <input type="hidden" name="message[content]" id="trix_input_1" value="&lt;h1&gt;hello world&lt;/h1&gt;"/>
       <trix-editor id="message_content" input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
       </trix-editor>
     HTML
@@ -67,6 +95,22 @@ class ActionText::FormHelperTest < ActionView::TestCase
     assert_dom_equal(<<~HTML, output_buffer)
       <form action="/messages" accept-charset="UTF-8" method="post">
         <input type="hidden" name="message[content]" id="message_content_trix_input_message" />
+        <trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
+        </trix-editor>
+      </form>
+    HTML
+  end
+
+  test "form with rich text area with block" do
+    form_with model: Message.new do |form|
+      form.rich_textarea :content do
+        "<h1>hello world</h1>"
+      end
+    end
+
+    assert_dom_equal(<<~HTML, output_buffer)
+      <form action="/messages" accept-charset="UTF-8" method="post">
+        <input type="hidden" name="message[content]" id="message_content_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;"/>
         <trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
         </trix-editor>
       </form>
@@ -134,6 +178,22 @@ class ActionText::FormHelperTest < ActionView::TestCase
     HTML
   end
 
+  test "modelless form with rich text area with block" do
+    form_with url: "/messages", scope: :message do |form|
+      form.rich_textarea :content, input: "trix_input_1" do
+        "<h1>hello world</h1>"
+      end
+    end
+
+    assert_dom_equal(<<~HTML, output_buffer)
+      <form action="/messages" accept-charset="UTF-8" method="post">
+        <input type="hidden" name="message[content]" id="trix_input_1" value="&lt;h1&gt;hello world&lt;/h1&gt;" />
+        <trix-editor id="message_content" input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
+        </trix-editor>
+      </form>
+    HTML
+  end
+
   test "form with rich text area having placeholder without locale" do
     form_with model: Message.new, scope: :message do |form|
       form.rich_textarea :content, placeholder: true
@@ -167,6 +227,24 @@ class ActionText::FormHelperTest < ActionView::TestCase
   test "form with rich text area with value" do
     form_with model: Message.new, scope: :message do |form|
       form.rich_textarea :title, value: "<h1>hello world</h1>"
+    end
+
+    assert_dom_equal(<<~HTML, output_buffer)
+      <form action="/messages" accept-charset="UTF-8" method="post">
+        <input type="hidden" name="message[title]" id="message_title_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;" />
+        <trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
+        </trix-editor>
+      </form>
+    HTML
+  end
+
+  test "form with rich text area with value with block" do
+    model = Message.new content: "<h1>ignored</h1>"
+
+    form_with model: model, scope: :message do |form|
+      form.rich_textarea :title do
+        "<h1>hello world</h1>"
+      end
     end
 
     assert_dom_equal(<<~HTML, output_buffer)


### PR DESCRIPTION
Problem
---

The next release of [basecamp/trix][] will support integrating with `<form>` element submissions *without* an associated `<input type="hidden">` element (see [basecamp/trix#1253][] to learn more). The next release will also include support for `<trix-editor>` elements reading their initial value from their child content (see [basecamp/trix#1128][]).

```html
<trix-editor name="message[content]">
  <h1>hello world</h1>
</trix-editor>
```

Similarly, [basecamp/lexxy][] (a potential Action Text-compatible successor to Trix) supports [configuring its underlying editor with content captured through the block passed to its form helpers][lexxy-block]:

```erb
<%= form.rich_text_area :body do %>
  <lexxy-prompt trigger="@">
  </lexxy-prompt>
<% end %>
```

Its helper method monkey-patch [already accepts and uses a block][lexxy-monkey-patch].

Proposal
---

This commit proposed that all Action Text-related form tag helpers accept `&block` arguments. In the short-term, there are no real changes to behavior: the captured content is treated the same way that a `value` argument or `:value` keyword argument would be. Trix will scrub and sanitize that content when its editor connects to the document.

In the long-term, this change will provide an additional integration and configuration opportunity for Action Text-compatible WYSIWYG text editors.

[basecamp/trix]: https://github.com/basecamp/trix
[basecamp/trix#1253]: https://github.com/basecamp/trix/pull/1253
[basecamp/trix#1128]: https://github.com/basecamp/trix/pull/1128
[basecamp/lexxy]: https://github.com/basecamp/lexxy
[lexxy-block]: https://github.com/basecamp/lexxy/?tab=readme-ov-file#general-setup
[lexxy-monkey-patch]: https://github.com/basecamp/lexxy/blob/v0.1.10.beta/lib/lexxy/rich_text_area_tag.rb#L17

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
