### PR TITLE
Add asc_nulls_first and desc_nulls_last to order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `:asc_nulls_first`, and `:desc_nulls_last` to Active Record's `order` method.
+
+    Postgresql and Mysql have different behaviors regarding the sorting order of NULL.
+    These methods allow a better control over sorting queries.
+
+    ```ruby
+    # Usage:
+    Post.order(title: :asc_nulls_first)
+    ```
+
+    *Matthew Nguyen*
+
 *   Add replicas to test database parallelization setup.
 
     Setup and configuration of databases for parallel testing now includes replicas.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2067,8 +2067,10 @@ module ActiveRecord
         arel.order(*orders) unless orders.empty?
       end
 
-      VALID_DIRECTIONS = [:asc, :desc, :ASC, :DESC,
-                          "asc", "desc", "ASC", "DESC"].to_set # :nodoc:
+      VALID_DIRECTIONS = [
+        :asc, :desc, :asc_nulls_first, :desc_nulls_last, :ASC, :DESC, :ASC_NULLS_FIRST, :DESC_NULLS_LAST,
+        "asc", "desc", "asc_nulls_first", "desc_nulls_last", "ASC", "DESC", "ASC_NULLS_FIRST", "DESC_NULLS_LAST"
+      ].to_set # :nodoc:
 
       def validate_order_args(args)
         args.each do |arg|

--- a/activerecord/lib/arel/order_predications.rb
+++ b/activerecord/lib/arel/order_predications.rb
@@ -3,11 +3,19 @@
 module Arel # :nodoc: all
   module OrderPredications
     def asc
-      Nodes::Ascending.new self
+      Nodes::Ascending.new(self)
     end
 
     def desc
-      Nodes::Descending.new self
+      Nodes::Descending.new(self)
+    end
+
+    def asc_nulls_first
+      Nodes::Ascending.new(self).nulls_first
+    end
+
+    def desc_nulls_last
+      Nodes::Descending.new(self).nulls_last
     end
   end
 end

--- a/activerecord/test/cases/relation/order_test.rb
+++ b/activerecord/test/cases/relation/order_test.rb
@@ -45,6 +45,36 @@ class OrderTest < ActiveRecord::TestCase
     assert_equal(reverse_alphabetical, Book.order(books: { name: :desc }))
   end
 
+  def test_order_asc_nulls_first
+    z = Book.create!(name: "Zulu", author: authors(:david))
+    y = Book.create!(name: "Yankee", author: authors(:mary))
+    x = Book.create!(name: "X-Ray", author: authors(:david))
+    n = Book.create!(name: nil, author: authors(:bob))
+
+    alphabetical = [n, x, y, z]
+
+    assert_equal(alphabetical, Book.order(name: :asc_nulls_first))
+    assert_equal(alphabetical, Book.order(name: :ASC_NULLS_FIRST))
+    assert_equal(alphabetical, Book.order(name: "asc_nulls_first"))
+    assert_equal(alphabetical, Book.order(Book.arel_table["name"].asc_nulls_first))
+    assert_equal(alphabetical, Book.order(books: { name: :asc_nulls_first }))
+  end
+
+  def test_order_desc_nulls_last
+    z = Book.create!(name: "Zulu", author: authors(:david))
+    y = Book.create!(name: "Yankee", author: authors(:mary))
+    x = Book.create!(name: "X-Ray", author: authors(:david))
+    n = Book.create!(name: nil, author: authors(:bob))
+
+    reverse_alphabetical = [z, y, x, n]
+
+    assert_equal(reverse_alphabetical, Book.order(name: :desc_nulls_last))
+    assert_equal(reverse_alphabetical, Book.order(name: :DESC_NULLS_LAST))
+    assert_equal(reverse_alphabetical, Book.order(name: "desc_nulls_last"))
+    assert_equal(reverse_alphabetical, Book.order(Book.arel_table["name"].desc_nulls_last))
+    assert_equal(reverse_alphabetical, Book.order(books: { name: :desc_nulls_last }))
+  end
+
   def test_order_with_association
     z = Book.create!(name: "Zulu", author: authors(:david))
     y = Book.create!(name: "Yankee", author: authors(:mary))

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -417,7 +417,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_raising_exception_on_invalid_hash_params
     e = assert_raise(ArgumentError) { Topic.order(:name, "id DESC", id: :asfsdf) }
-    assert_equal 'Direction "asfsdf" is invalid. Valid directions are: [:asc, :desc, :ASC, :DESC, "asc", "desc", "ASC", "DESC"]', e.message
+    assert_equal 'Direction "asfsdf" is invalid. Valid directions are: [:asc, :desc, :asc_nulls_first, :desc_nulls_last, :ASC, :DESC, :ASC_NULLS_FIRST, :DESC_NULLS_LAST, "asc", "desc", "asc_nulls_first", "desc_nulls_last", "ASC", "DESC", "ASC_NULLS_FIRST", "DESC_NULLS_LAST"]', e.message
   end
 
   def test_finding_last_with_arel_order


### PR DESCRIPTION
### Motivation / Background

Postgresql and Mysql have different behaviors regarding the sorting order of NULL.

For example:

```ruby
z = Book.create!(name: "Zulu", author: authors(:david))
y = Book.create!(name: "Yankee", author: authors(:mary))
x = Book.create!(name: "X-Ray", author: authors(:david))
n = Book.create!(name: nil, author: authors(:bob))

# In postgreSQL
Book.order(name: :asc) # => [ x, y, z, n ]
# In MySQL/SQLite3
Book.order(name: :asc) # => [ n, x, y, z ]
```

Allowing `asc_nulls_first` and `desc_nulls_last` enables more control on sorting.

### Detail

Usage:

```ruby
Book.order(name: :asc_nulls_first)
Book.order(name: :ASC_NULLS_FIRST)
Book.order(name: "asc_nulls_first")
Book.order(Book.arel_table["name"].asc_nulls_first)
Book.order(books: { name: :asc_nulls_first })
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
