### PR TITLE
Add Rails.app.revision for deployment tracking

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -538,6 +538,18 @@ Enables or disables reloading of classes only when tracked files change. By defa
 
 Causes the app to not boot if a master key hasn't been made available through `ENV["RAILS_MASTER_KEY"]` or the `config/master.key` file.
 
+#### `config.revision`
+
+Sets the application revision for deployment tracking and error reporting. Can be a string or a proc. When not set, reads from `REVISION` file in the application root (default: `nil`).
+
+```ruby
+config.revision = ENV["GIT_SHA"]
+# or
+config.revision = -> { File.read("BUILD_ID").strip }
+```
+
+Revision can be accessed via `Rails.app.revision`.
+
 #### `config.sandbox_by_default`
 
 When `true`, rails console starts in sandbox mode. To start rails console in non-sandbox mode, `--no-sandbox` must be specified. This is helpful to avoid accidental writing to the production database. Defaults to `false`.

--- a/railties/lib/rails/app_version.rb
+++ b/railties/lib/rails/app_version.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Rails
+  # Manages the application revision for deployment tracking and error reporting.
+  #
+  # The revision is determined in order of precedence:
+  # 1. Custom proc/string via config.revision
+  # 2. REVISION file in application root (created by deployment tools like Capistrano)
+  # 3. nil if none available
+  module AppVersion
+    class << self
+      def revision(config_revision)
+        @revision ||= load_revision(config_revision)
+      end
+
+      def reset!
+        @revision = nil
+      end
+
+      private
+        def load_revision(config_revision)
+          custom_revision(config_revision) || read_revision_file
+        end
+
+        def custom_revision(config_revision)
+          return unless config_revision
+
+          case config_revision
+          when Proc
+            config_revision.call&.to_s&.strip.presence
+          when String
+            config_revision.strip.presence
+          end
+        end
+
+        def read_revision_file
+          revision_file = Rails.root.join("REVISION")
+          revision_file.read.strip.presence if revision_file.exist?
+        rescue
+          nil
+        end
+    end
+  end
+end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -13,6 +13,7 @@ require "active_support/configuration_file"
 require "active_support/parameter_filter"
 require "rails/engine"
 require "rails/autoloaders"
+require "rails/app_version"
 
 module Rails
   # An Engine with the responsibility of coordinating the whole boot process.
@@ -101,6 +102,14 @@ module Rails
     attr_accessor :assets, :sandbox
     alias_method :sandbox?, :sandbox
     attr_reader :reloaders, :reloader, :executor, :autoloaders
+
+    # Returns the application's revision (deployment identifier).
+    # Useful for error reporting and deployment verification.
+    #
+    # Set via config.revision (string or proc) or REVISION file.
+    def revision
+      @revision ||= Rails::AppVersion.revision(config.revision)
+    end
 
     delegate :default_url_options, :default_url_options=, to: :routes
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -24,7 +24,7 @@ module Rails
                     :content_security_policy_nonce_auto,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
-                    :dom_testing_default_html_version, :yjit
+                    :dom_testing_default_html_version, :yjit, :revision
 
       attr_reader :encoding, :api_only, :loaded_config_version, :log_level
 
@@ -85,6 +85,7 @@ module Rails
         @server_timing                           = false
         @dom_testing_default_html_version        = :html4
         @yjit                                    = false
+        @revision                                = nil
       end
 
       # Loads default configuration values for a target version. This includes

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -93,6 +93,11 @@ module Rails
       Rails.env
     end
 
+    # The application's revision (deployment identifier)
+    property "Application revision" do
+      Rails.app.revision
+    end
+
     # The name of the database adapter for the current environment.
     property "Database adapter" do
       ActiveRecord::Base.connection_pool.db_config.adapter

--- a/railties/test/application/app_version_test.rb
+++ b/railties/test/application/app_version_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class AppVersionTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    test "Rails.app.revision returns nil by default" do
+      require "#{app_path}/config/environment"
+      assert_nil Rails.app.revision
+    end
+
+    test "revision reads from REVISION file when present" do
+      File.write("#{app_path}/REVISION", "abc123def456")
+      require "#{app_path}/config/environment"
+      assert_equal "abc123def456", Rails.app.revision
+    end
+
+    test "revision can be set via config.revision string" do
+      add_to_config <<-RUBY
+        config.revision = "deploy-123"
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "deploy-123", Rails.app.revision
+    end
+
+    test "revision can be set via config.revision proc" do
+      add_to_config <<-RUBY
+        config.revision = -> { "proc-456" }
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "proc-456", Rails.app.revision
+    end
+
+    test "config.revision takes precedence over REVISION file" do
+      File.write("#{app_path}/REVISION", "file-revision")
+
+      add_to_config <<-RUBY
+        config.revision = "config-wins"
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "config-wins", Rails.app.revision
+    end
+
+    test "Rails::Info includes revision when present" do
+      File.write("#{app_path}/REVISION", "deadbeef123")
+
+      require "#{app_path}/config/environment"
+
+      assert_equal "deadbeef123", Rails::Info.properties.value_for("Application revision")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add `Rails.app.revision` for deployment tracking and error reporting.

## Motivation

Common pattern seen everywhere:
```ruby
# Reading REVISION file (Capistrano)
APP_REVISION = File.read(Rails.root.join("REVISION")).strip rescue nil
```

Useful for error tracking and deployment verification.

## Usage

```ruby
# config/application.rb
config.revision = ENV["GIT_SHA"]
# or
config.revision = -> { File.read("BUILD_ID").strip }
```

```ruby
Rails.app.revision  # => "abc123def456"
```

## Revision Sources (priority order)
1. `config.revision` (string or proc)
2. `REVISION` file in Rails root
3. `nil`

## Integration

**Rails::Info** shows revision in the properties list.

Future: Could be added to health check endpoint.