### PR TITLE
Fix intermittent failure in test_timeout_in_fixture_set_insertion_doesnt_query_closed_connection

### DIFF
--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -33,7 +33,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
       ["traffic_lights", [
         { "location" => "US", "state" => ["NY"], "long_state" => ["a"] },
       ]]
-    ] * 1000
+    ] * 2000
 
     assert_raises(Timeout::Error) do
       Timeout.timeout(0.1) do


### PR DESCRIPTION
### Motivation / Background

This pull request fixes intermittent failure in test_timeout_in_fixture_set_insertion_doesnt_query_closed_connection .

### Detail

Increase fixtures from 1000 to 2000 to make the timeout deterministic. On my AMD Ryzen 9 7940HS this test fails about once in ten runs with 1000 because the insert sometimes finishes within 0.1 seconds and no Timeout::Error is raised.

```ruby
$ ARCONN=trilogy bin/test test/cases/adapters/trilogy/trilogy_adapter_test.rb -n test_timeout_in_fixture_set_insertion_doesnt_query_closed_connection
Using trilogy
Run options: -n test_timeout_in_fixture_set_insertion_doesnt_query_closed_connection --seed 13404

F

Failure:
TrilogyAdapterTest#test_timeout_in_fixture_set_insertion_doesnt_query_closed_connection [test/cases/adapters/trilogy/trilogy_adapter_test.rb:38]:
Timeout::Error expected but nothing was raised.

bin/test test/cases/adapters/trilogy/trilogy_adapter_test.rb:31

Finished in 0.097361s, 10.2710 runs/s, 10.2710 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
