### PR TITLE
Fix Arguments#serialize missing custom serializers

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Fix using custom serializers with `ActiveJob::Arguments.serialize` when
+    `ActiveJob::Base` hasn't been loaded.
+
+    *Hartley McGuire*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -50,7 +50,7 @@ module ActiveJob
           end
         end
       when Symbol
-        { OBJECT_SERIALIZER_KEY => "ActiveJob::Serializers::SymbolSerializer", "value" => argument.name }
+        { Serializers::OBJECT_SERIALIZER_KEY => "ActiveJob::Serializers::SymbolSerializer", "value" => argument.name }
       when GlobalID::Identification
         convert_to_global_id_hash(argument)
       when Array
@@ -94,15 +94,13 @@ module ActiveJob
       RUBY2_KEYWORDS_KEY = "_aj_ruby2_keywords"
       # :nodoc:
       WITH_INDIFFERENT_ACCESS_KEY = "_aj_hash_with_indifferent_access"
-      # :nodoc:
-      OBJECT_SERIALIZER_KEY = "_aj_serialized"
 
       # :nodoc:
       RESERVED_KEYS = [
         GLOBALID_KEY, GLOBALID_KEY.to_sym,
         SYMBOL_KEYS_KEY, SYMBOL_KEYS_KEY.to_sym,
         RUBY2_KEYWORDS_KEY, RUBY2_KEYWORDS_KEY.to_sym,
-        OBJECT_SERIALIZER_KEY, OBJECT_SERIALIZER_KEY.to_sym,
+        Serializers::OBJECT_SERIALIZER_KEY, Serializers::OBJECT_SERIALIZER_KEY.to_sym,
         WITH_INDIFFERENT_ACCESS_KEY, WITH_INDIFFERENT_ACCESS_KEY.to_sym,
       ].to_set
       private_constant :RESERVED_KEYS, :GLOBALID_KEY,
@@ -136,7 +134,7 @@ module ActiveJob
       end
 
       def custom_serialized?(hash)
-        hash.key?(OBJECT_SERIALIZER_KEY)
+        hash.key?(Serializers::OBJECT_SERIALIZER_KEY)
       end
 
       def serialize_hash(argument)
@@ -197,4 +195,6 @@ module ActiveJob
           "without an id. (Maybe you forgot to call save?)"
       end
   end
+
+  ActiveSupport.run_load_hooks(:active_job_arguments, Arguments)
 end

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -20,7 +20,7 @@ module ActiveJob
     end
 
     initializer "active_job.custom_serializers" do |app|
-      ActiveSupport.on_load(:active_job) do
+      ActiveSupport.on_load(:active_job_arguments) do
         custom_serializers = app.config.active_job.custom_serializers
         ActiveJob::Serializers.add_serializers custom_serializers
       end

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -38,7 +38,7 @@ module ActiveJob
       # Will look up through all known serializers.
       # If no serializer found will raise <tt>ArgumentError</tt>.
       def deserialize(argument)
-        serializer_name = argument[Arguments::OBJECT_SERIALIZER_KEY]
+        serializer_name = argument[OBJECT_SERIALIZER_KEY]
         raise ArgumentError, "Serializer name is not present in the argument: #{argument.inspect}" unless serializer_name
 
         serializer = serializer_name.safe_constantize
@@ -99,6 +99,9 @@ module ActiveJob
           end
         end
     end
+
+    # :nodoc:
+    OBJECT_SERIALIZER_KEY = "_aj_serialized"
 
     add_serializers SymbolSerializer.instance,
       DurationSerializer.instance,

--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -30,7 +30,7 @@ module ActiveJob
 
       def initialize
         super
-        @template = { Arguments::OBJECT_SERIALIZER_KEY => self.class.name }.freeze
+        @template = { Serializers::OBJECT_SERIALIZER_KEY => self.class.name }.freeze
       end
 
       # Determines if an argument should be serialized by a serializer.

--- a/railties/test/application/active_job_railtie_test.rb
+++ b/railties/test/application/active_job_railtie_test.rb
@@ -20,5 +20,23 @@ module ApplicationTests
 
       assert_equal "false", rails("runner", "p FooJob.enqueue_after_transaction_commit").strip
     end
+
+    test "custom serializers are loaded for Arguments#serialize" do
+      app_file "config/initializers/custom_serializers.rb", <<~RUBY
+        class Money; end
+
+        class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
+          def klass = Money
+          def serialize(money) = {}
+          def deserialize(hash) = Money.new
+        end
+
+        Rails.configuration.active_job.custom_serializers << MoneySerializer
+      RUBY
+
+      app "development"
+
+      assert_equal([{}], ActiveJob::Arguments.serialize([Money.new]))
+    end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3244,26 +3244,6 @@ module ApplicationTests
       assert_not ActiveSupport.parallelize_test_databases
     end
 
-    test "custom serializers should be able to set via config.active_job.custom_serializers in an initializer" do
-      class ::DummySerializer < ActiveJob::Serializers::ObjectSerializer
-        def klass
-          nil
-        end
-      end
-
-      app_file "config/initializers/custom_serializers.rb", <<-RUBY
-      Rails.application.config.active_job.custom_serializers << DummySerializer
-      RUBY
-
-      app "development"
-
-      assert_nothing_raised do
-        ActiveJob::Base
-      end
-
-      assert_includes ActiveJob::Serializers.serializers, DummySerializer.instance
-    end
-
     test "config.active_job.verbose_enqueue_logs defaults to true in development" do
       build_app
       app "development"


### PR DESCRIPTION
Fix https://github.com/rails/rails/issues/56090

Previously, custom serializer configuration was [moved][1] from `after_initialize` to `on_load(:active_job)` because the usage of `Serializer#klass` during boot meant loading custom serializers was now more likely to load autoloaded classes. However, this caused a problem for users of `ActiveJob::Arguments.serialize` since it is a documented public method and can be called without loading `ActiveJob::Base`.

This commit fixes the issue by giving `ActiveJob::Arguments` its own load hook. Now, `ActiveJob::Arguments.serialize` will correctly have custom serializers configured.

Adding this load hook also required resolving a circular dependency between ActiveJob::Serializers and ActiveJob::Arguments. Previously, the OBJECT_SERIALIZER_KEY was found under Arguments, so the ObjectSerializer singletons would cause Arguments to be loaded as soon as ActiveJob::Serializers is referenced (such as when subclassing ObjectSerializer). This commit moves OBJECT_SERIALIZATION_KEY under Serializers so that Arguments depends on Serializers but never the opposite.

[1]: https://github.com/rails/rails/commit/b7cd3018ef4c39fdc7fc0c22fb06b8a0cd035c12