### PR TITLE
Allow autosave association methods to be overwritten

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -216,18 +216,23 @@ module ActiveRecord
 
         def define_autosave_validation_callbacks(reflection)
           validation_method = :"validate_associated_records_for_#{reflection.name}"
-          if reflection.validate? && !method_defined?(validation_method)
+          if reflection.validate?
             if reflection.collection?
+              # TODO - I'll have to redefine this method, it depends on autosave
               method = :validate_collection_association
             elsif reflection.has_one?
+              # This one depends on inverse_of and stuff
               method = :validate_has_one_association
             else
               method = :validate_belongs_to_association
             end
+            # TODO - is calling `validate` only once here enough?
+            if !method_defined?(validation_method)
+              validate validation_method
+              after_validation :_ensure_no_duplicate_errors
+            end
 
             define_non_cyclic_method(validation_method) { send(method, reflection) }
-            validate validation_method
-            after_validation :_ensure_no_duplicate_errors
           end
         end
     end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -157,9 +157,7 @@ module ActiveRecord
     module ClassMethods # :nodoc:
       private
         def define_non_cyclic_method(name, &block)
-          return if method_defined?(name, false)
-
-          define_method(name) do |*args|
+          redefine_method(name) do |*args|
             result = true; @_already_called ||= {}
             # Loop prevention for validation of associations
             unless @_already_called[name]

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -45,6 +45,14 @@ require "models/human"
 require "models/face"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
+  module ShipExtension
+    def self.prepended(base)
+      base.class_eval do
+        has_many :treasures, autosave: true
+      end
+    end
+  end
+
   def test_autosave_works_even_when_other_callbacks_update_the_parent_model
     reference = Class.new(ActiveRecord::Base) do
       self.table_name = "references"
@@ -168,6 +176,14 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
 
     assert_not_predicate ship, :valid?
     assert_equal 1, ship.errors[:name].length
+  end
+
+  def test_autosave_association_save_method_callbacks_can_be_overridden
+    ship_with_overridden_save_method = Class.new(Ship) do
+      self.prepend(ShipExtension)
+    end
+
+    assert_equal true, ship_with_overridden_save_method.reflect_on_association(:treasures).options[:autosave]
   end
 
   private


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

There are many rails gems out there that define active record classes to be consumed.

Sometimes, consumers of those gems want to override the properties, such as associations of the active record classes in the gem. When you override an association by redefining it using a concern, prepended module, etc, rails generally lets you do this and respect it. For example, passing association arguments such as `disable_joins`, `foreign_key`, `inverse_of` to `has_many` in an overriding class will change the original ActiveRecord Class' behavior (e.g. association.rb:45:219:360)

However, if you try to override the `autosave` option, it does not change the behavior of the underlying class.

```
class OriginalClass < ActiveRecord::Base
  has_many :items
end

class MyExtension
  extend ActiveSupport::Concern

  # Adding autosave: true here doesn't do anything
  has_many :items, autosave: true

  OriginalClass.prepend(self)
end
```

This is because even though you can override the reflection attached to the class, the original reflection is still referenced within blocks that define the methods related to autosaving associations. This means that the original reflection behavior (in this example, autosave: false) is still used.

### Detail

This Pull Request changes the AutosaveAssociation behavior so that if a prepended module/subclass etc calls association methods (`has_many`, `has_one`, etc) that match an existing association on the class being modified, the old `autosave` association option value will be overwritten and the new value respected, like the behavior of other association options. 

### Additional information

The `add_autosave_association_callbacks` method are only defined when an association is first built; or in the example I gave above, when an association is rebuilt. I was not able to get this method to fire more than the number of times association helpers like `has_many` were called in the app with a specific association name. I don't think that checking if the method was already defined was buying any performance improvements, but it was preventing the existing behavior on a active record class from being overwritten.

I did consider an alternative that would keep the existing method defined checks but still allow for overriding the existing callbacks by passing a digest of the reflection. However, IMO this had more performance and complexity implications than what would be gained.

[Alternative Approach](https://gist.github.com/Noah-Silvera/5b156d60f8532bcd6b4f01b4611e8246)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
