### PR TITLE
Getting Started guide (section 16.4 — Extracting a Concern) Doc oversight

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2381,7 +2381,7 @@ Notifications module.
 
 ```ruby#2
 class Product < ApplicationRecord
-  include Notifications
+  include Product::Notifications
 
   has_one_attached :featured_image
   has_rich_text :description


### PR DESCRIPTION
The Getting Started guide (section 16.4 — Extracting a Concern) appears to be mixing two naming patterns:

It defines a namespaced module (`Product::Notifications`)

but then includes it as if it were a top-level module (`include Notifications`)

Should be a doc oversight, the correct line would be:

```ruby
include Product::Notifications
```


And that would match the file path and the constant definition.