### PR TITLE
Add structured event for open redirects

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Emit a structured event when `action_on_open_redirect` is set to `:notify`
+    in addition to the existing Active Support Notification.
+
+    *Adrianna Chang*, *Hartley McGuire*
+
 *   Support `text/markdown` format in `DebugExceptions` middleware.
 
     When `text/markdown` is requested via the Accept header, error responses

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -117,7 +117,7 @@ module ActionController
     # The `action_on_open_redirect` configuration option controls the behavior when an unsafe
     # redirect is detected:
     # * `:log` - Logs a warning but allows the redirect
-    # * `:notify` - Sends an Active Support notification for monitoring
+    # * `:notify` - Sends an Active Support notification and structured event for monitoring
     # * `:raise` - Raises an UnsafeRedirectError
     #
     # To allow any external redirects pass `allow_other_host: true`, though using a

--- a/actionpack/lib/action_controller/structured_event_subscriber.rb
+++ b/actionpack/lib/action_controller/structured_event_subscriber.rb
@@ -69,6 +69,17 @@ module ActionController
       emit_event("action_controller.data_sent", filename: event.payload[:filename], duration_ms: event.duration.round(1))
     end
 
+    def open_redirect(event)
+      payload = event.payload
+
+      emit_event("action_controller.open_redirect",
+        location: payload[:location],
+        request_method: payload[:request]&.method,
+        request_path: payload[:request]&.path,
+        stacktrace: payload[:stack_trace],
+      )
+    end
+
     def unpermitted_parameters(event)
       unpermitted_keys = event.payload[:keys]
       context = event.payload[:context]


### PR DESCRIPTION
### Motivation / Background

Follow up to: https://github.com/rails/rails/pull/55496

This Pull Request has been created so that applications with `config.action_controller.action_on_open_redirect = :notify` automatically get a structured log event, rather than having to configure their own subscriber to the Active Support Notification.

### Detail

Adds a method for `open_redirect` to `ActionController::StructuredEventSubscriber`. Uses the last line of the stacktrace for `stack_trace` to match `#rescue_from_callback`, but we could offer a bit more here if desired (return the last X lines, filter the trace, etc.)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
