### PR TITLE
Fix foreign key order and table name prefixing when dumping multiple schemas in postgres

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -42,7 +42,6 @@ module ActiveRecord
                 types.sort.each do |name, values|
                   stream.puts "  create_enum #{relation_name(name).inspect}, #{values.inspect}"
                 end
-                stream.puts
               end
             end
           end
@@ -64,6 +63,13 @@ module ActiveRecord
               stream.puts if previous_schema_had_tables
               super
               previous_schema_had_tables = @connection.tables.any?
+            end
+          end
+
+          def foreign_keys(stream)
+            previous_schema_had_tables = false
+            within_each_schema do
+              super
             end
           end
 
@@ -152,7 +158,7 @@ module ActiveRecord
           end
 
           def relation_name(name)
-            if @dump_schemas.size == 1
+            if @dump_schemas.size == 1 || name.include?(".")
               name
             elsif name.include?(".")
               name  # Already schema-qualified, don't add another prefix


### PR DESCRIPTION
Closes #56070.

### Motivation / Background

We have a postgres database with multiple schemas and foreign keys that reference tables across the schemas.  I noticed some issues when running `rails db:schema:dump` on this database:

1. The dumper does not handle table names properly if they're already in a schema, e.g it will dump the table reference `vault.credit_cards` as `public.vault.credit_cards`.

2. The dumper appends foreign keys after all tables have been dumped but within each schema.  This causes load order issues when keys in one schema reference tables in another which might not have been created yet.

### Detail

I had to do a larger refactor of the foreign key dumping strategy to fix the ordering but I think the result is clear.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
