### PR TITLE
[Fix #55957] has_many through persistence

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -2,10 +2,15 @@
 
 module ActiveRecord
   module AttributeAssignment
+    def assigning_attributes? # :nodoc:
+      @_assigning_attributes == true
+    end
+
     private
       def _assign_attributes(attributes)
         multi_parameter_attributes = nested_parameter_attributes = nil
 
+        @_assigning_attributes = true
         attributes.each do |k, v|
           key = k.to_s
 
@@ -20,6 +25,8 @@ module ActiveRecord
 
         assign_nested_parameter_attributes(nested_parameter_attributes) if nested_parameter_attributes
         assign_multiparameter_attributes(multi_parameter_attributes) if multi_parameter_attributes
+      ensure
+        @_assigning_attributes = false
       end
 
       # Assign any deferred nested attributes after the base attributes have been set.

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -459,6 +459,11 @@ module ActiveRecord
               raise(RecordInvalid.new(association.owner)) unless saved
             end
           end
+
+          # save pending through records for has_many :through associations
+          if association.respond_to?(:save_pending_through_records)
+            association.save_pending_through_records
+          end
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1705,6 +1705,19 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal(chapter.book, book)
   end
 
+  def test_assign_attributes_with_ids_does_not_persist_join_records_before_save
+    rosa = Person.create!(first_name: "Rosa")
+    post1 = Post.create!(author_id: 1, title: "Mochi's Diary", body: "Me gusta el perro Mochí... simo")
+    post2 = Post.create!(author_id: 1, title: "Running with Jorge", body: "Next marathon in Madrid!")
+    initial_reader_count = Reader.count
+
+    rosa.assign_attributes(post_ids: [post1.id, post2.id])
+    assert_equal initial_reader_count, Reader.count, "Join records should not persist during assign_attributes"
+
+    assert rosa.save
+    assert_equal initial_reader_count + 2, Reader.count, "Join records should persist after successful save"
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I thought that [this issue](https://github.com/rails/rails/issues/55957) might actually be a valid bug, since `assign_attributes` should indeed not touch the database in general, yet the test shows that it does. :exploding_head: 

However, I'm not sure whether it is _really_ a valid issue nor do I know whether my way of solving this is how one should do it.

### Detail

This Pull Request defers the persistence if the through-records were replaced rather than modified.
It's not a lot of code but it _feels_ rather too complicated and I think that there might be a better way?

Thus I'm very open for any kind of feedback here. :pray: 

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

fixes #55957

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a PO/PM or Ruby/Rails/Crystal dev