### PR TITLE
Skip `bundler-audit` for Ruby 3.5.0.dev with Bundler 4.0.0.dev tentatively

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,7 +142,8 @@ group :test do
 
   # Needed for Railties tests because it is included in generated apps.
   gem "brakeman"
-  gem "bundler-audit"
+  # Skip bundler-audit until https://github.com/rubysec/bundler-audit/issues/405 is resolved for Ruby 3.5.0dev
+  gem "bundler-audit" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.5.0")
 end
 
 platforms :ruby, :windows do


### PR DESCRIPTION
### Motivation / Background

This commit workarounds the Rails Nightly CI failure with Ruby 3.5.0.dev that installs the Bundler version 4.0.0.dev, which is not compatible with bundler-audit yet.

https://buildkite.com/rails/rails-nightly/builds/2964#0199cac6-9634-4a4f-b049-9340551022fe/157-209

### Detail

- Steps to reproduce Install Ruby 3.5.0.dev and follow these steps below.
```
git clone https://github.com/rails/rails
cd rails
rm Gemfile.lock
bundle install
```
- Actual result without this commit

```ruby
$ ruby -v
ruby 3.5.0dev (2025-10-09T21:11:53Z master 83d0b064c8) +PRISM [x86_64-linux]
$ gem -v
4.0.0.dev
$ bundler -v
4.0.0.dev
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Could not find compatible versions

Because bundler-audit >= 0.1.2, < 0.6.1 depends on bundler ~> 1.2
  and bundler-audit < 0.1.2 depends on bundler ~> 1.0,
  bundler-audit < 0.6.1 requires bundler >= 1.0, < 2.A.
And because bundler-audit >= 0.6.1 depends on bundler >= 1.2.0, < 3,
  bundler >= 1.0, < 3 is required.
Because the current Bundler version (4.0.0.dev) does not satisfy bundler >= 1.15.0, < 3
  and every version of rails depends on bundler >= 1.15.0,
  every version of rails requires bundler >= 3.
Thus, rails cannot be used.
So, because Gemfile depends on rails >= 0,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:2.7.2` and rerun bundler using `bundle _2.7.2_ install`
$
```

### Additional information
Refer to https://github.com/ruby/ruby/commit/afe40df42331e338411c84714ca5d21383dac3d4
This workaround can be removed once https://github.com/rubysec/bundler-audit/issues/405 is fixed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
