### PR TITLE
Enable `apply_rubocop_autocorrect_after_generate!` generator test on MRI 3.4

### DIFF
--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -266,24 +266,22 @@ module ApplicationTests
       assert_match(/# Add comment to model/, File.read(model_file))
     end
 
-    if RUBY_VERSION < "3.4" # Revisit when 3.4 is added to the matrix
-      test "generators with apply_rubocop_autocorrect_after_generate!" do
-        with_config do |c|
-          c.generators.apply_rubocop_autocorrect_after_generate!
-        end
-
-        output = rails("generate", "model", "post", "title:string", "body:string")
-        assert_no_match(/3 files inspected, no offenses detected/, output)
+    test "generators with apply_rubocop_autocorrect_after_generate!" do
+      with_config do |c|
+        c.generators.apply_rubocop_autocorrect_after_generate!
       end
 
-      test "generators with apply_rubocop_autocorrect_after_generate! and pretend" do
-        with_config do |c|
-          c.generators.apply_rubocop_autocorrect_after_generate!
-        end
+      output = rails("generate", "model", "post", "title:string", "body:string")
+      assert_no_match(/3 files inspected, no offenses detected/, output)
+    end
 
-        assert_nothing_raised do
-          rails("generate", "model", "post", "title:string", "body:string", "--pretend")
-        end
+    test "generators with apply_rubocop_autocorrect_after_generate! and pretend" do
+      with_config do |c|
+        c.generators.apply_rubocop_autocorrect_after_generate!
+      end
+
+      assert_nothing_raised do
+        rails("generate", "model", "post", "title:string", "body:string", "--pretend")
       end
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/commit/0d940e376ce5a9bc7af4e7e02988a52eb6989f24

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
