### PR TITLE
[ci skip] Small fix on the formatting of a code block in the 8.1 release notes.

### DIFF
--- a/guides/source/8_1_release_notes.md
+++ b/guides/source/8_1_release_notes.md
@@ -94,6 +94,7 @@ end
 ```
 
 As well as context:
+
 ```ruby
 # All events will contain context: {request_id: "abc123", shop_id: 456}
 Rails.event.set_context(request_id: "abc123", shop_id: 456)


### PR DESCRIPTION
The missing blank line before the code block cause d rendering issues in the html page. I noticed the
 problem is not exhibited in the markdown preview.

**I'm aware of the policy about not merging small or cometic changes but the result of this bug was so bad (and easy to fix) that I thought it would worth to give it a try:**

<img width="2134" height="2414" alt="2025-10-22_04-42" src="https://github.com/user-attachments/assets/44f5b9dc-047e-444e-887f-b0d8faabd8d6" />

## Result After Build

<img width="2118" height="1426" alt="image" src="https://github.com/user-attachments/assets/9d0bb911-75e7-41fe-aabe-c271ac9c0eb8" />
