### PR TITLE
Use strict version of `json` gem greater than or equal to 2.15.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.15.0)
+    json (2.15.2)
     jwt (2.10.1)
       base64
     kamal (2.4.0)

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -146,7 +146,7 @@ module ActiveSupport
       end
 
       # ruby/json 2.14.x yields non-String keys but doesn't let us know it's a key
-      if defined?(::JSON::Coder) && Gem::Version.new(::JSON::VERSION) >= Gem::Version.new("2.15")
+      if defined?(::JSON::Coder) && Gem::Version.new(::JSON::VERSION) >= Gem::Version.new("2.15.2")
         class JSONGemCoderEncoder # :nodoc:
           JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
           CODER = ::JSON::Coder.new do |value, is_key|

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -520,6 +520,23 @@ EXPECTED
     end
   end
 
+  def test_no_nesting_error_on_consecutive_encoding_calls
+    hash = { a: 1 }
+    assert_equal '{"a":1}', ActiveSupport::JSON.encode(hash)
+
+    # We simulate a circular reference
+    circular_array = []
+    circular_array << circular_array
+
+    assert_raise(SystemStackError, JSON::NestingError) do
+      ActiveSupport::JSON.encode(circular_array)
+    end
+
+    # We should be able to continue to generate JSONs as usual after
+    # encountering a JSON::NestingError
+    assert_equal '{"a":1}', ActiveSupport::JSON.encode(hash)
+  end
+
   private
     def object_keys(json_object)
       json_object[1..-2].scan(/([^{}:,\s]+):/).flatten.sort


### PR DESCRIPTION
related to #56005 

I feel we need to be stricter on the JSON version here

cc @byroot 

