### PR TITLE
Use truthy condition in instead of true for MSSQL support

### DIFF
--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -28,8 +28,8 @@ module ActiveRecord
       def test_with_when_hash_with_multiple_elements_of_different_type_is_passed_as_an_argument
         cte_options = {
           posts_with_tags: Post.arel_table.project(Arel.star).where(Post.arel_table[:tags_count].gt(0)),
-          posts_with_tags_and_true: Arel.sql("SELECT * FROM posts_with_tags WHERE true"),
-          posts_with_tags_and_comments: Arel.sql("SELECT * FROM posts_with_tags_and_true WHERE tags_count > ?", 0),
+          posts_with_tags_and_truthy: Arel.sql("SELECT * FROM posts_with_tags WHERE 1=1"),
+          posts_with_tags_and_comments: Arel.sql("SELECT * FROM posts_with_tags_and_truthy WHERE tags_count > ?", 0),
           "posts_with_tags_and_multiple_comments" => Post.where("legacy_comments_count > 1").from("posts_with_tags_and_comments AS posts")
         }
         relation = Post.with(cte_options).from("posts_with_tags_and_multiple_comments AS posts")


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This contains just a minor change to the `WithTest#test_with_when_hash_with_multiple_elements_of_different_type_is_passed_as_an_argument` test so that it doesn't need to be reimplemented in the [ActiveRecord SQL Server Adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter). 

MySQL/Postgres/SQLite support queries that contain `WHERE true` but SQL Server doesn't. Instead SQL Server (and MySQL/Postgres/SQLite) support `WHERE 1=1` which serves the same purpose. The change doesn't affect the original purpose of the test. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`