### PR TITLE
[skip-ci][doc] Fix typo in command_line.md

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -769,11 +769,10 @@ $ bin/rails runner lib/path_to_ruby_script.rb
 ```
 
 By default, `bin/rails runner` scripts are automatically wrapped with the Rails
-Executor (which is an instance of
-[ActiveSupport::Executor](https://api.rubyonrails.org/classes/ActiveSupport/Executor.html)
-associated with your Rails application. The Executor creates a “safe zone” to
-run arbitrary Ruby inside a Rails app so that the autoloader, middleware stack,
-and Active Support hooks all behave consistently.
+Executor (which is an instance of [`ActiveSupport::Executor`][]) associated with
+your Rails application. The Executor creates a “safe zone” to run arbitrary
+Ruby inside a Rails app so that the autoloader, middleware stack, and Active
+Support hooks all behave consistently.
 
 Therefore, executing `bin/rails runner lib/path_to_ruby_script.rb` is
 functionally equivalent to the following:
@@ -790,6 +789,9 @@ option.
 ```bash
 $ bin/rails runner --skip-executor lib/long_running_script.rb
 ```
+
+[`ActiveSupport::Executor`]:
+  https://api.rubyonrails.org/classes/ActiveSupport/Executor.html
 
 ### `bin/rails boot`
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created just to fix a typo.

Ref: https://github.com/rails/rails/pull/55977

### Detail

Fixed the missing `)`, as well as formatted to be wrapped in 80-chars.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
