### PR TITLE
Fix ActiveSupport::Configurable deprecation

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -39,6 +39,7 @@ module ActiveSupport
   autoload :Concern
   autoload :CodeGenerator
   autoload :ActionableError
+  autoload :Configurable
   autoload :ConfigurationFile
   autoload :ContinuousIntegration
   autoload :CurrentAttributes
@@ -65,7 +66,6 @@ module ActiveSupport
     autoload :Benchmarkable
     autoload :Cache
     autoload :Callbacks
-    autoload :Configurable
     autoload :ClassAttribute
     autoload :Deprecation
     autoload :Delegation
@@ -94,10 +94,6 @@ module ActiveSupport
   autoload :Rescuable
   autoload :SafeBuffer, "active_support/core_ext/string/output_safety"
   autoload :TestCase
-
-  include Deprecation::DeprecatedConstantAccessor
-
-  deprecate_constant :Configurable, "class_attribute :config, default: {}", deprecator: ActiveSupport.deprecator
 
   def self.eager_load!
     super

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+ActiveSupport.deprecator.warn <<~MSG
+  ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.
+
+  You can emulate the previous behavior with `class_attribute`.
+MSG
+
 require "active_support/concern"
 require "active_support/ordered_options"
 

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
-require "active_support/configurable"
+
+ActiveSupport.deprecator.silence do
+  require "active_support/configurable"
+end
 
 class ConfigurableActiveSupport < ActiveSupport::TestCase
   class Parent

--- a/guides/source/8_1_release_notes.md
+++ b/guides/source/8_1_release_notes.md
@@ -181,6 +181,8 @@ Please refer to the [Changelog][active-support] for detailed changes.
 
 *   Deprecate `config.active_support.to_time_preserves_timezone`.
 
+*   Deprecate `ActiveSupport::Configurable`.
+
 ### Notable changes
 
 Active Job


### PR DESCRIPTION
Ref https://github.com/rails/rails/pull/53970

Before this commit, the constant could be referenced without a deprecation warning:

```
$ ./tools/console
irb(main):001> ActiveSupport::Configurable
=> ActiveSupport::Configurable
irb(main):002>
```

This commit fixes the deprecation to fire when the file is required (which should happen when the constant is referenced, since it is autoloaded). It also removes the `eager_autoload` to prevent the deprecation from warning when eager loading.

```
$ ./tools/console
irb(main):001> ActiveSupport::Configurable
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without
replacement, and will be removed in Rails 8.2.

You can emulate the previous behavior with `class_attribute`.
 (called from <top (required)> at (irb):1)
=> ActiveSupport::Configurable
irb(main):002>
```