### PR TITLE
Fix devcontainer volume mount when app name differs from folder name

### DIFF
--- a/railties/lib/rails/commands/devcontainer/devcontainer_command.rb
+++ b/railties/lib/rails/commands/devcontainer/devcontainer_command.rb
@@ -22,6 +22,7 @@ module Rails
         def devcontainer_options
           @devcontainer_options ||= {
             app_name: Rails.application.railtie_name.chomp("_application"),
+            app_folder: File.basename(Rails.root),
             database: !!defined?(ActiveRecord) && database,
             active_storage: !!defined?(ActiveStorage),
             redis: !!((defined?(ActionCable) && !defined?(SolidCable)) || (defined?(ActiveJob) && !defined?(SolidQueue))),

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -283,6 +283,7 @@ module Rails
         dev: options[:dev],
         node: using_node?,
         app_name: app_name,
+        app_folder: File.basename(app_path),
         skip_solid: options[:skip_solid],
         pretend: options[:pretend]
       }

--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -8,6 +8,9 @@ module Rails
       class_option :app_name, type: :string, default: "rails_app",
                    desc: "Name of the app"
 
+      class_option :app_folder, type: :string, default: nil,
+                   desc: "The folder name where the app is generated"
+
       class_option :database, enum: Database::DATABASES, type: :string, default: "sqlite3",
                    desc: "Include configuration for selected database"
 
@@ -65,6 +68,10 @@ module Rails
 
         def app_name
           options[:app_name]
+        end
+
+        def app_folder
+          options[:app_folder] || app_name
         end
 
         def dependencies

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -7,7 +7,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
 
     volumes:
-    - ../../<%= options[:app_name] %>:/workspaces/<%= options[:app_name] %>:cached
+    - ../../<%= app_folder %>:/workspaces/<%= app_folder %>:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/railties/test/commands/devcontainer_test.rb
+++ b/railties/test/commands/devcontainer_test.rb
@@ -23,6 +23,29 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
     assert_match "system_test: true", output
     assert_match "node: false", output
     assert_match "kamal: false", output
+
+    assert_compose_file do |content|
+      assert_equal "app_template", content["name"]
+
+      expected_rails_app_config = {
+        "build" => {
+          "context" => "..",
+          "dockerfile" => ".devcontainer/Dockerfile"
+        },
+        "volumes" => ["../../app:/workspaces/app:cached"],
+        "command" => "sleep infinity",
+        "depends_on" => ["selenium"]
+      }
+
+      assert_equal expected_rails_app_config, content["services"]["rails-app"]
+
+      expected_selenium_config = {
+        "image" => "selenium/standalone-chromium",
+        "restart" => "unless-stopped",
+      }
+
+      assert_equal expected_selenium_config, content["services"]["selenium"]
+    end
   end
 
   test "generates dev container for without solid gems" do
@@ -50,5 +73,10 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
   private
     def read_file(relative)
       File.read(app_path(relative))
+    end
+
+    def assert_compose_file
+      content = read_file(".devcontainer/compose.yaml")
+      yield YAML.load(content)
     end
 end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1491,7 +1491,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
           "context" => "..",
           "dockerfile" => ".devcontainer/Dockerfile"
         },
-        "volumes" => ["../../#{compose_config["name"]}:/workspaces/#{compose_config["name"]}:cached"],
+        "volumes" => ["../../tmp:/workspaces/tmp:cached"],
         "command" => "sleep infinity",
         "depends_on" => ["selenium"]
       }

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -49,13 +49,29 @@ module Rails
       def test_app_name_option
         run_generator ["--app-name", "my-TestApp_name"]
 
-        test_common_config
+        test_common_config_with_folder("my-TestApp_name")
         assert_devcontainer_json_file do |devcontainer_json|
           assert_equal "my-TestApp_name", devcontainer_json["name"]
         end
 
         assert_compose_file do |compose|
           assert_equal "my-TestApp_name", compose["name"]
+        end
+      end
+
+      def test_app_folder_option
+        run_generator ["--app-name", "sample_app", "--app-folder", "my_folder"]
+
+        test_common_config_with_folder("my_folder")
+        assert_devcontainer_json_file do |devcontainer_json|
+          assert_equal "sample_app", devcontainer_json["name"]
+        end
+
+        assert_compose_file do |compose|
+          assert_equal "sample_app", compose["name"]
+          # Verify the volume mount uses app_folder, not app_name
+          expected_volume = "../../my_folder:/workspaces/my_folder:cached"
+          assert_equal expected_volume, compose["services"]["rails-app"]["volumes"].first
         end
       end
 
@@ -344,6 +360,10 @@ module Rails
 
       private
         def test_common_config
+          test_common_config_with_folder("rails_app")
+        end
+
+        def test_common_config_with_folder(folder_name)
           assert_file(".devcontainer/Dockerfile") do |dockerfile|
             assert_match(/ARG RUBY_VERSION=#{RUBY_VERSION}/, dockerfile)
             assert_match(/ENV BINDING="0.0.0.0"/, dockerfile)
@@ -360,7 +380,7 @@ module Rails
                 "context" => "..",
                 "dockerfile" => ".devcontainer/Dockerfile"
               },
-              "volumes" => ["../../#{compose["name"]}:/workspaces/#{compose["name"]}:cached"],
+              "volumes" => ["../../#{folder_name}:/workspaces/#{folder_name}:cached"],
               "command" => "sleep infinity"
             }
             actual_independent_config = compose["services"]["rails-app"].except("depends_on")


### PR DESCRIPTION
When generating a Rails app with `rails new folder --name=sample`, the devcontainer's compose.yaml was incorrectly mounting the volume using the app name instead of the actual folder name. This caused the devcontainer to fail with "Workspace does not exist" error.

The issue was introduced in PR #54631 which changed the volume mount to use `options[:app_name]` instead of the parent directory. While this improved isolation, it didn't account for cases where the app name and folder name differ.

Fixes #56024