### PR TITLE
Suppress structure load output during tests

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -237,7 +237,7 @@ module ActiveRecord
       filename = "awesome-file.sql"
 
       open(filename, "w") { |f| f.puts("select datetime('now', 'localtime');") }
-      ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, filename, "/rails/root"
+      quietly { ActiveRecord::Tasks::DatabaseTasks.structure_load @configuration, filename, "/rails/root" }
       assert File.exist?(dbfile)
     ensure
       FileUtils.rm_f(filename)


### PR DESCRIPTION
When running `sqlite_rake_test.rb`, the structure_load task was outputting SQL query results to stdout, polluting the test output. This happened because the SQLite CLI executes queries and prints results by default.

Before

```
$ ARCONN=sqlite3 bin/test test/cases/adapters/sqlite3/sqlite_rake_test.rb
Using sqlite3
Run options: --seed 2442

# Running:

....2025-10-23 06:49:34
..........

Finished in 0.074025s, 189.1253 runs/s, 459.3043 assertions/s.
14 runs, 34 assertions, 0 failures, 0 errors, 0 skips
```

After

```
$ ARCONN=sqlite3 bin/test test/cases/adapters/sqlite3/sqlite_rake_test.rb
Using sqlite3
Run options: --seed 2724

# Running:

..............

Finished in 0.071562s, 195.6346 runs/s, 475.1125 assertions/s.
14 runs, 34 assertions, 0 failures, 0 errors, 0 skips
```