### PR TITLE
ActiveRecord: Validate has_one :through source to prevent NotNullViolation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -103,6 +103,55 @@
 
     *Martin-Alexander*
 
+*   Fix inconsistency in PostgreSQL handling of unbounded time range types
+
+    Use `-infinity` rather than `NULL` for the lower value of PostgreSQL time
+    ranges when saving records with a Ruby range that begins with `nil`.
+
+    ```ruby
+    create_table :products do |t|
+      t.tsrange :period
+    end
+    class Product < ActiveRecord::Base; end
+
+    t = Time.utc(2000)
+
+    Product.create(period: t...nil)
+    Product.create(period: nil...t)
+    ```
+
+    Previously this would create two records using different values to represent
+    lower-unbounded and upper-unbounded ranges.
+
+    ```
+    ["2000-01-01 00:00:00",infinity)
+    (NULL,"2000-01-01 00:00:00")
+    ```
+
+    Now both will use `-infinity`/`infinity` which are handled differently than
+    `NULL` by some PostgreSQL range operators (e.g., `lower_inf`) and support
+    both exclusive and inclusive bounds.
+
+    ```
+    ["2000-01-01 00:00:00",infinity)
+    [-infinity,"2000-01-01 00:00:00")
+    ```
+
+    *Martin-Alexander*
+
+*   Fix `has_one :through` associations to validate their source record.
+
+    Previously, assigning an invalid record through a `has_one :through`
+    association could cause the parent model to appear valid while `save!`
+    failed at the database level with `ActiveRecord::NotNullViolation`.
+
+    Now, `has_one :through` associations validate their source record
+    (for non-collection, non-polymorphic cases), so the parent model reflects
+    associated errors and `save!` raises `ActiveRecord::RecordInvalid`
+    as expected.
+
+    *Dmytro Rymar*
+
 *   Database-specific shard swap prohibition
 
     In #43485 (v7.0.0), shard swapping prohibition was introduced as a global


### PR DESCRIPTION
### Motivation / Background

This pull request fixes a bug in ActiveRecord where assigning an invalid record through a `has_one :through` association would allow the parent record to appear valid and fail later at the database level with a `ActiveRecord::NotNullViolation`.

Example (from issue #56046)
```ruby
class A < ApplicationRecord
  has_one :x
  has_one :b, through: :x
end

class X < ApplicationRecord
  belongs_to :a
  belongs_to :b
end

class B < ApplicationRecord
  validates :name, presence: true
end

a = A.new
a.b = B.new(name: nil)

a.valid?   # => true (should be false)
a.save!    # => raises ActiveRecord::NotNullViolation
```

This patch ensures that `has_one :through` associations validate their source record (the `:b` in this example), so that:
- `a.valid?` returns `false` if `a.b` is invalid.
- `a.save!` raises `ActiveRecord::RecordInvalid` instead of `ActiveRecord::NotNullViolation`.

### Detail

This change updates `ActiveRecord::AutosaveAssociation#define_autosave_validation_callbacks` to include a validation callback for `has_one :through` reflections that meet all of the following conditions:
- The association is non-collection (`has_one` / `belongs_to` path only)
- The association is non-polymorphic
- The association chain can be resolved safely (no invalid or recursive reflection)

The validator checks the target record(s) for validity and merges any errors onto the parent, matching the behavior of regular `has_one` and `belongs_to` associations.
It also includes a recursion guard via `@_already_called` to avoid infinite validation loops in cyclic relationships.

#### Tests added

A new regression test class has been added to `activerecord/test/cases/associations/has_one_through_associations_test.rb`
covering both:
- `a.valid?` becoming `false` when the through-associated record is invalid.
- `a.save!` raising `ActiveRecord::RecordInvalid` instead of `ActiveRecord::NotNullViolation`.

All existing ActiveRecord tests remain green (`54 runs, 162 assertions, 0 failures, 0 errors, 0 skips`)

#### Example after fix

```ruby
a = A.new
a.b = B.new(name: nil)

a.valid?   # => false
a.save!    # => raises ActiveRecord::RecordInvalid: Validation failed: B name can't be blank
```

### Additional information

- Fixes: #56046
- Behavior verified against SQLite3 and PostgreSQL adapters
- This fix brings `has_one :through` behavior in line with other autosaved associations (`has_one`, `belongs_to`)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
