### PR TITLE
Reuse `#controller_path` in `:namespaced_controller` query log tag

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -133,15 +133,7 @@ module ActionController
           ActiveRecord::QueryLogs.taggings = ActiveRecord::QueryLogs.taggings.merge(
             controller:            ->(context) { context[:controller]&.controller_name },
             action:                ->(context) { context[:controller]&.action_name },
-            namespaced_controller: ->(context) {
-              if context[:controller]
-                controller_class = context[:controller].class
-                # based on ActionController::Metal#controller_name, but does not demodulize
-                unless controller_class.anonymous?
-                  controller_class.name.delete_suffix("Controller").underscore
-                end
-              end
-            }
+            namespaced_controller: ->(context) { context[:controller]&.controller_path }
           )
         end
       end


### PR DESCRIPTION
### Motivation / Background

Noticed a place where we could reduce code while searching for a namespaced `#controller_name` equivalent for my app (which ended up being `#controller_path`).

### Detail

The Active Record `:namespaced_controller` query log tag reimplements `#controller_path`, so we can just call it to reduce code.
