### PR TITLE
Fix `content_security_policy_nonce` error in mailers when using `content_security_policy_nonce_auto` setting

### DIFF
--- a/actionmailer/test/mail_helper_test.rb
+++ b/actionmailer/test/mail_helper_test.rb
@@ -67,6 +67,12 @@ The second
     end
   end
 
+  def use_stylesheet_link_tag
+    mail_with_defaults do |format|
+      format.html { render(inline: "<%= stylesheet_link_tag 'mailer' %>") }
+    end
+  end
+
   private
     def mail_with_defaults(&block)
       mail(to: "test@localhost", from: "tester@example.com",
@@ -120,6 +126,18 @@ class MailerHelperTest < ActionMailer::TestCase
       mail = HelperMailer.use_cache
       assert_equal "Greetings from a cache helper block", mail.body.encoded
     end
+  end
+
+  def test_stylesheet_link_tag_without_nonce_method
+    original_auto_include_nonce_for_styles = ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles
+    ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles = true
+
+    mail = HelperMailer.use_stylesheet_link_tag
+
+    assert_includes mail.body.encoded, %(<link rel="stylesheet" href="/stylesheets/mailer.css")
+    assert_not_includes mail.body.encoded, "nonce="
+  ensure
+    ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles = original_auto_include_nonce_for_styles
   end
 
   def helper

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -229,7 +229,7 @@ module ActionView
             "crossorigin" => crossorigin,
             "href" => href
           }.merge!(options)
-          if tag_options["nonce"] == true || (!tag_options.key?("nonce") && auto_include_nonce_for_styles)
+          if tag_options["nonce"] == true || (!tag_options.key?("nonce") && auto_include_nonce_for_styles && respond_to?(:content_security_policy_nonce))
             tag_options["nonce"] = content_security_policy_nonce
           elsif tag_options["nonce"] == false
             tag_options.delete("nonce")


### PR DESCRIPTION
### Detail

The `content_security_policy_nonce` helper is provided by ActionController::ContentSecurityPolicy, and it relies on `request.content_security_policy_nonce`. Mailers lack both the module and the request object.

If you have the default `content_security_policy.rb` enabled, you'll get the following error if you use a `stylesheet_link_tag` in a mailer view.

```
ActionView::Template::Error: undefined local variable or method `content_security_policy_nonce' for #<ActionView::Base:0x00000000004e70>
```

When `config.content_security_policy_nonce_directives` is set to `%w(script-src style-src)` (includes `style-src`) and `config.content_security_policy_nonce_auto` is `true`, this will break.

### Checklist

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
