### PR TITLE
Fix passing both module: and shallow: to resources

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1948,8 +1948,10 @@ module ActionDispatch
             end
 
             scope_options = options.slice!(*RESOURCE_OPTIONS)
-            if !scope_options.empty? || !shallow.nil?
-              scope(**scope_options, shallow:) do
+            scope_options[:shallow] = shallow unless shallow.nil?
+
+            unless scope_options.empty?
+              scope(**scope_options) do
                 public_send(method, resources.pop, **options, &block)
               end
               return true

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -18,6 +18,10 @@ module Backoffice
   end
 end
 
+module Products
+  class ImagesController < ResourcesController; end
+end
+
 class ResourcesTest < ActionController::TestCase
   def test_default_restful_routes
     with_restful_routing :messages do
@@ -506,6 +510,23 @@ class ResourcesTest < ActionController::TestCase
         namespace: "backoffice/admin/",
         name_prefix: "backoffice_admin_product_",
         path_prefix: "backoffice/admin/products/1/",
+        shallow: true,
+        options: { product_id: "1" }
+    end
+  end
+
+  def test_shallow_with_module
+    with_routing do |set|
+      set.draw do
+        resources :products do
+          resources :images, module: :products, shallow: true
+        end
+      end
+
+      assert_simply_restful_for :images,
+        controller: "products/images",
+        name_prefix: "product_",
+        path_prefix: "products/1/",
         shallow: true,
         options: { product_id: "1" }
     end


### PR DESCRIPTION
Fix #55915

This broke because the keyword arg change started always passing
`shallow:` through to this `scope` block. However, this caused an issue
because passing the `shallow` option caused it to _always_ override the
scope's current `shallow` value, instead of only doing that when
specified.

This commit fixes the behavior by only passing `shallow` to the `scope`
when it is specified, instead of unconditionally.

(no changelog because this fixes an issue in 8.1.0 which hasn't been released?)