### PR TITLE
Improve support for SQLite database URIs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,8 @@
+*   Improve support for SQLite database URIs.
+
+    The `db:create` and `db:drop` tasks now correctly handle SQLite database URIs, and the
+    SQLite3Adapter will create the parent directory if it does not exist.
+
+    *Mike Dalessio*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -9,15 +9,15 @@ module ActiveRecord
       end
 
       def create
-        raise DatabaseAlreadyExists if File.exist?(db_config.database)
+        file = ConnectionAdapters::SQLite3Adapter.resolve_path(db_config.database)
+        raise DatabaseAlreadyExists if File.exist?(file)
 
         establish_connection
         connection
       end
 
       def drop
-        db_path = db_config.database
-        file = File.absolute_path?(db_path) ? db_path : File.join(root, db_path)
+        file = ConnectionAdapters::SQLite3Adapter.resolve_path(db_config.database, root: root)
         FileUtils.rm(file)
         FileUtils.rm_f(["#{file}-shm", "#{file}-wal"])
       rescue Errno::ENOENT => error

--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -22,8 +22,10 @@ module ActiveRecord
 
     def test_db_checks_database_exists
       ActiveRecord::Base.stub(:establish_connection, nil) do
-        assert_called_with(File, :exist?, [@database], returns: false) do
-          ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
+        assert_called_with(ConnectionAdapters::SQLite3Adapter, :resolve_path, [@database], returns: @database_root) do
+          assert_called_with(File, :exist?, [@database_root], returns: false) do
+            ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
+          end
         end
       end
     end
@@ -91,30 +93,12 @@ module ActiveRecord
       $stdout, $stderr = @original_stdout, @original_stderr
     end
 
-    def test_checks_db_dir_is_absolute
-      assert_called_with(File, :absolute_path?, [@database], returns: false) do
-        ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
-      end
-    end
-
-    def test_removes_file_with_absolute_path
-      assert_called_with(FileUtils, :rm, [@database_root]) do
-        assert_called_with(FileUtils, :rm_f, [["#{@database_root}-shm", "#{@database_root}-wal"]]) do
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration_root, @root
-        end
-      end
-    end
-
-    def test_generates_absolute_path_with_given_root
-      assert_called_with(File, :join, [@root, @database], returns: "#{@root}/#{@database}") do
-        ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
-      end
-    end
-
-    def test_removes_file_with_relative_path
-      assert_called_with(FileUtils, :rm, [@database_root]) do
-        assert_called_with(FileUtils, :rm_f, [["#{@database_root}-shm", "#{@database_root}-wal"]]) do
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
+    def test_removes_fully_resolved_db_path
+      assert_called_with(ConnectionAdapters::SQLite3Adapter, :resolve_path, [@database], root: "/rails/root", returns: @database_root) do
+        assert_called_with(FileUtils, :rm, [@database_root]) do
+          assert_called_with(FileUtils, :rm_f, [["#{@database_root}-shm", "#{@database_root}-wal"]]) do
+            ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
+          end
         end
       end
     end


### PR DESCRIPTION
### Motivation / Background

A SQLite database may be configured with a relative path, an absolute path, or a nonstandard `file:` URIs (possibly with params). When it is a URI, it's non-trivial to determine the filesystem path to the database, and Rails has historically not handled them very well.

Specifically, when using a SQLite database URI:

- `db:create` does not correctly check for file existence
- `db:drop` does not work at all
- opening a database connection to a nonexistent file does not implicitly create the parent directory

All of these things work fine if a filesystem path is used, and so I want this behavior when I use URIs.

### Detail

This commit introduces a new singleton method on the connection adapter, `SQLite3Adapter.resolve_path`, to reliably resolve a filesystem path from the database configuration.

It uses this method in the connection adapter's initializer to ensure the database file's directory exists. Previously the adapter omitted this check for database URIs.

It also introduces usage of this method in the `create` and `drop` database tasks which also previously did not fully support database URIs.

### More information

You can read up on SQLite URIs here: https://www.sqlite.org/uri.html

They are, unfortunately, nonstandard around the edges and so we're unable to "just use" Ruby's `URI` class.

This code has been extracted from the [`activerecord-tenanted` gem](https://github.com/basecamp/activerecord-tenanted) where it's been working well for us for many months.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
