### PR TITLE
Add :restart option to retry_job and retry_on

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `:restart` option to `retry_job` and `retry_on` for jobs including `ActiveJob::Continuable`.
+
+    This option controls whether a retried job should resume from its last
+    saved checkpoint (`restart: false`, default) or restart from
+    the beginning (`restart: true`). It allows finer control over retry
+    behavior when certain exceptions require a full restart instead of resuming
+    partial progress.
+
+    *Georgiy Melnikov*
+
 *   Add structured events for Active Job:
     - `active_job.enqueued`
     - `active_job.bulk_enqueued`

--- a/activejob/lib/active_job/continuable.rb
+++ b/activejob/lib/active_job/continuable.rb
@@ -91,7 +91,9 @@ module ActiveJob
       def resume_job(exception) # :nodoc:
         executions_for(exception)
         if max_resumptions.nil? || resumptions < max_resumptions
-          retry_job(**self.resume_options)
+          opts = self.resume_options
+          opts[:restart] = false if exception.is_a?(Continuation::Interrupt)
+          retry_job(**opts)
         else
           raise Continuation::ResumeLimitError, "Job was resumed a maximum of #{max_resumptions} times"
         end


### PR DESCRIPTION
### Motivation / Background

Adds a new `:restart` option to `retry_job` and `retry_on` for jobs
including `ActiveJob::Continuable`. By default, retried jobs resume from the last
saved checkpoint. In some cases, certain exceptions require restarting the job
from the beginning instead of resuming partially completed work.

This feature allows developers to selectively reset the job progress when needed,
while preserving the default behavior for normal continuable jobs.

It also ensures that internal continuation interrupts (`Continuation::Interrupt`)
still always resume from the last checkpoint, keeping the built-in semantics of
`ActiveJob::Continuable` unchanged.

### Detail

* Add `restart` option to `retry_job`:
  `restart: false` → resume from last saved checkpoint (default)  
  `restart: true` → discard saved progress and start from the beginning
* Updated `retry_on` to accept and pass the `:restart` option to `retry_job`.
* Internal `Continuation::Interrupt` errors always force `restart: false` to maintain expected continuation flow and avoid resetting progress caused by normal pause or reschedule events.

Example usage:

```ruby
class MyJob < ApplicationJob
  include ActiveJob::Continuable

  self.resume_errors_after_advancing = false
  retry_on RestartError, restart: true
  retry_on StandardError

  def perform(*args)
    step :step1 do
      # some step logic
    end

    step :step2 do
      # some step 2 logic that may cause RestartError
    end
  end
end
```

The `:restart` option can also be defined at the job level through `resume_options`,
allowing the job to fully restart on any `StandardError`.

Example usage:

```ruby
class MyJob < ApplicationJob
  include ActiveJob::Continuable

  self.resume_options = { restart: true }

  def perform(*args)
    step :step1 do
      # some step logic
    end

    step :step2 do
      # some step 2 logic that may cause StandardError
    end
  end
end
```

### Additional information

Although I was thinking — it might make sense to name the option for
`resume_options` (and the corresponding `retry_job` method) something like
`:restart_on_exception`, to make the behavior more explicit,
while keeping `:restart` for the `retry_on` method. Do you think that would be a better choice?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
