### PR TITLE
Add zeitwerk:check to default CI workflow and bin/ci

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `zeitwerk:check` to default CI workflow and `bin/ci`.
+
+    The `zeitwerk:check` rake task verifies that the application can eager load
+    all constants without errors. This check is now included in both the GitHub
+    Actions workflow template and the `bin/ci` script to catch autoloading issues
+    before deployment.
+
+    *Trevor Turk*
+
 *   Do not assume and force SSL in production by default when using Kamal, to allow for out of the box Kamal deployments.
 
     It is still recommended to assume and force SSL in production as soon as you can.

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -5,6 +5,7 @@ CI.run do
 <% unless options.skip_rubocop? %>
   step "Style: Ruby", "bin/rubocop"
 <% end -%>
+  step "Zeitwerk: Eager loading check", "bin/rails zeitwerk:check"
 
 <% unless options.skip_bundler_audit? -%>
   step "Security: Gem audit", "bin/bundler-audit"

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -74,6 +74,9 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+      - name: Check Zeitwerk eager loading
+        run: bin/rails zeitwerk:check
+
 <% end -%>
 <% unless options[:skip_test] -%>
   test:

--- a/railties/test/application/bin_ci_test.rb
+++ b/railties/test/application/bin_ci_test.rb
@@ -18,6 +18,7 @@ module ApplicationTests
 
         # Default steps
         assert_match(/bin\/rubocop/, content)
+        assert_match(/bin\/rails zeitwerk:check/, content)
         assert_match(/bin\/brakeman/, content)
         assert_match(/bin\/bundler-audit/, content)
         assert_match(/"bin\/rails test"$/, content)


### PR DESCRIPTION
## Motivation

The `zeitwerk:check` rake task has existed since Rails 6 (April 2019) but is not included in the default CI configuration added in Rails 7.2.

While `config.eager_load = ENV["CI"].present?` causes tests to eager load in CI, a dedicated `zeitwerk:check` provides:

- **Fail-fast feedback**: ~2s check before running the full test suite
- **Explicit validation**: Clear CI step showing autoloading is verified
- **Exhaustive checking**: Tests might not exercise all autoload paths

## Real-World Impact

This check would have caught production crashes we experienced with:
- Missing Zeitwerk inflector rules for acronyms (MCP → Mcp)
- Files not defining expected constants

See upstream PRs for examples:
- https://github.com/parruda/swarm/pull/163 (MCP inflector fix)
- https://github.com/crmne/ruby_llm/pull/486 (Railtie eager loading fix)

## Implementation

Adds `zeitwerk:check` to:
1. **GitHub Actions workflow** (`lint` job, after rubocop)
2. **bin/ci script** (after Style: Ruby step)

Both are structural validation checks that fail fast before running expensive tests.

## Testing

- Added test assertion in `bin_ci_test.rb`
- Updated `CHANGELOG.md`
