### PR TITLE
Add an explicit dependency on json gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ PATH
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
       minitest (>= 5.1)
       securerandom (>= 0.3)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "bigdecimal"
+  s.add_dependency "json"
   s.add_dependency "logger", ">= 1.4.2"
   s.add_dependency "securerandom", ">= 0.3"
   s.add_dependency "uri", ">= 0.13.1"


### PR DESCRIPTION
### Motivation / Background

ActiveSupport depends on `json` gem, which has been  This pull request makes a small update to the `activesupport.gemspec` file, adding a new dependency to the gem specification.

Fixes #55853

### Detail

This pull request adds `json` as a dependency in the `Gem::Specification` for `activesupport`, ensuring that the gem explicitly requires the `json` library.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [n/a] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
