### PR TITLE
[ci-skip][doc] Fix typos and errors in wishlists.md

### DIFF
--- a/guides/source/wishlists.md
+++ b/guides/source/wishlists.md
@@ -142,7 +142,6 @@ Then in `app/models/product.rb`, add:
 class Product < ApplicationRecord
   include Notifications
 
-  has_many :subscribers, dependent: :destroy
   has_many :wishlist_products, dependent: :destroy
   has_many :wishlists, through: :wishlist_products
   has_one_attached :featured_image
@@ -159,7 +158,7 @@ SQL queries.
 We also set `wishlist_products` as `dependent: :destroy`. When a `Product` is
 destroyed, it will be automatically removed from any Wishlists.
 
-A counter cache stores the number of associated records to avoid running a separate query each time the count is needed. So in `app/models/wishlist.rb`, let's update both associations to enable counter
+A counter cache stores the number of associated records to avoid running a separate query each time the count is needed. So in `app/models/wishlist_product.rb`, let's update both associations to enable counter
 caching:
 
 ```ruby#2-5
@@ -934,7 +933,7 @@ Lastly, add the link to the sidebar layout:
         <h4>Store Settings</h4>
         <%= link_to "Products", store_products_path %>
         <%= link_to "Users", store_users_path %>
-        <%= link_to "Wishlists", store_products_path %>
+        <%= link_to "Wishlists", store_wishlists_path %>
       <% end %>
     </nav>
 
@@ -1118,7 +1117,7 @@ Let's create the index view next at
 `app/views/store/subscribers/index.html.erb`:
 
 ```erb
-<h1><%= pluralize "Subscriber", @subscribers.count %></h1>
+<h1><%= pluralize @subscribers.count, "Subscriber" %></h1>
 
 <%= form_with url: store_subscribers_path, method: :get do |form| %>
   <%= form.collection_select :product_id, Product.all, :id, :name, selected: params[:product_id], include_blank: "All Products" %>
@@ -1164,7 +1163,7 @@ Finally, add the link to the sidebar layout:
         <%= link_to "Products", store_products_path %>
         <%= link_to "Users", store_users_path %>
         <%= link_to "Subscribers", store_subscribers_path %>
-        <%= link_to "Wishlists", store_products_path %>
+        <%= link_to "Wishlists", store_wishlists_path %>
       <% end %>
     </nav>
 
@@ -1586,7 +1585,7 @@ should have no changes.
     second_wishlist = user.wishlists.create!(name: "Second")
     second_wishlist.wishlist_products.create(product_id: wishlist_product.product_id)
     patch wishlist_wishlist_product_path(wishlist, wishlist_product), params: { new_wishlist_id: second_wishlist.id }
-    assert_equal "T-Shirt is already on Second Wishlist.", flash[:alert]
+    assert_equal "T-Shirt is already on Second.", flash[:alert]
     assert_equal wishlist, wishlist_product.reload.wishlist
   end
 ```

--- a/guides/source/wishlists.md
+++ b/guides/source/wishlists.md
@@ -138,7 +138,7 @@ deleted, their wishlists are deleted too.
 
 Then in `app/models/product.rb`, add:
 
-```ruby#5-6
+```ruby#4-5
 class Product < ApplicationRecord
   include Notifications
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because wishlists.md contains some errors and typos that disturbs running tests.

### Detail

This Pull Request contains the following:

- Removing `has_many :subscribers, dependent: :destroy` from `Product` model because  it includes `Notifications` concern that already declares the `has_many: subscribers` association. Current declaration is redundant and inconsistent with the final `Product` model in [getting_started.md](https://guides.rubyonrails.org/getting_started.html#extracting-a-concern).
- Fixing incorrect filename `app/models/wishlist.rb` to `app/models/wishlist_product.rb`.
- Fixing incorrect path `store_products_path` to `store_wishlists_path`.
- Fixing incorrect call `pluralize "Subscriber", @subscribers.count` to `pluralize @subscribers.count, "Subscriber"`.
- Fixing incorrect assertion "T-Shirt is already on Second Wishlist." to "T-Shirt is already on Second.".

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
