### PR TITLE
Close more-info-needed after 2 weeks

### DIFF
--- a/.github/workflows/more-info-needed.yml
+++ b/.github/workflows/more-info-needed.yml
@@ -14,8 +14,8 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 14
-        days-before-close: 0 # Close immediately
+        days-before-stale: -1
+        days-before-close: 14
         operations-per-run: 100
         stale-issue-label: "more-information-needed"
         close-issue-message: >


### PR DESCRIPTION
* Disable auto stalling

<https://github.com/actions/stale?tab=readme-ov-file#days-before-stale>

> If set to a negative number like -1, no issues or pull requests will be marked as stale automatically.
> In that case, you can still add the stale label manually to mark as stale.

* Set `days-before-close` to 14

<https://github.com/actions/stale?tab=readme-ov-file#days-before-close>

> The idle number of days before closing the stale issues or the stale pull requests (due to the stale label).

The stale label we use here is "more-information-needed", after manually tagging an issue (or PR) with that, it will be closed after 14 days automatically.
