### PR TITLE
Fix negative scopes for the nil value enum definition

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -318,8 +318,7 @@ module ActiveRecord
 
               # scope :not_active, -> { where.not(status: 0) }
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              arel_column = klass.arel_table[name]
-              klass.scope "not_#{value_method_name}", -> { where(arel_column.not_eq(value).or(arel_column.eq(nil))) }
+              klass.scope "not_#{value_method_name}", -> { where(predicate_builder[name, value, :is_distinct_from]) }
             end
           end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -88,6 +88,8 @@ class EnumTest < ActiveRecord::TestCase
     assert Book.not_published.exclude?(@book)
     assert Book.not_proposed.include?(@book)
 
+    assert Book.not_forgotten.exclude?(books(:ddd))
+
     # Should include records with nils in the column.
     rfr = books(:rfr)
     rfr.update!(status: nil)


### PR DESCRIPTION
#55912 broke negative scopes if enum definitions includes nil values.
Instead of forcing push nil condition, use null safe comparison.

https://github.com/rails/rails/blob/4b7bf2617d190b7769393e975a2449f8cde12145/activerecord/test/models/book.rb#L18
