### PR TITLE
Fix double filtering rescue_from_handled backtrace

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -54,7 +54,7 @@ module ActionController
       exception_class = event[:payload][:exception_class]
       exception_message = event[:payload][:exception_message]
       exception_backtrace = event[:payload][:exception_backtrace]
-      info { "rescue_from handled #{exception_class} (#{exception_message}) - #{exception_backtrace.first.delete_prefix("#{Rails.root}/")}" }
+      info { "rescue_from handled #{exception_class} (#{exception_message}) - #{exception_backtrace}" }
     end
     event_log_level :rescue_from_handled, :info
 

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -152,7 +152,7 @@ class ACLogSubscriberTest < ActionController::TestCase
   def test_rescue_from_callback
     get :with_rescued_exception
     assert_equal 3, logs.size
-    assert_match "rescue_from handled #{Another::LogSubscribersController}::SpecialException", logs.second
+    assert_match(/rescue_from handled #{Another::LogSubscribersController}::SpecialException \(Oops\) - .*log_subscriber_test/, logs.second)
   end
 
   def test_process_action


### PR DESCRIPTION
When ActionController::StructuredEventSubscriber was created to consume events instead of notifications, it kept its previous logic to take the first frame of the backtrace and remove the Rails root. However, the event being consumed _already did this_, so the backtrace output was a single character.

This commit fixes the issue by removing the duplicate backtrace filtering. Now its only filtered once in the event and the log message properly displayed a whole path.