### PR TITLE
Fix subsequent call to AS::JSON.encode after a nesting error

### DIFF
--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -520,6 +520,25 @@ EXPECTED
     end
   end
 
+  if defined?(::JSON::Coder) && Gem::Version.new(::JSON::VERSION) >= Gem::Version.new("2.15")
+    def test_no_nesting_error_on_consecutive_encoding_calls
+      hash = { a: 1 }
+      assert_equal '{"a":1}', ActiveSupport::JSON.encode(hash)
+
+      # We simulate a circular reference
+      circular_array = []
+      circular_array << circular_array
+
+      assert_raise(SystemStackError, JSON::NestingError) do
+        ActiveSupport::JSON.encode(circular_array)
+      end
+
+      # We should be able to continue to generate JSONs as usual after
+      # encountering a JSON::NestingError
+      assert_equal '{"a":1}', ActiveSupport::JSON.encode(hash)
+    end
+  end
+
   private
     def object_keys(json_object)
       json_object[1..-2].scan(/([^{}:,\s]+):/).flatten.sort


### PR DESCRIPTION
When a circular reference is triggered, all subsequent attempts to encode any ruby hash fail with the same `JSON::NestingError`

The fix for now is to initialize a new coder each time there is an encoding attempt.

A better fix probably would be on the `json` gem so that the same JSON::Coder instance can be called multiple times even when one call raises a `JSON::NestingError`

cc @byroot 

### Detail

More details can be found here https://github.com/rails/rails/commit/90616277e3d8fc46c9cf35d6a7470ff1ea0092f7#r168752947

### Additional information

In my production app, this made all of my Sidekiq jobs on the same ruby process fail, even internal ActiveStorage job such as preview jobs started failing.
I fixed the issue by restarting the dyno.

- But this issue is really wild. This means if for some reason, my code or any gems in my application triggers a circular reference ==> the entire JSON generation of valid ruby hashes would fail for the entire duration of the ruby process until shutdown or restart!



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
