### PR TITLE
Raise specific exception when a prohibited shard change is attempted.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Raise specific exception when a prohibited shard change is attempted.
+
+    The new `ShardSwapProhibitedError` exception allows applications and
+    connection-related libraries to more easily recover from this specific
+    scenario. Previously an `ArgumentError` was raised, so the new exception
+    subclasses `ArgumentError` for backwards compatibility.
+
+    *Mike Dalessio*
+
 *   Fix SQLite3 data loss during table alterations with CASCADE foreign keys.
 
     When altering a table in SQLite3 that is referenced by child tables with

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -409,7 +409,7 @@ module ActiveRecord
 
       def append_to_connected_to_stack(entry)
         if shard_swapping_prohibited? && entry[:shard].present?
-          raise ArgumentError, "cannot swap `shard` while shard swapping is prohibited."
+          raise ShardSwapProhibitedError, "cannot swap `shard` while shard swapping is prohibited."
         end
 
         connected_to_stack << entry

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -131,6 +131,12 @@ module ActiveRecord
   class ReadOnlyError < ActiveRecordError
   end
 
+  # Raised when shard swapping is attempted on a connection that prohibits it.
+  # See {ActiveRecord::ConnectionHandling#prohibit_shard_swapping}[rdoc-ref:ConnectionHandling#prohibit_shard_swapping].
+  class ShardSwapProhibitedError < ArgumentError
+    # This subclasses ArgumentError for backwards compatibility.
+  end
+
   # Raised when Active Record cannot find a record by given id or set of ids.
   class RecordNotFound < ActiveRecordError
     attr_reader :model, :primary_key, :id

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -358,7 +358,7 @@ module ActiveRecord
             shard_one: { writing: :primary_shard_one }
           })
 
-          assert_raises(ArgumentError) do
+          assert_raises(ShardSwapProhibitedError) do
             ActiveRecord::Base.prohibit_shard_swapping do
               ActiveRecord::Base.connected_to(role: :reading, shard: :default) do
               end

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -232,19 +232,17 @@ module ActiveRecord
               assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
 
               PrimaryBase.prohibit_shard_swapping do
-                e = assert_raises(ArgumentError) do
+                assert_raises(ShardSwapProhibitedError) do
                   PrimaryBase.connected_to(shard: :shard_two) { }
                 end
-                assert_match(/cannot swap/, e.message)
               end
 
               assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
 
               PrimaryBase.prohibit_shard_swapping do
-                e = assert_raises(ArgumentError) do
+                assert_raises(ShardSwapProhibitedError) do
                   ActiveRecord::Base.connected_to_many([PrimaryBase], shard: :shard_two, role: :writing) { }
                 end
-                assert_match(/cannot swap/, e.message)
               end
 
               assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
@@ -255,6 +253,7 @@ module ActiveRecord
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
         end
+
         def test_roles_and_shards_can_be_swapped_granularly
           previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
 


### PR DESCRIPTION
### Motivation / Background

Currently Rails raises a generic `ArgumentError` when a prohibited shard change is attempted. This makes it challenging for applications and connection-related libraries to rescue and recover from a very specific condition.


### Detail

Introduce a new `ShardSwapProhibitedError` exception for this error condition. Previously an `ArgumentError` was raised, so the new exception subclasses `ArgumentError` for backwards compatibility.


### Additional information

See the original shard swap prohibition implementation in 32e2a8ef for more context.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
