### PR TITLE
Fix ActiveRecord::Migration.check_all_pending! to use a separate connection class

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Prevent connection pool errors when calling `ActiveRecord::Migration.check_all_pending!`
+
+    Use `ActiveRecord::PendingMigrationConnection` so that `ActiveRecord::Base` connection pools are
+    not affected.
+
+    *Heinrich Lee Yu*
+
 *   Fix SQLite3 data loss during table alterations with CASCADE foreign keys.
 
     When altering a table in SQLite3 that is referenced by child tables with

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -688,24 +688,6 @@ module ActiveRecord
         delegate || superclass.nearest_delegate
       end
 
-      # Raises ActiveRecord::PendingMigrationError error if any migrations are pending
-      # for all database configurations in an environment.
-      def check_all_pending!
-        pending_migrations = []
-
-        ActiveRecord::Tasks::DatabaseTasks.with_temporary_pool_for_each(env: env) do |pool|
-          if pending = pool.migration_context.open.pending_migrations
-            pending_migrations << pending
-          end
-        end
-
-        migrations = pending_migrations.flatten
-
-        if migrations.any?
-          raise ActiveRecord::PendingMigrationError.new(pending_migrations: migrations)
-        end
-      end
-
       def load_schema_if_pending!
         if any_schema_needs_update?
           load_schema!
@@ -736,13 +718,16 @@ module ActiveRecord
         @disable_ddl_transaction = true
       end
 
-      def check_pending_migrations # :nodoc:
+      # Raises ActiveRecord::PendingMigrationError error if any migrations are pending
+      # for all database configurations in an environment.
+      def check_pending_migrations
         migrations = pending_migrations
 
         if migrations.any?
           raise ActiveRecord::PendingMigrationError.new(pending_migrations: migrations)
         end
       end
+      alias :check_all_pending! :check_pending_migrations
 
       private
         def any_schema_needs_update?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

GitLab started using `ActiveRecord::Migration.check_all_pending!` to check for pending migrations and we saw connection pool errors because the `ActiveRecord::Base` connection pool was being mutated when this check ran.

More details in https://gitlab.com/gitlab-org/gitlab/-/issues/573581

### Detail

This prevents `ActiveRecord::Migration.check_all_pending!` from mutating `ActiveRecord::Base` connection pools which can cause errors when other threads are also using the same connection.

I just made this method an alias of `check_pending_migrations` since they achieve the same thing but with `check_pending_migrations` using a separate `PendingMigrationConnection`. 

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
