### PR TITLE
De-couple `@rails/actiontext/attachment_upload.js` from `Trix.Attachment`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   De-couple `@rails/actiontext/attachment_upload.js` from `Trix.Attachment`
+
+    Implement `@rails/actiontext/index.js` with a `direct-upload:progress` event
+    listeners and `Promise` resolution.
+
+    *Sean Doyle*
+
 *   Capture block content for form helper methods
 
     ```erb

--- a/actiontext/app/javascript/actiontext/index.js
+++ b/actiontext/app/javascript/actiontext/index.js
@@ -4,7 +4,16 @@ addEventListener("trix-attachment-add", event => {
   const { attachment, target } = event
 
   if (attachment.file) {
-    const upload = new AttachmentUpload(attachment, target)
+    const upload = new AttachmentUpload(attachment, target, attachment.file)
+    const onProgress = event => attachment.setUploadProgress(event.detail.progress)
+
+    target.addEventListener("direct-upload:progress", onProgress)
+
     upload.start()
+      .then(attributes => attachment.setAttributes(attributes))
+      .catch(error => alert(error))
+      .finally(() => target.removeEventListener("direct-upload:progress", onProgress))
   }
 })
+
+export { AttachmentUpload }


### PR DESCRIPTION
### Motivation / Background

Like https://github.com/rails/rails/pull/51238, this proposal aims to disentangle Action Text from Trix. While it supports aspirations to build-in support for other editors, this change is minimal for the sake of maintaining backwards compatibility while also incrementally making Action Text's JavaScript Editor-agnostic.

### Detail

`AttachmentUpload` property access
---

First, change the `AttachmentUpload` implementation to be less coupled to Trix and [Trix.Attachment][] instances. Add an optional `file` argument to its constructor.

When the `file` argument **is not** specified, it will be set to a default value of `attachment.file`. In that case, the constructor assumes that `attachment` is an instance of `Trix.Attachment`, and will read a [File][] instance from its `.file` property. The `attachment` argument is retained and set to an `.attachment` property. Subsequent `direct-upload:`-prefixed events will continue to be dispatched with the value of the `attachment` argument assigned to the event's `detail.attachment` property. **This aims to maintain backwards compatibility**.

When the `file` argument **is** specified and set to a [File][] instance, it will be used throughout the rest of the implementation. This enables future Action Text editors that are not Trix to provide `File` instances directly in case their variety of "attachment" does not have `.file` property.

Replace `AttachmentUpload` calls with events
---

Next, remove any calls to `Trix.Attachment.setUploadProgress` and replace them with code in the `@rails/actiontext/index.js` module that listens for corresponding `direct-upload:progress` event listeners.

Make `AttachmentUpload.start()` return a [Promise][]
---

Maintain the behavior that dispatches `direct-upload:error` and `direct-upload:end` events. In addition to those hooks, editors can also wait for the resolution of the [Promise][] instance returned by `AttachmentUpload.start()`. The resolved value will include the `sgid` and `url` attributes. Remove calls to `Trix.Attachment.setAttributes`, and instead move the assignment of those attributes to the `@rails/actiontext/index.js` module's event listeners.

[Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
[File]: https://developer.mozilla.org/en-US/docs/Web/API/File
[Trix.Attachment]: https://github.com/basecamp/trix/blob/v2.1.15/src/trix/models/attachment.js

### Additional information

If this change were merged, there would be an opportunity to remove the `trix-add-attachment` event listener from the `@rails/actiontext/index.js` module. The newly introduced [action_text-trix](https://github.com/basecamp/trix/tree/main/action_text-trix) engine could provide that event listener instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
