### PR TITLE
Fix upsert error on repeated timestamps

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix upsert_all when using repeated timestamp attributes.
+
+    *Gannon McGibbon*
+
 *   PostgreSQL enable drop database FORCE option.
 
     One of the benefits of developing with MySQL is that it allows dropping the

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -285,8 +285,8 @@ module ActiveRecord
           return "" unless update_duplicates? && record_timestamps?
 
           model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
-            if touch_timestamp_attribute?(column_name)
-              "#{column_name}=(CASE WHEN (#{updatable_columns.map(&block).join(" AND ")}) THEN #{model.quoted_table_name}.#{column_name} ELSE #{connection.high_precision_current_timestamp} END),"
+            if touch_timestamp_attribute?(column_name) && !column_name.to_sym.in?(insert_all.updatable_columns)
+              "#{column_name}=(CASE WHEN (#{updatable_columns.map(&block).join(" AND ")}) THEN #{model.quoted_table_name}.#{column_name} ELSE #{connection.high_precision_current_timestamp} END), "
             end
           end.join
         end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -809,6 +809,18 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_upsert_with_repeated_timstamp_columns
+    records = [Book.first.attributes]
+
+    assert_no_changes(proc { Book.count }) do
+      Book.upsert_all(
+        records,
+        update_only: [:updated_at],
+        record_timestamps: true,
+      )
+    end
+  end
+
   def test_upsert_all_resets_relation
     skip unless supports_insert_on_duplicate_update?
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because you can currently trigger a query error when upserting on Postgres using something like this:
```rb
records = [Book.first.attributes]
Book.upsert_all(
  records,
  update_only: [:updated_at],
  record_timestamps: true,
)
```
Updating a timestamp column and specifying `record_timestamps` generates redundant column sets:
```sql
INSERT INTO "books" 
  ("id","author_id","format","format_record_id","format_record_type","name","status","last_read","nullable_status","language","author_visibility","illustrator_visibility","font_size","difficulty","cover","symbol_status","isbn","external_id","original_name","published_on","boolean_status","tags_count","created_at","updated_at","updated_on")
VALUES 
  (1, 1, 'paperback', NULL, NULL, 'Agile Web Development with Rails', 2, 3, NULL, 0, 0, 0, 1, 1, 'soft', 'proposed', NULL, NULL, NULL, NULL, TRUE, 0, '2025-10-21 19:34:32.827580', '2025-10-21 19:34:32.827580', '2025-10-21') 
ON CONFLICT ("id") DO UPDATE 
SET updated_at=(
  CASE WHEN ("books"."updated_at" IS NOT DISTINCT FROM excluded."updated_at") THEN "books".updated_at ELSE
  CURRENT_TIMESTAMP END),updated_on=(CASE WHEN ("books"."updated_at" IS NOT DISTINCT FROM 
  excluded."updated_at") THEN "books".updated_on ELSE CURRENT_TIMESTAMP END
),
"updated_at"=excluded."updated_at" RETURNING "id"
```
This results in a `multiple assignments to same column "updated_at"` postgres error.

### Detail

This Pull Request changes upsert to omit timestamp column case statements in the set clause for these cases because they're ignored anyway. 

### Additional information

Keeping the case statement and omitting the latter timestamp column set line seems to make other tests fail, so this seems like the least destructive way to handle this case in upsert.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
