### PR TITLE
Add blank line after create_enum in db/schema.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -42,6 +42,7 @@ module ActiveRecord
                 types.sort.each do |name, values|
                   stream.puts "  create_enum #{relation_name(name).inspect}, #{values.inspect}"
                 end
+                stream.puts
               end
             end
           end


### PR DESCRIPTION
Separate PostgreSQL's `create_enum` from the first `create_table` with a new line in any generated db/schema.rb file.

### Motivation / Background

 This follows the pattern already in place to separate other commands such as `enable_extension`:

```ruby
ActiveRecord::Schema[8.2].define(version: 0) do
  # These are extensions that must be enabled in order to support this database
  enable_extension "pg_catalog.plpgsql"
  enable_extension "pgcrypto"
  enable_extension "uuid-ossp"

  # Custom types defined in this database.
  # Note that some types may not work with other database engines. Be careful if changing database.
  create_enum "enum_with_comma", ["value1", "value,2", "value3"]

  create_table "1_need_quoting", force: :cascade do |t|
    t.string "name"
  end
  ...
```

Before this commit there was no blank line between `create_enum` and `create_table`.

### Additional information

Since this commit is a cosmetic change to the formatting of db/schema.rb, I didn't add a test the output is already tested:

https://github.com/rails/rails/blob/2c76861864814ec0a95ea13a6e786cab9b2f66cd/activerecord/test/cases/schema_dumper_test.rb#L460

The change is meant to reflect what is already happening in the code, for instance after `enable_extensions`:

https://github.com/rails/rails/blob/2c76861864814ec0a95ea13a6e786cab9b2f66cd/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb#L32

or after `create_schema`:

https://github.com/rails/rails/blob/2c76861864814ec0a95ea13a6e786cab9b2f66cd/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb#L56