### PR TITLE
Prevent duplicates when eager-loading models with a composite primary key

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -103,7 +103,7 @@ module ActiveRecord
       end
 
       def instantiate(result_set, strict_loading_value, &block)
-        primary_key = aliases.column_alias(join_root, join_root.primary_key)
+        primary_key = Array(join_root.primary_key).map { |column| aliases.column_alias(join_root, column) }
 
         seen = Hash.new { |i, parent|
           i[parent] = Hash.new { |j, child_class|
@@ -141,7 +141,7 @@ module ActiveRecord
 
         message_bus.instrument("instantiation.active_record", payload) do
           result_set.each { |row_hash|
-            parent_key = primary_key ? row_hash[primary_key] : row_hash
+            parent_key = primary_key.empty? ? row_hash : row_hash.values_at(*primary_key)
             parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases, column_types, &block)
             construct(parent, join_root, row_hash, seen, model_cache, strict_loading_value)
           }


### PR DESCRIPTION
Fixes: #56087

When processing rows, `JoinDependency#instantiate` stores instantiated models in hash indexed by their primary key. The current code does not properly handle models with a composite primary key, and this can result in duplicate records being returned.

```ruby
create_table :buyers, primary_key: [:user_id, :tenant_id] do |t|
  t.bigint :user_id
  t.bigint :tenant_id
end
create_table :orders do |t|
  t.references :buyer_user
  t.references :buyer_tenant
end

class Buyer < ActiveRecord::Base
  self.primary_key = [:user_id, :tenant_id]

  has_many :orders, foreign_key: [:buyer_user_id, :buyer_tenant_id]
end

Buyer.create!(user_id: 1, tenant_id: 1)
Order.create!(id: 1, buyer_user_id: 1, buyer_tenant_id: 1)
Order.create!(id: 2, buyer_user_id: 1, buyer_tenant_id: 1)

buyers = Buyer.eager_load(:orders).to_a
# => [#<Buyer user_id: 1, tenant_id: 1>, #<Buyer user_id: 1, tenant_id: 1>]
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
