### PR TITLE
[ci skip] Add Ruby version requirement for Rails 8.1 in upgrading guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -20,9 +20,9 @@ The best way to be sure that your application still works after upgrading is to 
 
 Rails generally stays close to the latest released Ruby version when it's released:
 
-* Rails 8.0 requires Ruby 3.2.0 or newer.
+* Rails 8.0 and 8.1 require Ruby 3.2.0 or newer.
 * Rails 7.2 requires Ruby 3.1.0 or newer.
-* Rails 7.0 and 7.1 requires Ruby 2.7.0 or newer.
+* Rails 7.0 and 7.1 require Ruby 2.7.0 or newer.
 * Rails 6 requires Ruby 2.5.0 or newer.
 * Rails 5 requires Ruby 2.2.2 or newer.
 


### PR DESCRIPTION
Ruby Versions section:
* Adds the required Ruby version for Rails 8.1 (Ruby 3.2.0).
* Minor grammar fix for plural versions: Rails 8.0 and 8.1 require**~s~** Ruby 3.2.0 or newer.
