### PR TITLE
Introduce Parameter Object: QueryIntent

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -76,6 +76,7 @@ module ActiveRecord
     autoload :Column
     autoload :PoolConfig
     autoload :PoolManager
+    autoload :QueryIntent
     autoload :SchemaCache
     autoload :BoundSchemaReflection, "active_record/connection_adapters/schema_cache"
     autoload :SchemaReflection, "active_record/connection_adapters/schema_cache"

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -565,21 +565,12 @@ module ActiveRecord
 
         # Lowest level way to execute a query. Doesn't check for illegal writes, doesn't annotate queries, yields a native result object.
         def raw_execute(intent)
-          sql = intent.sql
-          name = intent.name
-          binds = intent.binds
-          prepare = intent.prepare
-          async = intent.async
-          allow_retry = intent.allow_retry
-          materialize_transactions = intent.materialize_transactions
-          batch = intent.batch
-
-          intent.type_casted_binds = type_casted_binds = type_casted_binds(binds)
-          log(sql, name, binds, type_casted_binds, async: async, allow_retry: allow_retry) do |notification_payload|
+          intent.type_casted_binds = type_casted_binds(intent.binds)
+          log(intent) do |notification_payload|
             intent.notification_payload = notification_payload
-            with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-              result = perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
-              handle_warnings(result, sql)
+            with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: intent.materialize_transactions) do |conn|
+              result = perform_query(conn, intent.sql, intent.binds, intent.type_casted_binds, prepare: intent.prepare, notification_payload: intent.notification_payload, batch: intent.batch)
+              handle_warnings(result, intent.sql)
               result
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -569,14 +569,14 @@ module ActiveRecord
           log(intent) do |notification_payload|
             intent.notification_payload = notification_payload
             with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: intent.materialize_transactions) do |conn|
-              result = perform_query(conn, intent.sql, intent.binds, intent.type_casted_binds, prepare: intent.prepare, notification_payload: intent.notification_payload, batch: intent.batch)
+              result = perform_query(conn, intent)
               handle_warnings(result, intent.sql)
               result
             end
           end
         end
 
-        def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch:)
+        def perform_query(raw_connection, intent)
           raise NotImplementedError
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -574,8 +574,9 @@ module ActiveRecord
           materialize_transactions = intent.materialize_transactions
           batch = intent.batch
 
-          type_casted_binds = type_casted_binds(binds)
+          intent.type_casted_binds = type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds, async: async, allow_retry: allow_retry) do |notification_payload|
+            intent.notification_payload = notification_payload
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
               result = perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
               handle_warnings(result, sql)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1203,7 +1203,7 @@ module ActiveRecord
 
             instrumenter.instrument(
               "sql.active_record",
-              sql:               intent.sql,
+              sql:               intent.processed_sql,
               name:              intent.name,
               binds:             intent.binds,
               type_casted_binds: intent.type_casted_binds,
@@ -1240,7 +1240,7 @@ module ActiveRecord
           end
         rescue ActiveRecord::StatementInvalid => ex
           if intent
-            raise ex.set_query(intent.sql, intent.binds)
+            raise ex.set_query(intent.processed_sql, intent.binds)
           else
             raise ex.set_query(sql, binds)
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -986,7 +986,11 @@ module ActiveRecord
           end.join(", ")
 
           # ...and send them all in one query
-          raw_execute("SET #{encoding} #{sql_mode_assignment} #{variable_assignments}", "SCHEMA")
+          intent = QueryIntent.new(
+            sql: "SET #{encoding} #{sql_mode_assignment} #{variable_assignments}",
+            name: "SCHEMA"
+          )
+          raw_execute(intent)
         end
 
         def column_definitions(table_name) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -987,7 +987,7 @@ module ActiveRecord
 
           # ...and send them all in one query
           intent = QueryIntent.new(
-            sql: "SET #{encoding} #{sql_mode_assignment} #{variable_assignments}",
+            processed_sql: "SET #{encoding} #{sql_mode_assignment} #{variable_assignments}",
             name: "SCHEMA"
           )
           raw_execute(intent)

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -16,7 +16,17 @@ module ActiveRecord
         private
           def execute_batch(statements, name = nil, **kwargs)
             combine_multi_statements(statements).each do |statement|
-              raw_execute(statement, name, batch: true, **kwargs)
+              intent = QueryIntent.new(
+                sql: statement,
+                name: name,
+                batch: true,
+                binds: kwargs[:binds] || [],
+                prepare: kwargs[:prepare] || false,
+                async: kwargs[:async] || false,
+                allow_retry: kwargs[:allow_retry] || false,
+                materialize_transactions: kwargs[:materialize_transactions] != false
+              )
+              raw_execute(intent)
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -202,7 +202,17 @@ module ActiveRecord
           end
 
           def execute_batch(statements, name = nil, **kwargs)
-            raw_execute(combine_multi_statements(statements), name, batch: true, **kwargs)
+            intent = QueryIntent.new(
+              sql: combine_multi_statements(statements),
+              name: name,
+              batch: true,
+              binds: kwargs[:binds] || [],
+              prepare: kwargs[:prepare] || false,
+              async: kwargs[:async] || false,
+              allow_retry: kwargs[:allow_retry] || false,
+              materialize_transactions: kwargs[:materialize_transactions] != false
+            )
+            raw_execute(intent)
           end
 
           def build_truncate_statements(table_names)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -42,13 +42,13 @@ module ActiveRecord
           @notice_receiver_sql_warnings = []
         end
 
-        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
+        def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
           if use_insert_returning? || pk == false
             super
           else
-            result = internal_exec_query(sql, name, binds)
+            result = raw_exec_query(intent)
             unless sequence_name
-              table_ref = extract_table_ref_from_insert_sql(sql)
+              table_ref = extract_table_ref_from_insert_sql(intent.raw_sql)
               if table_ref
                 pk = primary_key(table_ref) if pk.nil?
                 pk = suppress_composite_primary_key(pk)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1027,10 +1027,10 @@ module ActiveRecord
           # If using Active Record's time zone support configure the connection
           # to return TIMESTAMP WITH ZONE types in UTC.
           if default_timezone == :utc
-            intent = QueryIntent.new(sql: "SET SESSION timezone TO 'UTC'", name: "SCHEMA")
+            intent = QueryIntent.new(processed_sql: "SET SESSION timezone TO 'UTC'", name: "SCHEMA")
             raw_execute(intent)
           else
-            intent = QueryIntent.new(sql: "SET SESSION timezone TO DEFAULT", name: "SCHEMA")
+            intent = QueryIntent.new(processed_sql: "SET SESSION timezone TO DEFAULT", name: "SCHEMA")
             raw_execute(intent)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1027,9 +1027,11 @@ module ActiveRecord
           # If using Active Record's time zone support configure the connection
           # to return TIMESTAMP WITH ZONE types in UTC.
           if default_timezone == :utc
-            raw_execute("SET SESSION timezone TO 'UTC'", "SCHEMA")
+            intent = QueryIntent.new(sql: "SET SESSION timezone TO 'UTC'", name: "SCHEMA")
+            raw_execute(intent)
           else
-            raw_execute("SET SESSION timezone TO DEFAULT", "SCHEMA")
+            intent = QueryIntent.new(sql: "SET SESSION timezone TO DEFAULT", name: "SCHEMA")
+            raw_execute(intent)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -3,13 +3,17 @@
 module ActiveRecord
   module ConnectionAdapters
     class QueryIntent # :nodoc:
-      attr_reader :sql, :name, :binds, :prepare, :allow_retry,
+      attr_reader :raw_sql, :name, :binds, :prepare, :allow_retry,
                   :materialize_transactions, :batch
-      attr_accessor :async, :type_casted_binds, :notification_payload
+      attr_accessor :async, :processed_sql, :type_casted_binds, :notification_payload
 
-      def initialize(sql:, name: "SQL", binds: [], prepare: false, async: false,
+      def initialize(raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, async: false,
                      allow_retry: false, materialize_transactions: true, batch: false)
-        @sql = sql
+        if raw_sql.nil? && processed_sql.nil?
+          raise ArgumentError, "Either raw_sql or processed_sql must be provided"
+        end
+
+        @raw_sql = raw_sql
         @name = name
         @binds = binds
         @prepare = prepare
@@ -17,6 +21,7 @@ module ActiveRecord
         @allow_retry = allow_retry
         @materialize_transactions = materialize_transactions
         @batch = batch
+        @processed_sql = processed_sql
         @type_casted_binds = nil
         @notification_payload = nil
       end
@@ -24,7 +29,8 @@ module ActiveRecord
       # Returns a hash representation of the QueryIntent for debugging/introspection
       def to_h
         {
-          sql: sql,
+          raw_sql: raw_sql,
+          processed_sql: processed_sql,
           name: name,
           binds: binds,
           prepare: prepare,

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -3,8 +3,9 @@
 module ActiveRecord
   module ConnectionAdapters
     class QueryIntent # :nodoc:
-      attr_reader :sql, :name, :binds, :prepare, :async, :allow_retry,
+      attr_reader :sql, :name, :binds, :prepare, :allow_retry,
                   :materialize_transactions, :batch
+      attr_accessor :async, :type_casted_binds, :notification_payload
 
       def initialize(sql:, name: "SQL", binds: [], prepare: false, async: false,
                      allow_retry: false, materialize_transactions: true, batch: false)
@@ -16,7 +17,8 @@ module ActiveRecord
         @allow_retry = allow_retry
         @materialize_transactions = materialize_transactions
         @batch = batch
-        freeze
+        @type_casted_binds = nil
+        @notification_payload = nil
       end
 
       # Returns a hash representation of the QueryIntent for debugging/introspection
@@ -29,7 +31,9 @@ module ActiveRecord
           async: async,
           allow_retry: allow_retry,
           materialize_transactions: materialize_transactions,
-          batch: batch
+          batch: batch,
+          type_casted_binds: type_casted_binds,
+          notification_payload: notification_payload
         }
       end
 

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -3,9 +3,9 @@
 module ActiveRecord
   module ConnectionAdapters
     class QueryIntent # :nodoc:
-      attr_reader :arel, :raw_sql, :name, :binds, :prepare, :allow_retry,
+      attr_reader :arel, :name, :prepare, :allow_retry,
                   :materialize_transactions, :batch
-      attr_accessor :async, :processed_sql, :type_casted_binds, :notification_payload
+      attr_accessor :raw_sql, :binds, :async, :processed_sql, :type_casted_binds, :notification_payload
 
       def initialize(arel: nil, raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, async: false,
                      allow_retry: false, materialize_transactions: true, batch: false)

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    class QueryIntent # :nodoc:
+      attr_reader :sql, :name, :binds, :prepare, :async, :allow_retry,
+                  :materialize_transactions, :batch
+
+      def initialize(sql:, name: "SQL", binds: [], prepare: false, async: false,
+                     allow_retry: false, materialize_transactions: true, batch: false)
+        @sql = sql
+        @name = name
+        @binds = binds
+        @prepare = prepare
+        @async = async
+        @allow_retry = allow_retry
+        @materialize_transactions = materialize_transactions
+        @batch = batch
+        freeze
+      end
+
+      # Returns a hash representation of the QueryIntent for debugging/introspection
+      def to_h
+        {
+          sql: sql,
+          name: name,
+          binds: binds,
+          prepare: prepare,
+          async: async,
+          allow_retry: allow_retry,
+          materialize_transactions: materialize_transactions,
+          batch: batch
+        }
+      end
+
+      # Returns a string representation showing key attributes
+      def inspect
+        "#<#{self.class.name} name=#{name.inspect} allow_retry=#{allow_retry} materialize_transactions=#{materialize_transactions}>"
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -83,23 +83,23 @@ module ActiveRecord
             end
           end
 
-          def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch: false)
+          def perform_query(raw_connection, intent)
             total_changes_before_query = raw_connection.total_changes
             affected_rows = nil
 
-            if batch
-              raw_connection.execute_batch2(sql)
+            if intent.batch
+              raw_connection.execute_batch2(intent.sql)
             else
-              stmt = if prepare
-                @statements[sql] ||= raw_connection.prepare(sql)
-                @statements[sql].reset!
+              stmt = if intent.prepare
+                @statements[intent.sql] ||= raw_connection.prepare(intent.sql)
+                @statements[intent.sql].reset!
               else
                 # Don't cache statements if they are not prepared.
-                raw_connection.prepare(sql)
+                raw_connection.prepare(intent.sql)
               end
               begin
-                unless binds.nil? || binds.empty?
-                  stmt.bind_params(type_casted_binds)
+                unless intent.binds.nil? || intent.binds.empty?
+                  stmt.bind_params(intent.type_casted_binds)
                 end
                 result = if stmt.column_count.zero? # No return
                   stmt.step
@@ -123,13 +123,13 @@ module ActiveRecord
                   ActiveRecord::Result.new(stmt.columns, rows, stmt.types.map { |t| type_map.lookup(t) }, affected_rows: affected_rows)
                 end
               ensure
-                stmt.close unless prepare
+                stmt.close unless intent.prepare
               end
             end
             verified!
 
-            notification_payload[:affected_rows] = affected_rows
-            notification_payload[:row_count] = result&.length || 0
+            intent.notification_payload[:affected_rows] = affected_rows
+            intent.notification_payload[:row_count] = result&.length || 0
             result
           end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -88,14 +88,14 @@ module ActiveRecord
             affected_rows = nil
 
             if intent.batch
-              raw_connection.execute_batch2(intent.sql)
+              raw_connection.execute_batch2(intent.processed_sql)
             else
               stmt = if intent.prepare
-                @statements[intent.sql] ||= raw_connection.prepare(intent.sql)
-                @statements[intent.sql].reset!
+                @statements[intent.processed_sql] ||= raw_connection.prepare(intent.processed_sql)
+                @statements[intent.processed_sql].reset!
               else
                 # Don't cache statements if they are not prepared.
-                raw_connection.prepare(intent.sql)
+                raw_connection.prepare(intent.processed_sql)
               end
               begin
                 unless intent.binds.nil? || intent.binds.empty?
@@ -146,7 +146,7 @@ module ActiveRecord
           def execute_batch(statements, name = nil, **kwargs)
             sql = combine_multi_statements(statements)
             intent = QueryIntent.new(
-              sql: sql,
+              processed_sql: sql,
               name: name,
               batch: true,
               binds: kwargs[:binds] || [],

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -145,7 +145,17 @@ module ActiveRecord
 
           def execute_batch(statements, name = nil, **kwargs)
             sql = combine_multi_statements(statements)
-            raw_execute(sql, name, batch: true, **kwargs)
+            intent = QueryIntent.new(
+              sql: sql,
+              name: name,
+              batch: true,
+              binds: kwargs[:binds] || [],
+              prepare: kwargs[:prepare] || false,
+              async: kwargs[:async] || false,
+              allow_retry: kwargs[:allow_retry] || false,
+              materialize_transactions: kwargs[:materialize_transactions] != false
+            )
+            raw_execute(intent)
           end
 
           def build_truncate_statement(table_name)

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -4,9 +4,14 @@ module ActiveRecord
   module ConnectionAdapters
     module Trilogy
       module DatabaseStatements
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          sql, _binds = sql_for_insert(sql, pk, binds, returning)
-          internal_execute(sql, name)
+        def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
+          sql, binds = sql_for_insert(intent.raw_sql, pk, intent.binds, returning)
+          intent.raw_sql = sql
+          intent.binds = binds
+
+          # AbstractAdapter calls raw_exec_query (returning an AR::Result), but
+          # our last_inserted_id needs the raw Trilogy result object
+          raw_execute(intent)
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -61,7 +61,17 @@ module ActiveRecord
 
           def execute_batch(statements, name = nil, **kwargs)
             combine_multi_statements(statements).each do |statement|
-              raw_execute(statement, name, batch: true, **kwargs)
+              intent = QueryIntent.new(
+                sql: statement,
+                name: name,
+                batch: true,
+                binds: kwargs[:binds] || [],
+                prepare: kwargs[:prepare] || false,
+                async: kwargs[:async] || false,
+                allow_retry: kwargs[:allow_retry] || false,
+                materialize_transactions: kwargs[:materialize_transactions] != false
+              )
+              raw_execute(intent)
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -24,7 +24,7 @@ module ActiveRecord
               raw_connection.query_flags &= ~::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
             end
 
-            result = raw_connection.query(intent.sql)
+            result = raw_connection.query(intent.processed_sql)
             while raw_connection.more_results_exist?
               raw_connection.next_result
             end
@@ -62,7 +62,7 @@ module ActiveRecord
           def execute_batch(statements, name = nil, **kwargs)
             combine_multi_statements(statements).each do |statement|
               intent = QueryIntent.new(
-                sql: statement,
+                processed_sql: statement,
                 name: name,
                 batch: true,
                 binds: kwargs[:binds] || [],

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -10,8 +10,8 @@ module ActiveRecord
         end
 
         private
-          def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch: false)
-            reset_multi_statement = if batch && !@config[:multi_statement]
+          def perform_query(raw_connection, intent)
+            reset_multi_statement = if intent.batch && !@config[:multi_statement]
               raw_connection.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_ON)
               true
             end
@@ -24,14 +24,14 @@ module ActiveRecord
               raw_connection.query_flags &= ~::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
             end
 
-            result = raw_connection.query(sql)
+            result = raw_connection.query(intent.sql)
             while raw_connection.more_results_exist?
               raw_connection.next_result
             end
             verified!
 
-            notification_payload[:affected_rows] = result.affected_rows
-            notification_payload[:row_count] = result.count
+            intent.notification_payload[:affected_rows] = result.affected_rows
+            intent.notification_payload[:row_count] = result.count
             result
           ensure
             if reset_multi_statement && active?

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -168,23 +168,10 @@ module ActiveRecord
       end
 
       def exec_query(connection, intent, async: false)
-        # Create a new intent with the actual async execution mode for accurate logging
-        if intent.async != async
-          actual_intent = ConnectionAdapters::QueryIntent.new(
-            sql: intent.sql,
-            name: intent.name,
-            binds: intent.binds,
-            prepare: intent.prepare,
-            async: async,
-            allow_retry: intent.allow_retry,
-            materialize_transactions: intent.materialize_transactions,
-            batch: intent.batch
-          )
-        else
-          actual_intent = intent
-        end
+        # Update intent with actual async execution mode for accurate logging
+        intent.async = async
 
-        connection.raw_exec_query(actual_intent)
+        connection.raw_exec_query(intent)
       end
 
       class SelectAll < FutureResult # :nodoc:

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record/connection_adapters/query_intent"
+
 module ActiveRecord
   class FutureResult # :nodoc:
     class Complete
@@ -63,13 +65,12 @@ module ActiveRecord
 
     attr_reader :lock_wait
 
-    def initialize(pool, *args, **kwargs)
+    def initialize(pool, intent)
       @mutex = Mutex.new
 
       @session = nil
       @pool = pool
-      @args = args
-      @kwargs = kwargs
+      @intent = intent
 
       @pending = true
       @error = nil
@@ -159,15 +160,31 @@ module ActiveRecord
       end
 
       def execute_query(connection, async: false)
-        @result = exec_query(connection, *@args, **@kwargs, async: async)
+        @result = exec_query(connection, @intent, async: async)
       rescue => error
         @error = error
       ensure
         @pending = false
       end
 
-      def exec_query(connection, *args, **kwargs)
-        connection.raw_exec_query(*args, **kwargs)
+      def exec_query(connection, intent, async: false)
+        # Create a new intent with the actual async execution mode for accurate logging
+        if intent.async != async
+          actual_intent = ConnectionAdapters::QueryIntent.new(
+            sql: intent.sql,
+            name: intent.name,
+            binds: intent.binds,
+            prepare: intent.prepare,
+            async: async,
+            allow_retry: intent.allow_retry,
+            materialize_transactions: intent.materialize_transactions,
+            batch: intent.batch
+          )
+        else
+          actual_intent = intent
+        end
+
+        connection.raw_exec_query(actual_intent)
       end
 
       class SelectAll < FutureResult # :nodoc:

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
@@ -175,13 +175,13 @@ module ActiveRecord
       end
 
       first_begin_failed = false
-      @connection.singleton_class.define_method(:perform_query) do |raw_connection, sql, *args, **kwargs|
+      @connection.singleton_class.define_method(:perform_query) do |raw_connection, intent, *args, **kwargs|
         # Simulates the first BEGIN attempt failing
-        if sql.include?("BEGIN") && !first_begin_failed
+        if intent.sql.include?("BEGIN") && !first_begin_failed
           first_begin_failed = true
           raise ActiveRecord::ConnectionFailed, "Simulated failure"
         end
-        super(raw_connection, sql, *args, **kwargs)
+        super(raw_connection, intent, *args, **kwargs)
       end
 
       Sample.transaction(isolation: :read_committed) do

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
@@ -177,7 +177,7 @@ module ActiveRecord
       first_begin_failed = false
       @connection.singleton_class.define_method(:perform_query) do |raw_connection, intent, *args, **kwargs|
         # Simulates the first BEGIN attempt failing
-        if intent.sql.include?("BEGIN") && !first_begin_failed
+        if intent.processed_sql.include?("BEGIN") && !first_begin_failed
           first_begin_failed = true
           raise ActiveRecord::ConnectionFailed, "Simulated failure"
         end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -527,7 +527,8 @@ module ActiveRecord
 
       def test_raise_error_when_cannot_translate_exception
         assert_raise TypeError do
-          @connection.send(:log, nil) { @connection.execute(nil) }
+          intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(sql: nil)
+          @connection.send(:log, intent) { @connection.execute(nil) }
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -527,8 +527,7 @@ module ActiveRecord
 
       def test_raise_error_when_cannot_translate_exception
         assert_raise TypeError do
-          intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(sql: nil)
-          @connection.send(:log, intent) { @connection.execute(nil) }
+          @connection.execute(:not_a_query)
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -172,28 +172,36 @@ module ActiveRecord
 
       def test_exec_insert_with_returning_disabled
         connection = connection_without_insert_returning
-        result = connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
+        result = assert_deprecated(ActiveRecord.deprecator) do
+          connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
+        end
         expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
         assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_with_returning_disabled_and_no_sequence_name_given
         connection = connection_without_insert_returning
-        result = connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
+        result = assert_deprecated(ActiveRecord.deprecator) do
+          connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
+        end
         expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
         assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_default_values_with_returning_disabled_and_no_sequence_name_given
         connection = connection_without_insert_returning
-        result = connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
+        result = assert_deprecated(ActiveRecord.deprecator) do
+          connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
+        end
         expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
         assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_default_values_quoted_schema_with_returning_disabled_and_no_sequence_name_given
         connection = connection_without_insert_returning
-        result = connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
+        result = assert_deprecated(ActiveRecord.deprecator) do
+          connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
+        end
         expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
         assert_equal expect.to_i, result.rows.first.first
       end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -96,7 +96,9 @@ module ActiveRecord
       def test_exec_insert
         with_example_table do
           vals = [Relation::QueryAttribute.new("number", 10, Type::Value.new)]
-          @conn.exec_insert("insert into ex (number) VALUES (?)", "SQL", vals)
+          assert_deprecated(ActiveRecord.deprecator) do
+            @conn.exec_insert("insert into ex (number) VALUES (?)", "SQL", vals)
+          end
 
           result = @conn.exec_query(
             "select number from ex where number = ?", "SQL", vals)
@@ -109,7 +111,9 @@ module ActiveRecord
       def test_exec_insert_with_quote
         with_example_table do
           vals = [Relation::QueryAttribute.new("number", 10, Type::Value.new)]
-          @conn.exec_insert("insert into \"ex\" (number) VALUES (?)", "SQL", vals)
+          assert_deprecated(ActiveRecord.deprecator) do
+            @conn.exec_insert("insert into \"ex\" (number) VALUES (?)", "SQL", vals)
+          end
 
           result = @conn.exec_query(
             "select number from \"ex\" where number = ?", "SQL", vals)
@@ -536,7 +540,9 @@ module ActiveRecord
           insert_returning: false,
         )
         with_example_table do
-          result = @conn.exec_insert("insert into ex (number) VALUES ('foo')", nil, [], "id")
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            @conn.exec_insert("insert into ex (number) VALUES ('foo')", nil, [], "id")
+          end
           expect = @conn.query("select max(id) from ex").first.first
           assert_equal expect.to_i, result.rows.first.first
         end
@@ -551,7 +557,9 @@ module ActiveRecord
           insert_returning: false,
         )
         with_example_table do
-          result = @conn.exec_insert("insert into ex DEFAULT VALUES", nil, [], "id")
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            @conn.exec_insert("insert into ex DEFAULT VALUES", nil, [], "id")
+          end
           expect = @conn.query("select max(id) from ex").first.first
           assert_equal expect.to_i, result.rows.first.first
         end

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -8,7 +8,9 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
   end
 
   def test_exec_insert
-    result = @connection.exec_insert("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)", nil, [])
+    result = assert_deprecated(ActiveRecord.deprecator) do
+      @connection.exec_insert("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)", nil, [])
+    end
     assert_not_nil @connection.send(:last_inserted_id, result)
   end
 

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -24,6 +24,7 @@ module ActiveRecord
       def test_rename_table_should_work_with_reserved_words
         renamed = false
 
+        connection.drop_table :old_references, if_exists: true
         connection.rename_table :references, :old_references
         connection.rename_table :test_models, :references
 

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -168,14 +168,14 @@ module ActiveRecord
         old_log = ActiveRecord::Base.connection.method(:log)
         ActiveRecord::Base.connection.singleton_class.undef_method(:log)
 
-        ActiveRecord::Base.connection.singleton_class.define_method(:log) do |*args, **kwargs, &block|
-          unless kwargs[:async]
-            return old_log.call(*args, **kwargs, &block)
+        ActiveRecord::Base.connection.singleton_class.define_method(:log) do |intent, *args, **kwargs, &block|
+          unless intent.async
+            return old_log.call(intent, *args, **kwargs, &block)
           end
 
           latch1.count_down
           latch2.wait
-          old_log.call(*args, **kwargs, &block)
+          old_log.call(intent, *args, **kwargs, &block)
         end
 
         Post.async_count

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
     test "message contains no sql" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
-      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(sql: sql, name: Book.name)
+      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(processed_sql: sql, name: Book.name)
       error = assert_raises(ActiveRecord::StatementInvalid) do
         Book.lease_connection.send(:log, intent) do
           Book.lease_connection.send(:with_raw_connection) do
@@ -33,7 +33,7 @@ module ActiveRecord
     test "statement and binds are set on select" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       binds = [Minitest::Mock.new, Minitest::Mock.new]
-      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(sql: sql, name: Book.name, binds: binds)
+      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(processed_sql: sql, name: Book.name, binds: binds)
       error = assert_raises(ActiveRecord::StatementInvalid) do
         Book.lease_connection.send(:log, intent) do
           Book.lease_connection.send(:with_raw_connection) do

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -19,8 +19,9 @@ module ActiveRecord
 
     test "message contains no sql" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
+      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(sql: sql, name: Book.name)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        Book.lease_connection.send(:log, sql, Book.name) do
+        Book.lease_connection.send(:log, intent) do
           Book.lease_connection.send(:with_raw_connection) do
             raise MockDatabaseError
           end
@@ -32,8 +33,9 @@ module ActiveRecord
     test "statement and binds are set on select" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       binds = [Minitest::Mock.new, Minitest::Mock.new]
+      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(sql: sql, name: Book.name, binds: binds)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        Book.lease_connection.send(:log, sql, Book.name, binds) do
+        Book.lease_connection.send(:log, intent) do
           Book.lease_connection.send(:with_raw_connection) do
             raise MockDatabaseError
           end


### PR DESCRIPTION
This has been on my todo list for a while, as we've continued to gradually accumulate extra context that we end up needing to pass along with queries.

~~**This is a draft** -- for exploration, I've changed a number of low-level-but-public APIs. Even if we agree that's a reasonable end-goal, they would require deprecations along the way.~~

Affected Public APIs:

`exec_update` and `exec_delete` are deprecated, pointing callers to `update` and `delete` instead. Those methods (the only internal callers) now just `affected_rows(raw_execute(intent))` directly.

`exec_insert` is likewise deprecated in favour of `insert`. We [currently?] still need to keep it for overriding, so the internal intent-using one is now `_exec_insert`. That's ugly, but I'm hopeful we can later evolve it away, and failing that we'll be able to reclaim `exec_insert` post-deprecation.

`log` is now called exclusively with an `intent`, but still accepts `sql, name, binds` calls too (with deprecation). In practice I don't anticipate many people calling it with existing parameters, but it is technically documented (as a `:doc:` private method). I anticipate most external users of `log` are overriding/wrapping it, so will be broken by the signature change on our existing calls -- but I think that's unavoidable.