### PR TITLE
Don't destroy ActiveStorage::Blob when its file deletion on the service fails

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -3,4 +3,12 @@
 
     *Bart de Water*
 
+*   `ActiveStorage::Blob#purge` won't delete blob records when their file deletion on the service fails.
+    This prevents dangling files on the storage.
+
+    For example, GCS sometimes fails with `Google::Cloud::UnavailableError`. In such cases, we want to keep the blob
+    record intact so that we can retry deletion later.
+
+    *Peter Toth*
+
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -310,6 +310,19 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "purge doesn't delete the blob when the file deletion fails" do
+    blob = create_blob
+
+    blob.service.stub(:delete, ->(*_) { raise "File deletion failed" }) do
+      assert_raises(RuntimeError, "File deletion failed") do
+        blob.purge
+      end
+    end
+
+    assert_not_predicate blob, :destroyed?
+    assert ActiveStorage::Blob.service.exist?(blob.key)
+  end
+
   test "uses service from blob when provided" do
     with_service("mirror") do
       blob = create_blob(filename: "funky.jpg", service_name: :local)


### PR DESCRIPTION
### Motivation / Background

To fix the following scenario:
- Call `ActiveStorage::Blob#purge_later` which calls `ActiveStorage::Blob#purge`.
- System removes the blob record from the DB.
- System tries to remove the file from the storage (`ActiveStorage::Blob#delete`).
  - It crashes, e.g., with a `Google::Cloud::UnavailableError`.
- File stays in the storage, the DB record gallops to the sunset.
- The file in the storage becomes orphaned and difficult to remove when we have hundreds of terabytes of data in the storage.
- Retrying the job won't help because the blob record got deleted in the first run that failed halfway

### Details

This Pull Request allows removing `ActiveStorage::Blob` records only after their file in the service got removed successfully.

The provided solution
- Checks if the blob can be destroyed.
- Deletes its file from the service.
- If the file deletion is successful, removes the blob record from the DB.

The `with_no_destroy_preconditions_check` method is added to avoid sending duplicate DB queries caused by `attachments.exists?`.

Alternative solution would be to wrap `destroy` and `delete` calls in a transaction, like below:

```rb
def purge
  ActiveRecord::Base.transaction do
    destroy
    delete if previously_persisted?
  end
rescue ActiveRecord::InvalidForeignKey
end
```

I'd go with the transactional solution if there is no argument against it.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
