### PR TITLE
Add block support to ActiveModel::Access#slice

### DIFF
--- a/activemodel/lib/active_model/access.rb
+++ b/activemodel/lib/active_model/access.rb
@@ -4,11 +4,43 @@ require "active_support/core_ext/enumerable"
 require "active_support/core_ext/hash/indifferent_access"
 
 module ActiveModel
-  module Access # :nodoc:
-    def slice(*methods)
-      methods.flatten.index_with { |method| public_send(method) }.with_indifferent_access
+  # = Active \Model \Access
+  #
+  # Provides methods to access object attributes by name.
+  #
+  #   class Person
+  #     include ActiveModel::Access
+  #     attr_accessor :id, :name
+  #   end
+  #
+  #   person = Person.new(id: 1, name: "bob")
+  #   person.slice(:id, :name)  # => { "id" => 1, "name" => "bob" }
+  #   person.values_at(:id, :name)  # => [1, "bob"]
+  module Access
+    # Returns a hash of the given methods with their names as keys and returned
+    # values as values. The hash has indifferent access.
+    #
+    #   person.slice(:id, :name)  # => { "id" => 1, "name" => "bob" }
+    #   person.slice([:id, :name])  # => same as above
+    #   person.slice { |method| [:id, :name].include?(method) }  # => same as above
+    #
+    # Raises +NoMethodError+ if any of the given methods don't exist.
+    def slice(*methods, &block)
+      method_list = if block_given?
+        self.class.public_instance_methods(false).select(&block)
+      else
+        methods.flatten
+      end
+
+      method_list.index_with { |method| public_send(method) }.with_indifferent_access
     end
 
+    # Returns an array of the values returned by the given methods.
+    #
+    #   person.values_at(:id, :name)  # => [1, "bob"]
+    #   person.values_at([:id, :name])  # => same as above
+    #
+    # Raises +NoMethodError+ if any of the given methods don't exist.
     def values_at(*methods)
       methods.flatten.map! { |method| public_send(method) }
     end

--- a/activemodel/test/cases/access_test.rb
+++ b/activemodel/test/cases/access_test.rb
@@ -42,7 +42,39 @@ class AccessTest < ActiveModel::TestCase
 
   test "slice with array" do
     expected = { z: @point.z, x: @point.x }.with_indifferent_access
+
     assert_equal expected, @point.slice([:z, :x])
+  end
+
+  test "slice with block" do
+    expected = { z: @point.z }.with_indifferent_access
+    actual = @point.slice { |method| [:z].include?(method) }
+
+    assert_equal expected.keys, actual.keys
+  end
+
+  test "slice with block filtering multiple methods" do
+    expected = { x: @point.x, z: @point.z }.with_indifferent_access
+    actual = @point.slice { |method| [:x, :z].include?(method) }
+
+    assert_equal expected.keys.sort, actual.keys.sort
+
+    expected.each do |key, value|
+      assert_equal value, actual[key.to_s]
+      assert_equal value, actual[key.to_sym]
+    end
+  end
+
+  test "slice with block returning empty result" do
+    expected = {}.with_indifferent_access
+    actual = @point.slice { |method| false }
+
+    assert_equal expected, actual
+    assert_equal 0, actual.keys.length
+  end
+
+  test "slice with missing method" do
+    assert_raise(NoMethodError) { @point.slice(:a) }
   end
 
   test "values_at" do

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -148,7 +148,7 @@ module ActiveRecord
           end
 
           def []=(key, value)
-            @map.select! { |c, _| c&.alive? }
+            @map = @map.select { |c, _| c&.alive? }
             @map[key] = value
           end
         end


### PR DESCRIPTION
Allow `slice` to accept a block that filters public instance methods dynamically. When a block is provided, it selects methods from the object's public instance methods based on the block's criteria.

Examples:

```
person.slice { |method| [:id, :name].include?(method) }
person.slice { |method| method.start_with?("display_") }
```

Also adds documentation for the `Access` module and its methods, including usage examples for both `slice` and `values_at`.