### PR TITLE
Fix MySQL EXPLAIN tests to support both TRADITIONAL and TREE formats

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
@@ -10,15 +10,15 @@ class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
   def test_explain_for_one_query
     explain = Author.where(id: 1).explain.inspect
     assert_match %(EXPLAIN SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
-    assert_match %r(authors |.* const), explain
+    assert_match %r(authors), explain
   end
 
   def test_explain_with_eager_loading
     explain = Author.where(id: 1).includes(:posts).explain.inspect
     assert_match %(EXPLAIN SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
-    assert_match %r(authors |.* const), explain
+    assert_match %r(authors), explain
     assert_match %(EXPLAIN SELECT `posts`.* FROM `posts` WHERE `posts`.`author_id` = 1), explain
-    assert_match %r(posts |.* ALL), explain
+    assert_match %r(posts), explain
   end
 
   def test_explain_with_options_as_symbol

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
@@ -11,7 +11,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
       assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         posts = Post.optimizer_hints("NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id)")
         posts = posts.select(:id).where(author_id: [0, 1])
-        assert_includes posts.explain.inspect, "| index | index_posts_on_author_id | index_posts_on_author_id |"
+        assert_includes posts.explain.inspect, "index_posts_on_author_id"
       end
     end
 
@@ -27,7 +27,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
       assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         posts = Post.optimizer_hints("/*+ NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id) */")
         posts = posts.select(:id).where(author_id: [0, 1])
-        assert_includes posts.explain.inspect, "| index | index_posts_on_author_id | index_posts_on_author_id |"
+        assert_includes posts.explain.inspect, "index_posts_on_author_id"
       end
 
       assert_queries_match(%r{\ASELECT /\*\+ \*\* // `posts`\.\*, // \*\* \*/}) do

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -54,7 +54,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
 
   test "#explain for one query" do
     explain = @conn.explain("select * from posts")
-    assert_match %(possible_keys), explain
+    assert_match %r(posts), explain
   end
 
   test "#adapter_name answers name" do


### PR DESCRIPTION
### Detail

MySQL 9.5.0 changed the default `explain_format` from `TRADITIONAL` to `TREE`, causing tests to fail when they matched on format-specific output.

Fixes #55958

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
