### PR TITLE
[ci-skip][doc] Update steps for emails_controller_test.rb in sign_up_and_settings.md

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -1556,14 +1556,18 @@ module SessionTestHelper
 
     ActionDispatch::TestRequest.create.cookie_jar.tap do |cookie_jar|
       cookie_jar.signed[:session_id] = Current.session.id
-      cookies[:session_id] = cookie_jar[:session_id]
+      cookies["session_id"] = cookie_jar[:session_id]
     end
   end
 
   def sign_out
     Current.session&.destroy!
-    cookies.delete(:session_id)
+    cookies.delete("session_id")
   end
+end
+
+ActiveSupport.on_load(:action_dispatch_integration_test) do
+  include SessionTestHelper
 end
 ```
 
@@ -1733,6 +1737,25 @@ test "sends email confirmation on successful update" do
 end
 ```
 
+Then add first and last names to the fixtures in `test/fixtures/users.yml` to
+pass validations:
+
+```yaml#6-7,12-13
+<% password_digest = BCrypt::Password.create("password") %>
+
+one:
+  email_address: one@example.com
+  password_digest: <%= password_digest %>
+  first_name: User
+  last_name: One
+
+two:
+  email_address: two@example.com
+  password_digest: <%= password_digest %>
+  first_name: User
+  last_name: Two
+```
+
 This tests submits successful params, confirms the email is saved to the
 database, the user was redirected and the confirmation email was queued for
 delivery.
@@ -1821,10 +1844,9 @@ confirm their new email address.
 Another area that we should test is the Settings navigation. We want to ensure
 the appropriate links are visible to admins and not visible to regular users.
 
-Let's first create an admin user fixture in `test/fixtures/users.yml` and add
-names to the fixtures so they pass validations.
+Let's first create an admin user fixture in `test/fixtures/users.yml`:
 
-```yaml#6-7,12-13,15-20
+```yaml#15-20
 <% password_digest = BCrypt::Password.create("password") %>
 
 one:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because some steps to write tests need improvements.

### Detail

This Pull Request changes:

- `SessionTestHelper` to be consistent with [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/railties/lib/rails/generators/test_unit/authentication/templates/test/test_helpers/session_test_helper.rb.tt)
- add a step for updating `test/fixtures/users.yml` because the tests ("validates current password" and "sends email confirmation on successful update") depend on the updated `test/fixtures/users.yml` with first and last names to pass validations. If the first/last names are missing in `test/fixtures/users.yml`, the tests fail.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
