### PR TITLE
Introduce a specific exception for unresolved models in AssociationReflection#compute_class

### DIFF
--- a/activerecord/lib/active_record/associations/errors.rb
+++ b/activerecord/lib/active_record/associations/errors.rb
@@ -174,6 +174,9 @@ module ActiveRecord
     end
   end
 
+  class AssociationModelTypeError < ActiveRecordError # :nodoc:
+  end
+
   class ThroughCantAssociateThroughHasOneOrManyReflection < ActiveRecordError # :nodoc:
     def initialize(owner = nil, reflection = nil)
       if owner && reflection

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -427,8 +427,10 @@ module ActiveRecord
         if active_record.name.demodulize == class_name
           begin
             return compute_class("::#{class_name}")
-          rescue
-            # Ignored
+          rescue NameError, AssociationModelTypeError
+            # If NameError or AssociationModelTypeError raised during above method call,
+            # we safely ignore it to allow compute_class method to be called again without
+            # "::" in order to find the model in a nested module, if possible.
           end
         end
 
@@ -509,7 +511,7 @@ module ActiveRecord
         end
 
         unless klass < ActiveRecord::Base
-          raise ArgumentError, "The #{name} model class for the #{active_record}##{self.name} association is not an ActiveRecord::Base subclass."
+          raise AssociationModelTypeError, "The #{name} model class for the #{active_record}##{self.name} association is not an ActiveRecord::Base subclass."
         end
 
         klass

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -176,7 +176,7 @@ class ReflectionTest < ActiveRecord::TestCase
       :infos_class_name,         # has_many through, with :class_name
       :infos_through_class_name, # has_many through other :class_name, with :class_name
     ].each do |rel|
-      error = assert_raise(ArgumentError) do
+      error = assert_raise(ActiveRecord::AssociationModelTypeError) do
         UserWithInvalidRelation.reflect_on_association(rel).klass
       end
 


### PR DESCRIPTION
### Motivation / Background

Follow up #55968

### Detail

`AssociationReflection#compute_class` previously raised a generic `ArgumentError` when it couldn’t
derive the model name. Callers that needed to recover (e.g., retrying lookup within a nested module
when a top-level constant shadows the model name) had to rescue `ArgumentError`, which risks masking
unrelated bugs that also manifest as `ArgumentError`.

This change defines and raises a dedicated exception for this case, allowing callers to rescue
precisely the failure they intend to handle and eliminating the need for a blank/broad `rescue`.

### Additional information

**Why**

* Avoids swallowing unrelated `ArgumentError`s.
* Makes the recovery path (nested module lookup) explicit and safe.
* Improves readability and intent, replacing a blanket rescue with targeted handling.

**What**

* Add a new error class for “unable to compute model” failures.
* Update `AssociationReflection#compute_class` to raise this specific error.
* Adjust call sites to rescue the new error only where fallback lookup is required.

**Behavior**

* No change to successful code paths.
* Failure is now surfaced via a specific, self-describing exception, reducing the chance of hiding genuine bugs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
