### PR TITLE
Update shard swap prohibition so exceptions do not modify `connected_to` stack

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -173,9 +173,11 @@ module ActiveRecord
       prevent_writes = true if role == ActiveRecord.reading_role
 
       append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: classes)
-      yield
-    ensure
-      connected_to_stack.pop
+      begin
+        yield
+      ensure
+        connected_to_stack.pop
+      end
     end
 
     # Passes the block to +connected_to+ for every +shard+ the
@@ -396,11 +398,13 @@ module ActiveRecord
         prevent_writes = true if role == ActiveRecord.reading_role
 
         append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self])
-        return_value = yield
-        return_value.load if return_value.is_a? ActiveRecord::Relation
-        return_value
-      ensure
-        self.connected_to_stack.pop
+        begin
+          return_value = yield
+          return_value.load if return_value.is_a? ActiveRecord::Relation
+          return_value
+        ensure
+          self.connected_to_stack.pop
+        end
       end
 
       def append_to_connected_to_stack(entry)


### PR DESCRIPTION

### Motivation / Background

If an exception is raised due to shard swap prohibition, the top frame of the `connected_to` stack is popped, potentially leading to inconsistent behavior if this exception is rescued.


### Detail

This PR is a minor change to the `ensure` block in `with_role_and_shard` so that, if an execption is raised by `append_to_connected_to_stack` (which is where the shard swap prohibition is enforced) then a `connected_to` stack frame is not popped.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
