### PR TITLE
Add tests for guides code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -199,7 +199,8 @@ task :preview_docs do
   FileUtils.mkdir_p("preview")
   PreviewDocs.new.render("preview")
 
-  require "guides/rails_guides"
+  system(%(cd guides && #{$0} guides:generate --trace))
+
   Rake::Task[:rdoc].invoke
 
   FileUtils.mv("doc/rdoc", "preview/api")

--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.verbose = true
+  t.options = "--profile" if ENV["CI"]
+end
+
 namespace :guides do
   desc 'Generate guides (for authors), use ONLY=foo to process just "foo.md"'
   task generate: "generate:html"
@@ -7,7 +16,7 @@ namespace :guides do
   namespace :generate do
     desc "Generate HTML guides"
     task :html do
-      ruby "-Eutf-8:utf-8", "rails_guides.rb"
+      generate_guides
     end
 
     desc "Generate .mobi file"
@@ -30,7 +39,7 @@ namespace :guides do
     desc "Check links in generated HTML guides"
     task :check_links do
       ENV["GUIDES_LINT"] = "1"
-      ruby "-Eutf-8:utf-8", "rails_guides.rb"
+      generate_guides
     end
 
     desc "Run mdl to check Markdown files for style guide violations and lint errors"
@@ -45,7 +54,8 @@ namespace :guides do
   # Validate guides -------------------------------------------------------------------------
   desc 'Validate guides, use ONLY=foo to process just "foo.html"'
   task :validate do
-    ruby "w3c_validator.rb"
+    require_relative "w3c_validator.rb"
+    RailsGuides::Validator.new.validate
   end
 
   task :vendor_javascript do
@@ -105,15 +115,24 @@ HELP
   end
 end
 
-task :test do
-  templates = Dir.glob("bug_report_templates/*.rb")
-  counter = templates.count do |file|
-    puts "--- Running #{file}"
-    Bundler.unbundled_system(Gem.ruby, "-w", file) ||
-      puts("+++ 💥 FAILED (exit #{$?.exitstatus})")
-  end
-  puts "+++ #{counter} / #{templates.size} templates executed successfully"
-  exit 1 if counter < templates.size
-end
-
 task default: "guides:help"
+
+def generate_guides
+  require_relative "rails_guides"
+  env_value = ->(name) { ENV[name].presence }
+  env_flag  = ->(name) { "1" == env_value[name] }
+
+  version = env_value["RAILS_VERSION"]
+  edge    = `git rev-parse HEAD`.strip unless version
+
+  RailsGuides::Generator.new(
+    edge:      edge,
+    version:   version,
+    all:       env_flag["ALL"],
+    only:      env_value["ONLY"],
+    epub:      env_flag["EPUB"],
+    language:  env_value["GUIDES_LANGUAGE"],
+    direction: env_value["DIRECTION"],
+    lint:      env_flag["GUIDES_LINT"]
+  ).generate
+end

--- a/guides/bin/test
+++ b/guides/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+COMPONENT_ROOT = File.expand_path("..", __dir__)
+require_relative "../../tools/test"

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -2,30 +2,4 @@
 
 $:.unshift __dir__
 
-as_lib = File.expand_path("../activesupport/lib", __dir__)
-ap_lib = File.expand_path("../actionpack/lib", __dir__)
-av_lib = File.expand_path("../actionview/lib", __dir__)
-
-$:.unshift as_lib if File.directory?(as_lib)
-$:.unshift ap_lib if File.directory?(ap_lib)
-$:.unshift av_lib if File.directory?(av_lib)
-
 require "rails_guides/generator"
-require "active_support/core_ext/object/blank"
-
-env_value = ->(name) { ENV[name].presence }
-env_flag  = ->(name) { "1" == env_value[name] }
-
-version = env_value["RAILS_VERSION"]
-edge    = `git rev-parse HEAD`.strip unless version
-
-RailsGuides::Generator.new(
-  edge:      edge,
-  version:   version,
-  all:       env_flag["ALL"],
-  only:      env_value["ONLY"],
-  epub:      env_flag["EPUB"],
-  language:  env_value["GUIDES_LANGUAGE"],
-  direction: env_value["DIRECTION"],
-  lint:      env_flag["GUIDES_LINT"]
-).generate

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -4,7 +4,6 @@ require "redcarpet"
 require "nokogiri"
 require "rails_guides/markdown/renderer"
 require "rails_guides/markdown/epub_renderer"
-require "rails-html-sanitizer"
 
 module RailsGuides
   class Markdown

--- a/guides/test/bug_report_template_test.rb
+++ b/guides/test/bug_report_template_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_support/testing/stream"
+
+class BugReportTemplatesTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Stream
+
+  templates = Dir.glob("bug_report_templates/*.rb")
+  templates.each do |file|
+    test "#{file} can be executed " do
+      success = silence_stream($stdout) do
+        Bundler.unbundled_system(Gem.ruby, "-w", file) ||
+          puts("+++ 💥 FAILED (exit #{$?.exitstatus})")
+      end
+      assert success
+    end
+  end
+end

--- a/guides/test/markdown/renderer_test.rb
+++ b/guides/test/markdown/renderer_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Markdown::RendererTest < ActiveSupport::TestCase
+  def renderer
+    RailsGuides::Markdown::Renderer.new
+  end
+
+  test "link returns an anchor tag" do
+    assert_equal "<a href=\"http://example.com\">example</a>", renderer.link("http://example.com", nil, "example")
+    assert_equal "<a href=\"http://example.com\" title=\"title\">example</a>", renderer.link("http://example.com", "title", "example")
+  end
+
+  test "link to the API" do
+    assert_equal "<a href=\"https://api.rubyonrails.org/\">Rails</a>", renderer.link("https://api.rubyonrails.org", nil, "Rails")
+  end
+
+  test "link to a versioned API" do
+    assert_equal "<a href=\"https://api.rubyonrails.org/v7.0\">Rails</a>", renderer.link("https://api.rubyonrails.org/v7.0", nil, "Rails")
+  end
+
+  test "link to the edge API" do
+    renderer.edge = true
+    assert_equal "<a href=\"https://edgeapi.rubyonrails.org\">Rails</a>", renderer.link("https://api.rubyonrails.org", nil, "Rails")
+  ensure
+    renderer.edge = false
+  end
+end

--- a/guides/test/test_helper.rb
+++ b/guides/test/test_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "../../tools/strict_warnings"
+
+$LOAD_PATH.unshift File.expand_path("..", __dir__)
+
+require "rails_guides"

--- a/guides/w3c_validator.rb
+++ b/guides/w3c_validator.rb
@@ -94,5 +94,3 @@ module RailsGuides
       end
   end
 end
-
-RailsGuides::Validator.new.validate


### PR DESCRIPTION
The guides have a lot of untested code, making it easy to break things.

This sets up the guides directory to also support tests. `guides/rails_guides.rb`
will no longer generate the guides by default so we can include it in tests
without generating the guides.

 The existing `test` task for bug_report_templates has been moved to a
namespace: `test:bug_report_templates`.

The w3c_validator script requires being run from a Rake task now as well
for consistency.

For the tests to run we'd also need to update the buildkite config.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
