### PR TITLE
Revert "Skip ApiAppGeneratorTest and AppGeneratorTest for Ruby 3.5.0dev tentatively"

### DIFF
--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -134,8 +134,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_app_update_does_not_generate_public_files
-    skip "bundler-audit does not support Ruby 3.5.0dev yet" unless Gem.loaded_specs.key?("bundler-audit")
-
     run_generator
     run_app_update
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -97,10 +97,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
   # brings setup, teardown, and some tests
   include SharedGeneratorTests
 
-  setup do
-    skip "bundler-audit does not support Ruby 3.5.0dev yet" unless Gem.loaded_specs.key?("bundler-audit")
-  end
-
   def default_files
     ::DEFAULT_APP_FILES
   end


### PR DESCRIPTION
Reverts rails/rails#55893

### Background
Skipping tests are not allowed in Rails CI.

https://buildkite.com/rails/rails-nightly/builds/2984#0199df60-17e8-4246-a15d-7ce642a8017e/1476-1482

```
F

Failure:
AppGeneratorTest#test_devcontainer [test/generators/app_generator_test.rb:101]:
Skipping tests is not allowed in this environment (bundler-audit does not support Ruby 3.5.0dev yet)
Tests should only be skipped when the environment is missing a required dependency.
This should never happen on CI.
```

Refer to 
https://github.com/rails/rails/pull/49806
https://github.com/rails/rails/pull/49455
