### PR TITLE
Only preconnect connections that have been prepopulated

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -788,6 +788,7 @@ module ActiveRecord
 
         if need_new_connections
           while new_conn = try_to_checkout_new_connection { @connections.size < @min_connections }
+            new_conn.allow_preconnect = true
             checkin(new_conn)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
       attr_reader :pool
       attr_reader :visitor, :owner, :logger, :lock
-      attr_accessor :allow_preconnect
+      attr_reader :allow_preconnect # :nodoc:
       attr_accessor :pinned # :nodoc:
       alias :in_use? :owner
 
@@ -51,6 +51,12 @@ module ActiveRecord
         return if value.eql?(@pool)
         @schema_cache = nil
         @pool = value
+      end
+
+      def allow_preconnect=(value) # :nodoc:
+        @lock.synchronize do
+          @allow_preconnect = value
+        end
       end
 
       def self.type_cast_config_to_integer(config)
@@ -156,7 +162,7 @@ module ActiveRecord
         @pinned = false
         @pool = ActiveRecord::ConnectionAdapters::NullPool.new
         @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        @allow_preconnect = true
+        @allow_preconnect = false
         @visitor = arel_visitor
         @statements = build_statement_pool
         self.lock_thread = nil


### PR DESCRIPTION
Otherwise-manually-created connections that have not directly cause a connection should remain lazy.

Since #54175, merely touching `AR::Base.lease_connection` was sufficient to cause a network connection, which could inflate database server connection counts. We don't want that.