### PR TITLE
Add structured event for Rails deprecations, when `config.active_support.deprecation` is set to `:notify`.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add structured event for Rails deprecations, when `config.active_support.deprecation` is set to `:notify`.
+
+    *zzak*
+
 *   Report unhandled exceptions to the Error Reporter when running rake tasks via Rails command.
 
     *Akimichi Tanei*

--- a/railties/lib/rails/structured_event_subscriber.rb
+++ b/railties/lib/rails/structured_event_subscriber.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "active_support/structured_event_subscriber"
+
+module Rails
+  class StructuredEventSubscriber < ActiveSupport::StructuredEventSubscriber # :nodoc:
+    def deprecation(event)
+      emit_event("rails.deprecation",
+        message: event.payload[:message],
+        callstack: event.payload[:callstack],
+        gem_name: event.payload[:gem_name],
+        deprecation_horizon: event.payload[:deprecation_horizon],
+      )
+    end
+  end
+end
+
+Rails::StructuredEventSubscriber.attach_to :rails

--- a/railties/test/structured_event_subscriber_test.rb
+++ b/railties/test/structured_event_subscriber_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/testing/event_reporter_assertions"
+require "rails/structured_event_subscriber"
+
+module Rails
+  class StructuredEventSubscriberTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::EventReporterAssertions
+
+    def run(*)
+      ActiveSupport.event_reporter.with_debug do
+        super
+      end
+    end
+
+    def test_deprecation_is_notified_when_behavior_is_notify
+      Rails.deprecator.with(behavior: :notify) do
+        event = assert_event_reported("rails.deprecation", payload: { gem_name: "Rails" }) do
+          Rails.deprecator.warn("This is a deprecation warning")
+        end
+
+        assert_includes event[:payload][:message], "This is a deprecation warning"
+        assert_includes event[:payload].keys, :callstack
+        assert_includes event[:payload].keys, :gem_name
+        assert_includes event[:payload].keys, :deprecation_horizon
+      end
+    end
+
+    def test_deprecation_is_not_notified_when_behavior_is_not_notify
+      Rails.deprecator.with(behavior: :stderr) do
+        output = capture(:stderr) do
+          assert_no_event_reported("rails.deprecation") do
+            Rails.deprecator.warn("This is a deprecation warning")
+          end
+        end
+
+        assert_includes output, "This is a deprecation warning"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Opted to make it dependent on the `:notify` behavior than adding yet another behavior just for structured events, but happy to go that way if there is a strong opion.

/cc @gmcgibbon @adrianna-chang-shopify 