### PR TITLE
Standardize event name formatting in `assert_event_reported`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Standardize event name formatting in `assert_event_reported` error messages.
+
+    The event name in failure messages now uses `.inspect` (e.g., `name: "user.created"`)
+    to match `assert_events_reported` and provide type clarity between strings and symbols.
+    This only affects tests that assert on the failure message format itself.
+
+    *George Ma*
+
 *   Fix `Enumerable#sole` to return the full tuple instead of just the first element of the tuple.
 
     *Olivier Bellone*

--- a/activesupport/lib/active_support/testing/event_reporter_assertions.rb
+++ b/activesupport/lib/active_support/testing/event_reporter_assertions.rb
@@ -149,7 +149,7 @@ module ActiveSupport
           event.event_data
         else
           message = "Expected an event to be reported matching:\n  " \
-            "name: #{name}\n  " \
+            "name: #{name.inspect}\n  " \
             "payload: #{payload.inspect}\n  " \
             "tags: #{tags.inspect}\n" \
             "but none of the #{events.size} reported events matched:\n  " \

--- a/activesupport/test/testing/event_reporter_assertions_test.rb
+++ b/activesupport/test/testing/event_reporter_assertions_test.rb
@@ -103,7 +103,7 @@ module ActiveSupport
         end
 
         assert_match(/Expected an event to be reported matching:/, e.message)
-        assert_match(/name: user\.created/, e.message)
+        assert_match(/name: "user\.created"/, e.message)
         assert_match(/but none of the 1 reported events matched:/, e.message)
         assert_match(/another\.event/, e.message)
       end


### PR DESCRIPTION
This change adds `.inspect` to the event name in `assert_event_reported`'s failure message, making it consistent with how `payload` and `tags` and `assert_events_reported` are displayed.

`.inspect` is better and it helps distinguish between event names that are strings vs symbols and is consistent with the other fields.

This will only effect tests that explicitly assert on the failure message format itself. (has no effect on `assert_event_reported`)