### PR TITLE
Respect `remove_hidden_field_autocomplete` config in form builder `hidden_field`

### DIFF
--- a/actionview/lib/action_view/helpers/tags/hidden_field.rb
+++ b/actionview/lib/action_view/helpers/tags/hidden_field.rb
@@ -5,7 +5,7 @@ module ActionView
     module Tags # :nodoc:
       class HiddenField < TextField # :nodoc:
         def render
-          @options.reverse_merge!(autocomplete: "off")
+          @options.reverse_merge!(autocomplete: "off") unless ActionView::Base.remove_hidden_field_autocomplete
           super
         end
       end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -673,6 +673,24 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_hidden_field_omits_autocomplete_when_remove_hidden_field_autocomplete_is_true
+    ActionView::Base.with(remove_hidden_field_autocomplete: true) do
+      assert_dom_equal(
+        '<input id="post_title" name="post[title]" type="hidden" value="Hello World" />',
+        hidden_field("post", "title")
+      )
+    end
+  end
+
+  def test_hidden_field_respects_explicit_autocomplete_when_remove_hidden_field_autocomplete_is_true
+    ActionView::Base.with(remove_hidden_field_autocomplete: true) do
+      assert_dom_equal(
+        '<input id="session_username" name="session[username]" type="hidden" value="me@example.com" autocomplete="username" />',
+        hidden_field("session", "username", value: "me@example.com", autocomplete: "username")
+      )
+    end
+  end
+
   def test_text_field_with_custom_type
     assert_dom_equal(
       '<input id="user_email" name="user[email]" type="email" />',

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/core_ext/object/with"
 
 class FormTagHelperTest < ActionView::TestCase
   include RenderERBUtils
@@ -331,7 +332,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_hidden_field_tag_default_omits_autocomplete
-    with_remove_hidden_field_autocomplete(true) do
+    ActionView::Base.with(remove_hidden_field_autocomplete: true) do
       actual = hidden_field_tag "id", 3
       expected = %(<input id="id" name="id" type="hidden" value="3" />)
       assert_dom_equal expected, actual
@@ -339,7 +340,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_hidden_field_tag_legacy_includes_autocomplete_off
-    with_remove_hidden_field_autocomplete(false) do
+    ActionView::Base.with(remove_hidden_field_autocomplete: false) do
       actual = hidden_field_tag "id", 3
       expected = %(<input id="id" name="id" type="hidden" value="3" autocomplete="off" />)
       assert_dom_equal expected, actual
@@ -347,7 +348,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_hidden_field_tag_respects_explicit_autocomplete_when_default_omits
-    with_remove_hidden_field_autocomplete(true) do
+    ActionView::Base.with(remove_hidden_field_autocomplete: true) do
       actual = hidden_field_tag "username", "me@example.com", autocomplete: "username"
       expected = %(<input id="username" name="username" type="hidden" value="me@example.com" autocomplete="username" />)
       assert_dom_equal expected, actual
@@ -355,7 +356,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_hidden_field_tag_respects_explicit_autocomplete_when_legacy_includes_off
-    with_remove_hidden_field_autocomplete(false) do
+    ActionView::Base.with(remove_hidden_field_autocomplete: false) do
       actual = hidden_field_tag "username", "me@example.com", autocomplete: "username"
       expected = %(<input id="username" name="username" type="hidden" value="me@example.com" autocomplete="username" />)
       assert_dom_equal expected, actual
@@ -363,7 +364,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_hidden_field_tag_with_autocomplete_false_in_legacy_mode
-    with_remove_hidden_field_autocomplete(false) do
+    ActionView::Base.with(remove_hidden_field_autocomplete: false) do
       actual = hidden_field_tag "id", 3, autocomplete: nil
       expected = %(<input id="id" name="id" type="hidden" value="3" />)
       assert_dom_equal expected, actual
@@ -371,7 +372,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_form_tag_hidden_helpers_omit_autocomplete_by_default
-    with_remove_hidden_field_autocomplete(true) do
+    ActionView::Base.with(remove_hidden_field_autocomplete: true) do
       actual = form_tag({}, { method: :patch })
       expected = whole_form("http://www.example.com", method: :patch, no_autocomplete: true)
       assert_dom_equal expected, actual
@@ -379,7 +380,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_form_tag_hidden_helpers_include_autocomplete_off_in_legacy_mode
-    with_remove_hidden_field_autocomplete(false) do
+    ActionView::Base.with(remove_hidden_field_autocomplete: false) do
       actual = form_tag({}, { method: :patch })
       expected = whole_form("http://www.example.com", method: :patch)
       assert_dom_equal expected, actual
@@ -1082,13 +1083,5 @@ class FormTagHelperTest < ActionView::TestCase
       yield
     ensure
       ActionView::Helpers::ContentExfiltrationPreventionHelper.prepend_content_exfiltration_prevention = old_value
-    end
-
-    def with_remove_hidden_field_autocomplete(value)
-      old = ActionView::Base.remove_hidden_field_autocomplete
-      ActionView::Base.remove_hidden_field_autocomplete = value
-      yield
-    ensure
-      ActionView::Base.remove_hidden_field_autocomplete = old
     end
 end


### PR DESCRIPTION
The configuration option `config.action_view.remove_hidden_field_autocomplete` was not being respected by the `Tags::HiddenField` class used by form builders (e.g., `form.hidden_field`), even though it worked correctly for `hidden_field_tag` and other helpers.

This change updates the `HiddenField#render` method to conditionally add the `autocomplete="off"` attribute only when `remove_hidden_field_autocomplete` is false, matching the pattern established in https://github.com/rails/rails/pull/55336 for other form helpers.

Explicit autocomplete values are still respected regardless of the configuration.

Fixes https://github.com/rails/rails/issues/55984.