### PR TITLE
Update shard swap prohibition to be more granular

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Database-specific shard swap prohibition
+
+    In #43485 (v7.0.0), shard swapping prohibition was introduced as a global
+    switch that applied to all databases.
+
+    For the use case of a multi-database application, the global prohibition is
+    overly broad, and so with this change the method `prohibit_shard_swapping`
+    will scope the prohibition to the same connection class (i.e.,
+    `connection_specification_name`). This allows an application to prohibit
+    shard swapping on a specific database while allowing it on all others.
+
+    *Mike Dalessio*
+
 *   Fix upsert_all when using repeated timestamp attributes.
 
     *Gannon McGibbon*

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -218,7 +218,8 @@ module ActiveRecord
 
           PrimaryBase.connects_to(shards: {
             default: { writing: :primary },
-            shard_one: { writing: :primary_shard_one }
+            shard_one: { writing: :primary_shard_one },
+            shard_two: { writing: :primary_shard_two }
           })
 
           global_role = :writing
@@ -235,17 +236,126 @@ module ActiveRecord
                 assert_raises(ShardSwapProhibitedError) do
                   PrimaryBase.connected_to(shard: :shard_two) { }
                 end
-              end
 
-              assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+                assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+
+                # Prohibition can be lifted
+                PrimaryBase.prohibit_shard_swapping(false) do
+                  PrimaryBase.connected_to(shard: :shard_two) do
+                    assert_equal "primary_shard_two", PrimaryBase.connection_pool.db_config.name
+                  end
+                end
+              end
 
               PrimaryBase.prohibit_shard_swapping do
                 assert_raises(ShardSwapProhibitedError) do
                   ActiveRecord::Base.connected_to_many([PrimaryBase], shard: :shard_two, role: :writing) { }
                 end
+
+                assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+
+                # Prohibition can be lifted
+                PrimaryBase.prohibit_shard_swapping(false) do
+                  ActiveRecord::Base.connected_to_many([PrimaryBase], shard: :shard_two, role: :writing) do
+                    assert_equal "primary_shard_two", PrimaryBase.connection_pool.db_config.name
+                  end
+                end
+              end
+            end
+          end
+        ensure
+          ActiveRecord::Base.configurations = @prev_configs
+          ActiveRecord::Base.establish_connection(:arunit)
+          ENV["RAILS_ENV"] = previous_env
+        end
+
+        def test_granular_prohibition_of_shard_swapping
+          previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
+
+          config = {
+            "default_env" => {
+              "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3" },
+              "primary_shard_two" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_two.sqlite3" },
+              "secondary" => { "adapter" => "sqlite3", "database" => "test/db/secondary.sqlite3" },
+              "secondary_shard_one" => { "adapter" => "sqlite3", "database" => "test/db/secondary_shard_one.sqlite3" },
+              "secondary_shard_two" => { "adapter" => "sqlite3", "database" => "test/db/secondary_shard_two.sqlite3" },
+            }
+          }
+
+          @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+          PrimaryBase.connects_to(shards: {
+            default: { writing: :primary },
+            shard_one: { writing: :primary_shard_one },
+            shard_two: { writing: :primary_shard_two }
+          })
+
+          SecondaryBase.connects_to(shards: {
+            default: { writing: :secondary },
+            shard_one: { writing: :secondary_shard_one },
+            shard_two: { writing: :secondary_shard_two }
+          })
+
+          global_role = :writing
+
+          # Switch everything to default
+          ActiveRecord::Base.connected_to(role: global_role, shard: :default) do
+            assert_equal "primary", PrimaryBase.connection_pool.db_config.name
+            assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
+
+            # Switch only primary to shard_one
+            PrimaryBase.connected_to(shard: :shard_one) do
+              assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+              assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
+
+              # No prohibition on changing PrimaryBase again
+              PrimaryBase.connected_to(shard: :shard_two) do
+                assert_equal "primary_shard_two", PrimaryBase.connection_pool.db_config.name
+                assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
               end
 
-              assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+              ActiveRecord::Base.connected_to_many([PrimaryBase], shard: :shard_two, role: :writing) do
+                assert_equal "primary_shard_two", PrimaryBase.connection_pool.db_config.name
+                assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
+              end
+
+              # Prohibit shard swapping on PrimaryBase
+              PrimaryBase.prohibit_shard_swapping do
+                assert_raises(ShardSwapProhibitedError) do
+                  PrimaryBase.connected_to(shard: :shard_two) { }
+                end
+
+                assert_raises(ShardSwapProhibitedError) do
+                  ActiveRecord::Base.connected_to_many([PrimaryBase], shard: :shard_two, role: :writing) { }
+                end
+
+                # Shard swapping on SecondaryBase has not been prohibited
+                SecondaryBase.connected_to(shard: :shard_one) do
+                  assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+                  assert_equal "secondary_shard_one", SecondaryBase.connection_pool.db_config.name
+
+                  SecondaryBase.prohibit_shard_swapping do
+                    assert_raises(ShardSwapProhibitedError) do
+                      SecondaryBase.connected_to(shard: :shard_two) { }
+                    end
+
+                    assert_raises(ShardSwapProhibitedError) do
+                      ActiveRecord::Base.connected_to_many([SecondaryBase], shard: :shard_two, role: :writing) { }
+                    end
+                  end
+
+                  SecondaryBase.connected_to(shard: :shard_two) do
+                    assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+                    assert_equal "secondary_shard_two", SecondaryBase.connection_pool.db_config.name
+                  end
+
+                  ActiveRecord::Base.connected_to_many([SecondaryBase], shard: :shard_two, role: :writing) do
+                    assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
+                    assert_equal "secondary_shard_two", SecondaryBase.connection_pool.db_config.name
+                  end
+                end
+              end
             end
           end
         ensure


### PR DESCRIPTION
### Motivation / Background

In #43485, shard swapping prohibition was introduced. It was implemented as a boolean that applied to all databases (within the isolated execution state).

I believe the spirit of the original feature was to prevent swapping shards on a specific database, and so I think the implementation should support the use case of a multi-database application.

cc @eileencodes @seejohnrun @matthewd 

### Detail

This change scopes the shard swap prohibition to the "connection specification name", which allows an application to prohibit shard swapping on a specific database while allowing it on all others.

Test coverage has been added to cover the `prohibit_shard_swapping(false)` use case.

### Additional information

Depends on https://github.com/rails/rails/pull/55933, please review that PR first. 🙏


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
