### PR TITLE
Set ENV["CI"] in default CI configuration

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Enable eager loading in CI by setting `ENV["CI"]` in default CI configuration.
+
+    The `CI` environment variable is now set to `"true"` when running tests via `bin/ci`
+    and GitHub Actions, which activates `config.eager_load = ENV["CI"].present?` in
+    `config/environments/test.rb`. This ensures autoloading issues are caught during
+    test runs in continuous integration environments.
+
+    *Trevor Turk*
+
 *   Do not assume and force SSL in production by default when using Kamal, to allow for out of the box Kamal deployments.
 
     It is still recommended to assume and force SSL in production as soon as you can.

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -20,10 +20,10 @@ CI.run do
 <% end -%>
 <% unless options[:skip_test] -%>
 <% if options[:api] || options[:skip_system_test] -%>
-  step "Tests: Rails", "bin/rails test"
+  step "Tests: Rails", "env CI=true bin/rails test"
 <% else %>
-  step "Tests: Rails", "bin/rails test"
-  step "Tests: System", "bin/rails test:system"
+  step "Tests: Rails", "env CI=true bin/rails test"
+  step "Tests: System", "env CI=true bin/rails test:system"
 <% end -%>
 <% unless options.skip_active_record? -%>
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -136,6 +136,7 @@ jobs:
 
       - name: Run tests
         env:
+          CI: true
           RAILS_ENV: test
           <%- if options[:database] == "mysql" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306
@@ -209,6 +210,7 @@ jobs:
 
       - name: Run System Tests
         env:
+          CI: true
           RAILS_ENV: test
           <%- if options[:database] == "mysql" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306

--- a/railties/test/application/bin_ci_test.rb
+++ b/railties/test/application/bin_ci_test.rb
@@ -20,8 +20,8 @@ module ApplicationTests
         assert_match(/bin\/rubocop/, content)
         assert_match(/bin\/brakeman/, content)
         assert_match(/bin\/bundler-audit/, content)
-        assert_match(/"bin\/rails test"$/, content)
-        assert_match(/"bin\/rails test:system"$/, content)
+        assert_match(/env CI=true bin\/rails test/, content)
+        assert_match(/env CI=true bin\/rails test:system/, content)
         assert_match(/bin\/rails db:seed:replant/, content)
 
         # Node-specific steps excluded by default

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -719,11 +719,31 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_config_ci_sets_ci_env_var_for_test_commands
+    run_generator [destination_root]
+
+    assert_file "config/ci.rb" do |content|
+      assert_match(/env CI=true bin\/rails test/, content)
+      assert_match(/env CI=true bin\/rails test:system/, content)
+    end
+  end
+
   def test_ci_workflow_includes_db_test_prepare_by_default
     run_generator
     assert_file ".github/workflows/ci.yml" do |content|
       assert_match(/db:test:prepare test/, content)
       assert_match(/db:test:prepare test:system/, content)
+    end
+  end
+
+  def test_ci_workflow_sets_ci_env_var_for_test_jobs
+    run_generator
+
+    assert_file ".github/workflows/ci.yml" do |content|
+      # Check that CI: true is set in the test job env block
+      assert_match(/CI: true/, content)
+      # Verify it appears in the context of the test job
+      assert_match(/- name: Run tests\s+env:\s+CI: true/m, content)
     end
   end
 


### PR DESCRIPTION
## Summary

This PR activates eager loading in CI by setting `ENV["CI"]` in the default CI configuration templates (bin/ci and GitHub Actions workflow).

Since Rails 6.1 ([#43508](https://github.com/rails/rails/pull/43508)), `config.eager_load = ENV["CI"].present?` has been the default in `config/environments/test.rb`, but the `CI` environment variable was not set in the CI configuration templates, so eager loading was not enabled by default.

## Changes

- Sets `CI=true` in `bin/ci` test commands (using `env CI=true` prefix)
- Sets `CI: true` in GitHub Actions workflow test job env blocks

## Alternative Approach

See [#56065](https://github.com/rails/rails/pull/56065) for an alternative approach that adds an explicit `zeitwerk:check` step to CI.

## Comparison: ENV["CI"] vs. explicit zeitwerk:check

### ENV["CI"] approach (this PR)
**Pros:**
- Leverages existing Rails configuration pattern from #43508
- Tests eager loading in actual test context (more realistic)
- Catches runtime issues that may only appear during actual usage
- No additional CI step needed

**Cons:**
- Less explicit about what's being validated
- Slower (eager loading overhead on all test runs)
- Error messages can be buried in test output
- May not exercise all autoload paths if tests fail early

### Explicit zeitwerk:check approach (#56065)
**Pros:**
- Clear, visible validation step in CI logs
- Fails fast (~2s check before running full test suite)
- Clean, focused error messages
- Properly placed in lint job alongside other static checks
- Exhaustive checking of all autoload paths

**Cons:**
- Adds another CI step
- Doesn't test eager loading in actual runtime context
- Slight duplication with the eager_load configuration

Both approaches are valid. This PR is simpler and uses existing Rails patterns, while the explicit approach provides faster feedback and clearer validation.

Related: #43508