### PR TITLE
[Fix #55582] Skip eager loading strategy for `#pluck`/`#calculate`/`#ids`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Fix `pluck`, `pick`, `calculate`, and `ids` with eager loading and `limit` on empty tables.
+
+    When these methods are called on a relation with eager loading and `limit`/`offset`,
+    they now skip the two-query eager loading strategy. This fixes aggregation queries
+    returning `[]` instead of a row with null/zero values on empty tables, and makes
+    `limit` apply to the result set rather than to select parent record IDs first.
+
+    Before:
+
+    ```ruby
+    Schedule.includes(:user).joins(:user).limit(1).pluck("MAX(updated_at), COUNT(*)")
+    # => [] (empty array on empty tables)
+    ```
+
+    After:
+
+    ```ruby
+    Schedule.includes(:user).joins(:user).limit(1).pluck("MAX(updated_at), COUNT(*)")
+    # => [[nil, 0]] (correct aggregation result)
+    ```
+
+    The two-query strategy exists to ensure the correct number of parent records are
+    loaded when eager loading associations, but `pluck`, `calculate`, and `ids` extract
+    values rather than load records, making the optimization unnecessary for these methods.
+
+    *Joshua Young*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -228,7 +228,7 @@ module ActiveRecord
       end
 
       if has_include?(column_name)
-        relation = apply_join_dependency
+        relation = apply_join_dependency(eager_loading: false)
 
         if operation == "count"
           unless distinct_value || distinct_select?(column_name || select_for_count)
@@ -311,7 +311,7 @@ module ActiveRecord
       end
 
       if has_include?(column_names.first)
-        relation = apply_join_dependency
+        relation = apply_join_dependency(eager_loading: false)
         relation.pluck(*column_names)
       else
         model.disallow_raw_sql!(flattened_args(column_names))
@@ -374,7 +374,7 @@ module ActiveRecord
     #   Person.joins(:company).ids # SELECT people.id FROM people INNER JOIN companies ON companies.id = people.company_id
     def ids
       if !loaded? && has_include?(primary_key)
-        return apply_join_dependency.group(*primary_key).pluck(*primary_key)
+        return apply_join_dependency(eager_loading: false).group(*primary_key).pluck(*primary_key)
       end
 
       pluck(*primary_key)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1227,6 +1227,13 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [], Topic.includes(:replies).limit(1).where("0 = 1").ids
   end
 
+  def test_ids_with_includes_joins_limit_and_empty_table
+    Post.delete_all
+    Comment.delete_all
+
+    assert_equal [], Post.includes(:comments).joins(:comments).limit(1).ids
+  end
+
   def test_ids_with_includes_offset
     assert_equal [5], Topic.includes(:replies).order(:id).offset(4).ids
     assert_equal [], Topic.includes(:replies).order(:id).offset(5).ids
@@ -1235,6 +1242,20 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_pluck_with_includes_limit_and_empty_result
     assert_equal [], Topic.includes(:replies).limit(0).pluck(:id)
     assert_equal [], Topic.includes(:replies).limit(1).where("0 = 1").pluck(:id)
+  end
+
+  def test_pluck_with_includes_joins_limit_and_empty_table
+    Post.delete_all
+    Comment.delete_all
+
+    assert_equal [], Post.includes(:comments).joins(:comments).limit(1).pluck(:id)
+  end
+
+  def test_pluck_aggregation_with_includes_joins_limit_and_empty_table
+    Post.delete_all
+    Comment.delete_all
+
+    assert_equal [[nil, 0]], Post.includes(:comments).joins(:comments).limit(1).pluck(Arel.sql("MAX(posts.id), COUNT(*)"))
   end
 
   def test_pluck_with_includes_offset
@@ -1252,6 +1273,14 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [[2, 1], [4, 3]], Reply.includes(:topic).order(:id).pluck(:id, topic: [:id])
     assert_equal [[2, 1], [4, 3]], Reply.includes(:topic).order(:id).pluck(:id, topic: :id)
     assert_equal [[2, 1], [4, 3]], Reply.includes(:topic).order(:id).pluck(:id, :"topic.id")
+  end
+
+  def test_calculate_with_includes_joins_limit_and_empty_table
+    Post.delete_all
+    Comment.delete_all
+
+    assert_equal 0, Post.includes(:comments).joins(:comments).limit(1).count
+    assert_nil Post.includes(:comments).joins(:comments).limit(1).maximum(:id)
   end
 
   def test_group_by_with_order_by_virtual_count_attribute
@@ -1499,6 +1528,13 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_no_queries do
       assert_equal "37signals", companies.pick(:new_name)
     end
+  end
+
+  def test_pick_aggregation_with_includes_joins_limit_and_empty_table
+    Post.delete_all
+    Comment.delete_all
+
+    assert_equal [nil, 0], Post.includes(:comments).joins(:comments).pick(Arel.sql("MAX(posts.id), COUNT(*)"))
   end
 
   def test_grouped_calculation_with_polymorphic_relation


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Closes https://github.com/rails/rails/issues/55582.

### Detail

When `pluck`, `calculate`, or `ids` are called on a relation with `includes` and `limit`/`offset`, they incorrectly apply the two-query eager loading strategy via `distinct_relation_for_primary_key`. This causes aggregation queries on empty tables to return `[]` instead of a row with null/zero values.

The two-query strategy exists to ensure the correct number of parent records are loaded when eager loading associations. For example, `Post.eager_load(:comments).limit(5)` should load exactly 5 posts, not 5 arbitrary join rows. However, `pluck`, `calculate`, and `ids` don't load records - they extract values. The optimization is unnecessary and breaks aggregation semantics.

This changes `apply_join_dependency` in these methods to pass `eager_loading: false`, skipping the two-query path. Aggregations now correctly return a result row even on empty relations, and `limit` applies to the result set rather than being used to select parent record IDs first. The `pick` method is also fixed since it calls `pluck` internally with a limit.

<!-- ### Additional information -->

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.