### PR TITLE
Fix typo in idle_time method docs

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -164,7 +164,7 @@ module ActiveSupport
         @cpu_time_finish - @cpu_time_start
       end
 
-      # Returns the idle time time (in milliseconds) passed between the call to
+      # Returns the idle time (in milliseconds) passed between the call to
       # #start! and the call to #finish!.
       def idle_time
         diff = duration - cpu_time


### PR DESCRIPTION
[idle_time](https://api.rubyonrails.org/classes/ActiveSupport/Notifications/Event.html#method-i-idle_time) method contains I think a duplicate word time that can be removed.