### PR TITLE
[RF-Docs] [ci-skip] Explain flash better in Getting Started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1348,8 +1348,14 @@ We also want to replace any instance variables with a local variable, which we
 can define when we render the partial. We'll do this by replacing `@product`
 with `product`.
 
-```erb#1
+Let's also display any errors from the form submission inside the form.
+
+```erb#1-4
 <%= form_with model: product do |form| %>
+  <% if form.object.errors.any? %>
+    <p class="error"><%= form.object.errors.full_messages.first %></p>
+  <% end %>
+
   <div>
     <%= form.label :name %>
     <%= form.text_field :name %>
@@ -2113,21 +2119,31 @@ class SubscribersController < ApplicationController
 end
 ```
 
-Our redirect sets a notice in the Rails flash. The flash is used for storing
-messages to display on the next page.
+The `redirect_to` uses the `notice:` argument to set a "flash" message to tell
+the user they are subscribed.
 
-To display the flash message, let's add the notice to
+The [flash](https://api.rubyonrails.org/classes/ActionDispatch/Flash.html)
+provides a way to pass temporary data between controller actions. Anything you
+place in the flash will be available to the very next action and then cleared.
+The flash is typically used for setting messages (e.g. notices and alerts) in a
+controller action before redirecting to an action that displays the message to
+the user.
+
+To display the flash message, let's add the flash to
 `app/views/layouts/application.html.erb` inside the body:
 
-```erb#4
+```erb#4-5
 <html>
   <!-- ... -->
   <body>
-    <div class="notice"><%= notice %></div>
+    <div class="notice"><%= flash[:notice] %></div>
+    <div class="alert"><%= flash[:alert] %></div>
     <!-- ... -->
   </body>
 </html>
 ```
+
+Learn more about the Flash in the [Action Controller Overview](action_controller_overview.html#the-flash)
 
 To subscribe users to a specific product, we'll use a nested route so we know
 which product the subscriber belongs to. In `config/routes.rb` change
@@ -2506,6 +2522,11 @@ nav a {
 main {
   max-width: 1024px;
   margin: 0 auto;
+}
+
+.alert,
+.error {
+  color: red;
 }
 
 .notice {

--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -498,10 +498,9 @@ You can now visit http://localhost:3000/settings/profile to update your name.
 Let's update the navigation to include a link to Settings next to the Log out
 button.
 
-Open `app/views/layouts/application.html.erb` and update the navbar. We'll also
-add a div for any alert messages from our controllers while we're here.
+Open `app/views/layouts/application.html.erb` and update the navbar.
 
-```erb#9,13-19
+```erb#13-19
 <!DOCTYPE html>
 <html>
   <head>
@@ -509,8 +508,8 @@ add a div for any alert messages from our controllers while we're here.
   </head>
 
   <body>
-    <div class="notice"><%= notice %></div>
-    <div class="alert"><%= alert %></div>
+    <div class="notice"><%= flash[:notice] %></div>
+    <div class="alert"><%= flash[:alert] %></div>
 
     <nav class="navbar">
       <%= link_to "Home", root_path %>
@@ -570,8 +569,8 @@ layout using `yield(:content)`.
   </head>
 
   <body>
-    <div class="notice"><%= notice %></div>
-    <div class="alert"><%= alert %></div>
+    <div class="notice"><%= flash[:notice] %></div>
+    <div class="alert"><%= flash[:alert] %></div>
 
     <nav class="navbar">
       <%= link_to "Home", root_path %>
@@ -1432,21 +1431,11 @@ important changes:
 
 The admin views need some tweaks to work inside the `store` namespace.
 
-First, let's fix the form by updating the `model:` argument to use the `store`
-namespace. We should also display validation errors in the form while we're
-here.
+First, let's fix the form in `app/views/store/products/_form.html.erb` by
+updating the `model:` argument to use the `store` namespace.
 
-```erb#1-4
+```erb#1
 <%= form_with model: [ :store, product ] do |form| %>
-  <% if form.object.errors.any? %>
-    <div>Error: <%= form.object.errors.full_messages.first %></div>
-  <% end %>
-
-  <div>
-    <%= form.label :name %>
-    <%= form.text_field :name %>
-  </div>
-
   <%# ... %>
 ```
 


### PR DESCRIPTION
### Motivation / Background

This improves the Getting Started guide by adding more explanation for the Flash and links to the Action Controller Overview for further reading.

### Detail

Instead of using the `notice` helper, using `flash` directly clarifies a bit more of how flash works.

While we're there, adding the `alert` flash in the Getting Started guide helps showcase it can be used with multiple names and simplifies future tutorials (and anyone who goes on side quests adding their own features).

This also improves the form partial to render errors inline instead than using a flash.now in #55914. Errors and alerts will be displayed in red so they stand out like notices as well.

### Additional information

This PR is an alternative to #55914

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @AmandaPerino @p8 @zzak 