### PR TITLE
[ci skip] Fix missing quote in EventReporter documentation

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -225,7 +225,7 @@ module ActiveSupport
   #   #    name: "user_created",
   #   #    payload: { id: 123 },
   #   #    tags: {},
-  #   #    context: { request_id: "abcd123", user_agent: TestAgent" },
+  #   #    context: { request_id: "abcd123", user_agent: "TestAgent" },
   #   #    timestamp: 1738964843208679035,
   #   #    source_location: { filepath: "path/to/file.rb", lineno: 123, label: "UserService#create" }
   #   #  }


### PR DESCRIPTION
Fix a typo in the EventReporter documentation example where the opening quote was missing for the user_agent value in the context hash example.

Before: user_agent: TestAgent"
After: user_agent: "TestAgent"
