### PR TITLE
Revert 53969 and add test

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -425,14 +425,10 @@ module ActiveRecord
 
       def _klass(class_name) # :nodoc:
         if active_record.name.demodulize == class_name
-          begin
-            compute_class("::#{class_name}")
-          rescue NameError
-            compute_class(class_name)
-          end
-        else
-          compute_class(class_name)
+          return compute_class("::#{class_name}") rescue NameError
         end
+
+        compute_class(class_name)
       end
 
       def compute_class(name)

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -221,6 +221,18 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal Nested::NestedUser, reflection.klass
   end
 
+  def test_reflection_klass_for_nested_association_with_top_level_module
+    reflection = ActiveRecord::Reflection.create(
+      :has_many,
+      :children,
+      nil,
+      {},
+      Nested::Child
+    )
+
+    assert_equal Nested::Child, reflection.klass
+  end
+
   def test_aggregation_reflection
     reflection_for_address = AggregateReflection.new(
       :address, nil, { mapping: [ %w(address_street street), %w(address_city city), %w(address_country country) ] }, Customer

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -27,6 +27,9 @@ class UserWithNotification < User
   after_create -> { Notification.create! message: "A new user has been created." }
 end
 
+module Child
+end
+
 module Nested
   class User < ActiveRecord::Base
     self.table_name = "users"
@@ -34,5 +37,8 @@ module Nested
 
   class NestedUser < ActiveRecord::Base
     has_many :nested_users
+  end
+
+  class Child < ActiveRecord::Base
   end
 end


### PR DESCRIPTION

### Motivation / Background

Revert https://github.com/rails/rails/pull/53969
Fixes https://github.com/rails/rails/issues/55935

### Detail

This PR reverts #53969, which introduced a name resolution failure for the pattern described in https://github.com/rails/rails/issues/55935 .

This issue does not occur in Rails 8.0.3. I believe reverting this change is preferable to refactoring at this time.

This PR also adds tests to cover this scenario.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
