### PR TITLE
Permit eager loading of optional instance dependent association scopes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support eager loading of instance dependent scopes with an optional parameter.
+
+    *Martin-Alexander*
+
 *   Allow either explain format syntax for EXPLAIN queries.
 
     MySQL uses FORMAT=JSON whereas Postgres uses FORMAT JSON. We should be

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -642,10 +642,12 @@ module ActiveRecord
       def check_eager_loadable!
         return unless scope
 
-        unless scope.arity == 0
+        required_scope_args = scope.arity < 0 ? ~scope.arity : scope.arity
+
+        unless required_scope_args == 0
           raise ArgumentError, <<-MSG.squish
             The association scope '#{name}' is instance dependent (the scope
-            block takes an argument). Eager loading instance dependent scopes
+            block requires  an argument). Eager loading instance dependent scopes
             is not supported.
           MSG
         end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1517,12 +1517,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
-  test "eager loading of optional instance dependent associations is not supported" do
-    message = "association scope 'posts_mentioning_author' is"
-    error = assert_raises(ArgumentError) do
-      Author.eager_load(:posts_mentioning_author).to_a
+  test "eager loading of optional instance dependent associations is supported" do
+    authors = Author.eager_load(:posts_mentioning_author).to_a
+    assert_not authors.empty?
+    authors.each do |author|
+      assert_predicate author.posts_mentioning_author, :loaded?
     end
-    assert_match message, error.message
   end
 
   test "preload with invalid argument" do


### PR DESCRIPTION
Support for preloading instance-dependent associations was added here https://github.com/rails/rails/pull/42553.

Eager-loading and joining instance dependent associations remains unsupported. 

```ruby
class Author < ActiveRecord::Base
  has_many :books, ->(owner) { owner.trusted ? all : where(approved: true) }
end

Author.eager_load(:books)
# => The association scope 'books' is instance dependent (the scope block takes an argument). Eager loading
#   instance dependent scopes is not supported. (ArgumentError)

Author.joins(:books)
# => The association scope 'books' is instance dependent (the scope block takes an argument). Eager loading
#   instance dependent scopes is not supported. (ArgumentError)
```

This makes sense since we can't use Ruby logic to make SQL joins.

But association could have scopes with an optional parameter.

```ruby
class Author < ActiveRecord::Base
  has_many :books, ->(owner = nil) { owner&.trusted ? all : where(approved: true) }
end
```

At the moment, such scopes are also blocked from being eager-loaded/joined. But there can be situations where you would want the association scope to behave differently depending on whether it was eager-loaded/joined or called on an instance (or preloaded).

In my case, I've run into a scenario where I want to use this behaviour to support temporal queries.

Something very roughly like this:
```ruby
class Author < ActiveRecord::Base
  attr_accessor :as_of

  has_many :books, ->(owner = nil) { owner ? where("valid_from > ?", owner.as_of) : where(valid_until: nil) }
end
```

Admittedly it's niche, but I don't see any why the restriction couldn't be loosened to only prohibit association scopes that would necessarily break if eager-loaded/joined.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.