### PR TITLE
[ci skip] [docs] Make code blocks horizontally scrollable when lines exceed the visible area instead of wrapping

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -372,6 +372,13 @@ body.guide {
     word-wrap: break-word; /* Internet Explorer 5.5+ */
   }
 
+  // Ensures that 'code' inside 'pre' preserves formatting and does not wrap, makes it horizontally scrollable instead
+  pre {
+    code {
+      white-space: pre;
+    }
+  }
+
   // Back to Top element
 
   a.back-to-top {


### PR DESCRIPTION
### Motivation / Background


Previously, long lines in code examples wrapped to the next line, making the code harder to read. 

This change enables horizontal scrolling to maintain proper code formatting and improve readability.

---

<img width="1620" height="713" alt="rails-guide-code-line-wrap" src="https://github.com/user-attachments/assets/87d20723-7f45-41b0-a560-efe5c6979b12" />


---

[Click To See The Live Preview](https://shivabhusal-guide-code-block.rails-docs-preview.pages.dev/guides/association_basics#has-and-belongs-to-many)