### PR TITLE
Mask secure tokens by default while displaying prefix

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `prefix:` and `skip_inspection_filter:` options to `has_secure_token` and filter token values by default.
+
+    *Benjamin Garcia*
+
 *   PostgreSQL enable drop database FORCE option.
 
     One of the benefits of developing with MySQL is that it allows dropping the

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -130,4 +130,19 @@ class SecureTokenTest < ActiveRecord::TestCase
     assert_match(/^token_/, user.token)
     assert_match(/^auth/, user.auth_token)
   end
+
+  def test_token_masked_on_inspect
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "users"
+      attribute :auth_token
+      has_secure_token on: :initialize, prefix: true, skip_inspection_filter: true
+      has_secure_token :auth_token, on: :initialize, prefix: "auth_"
+    end
+
+    user = model.new
+
+    assert_not_includes user.inspect, "token: token_[FILTERED]"
+    assert_includes user.inspect, "auth_token: auth_[FILTERED]"
+    assert_equal 1, user.inspect.scan("[FILTERED]").length
+  end
 end


### PR DESCRIPTION
Following up on #55822 - It makes sense to mask token values by default for a module named SecureToken.

Notably, this PR still respects prefix definitions.

* Before 
`user.inspect => #<User ..., token: token_tU9bLuZseefXQ4yQxQo8wjtB>`

* After
`user.inspect => #<User ..., token: token_[FILTERED]>`