### PR TITLE
Fix verbose redirect output and route source mapping

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -64,10 +64,8 @@ module ActionController
     def redirect_to(event)
       info { "Redirected to #{event.payload[:location]}" }
 
-      info do
-        if ActionDispatch.verbose_redirect_logs && (source = redirect_source_location)
-          "↳ #{source}"
-        end
+      if ActionDispatch.verbose_redirect_logs && (source = redirect_source_location)
+        info { "↳ #{source}" }
       end
     end
     subscribe_log_level :redirect_to, :info

--- a/actionpack/lib/action_dispatch/log_subscriber.rb
+++ b/actionpack/lib/action_dispatch/log_subscriber.rb
@@ -9,10 +9,8 @@ module ActionDispatch
 
       info { "Redirected to #{payload[:location]}" }
 
-      info do
-        if ActionDispatch.verbose_redirect_logs && (source = redirect_source_location)
-          "↳ #{source}"
-        end
+      if ActionDispatch.verbose_redirect_logs
+        info { "↳ #{payload[:source_location]}" }
       end
 
       info do
@@ -25,11 +23,6 @@ module ActionDispatch
       end
     end
     subscribe_log_level :redirect, :info
-
-    private
-      def redirect_source_location
-        backtrace_cleaner.first_clean_frame
-      end
   end
 end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -91,9 +91,5 @@ module ActionDispatch
       ActionDispatch::Http::Cache::Request.strict_freshness = app.config.action_dispatch.strict_freshness
       ActionDispatch.test_app = app
     end
-
-    initializer "action_dispatch.backtrace_cleaner" do
-      ActionDispatch::LogSubscriber.backtrace_cleaner = Rails.backtrace_cleaner
-    end
   end
 end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -318,6 +318,7 @@ class ACLogSubscriberTest < ActionController::TestCase
   end
 
   def test_verbose_redirect_logs
+    line = Another::LogSubscribersController.instance_method(:redirector).source_location.last + 1
     old_cleaner = ActionController::LogSubscriber.backtrace_cleaner
     ActionController::LogSubscriber.backtrace_cleaner = ActionController::LogSubscriber.backtrace_cleaner.dup
     ActionController::LogSubscriber.backtrace_cleaner.add_silencer { |location| !location.include?(__FILE__) }
@@ -327,7 +328,7 @@ class ACLogSubscriberTest < ActionController::TestCase
     wait
 
     assert_equal 4, logs.size
-    assert_match(/↳ #{__FILE__}/, logs[2])
+    assert_match(/↳ #{__FILE__}:#{line}/, logs[2])
   ensure
     ActionDispatch.verbose_redirect_logs = false
     ActionController::LogSubscriber.backtrace_cleaner = old_cleaner

--- a/actionpack/test/dispatch/routing/log_subscriber_test.rb
+++ b/actionpack/test/dispatch/routing/log_subscriber_test.rb
@@ -26,6 +26,7 @@ class RoutingLogSubscriberTest < ActionDispatch::IntegrationTest
   end
 
   test "verbose redirect logs" do
+    line = __LINE__ + 7
     old_cleaner = ActionDispatch::LogSubscriber.backtrace_cleaner
     ActionDispatch::LogSubscriber.backtrace_cleaner = ActionDispatch::LogSubscriber.backtrace_cleaner.dup
     ActionDispatch::LogSubscriber.backtrace_cleaner.add_silencer { |location| !location.include?(__FILE__) }
@@ -39,7 +40,7 @@ class RoutingLogSubscriberTest < ActionDispatch::IntegrationTest
     wait
 
     assert_equal 3, logs.size
-    assert_match(/↳ #{__FILE__}/, logs[1])
+    assert_match(/↳ #{__FILE__}:#{line}/, logs[1])
   ensure
     ActionDispatch.verbose_redirect_logs = false
     ActionDispatch::LogSubscriber.backtrace_cleaner = old_cleaner

--- a/guides/source/8_1_release_notes.md
+++ b/guides/source/8_1_release_notes.md
@@ -96,6 +96,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 ### Notable changes
 
+*   Redirects are now verbose in development for new Rails apps. To enable it in an existing app, add `config.action_dispatch.verbose_redirect_logs = true` to your `config/development.rb` file.
+
 Action View
 -----------
 

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -287,10 +287,11 @@ Additional keys may be added by the caller.
 #### `redirect.action_dispatch`
 
 | Key         | Value                                    |
-| ----------- | ---------------------------------------- |
-| `:status`   | HTTP response code                       |
-| `:location` | URL to redirect to                       |
-| `:request`  | The [`ActionDispatch::Request`][] object |
+| ------------------ | ---------------------------------------- |
+| `:status`          | HTTP response code                       |
+| `:location`        | URL to redirect to                       |
+| `:request`         | The [`ActionDispatch::Request`][] object |
+| `:source_location` | Source location of redirect in routes    |
 
 #### `request.action_dispatch`
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because https://github.com/rails/rails/pull/52297 isn't working exactly the way I expected.

Previously, we would sometimes log nil when verbose logs are disabled, and dispatch route level source locations could not be found.

### Detail

This Pull Request changes mostly dispatch code to record some source location in redirect endpoints when needed. This allows this feature to work in environments other than development, if needed, instead of depending on the other route source locations feature.

This adds an additional parameter to `redirect.action_dispatch` which may not be desirable. We can instead hack the caller trace to include the source location or use route source locations. Open to feedback on this, but I prefer to keep things simple here with an event parameter. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
