### PR TITLE
Various event related fixes

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -117,7 +117,7 @@ module ActionController
     # The `action_on_open_redirect` configuration option controls the behavior when an unsafe
     # redirect is detected:
     # * `:log` - Logs a warning but allows the redirect
-    # * `:notify` - Sends an ActiveSupport notification for monitoring
+    # * `:notify` - Sends an Active Support notification for monitoring
     # * `:raise` - Raises an UnsafeRedirectError
     #
     # To allow any external redirects pass `allow_other_host: true`, though using a
@@ -144,7 +144,7 @@ module ActionController
     #     config.action_controller.action_on_path_relative_redirect = :raise
     #
     # * `:log` - Logs a warning but allows the redirect
-    # * `:notify` - Sends an ActiveSupport notification but allows the redirect
+    # * `:notify` - Sends an Active Support notification but allows the redirect
     #   (includes stack trace to help identify the source)
     # * `:raise` - Raises an UnsafeRedirectError
     def redirect_to(options = {}, response_options = {})

--- a/actionpack/lib/action_controller/structured_event_subscriber.rb
+++ b/actionpack/lib/action_controller/structured_event_subscriber.rb
@@ -46,10 +46,14 @@ module ActionController
 
     def rescue_from_callback(event)
       exception = event.payload[:exception]
+
+      exception_backtrace = exception.backtrace&.first
+      exception_backtrace = exception_backtrace&.delete_prefix("#{Rails.root}/") if defined?(Rails.root) && Rails.root
+
       emit_event("action_controller.rescue_from_handled",
         exception_class: exception.class.name,
         exception_message: exception.message,
-        exception_backtrace: exception.backtrace&.first&.delete_prefix("#{Rails.root}/")
+        exception_backtrace:
       )
     end
 

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -676,7 +676,7 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_to_path_relative_url_starting_with_an_at_with_notify
     with_path_relative_redirect(:notify) do
       events = []
-      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
         events << ActiveSupport::Notifications::Event.new(*args)
       end
 
@@ -692,14 +692,14 @@ class RedirectTest < ActionController::TestCase
       assert_kind_of Array, event.payload[:stack_trace]
       assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url_starting_with_an_at") }
     ensure
-      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
   def test_redirect_to_path_relative_url_with_notify
     with_path_relative_redirect(:notify) do
       events = []
-      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
         events << ActiveSupport::Notifications::Event.new(*args)
       end
 
@@ -715,7 +715,7 @@ class RedirectTest < ActionController::TestCase
       assert_kind_of Array, event.payload[:stack_trace]
       assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url") }
     ensure
-      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
@@ -760,7 +760,7 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_to_absolute_url_does_not_notify
     with_path_relative_redirect(:notify) do
       events = []
-      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
         events << ActiveSupport::Notifications::Event.new(*args)
       end
 
@@ -774,7 +774,7 @@ class RedirectTest < ActionController::TestCase
       assert_equal "http://test.host/things/stuff", redirect_to_url
       assert_empty events
     ensure
-      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
@@ -808,7 +808,7 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_to_query_string_url_does_not_trigger_path_relative_warning_with_notify
     with_path_relative_redirect(:notify) do
       events = []
-      ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
+      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
         events << ActiveSupport::Notifications::Event.new(*args)
       end
 
@@ -818,7 +818,7 @@ class RedirectTest < ActionController::TestCase
 
       assert_empty events.select { |e| e.payload[:message]&.include?("Path relative URL redirect detected") }
     ensure
-      ActiveSupport::Notifications.unsubscribe("unsafe_redirect.action_controller")
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
@@ -864,7 +864,7 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_to_external_with_action_on_open_redirect_notify
     with_action_on_open_redirect(:notify) do
       events = []
-      ActiveSupport::Notifications.subscribe("open_redirect.action_controller") do |*args|
+      subscriber = ActiveSupport::Notifications.subscribe("open_redirect.action_controller") do |*args|
         events << ActiveSupport::Notifications::Event.new(*args)
       end
 
@@ -878,7 +878,7 @@ class RedirectTest < ActionController::TestCase
       assert_kind_of ActionDispatch::Request, event.payload[:request]
       assert_kind_of Array, event.payload[:stack_trace]
     ensure
-      ActiveSupport::Notifications.unsubscribe("open_redirect.action_controller")
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 


### PR DESCRIPTION
(extracted from #56019)

---

[Fix ActiveSupport -> Active Support](https://github.com/rails/rails/commit/b10a43e67dbb1df82c1c4fd5b819718742bb564b)

We're describing the framework, not the module.

---

[Fix dependency on Rails constant](https://github.com/rails/rails/commit/3d4e3bd35f87ffec543034c4e987e51dfbc3f664)

Action Pack can be used without Rails

---

[Fix redirect_test leaking subscription state](https://github.com/rails/rails/commit/fd27a9c5c0dd58a70c72f3d093ba32520c04b239)

Previously these tests would unsubscribe _all_ subscribers for
{unsafe,open}_redirect notifications. This becomes a problem when Action
Pack provides a default subscription for these events because those
subscribers will get unsubscribed as well.

This commit fixes the issue by only unsubscribing the subscriber used
in the tests.