### PR TITLE
Disable SSL default config for out of the box Kamal deployments

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Do not assume and force SSL in production by default, to allow for out of the box Kamal deployments when creating new Rails apps.
+*   Do not assume and force SSL in production by default when using Kamal, to allow for out of the box Kamal deployments.
 
     It is still recommended to assume and force SSL in production as soon as you can.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Do not assume and force SSL in production by default, to allow for out of the box Kamal deployments when creating new Rails apps.
+
+    It is still recommended to assume and force SSL in production as soon as you can.
+
+    *Jerome Dalbert*
+
 *   Add environment config file existence check
 
     `Rails::Application` will raise an error if unable to load any environment file.

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -16,7 +16,7 @@ servers:
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
 # Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
 #
-# You should also set assume_ssl and force_ssl to true in production.rb.
+# It is recommended to set assume_ssl and force_ssl to true in production.rb.
 # If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 # proxy:
 #   ssl: true

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -16,7 +16,8 @@ servers:
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
 # Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
 #
-# Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
+# You should also set assume_ssl and force_ssl to true in production.rb.
+# If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 # proxy:
 #   ssl: true
 #   host: app.example.com

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -14,10 +14,12 @@ servers:
   #   cmd: bin/jobs
 
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
-# Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
+# If used with Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 #
-# It is recommended to set assume_ssl and force_ssl to true in production.rb.
-# If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
+# Using an SSL proxy like this requires turning on config.assume_ssl and config.force_ssl in production.rb!
+#
+# Don't use this when deploying to multiple web servers (then you have to terminate SSL at your load balancer).
+#
 # proxy:
 #   ssl: true
 #   host: app.example.com

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -29,10 +29,18 @@ Rails.application.configure do
 
   <%- end -%>
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  <%- if skip_kamal? -%>
+  config.assume_ssl = true
+  <%- else -%>
   # config.assume_ssl = true
+  <%- end -%>
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  <%- if skip_kamal? -%>
+  config.force_ssl = true
+  <%- else -%>
   # config.force_ssl = true
+  <%- end -%>
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -29,10 +29,10 @@ Rails.application.configure do
 
   <%- end -%>
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = true
+  # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/commit/29ddc03fe33df52077cf601fa3dbe0b2ebcd3811.
Fixes https://github.com/rails/rails/issues/56011.

### Motivation / Background

The kamal SSL config was commented out in https://github.com/rails/rails/commit/29ddc03fe33df52077cf601fa3dbe0b2ebcd3811 to make Kamal deploys possible out of the box.

But for such an out of the box experience to be truly possible, you need `config.assume_ssl` and `config.force_ssl` to be both disabled in `production.rb`, otherwise you get a `HTTP Origin header (http://<redacted_ip>) didn't match request.base_url (https://<redacted_ip>)` error when submitting forms.

### Detail

This Pull Request comments out the `config.assume_ssl` and `config.force_ssl` options in `production.rb`, with a recommendation in `config/deploy.rb` to enable them whenever you start using SSL.

### Additional notes

It may feel a bit odd to partially revert the practice of forcing SSL (introduced in https://github.com/rails/rails/pull/47852), but the practice is still kept if Kamal is skipped, so at least there is that.

Alternatively, https://github.com/rails/rails/commit/29ddc03fe33df52077cf601fa3dbe0b2ebcd3811 could be reverted, at the cost of being even less out of the box, which doesn't seem great.

Another alternative or addition would be to make Rails or Kamal emit a warning on Rails boot whenever the SSL configuration in `config/deploy.yml` does not match the recommended SSL configuration in `production.rb`.