### PR TITLE
avoid direct interpolation for args in structure_load

### DIFF
--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -51,8 +51,10 @@ module ActiveRecord
       end
 
       def structure_load(filename, extra_flags)
-        flags = extra_flags.join(" ") if extra_flags
-        `sqlite3 #{flags} #{db_config.database} < "#{filename}"`
+        args = []
+        args.concat(extra_flags) if extra_flags
+        args << db_config.database
+        run_cmd("sqlite3", *args, in: filename)
       end
 
       def check_current_protected_environment!(db_config, migration_class)

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -106,7 +106,7 @@ module ApplicationTests
             assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"dogs"/, schema_dump_animals)
           end
 
-          rails "db:schema:load"
+          rails "db:drop", "db:create", "db:schema:load"
 
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }
@@ -146,7 +146,7 @@ module ApplicationTests
             end
           end
 
-          rails "db:schema:load:#{database}"
+          rails "db:drop:#{database}", "db:create:#{database}", "db:schema:load:#{database}"
 
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current implementation of `structure_load` in `ActiveRecord::Tasks::SQLiteDatabaseTasks` uses a backtick-executed shell command to invoke `sqlite3`.  
This approach directly interpolates supplied values (such as the database name) into the command string, which could allow **command injection** if a maliciously crafted database path is used.  

By switching to `Kernel.system` with properly separated arguments, we prevent unescaped shell interpretation and ensure the command is executed safely.  

No functional behavior changes are expected under normal conditions.

From H1 report @jhawthorn @matthewd 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
