### PR TITLE
Remove action_on_open_redirects from new_framework_defaults

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -108,10 +108,7 @@ module ActionController
     # ### Open Redirect protection
     #
     # By default, Rails protects against redirecting to external hosts for your
-    # app's safety, so called open redirects. Note: this was a new default in Rails
-    # 7.0, after upgrading opt-in by uncommenting the line with
-    # `raise_on_open_redirects` in
-    # `config/initializers/new_framework_defaults_7_0.rb`
+    # app's safety, so called open redirects.
     #
     # Here #redirect_to automatically validates the potentially-unsafe URL:
     #

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -61,26 +61,6 @@
 # Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
 
 ###
-# Controls how Rails handles open redirect vulnerabilities.
-# When set to `:raise`, Rails will raise an `ActionController::Redirecting::UnsafeRedirectError`
-# for redirects to external hosts, which helps prevent open redirect attacks.
-#
-# This configuration replaces the deprecated `raise_on_open_redirects` setting, providing
-# the ability for large codebases to safely turn on the protection (after monitoring it with :log/:notifications)
-#
-# Example:
-#   redirect_to params[:redirect_url]  # May raise UnsafeRedirectError if URL is external
-#   redirect_to "http://evil.com"      # Raises UnsafeRedirectError
-#   redirect_to "/safe/path"           # Works correctly (internal URL)
-#   redirect_to "http://evil.com", allow_other_host: true  # Works (explicitly allowed)
-#
-# Applications that want to allow these redirects can set the config to `:log` (previous default)
-# to only log warnings, or `:notify` to send ActiveSupport notifications for monitoring.
-#
-#++
-# Rails.configuration.action_controller.action_on_open_redirect = :raise
-
-###
 # Use a Ruby parser to track dependencies between Action View templates
 #++
 # Rails.configuration.action_view.render_tracker = :ruby


### PR DESCRIPTION
[Originally][1] this _was_ implemented as a new framework default, but
it was [later][2] changed so that it carries forward the behavior of the
existing configuration (meaning setting the value to :raise shouldn't be
necessary for upgrading applications).

[1]: https://github.com/rails/rails/commit/b95ee14e564e4dfbeae7a87f273ca66a2cdfcfeb
[2]: https://github.com/rails/rails/commit/808ca69b7e9d973c46541a9176fded00560ca729