### PR TITLE
Fallback DiskService URL options

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -172,7 +172,7 @@ module ActiveStorage
       end
 
       def url_options
-        ActiveStorage::Current.url_options
+        ActiveStorage::Current.url_options || Rails.application.config.active_storage.url_options
       end
   end
 end


### PR DESCRIPTION
We should allow the DiskService to be configured


### Motivation / Background


There are many times when I have a small or simple setup one a single server, and I want to be able to test my active storage download url for example. This change allows for syntax like the following:

```ruby
  # config/environments/development.rb
  config.active_storage.service = :local
  config.active_storage.url_options = { host: "example.com", protocol: "https", port: 443 }
  
  # Extends the same convention as the existing actionmailer gem
  config.action_mailer.default_url_options = { host: "example.com", port: 8443 }
```

This Pull Request has been created because it is often the case that I do not have nor want to setup a full s3 integration, and I think it makes sense to give users the ability to opt-into more complete functionality if they choose to. 

### Detail

This Pull Request changes the disk service url options to have a fallback to an environment specific configuration if defined.

### Additional information

This may not be the best implementation, it might make more sense to call `ActiveStorage::Current.url_options=(value)` during initialization.


This is what I have in my application as a workaround.

```ruby
  config.active_storage.service = :local
  config.after_initialize do
    ActiveStorage::Current.attribute :url_options, default: { host: "example.com", protocol: "https", port: 443 }
  end
```

IMO I don't think I should put this snippet in an initializer because that spreads the configuration over multiple files without adding much. However this makes my environment inconsistent and more complicated that it should be.

We should consider that perhaps this DiskService should not depend on Rails directly, but we already have `url_helpers` method that depends on `Rails`, so I think this is not an issue. Users of activestorage without rails will have to always set `url_options` manually anyway.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

