### PR TITLE
Refactors `ActiveRecord::Reflection::MacroReflection#_klass` inline rescue

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -425,7 +425,11 @@ module ActiveRecord
 
       def _klass(class_name) # :nodoc:
         if active_record.name.demodulize == class_name
-          return compute_class("::#{class_name}") rescue NameError
+          begin
+            return compute_class("::#{class_name}")
+          rescue
+            # Ignored
+          end
         end
 
         compute_class(class_name)


### PR DESCRIPTION
### Motivation / Background

Follow up #55949

The #55949 reverted #53969 because of the regression introduced by that PR, which broke resolution on nested models when a top-level module with the same name as the nested model exists. With that change the original issue that was raised in #53969 has been reverted as well.

The inline `rescue` could be mistaken for having the same functionality as a regular `rescue` block, and it is confusing to some people. This commit converts the inline `rescue` to a normal `begin / rescue` block, which makes it easier to understand and avoid potential issues in refactoring in the future.

### Detail

- Refactors `ActiveRecord::Reflection::MacroReflection#_klass` inline rescue

### Additional information

Note that there is already a test to make sure this refactoring is not introducing the regression discussed in #55949.

I couldn't find the official ruby document for inline rescue. The Control [Expressions page](https://docs.ruby-lang.org/en/master/syntax/control_expressions_rdoc.html#label-Modifier+Statements) talks about some examples of inline rescue with `if` statement, and the [Exception Handling](https://docs.ruby-lang.org/en/master/syntax/exceptions_rdoc.html) page does not have any examples of it.

Basically, what inline rescue does is that if an exception is raised on the left side statement, the right side will be evaluated.

```
left statement rescue right statement
```

In this case, 

```ruby
return compute_class("::#{class_name}") rescue NameError
```

`return compute_class("::#{class_name}")` will be executed, and when the exception is raised, the `NameError` is evaluated as the last line result, but will not be returned because `return` is part of the left statement, the entire left statement has been ignored by `rescue`.


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] ~~Tests are added or updated if you fix a bug or add a feature.~~
* [X] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
