### PR TITLE
Add ActiveRecord.parallel_test_table_reset_method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `ActiveRecord.parallel_test_table_reset_method` configuration to control
+    how test database tables are reset during parallel test database initialization.
+
+    Can be set to `:truncate` (default), `:delete`, or `:skip`.
+
+    When running parallel tests, each worker gets a separate database copy. If the
+    schema is up to date, by default the tables are truncated to reset them.
+
+    On MySQL deletion can be significantly faster, so this allow us to use that as
+    an alternative method to clear out the tables.
+
+    Example:
+
+        # config/environments/test.rb
+        config.active_record.parallel_test_table_reset_method = :delete
+
+    *Donal McBreen*
+
 *   Fix upsert_all when using repeated timestamp attributes.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -345,6 +345,31 @@ module ActiveRecord
   singleton_class.attr_accessor :maintain_test_schema
   self.maintain_test_schema = nil
 
+  ##
+  # :singleton-method:
+  # Specifies how to reset test database tables when preparing parallel test databases.
+  #
+  # Valid values are:
+  # * +:truncate+ (default) - Fast, resets auto-increment counters (MySQL/PostgreSQL)
+  # * +:delete+ - Slower, preserves auto-increment counters
+  # * +:skip+ - Don't reset tables
+  #
+  # On MySQL and PostgreSQL, +:truncate+ resets the auto-increment counters, while
+  # +:delete+ preserves them. The SQLite adapter uses deletion to truncate tables, so
+  # both +:truncate+ and +:delete+ behave the same way there.
+  def self.parallel_test_table_reset_method=(value)
+    unless [:truncate, :delete, :skip].include?(value)
+      raise ArgumentError, "Invalid parallel_test_table_reset_method: #{value.inspect}. Valid values are: :truncate, :delete, :skip"
+    end
+    @parallel_test_table_reset_method = value
+  end
+
+  def self.parallel_test_table_reset_method
+    @parallel_test_table_reset_method
+  end
+
+  self.parallel_test_table_reset_method = :truncate
+
   singleton_class.attr_accessor :raise_on_assign_to_attr_readonly
   self.raise_on_assign_to_attr_readonly = false
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -30,6 +30,7 @@ module ActiveRecord
     config.active_record.use_schema_cache_dump = true
     config.active_record.check_schema_cache_dump_version = true
     config.active_record.maintain_test_schema = true
+    config.active_record.parallel_test_table_reset_method = :truncate
     config.active_record.has_many_inversing = false
     config.active_record.query_log_tags_enabled = false
     config.active_record.query_log_tags = [ :application ]

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -23,7 +23,7 @@ module ActiveRecord
         db_config._database = "#{db_config.database}_#{i}"
 
         if db_config.database_tasks?
-          ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, nil)
+          ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, nil, reset_method: ActiveRecord.parallel_test_table_reset_method)
         end
       end
     ensure

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1240,6 +1240,11 @@ The default value depends on the `config.load_defaults` target version:
 
 Is a boolean value and controls whether or not partial writes are used when updating existing records (i.e. whether updates only set attributes that are dirty). Note that when using partial updates, you should also use optimistic locking `config.active_record.lock_optimistically` since concurrent updates may write attributes based on a possibly stale read state. The default value is `true`.
 
+#### `config.active_record.parallel_test_table_reset_method`
+
+Controls how tables are reset at the start of a test run when using parallel
+tests. Default is `:truncate`. The other options are `:delete` and `:skip`.
+
 #### `config.active_record.maintain_test_schema`
 
 Is a boolean value which controls whether Active Record should try to keep your test database schema up-to-date with `db/schema.rb` (or `db/structure.sql`) when you run your tests. The default is `true`.


### PR DESCRIPTION
### Motivation / Background

Truncating tables is very slow on MySQL compared to deleting from them, so allow the method used by parallel tests to reset tables to be configurable.

### Detail

When doing parallel testing with many databases, truncating all the tables is very slow, at least on MySQL. Deleting from the tables is much faster.

Add a configuration option `parallel_test_table_reset_method` that can be set to `:truncate`, `:delete`, or `:skip` to control how test database tables are emptied.

The `:skip` option makes the `SKIP_TEST_DATABASE_TRUNCATE` env variable obsolete, but that has been kept for backward compatibility.

There's no difference between the two methods for SQLite, as the adapter uses DELETE for truncation anyway.

On MySQL and PostgreSQL, TRUNCATE resets the auto-increment counters, while DELETE preserves them.
### Additional information

Running on a schema with about 200 tables and 32 parallel databases, I can delete from all tables in about 3 seconds, while truncating takes about 20 seconds.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
