### PR TITLE
Kamal localhost registry

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -21,15 +21,15 @@ proxy:
   ssl: true
   host: app.example.com
 
-# Credentials for your image host.
+# Registry is where your images are kept.
 registry:
-  # Specify the registry server, if you're not using Docker Hub
+  server: localhost:5555
+  # Specify the registry server, if you're not using local host
   # server: registry.digitalocean.com / ghcr.io / ...
-  username: your-user
-
+  # username: your-user
   # Always use an access token rather than real password when possible.
-  password:
-    - KAMAL_REGISTRY_PASSWORD
+  # password:
+  #   - KAMAL_REGISTRY_PASSWORD
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -21,12 +21,12 @@ proxy:
   ssl: true
   host: app.example.com
 
-# Registry is where your images are kept.
+# Where you keep your container images.
 registry:
+  # Alternatives: hub.docker.com / registry.digitalocean.com / ghcr.io / ...
   server: localhost:5555
 
-  # Specify the registry server, if you're not using local host
-  # server: registry.digitalocean.com / ghcr.io / ...
+  # Needed for authenticated registries.
   # username: your-user
 
   # Always use an access token rather than real password when possible.

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -1,8 +1,8 @@
 # Name of your application. Used to uniquely configure containers.
 service: <%= app_name %>
 
-# Name of the container image.
-image: your-user/<%= app_name %>
+# Name of the container image (use your-user/app-name on external registries).
+image: <%= app_name %>
 
 # Deploy to these servers.
 servers:
@@ -24,9 +24,11 @@ proxy:
 # Registry is where your images are kept.
 registry:
   server: localhost:5555
+
   # Specify the registry server, if you're not using local host
   # server: registry.digitalocean.com / ghcr.io / ...
   # username: your-user
+
   # Always use an access token rather than real password when possible.
   # password:
   #   - KAMAL_REGISTRY_PASSWORD

--- a/railties/lib/rails/generators/rails/app/templates/kamal-secrets.tt
+++ b/railties/lib/rails/generators/rails/app/templates/kamal-secrets.tt
@@ -14,7 +14,7 @@
 # GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
 
 # Grab the registry password from ENV
-KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+# KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 
 # Improve security by using a password manager. Never check config/master.key into git!
 RAILS_MASTER_KEY=$(cat config/master.key)


### PR DESCRIPTION
Kamal 2.8.0 is shipping with the long-awaited localhost registry option. We should use that out of the box for new installs, so there's one less thing to setup before you can get that "hurrah, I'm live in production" feeling. 