### PR TITLE
Add `:algorithm` option to `has_secure_password`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -2,10 +2,6 @@
 
     ```ruby
     class CustomPassword
-      def algorithm_name
-        :custom
-      end
-
       def hash_password(unencrypted_password)
         CustomHashingLibrary.create(unencrypted_password)
       end
@@ -19,6 +15,11 @@
       end
 
       def validate(record, attribute)
+        # ...
+      end
+
+      def algorithm_name
+        :custom
       end
     end
     ```

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,36 @@
+*   `has_secure_password` can support different password hashing algorithms (if defined) using the `:algorithm` option:
+
+    ```ruby
+    class CustomPassword
+      def algorithm_name
+        :custom
+      end
+
+      def hash_password(unencrypted_password)
+        CustomHashingLibrary.create(unencrypted_password)
+      end
+
+      def verify_password(password, digest)
+        CustomHashingLibrary.verify(password, digest)
+      end
+
+      def password_salt(digest)
+        CustomHashingLibrary.salt(digest)
+      end
+
+      def validate(record, attribute)
+      end
+    end
+    ```
+
+    ```ruby
+    class User < ActiveRecord::Base
+      has_secure_password algorithm: CustomPassword.new
+    end
+    ```
+
+    *Justin Bull, Lucas Mazza*
+
 *   Allow passing method name or proc to `allow_nil` and `allow_blank`
 
     ```ruby

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
+require "active_model/secure_password/bcrypt_password"
+
 module ActiveModel
   module SecurePassword
     extend ActiveSupport::Concern
-
-    # BCrypt hash function can handle maximum 72 bytes, and if we pass
-    # password of length more than 72 bytes it ignores extra characters.
-    # Hence need to put a restriction on password length.
-    MAX_PASSWORD_LENGTH_ALLOWED = 72
 
     DEFAULT_RESET_TOKEN_EXPIRES_IN = 15.minutes
 
@@ -54,6 +51,10 @@ module ActiveModel
       #
       #   gem "bcrypt", "~> 3.1.7"
       #
+      # If you want to use a different password hashing algorithm, you can implement your own
+      # class that responds to +algorithm_name+, +hash_password+, +verify_password+, +password_salt+ and +validate+.
+      # For an example implementation, see +BCryptPassword+ in +bcrypt_password.rb+.
+      #
       # ==== Examples
       #
       # ===== Using Active Record (which automatically includes ActiveModel::SecurePassword)
@@ -66,6 +67,7 @@ module ActiveModel
       #
       #   user = User.new(name: "david", password: "", password_confirmation: "nomatch")
       #
+      #   user.password_algorithm                                        # => :bcrypt
       #   user.save                                                      # => false, password required
       #   user.password = "vr00m"
       #   user.save                                                      # => false, confirmation doesn't match
@@ -120,18 +122,45 @@ module ActiveModel
       #
       #   # raises ActiveSupport::MessageVerifier::InvalidSignature since the token is expired
       #   User.find_by_password_reset_token!(token)
-      def has_secure_password(attribute = :password, validations: true, reset_token: true)
+      #
+      # ===== Customizing the hashing algorithm
+
+      # class Argon2Password
+      #   def algorithm_name
+      #     :argon2
+      #   end
+
+      #   def hash_password(unencrypted_password)
+      #     Argon2::Password.create(unencrypted_password)
+      #   end
+
+      #   def verify_password(password, digest)
+      #     Argon2::Password.verify_password(password, digest)
+      #   end
+
+      #   def password_salt(digest)
+      #     Argon2::HashFormat.new(digest).salt
+      #   end
+
+      #   def validate(_record, _attribute)
+      #     # Argon2 has no maximum input size, no validation needed
+      #   end
+      # end
+
+      # class User < ActiveRecord::Base
+      #   has_secure_password algorithm: Argon2Password.new
+      # end
+
+      # user = User.new(name: "david", password: "", password_confirmation: "nomatch")
+      # user.password_algorithm                                        # => :argon2
+      # user.password_digest                                           # => "$argon2id$v=19$m=65536,t=3,p=4$/hM+NKjC0FTYDpN3LNTzBQ$5V1T31fHB57+Y8G9TUkqSUMgEkSygv8AW/AHNfOm2ts"
+      def has_secure_password(attribute = :password, validations: true, reset_token: true, algorithm: nil)
         # Load bcrypt gem only when has_secure_password is used.
         # This is to avoid ActiveModel (and by extension the entire framework)
         # being dependent on a binary library.
-        begin
-          require "bcrypt"
-        rescue LoadError
-          warn "You don't have bcrypt installed in your application. Please add it to your Gemfile and run bundle install."
-          raise
-        end
+        algorithm ||= BCryptPassword.new
 
-        include InstanceMethodsOnActivation.new(attribute, reset_token: reset_token)
+        include InstanceMethodsOnActivation.new(attribute, reset_token: reset_token, algorithm: algorithm)
 
         if validations
           include ActiveModel::Validations
@@ -148,18 +177,15 @@ module ActiveModel
             if challenge = record.public_send(:"#{attribute}_challenge")
               digest_was = record.public_send(:"#{attribute}_digest_was") if record.respond_to?(:"#{attribute}_digest_was")
 
-              unless digest_was.present? && BCrypt::Password.new(digest_was).is_password?(challenge)
+              unless digest_was.present? && algorithm.verify_password(challenge, digest_was)
                 record.errors.add(:"#{attribute}_challenge")
               end
             end
           end
 
-          # Validates that the password does not exceed the maximum allowed bytes for BCrypt (72 bytes).
+          # Performs password hashing algorithm-specific validations (such as a max input size)
           validate do |record|
-            password_value = record.public_send(attribute)
-            if password_value.present? && password_value.bytesize > ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
-              record.errors.add(attribute, :password_too_long)
-            end
+            algorithm.validate(record, attribute)
           end
 
           validates_confirmation_of attribute, allow_nil: true
@@ -192,7 +218,7 @@ module ActiveModel
     end
 
     class InstanceMethodsOnActivation < Module
-      def initialize(attribute, reset_token:)
+      def initialize(attribute, reset_token:, algorithm:)
         attr_reader attribute
 
         define_method("#{attribute}=") do |unencrypted_password|
@@ -201,8 +227,8 @@ module ActiveModel
             self.public_send("#{attribute}_digest=", nil)
           elsif !unencrypted_password.empty?
             instance_variable_set("@#{attribute}", unencrypted_password)
-            cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
-            self.public_send("#{attribute}_digest=", BCrypt::Password.create(unencrypted_password, cost: cost))
+            password_digest = algorithm.hash_password(unencrypted_password)
+            self.public_send("#{attribute}_digest=", password_digest)
           end
         end
 
@@ -220,13 +246,13 @@ module ActiveModel
         #   user.authenticate_password('mUc3m00RsqyRe') # => user
         define_method("authenticate_#{attribute}") do |unencrypted_password|
           attribute_digest = public_send("#{attribute}_digest")
-          attribute_digest.present? && BCrypt::Password.new(attribute_digest).is_password?(unencrypted_password) && self
+          attribute_digest.present? && algorithm.verify_password(unencrypted_password, attribute_digest) && self
         end
 
         # Returns the salt, a small chunk of random data added to the password before it's hashed.
         define_method("#{attribute}_salt") do
           attribute_digest = public_send("#{attribute}_digest")
-          attribute_digest.present? ? BCrypt::Password.new(attribute_digest).salt : nil
+          attribute_digest.present? ? algorithm.password_salt(attribute_digest) : nil
         end
 
         alias_method :authenticate, :authenticate_password if attribute == :password
@@ -236,6 +262,10 @@ module ActiveModel
           define_method("#{attribute}_reset_token") do
             generate_token_for(:"#{attribute}_reset")
           end
+        end
+
+        define_method("#{attribute}_algorithm") do
+          algorithm.algorithm_name
         end
       end
     end

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -124,14 +124,12 @@ module ActiveModel
       #   User.find_by_password_reset_token!(token)
       #
       # ===== Customizing the hashing algorithm
+      # To add a custom algorithm, create a class that implements +hash_password+, +verify_password+, +password_salt+,
+      # +validate+ and +algorithm_name+ methods.
       #
       #   class Argon2Password
       #     def initialize
       #       require "argon2"
-      #     end
-      #
-      #     def algorithm_name
-      #       :argon2
       #     end
       #
       #     def hash_password(unencrypted_password)
@@ -148,6 +146,10 @@ module ActiveModel
       #
       #     def validate(_record, _attribute)
       #       # Argon2 has no maximum input size, no validation needed
+      #     end
+      #
+      #     def algorithm_name
+      #       :argon2
       #     end
       #   end
       #

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -124,36 +124,40 @@ module ActiveModel
       #   User.find_by_password_reset_token!(token)
       #
       # ===== Customizing the hashing algorithm
-
-      # class Argon2Password
-      #   def algorithm_name
-      #     :argon2
+      #
+      #   class Argon2Password
+      #     def initialize
+      #       require "argon2"
+      #     end
+      #
+      #     def algorithm_name
+      #       :argon2
+      #     end
+      #
+      #     def hash_password(unencrypted_password)
+      #       Argon2::Password.create(unencrypted_password)
+      #     end
+      #
+      #     def verify_password(password, digest)
+      #       Argon2::Password.verify_password(password, digest)
+      #     end
+      #
+      #     def password_salt(digest)
+      #       Argon2::HashFormat.new(digest).salt
+      #     end
+      #
+      #     def validate(_record, _attribute)
+      #       # Argon2 has no maximum input size, no validation needed
+      #     end
       #   end
-
-      #   def hash_password(unencrypted_password)
-      #     Argon2::Password.create(unencrypted_password)
+      #
+      #   class User < ActiveRecord::Base
+      #     has_secure_password algorithm: Argon2Password.new
       #   end
-
-      #   def verify_password(password, digest)
-      #     Argon2::Password.verify_password(password, digest)
-      #   end
-
-      #   def password_salt(digest)
-      #     Argon2::HashFormat.new(digest).salt
-      #   end
-
-      #   def validate(_record, _attribute)
-      #     # Argon2 has no maximum input size, no validation needed
-      #   end
-      # end
-
-      # class User < ActiveRecord::Base
-      #   has_secure_password algorithm: Argon2Password.new
-      # end
-
-      # user = User.new(name: "david", password: "", password_confirmation: "nomatch")
-      # user.password_algorithm                                        # => :argon2
-      # user.password_digest                                           # => "$argon2id$v=19$m=65536,t=3,p=4$/hM+NKjC0FTYDpN3LNTzBQ$5V1T31fHB57+Y8G9TUkqSUMgEkSygv8AW/AHNfOm2ts"
+      #
+      #   user = User.new(name: "david", password: "", password_confirmation: "nomatch")
+      #   user.password_algorithm                                        # => :argon2
+      #   user.password_digest                                           # => "$argon2id$v=19$m=65536,t=3,p=4$/hM+NKjC0FTYDpN3LNTzBQ$5V1T31fHB57+Y8G9TUkqSUMgEkSygv8AW/AHNfOm2ts"
       def has_secure_password(attribute = :password, validations: true, reset_token: true, algorithm: nil)
         # Load bcrypt gem only when has_secure_password is used.
         # This is to avoid ActiveModel (and by extension the entire framework)

--- a/activemodel/lib/active_model/secure_password/bcrypt_password.rb
+++ b/activemodel/lib/active_model/secure_password/bcrypt_password.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module SecurePassword
+    class BCryptPassword
+      # BCrypt hash function can handle maximum 72 bytes, and if we pass
+      # password of length more than 72 bytes it ignores extra characters.
+      # Hence need to put a restriction on password length.
+      MAX_PASSWORD_LENGTH_ALLOWED = 72
+
+      # Load bcrypt gem only when has_secure_password is used.
+      # This is to avoid ActiveModel (and by extension the entire framework)
+      # being dependent on a binary library.
+      def initialize
+        require "bcrypt"
+      rescue LoadError
+        warn "You don't have bcrypt installed in your application. Please add it to your Gemfile and run bundle install."
+        raise
+      end
+
+      def algorithm_name
+        :bcrypt
+      end
+
+      def validate(record, attribute)
+        password = record.public_send(attribute)
+        if password.present?
+          record.errors.add(attribute, :password_too_long) if password.bytesize > MAX_PASSWORD_LENGTH_ALLOWED
+        end
+      end
+
+      def hash_password(unencrypted_password)
+        ::BCrypt::Password.create(unencrypted_password, cost: cost)
+      end
+
+      def verify_password(password, digest)
+        ::BCrypt::Password.new(digest).is_password?(password)
+      end
+
+      def password_salt(digest)
+        ::BCrypt::Password.new(digest).salt
+      end
+
+      private
+        def cost
+          ActiveModel::SecurePassword.min_cost ? ::BCrypt::Engine::MIN_COST : ::BCrypt::Engine.cost
+        end
+    end
+  end
+end

--- a/activemodel/lib/active_model/secure_password/bcrypt_password.rb
+++ b/activemodel/lib/active_model/secure_password/bcrypt_password.rb
@@ -18,17 +18,6 @@ module ActiveModel
         raise
       end
 
-      def algorithm_name
-        :bcrypt
-      end
-
-      def validate(record, attribute)
-        password = record.public_send(attribute)
-        if password.present?
-          record.errors.add(attribute, :password_too_long) if password.bytesize > MAX_PASSWORD_LENGTH_ALLOWED
-        end
-      end
-
       def hash_password(unencrypted_password)
         ::BCrypt::Password.create(unencrypted_password, cost: cost)
       end
@@ -39,6 +28,17 @@ module ActiveModel
 
       def password_salt(digest)
         ::BCrypt::Password.new(digest).salt
+      end
+
+      def validate(record, attribute)
+        password = record.public_send(attribute)
+        if password.present?
+          record.errors.add(attribute, :password_too_long) if password.bytesize > MAX_PASSWORD_LENGTH_ALLOWED
+        end
+      end
+
+      def algorithm_name
+        :bcrypt
       end
 
       private

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -28,7 +28,7 @@ class CustomAlgorithm
   end
 end
 
-class UserWithCustomAlgorithim < User
+class UserWithCustomAlgorithm < User
   has_secure_password algorithm: CustomAlgorithm.new
 end
 

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -6,6 +6,32 @@ require "models/pilot"
 require "models/slow_pilot"
 require "models/visitor"
 
+class CustomAlgorithm
+  def algorithm_name
+    :custom_algorithm
+  end
+
+  def validate(record, attribute)
+    # No-op for testing
+  end
+
+  def hash_password(unencrypted_password)
+    "hashed-#{unencrypted_password}"
+  end
+
+  def verify_password(password, digest)
+    digest == "hashed-#{password}"
+  end
+
+  def password_salt(digest)
+    "custom-salt"
+  end
+end
+
+class UserWithCustomAlgorithim < User
+  has_secure_password algorithm: CustomAlgorithm.new
+end
+
 class SecurePasswordTest < ActiveModel::TestCase
   setup do
     # Used only to speed up tests
@@ -346,5 +372,26 @@ class SecurePasswordTest < ActiveModel::TestCase
   test "password reset token duration" do
     assert_equal "password_reset-token-3600", @slow_pilot.password_reset_token
     assert_equal 1.hour, @slow_pilot.password_reset_token_expires_in
+  end
+
+  test "password algorithm defaults to bcrypt" do
+    assert_equal :bcrypt, @user.password_algorithm
+  end
+
+  test "custom password algorithm is supported" do
+    user_with_diff_algo = UserWithCustomAlgorithim.new
+
+    user_with_diff_algo.password = "secret"
+    assert_equal "hashed-secret", user_with_diff_algo.password_digest
+
+    assert_equal false, user_with_diff_algo.authenticate("wrong")
+    assert_equal user_with_diff_algo, user_with_diff_algo.authenticate("secret")
+
+    assert_equal false, user_with_diff_algo.authenticate_password("wrong")
+    assert_equal user_with_diff_algo, user_with_diff_algo.authenticate_password("secret")
+
+    assert_equal "custom-salt", user_with_diff_algo.password_salt
+
+    assert_equal :custom_algorithm, user_with_diff_algo.password_algorithm
   end
 end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -379,7 +379,7 @@ class SecurePasswordTest < ActiveModel::TestCase
   end
 
   test "custom password algorithm is supported" do
-    user_with_diff_algo = UserWithCustomAlgorithim.new
+    user_with_diff_algo = UserWithCustomAlgorithm.new
 
     user_with_diff_algo.password = "secret"
     assert_equal "hashed-secret", user_with_diff_algo.password_digest


### PR DESCRIPTION
### Detail

This is a new take on #48993, with a branch up to speed with recent `main` and without the base class or the `available_password_algorithms` registry like Hash.

libraries/apps can just bring an object that responds to the required methods and `has_secure_password` will just work with the custom implementation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
