### PR TITLE
Make `ActiveRecord::Assertions::QueryAssertions` method outputs consistent

### DIFF
--- a/activerecord/lib/active_record/testing/query_assertions.rb
+++ b/activerecord/lib/active_record/testing/query_assertions.rb
@@ -29,9 +29,9 @@ module ActiveRecord
           result = _assert_nothing_raised_or_warn("assert_queries_count", &block)
           queries = include_schema ? counter.log_all : counter.log
           if count
-            assert_equal count, queries.size, "#{queries.size} instead of #{count} queries were executed. Queries: #{queries.join("\n\n")}"
+            assert_equal count, queries.size, "#{queries.size} instead of #{count} queries were executed#{queries.empty? ? '' : ". Queries:\n\n#{queries.join("\n\n")}"}"
           else
-            assert_operator queries.size, :>=, 1, "1 or more queries expected, but none were executed.#{queries.empty? ? '' : "\nQueries:\n#{queries.join("\n")}"}"
+            assert_operator queries.size, :>=, 1, "1 or more queries expected, but none were executed"
           end
           result
         end
@@ -72,9 +72,9 @@ module ActiveRecord
           matched_queries = queries.select { |query| match === query }
 
           if count
-            assert_equal count, matched_queries.size, "#{matched_queries.size} instead of #{count} queries were executed.#{queries.empty? ? '' : "\nQueries:\n#{queries.join("\n")}"}"
+            assert_equal count, matched_queries.size, "#{matched_queries.size} instead of #{count} matching queries were executed#{queries.empty? ? '' : ". Queries:\n\n#{queries.join("\n\n")}"}"
           else
-            assert_operator matched_queries.size, :>=, 1, "1 or more queries expected, but none were executed.#{queries.empty? ? '' : "\nQueries:\n#{queries.join("\n")}"}"
+            assert_operator matched_queries.size, :>=, 1, "1 or more matching queries expected, but none were executed#{queries.empty? ? '' : ". Queries:\n\n#{queries.join("\n\n")}"}"
           end
 
           result

--- a/activerecord/test/cases/assertions/query_assertions_test.rb
+++ b/activerecord/test/cases/assertions/query_assertions_test.rb
@@ -47,12 +47,12 @@ module ActiveRecord
         error = assert_raises(Minitest::Assertion) {
           assert_queries_match(/ASC LIMIT/i, count: 2) { Post.first }
         }
-        assert_match(/1 instead of 2 queries/, error.message)
+        assert_match(/1 instead of 2 matching queries/, error.message)
 
         error = assert_raises(Minitest::Assertion) {
           assert_queries_match(/ASC LIMIT/i, count: 0) { Post.first }
         }
-        assert_match(/1 instead of 0 queries/, error.message)
+        assert_match(/1 instead of 0 matching queries/, error.message)
       end
 
       def test_assert_queries_match_with_matcher
@@ -61,11 +61,11 @@ module ActiveRecord
             Post.where(id: 1).first
           end
         }
-        assert_match(/0 instead of 1 queries/, error.message)
+        assert_match(/0 instead of 1 matching queries/, error.message)
       end
 
       def test_assert_queries_match_when_there_are_no_queries
-        assert_raises(Minitest::Assertion, match: "1 or more queries expected, but none were executed") do
+        assert_raises(Minitest::Assertion, match: "1 or more matching queries expected, but none were executed") do
           assert_queries_match(/something/) { Post.none }
         end
       end
@@ -113,7 +113,7 @@ module ActiveRecord
 
         def test_assert_queries_match_include_schema
           Post.columns # load columns
-          assert_raises(Minitest::Assertion, match: "1 or more queries expected") do
+          assert_raises(Minitest::Assertion, match: "1 or more matching queries expected") do
             assert_queries_match(/SELECT/i, include_schema: true) { Post.columns }
           end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I noticed some inconsistencies in the failure messages of the query assertion helpers, these changes address those.

### Detail

<details>

<summary>I QA'ed all the possible failure scenarios.</summary>

<br>

`assert_queries_count`:

Before:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
1 or more queries expected, but none were executed..
Expected 0 to be >= 1.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

After:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
1 or more queries expected, but none were executed.
Expected 0 to be >= 1.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

<hr>


`assert_queries_count 2`:

Before:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
6 instead of 2 queries were executed. Queries: BEGIN immediate TRANSACTION

INSERT INTO "posts" DEFAULT VALUES RETURNING "id"

COMMIT TRANSACTION

BEGIN immediate TRANSACTION

INSERT INTO "comments" ("post_id") VALUES (?) RETURNING "id"

COMMIT TRANSACTION.
Expected: 2
  Actual: 6

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

After:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
6 instead of 2 queries were executed. Queries:

BEGIN immediate TRANSACTION

INSERT INTO "posts" DEFAULT VALUES RETURNING "id"

COMMIT TRANSACTION

BEGIN immediate TRANSACTION

INSERT INTO "comments" ("post_id") VALUES (?) RETURNING "id"

COMMIT TRANSACTION.
Expected: 2
  Actual: 6
  
1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

<hr>

`assert_queries_count 2` without queries:

Before:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
0 instead of 2 queries were executed. Queries: .
Expected: 2
  Actual: 0

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

After:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
0 instead of 2 queries were executed.
Expected: 2
  Actual: 0

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

<hr>

`assert_queries_match /test/`:

Before:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
1 or more queries expected, but none were executed.
Queries:
BEGIN immediate TRANSACTION
INSERT INTO "posts" DEFAULT VALUES RETURNING "id"
COMMIT TRANSACTION
BEGIN immediate TRANSACTION
INSERT INTO "comments" ("post_id") VALUES (?) RETURNING "id"
COMMIT TRANSACTION.
Expected 0 to be >= 1.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

After:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
1 or more matching queries expected, but none were executed. Queries:

BEGIN immediate TRANSACTION

INSERT INTO "posts" DEFAULT VALUES RETURNING "id"

COMMIT TRANSACTION

BEGIN immediate TRANSACTION

INSERT INTO "comments" ("post_id") VALUES (?) RETURNING "id"

COMMIT TRANSACTION.
Expected 0 to be >= 1.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

<hr>

`assert_queries_match /test/` without queries:

Before:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
1 or more queries expected, but none were executed..
Expected 0 to be >= 1.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

After:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
1 or more matching queries expected, but none were executed.
Expected 0 to be >= 1.

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

<hr>

`assert_queries_match /test/, count: 1`:

Before:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
0 instead of 1 queries were executed.
Queries:
BEGIN immediate TRANSACTION
INSERT INTO "posts" DEFAULT VALUES RETURNING "id"
COMMIT TRANSACTION
BEGIN immediate TRANSACTION
INSERT INTO "comments" ("post_id") VALUES (?) RETURNING "id"
COMMIT TRANSACTION.
Expected: 1
  Actual: 0

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

After:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
0 instead of 1 matching queries were executed. Queries:

BEGIN immediate TRANSACTION

INSERT INTO "posts" DEFAULT VALUES RETURNING "id"

COMMIT TRANSACTION

BEGIN immediate TRANSACTION

INSERT INTO "comments" ("post_id") VALUES (?) RETURNING "id"

COMMIT TRANSACTION.
Expected: 1
  Actual: 0

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

<hr>

`assert_queries_match /test/, count: 1` without queries:

Before:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
0 instead of 1 queries were executed..
Expected: 1
  Actual: 0

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

After:
```
  1) Failure:
BugTest#test_association_stuff [test.rb:53]:
0 instead of 1 matching queries were executed.
Expected: 1
  Actual: 0

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

</details>

<!-- ### Additional information -->

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.