### PR TITLE
Missing require for `Numeric#minutes` in `ActiveModel::SecurePassword`

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -2,6 +2,7 @@
 
 require "active_model/secure_password/bcrypt_password"
 require "active_model/secure_password/argon2_password"
+require "active_support/core_ext/numeric/time"
 
 module ActiveModel
   module SecurePassword


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because there is a missing require for `Numeric#minutes` that `ActiveModel::SecurePassword` has come to depend on in Rails 8.1. This can be seen by running the following script:
```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "activemodel", "8.1"
end

require "active_model"

p ActiveModel::SecurePassword
```
which outputs something like the following before this PR:
```
/Users/ufuk/.gem/ruby/3.4.5/gems/activemodel-8.1.0/lib/active_model/secure_password.rb:12:in '<module:SecurePassword>': undefined method 'minutes' for an instance of Integer (NoMethodError)

    DEFAULT_RESET_TOKEN_EXPIRES_IN = 15.minutes
                                       ^^^^^^^^
        from /Users/ufuk/.gem/ruby/3.4.5/gems/activemodel-8.1.0/lib/active_model/secure_password.rb:4:in '<module:ActiveModel>'
        from /Users/ufuk/.gem/ruby/3.4.5/gems/activemodel-8.1.0/lib/active_model/secure_password.rb:3:in '<top (required)>'
        from /opt/rubies/3.4.5/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /opt/rubies/3.4.5/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from -e:10:in '<main>'
```

### Detail

This Pull Request changes the `secure_password.rb` file to require the Active Support core extension that defines `Numeric#minutes`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
/cc 
* @st0012: who discovered the problem and wrote the original fix in [Shopify/tapioca](https://github.com/Shopify/tapioca)
* @jevin: who authored the change in `ActiveModel::SecurePassword`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
