### PR TITLE
PostgreSQL drop database FORCE option.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   PostgreSQL enable drop database FORCE option.
+
+    One of the benefits of developing with MySQL is that it allows dropping the
+    current database without first disconnecting clients. As a result developers
+    can use `bin/rails db:reset` and similar, without first shutting down
+    instances of the app, Rails consoles, background workers, etc. By default
+    PostgreSQL fails to drop a database when clients are connected and displays
+    the following error:
+
+      > PG::ObjectInUse: ERROR:  database "xyz" is being accessed by other users (PG::ObjectInUse)
+
+    This is frustrating when working in development where the database may be
+    dropped frequently.
+
+    PostgreSQL 13 added the `FORCE` option to the `DROP DATABASE` statement
+    ([PostgreSQL docs](https://www.postgresql.org/docs/current/sql-dropdatabase.html))
+    which automatically disconnects clients before dropping the database.
+    This option is automatically enabled for supported PostgreSQL versions.
+
+    *Steven Webb*
+
 *   Raise specific exception when a prohibited shard change is attempted.
 
     The new `ShardSwapProhibitedError` exception allows applications and

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -55,8 +55,15 @@ module ActiveRecord
         #
         # Example:
         #   drop_database 'matt_development'
-        def drop_database(name) # :nodoc:
-          execute "DROP DATABASE IF EXISTS #{quote_table_name(name)}"
+        #
+        # Note, for PostgreSQL versions >= 13 the SQL statement will include `WITH (FORCE)` to
+        # disconnect clients before dropping the database. This allows you to drop/reset the
+        # database without stopping the Rails server etc. See:
+        # https://www.postgresql.org/docs/current/sql-dropdatabase.html
+        def drop_database(name)
+          statement = "DROP DATABASE IF EXISTS #{quote_table_name(name)}"
+          statement += " WITH (FORCE)" if supports_force_drop_database?
+          execute statement
         end
 
         def drop_table(*table_names, **options) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -466,6 +466,10 @@ module ActiveRecord
         true
       end
 
+      def supports_force_drop_database?
+        database_version >= 13_00_00 # >= 13.0
+      end
+
       def get_advisory_lock(lock_id) # :nodoc:
         unless lock_id.is_a?(Integer) && lock_id.bit_length <= 63
           raise(ArgumentError, "PostgreSQL requires advisory lock ids to be a signed 64 bit integer")

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -114,6 +114,18 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_drop_database_without_force
+    ActiveRecord::Base.lease_connection.stub(:database_version, 12_99_99) do
+      assert_equal %(DROP DATABASE IF EXISTS "development"), drop_database(:development)
+    end
+  end
+
+  def test_drop_database_with_force
+    ActiveRecord::Base.lease_connection.stub(:database_version, 13_00_00) do
+      assert_equal %(DROP DATABASE IF EXISTS "development" WITH (FORCE)), drop_database(:development)
+    end
+  end
+
   private
     def method_missing(...)
       ActiveRecord::Base.lease_connection.public_send(...)


### PR DESCRIPTION
### Motivation / Background

One of the benefits of developing with MySQL is that it allows dropping the current database without first disconnecting clients. As a result developers can use `bin/rails db:reset` and similar, without first shutting down instances of the app, Rails consoles, background workers, etc. By default PostgreSQL fails to drop a database when clients are connected and displays the following error:

  > PG::ObjectInUse: ERROR:  database "xyz" is being accessed by other users (PG::ObjectInUse)

This is frustrating when working in development where the database may be dropped frequently.

### Detail

PostgreSQL 13 added the `FORCE` option to the `DROP DATABASE` statement ([PostgreSQL docs](https://www.postgresql.org/docs/current/sql-dropdatabase.html)) which automatically disconnects clients before dropping the database. This PR adds the `RAILS_PG_DROP_FORCE` environment variable which sets this new option. This allows developers to easily drop/reset the database without shutting down their app, etc. E.g.,

  $ RAILS_PG_DROP_FORCE=true bin/rails db:reset

### Additional information

My first attempt at this feature used the PostgreSQL function [pg_terminate_backend](https://www.postgresql.org/docs/current/functions-admin.html), similar to the [test helper](https://github.com/rails/rails/blob/44b6847ead440f8ab5b17e3a0036fb4e75c6e2d4/activerecord/test/support/adapter_helper.rb#L173). By using that function it would work for Postgres versions < 13; however, it felt significantly more complicated. As those versions have already reached EOL I didn't think the extra complexity was justified.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
