### PR TITLE
[doc] Document new cache format version 7.1 in upgrade guide(7.0 -> 7.1)

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -205,6 +205,14 @@ This will invalidate all existing sessions/cookies in development and test envir
 
 Production and other environments are not affected.
 
+### New ActiveSupport::Cache serialization format
+
+A new 7.1 cache format is available which includes an optimization for bare string values such as view fragments.
+
+The 7.1 cache format is used by default for new apps, and existing apps can enable the format by setting `config.load_defaults 7.1` or by setting `config.active_support.cache_format_version = 7.1` in `config/application.rb` or a `config/environments/*.rb` file.
+
+Cache entries written using the 6.1 or 7.0 cache formats can be read when using the 7.1 format. To perform a rolling deploy of a Rails 7.1 upgrade, wherein servers that have not yet been upgraded must be able to read caches from upgraded servers, leave the cache format unchanged on the first deploy, then enable the 7.1 cache format on a subsequent deploy.
+
 ### Autoloaded paths are no longer in $LOAD_PATH
 
 Starting from Rails 7.1, the directories managed by the autoloaders are no


### PR DESCRIPTION
### Motivation / Background

The Rails 7.1 release introduced a new cache format version (7.1) with optimizations for bare string values such as view fragments, as documented in the [ActiveSupport CHANGELOG](https://github.com/rails/rails/blob/v7.1.0/activesupport/CHANGELOG.md). However, this important change was not mentioned in the upgrade guide, making it easy for developers to miss during upgrades.

Similar cache format changes were prominently documented in the "Upgrading from Rails 6.1 to Rails 7.0" section, but the 7.0 to 7.1 upgrade section lacked equivalent documentation. This creates an inconsistency in the upgrade guide and may lead to developers not benefiting from the performance improvements or encountering issues during rolling deployments.

### Detail

This Pull Request adds a new section **"New ActiveSupport::Cache serialization format"** to the "Upgrading from Rails 7.0 to Rails 7.1" section of the upgrade guide.

The new section documents:
- The availability of the new 7.1 cache format with optimizations for bare string values
- How to enable the format (`config.load_defaults 7.1` or `config.active_support.cache_format_version = 7.1`)
- Critical guidance for rolling deployments: backward compatibility with 6.1 and 7.0 formats, and the recommended approach of deploying without changing the format first, then enabling 7.1 in a subsequent deploy

The content follows the exact wording from the ActiveSupport CHANGELOG by @jonathanhefner and maintains consistency with the similar section in the 6.1→7.0 upgrade documentation.

### Additional information

- This change uses the exact text from the [ActiveSupport CHANGELOG for Rails 7.1.0.beta1](https://github.com/rails/rails/blob/v7.1.0/activesupport/CHANGELOG.md)
- The documentation style and structure mirrors the existing ["New ActiveSupport::Cache serialization format"](https://github.com/rails/rails/blob/main/guides/source/upgrading_ruby_on_rails.md#new-activesupportcache-serialization-format) section in the 6.1→7.0 upgrade guide
- The rolling deployment guidance is particularly important for production applications to avoid cache-related issues during upgrades

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.