### PR TITLE
Optional event reporter-specific filter parameters

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -278,6 +278,9 @@ module ActiveSupport
     attr_reader :subscribers # :nodoc
 
     class << self
+      # Filter parameters used to filter event payloads. If nil,
+      # Active Support's filter parameters will be used instead.
+      attr_accessor :filter_parameters
       attr_accessor :context_store # :nodoc:
     end
 
@@ -537,6 +540,10 @@ module ActiveSupport
     end
 
     private
+      def filter_parameters
+        self.class.filter_parameters || ActiveSupport.filter_parameters
+      end
+
       def raise_on_error?
         @raise_on_error
       end
@@ -548,7 +555,7 @@ module ActiveSupport
       def payload_filter
         @payload_filter ||= begin
           mask = ActiveSupport::ParameterFilter::FILTERED
-          ActiveSupport::ParameterFilter.new(ActiveSupport.filter_parameters, mask: mask)
+          ActiveSupport::ParameterFilter.new(filter_parameters, mask: mask)
         end
       end
 

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -259,6 +259,32 @@ module ActiveSupport
       end
     end
 
+    test "default filter_parameters is used by default" do
+      old_filter_parameters = ActiveSupport.filter_parameters
+      ActiveSupport.filter_parameters = [:secret]
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value", secret: "[FILTERED]" })
+      ]) do
+        @reporter.notify(:test_event, { key: "value", secret: "hello" })
+      end
+    ensure
+      ActiveSupport.filter_parameters = old_filter_parameters
+    end
+
+    test ".filter_parameters is used when present" do
+      old_filter_parameters = EventReporter.filter_parameters
+      EventReporter.filter_parameters = [:foo]
+
+      assert_called_with(@subscriber, :emit, [
+        event_matcher(name: "test_event", payload: { key: "value", foo: "[FILTERED]" })
+      ]) do
+        @reporter.notify(:test_event, { key: "value", foo: "hello" })
+      end
+    ensure
+      EventReporter.filter_parameters = old_filter_parameters
+    end
+
     test "#with_debug" do
       @reporter.with_debug do
         assert_predicate @reporter, :debug_mode?


### PR DESCRIPTION
### Motivation / Background

Related to https://github.com/rails/rails/pull/55489

This Pull Request has been created because `ActiveSupport::EventReporter` is currently forced to use the global filter parameters set by Rails. This isn't always desired behaviour, especially if you want to filter different keys for events vs parameters. So, we should provide an optional override.



### Detail

This Pull Request changes `ActiveSupport::EventReporter` to allow use of separate filter parameters for event payload filtering. Filtering will by default inherit the global filter parameters, and use specific ones if they are set.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
