### PR TITLE
Fix rails new to use stylesheet_link_tag "application" when --css is present

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -536,6 +536,10 @@ module Rails
         using_js_runtime? && %w[bun].include?(options[:javascript])
       end
 
+      def using_css_bundling?
+        options[:skip_asset_pipeline] || options[:css]
+      end
+
       def capture_command(command, pattern = nil)
         output = `#{command}`
         if pattern

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -18,7 +18,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
-    <%- style_link_target = options[:skip_asset_pipeline] ? "\"application\"" : ":app" -%>
+    <%- style_link_target = using_css_bundling? ? "\"application\"" : ":app" -%>
     <%- if options[:skip_hotwire] || options[:skip_javascript] -%>
     <%%# Includes all stylesheet files in app/assets/stylesheets %>
     <%%= stylesheet_link_tag <%= style_link_target %> %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1149,6 +1149,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "importmap-rails"
   end
 
+  def test_css_option_uses_application_stylesheet_link_tag
+    run_generator [destination_root, "--css=tailwind"]
+
+    assert_file "app/views/layouts/application.html.erb" do |content|
+      assert_match(/stylesheet_link_tag\s+"application"/, content)
+      assert_no_match(/stylesheet_link_tag\s+:app/, content)
+    end
+  end
+
   def test_default_generator_executes_all_rails_commands
     generator [destination_root]
     run_generator_instance


### PR DESCRIPTION
When generating a Rails app with CSS bundling, e.g., `rails new myapp --css tailwind --js esbuild`, the browser console shows:

   GET /assets/tailwindcss net::ERR_ABORTED 404 (Not Found)

The problem:

1. CSS build tools output to `app/assets/builds/application.css`
2. The generated layout has `stylesheet_link_tag :app`, which expands to link tags for ALL .css files in app/assets/:

   <link rel="stylesheet" href="/assets/application-{hash}.css">
   <link rel="stylesheet" href="/assets/application.tailwind-{hash}.css">

3. The source file application.tailwind.css shouldn't be served directly: only the built output (application.css) should be linked.

This fix:
- Adds `using_css_bundling?` helper to detect when CSS bundlers are used
- Updates layout template to use "application" when --css is present
- Applies to all CSS bundlers (tailwind, sass, postcss, bootstrap, bulma)

Related: rails/cssbundling-rails#175, rails/cssbundling-rails@1332e42