### PR TITLE
Clarify behavior of `db:prepare` task that indeed runs migrations if schema and tables are created

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1283,7 +1283,7 @@ only perform the necessary tasks once.
   load the schema, run any pending migrations, dump the updated schema, and
   finally load the seed data. See the [Seeding Data
   documentation](#migrations-and-seed-data) for more details.
-* If the database and tables exist, the command run pending database migrations.
+* If the database and tables already exist, the command will run any pending database migrations.
 
 Once the database and tables exist, the `db:prepare` task will not try to reload
 the seed data, even if the previously loaded seed data or the existing seed file

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1283,7 +1283,7 @@ only perform the necessary tasks once.
   load the schema, run any pending migrations, dump the updated schema, and
   finally load the seed data. See the [Seeding Data
   documentation](#migrations-and-seed-data) for more details.
-* If the database and tables exist, the command will do nothing.
+* If the database and tables exist, the command run pending database migrations.
 
 Once the database and tables exist, the `db:prepare` task will not try to reload
 the seed data, even if the previously loaded seed data or the existing seed file


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because documentation about behaviour of `db:prepare` task was incorrect.

### Detail

This Pull Request changes Rails guide in "Preparing a database" section. At the moment it's saying that if schema and tables exists - `db:prepare` task will do nothing. As a matter of fact it'll run pending migrations if they exist.