### PR TITLE
Allow preloader queries to be split in batches

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -4,9 +4,10 @@ module ActiveRecord
   module Associations
     class Preloader
       class Batch # :nodoc:
-        def initialize(preloaders, available_records:)
+        def initialize(preloaders, available_records:, batch_size: nil)
           @preloaders = preloaders.reject(&:empty?)
           @available_records = available_records.flatten.group_by { |r| r.class.base_class }
+          @batch_size = batch_size
         end
 
         def call
@@ -39,7 +40,7 @@ module ActiveRecord
 
           def group_and_load_similar(loaders)
             loaders.grep_v(ThroughAssociation).group_by(&:loader_query).each_pair do |query, similar_loaders|
-              query.load_records_in_batch(similar_loaders)
+              query.load_records_in_batch(similar_loaders, batch_size: @batch_size)
             end
           end
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we sometimes found ourselves manually preloading records because the standard preloading generated queries that were quite slow. 
We found this was because the standard preloader tried to load associated records in a single query. While that is perfectly understandable, exactly the point of a preloader, but in some cases we want multiple queries that each retrieved a batch of the records to be preloaded. 

### Detail

This Pull Request adds an additional option to the preloader: `batch_size`. If that option is supplied the preloader limits the number of ids to be retrieved in a single query. 

So when it has determined it needs to loads 10,000 categories, and batch size is set to 1,000, instead of doing a single query on the categories table supplying 10,000 ids it does 10 queries each retrieving 1,000 categories.

Especially when preloading belongs_to_and_has_many we found that the overall system performance was better splitting the preloader queries in multiple smaller ones.
