### PR TITLE
Fix `change_column` to preserve old column attributes for sqlite3

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
@@ -7,6 +7,13 @@ module ActiveRecord
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         def change_column(column_name, type, **options)
           name = column_name.to_s
+
+          existing_column = @columns_hash[name]
+          if existing_column
+            existing_options = existing_column.options.except(:precision)
+            options = existing_options.merge(options)
+          end
+
           @columns_hash[name] = nil
           column(name, type, **options)
         end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -242,6 +242,15 @@ module ActiveRecord
         assert_not_predicate TestModel.new, :administrator?
       end
 
+      def test_change_column_preserves_old_attributes
+        add_column "test_models", "user_id", :integer, default: 0, null: false
+        change_column "test_models", "user_id", :bigint
+
+        new_column = connection.columns("test_models").find { |c| c.name == "user_id" }
+        assert_equal 0, new_column.default
+        assert_equal false, new_column.null
+      end
+
       def test_change_column_with_custom_index_name
         add_column "test_models", "category", :string
         add_index :test_models, :category, name: "test_models_categories_idx"


### PR DESCRIPTION
Fixes #55834.