### PR TITLE
Address test_verbose_redirect_logs failure for Ruby 3.5.0dev

### DIFF
--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -318,7 +318,7 @@ class ACLogSubscriberTest < ActionController::TestCase
   end
 
   def test_verbose_redirect_logs
-    line = Another::LogSubscribersController.instance_method(:redirector).source_location.last + 1
+    line = Another::LogSubscribersController.instance_method(:redirector).source_location[1] + 1
     old_cleaner = ActionController::LogSubscriber.backtrace_cleaner
     ActionController::LogSubscriber.backtrace_cleaner = ActionController::LogSubscriber.backtrace_cleaner.dup
     ActionController::LogSubscriber.backtrace_cleaner.add_silencer { |location| !location.include?(__FILE__) }


### PR DESCRIPTION

### Motivation / Background

This pull request addresses the following failure with Ruby 3.5.0.dev at https://buildkite.com/rails/rails-nightly/builds/2989#0199e486-8274-4e30-99af-ff93b33b2cfb/1393-1405 since `source_location` includes start_column, end_line, end_column.

Follow up #55889

### Detail
- Fixed by this commit
```ruby
$ ruby -v
ruby 3.5.0dev (2025-10-14T22:26:08Z master df5d63cfa2) +PRISM [x86_64-linux]
$ bin/test test/controller/log_subscriber_test.rb:331
Running 36 tests in a single process (parallelization threshold is 50)
Run options: --seed 1476

F

Failure:
ACLogSubscriberTest#test_verbose_redirect_logs [test/controller/log_subscriber_test.rb:331]:
Expected /\u21B3 \/home\/yahonda\/src\/github.com\/rails\/rails\/actionpack\/test\/controller\/log_subscriber_test.rb:8/ to match "↳ /home/yahonda/src/github.com/rails/rails/actionpack/test/controller/log_subscriber_test.rb:28:in 'Another::LogSubscribersController#redirector'".

bin/test test/controller/log_subscriber_test.rb:320

Finished in 0.063581s, 15.7279 runs/s, 47.1836 assertions/s.
1 runs, 3 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information
- Modified to show the entire source_location
```ruby
$ git diff -- test/controller/log_subscriber_test.rb
diff --git a/actionpack/test/controller/log_subscriber_test.rb b/actionpack/test/controller/log_subscriber_test.rb
index 0b6e5b0443..e19848b769 100644
--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -318,6 +318,7 @@ def test_filter_redirect_bad_uri
   end

   def test_verbose_redirect_logs
+    pp Another::LogSubscribersController.instance_method(:redirector).source_location
     line = Another::LogSubscribersController.instance_method(:redirector).source_location.last + 1
     old_cleaner = ActionController::LogSubscriber.backtrace_cleaner
     ActionController::LogSubscriber.backtrace_cleaner = ActionController::LogSubscriber.backtrace_cleaner.dup
$
```

- Ruby 3.5.0dev source_location returns an array of 5 elements.
```ruby
$ ruby -v
ruby 3.5.0dev (2025-10-14T22:26:08Z master df5d63cfa2) +PRISM [x86_64-linux]
$ bin/test test/controller/log_subscriber_test.rb:331
Running 36 tests in a single process (parallelization threshold is 50)
Run options: --seed 37374

["/home/yahonda/src/github.com/rails/rails/actionpack/test/controller/log_subscriber_test.rb", 27, 4, 29, 7]
F

Failure:
ACLogSubscriberTest#test_verbose_redirect_logs [test/controller/log_subscriber_test.rb:332]:
Expected /\u21B3 \/home\/yahonda\/src\/github.com\/rails\/rails\/actionpack\/test\/controller\/log_subscriber_test.rb:8/ to match "↳ /home/yahonda/src/github.com/rails/rails/actionpack/test/controller/log_subscriber_test.rb:28:in 'Another::LogSubscribersController#redirector'".

bin/test test/controller/log_subscriber_test.rb:320

Finished in 0.067459s, 14.8237 runs/s, 44.4712 assertions/s.
1 runs, 3 assertions, 1 failures, 0 errors, 0 skips
$
```
- Ruby 3.4.7 source_location returns an array of 2 elements.
```ruby
$ ruby -v
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [x86_64-linux]
$ bin/test test/controller/log_subscriber_test.rb:331
Running 36 tests in a single process (parallelization threshold is 50)
Run options: --seed 6959

["/home/yahonda/src/github.com/rails/rails/actionpack/test/controller/log_subscriber_test.rb", 27]
.

Finished in 0.067913s, 14.7247 runs/s, 44.1740 assertions/s.
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
$
```

https://bugs.ruby-lang.org/issues/6012
https://github.com/ruby/ruby/pull/12539

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
