### PR TITLE
Fix rdoc comment formatting for all_helpers_from_path method

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -90,7 +90,7 @@ module AbstractController
       #--
       # Implemented by Resolution#modules_for_helpers.
 
-      # :method: # all_helpers_from_path
+      # :method: all_helpers_from_path
       # :call-seq: all_helpers_from_path(path)
       #
       # Returns a list of helper names in a given path.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I noticed a typo in the rdoc for `AbstractController::Helpers` while browsing the docs.
The method name in the docs for `all_helpers_from_path` is being parsed as `#`

<img width="1057" height="838" alt="Screenshot 2025-10-20 at 12 46 53" src="https://github.com/user-attachments/assets/119ce043-888c-4c12-b020-4de62c632422" />


### Detail

This Pull Request removes the extraneous `#` from the `:method:` rdoc directive
