### PR TITLE
Railties: raise when both config.force_ssl and config.assume_ssl are enabled

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Raise RuntimeError when both config.force_ssl and config.assume_ssl are enabled.
+
+    **This is a breaking change:** These settings target different deployment setups (`ActionDispatch::SSL` vs. `ActionDispatch::AssumeSSL`) and
+    are mutually exclusive. Attempting to enable both now raises early to prevent ambiguous SSL configuration.
+
+    *Daniel Niknam*
+
 *   Do not assume and force SSL in production by default when using Kamal, to allow for out of the box Kamal deployments.
 
     It is still recommended to assume and force SSL in production as soon as you can.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -11,10 +11,10 @@ require "rails/source_annotation_extractor"
 module Rails
   class Application
     class Configuration < ::Rails::Engine::Configuration
-      attr_accessor :allow_concurrency, :asset_host, :assume_ssl, :autoflush_log,
+      attr_accessor :allow_concurrency, :asset_host, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters, :precompile_filter_parameters,
-                    :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
+                    :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
                     :log_tags, :silence_healthcheck_path, :railties_order, :relative_url_root,
                     :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
@@ -26,7 +26,8 @@ module Rails
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
                     :dom_testing_default_html_version, :yjit
 
-      attr_reader :encoding, :api_only, :loaded_config_version, :log_level
+      attr_reader :encoding, :api_only, :loaded_config_version, :log_level,
+                  :assume_ssl, :force_ssl
 
       def initialize(*)
         super
@@ -618,6 +619,18 @@ module Rails
         f
       end
 
+      def assume_ssl=(value)
+        check_for_only_assume_or_force_ssl
+
+        @assume_ssl = value
+      end
+
+      def force_ssl=(value)
+        check_for_only_assume_or_force_ssl
+
+        @force_ssl = value
+      end
+
       def inspect # :nodoc:
         "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
       end
@@ -665,6 +678,13 @@ module Rails
           end
 
           File.binread(key_file)
+        end
+
+        def check_for_only_assume_or_force_ssl
+          raise RuntimeError, <<~MSG.squish if @assume_ssl || @force_ssl
+            Both config.force_ssl and config.assume_ssl cannot be enabled simultaneously. The
+            config.force_ssl and config.assume_ssl are mutually exclusive, consider enabling only one of them.
+          MSG
         end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1559,6 +1559,22 @@ module ApplicationTests
       assert_equal false, ActionView::Resolver.caching?
     end
 
+    test "config.force_ssl = true and config.assume_ssl = true" do
+      add_to_config <<~RUBY
+        config.assume_ssl = true
+        config.force_ssl = true
+      RUBY
+
+      e = assert_raise RuntimeError do
+        app "development"
+      end
+
+      assert_equal <<~MSG.squish, e.message
+        Both config.force_ssl and config.assume_ssl cannot be enabled simultaneously. The
+        config.force_ssl and config.assume_ssl are mutually exclusive, consider enabling only one of them.
+      MSG
+    end
+
     test "ActionController::Base::renderer uses Rails.application.default_url_options and config.force_ssl" do
       add_to_config <<~RUBY
         config.force_ssl = true


### PR DESCRIPTION
### Motivation / Background

Fixes #55695

`config.force_ssl` (adds `ActionDispatch::SSL`) and `config.assume_ssl` (adds `ActionDispatch::AssumeSSL`) are intended for different deployment setups and should not be enabled together. Enabling both can lead to confusion and makes the effective SSL policy ambiguous.

This change raises early if an application attempts to enable both settings at the same time, guiding the user to choose a single, correct configuration for their environment.


### Detail

**What changed**

* Convert `assume_ssl` and `force_ssl` from simple accessors to reader methods with custom writer methods that validate exclusivity.

* Add a private guard `check_for_only_assume_or_force_ssl` that raises:

  > Both config.force_ssl and config.assume_ssl cannot be enabled
  > simultaneously. The config.force_ssl and config.assume_ssl are
  > mutually exclusive, consider enabling only one of them.

* Add a test to assert a `RuntimeError` is raised when both options are set to `true`.

**Why**

* Prevents misconfiguration at boot time.
* Matches Rails’ pattern of validating incompatible configuration options early and providing a clear, actionable error message.

**Tests**

* `railties/test/application/configuration_test.rb`:

  * Adds `config.force_ssl = true and config.assume_ssl = true` test that asserts a `RuntimeError` during boot.

### Additional information

**Backwards compatibility**

* Applications that previously set both options will now fail fast with a clear error, prompting the operator to select exactly one of the two settings based on their deployment (reverse proxy/LB vs. app-level enforcement).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
