### PR TITLE
Add a summary report at the end of `ContinousIntegration.run`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a summary report to `ActiveSupport::ContinuousIntegration`.
+
+    *Mike Dalessio*
+
 *   Introduce `ActiveSupport::EventReporter::LogSubscriber` structured event logging.
 
     ```ruby

--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -42,6 +42,20 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert_not @CI.success?
   end
 
+  test "summary with successful and failed steps combined" do
+    capture_io do
+      @CI.step "Success!", "true"
+      @CI.step "Failed!", "false"
+    end
+
+    output = capture_io do
+      @CI.summary
+    end.to_s
+
+    assert_match(/PASS.*Success/, output)
+    assert_match(/FAIL.*Failed/, output)
+  end
+
   test "echo uses terminal coloring" do
     output = capture_io { @CI.echo "Hello", type: :success }.first.to_s
     assert_equal "\e[1;32mHello\e[0m\n", output


### PR DESCRIPTION
### Motivation / Background

In applications where there are multiple verbose CI steps, I frequently find myself scrolling backwards in my terminal to see what steps failed. A summary report at the end of a run helps me quickly understand what has failed, and whether there are multiple failures.


### Detail

The `@results` ivar is changed to hold the step title in addition to the success boolean, and any multi-step `run` or `step` block will print the failed steps.

The output looks like:

```
❌ Continuous Integration failed in 0.02s
   ↳ Tests: Rails failed
   ↳ Tests: Engine failed
```

In color:

<img width="822" height="122" alt="image" src="https://github.com/user-attachments/assets/91d22cf2-8f29-48d4-aa08-08529f4e37ca" />


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
