### PR TITLE
[ci skip] fix(guides): Update AJ serializer example to have public klass

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -988,11 +988,10 @@ class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
     Money.new(hash["amount"], hash["currency"])
   end
 
-  private
-    # Checks if an argument should be serialized by this serializer.
-    def klass
-      Money
-    end
+  # Checks if an argument should be serialized by this serializer.
+  def klass
+    Money
+  end
 end
 ```
 


### PR DESCRIPTION
### Motivation / Background

As of Rails 8.1 ActiveJob custom serializer example yields deprecation warnings:

```
DEPRECATION WARNING: IpAddrSerializer#klass method should be public. 
This will raise an error in Rails 8.2.
```

### Detail

This Pull Request changes ActiveJob custom serializer example in guides.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
