### PR TITLE
[#55866] Fix SQLite3 data loss during table alterations with CASCADE foreign keys.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Fix SQLite3 data loss during table alterations with CASCADE foreign keys.
+
+    When altering a table in SQLite3 that is referenced by child tables with
+    `ON DELETE CASCADE` foreign keys, ActiveRecord would silently delete all
+    data from the child tables. This occurred because SQLite requires table
+    recreation for schema changes, and during this process the original table
+    is temporarily dropped, triggering CASCADE deletes on child tables.
+
+    The root cause was incorrect ordering of operations. The original code
+    wrapped `disable_referential_integrity` inside a transaction, but
+    `PRAGMA foreign_keys` cannot be modified inside a transaction in SQLite -
+    attempting to do so simply has no effect. This meant foreign keys remained
+    enabled during table recreation, causing CASCADE deletes to fire.
+
+    The fix reverses the order to follow the official SQLite 12-step ALTER TABLE
+    procedure: `disable_referential_integrity` now wraps the transaction instead
+    of being wrapped by it. This ensures foreign keys are properly disabled
+    before the transaction starts and re-enabled after it commits, preventing
+    CASCADE deletes while maintaining data integrity through atomic transactions.
+
+    *Ruy Rocha*
+
 *   Fix negative scopes for enums to include records with `nil` values.
 
     *fatkodima*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -639,8 +639,8 @@ module ActiveRecord
             yield definition if block_given?
           end
 
-          transaction do
-            disable_referential_integrity do
+          disable_referential_integrity do
+            transaction do
               move_table(table_name, altered_table_name, options.merge(temporary: true))
               move_table(altered_table_name, table_name, &caller)
             end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -1185,6 +1185,132 @@ module ActiveRecord
         end
       end
 
+      def test_alter_table_with_fk_preserves_rows_when_referenced_table_altered
+        conn = SQLite3Adapter.new(database: ":memory:", adapter: "sqlite3", strict: false)
+
+        conn.create_table :authors do |t|
+          t.string :name, null: false
+        end
+
+        conn.create_table :books do |t|
+          t.string  :title, null: false
+          t.integer :author_id, null: false
+        end
+        conn.add_foreign_key :books, :authors, on_delete: :cascade
+
+        conn.execute("INSERT INTO authors (id, name) VALUES (1, 'Douglas Adams');")
+        conn.execute("INSERT INTO books (id, title, author_id) VALUES (42, 'The Hitchhiker''s Guide', 1);")
+        conn.execute("INSERT INTO books (id, title, author_id) VALUES (43, 'Restaurant at the End', 1);")
+
+        initial_book_count = conn.select_value("SELECT COUNT(*) FROM books")
+        assert_equal 2, initial_book_count
+
+        conn.add_column :authors, :email, :string
+
+        book_count = conn.select_value("SELECT COUNT(*) FROM books")
+        author_count = conn.select_value("SELECT COUNT(*) FROM authors")
+
+        assert_equal 2, book_count, "Books were CASCADE deleted when authors table was altered!"
+        assert_equal 1, author_count, "Authors were lost during table alteration!"
+      ensure
+        conn.disconnect! if conn
+      end
+
+      def test_alter_table_with_fk_preserves_rows_when_adding_fk_to_referenced_table
+        conn = SQLite3Adapter.new(database: ":memory:", adapter: "sqlite3", strict: false)
+
+        conn.create_table :groups do |t|
+          t.string :name, null: false
+        end
+
+        conn.create_table :users do |t|
+          t.string :username, null: false
+        end
+
+        conn.create_table :reports do |t|
+          t.string  :title, null: false
+          t.integer :group_id, null: false
+        end
+        conn.add_foreign_key :reports, :groups, on_delete: :cascade
+
+        conn.execute("INSERT INTO groups (id, name) VALUES (1, 'Admin Group');")
+        conn.execute("INSERT INTO users (id, username) VALUES (1, 'alice');")
+        conn.execute("INSERT INTO reports (id, title, group_id) VALUES (1, 'Report A', 1);")
+        conn.execute("INSERT INTO reports (id, title, group_id) VALUES (2, 'Report B', 1);")
+
+        initial_report_count = conn.select_value("SELECT COUNT(*) FROM reports")
+        assert_equal 2, initial_report_count
+
+        conn.add_column :groups, :owner_id, :integer
+        conn.add_foreign_key :groups, :users, column: :owner_id
+
+        report_count = conn.select_value("SELECT COUNT(*) FROM reports")
+        group_count = conn.select_value("SELECT COUNT(*) FROM groups")
+
+        assert_equal 2, report_count, "Reports were CASCADE deleted when groups table was altered!"
+        assert_equal 1, group_count, "Groups were lost during table alteration!"
+      ensure
+        conn.disconnect! if conn
+      end
+
+      def test_alter_table_with_multiple_cascade_fks_preserves_all_data
+        conn = SQLite3Adapter.new(database: ":memory:", adapter: "sqlite3", strict: false)
+
+        conn.create_table :authors do |t|
+          t.string :name, null: false
+        end
+
+        conn.create_table :books do |t|
+          t.string  :title, null: false
+          t.integer :author_id, null: false
+        end
+        conn.add_foreign_key :books, :authors, on_delete: :cascade
+
+        conn.create_table :articles do |t|
+          t.string  :headline, null: false
+          t.integer :author_id, null: false
+        end
+        conn.add_foreign_key :articles, :authors, on_delete: :cascade
+
+        conn.execute("INSERT INTO authors (id, name) VALUES (1, 'Douglas Adams');")
+        conn.execute("INSERT INTO books (id, title, author_id) VALUES (1, 'HHGTTG', 1);")
+        conn.execute("INSERT INTO articles (id, headline, author_id) VALUES (1, 'Towel Day', 1);")
+
+        conn.add_column :authors, :bio, :text
+
+        book_count = conn.select_value("SELECT COUNT(*) FROM books")
+        article_count = conn.select_value("SELECT COUNT(*) FROM articles")
+
+        assert_equal 1, book_count, "Books were CASCADE deleted when authors table was altered!"
+        assert_equal 1, article_count, "Articles were CASCADE deleted when authors table was altered!"
+      ensure
+        conn.disconnect! if conn
+      end
+
+      def test_rename_table_with_cascade_fk_preserves_referencing_data
+        conn = SQLite3Adapter.new(database: ":memory:", adapter: "sqlite3", strict: false)
+
+        conn.create_table :authors do |t|
+          t.string :name, null: false
+        end
+
+        conn.create_table :books do |t|
+          t.string  :title, null: false
+          t.integer :author_id, null: false
+        end
+        conn.add_foreign_key :books, :authors, on_delete: :cascade
+
+        conn.execute("INSERT INTO authors (id, name) VALUES (1, 'Douglas Adams');")
+        conn.execute("INSERT INTO books (id, title, author_id) VALUES (1, 'HHGTTG', 1);")
+
+        conn.rename_table :authors, :writers
+
+        book_count = conn.select_value("SELECT COUNT(*) FROM books")
+        assert_equal 1, book_count, "Books were CASCADE deleted when authors table was renamed!"
+      ensure
+        conn.disconnect! if conn
+      end
+
       private
         def with_rails_root(&block)
           mod = Module.new do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because #55866.

### Detail

Fix SQLite3 data loss during table alterations with CASCADE foreign keys

When altering a table in SQLite3 that is referenced by child tables with `ON DELETE CASCADE` foreign keys, ActiveRecord would silently delete all data from the child tables. This occurred because SQLite requires table recreation for schema changes, and during this process:

1. The original table is temporarily dropped
2. CASCADE deletes fire immediately on child tables
3. The table is recreated, but child data is already gone

This issue could result in catastrophic production data loss when adding columns, renaming tables, or adding foreign keys to tables that are referenced by other tables with CASCADE constraints.

The fix simply reverses the order to follow the [official SQLite 12-step ALTER TABLE procedure](https://www.sqlite.org/lang_altertable.html#otheralter).

This Pull Request fixes #55866.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
