### PR TITLE
Add missing structured event data for logs

### DIFF
--- a/actionpack/lib/action_controller/structured_event_subscriber.rb
+++ b/actionpack/lib/action_controller/structured_event_subscriber.rb
@@ -34,6 +34,7 @@ module ActionController
         controller: payload[:controller],
         action: payload[:action],
         status: status,
+        **additions_for(payload),
         duration_ms: event.duration.round(2),
         gc_time_ms: event.gc_time.round(1),
       }.compact)
@@ -100,6 +101,10 @@ module ActionController
           key: key,
           duration_ms: event.duration.round(1)
         )
+      end
+
+      def additions_for(payload)
+        payload.slice(:view_runtime, :db_runtime, :queries_count, :cached_queries_count)
       end
   end
 end

--- a/activejob/test/cases/structured_event_subscriber_test.rb
+++ b/activejob/test/cases/structured_event_subscriber_test.rb
@@ -159,6 +159,7 @@ module ActiveJob
         end
       end
 
+      assert event[:payload][:exception_backtrace].is_a?(Array)
       assert event[:payload][:job_id].present?
       assert event[:payload][:duration].is_a?(Numeric)
     end
@@ -173,6 +174,7 @@ module ActiveJob
       assert_event_reported("active_job.enqueued", payload: {
         job_class: failing_enqueue_job_class.name,
         queue: "default",
+        adapter: ActiveJob.adapter_name(ActiveJob::Base.queue_adapter),
         exception_class: "StandardError",
         exception_message: "Enqueue failed"
       }) do
@@ -192,6 +194,7 @@ module ActiveJob
       assert_event_reported("active_job.enqueued", payload: {
         job_class: aborting_enqueue_job_class.name,
         queue: "default",
+        adapter: ActiveJob.adapter_name(ActiveJob::Base.queue_adapter),
         aborted: true,
       }) do
         aborting_enqueue_job_class.perform_later

--- a/activerecord/lib/active_record/structured_event_subscriber.rb
+++ b/activerecord/lib/active_record/structured_event_subscriber.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
       emit_debug_event("active_record.strict_loading_violation",
         owner: owner.name,
-        class: reflection.klass.name,
+        class: reflection.polymorphic? ? nil : reflection.klass.name,
         name: reflection.name,
       )
     end


### PR DESCRIPTION
Followup on https://github.com/rails/rails/pull/55904.

Related to #55900.

This will be backported to 8.1.
