### PR TITLE
Add a summary report at the end of `ContinousIntegration.run`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a detailed failure summary to `ActiveSupport::ContinuousIntegration`.
+
+    *Mike Dalessio*
+
 *   Introduce `ActiveSupport::EventReporter::LogSubscriber` structured event logging.
 
     ```ruby


### PR DESCRIPTION
### Motivation / Background

In applications where there are multiple verbose CI steps, I frequently find myself scrolling backwards in my terminal to see what steps failed. A summary report at the end of a run helps me quickly understand what has failed, and whether there are multiple failures.


### Detail

The `@results` ivar is changed to hold the step title in addition to the success boolean, and any multi-step `run` or `step` block will print the failed steps.

The output looks like:

```
❌ Continuous Integration failed in 0.02s
   ↳ Tests: Rails failed
   ↳ Tests: Engine failed
```

In color:

<img width="822" height="122" alt="image" src="https://github.com/user-attachments/assets/91d22cf2-8f29-48d4-aa08-08529f4e37ca" />

### Other details

See previous conversation at https://github.com/rails/rails/pull/56048

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
