### PR TITLE
Memoize IAM client and set authorization to ADC for GCS Active Storage service

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Restore ADC when signing URLs with IAM for GCS
+
+    ADC was previously used for automatic authorization when signing URLs with IAM.
+    Now it is again, but the auth client is memoized so that new credentials are only
+    requested when the current ones expire. Other auth methods can now be used
+    instead by setting the authorization on `ActiveStorage::Service::GCSService#iam_client`.
+
+    ```ruby
+    ActiveStorage::Blob.service.iam_client.authorization = Google::Auth::ImpersonatedServiceAccountCredentials.new(options)
+    ```
+
+    This is safer than setting `Google::Apis::RequestOptions.default.authorization`
+    because it only applies to Active Storage and does not affect other Google API
+    clients.
+
+    *Justin Malčić*
+
 *   Move responsibility for checksums storage service
 
     The storage service should implement calculating and

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -11,6 +11,7 @@ require "active_support/test_case"
 require "active_support/core_ext/object/try"
 require "active_support/testing/autorun"
 require "image_processing/mini_magick"
+require "webmock/minitest"
 
 require "active_support/current_attributes/test_helper"
 require "active_record/testing/query_assertions"
@@ -22,6 +23,8 @@ ActiveJob::Base.logger = ActiveSupport::Logger.new(nil)
 ActiveStorage.logger = ActiveSupport::Logger.new(nil)
 ActiveStorage.verifier = ActiveSupport::MessageVerifier.new("Testing")
 ActiveStorage::FixtureSet.file_fixture_path = File.expand_path("fixtures/files", __dir__)
+
+WebMock.disable!
 
 class ActiveSupport::TestCase
   self.file_fixture_path = ActiveStorage::FixtureSet.file_fixture_path


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because #55353 breaks signed URLs for applications using the default ADC auth behaviour.

### Detail

This Pull Request restores the previous behaviour where ADC is used when `iam: true` is set, but avoids excessive ADC calls by memoising the client. This means that calls are only made at instantiation time and when the credentials eventually expire (which the client takes care of). It also still allows overriding the auth used by either the mechanism suggested in #55353 (using `Google::Apis::RequestOptions.default.authorization`, which affects all clients) or by setting the `authorization` value on the IAM client directly.

This is necessary because the assumption in #55353 that the libraries will request auth themselves with the right scope isn't true in practice. So e.g [this test](https://github.com/rails/rails/blob/4a753c2f79a9c41ec3ab5551724599193da180e5/activestorage/test/service/gcs_service_test.rb#L193) when run locally and where `GOOGLE_APPLICATION_CREDENTIALS` is set to the path to a service account key will fail with `Google::Apis::AuthorizationError: Unauthorized`. This is also what we have seen in production.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.