### PR TITLE
Document change in config for open redirects

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -113,6 +113,10 @@ For more information on changes made to Rails 8.1 please see the [release notes]
 
 Active Record now alphabetically sorts table columns in `schema.rb` by default, so dumps are consistent across machines and don’t flip-flop with migration order -- meaning fewer noisy diffs. `structure.sql` can still be leveraged to preserve exact column order. [See #53281 for more details on alphabetizing schema changes.](https://github.com/rails/rails/pull/53281)
 
+### More configuration for open redirects
+
+Rails 8.1 replaced `raise_on_open_redirects` with `action_on_open_redirects`, adding `:log` and `:notify` actions. This also changed default behavior for apps using `load_defaults` -- you app will now raise if it detects open redirects. Using the new configuration will update the behavior. [See #55496 for more details.](https://github.com/rails/rails/pull/55496)
+
 Upgrading from Rails 7.2 to Rails 8.0
 -------------------------------------
 


### PR DESCRIPTION
### Motivation / Background

The behavior introduced in https://github.com/rails/rails/pull/55496 is fantastic and totally makes sense. It felt worth calling out in the upgrade guides, just for people who may be using `load_defaults` in their applications so would now be getting raises, regardless of whether they'd previously configured something else.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
