### PR TITLE
Ensure one stream write per SSE event

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -133,15 +133,16 @@ module ActionController
       private
         def perform_write(json, options)
           current_options = @options.merge(options).stringify_keys
-
+          event = +""
           PERMITTED_OPTIONS.each do |option_name|
             if (option_value = current_options[option_name])
-              @stream.write "#{option_name}: #{option_value}\n"
+              event << "#{option_name}: #{option_value}\n"
             end
           end
 
           message = json.gsub("\n", "\ndata: ")
-          @stream.write "data: #{message}\n\n"
+          event << "data: #{message}\n\n"
+          @stream.write event
         end
     end
 

--- a/actionpack/test/controller/sse_perform_write_test.rb
+++ b/actionpack/test/controller/sse_perform_write_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+module ActionController
+  # Unit tests for ActionController::Live::SSE focusing on underlying write semantics.
+  # These tests ensure that each call to SSE#write results in exactly one call to the
+  # underlying stream#write, even when multiple options (event, retry, id) are supplied
+  # and when multiline data requires transformation.
+  class SSEPerformWriteTest < ActiveSupport::TestCase
+    class FakeStream
+      attr_reader :writes
+
+      def initialize
+        @writes = []
+      end
+
+      def write(chunk)
+        @writes << chunk
+      end
+
+      def close; end
+    end
+
+    def test_single_underlying_write_with_options_and_object_payload
+      stream = FakeStream.new
+      sse = Live::SSE.new(stream, event: "base", retry: 100)
+
+      sse.write({ name: "John" }, id: 123, event: "override", retry: 500)
+
+      assert_equal 1, stream.writes.size, "Expected exactly one underlying write call"
+      payload = stream.writes.first
+
+      assert_match(/event: override/, payload)
+      assert_match(/retry: 500/, payload)
+      assert_match(/id: 123/, payload)
+      assert_match(/data: {"name":"John"}/, payload)
+      assert_match(/\n\n\z/, payload, "Payload should terminate with a blank line per SSE spec")
+    end
+
+    def test_single_underlying_write_with_preencoded_string
+      stream = FakeStream.new
+      sse = Live::SSE.new(stream)
+
+      sse.write("{\"a\":1}")
+
+      assert_equal 1, stream.writes.size
+      assert_match(/data: {"a":1}/, stream.writes.first)
+    end
+
+    def test_single_underlying_write_with_multiline_string
+      stream = FakeStream.new
+      sse = Live::SSE.new(stream)
+
+      sse.write("line1\nline2", event: "multi")
+
+      assert_equal 1, stream.writes.size
+      payload = stream.writes.first
+      # Each newline becomes a new data: line (after the first) but still one underlying write
+      assert_match(/event: multi/, payload)
+      assert_match(/data: line1/, payload)
+      assert_match(/data: line2/, payload)
+    end
+
+    def test_number_of_underlying_writes_matches_number_of_sse_writes
+      stream = FakeStream.new
+      sse = Live::SSE.new(stream)
+
+      sse.write(a: 1)
+      sse.write(b: 2, id: 10)
+      sse.write({ c: 3 }, event: "evt", retry: 2500)
+
+      assert_equal 3, stream.writes.size, "Each SSE#write should map to exactly one stream.write"
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to optimize Server-Sent Events (SSE) streaming in `ActionController::Live::SSE` by ensuring each logical SSE is delivered via exactly one underlying `stream.write` call.

While building an AI chatbot client that consumes streaming responses (using an API that yields chunks as they arrive), I noticed a discrepancy between OpenAI's streaming responses and those produced by a Rails application using `ActionController::Live::SSE`.

OpenAI sends each SSE event as a single TCP/application chunk (i.e. one cohesive unit containing the optional `event`, `id`, `retry`, and all `data:` lines). Rails, however, was emitting *multiple* writes per logical event: one for each option/value lines and an additional one for the `data:` payload. For consumers that process chunks incrementally, this results in:

* Extra syscalls / write overhead.
* Partial events being observed mid-assembly (forcing additional buffering logic client-side).
* Reduced efficiency when the event is the natural unit of work (especially for LLM / AI streaming token consumption patterns).

This change reduces fragmentation so downstream clients receive a fully formed SSE in a single chunk whenever possible.

### Detail

This Pull Request changes the implementation of `ActionController::Live::SSE#perform_write` to build the entire event payload (all permitted option lines plus transformed multiline data) into a single mutable string and invoke `@stream.write` once per `SSE#write` call.

No public API changes are introduced; behavior is the same from a semantic perspective except for improved chunk consolidation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message will include a detailed description of what changed and why.
* [x] Tests are added or updated (new unit test file asserting single write per event).
* [ ] CHANGELOG files are updated if the core team deems this worthy of mention (currently omitted as an internal optimization without public behavior change).
