### PR TITLE
Remove extra blank lines in ci.yml

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -18,16 +18,16 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      <%- unless skip_brakeman? -%>
 
-      <%- unless skip_brakeman? %>
       - name: Scan for common Rails security vulnerabilities using static analysis
         run: bin/brakeman --no-pager
-      <% end %>
-
+      <% end -%>
       <%- unless skip_bundler_audit? -%>
+
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
-      <% end %>
+      <% end -%>
 
 <% end -%>
 <%- if using_importmap? -%>


### PR DESCRIPTION
Fix extra `ci.yml` blank lines introduced in https://github.com/rails/rails/pull/55714. The issue currently happens in Rails `8.1.0.rc1` apps.

#### Before fix

```yml
      - name: Set up Ruby
        uses: ruby/setup-ruby@v1
        with:
          bundler-cache: true


      - name: Scan for common Rails security vulnerabilities using static analysis
        run: bin/brakeman --no-pager
      

      - name: Scan for known security vulnerabilities in gems used
        run: bin/bundler-audit
      

  scan_js:
```

#### After fix

```yml
      - name: Set up Ruby
        uses: ruby/setup-ruby@v1
        with:
          bundler-cache: true

      - name: Scan for common Rails security vulnerabilities using static analysis
        run: bin/brakeman --no-pager
      
      - name: Scan for known security vulnerabilities in gems used
        run: bin/bundler-audit
      
  scan_js:
```