### PR TITLE
Add built-in Argon2 support for `has_secure_password`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,11 @@ gem "solid_queue"
 gem "solid_cable"
 gem "kamal", ">= 2.1.0", require: false
 gem "thruster", require: false
-# require: false so bcrypt is loaded only when has_secure_password is used.
+# require: false so bcrypt and argon2 are loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)
-# being dependent on a binary library.
+# being dependent on binary libraries.
 gem "bcrypt", "~> 3.1.11", require: false
+gem "argon2", "~> 2.3.2", require: false
 
 # This needs to be with require false to avoid it being automatically loaded by
 # sprockets.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     amq-protocol (2.3.2)
+    argon2 (2.3.2)
+      ffi (~> 1.15)
+      ffi-compiler (~> 1.0)
     ast (2.4.2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1150.0)
@@ -230,6 +233,9 @@ GEM
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi (1.17.1-x86_64-linux-musl)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
+      rake
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -730,6 +736,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  argon2 (~> 2.3.2)
   aws-sdk-s3
   aws-sdk-sns
   backburner

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add built-in Argon2 support for `has_secure_password`.
+
+    `has_secure_password` now supports Argon2 as a built-in algorithm:
+
+    ```ruby
+    class User < ActiveRecord::Base
+      has_secure_password algorithm: :argon2
+    end
+    ```
+
+    To use Argon2, add `gem "argon2", "~> 2.3"` to your Gemfile.
+
+    Argon2 has no password length limit, unlike BCrypt's 72-byte restriction.
+
+    *Justin Bull*, *Guillermo Iguaran*
+
 *   Add ActiveModel::SecurePassword.register_algorithm to register new algorithms for `has_secure_password` by symbol:
 
     `ActiveModel::SecurePassword.register_algorithm` can be used to register new algorithms:

--- a/activemodel/lib/active_model/secure_password/argon2_password.rb
+++ b/activemodel/lib/active_model/secure_password/argon2_password.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module SecurePassword
+    class Argon2Password
+      # Load argon2 gem only when has_secure_password with :argon2 is used.
+      # This is to avoid ActiveModel (and by extension the entire framework)
+      # being dependent on a binary library.
+      def initialize
+        require "argon2"
+      rescue LoadError
+        warn "You don't have argon2 installed in your application. Please add it to your Gemfile and run bundle install."
+        raise
+      end
+
+      def hash_password(unencrypted_password)
+        if ActiveModel::SecurePassword.min_cost
+          ::Argon2::Password.new(profile: :unsafe_cheapest).create(unencrypted_password)
+        else
+          ::Argon2::Password.create(unencrypted_password)
+        end
+      end
+
+      def verify_password(password, digest)
+        ::Argon2::Password.verify_password(password, digest)
+      end
+
+      def password_salt(digest)
+        ::Argon2::HashFormat.new(digest).salt
+      end
+
+      def validate(_record, _attribute)
+        # Argon2 has no maximum input size, no validation needed
+      end
+
+      def algorithm_name
+        :argon2
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -5,6 +5,7 @@ require "models/user"
 require "models/pilot"
 require "models/slow_pilot"
 require "models/visitor"
+require "models/argonaut"
 
 class CustomAlgorithm
   def algorithm_name
@@ -427,6 +428,52 @@ class SecurePasswordTest < ActiveModel::TestCase
 
   test "algorithm registry can be inspected" do
     assert_includes ActiveModel::SecurePassword.algorithm_registry.keys, :bcrypt
+    assert_includes ActiveModel::SecurePassword.algorithm_registry.keys, :argon2
     assert_includes ActiveModel::SecurePassword.algorithm_registry.keys, :custom_algorithm
+  end
+end
+
+# Argon2 tests
+class SecurePasswordArgon2Test < ActiveModel::TestCase
+  setup do
+    @original_min_cost = ActiveModel::SecurePassword.min_cost
+    ActiveModel::SecurePassword.min_cost = true
+    @argonaut = Argonaut.new
+  end
+
+  teardown do
+    ActiveModel::SecurePassword.min_cost = @original_min_cost
+  end
+
+  test "argon2 algorithm is registered" do
+    assert_includes ActiveModel::SecurePassword.algorithm_registry.keys, :argon2
+  end
+
+  test "argon2 digest is generated and authenticate works" do
+    @argonaut.password = "secret"
+    assert_match(/\A\$argon2/, @argonaut.password_digest)
+    assert_equal @argonaut, @argonaut.authenticate("secret")
+    assert_equal false, @argonaut.authenticate("wrong")
+    assert_equal :argon2, @argonaut.password_algorithm
+  end
+
+  test "argon2 password salt extraction" do
+    @argonaut.password = "secret"
+    salt_from_algo = @argonaut.password_salt
+    salt_from_parser = Argon2::HashFormat.new(@argonaut.password_digest).salt
+    assert_equal salt_from_parser, salt_from_algo
+    assert_not_nil salt_from_algo
+  end
+
+  test "argon2 allows long passwords" do
+    long = "a" * 200
+    @argonaut.password = long
+    @argonaut.password_confirmation = long
+
+    # Argon2 has no length restriction, unlike BCrypt's 72-byte limit
+    assert @argonaut.valid?(:create), "should be valid with long password"
+    assert_not @argonaut.errors[:password].include?("is too long (maximum is 72 characters)"), "Argon2 should not have BCrypt's 72-byte limit"
+
+    assert_equal @argonaut, @argonaut.authenticate(long)
   end
 end

--- a/activemodel/test/models/argonaut.rb
+++ b/activemodel/test/models/argonaut.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Argonaut
+  include ActiveModel::SecurePassword
+  include ActiveModel::Attributes
+
+  attribute :password_digest
+  has_secure_password algorithm: :argon2
+end


### PR DESCRIPTION
`has_secure_password` now supports Argon2 as a built-in algorithm:

```ruby
class User < ActiveRecord::Base
  has_secure_password algorithm: :argon2
end
```

To use Argon2, add `gem "argon2", "~> 2.3"` to your Gemfile.

Argon2 has no password length limit, unlike BCrypt's 72-byte restriction.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
