### PR TITLE
Add `tzdata-legacy` package for Debian 13 (trixie) based image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
         mariadb-client libmariadb-dev \
         postgresql-client postgresql-contrib libpq-dev \
         ffmpeg mupdf mupdf-tools libvips-dev poppler-utils \
-        libxml2-dev sqlite3 imagemagick
+        libxml2-dev sqlite3 imagemagick tzdata-legacy
 
 # Add the Rails main Gemfile and install the gems. This means the gem install can be done
 # during build instead of on start. When a fork or branch has different gems, we still have an


### PR DESCRIPTION
### Motivation / Background

This commit adds `tzdata-legacy` package for Debian 13 (trixie) based image since https://github.com/rails/devcontainer/pull/99 changes the base image from Debian 12 (bookworm) based image to Debian 13 (trixie) based one that implements https://www.debian.org/releases/trixie/release-notes/issues.ja.html#timezones-split-off-into-tzdata-legacy-package

### Detail
This pull request addresses these Active Support unit tests.

1. Follow this steps https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#using-vs-code-remote-containers to start the devcontainer

2. Run these tests

```ruby
cd activesupport
bin/test -n "/^(?:XmlMiniTest::ThreadSafetyTest#(?:test_nested_#with_backend_should_be_thread-safe)|DateExtCalculationsTest#(?:test_xmlschema)|DateTimeExtCalculationsTest#(?:test_current_returns_date_today_when_zone_is_not_set|test_current_returns_time_zone_today_when_zone_is_set|test_getlocal|test_localtime|test_to_time)|DurationTest#(?:test_adding_hours_across_dst_boundary|test_since_and_ago_anchored_to_time_zone_now_when_time_zone_is_set)|OldJSONEncodingTest#(?:test_time_to_json_includes_local_offset)|StringConversionsTest#(?:test_daylight_savings_string_to_time_when_current_time_is_daylight_savings|test_daylight_savings_string_to_time_when_current_time_is_standard_time|test_partial_string_to_time_when_current_time_is_daylight_savings|test_partial_string_to_time_when_current_time_is_standard_time|test_standard_time_string_to_time_when_current_time_is_daylight_savings|test_standard_time_string_to_time_when_current_time_is_standard_time|test_string_to_time_utc_offset)|TestJSONEncoding#(?:test_time_to_json_includes_local_offset)|TimeExtCalculationsTest#(?:test_advance_preserves_offset_for_local_times_around_end_of_dst|test_advance_preserves_offset_for_zoned_times_around_end_of_dst|test_at_with_datetime_returns_local_time|test_at_with_local_time|test_at_with_time_with_zone_returns_local_time|test_change_preserves_fractional_seconds_on_zoned_time|test_change_preserves_offset_for_local_times_around_end_of_dst|test_change_preserves_offset_for_zoned_times_around_end_of_dst|test_daylight_savings_time_crossings_backward_end|test_daylight_savings_time_crossings_backward_start|test_daylight_savings_time_crossings_forward_end|test_daylight_savings_time_crossings_forward_start|test_formatted_offset_with_local|test_future_with_time_current_as_time_local|test_future_with_time_current_as_time_with_zone|test_past_with_time_current_as_time_local|test_past_with_time_current_as_time_with_zone|test_seconds_since_midnight_at_daylight_savings_time_end|test_seconds_since_midnight_at_daylight_savings_time_start|test_seconds_until_end_of_day_at_daylight_savings_time_end|test_seconds_until_end_of_day_at_daylight_savings_time_start|test_time_created_with_local_constructor_cannot_represent_times_during_hour_skipped_by_dst|test_to_fs)|TimeTravelTest#(?:test_time_helper_travel_to_with_datetime_and_usec|test_time_helper_travel_to_with_datetime_and_usec_true|test_time_helper_travel_to_with_different_system_and_application_time_zones|test_time_helper_travel_to_with_string_and_milliseconds)|TimeWithZoneMethodsForTimeAndDateTimeTest#(?:test_current_returns_time_zone_now_when_zone_set|test_in_time_zone_with_time_local_instance)|TimeWithZoneTest#(?:test_future_with_time_current_as_time_local|test_past_with_time_current_as_time_local|test_to_time_preserve_timezone|test_utc\\?)|TimeZoneTest#(?:test_map_kyiv_to_tzinfo|test_map_rangoon_to_tzinfo|test_now|test_now_enforces_spring_dst_rules|test_parse_with_day_omitted|test_strptime_with_day_omitted))$/"
```

- Failures / errors without this fix

```
$ bin/test -n "/^(?:XmlMiniTest::ThreadSafetyTest#(?:test_nested_#with_backend_should_be_thread-safe)|DateExtCalculationsTest#(?:test_xmlschema)|DateTimeExtCalculationsTest#(?:test_current_returns_date_today_when_zone_is_not_set|test_current_returns_time_zone_today_when_zone_is_set|test_getlocal|test_localtime|test_to_time)|DurationTest#(?:test_adding_hours_across_dst_boundary|test_since_and_ago_anchored_to_time_zone_now_when_time_zone_is_set)|OldJSONEncodingTest#(?:test_time_to_json_includes_local_offset)|StringConversionsTest#(?:test_daylight_savings_string_to_time_when_current_time_is_daylight_savings|test_daylight_savings_string_to_time_when_current_time_is_standard_time|test_partial_string_to_time_when_current_time_is_daylight_savings|test_partial_string_to_time_when_current_time_is_standard_time|test_standard_time_string_to_time_when_current_time_is_daylight_savings|test_standard_time_string_to_time_when_current_time_is_standard_time|test_string_to_time_utc_offset)|TestJSONEncoding#(?:test_time_to_json_includes_local_offset)|TimeExtCalculationsTest#(?:test_advance_preserves_offset_for_local_times_around_end_of_dst|test_advance_preserves_offset_for_zoned_times_around_end_of_dst|test_at_with_datetime_returns_local_time|test_at_with_local_time|test_at_with_time_with_zone_returns_local_time|test_change_preserves_fractional_seconds_on_zoned_time|test_change_preserves_offset_for_local_times_around_end_of_dst|test_change_preserves_offset_for_zoned_times_around_end_of_dst|test_daylight_savings_time_crossings_backward_end|test_daylight_savings_time_crossings_backward_start|test_daylight_savings_time_crossings_forward_end|test_daylight_savings_time_crossings_forward_start|test_formatted_offset_with_local|test_future_with_time_current_as_time_local|test_future_with_time_current_as_time_with_zone|test_past_with_time_current_as_time_local|test_past_with_time_current_as_time_with_zone|test_seconds_since_midnight_at_daylight_savings_time_end|test_seconds_since_midnight_at_daylight_savings_time_start|test_seconds_until_end_of_day_at_daylight_savings_time_end|test_seconds_until_end_of_day_at_daylight_savings_time_start|test_time_created_with_local_constructor_cannot_represent_times_during_hour_skipped_by_dst|test_to_fs)|TimeTravelTest#(?:test_time_helper_travel_to_with_datetime_and_usec|test_time_helper_travel_to_with_datetime_and_usec_true|test_time_helper_travel_to_with_different_system_and_application_time_zones|test_time_helper_travel_to_with_string_and_milliseconds)|TimeWithZoneMethodsForTimeAndDateTimeTest#(?:test_current_returns_time_zone_now_when_zone_set|test_in_time_zone_with_time_local_instance)|TimeWithZoneTest#(?:test_future_with_time_current_as_time_local|test_past_with_time_current_as_time_local|test_to_time_preserve_timezone|test_utc\\?)|TimeZoneTest#(?:test_map_kyiv_to_tzinfo|test_map_rangoon_to_tzinfo|test_now|test_now_enforces_spring_dst_rules|test_parse_with_day_omitted|test_strptime_with_day_omitted))$/"
WARNING: Nokogiri was built against libxml version 2.13.9, but has dynamically loaded 2.9.14

Run options: -n "/^(?:XmlMiniTest::ThreadSafetyTest#(?:test_nested_#with_backend_should_be_thread-safe)|DateExtCalculationsTest#(?:test_xmlschema)|DateTimeExtCalculationsTest#(?:test_current_returns_date_today_when_zone_is_not_set|test_current_returns_time_zone_today_when_zone_is_set|test_getlocal|test_localtime|test_to_time)|DurationTest#(?:test_adding_hours_across_dst_boundary|test_since_and_ago_anchored_to_time_zone_now_when_time_zone_is_set)|OldJSONEncodingTest#(?:test_time_to_json_includes_local_offset)|StringConversionsTest#(?:test_daylight_savings_string_to_time_when_current_time_is_daylight_savings|test_daylight_savings_string_to_time_when_current_time_is_standard_time|test_partial_string_to_time_when_current_time_is_daylight_savings|test_partial_string_to_time_when_current_time_is_standard_time|test_standard_time_string_to_time_when_current_time_is_daylight_savings|test_standard_time_string_to_time_when_current_time_is_standard_time|test_string_to_time_utc_offset)|TestJSONEncoding#(?:test_time_to_json_includes_local_offset)|TimeExtCalculationsTest#(?:test_advance_preserves_offset_for_local_times_around_end_of_dst|test_advance_preserves_offset_for_zoned_times_around_end_of_dst|test_at_with_datetime_returns_local_time|test_at_with_local_time|test_at_with_time_with_zone_returns_local_time|test_change_preserves_fractional_seconds_on_zoned_time|test_change_preserves_offset_for_local_times_around_end_of_dst|test_change_preserves_offset_for_zoned_times_around_end_of_dst|test_daylight_savings_time_crossings_backward_end|test_daylight_savings_time_crossings_backward_start|test_daylight_savings_time_crossings_forward_end|test_daylight_savings_time_crossings_forward_start|test_formatted_offset_with_local|test_future_with_time_current_as_time_local|test_future_with_time_current_as_time_with_zone|test_past_with_time_current_as_time_local|test_past_with_time_current_as_time_with_zone|test_seconds_since_midnight_at_daylight_savings_time_end|test_seconds_since_midnight_at_daylight_savings_time_start|test_seconds_until_end_of_day_at_daylight_savings_time_end|test_seconds_until_end_of_day_at_daylight_savings_time_start|test_time_created_with_local_constructor_cannot_represent_times_during_hour_skipped_by_dst|test_to_fs)|TimeTravelTest#(?:test_time_helper_travel_to_with_datetime_and_usec|test_time_helper_travel_to_with_datetime_and_usec_true|test_time_helper_travel_to_with_different_system_and_application_time_zones|test_time_helper_travel_to_with_string_and_milliseconds)|TimeWithZoneMethodsForTimeAndDateTimeTest#(?:test_current_returns_time_zone_now_when_zone_set|test_in_time_zone_with_time_local_instance)|TimeWithZoneTest#(?:test_future_with_time_current_as_time_local|test_past_with_time_current_as_time_local|test_to_time_preserve_timezone|test_utc\\?)|TimeZoneTest#(?:test_map_kyiv_to_tzinfo|test_map_rangoon_to_tzinfo|test_now|test_now_enforces_spring_dst_rules|test_parse_with_day_omitted|test_strptime_with_day_omitted))$/" --seed 28572

# Running:

F

Failure:
TimeWithZoneMethodsForTimeAndDateTimeTest#test_in_time_zone_with_time_local_instance [test/core_ext/time_with_zone_test.rb:1142]:
--- expected
+++ actual
@@ -1 +1 @@
-"1999-12-31 15:00:00.000000000 AKST -09:00"
+"1999-12-31 10:00:00.000000000 AKST -09:00"



bin/test test/core_ext/time_with_zone_test.rb:1139

F

Failure:
TimeWithZoneMethodsForTimeAndDateTimeTest#test_current_returns_time_zone_now_when_zone_set [test/core_ext/time_with_zone_test.rb:1281]:
Expected: 2000-01-01 00:00:00 UTC
  Actual: 1999-12-31 19:00:00 UTC


bin/test test/core_ext/time_with_zone_test.rb:1275

F

Failure:
StringConversionsTest#test_standard_time_string_to_time_when_current_time_is_daylight_savings [test/core_ext/string_ext_test.rb:655]:
Expected: 2012-01-01 13:00:00 +0000
  Actual: 2012-01-01 10:00:00 -0800


bin/test test/core_ext/string_ext_test.rb:650

F

Failure:
StringConversionsTest#test_partial_string_to_time_when_current_time_is_daylight_savings [test/core_ext/string_ext_test.rb:735]:
Expected: 2012-07-01 07:00:00 +0000
  Actual: 2012-07-01 10:00:00 -0100


bin/test test/core_ext/string_ext_test.rb:730

F

Failure:
StringConversionsTest#test_string_to_time_utc_offset [test/core_ext/string_ext_test.rb:615]:
Expected: -18000
  Actual: 0


bin/test test/core_ext/string_ext_test.rb:612

F

Failure:
StringConversionsTest#test_partial_string_to_time_when_current_time_is_standard_time [test/core_ext/string_ext_test.rb:712]:
Expected: 2012-01-01 06:00:00 +0000
  Actual: 2012-01-01 10:00:00 -0100


bin/test test/core_ext/string_ext_test.rb:707

F

Failure:
StringConversionsTest#test_standard_time_string_to_time_when_current_time_is_standard_time [test/core_ext/string_ext_test.rb:636]:
Expected: 2012-01-01 13:00:00 +0000
  Actual: 2012-01-01 10:00:00 -0800


bin/test test/core_ext/string_ext_test.rb:631

F

Failure:
StringConversionsTest#test_daylight_savings_string_to_time_when_current_time_is_daylight_savings [test/core_ext/string_ext_test.rb:693]:
Expected: 2012-07-01 13:00:00 +0000
  Actual: 2012-07-01 10:00:00 -0700


bin/test test/core_ext/string_ext_test.rb:688

F

Failure:
StringConversionsTest#test_daylight_savings_string_to_time_when_current_time_is_standard_time [test/core_ext/string_ext_test.rb:674]:
Expected: 2012-07-01 13:00:00 +0000
  Actual: 2012-07-01 10:00:00 -0700


bin/test test/core_ext/string_ext_test.rb:669

F

Failure:
TimeZoneTest#test_parse_with_day_omitted [test/time_zone_test.rb:443]:
--- expected
+++ actual
@@ -1 +1 @@
-2000-02-01 00:00:00 +0000
+2000-02-01 00:00:00.000000000 EST -05:00



bin/test test/time_zone_test.rb:440

E

Error:
TimeZoneTest#test_map_kyiv_to_tzinfo:
NoMethodError: undefined method 'tzinfo' for nil
    test/time_zone_test.rb:54:in 'block (2 levels) in <class:TimeZoneTest>'


bin/test test/time_zone_test.rb:52

F

Failure:
TimeZoneTest#test_strptime_with_day_omitted [test/time_zone_test.rb:671]:
--- expected
+++ actual
@@ -1 +1 @@
-2000-02-01 00:00:00 +0000
+2000-02-01 00:00:00.000000000 EST -05:00



bin/test test/time_zone_test.rb:668

F

Failure:
TimeZoneTest#test_now [test/time_zone_test.rb:95]:
Expected: 2000-01-01 05:00:00 UTC
  Actual: 2000-01-01 00:00:00 UTC


bin/test test/time_zone_test.rb:90

E

Error:
TimeZoneTest#test_map_rangoon_to_tzinfo:
NoMethodError: undefined method 'tzinfo' for nil
    test/time_zone_test.rb:54:in 'block (2 levels) in <class:TimeZoneTest>'


bin/test test/time_zone_test.rb:52

F

Failure:
TimeZoneTest#test_now_enforces_spring_dst_rules [test/time_zone_test.rb:108]:
Expected: 2006-04-02 03:00:00 UTC
  Actual: 2006-04-01 21:00:00 UTC


bin/test test/time_zone_test.rb:101

F

Failure:
TimeExtCalculationsTest#test_at_with_time_with_zone_returns_local_time [test/core_ext/time_ext_test.rb:1192]:
Expected: 1999-12-31 19:00:00 +0000
  Actual: 2000-01-01 00:00:00 +0000


bin/test test/core_ext/time_ext_test.rb:1189

F

Failure:
TimeExtCalculationsTest#test_at_with_local_time [test/core_ext/time_ext_test.rb:1219]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"EST"
+# encoding: US-ASCII
+#    valid: true
+""



bin/test test/core_ext/time_ext_test.rb:1216

F

Failure:
TimeExtCalculationsTest#test_time_created_with_local_constructor_cannot_represent_times_during_hour_skipped_by_dst [test/core_ext/time_ext_test.rb:1246]:
Expected: 2006-04-02 03:00:00 +0000
  Actual: 2006-04-02 02:00:00 +0000


bin/test test/core_ext/time_ext_test.rb:1242

F

Failure:
TimeExtCalculationsTest#test_past_with_time_current_as_time_with_zone [test/core_ext/time_ext_test.rb:1068]:
Expected: false
  Actual: true


bin/test test/core_ext/time_ext_test.rb:1063

F

Failure:
TimeExtCalculationsTest#test_seconds_since_midnight_at_daylight_savings_time_end [test/core_ext/time_ext_test.rb:43]:
just after DST end.
Expected: 10801
  Actual: 7201.0


bin/test test/core_ext/time_ext_test.rb:38

F

Failure:
TimeExtCalculationsTest#test_seconds_since_midnight_at_daylight_savings_time_start [test/core_ext/time_ext_test.rb:28]:
just after DST start.
Expected: 7201
  Actual: 10801.0


bin/test test/core_ext/time_ext_test.rb:24

F

Failure:
TimeExtCalculationsTest#test_seconds_until_end_of_day_at_daylight_savings_time_start [test/core_ext/time_ext_test.rb:75]:
just before DST start.
Expected: 75600
  Actual: 79200


bin/test test/core_ext/time_ext_test.rb:72

F

Failure:
TimeExtCalculationsTest#test_change_preserves_offset_for_local_times_around_end_of_dst [test/core_ext/time_ext_test.rb:474]:
Expected 2005-10-30 01:00:00 +0000 to be < 2005-10-30 01:00:00 +0000.


bin/test test/core_ext/time_ext_test.rb:466

F

Failure:
TimeExtCalculationsTest#test_advance_preserves_offset_for_local_times_around_end_of_dst [test/core_ext/time_ext_test.rb:684]:
Expected 2005-10-30 01:00:00 +0000 to be < 2005-10-30 01:00:00 +0000.


bin/test test/core_ext/time_ext_test.rb:676

F

Failure:
TimeExtCalculationsTest#test_daylight_savings_time_crossings_backward_end [test/core_ext/time_ext_test.rb:239]:
st-24.hours=>dt.
Expected: 2005-10-29 05:03:00 +0000
  Actual: 2005-10-29 04:03:00 +0000


bin/test test/core_ext/time_ext_test.rb:236

F

Failure:
TimeExtCalculationsTest#test_future_with_time_current_as_time_local [test/core_ext/time_ext_test.rb:1083]:
Expected: false
  Actual: true


bin/test test/core_ext/time_ext_test.rb:1077

F

Failure:
TimeExtCalculationsTest#test_to_fs [test/core_ext/time_ext_test.rb:849]:
--- expected
+++ actual
@@ -1 +1 @@
-"Thu, 05 Feb 2009 14:30:05 -0600"
+"Thu, 05 Feb 2009 14:30:05 +0000"



bin/test test/core_ext/time_ext_test.rb:832

E

Error:
TimeExtCalculationsTest#test_change_preserves_fractional_seconds_on_zoned_time:
ArgumentError: Invalid Timezone: US/Eastern
    lib/active_support/core_ext/time/zones.rb:84:in 'Time.find_zone!'
    lib/active_support/core_ext/time/zones.rb:42:in 'Time.zone='
    test/time_zone_test_helpers.rb:6:in 'TimeZoneTestHelpers#with_tz_default'
    test/core_ext/time_ext_test.rb:523:in 'TimeExtCalculationsTest#test_change_preserves_fractional_seconds_on_zoned_time'


bin/test test/core_ext/time_ext_test.rb:522

F

Failure:
TimeExtCalculationsTest#test_past_with_time_current_as_time_local [test/core_ext/time_ext_test.rb:1056]:
Expected: true
  Actual: false


bin/test test/core_ext/time_ext_test.rb:1050

E

Error:
TimeExtCalculationsTest#test_change_preserves_offset_for_zoned_times_around_end_of_dst:
ArgumentError: Invalid Timezone: US/Eastern
    lib/active_support/core_ext/time/zones.rb:84:in 'Time.find_zone!'
    lib/active_support/core_ext/time/zones.rb:42:in 'Time.zone='
    test/time_zone_test_helpers.rb:6:in 'TimeZoneTestHelpers#with_tz_default'
    test/core_ext/time_ext_test.rb:495:in 'TimeExtCalculationsTest#test_change_preserves_offset_for_zoned_times_around_end_of_dst'


bin/test test/core_ext/time_ext_test.rb:494

F

Failure:
TimeExtCalculationsTest#test_daylight_savings_time_crossings_forward_end [test/core_ext/time_ext_test.rb:359]:
dt+24.hours=>st.
Expected: 2005-10-30 23:45:00 +0000
  Actual: 2005-10-31 00:45:00 +0000


bin/test test/core_ext/time_ext_test.rb:356

F

Failure:
TimeExtCalculationsTest#test_daylight_savings_time_crossings_forward_start [test/core_ext/time_ext_test.rb:297]:
st+24.hours=>dt.
Expected: 2005-04-03 20:27:00 +0000
  Actual: 2005-04-03 19:27:00 +0000


bin/test test/core_ext/time_ext_test.rb:294

F

Failure:
TimeExtCalculationsTest#test_at_with_datetime_returns_local_time [test/core_ext/time_ext_test.rb:1162]:
Expected: 1999-12-31 19:00:00 +0000
  Actual: 2000-01-01 00:00:00 +0000


bin/test test/core_ext/time_ext_test.rb:1159

F

Failure:
TimeExtCalculationsTest#test_formatted_offset_with_local [test/core_ext/time_ext_test.rb:1116]:
Expected: "-05:00"
  Actual: "+00:00"


bin/test test/core_ext/time_ext_test.rb:1114

F

Failure:
TimeExtCalculationsTest#test_seconds_until_end_of_day_at_daylight_savings_time_end [test/core_ext/time_ext_test.rb:90]:
just before DST end.
Expected: 86400
  Actual: 82800


bin/test test/core_ext/time_ext_test.rb:86

E

Error:
TimeExtCalculationsTest#test_advance_preserves_offset_for_zoned_times_around_end_of_dst:
ArgumentError: Invalid Timezone: US/Eastern
    lib/active_support/core_ext/time/zones.rb:84:in 'Time.find_zone!'
    lib/active_support/core_ext/time/zones.rb:42:in 'Time.zone='
    test/time_zone_test_helpers.rb:6:in 'TimeZoneTestHelpers#with_tz_default'
    test/core_ext/time_ext_test.rb:709:in 'TimeExtCalculationsTest#test_advance_preserves_offset_for_zoned_times_around_end_of_dst'


bin/test test/core_ext/time_ext_test.rb:708

F

Failure:
TimeExtCalculationsTest#test_future_with_time_current_as_time_with_zone [test/core_ext/time_ext_test.rb:1096]:
Expected: true
  Actual: false


bin/test test/core_ext/time_ext_test.rb:1090

F

Failure:
TimeExtCalculationsTest#test_daylight_savings_time_crossings_backward_start [test/core_ext/time_ext_test.rb:216]:
dt-24.hours=>st.
Expected: 2005-04-02 03:18:00 +0000
  Actual: 2005-04-02 04:18:00 +0000


bin/test test/core_ext/time_ext_test.rb:213

F

Failure:
OldJSONEncodingTest#test_time_to_json_includes_local_offset [test/json/encoding_test.rb:129]:
--- expected
+++ actual
@@ -1 +1 @@
-"\"2005-02-01T15:15:10.000-05:00\""
+"\"2005-02-01T15:15:10.000+00:00\""



bin/test test/json/encoding_test.rb:126

F

Failure:
DurationTest#test_adding_hours_across_dst_boundary [test/core_ext/duration_test.rb:333]:
Expected: 2009-03-30 00:00:00 +0000
  Actual: 2009-03-30 01:00:00 +0000


bin/test test/core_ext/duration_test.rb:331

F

Failure:
DurationTest#test_since_and_ago_anchored_to_time_zone_now_when_time_zone_is_set [test/core_ext/duration_test.rb:306]:
Expected: 2000-01-01 00:00:05 UTC
  Actual: 1999-12-31 19:00:05 UTC


bin/test test/core_ext/duration_test.rb:300

F

Failure:
TimeTravelTest#test_time_helper_travel_to_with_datetime_and_usec_true [test/time_travel_test.rb:367]:
--- expected
+++ actual
@@ -1 +1 @@
-2004-11-24 01:04:44 3602879701896397/36028797018963968 +0000
+2004-11-24 06:04:44 3602879701896397/36028797018963968 +0000



bin/test test/time_travel_test.rb:359

F

Failure:
TimeTravelTest#test_time_helper_travel_to_with_string_and_milliseconds [test/time_travel_test.rb:174]:
--- expected
+++ actual
@@ -1 +1 @@
-2004-11-24 01:04:44 +0000
+2004-11-24 06:04:44.000000000 UTC +00:00



bin/test test/time_travel_test.rb:167

F

Failure:
TimeTravelTest#test_time_helper_travel_to_with_datetime_and_usec [test/time_travel_test.rb:345]:
--- expected
+++ actual
@@ -1 +1 @@
-2004-11-24 01:04:44 +0000
+2004-11-24 06:04:44.000000000 UTC +00:00



bin/test test/time_travel_test.rb:337

F

Failure:
TimeTravelTest#test_time_helper_travel_to_with_different_system_and_application_time_zones [test/time_travel_test.rb:130]:
Expected: "2023-11-30 19:06:07"
  Actual: "2023-12-01 00:06:07"


bin/test test/time_travel_test.rb:115

F

Failure:
TimeWithZoneTest#test_past_with_time_current_as_time_local [test/core_ext/time_with_zone_test.rb:322]:
Expected: true
  Actual: false


bin/test test/core_ext/time_with_zone_test.rb:319

E

Error:
TimeWithZoneTest#test_utc?:
NoMethodError: undefined method 'period_for_utc' for nil
    lib/active_support/time_with_zone.rb:79:in 'ActiveSupport::TimeWithZone#period'
    lib/active_support/time_with_zone.rb:140:in 'ActiveSupport::TimeWithZone#zone'
    lib/active_support/time_with_zone.rb:60:in 'ActiveSupport::TimeWithZone#initialize'
    test/core_ext/time_with_zone_test.rb:69:in 'Class#new'
    test/core_ext/time_with_zone_test.rb:69:in 'TimeWithZoneTest#test_utc?'


bin/test test/core_ext/time_with_zone_test.rb:64

F

Failure:
TimeWithZoneTest#test_future_with_time_current_as_time_local [test/core_ext/time_with_zone_test.rb:341]:
Expected: false
  Actual: true


bin/test test/core_ext/time_with_zone_test.rb:338

F

Failure:
TimeWithZoneTest#test_to_time_preserve_timezone [test/core_ext/time_with_zone_test.rb:544]:
Expected: 1999-12-31 19:00:00 +0000
  Actual: 1999-12-31 19:00:00 -0500


bin/test test/core_ext/time_with_zone_test.rb:538

F

Failure:
DateTimeExtCalculationsTest#test_current_returns_date_today_when_zone_is_not_set [test/core_ext/date_time_ext_test.rb:364]:
--- expected
+++ actual
@@ -1 +1 @@
-Fri, 31 Dec 1999 23:59:59 -0500
+Fri, 31 Dec 1999 23:59:59 +0000



bin/test test/core_ext/date_time_ext_test.rb:361

F

Failure:
DateTimeExtCalculationsTest#test_localtime [test/core_ext/date_time_ext_test.rb:54]:
Expected: 2016-03-11 10:11:12 +0000
  Actual: 2016-03-11 15:11:12 +0000


bin/test test/core_ext/date_time_ext_test.rb:51

F

Failure:
DateTimeExtCalculationsTest#test_getlocal [test/core_ext/date_time_ext_test.rb:63]:
Expected: 2016-03-11 10:11:12 +0000
  Actual: 2016-03-11 15:11:12 +0000


bin/test test/core_ext/date_time_ext_test.rb:60

F

Failure:
DateTimeExtCalculationsTest#test_to_time [test/core_ext/date_time_ext_test.rb:81]:
Expected: 2005-02-21 05:11:12 +0000
  Actual: 2005-02-21 10:11:12 +0000


bin/test test/core_ext/date_time_ext_test.rb:77

F

Failure:
DateTimeExtCalculationsTest#test_current_returns_time_zone_today_when_zone_is_set [test/core_ext/date_time_ext_test.rb:373]:
--- expected
+++ actual
@@ -1 +1 @@
-Fri, 31 Dec 1999 23:59:59 -0500
+Fri, 31 Dec 1999 18:59:59 -0500



bin/test test/core_ext/date_time_ext_test.rb:369

F

Failure:
DateExtCalculationsTest#test_xmlschema [test/core_ext/date_ext_test.rb:315]:
Expected /^1980-02-28T00:00:00-05:?00$/ to match # encoding: US-ASCII
#    valid: true
"1980-02-28T00:00:00+00:00".


bin/test test/core_ext/date_ext_test.rb:313

.F

Failure:
TestJSONEncoding#test_time_to_json_includes_local_offset [test/json/encoding_test.rb:129]:
--- expected
+++ actual
@@ -1 +1 @@
-"\"2005-02-01T15:15:10.000-05:00\""
+"\"2005-02-01T15:15:10.000+00:00\""



bin/test test/json/encoding_test.rb:126



Finished in 0.371402s, 153.4725 runs/s, 274.6349 assertions/s.
57 runs, 102 assertions, 50 failures, 6 errors, 0 skips
vscode ➜ /workspaces/rails/activesupport (add-tzdata-legacy) $ 
```

### Additional information
Related to https://github.com/rails/rails/issues/49648

### Checklist
Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
