### PR TITLE
Always pass default precision to BigDecimal when parsing Float in XmlMini

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -73,6 +73,8 @@ module ActiveSupport
         "decimal"      => Proc.new do |number|
           if String === number
             number.to_d
+          elsif Float === number
+            BigDecimal(number, 0)
           else
             BigDecimal(number)
           end


### PR DESCRIPTION
Fixes #55803

Works with BigDecimal `3.2.2` and `3.2.3`.

See: https://github.com/ruby/bigdecimal/blob/cb2458bde33bf90a8364b58d53e8948a7ba555ea/ext/bigdecimal/bigdecimal.c#L2747-L2749