### PR TITLE
Add support for bound SQL literals in CTEs

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1923,7 +1923,8 @@ module ActiveRecord
 
       def build_with_expression_from_value(value, nested = false)
         case value
-        when Arel::Nodes::SqlLiteral then Arel::Nodes::Grouping.new(value)
+        when Arel::Nodes::SqlLiteral, Arel::Nodes::BoundSqlLiteral
+          Arel::Nodes::Grouping.new(value)
         when ActiveRecord::Relation
           if nested
             value.arel.ast

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -28,7 +28,8 @@ module ActiveRecord
       def test_with_when_hash_with_multiple_elements_of_different_type_is_passed_as_an_argument
         cte_options = {
           posts_with_tags: Post.arel_table.project(Arel.star).where(Post.arel_table[:tags_count].gt(0)),
-          posts_with_tags_and_comments: Arel.sql("SELECT * FROM posts_with_tags WHERE legacy_comments_count > 0"),
+          posts_with_tags_and_true: Arel.sql("SELECT * FROM posts_with_tags WHERE true"),
+          posts_with_tags_and_comments: Arel.sql("SELECT * FROM posts_with_tags_and_true WHERE tags_count > ?", 0),
           "posts_with_tags_and_multiple_comments" => Post.where("legacy_comments_count > 1").from("posts_with_tags_and_comments AS posts")
         }
         relation = Post.with(cte_options).from("posts_with_tags_and_multiple_comments AS posts")


### PR DESCRIPTION
### Motivation / Background

Fixes #55917.

### Detail

When creating a SQL literal with bind value parameters, `Arel.sql` returns an instance of `Arel::Nodes::BoundSqlLiteral`, which is not currently supported by `#build_with_expression_from_value`.

This Pull Request updates the method to accept both `Arel::Nodes::SqlLiteral` and `Arel::Nodes::BoundSqlLiteral`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.~~ Minor bug fixes and documentation changes should not be included.
