### PR TITLE
[ci skip][docs] Fix syntax for validating product_params

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1287,7 +1287,7 @@ class ProductsController < ApplicationController
 
   private
     def product_params
-      params.expect(product: [ :name ])
+      params.require(:product).permit(:name)
     end
 end
 ```


### PR DESCRIPTION
Hi,

First contribution here, apologies if I didn't follow all guidelines. I am new to rails, but the following function in the getting started tutorial (creating a new product) does not work:

```ruby
   def product_params
     params.expect(product: [ :name ])
   end
```

Instead this works:
```ruby
   def product_params
     params.require(:product).permit(:name)
   end
```

I'll let you judge the correctness of the proposed change ;)

`ruby 3.4.7`, `Rails 8.1.1`

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->
