### PR TITLE
Prefer Adapter#schema_cache to Model#schema_cache

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -59,7 +59,7 @@ module ActiveRecord
     end
 
     def primary_keys
-      Array(@model.schema_cache.primary_keys(model.table_name))
+      Array(@connection.schema_cache.primary_keys(model.table_name))
     end
 
     def skip_duplicates?
@@ -167,7 +167,7 @@ module ActiveRecord
       end
 
       def unique_indexes
-        @model.schema_cache.indexes(model.table_name).select(&:unique)
+        @connection.schema_cache.indexes(model.table_name).select(&:unique)
       end
 
       def ensure_valid_options_for_connection!


### PR DESCRIPTION
Model#schema_cache has to lookup the current pool, but we already have a connection/pool inside InsertAll, so this lookup is not needed.

This lookup currently happens 6 times inside InsertAll, and removing them all saves about ~3.5% of time on the `/updates` TechEmpower benchmark when using a SQLite memory database.