### PR TITLE
Don't use moby in the docker-outside-of-docker feature

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -112,7 +112,7 @@ module Rails
 
           @features["ghcr.io/rails/devcontainer/features/activestorage"] = {} if options[:active_storage]
           @features["ghcr.io/devcontainers/features/node:1"] = {} if options[:node]
-          @features["ghcr.io/devcontainers/features/docker-outside-of-docker:1"] = {} if options[:kamal]
+          @features["ghcr.io/devcontainers/features/docker-outside-of-docker:1"] = { moby: false } if options[:kamal]
 
           @features.merge!(database.feature) if database.feature
 

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/devcontainer.json.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/devcontainer.json.tt
@@ -8,7 +8,7 @@
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    <%= features.map { |key, value| "\"#{key}\": #{value.as_json}" }.join(",\n    ") %>
+    <%= features.map { |key, value| "\"#{key}\": #{value.to_json}" }.join(",\n    ") %>
   },
 
 <%- if !container_env.empty? -%>

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -135,6 +135,9 @@ module GeneratorsTestHelper
   def assert_devcontainer_json_file
     assert_file ".devcontainer/devcontainer.json" do |content|
       yield JSON.load(content)
+    rescue JSON::ParserError
+      puts "Failed to parse JSON: #{content}"
+      raise
     end
   end
 


### PR DESCRIPTION
Moby isn't available in debian trixie. that is now used for the base image.

See https://github.com/devcontainers/features/blob/eea561a9ad45c383c2d9832d2da031410be8b5a0/src/docker-outside-of-docker/install.sh#L205-L209