### PR TITLE
Fix negative scopes for enums to include records with `nil` values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix negative scopes for enums to include records with `nil` values.
+
+    *fatkodima*
+
 *   Improve support for SQLite database URIs.
 
     The `db:create` and `db:drop` tasks now correctly handle SQLite database URIs, and the

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -318,7 +318,8 @@ module ActiveRecord
 
               # scope :not_active, -> { where.not(status: 0) }
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              arel_column = klass.arel_table[name]
+              klass.scope "not_#{value_method_name}", -> { where(arel_column.not_eq(value).or(arel_column.eq(nil))) }
             end
           end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -87,6 +87,11 @@ class EnumTest < ActiveRecord::TestCase
   test "find via negative scope" do
     assert Book.not_published.exclude?(@book)
     assert Book.not_proposed.include?(@book)
+
+    # Should include records with nils in the column.
+    rfr = books(:rfr)
+    rfr.update!(status: nil)
+    assert Book.not_published.include?(rfr)
   end
 
   test "find via where with values" do

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -82,6 +82,28 @@ Upgrading from Rails 8.1 to Rails 8.2
 
 For more information on changes made to Rails 8.2 please see the [release notes](8_2_release_notes.html).
 
+### The negative scopes for enums now include records with `nil` values.
+
+Active Record negative scopes for enums now include records with `nil` values.
+
+```ruby
+class Book < ApplicationRecord
+  enum :status, [:proposed, :written, :published]
+end
+
+book1 = Book.create!(status: :published)
+book2 = Book.create!(status: :written)
+book3 = Book.create!(status: nil)
+
+# Before
+
+Book.not_published # => [book2]
+
+# After
+
+Book.not_published # => [book2, book3]
+```
+
 Upgrading from Rails 8.0 to Rails 8.1
 -------------------------------------
 


### PR DESCRIPTION
Since NULL != NULL in SQL, the condition where `column != 'value'` always ignores rows with NULLs, but should include them too.

Fixes #55908.