### PR TITLE
[ci skip] Add after_discard to the ActiveJob callback list

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -715,6 +715,7 @@ end
 * [`before_perform`][]
 * [`around_perform`][]
 * [`after_perform`][]
+* [`after_discard`][]
 
 [`before_enqueue`]:
     https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_enqueue
@@ -728,6 +729,8 @@ end
     https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
 [`after_perform`]:
     https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
+[`after_discard`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-after_discard
 
 Please note that when enqueuing jobs in bulk using `perform_all_later`,
 callbacks such as `around_enqueue` will not be triggered on the individual jobs.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the ActiveJob Rails Guide mentions the list of [available callbacks](https://guides.rubyonrails.org/active_job_basics.html#available-callbacks), but the `after_discard` is missing. 

### Detail

This pull request adds the `after_discard` callback to the list of available callbacks.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
