### PR TITLE
Fix strict_loading!(false) to override the strict_loading option in macro

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -286,6 +286,9 @@ module ActiveRecord
 
           return unless owner.validation_context.nil?
 
+          strict_loading = owner.instance_eval { @strict_loading }
+          return strict_loading && !owner.strict_loading_n_plus_one_only? unless strict_loading.nil?
+
           return reflection.strict_loading? if reflection.options.key?(:strict_loading)
 
           owner.strict_loading? && !owner.strict_loading_n_plus_one_only?

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -696,7 +696,9 @@ module ActiveRecord
 
     # Returns +true+ if the record is in strict_loading mode.
     def strict_loading?
-      @strict_loading
+      return @strict_loading if defined?(@strict_loading)
+
+      self.class.strict_loading_by_default
     end
 
     # Sets the record to strict_loading mode. This will raise an error
@@ -855,7 +857,6 @@ module ActiveRecord
         klass = self.class
 
         @primary_key         = klass.primary_key
-        @strict_loading      = klass.strict_loading_by_default
         @strict_loading_mode = klass.strict_loading_mode
 
         klass.define_attribute_methods

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -499,6 +499,16 @@ class StrictLoadingTest < ActiveRecord::TestCase
     assert_nothing_raised { developer.strict_loading_mentor }
   end
 
+  def test_disabling_strict_loading_belongs_to_relation
+    mentor = Mentor.create!(name: "Mentor")
+
+    Developer.first.update_column(:mentor_id, mentor.id)
+    developer = Developer.first
+    developer.strict_loading!(false)
+
+    assert_nothing_raised { developer.strict_loading_mentor }
+  end
+
   def test_does_not_raise_on_eager_loading_a_belongs_to_relation_if_strict_loading_by_default
     with_strict_loading_by_default(Developer) do
       mentor = Mentor.create!(name: "Mentor")
@@ -537,6 +547,14 @@ class StrictLoadingTest < ActiveRecord::TestCase
   def test_does_not_raise_on_eager_loading_a_strict_loading_has_one_relation
     Ship.first.update_column(:developer_id, Developer.first.id)
     developer = Developer.includes(:strict_loading_ship).first
+
+    assert_nothing_raised { developer.strict_loading_ship }
+  end
+
+  def test_disabling_strict_loading_has_one_relation
+    Ship.first.update_column(:developer_id, Developer.first.id)
+    developer = Developer.first
+    developer.strict_loading!(false)
 
     assert_nothing_raised { developer.strict_loading_ship }
   end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -165,8 +165,10 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
 
   test "attaching with strict_loading and getting a signed blob ID from an attachment" do
     blob = create_blob
-    @user.strict_loading!(true)
-    @user.avatar.attach(blob)
+
+    with_strict_loading_by_default do
+      @user.avatar.attach(blob)
+    end
 
     signed_id = @user.avatar.signed_id
     assert_equal blob, ActiveStorage::Blob.find_signed(signed_id)


### PR DESCRIPTION
Problem:

When `strict_loading: true` is specified in has_many/has_one macro, calling `strict_loading!(false)` does not override the option.

Closes https://github.com/rails/rails/issues/56014.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
