### PR TITLE
Skip analyze job if ruby-vips or mini_magick gem are missing

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
@@ -3,7 +3,9 @@
 begin
   gem "mini_magick"
   require "mini_magick"
+  ActiveStorage::MINIMAGICK_AVAILABLE = true # :nodoc:
 rescue LoadError => error
+  ActiveStorage::MINIMAGICK_AVAILABLE = false # :nodoc:
   raise error unless error.message.include?("mini_magick")
 end
 
@@ -17,6 +19,11 @@ module ActiveStorage
 
     private
       def read_image
+        unless MINIMAGICK_AVAILABLE
+          logger.error "Skipping image analysis because the mini_magick gem isn't installed"
+          return {}
+        end
+
         download_blob_to_tempfile do |file|
           image = instrument("mini_magick") do
             MiniMagick::Image.new(file.path)

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -11,7 +11,9 @@ end
 begin
   gem "ruby-vips"
   require "ruby-vips"
+  ActiveStorage::VIPS_AVAILABLE = true # :nodoc:
 rescue LoadError => error
+  ActiveStorage::VIPS_AVAILABLE = false # :nodoc:
   raise error unless error.message.match?(/libvips|ruby-vips/)
 end
 
@@ -25,6 +27,11 @@ module ActiveStorage
 
     private
       def read_image
+        unless VIPS_AVAILABLE
+          logger.error "Skipping image analysis because the ruby-vips gem isn't installed"
+          return {}
+        end
+
         download_blob_to_tempfile do |file|
           image = instrument("vips") do
             # ruby-vips will raise Vips::Error if it can't find an appropriate loader for the file

--- a/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
@@ -70,6 +70,23 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
     end
   end
 
+  test "when image_magick is not installed" do
+    stub_const(ActiveStorage, :MINIMAGICK_AVAILABLE, false) do
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+      output = StringIO.new
+      logger = ActiveSupport::Logger.new(output)
+
+      ActiveStorage.with(logger: logger) do
+        analyze_with_image_magick do
+          blob.analyze
+        end
+      end
+
+      assert_includes output.string, "Skipping image analysis because the mini_magick gem isn't installed"
+    end
+  end
+
   private
     def analyze_with_image_magick
       previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, :mini_magick

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -58,6 +58,23 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
     end
   end
 
+  test "when ruby-vips is not installed" do
+    stub_const(ActiveStorage, :VIPS_AVAILABLE, false) do
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+      output = StringIO.new
+      logger = ActiveSupport::Logger.new(output)
+
+      ActiveStorage.with(logger: logger) do
+        analyze_with_vips do
+          blob.analyze
+        end
+      end
+
+      assert_includes output.string, "Skipping image analysis because the ruby-vips gem isn't installed"
+    end
+  end
+
   private
     def analyze_with_vips
       previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, :vips


### PR DESCRIPTION
If you're using Active Storage, but don't have `image_processing` gem installed, because the [default analyzers][^1] includes Vips and ImageMagick analyzers, you would see the following error:

```
[ActiveJob] Enqueued ActiveStorage::AnalyzeJob ...
[ActiveJob] [ActiveStorage::AnalyzeJob] Performing ActiveStorage::AnalyzeJob ...
[ActiveJob] [ActiveStorage::AnalyzeJob] [0efa0f81-23e0-4a09-9fb2-55ecb484c10a] Error performing ActiveStorage::AnalyzeJob: NameError (uninitialized constant Vips):
```

Previously, this would rescue LoadError because the gems were required lazily.[^2]

```
def read_image
  begin
    require "ruby-vips"
  rescue LoadError
    logger.info "Skipping image analysis because the ruby-vips gem isn't installed"
    return {}
  end

  # ...
```

---

Thanks to @claudiob for [reporting][^3] and @Earlopain for all your help with this issue!

[^1]: https://guides.rubyonrails.org/configuring.html#config-active-storage-analyzers
[^2]: https://github.com/rails/rails/blob/ab8e833991e493f57f03c10ee2a8a7fda218faae/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb#L13-L18
[^3]: https://github.com/rails/rails/pull/55697#issuecomment-3364212327