### PR TITLE
Remove documentation about `.subclasses`

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1018,31 +1018,7 @@ NOTE: Defined in `active_support/core_ext/module/attribute_accessors.rb`.
 [Module#cattr_reader]: https://api.rubyonrails.org/classes/Module.html#method-i-cattr_reader
 [Module#cattr_writer]: https://api.rubyonrails.org/classes/Module.html#method-i-cattr_writer
 
-### Subclasses and Descendants
-
-#### `subclasses`
-
-The [`subclasses`][Class#subclasses] method returns the subclasses of the receiver:
-
-```ruby
-class C; end
-C.subclasses # => []
-
-class B < C; end
-C.subclasses # => [B]
-
-class A < B; end
-C.subclasses # => [B]
-
-class D < C; end
-C.subclasses # => [B, D]
-```
-
-The order in which these classes are returned is unspecified.
-
-NOTE: Defined in `active_support/core_ext/class/subclasses.rb`.
-
-[Class#subclasses]: https://api.rubyonrails.org/classes/Class.html#method-i-subclasses
+### Descendants
 
 #### `descendants`
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the `.subclasses` method is now part of Ruby's core `Class` as of Ruby 3.1, and no longer needs to be documented as an `ActiveSupport` extension.

### Detail

This Pull Request removes the documentation for the `.subclasses` method from the Active Support Core Extensions guide.
[As Hartley pointed out](https://github.com/rails/rails/pull/55965#pullrequestreview-3365768140), the method is now a standard Ruby feature and should be documented in Ruby's official documentation rather than Rails guides.

Changes made:
- Removed `.subclasses` documentation

### Additional information

The `.subclasses` method was added to Ruby core in Ruby 3.1, making the Active Support extension redundant. Since Rails 7.0+ requires Ruby 2.7+ and Rails 8.0 requires Ruby 3.2+, this documentation cleanup helps clarify which features are Rails-specific extensions versus standard Ruby features.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a Ruby/Rails/Crystal dev
**PPS:** would you be so kind and add the `hacktoberfest-accepted` label to this issue in case you find that PR helpful? :pleading_face: 