### PR TITLE
Treat empty strings as nil for optional route segments

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -71,6 +71,10 @@ module ActionDispatch
         missing_keys = nil
 
         match_route(name, constraints) do |route|
+          (route.parts - route.required_parts).each do |part|
+            options[part] = nil if options[part] == ""
+          end
+
           parameterized_parts = extract_parameterized_parts(route, options, path_parameters)
 
           # Skip this route unless a name has been provided or it is a standard Rails

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2713,6 +2713,42 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       url_for(controller: "photos", action: "index", username: nil)
   end
 
+  def test_url_generator_treats_empty_strings_like_nil_for_optional_segments
+    draw do
+      get "(/locale/:locale)(/currency/:currency)/products(/:id)" => "products#show"
+    end
+
+    assert_equal "http://www.example.com/currency/USD/products/123",
+      url_for(controller: "products", action: "show", locale: "", currency: "USD", id: 123)
+    assert_equal "http://www.example.com/currency/USD/products/123",
+      url_for(controller: "products", action: "show", locale: nil, currency: "USD", id: 123)
+
+    assert_equal "http://www.example.com/locale/en/products/123",
+      url_for(controller: "products", action: "show", locale: "en", currency: "", id: 123)
+    assert_equal "http://www.example.com/locale/en/products/123",
+      url_for(controller: "products", action: "show", locale: "en", currency: nil, id: 123)
+
+    assert_equal "http://www.example.com/locale/en/currency/USD/products",
+      url_for(controller: "products", action: "show", locale: "en", currency: "USD", id: "")
+    assert_equal "http://www.example.com/locale/en/currency/USD/products",
+      url_for(controller: "products", action: "show", locale: "en", currency: "USD", id: nil)
+
+    assert_equal "http://www.example.com/locale/false/currency/USD/products/123",
+      url_for(controller: "products", action: "show", locale: false, currency: "USD", id: 123)
+
+    assert_equal "http://www.example.com/currency/USD/products/123?filter=",
+      url_for(controller: "products", action: "show", locale: "", currency: "USD", id: 123, filter: "")
+  end
+
+  def test_url_generator_preserves_empty_strings_for_required_segments
+    draw do
+      get "/products/:id" => "products#show"
+    end
+
+    assert_equal "http://www.example.com/products/",
+      url_for(controller: "products", action: "show", id: "")
+  end
+
   def test_url_recognition_for_optional_static_segments
     draw do
       scope "(groups)" do


### PR DESCRIPTION
### Motivation / Background

Fixes #55845.

Rails omits an empty string from a single optional route segment, but an empty string in a non-trailing optional group remains in the generated path:

```ruby
get "(/a/:a_id)(/b/:b_id)(/c/:c_id)", to: "test#index", as: :optional_segments

optional_segments_path(a_id: nil, b_id: 2, c_id: 3) # => "/b/2/c/3"
optional_segments_path(a_id: "", b_id: 2, c_id: 3)  # => "/a//b/2/c/3"
```

This is inconsistent with the established empty-string behavior covered by #42283 and commonly surfaces when route values come from form parameters.

### Detail

This change normalizes empty strings to `nil` for optional route parts before parameter extraction, allowing the existing nil handling to omit the corresponding optional group.

The normalization is intentionally limited to optional parts. Regression coverage verifies that required empty segments, `false` route values, and unrelated empty query parameters retain their existing behavior.

### Testing

- `bin/test actionpack/test/dispatch/routing_test.rb actionpack/test/dispatch/url_generation_test.rb`
- `PARALLEL_WORKERS=1 actionpack/bin/test` (4,249 tests, 19,971 assertions)
- `bundle exec rubocop actionpack/lib/action_dispatch/journey/formatter.rb actionpack/test/dispatch/routing_test.rb`

### Checklist

- [x] This Pull Request is related to one change.
- [x] The commit message describes what changed and why.
- [x] Tests are added for the bug and compatibility boundaries.
- [x] No CHANGELOG entry is included because this is a minor bug fix.