### PR TITLE
Add class option `primary_key_default` for migration and model generator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Add new generator option primary_key_default
+
+    You can change create_table option :default in config/application.rb as follows:
+
+    ```ruby
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+      g.orm :active_record, primary_key_default: "uuidv7()"
+    end
+    ```
+
+    This config generates migration like follows:
+
+    ```shell
+    bin/rails g migration createUser name:string
+    ```
+
+    ```ruby
+    class CreateUser < ActiveRecord::Migration[8.2]
+      def change
+        create_table :users, id: :uuid, default: "uuidv7()" do |t|
+          t.string :name
+
+          t.timestamps
+        end
+      end
+    end
+    ```
+
+    *kinoppyd*
+
 *   Fix inconsistency in PostgreSQL handling of unbounded time range types
 
     Use `-infinity` rather than `NULL` for the lower value of PostgreSQL time

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -22,6 +22,11 @@ module ActiveRecord
           ", id: :#{key_type}" if key_type
         end
 
+        def primary_key_default
+          default = options[:primary_key_default]
+          %(, default: "#{default}") if default
+        end
+
         def foreign_key_type
           key_type = options[:primary_key_type]
           ", type: :#{key_type}" if key_type

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -9,6 +9,7 @@ module ActiveRecord
 
       class_option :timestamps, type: :boolean
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :primary_key_default, type: :string, desc: "The default options for primary key"
       class_option :database, type: :string, aliases: %i(--db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
       def create_migration_file

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -1,6 +1,6 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
-    create_table :<%= table_name %><%= primary_key_type %> do |t|
+    create_table :<%= table_name %><%= primary_key_type %><%= primary_key_default %> do |t|
 <% attributes.each do |attribute| -%>
 <% if attribute.password_digest? -%>
       t.string :password_digest<%= attribute.inject_options %>

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -14,6 +14,7 @@ module ActiveRecord
       class_option :parent, type: :string, default: "ApplicationRecord", desc: "The parent class for the generated model"
       class_option :indexes, type: :boolean, default: true, desc: "Add indexes for references and belongs_to columns"
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :primary_key_default, type: :string, desc: "The default options for primary key"
       class_option :database, type: :string, aliases: %i(--db), desc: "The database for your model's migration. By default, the current environment's primary database is used."
 
       Rails::Generators.templates_path.each do |path|


### PR DESCRIPTION
### Motivation / Background

The purpose of this PR is to add a way to set the uuidv7 function (introduced in PostgreSQL 18) as the default value in migrations. With the existing generator, it was possible to change the primary_key_type, but not the default value itself — resulting in gen_random_uuid() being automatically selected. To address this, a new option primary_key_default has been added, allowing developers to choose any UUID generation function they prefer.

### Detail

This PR allows developers to specify the default value for the primary key generated by Rails generators.
You can now configure this behavior in config/application.rb as follows:

```
config.generators do |g|
  g.orm :active_record, primary_key_type: :uuid
  g.orm :active_record, primary_key_default: "uuidv7()"
end
```

Previously, only primary_key_type could be configured.
To achieve a similar effect, developers had to write something like:

```
config.generators do |g|
  g.orm :active_record, primary_key_type: ":uuid, default: 'uuidv7()'"
end
```

This approach overloads a single option with multiple responsibilities and is not ideal for compatibility or readability.
By introducing a dedicated primary_key_default option, this PR provides a clearer and more flexible way to define custom UUID generation functions (such as uuidv7()).

### Additional information

I was not able to find any existing tests related to generators that cover this kind of configuration behavior.
Because of that, I haven’t added a test in this PR.
If there is a suitable place or existing test file where such generator configuration tests should be added, I’d appreciate any guidance.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
