### PR TITLE
Add `Rails::CodeStatistics#register_extension` to register file extensions for `rails stats`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `Rails::CodeStatistics#register_extension` to register file extensions for `rails stats`
+
+    ```ruby
+    Rails::CodeStatistics.register_extension("txt")
+    ```
+
+    *Taketo Takashima*
+
 *   Wrap console command with an executor by default
 
     This can be disabled with `-w` or `--skip_executor`, same as runner.

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -42,10 +42,13 @@ module Rails
 
     HEADERS = { lines: " Lines", code_lines: "   LOC", classes: "Classes", methods: "Methods" }
 
-    PATTERN = /^(?!\.).*?\.(rb|js|ts|css|scss|coffee|rake|erb)$/
+    EXTENSIONS = %w[rb js ts css scss coffee rake erb]
+
+    PATTERN = /^(?!\.).*?\.(#{EXTENSIONS.join("|")})$/
 
     class_attribute :directories, default: DIRECTORIES
     class_attribute :test_types, default: TEST_TYPES
+    class_attribute :extensions, default: EXTENSIONS
     class_attribute :pattern, default: PATTERN
 
     # Add directories to the output of the <tt>bin/rails stats</tt> command.
@@ -58,6 +61,14 @@ module Rails
     def self.register_directory(label, path, test_directory: false)
       self.directories << [label, path]
       self.test_types << label if test_directory
+    end
+
+    # Add extensions to the output of the <tt>bin/rails stats</tt> command.
+    #
+    #   Rails::CodeStatistics.register_extension("txt")
+    def self.register_extension(extension)
+      self.extensions += [extension]
+      self.pattern = /^(?!\.).*?\.(#{Regexp.union(extensions.map { |e| Regexp.escape(e) })})$/
     end
 
     def initialize(*pairs)

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -29,6 +29,14 @@ class CodeStatisticsTest < ActiveSupport::TestCase
     Rails::CodeStatistics.test_types.delete("Model specs")
   end
 
+  test "register test extensions" do
+    Rails::CodeStatistics.register_extension("slim")
+    assert Rails::CodeStatistics.pattern.to_s.include?("slim")
+  ensure
+    Rails::CodeStatistics.extensions = Rails::CodeStatistics::EXTENSIONS
+    Rails::CodeStatistics.pattern = Rails::CodeStatistics::PATTERN
+  end
+
   test "ignores directories that happen to have source files extensions" do
     assert_nothing_raised do
       @code_statistics = Rails::CodeStatistics.new(["tmp dir", @tmp_path])


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In the following Pull Request, support was added for customizing the file extensions included in the `rails stats` command by overriding `Rails::CodeStatistics.pattern`:
- https://github.com/rails/rails/pull/55734

However, since this approach overrides `Rails::CodeStatistics.pattern`, any future changes to the default `PATTERN` cannot be detected or followed automatically.
I'd like to make it possible to add extensions while keeping compatibility with future updates to the default pattern.

Below is an example from Rails v8.1.0 showing how to add the `.slim` extension:
```ruby
# default value
# PATTERN = /^(?!\.).*?\.(rb|js|ts|css|scss|coffee|rake|erb)$/

#  override value to add the `slim` extension
Rails::CodeStatistics.pattern = /^(?!\.).*?\.(rb|js|ts|css|scss|coffee|rake|erb|slim)$/
```

If a new default extension (e.g., `.txt`) is added in the future, we would ideally like the updated default pattern plus our custom extensions.
However, because the entire pattern is overridden, this is not currently possible:
```ruby
# default value after adding the `txt` extension
# PATTERN = /^(?!\.).*?\.(rb|js|ts|css|scss|coffee|rake|erb|txt)$/

# actual behavior: .txt is not included
Rails::CodeStatistics.pattern = /^(?!\.).*?\.(rb|js|ts|css|scss|coffee|rake|erb|slim)$/

# expected behavior: .txt is included
Rails::CodeStatistics.pattern = /^(?!\.).*?\.(rb|js|ts|css|scss|coffee|rake|erb|txt|slim)$/
```

In addition, due to this behavior, when a third-party gem such as the `slim-rails` gem tries to add an extension, it ends up overwriting the existing `pattern` and therefore cannot actually add it.

### Detail

This Pull Request proposes adding a `register_extension` method to `CodeStatistics` for adding file extensions.
By using `register_extension`, users can add extensions without needing to override `Rails::CodeStatistics.pattern`, ensuring compatibility with future updates to the default pattern.

```ruby
Rails::CodeStatistics.register_extension("slim")
```

With `register_extension`, file extensions can be added to the default pattern, enabling third-party gems such as the `slim-rails` gem to register their own extensions.

Note that the existing `Rails::CodeStatistics.pattern` will continue to work.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Although the new `register_extension` method could eventually make `Rails::CodeStatistics.pattern` unnecessary, it is already available in Rails 8.1.0 and may be in use by existing users.
The `Rails::CodeStatistics.pattern` feature was originally introduced in the following Pull Request to allow overriding extensions such as `haml`
- https://github.com/rails/rails/pull/55734

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
