### PR TITLE
Simplify SQL statement to load records in batch

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -437,7 +437,7 @@ module ActiveRecord
             values = records.pluck(*cursor)
             values_size = values.size
             values_last = values.last
-            yielded_relation = where(cursor => values)
+            yielded_relation = rewhere(cursor => values)
             yielded_relation.load_records(records)
           elsif (empty_scope && use_ranges != false) || use_ranges
             # Efficiently peak at the last value for the next batch using offset and limit.
@@ -462,7 +462,7 @@ module ActiveRecord
             values = batch_relation.pluck(*cursor)
             values_size = values.size
             values_last = values.last
-            yielded_relation = where(cursor => values)
+            yielded_relation = rewhere(cursor => values)
           end
 
           break if values_size == 0


### PR DESCRIPTION
### Motivation / Background

When querying a relation for a large number of records we can use the `in_batches` method to ensure we only query a limited set or records from the database at a time. This is a great feature, but ...

When the relation has a 'where' clause on the key used to batch on (the 'cursor' column) the queries to load each individual batch are unnecessary complex. This is not only less nice when reviewing query logs, but also increases network traffic and makes us rely more on the database's query optimizer to see the complexity and still produce an efficient query.

For instance when I already have an array `ids` containing 10,000 Post ids and I do `Post.where(id: ids).in_batches(of: 100)` the query sent to the database will have a WHERE-clause with 2 expressions: 1 stating that the record's id value should be one of the 10,000 values of `ids` and another stating the record's id value should be one of a 100 ids for that specific batch. Given that the 2nd expression is more specific for the same column there is no need to have the 1st expression.

This Pull Request has been created because although the complex query in the previous example can be avoided by doing a `slice_each` on the `ids` array before creating the relation (`ids.each_slice(100) { |ids_slice| Post.where(id: ids_slice)`) I rather not have to worry about that. 


### Detail

The change to prevent the complex query is trivial: instead of just adding a clause specifying the values to include in a specific batch, first remove any existing where clauses on the cursor column.

