### PR TITLE
Show help hint when starting `bin/rails console`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Show help hint when starting `bin/rails console`
+
+    *Petrik de Heus*
+
 *   Persist `/rails/info/routes` search query and results between page reloads.
 
     *Ryan Kulp*

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -55,6 +55,7 @@ module Rails
       else
         puts "Loading #{Rails.env} environment (Rails #{Rails.version})"
       end
+      puts "Type 'help' for help."
 
       console.start
     end

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -46,6 +46,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
 
     assert_predicate app.console, :started?
     assert_match(/Loading \w+ environment \(Rails/, output)
+    assert_match(/Type 'help' for help/, output)
   end
 
   def test_start_with_sandbox
@@ -54,6 +55,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_predicate app.console, :started?
     assert app.sandbox
     assert_match(/Loading \w+ environment in sandbox \(Rails/, output)
+    assert_match(/Type 'help' for help/, output)
   end
 
   def test_console_with_environment


### PR DESCRIPTION
The `help` command in the Rails console shows which Rails specific commands are available and what they do.

Similar to `bin/rails dbconsole` (where database clients show a help hint), show a hint on how to use help when opening `bin/rails console`.

```
$ bin/rails console
Loading development environment (Rails 8.1.0.beta1)
Type 'help' for help.
example(dev):001>
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
