### PR TITLE
Refresh event payload filtering when application boots

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -531,6 +531,11 @@ module ActiveSupport
       context_store.context
     end
 
+    def reload_payload_filter # :nodoc:
+      @payload_filter = nil
+      payload_filter
+    end
+
     private
       def raise_on_error?
         @raise_on_error

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -82,6 +82,7 @@ module ActiveSupport
     initializer "active_support.set_filter_parameters" do |app|
       config.after_initialize do
         ActiveSupport.filter_parameters += Rails.application.config.filter_parameters
+        ActiveSupport.event_reporter.reload_payload_filter
       end
     end
 

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -565,6 +565,27 @@ module ActiveSupport
         end
       end
     end
+
+    test "payload filter reloading" do
+      @reporter.notify(:some_event, test: true)
+      ActiveSupport.filter_parameters << :param_to_be_filtered
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "some_event", payload: { param_to_be_filtered: "test" })
+      ]) do
+        @reporter.notify(:some_event, param_to_be_filtered: "test")
+      end
+
+      @reporter.reload_payload_filter
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "some_event", payload: { param_to_be_filtered: "[FILTERED]" })
+      ]) do
+        @reporter.notify(:some_event, param_to_be_filtered: "test")
+      end
+    ensure
+      ActiveSupport.filter_parameters.pop
+    end
   end
 
   class EncodersTest < ActiveSupport::TestCase


### PR DESCRIPTION
This Pull Request has been created because parameter filtering is broken when structured events get emitted before or during application initialization.

### Detail

This Pull Request changes ActiveSupport::EventReporter to update the payload filter when the app configured filter params get passed off to Active Support.

### Additional information

Introduced in https://github.com/rails/rails/pull/55489

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
