### PR TITLE
[8-0-stable] Always pass default precision to BigDecimal when parsing Float in XmlMini

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -74,6 +74,8 @@ module ActiveSupport
         "decimal"      => Proc.new do |number|
           if String === number
             number.to_d
+          elsif Float === number
+            BigDecimal(number, 0)
           else
             BigDecimal(number)
           end


### PR DESCRIPTION
Backports 6173cc5 to 8-0-stable