### PR TITLE
Correct WHERE condition in CTE test

### DIFF
--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -29,7 +29,7 @@ module ActiveRecord
         cte_options = {
           posts_with_tags: Post.arel_table.project(Arel.star).where(Post.arel_table[:tags_count].gt(0)),
           posts_with_tags_and_truthy: Arel.sql("SELECT * FROM posts_with_tags WHERE 1=1"),
-          posts_with_tags_and_comments: Arel.sql("SELECT * FROM posts_with_tags_and_truthy WHERE tags_count > ?", 0),
+          posts_with_tags_and_comments: Arel.sql("SELECT * FROM posts_with_tags_and_truthy WHERE legacy_comments_count > ?", 0),
           "posts_with_tags_and_multiple_comments" => Post.where("legacy_comments_count > 1").from("posts_with_tags_and_comments AS posts")
         }
         relation = Post.with(cte_options).from("posts_with_tags_and_multiple_comments AS posts")


### PR DESCRIPTION
`posts_with_tags_and_comments` should filter on comments count instead of tags count. While the test still passed, this change aligns the query with the CTE’s intent and naming.

Introduced in https://github.com/rails/rails/pull/55918 when adding support for bound SQL literals in CTEs.
