### PR TITLE
ci.rb: Do not add "Tests" step if `--no-test` is provided

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -18,14 +18,16 @@ CI.run do
 <% unless options.skip_brakeman? -%>
   step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
 <% end -%>
+<% unless options[:skip_test] -%>
 <% if options[:api] || options[:skip_system_test] -%>
   step "Tests: Rails", "bin/rails test"
 <% else %>
   step "Tests: Rails", "bin/rails test"
   step "Tests: System", "bin/rails test:system"
 <% end -%>
-<% unless options.skip_active_record?  -%>
+<% unless options.skip_active_record? -%>
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+<% end -%>
 <% end -%>
 
   # Optional: set a green GitHub commit status to unblock PR merge.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -699,6 +699,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_config_ci_does_not_include_test_steps_when_skip_test_is_given
+    run_generator [destination_root, "--skip-test"]
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/step "Tests: Rails"/, content)
+      assert_no_match(/step "Tests: System"/, content)
+      assert_no_match(/step "Tests: Seeds"/, content)
+      assert_no_match(/bin\/rails db:seed:replant/, content)
+    end
+  end
+
   def test_config_ci_does_not_include_seed_step_when_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
 


### PR DESCRIPTION
Looks like if the `--no-test` option is provided, there's no reason to add "Tests: Rails", "Tests: System" and "Tests: Seeds" into the `ci.rb`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

