### PR TITLE
Set podman user as root so thruster can start

### DIFF
--- a/.github/workflows/rails-new-docker.yml
+++ b/.github/workflows/rails-new-docker.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Run container
       run: |
         podman run --name $APP_NAME \
+        --user root \
         -v $(pwd):$(pwd) \
         -e SECRET_KEY_BASE_DUMMY=1 \
         -e DATABASE_URL=sqlite3:storage/production.sqlite3 \


### PR DESCRIPTION
```
  podman run --name $APP_NAME \
  -v $(pwd):$(pwd) \
  -e SECRET_KEY_BASE_DUMMY=1 \
  -e DATABASE_URL=sqlite3:storage/production.sqlite3 \
  -p 3000:3000 $APP_NAME &
  shell: /usr/bin/bash -e {0}
  env:
    APP_NAME: devrails
    APP_PATH: dev/devrails
    BUNDLE_WITHOUT: db:job:cable:storage
{"time":"2025-10-20T10:35:34.923781791Z","level":"ERROR","msg":"Failed to start HTTP listener","error":"listen tcp :80: bind: permission denied"}
```

[[ref](https://github.com/rails/rails/actions/runs/18646792703/job/53163435215)]

Repro:

```
bundle exec railties/exe/rails new dev/devrails --dev`

export APP_NAME=devrails
export APP_PATH=dev/devrails
podman build -t $APP_NAME \
  -v "$(pwd):$(pwd)" \
  -f "$APP_PATH/Dockerfile" \
  "$APP_PATH"

podman run --rm --name $APP_NAME \
  -v "$(pwd):$(pwd)" \
  -e SECRET_KEY_BASE_DUMMY=1 \
  -e DATABASE_URL=sqlite3:storage/production.sqlite3 \
  -p 3000:3000 \
  $APP_NAME
```

We don't hand any secrets to this environment, so giving podman root inside the container is probably ok.

Alternatively, we could `sed -i 's/EXPOSE 80//' dev/devrails/Dockerfile`, but if you try this you will still get an error:

```
podman run --rm --name $APP_NAME \
  -v "$(pwd):$(pwd)" \
  -e SECRET_KEY_BASE_DUMMY=1 \
  -e DATABASE_URL=sqlite3:storage/production.sqlite3 \
  -e PORT=3000 \
  -e RAILS_ENV=development \
  -p 80:3000 \
  $APP_NAME
Error: rootlessport cannot expose privileged port 80, you can add 'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024), or choose a larger port number (>= 1024): listen tcp 0.0.0.0:80: bind: permission denied
```