### PR TITLE
Fix event reporter log subscriber consuming events without namespaces

### DIFF
--- a/activesupport/lib/active_support/event_reporter/log_subscriber.rb
+++ b/activesupport/lib/active_support/event_reporter/log_subscriber.rb
@@ -31,8 +31,10 @@ module ActiveSupport
           namespace = self.namespace.to_s
           proc do |event|
             name = event[:name]
-            event_namespace = name[0, name.index(".")]
-            namespace == event_namespace
+            if (dot_idx = name.index("."))
+              event_namespace = name[0, dot_idx]
+              namespace == event_namespace
+            end
           end
         end
       end

--- a/activesupport/test/event_reporter/log_subscriber_test.rb
+++ b/activesupport/test/event_reporter/log_subscriber_test.rb
@@ -74,7 +74,20 @@ class ActiveSupport::EventReporter::LogSubscriberTest < ActiveSupport::TestCase
   end
 
   test ".subscription_filter" do
-    ActiveSupport.event_reporter.notify("other_namespace_that_shouldnt_work.info_only")
-    assert_equal [], @logger.logged(:info)
+    event_reporter_raise_on_error do
+      ActiveSupport.event_reporter.notify("other_namespace_that_shouldnt_work.info_only")
+      assert_equal [], @logger.logged(:info)
+
+      ActiveSupport.event_reporter.notify("no_namespace_info_only")
+      assert_equal [], @logger.logged(:info)
+    end
   end
+
+  private
+    def event_reporter_raise_on_error
+      ActiveSupport.event_reporter.raise_on_error = true
+      yield
+    ensure
+      ActiveSupport.event_reporter.raise_on_error = false
+    end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because https://github.com/rails/rails/pull/55900 doesn't like events without namespaces. Event namespaces aren't required so don't expect them.

### Detail

This Pull Request changes event reporter subscription filter to not crash when processing namespaceless events.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
