### PR TITLE
add config.activestorage.default_url_options

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `config.active_storage.default_url_options` configuration option.
+
+    Allows setting default URL options for Active Storage disk service at the application level.
+    This provides a fallback when `ActiveStorage::Current.url_options` is not set.
+
+    ```ruby
+    # config/application.rb
+    config.active_storage.default_url_options = { host: "example.com", protocol: "https" }
+    ```
+
+    *Agustin Gomez Campero*
+
 *   Add structured events for Active Storage:
     - `active_storage.service_upload`
     - `active_storage.service_download`

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -362,6 +362,8 @@ module ActiveStorage
 
   mattr_accessor :track_variants, default: false
 
+  mattr_accessor :default_url_options, default: {}
+
   singleton_class.attr_accessor :checksum_implementation
   @checksum_implementation = OpenSSL::Digest::MD5
   begin

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -149,6 +149,7 @@ module ActiveStorage
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
         ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
+        ActiveStorage.default_url_options = app.config.active_storage.default_url_options || {}
         if app.config.active_storage.checksum_implementation
           ActiveStorage.checksum_implementation = app.config.active_storage.checksum_implementation
         end

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -135,7 +135,7 @@ module ActiveStorage
         )
 
         if url_options.blank?
-          raise ArgumentError, "Cannot generate URL for #{filename} using Disk service, please set ActiveStorage::Current.url_options."
+          raise ArgumentError, "Cannot generate URL for #{filename} using Disk service, please set ActiveStorage::Current.url_options or config.active_storage.default_url_options."
         end
 
         url_helpers.rails_disk_service_url(verified_key_with_expiration, filename: filename, **url_options)
@@ -172,7 +172,7 @@ module ActiveStorage
       end
 
       def url_options
-        ActiveStorage::Current.url_options
+        ActiveStorage::Current.url_options.presence || ActiveStorage.default_url_options
       end
   end
 end

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -46,7 +46,20 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
       @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
     end
 
-    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options.", error.message)
+    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options or config.active_storage.default_url_options.", error.message)
+  end
+
+  test "URL generation without ActiveStorage::Current.url_options set, but with ActiveStorage.default_url_options set" do
+    ActiveStorage::Current.url_options = nil
+    original_default_url_options = ActiveStorage.default_url_options
+    ActiveStorage.default_url_options = { protocol: "https", host: "default.example.com" }
+
+    begin
+      assert_match(/^https:\/\/default.example.com\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+    ensure
+      ActiveStorage.default_url_options = original_default_url_options
+    end
   end
 
   test "URL generation keeps working with ActiveStorage::Current.host set" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because when using Disk service in development and something else in production you end up having to set ActiveStorage::Current.url_options conditionally. This usually leads to code in a controller that looks like this:

```ruby
ActiveStorage::Current.url_options = { host: , protocol: } if Rails.env.development?
```

I believe it would be cleaner to set this up in the configs and not have to add any code to the controller just to get ActiveStorage working in development.

### Detail

This Pull Request adds the ability to add config.active_storage.default_url_options in your config file to avoid having to set ActiveStorage::Current.url_options.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
