### PR TITLE
Document risks of using `.descendants`

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -16,6 +16,19 @@ class Class
   #
   #   class D < C; end
   #   C.descendants # => [B, A, D]
+  #
+  # WARNING: This method is unreliable in certain situations:
+  #
+  # * It only returns classes that have already been loaded. When using
+  #   autoloading, classes that haven't been referenced yet won't appear
+  #   in the results, even if their files exist in the codebase.
+  #
+  # * The results are non-deterministic with regards to Garbage Collection.
+  #   If you use this method in tests where classes are dynamically defined,
+  #   GC is unpredictable about when those classes are cleaned up and removed.
+  #
+  # Consider these limitations carefully when using this method, especially in
+  # production code.
   def descendants
     subclasses.concat(subclasses.flat_map(&:descendants))
   end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1064,6 +1064,12 @@ C.descendants # => [B, A, D]
 
 The order in which these classes are returned is unspecified.
 
+WARNING: This method is unreliable in certain situations and should be used with caution:
+
+* **Autoloading**: It only returns classes that have already been loaded. When using autoloading (the default in Rails), classes that haven't been referenced yet won't appear in the results, even if their files exist in the codebase. This can lead to incomplete results in production code.
+
+* **Garbage Collection**: The results are non-deterministic with regards to Garbage Collection. If you use this method in tests where classes are dynamically defined, GC is unpredictable about when those classes are cleaned up and removed from the descendants list.
+
 NOTE: Defined in `active_support/core_ext/class/subclasses.rb`.
 
 [Class#descendants]: https://api.rubyonrails.org/classes/Class.html#method-i-descendants


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because developers should be aware of the risks of using `Class.descendants`, particularly when using autoloading or in test environments with dynamically defined classes.

As discussed in [rubocop/rubocop-rails#1544](https://github.com/rubocop/rubocop-rails/issues/1544), these methods have two limitations:

1. They only return classes that have already been loaded, missing classes that haven't been autoloaded yet
2. They are non-deterministic with regards to Garbage Collection, especially problematic in test environments where classes are dynamically defined

Without proper documentation, developers may unknowingly use these methods in production code expecting complete and reliable results, leading to subtle bugs that are difficult to diagnose.

### Detail

This Pull Request changes the documentation for `Class#descendants`

### Additional information

Related discussion at https://github.com/github/rubocop-github/issues/110

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a Ruby/Rails/Crystal dev
**PPS:** would you be so kind and add the `hacktoberfest-accepted` label to this issue in case you find that PR helpful? :pleading_face: 