### PR TITLE
Bump devcontainer Ruby from 3.4.6 to 3.4.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3.4, 3.3, 3.2
-ARG VARIANT="3.4.6"
+ARG VARIANT="3.4.7"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Quick and simple little bump of the devcontainer Ruby from 3.4.6 to the latest 3.4.7.

- https://www.ruby-lang.org/en/news/2025/10/07/ruby-3-4-7-released/
- https://github.com/ruby/ruby/releases/tag/v3_4_7