### PR TITLE
Add ability to use a block when rendering a collection

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add ability to pass a block when rendering collection. The block will be executed for each rendered element in the collection.
+
+    *Vincent Robert*
+
 *   Add `key:` and `expires_in:` options under `cached:` to `render` when used with `collection:`
 
     *Jarrett Lusso*

--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -167,10 +167,10 @@ module ActionView
 
           collection_body = if template
             cache_collection_render(payload, view, template, collection) do |filtered_collection|
-              collection_with_template(view, template, layout, filtered_collection)
+              collection_with_template(view, template, layout, filtered_collection, block)
             end
           else
-            collection_with_template(view, nil, layout, collection)
+            collection_with_template(view, nil, layout, collection, block)
           end
 
           return RenderedCollection.empty(@lookup_context.formats.first) if collection_body.empty?
@@ -179,7 +179,7 @@ module ActionView
         end
       end
 
-      def collection_with_template(view, template, layout, collection)
+      def collection_with_template(view, template, layout, collection, block)
         locals = @locals
         cache = {}
 
@@ -194,7 +194,7 @@ module ActionView
 
           _template = (cache[path] ||= (template || find_template(path, @locals.keys + [as, counter, iteration])))
 
-          content = _template.render(view, locals, implicit_locals: [counter, iteration])
+          content = _template.render(view, locals, implicit_locals: [counter, iteration], &block)
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
           build_rendered_template(content, _template)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -430,6 +430,11 @@ module RenderTestCases
       @view.render(partial: "test/local_inspector", collection: [ Customer.new("mary") ])
   end
 
+  def test_render_partial_collection_with_block
+    assert_equal "Before\narg2,arg1\nAfterBefore\narg2,arg1\nAfter",
+      @view.render(layout: "test/layout_for_block_with_args", collection: [ Customer.new, Customer.new ], as: :customer) { |a, b| "#{b},#{a}" }
+  end
+
   def test_render_partial_collection_with_different_partials_still_provides_partial_iteration
     a = {}
     b = {}


### PR DESCRIPTION
### Motivation / Background

When using a partial that yields, we can already use this partial with `render partial: ` or directly `render @model`.
But this was not working with `render collection` or `render @models`. 

The alternative was to use `@models.each { |model| render model }` but we lose some advantages of `render collection:` like collection caching.

This allows to use a code like this:

```
# _post.html.erb
<article class="post">
  <h1><%= post.title %></h1>
  <div class="post__body"><%= post.body %></div>

  <%# Render additional content %>
  <%= yield post if block_given? %>
</article>

# index.html.erb
<%= render @posts do |post| %>
  <%= link_to "Edit", [:edit, post] %>
<% end %>
```

### Detail

This Pull Request changes the `CollectionRenderer` to make use of the already existing `block` argument. The block is sent to every rendered element.

### Additional information

For my test, I was unable to use `render partial:`and had to use `render layout:`. Otherwise, I end up with a nil partial. I was unable to investigate this issue, but the code works fine in an application using `render partial:` or `render layout:`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
