### PR TITLE
ActiveJob/serializers: Only index new serializers

### DIFF
--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -51,30 +51,34 @@ module ActiveJob
       attr_reader :serializers
 
       def serializers=(serializers)
-        @serializers = serializers
-        index_serializers
+        @serializers_index.clear
+        @serializers = Set.new
+        add_new_serializers(serializers)
       end
 
       # Adds new serializers to a list of known serializers.
       def add_serializers(*new_serializers)
         new_serializers = new_serializers.flatten
-        new_serializers.map! do |s|
-          if s.is_a?(Class) && s < ObjectSerializer
-            s.instance
-          else
-            s
-          end
-        end
-
-        @serializers += new_serializers
-        index_serializers
-        @serializers
+        add_new_serializers(new_serializers)
       end
 
       private
-        def index_serializers
-          @serializers_index.clear
-          serializers.each do |s|
+        def add_new_serializers(new_serializers)
+          new_serializers.map! do |s|
+            if s.is_a?(Class) && s < ObjectSerializer
+              s.instance
+            else
+              s
+            end
+          end
+
+          @serializers += new_serializers
+          index_serializers(new_serializers)
+          @serializers
+        end
+
+        def index_serializers(new_serializers)
+          new_serializers.each do |s|
             if s.respond_to?(:klass)
               @serializers_index[s.klass] = s
             elsif s.respond_to?(:klass, true)

--- a/activejob/test/cases/serializers_test.rb
+++ b/activejob/test/cases/serializers_test.rb
@@ -84,6 +84,16 @@ class SerializersTest < ActiveSupport::TestCase
     assert_equal DummyValueObject.new(123), ActiveJob::Serializers.deserialize(hash)
   end
 
+  test "resets serializers when directly setting" do
+    class DummySerializerAlt < DummySerializer
+      def klass; DummySerializer end
+    end
+    ActiveJob::Serializers.add_serializers DummySerializer
+    ActiveJob::Serializers.serializers = [DummySerializerAlt]
+    assert ActiveJob::Serializers.serializers.include?(DummySerializerAlt.instance)
+    assert_not ActiveJob::Serializers.serializers.include?(DummySerializer.instance)
+  end
+
   test "adds new serializer" do
     ActiveJob::Serializers.add_serializers DummySerializer
     assert ActiveJob::Serializers.serializers.include?(DummySerializer.instance)


### PR DESCRIPTION
Instead of reprocessing every serializer everytime a new serializer is added, just process the new one. This has the intended side-effect of only issuing the deprecation warning for non-compliant serializers once (when added) instead of on every subsequent call to add serializers. This also ensures that the location deperecation warning does not point to the innocent compliant serializers. Currently when it reports the deprecation it will include the location of the most recent call to add_serializers which falsely implicates those serializers.