### PR TITLE
Reset parallel test tables by deleting

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,12 +1,6 @@
-*   Change parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
+*   On MySQL parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
 
-    When running parallel tests, each worker gets a separate database copy. If the
-    schema is up to date, tables are now reset using `DELETE FROM` instead of `TRUNCATE`.
-
-    - On MySQL, `DELETE FROM` is significantly faster than `TRUNCATE`.
-    - For Postgresql, `DELETE FROM` is also slightly faster for tables with 100s of records,
-      though `TRUNCATE` is pretty quick as well.
-    - On SQLite there is no difference as the adapter already converted `TRUNCATE` to `DELETE FROM`.
+    Truncating on MySQL is very slow even on empty or nearly empty tables.
 
     As a result of this change auto increment counters are now no longer reset between test
     runs on MySQL and the `SKIP_TEST_DATABASE_TRUNCATE` environment variable no longer has

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Change parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
+
+    When running parallel tests, each worker gets a separate database copy. If the
+    schema is up to date, tables are now reset using `DELETE FROM` instead of `TRUNCATE`.
+
+    - On MySQL, `DELETE FROM` is significantly faster than `TRUNCATE`.
+    - For Postgresql, `DELETE FROM` is also slightly faster for tables with 100s of records,
+      though `TRUNCATE` is pretty quick as well.
+    - On SQLite there is no difference as the adapter already converted `TRUNCATE` to `DELETE FROM`.
+
+    As a result of this change auto increment counters are now no longer reset between test
+    runs on MySQL and the `SKIP_TEST_DATABASE_TRUNCATE` environment variable no longer has
+    any effect.
+
+    *Donal McBreen*
+
 *   Fix inconsistency in PostgreSQL handling of unbounded time range types
 
     Use `-infinity` rather than `NULL` for the lower value of PostgreSQL time

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -541,7 +541,7 @@ module ActiveRecord
 
       def insert_fixtures_set(fixture_set, tables_to_delete = [])
         fixture_inserts = build_fixture_statements(fixture_set)
-        table_deletes = tables_to_delete.map { |table| "DELETE FROM #{quote_table_name(table)}" }
+        table_deletes = build_delete_from_statements(tables_to_delete)
         statements = table_deletes + fixture_inserts
 
         transaction(requires_new: true) do
@@ -549,6 +549,10 @@ module ActiveRecord
             execute_batch(statements, "Fixtures Load")
           end
         end
+      end
+
+      def empty_all_tables # :nodoc:
+        truncate_tables(*tables)
       end
 
       def empty_insert_statement_value(primary_key = nil)
@@ -733,6 +737,12 @@ module ActiveRecord
         def build_truncate_statements(table_names)
           table_names.map do |table_name|
             build_truncate_statement(table_name)
+          end
+        end
+
+        def build_delete_from_statements(table_names)
+          table_names.map do |table_name|
+            "DELETE FROM #{quote_table_name(table_name)}"
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -13,6 +13,18 @@ module ActiveRecord
           end
         end
 
+        def empty_all_tables # :nodoc:
+          table_names = tables - [pool.schema_migration.table_name, pool.internal_metadata.table_name]
+          return if table_names.empty?
+
+          statements = build_delete_from_statements(table_names)
+
+          # Deleting is generally much faster than truncating in MySQL
+          disable_referential_integrity do
+            execute_batch(statements, "Delete Tables")
+          end
+        end
+
         private
           def execute_batch(statements, name = nil, **kwargs)
             combine_multi_statements(statements).each do |statement|

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -232,6 +232,19 @@ module ActiveRecord
       end
       private :truncate_tables
 
+      def delete_from_tables(db_config)
+        with_temporary_connection(db_config) do |conn|
+          tables = conn.tables - [conn.pool.schema_migration.table_name, conn.pool.internal_metadata.table_name]
+          return if tables.empty?
+
+          conn.disable_referential_integrity do
+            statements = tables.map { |table| "DELETE FROM #{conn.quote_table_name(table)}" }
+            conn.send(:execute_batch, statements, "Delete Tables")
+          end
+        end
+      end
+      private :delete_from_tables
+
       def truncate_all(environment = env)
         configs_for(env_name: environment).each do |db_config|
           truncate_tables(db_config)
@@ -416,7 +429,7 @@ module ActiveRecord
 
         with_temporary_pool(db_config, clobber: true) do
           if schema_up_to_date?(db_config, nil, file)
-            truncate_tables(db_config) unless ENV["SKIP_TEST_DATABASE_TRUNCATE"]
+            delete_from_tables(db_config)
           else
             purge(db_config)
             load_schema(db_config, db_config.schema_format, file)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -517,6 +517,37 @@ module ActiveRecord
       @connection.disable_query_cache!
     end
 
+    def test_empty_all_tables
+      assert_operator Post.count, :>, 0
+      assert_operator Author.count, :>, 0
+      assert_operator AuthorAddress.count, :>, 0
+
+      @connection.empty_all_tables
+
+      assert_equal 0, Post.count
+      assert_equal 0, Author.count
+      assert_equal 0, AuthorAddress.count
+    ensure
+      reset_fixtures("posts", "authors", "author_addresses")
+    end
+
+    def test_empty_all_tables_with_query_cache
+      @connection.enable_query_cache!
+
+      assert_operator Post.count, :>, 0
+      assert_operator Author.count, :>, 0
+      assert_operator AuthorAddress.count, :>, 0
+
+      @connection.empty_all_tables
+
+      assert_equal 0, Post.count
+      assert_equal 0, Author.count
+      assert_equal 0, AuthorAddress.count
+    ensure
+      reset_fixtures("posts", "authors", "author_addresses")
+      @connection.disable_query_cache!
+    end
+
     # test resetting sequences in odd tables in PostgreSQL
     if ActiveRecord::Base.lease_connection.respond_to?(:reset_pk_sequence!)
       require "models/movie"


### PR DESCRIPTION
### Motivation / Background

Switch from truncating to deleting when resetting parallel test databases. This PR is an alternative to https://github.com/rails/rails/pull/56026 without the configuration option.

When doing parallel testing with many databases, truncating all the tables is very slow on MySQL. Deleting from the tables is much faster even if they contain a reasonable amount of data.

### Detail

Running on a schema with about 200 empty tables and 32 parallel databases, deleting from all tables takes about 0.3 seconds, while truncating takes 18 seconds. Even with 1000 rows to delete in each table deleting is about 2.7x faster than truncating.

On PostgreSQL, truncating the tables is slower than deleting if they have small amounts of data which is typical for test databases. Both methods are very quick anyway.

There's no difference between the two methods for SQLite, as the adapter uses DELETE for truncation anyway.

Functionally DELETE and TRUNCATE are identical on PostgreSQL, but on MySQL TRUNCATE will reset AUTO_INCREMENT counters while DELETE will not.

Tests should not be relying on them being reset and since this is only for parallel tests where test orders are going to be randomised anyway so the IDs are unlikely to be consistent between test runs anyway.

By switching to DELETE all three databases will behave identically and not reset the ID sequence counters.

If there's much more data in the tables then TRUNCATE may become faster, but in that case the tests are likely to be slow as they'll need to generate the data.

This PR also removed the SKIP_TEST_DATABASE_TRUNCATE environment variable - we no longer truncate so the name doesn't make sense and deleting should be fast enough to not need to skip.


### Additional information

Timings for resetting tables with TRUNCATE vs DELETE, based on 32 databases with 200 tables each, with 0, 100 and 1000 rows per table:
```
  ┌──────────────┬─────────┬──────────┬───────┬───────┬───────┬─────────┐
  │   Database   │  Rows/  │  Method  │  Min  │  Avg  │  Max  │ Winner  │
  │              │  Table  │          │ (sec) │ (sec) │ (sec) │         │
  ├──────────────┼─────────┼──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ TRUNCATE │ 0.269 │ 0.535 │ 0.578 │         │
  │ PostgreSQL   │    0    │──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ DELETE   │ 0.038 │ 0.051 │ 0.067 │  10.6x  │
  ├──────────────┼─────────┼──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ TRUNCATE │ 0.174 │ 0.323 │ 0.408 │         │
  │ PostgreSQL   │   100   │──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ DELETE   │ 0.104 │ 0.132 │ 0.150 │  2.45x  │
  ├──────────────┼─────────┼──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ TRUNCATE │ 0.511 │ 0.578 │ 0.604 │  2.48x  │
  │ PostgreSQL   │  1000   │──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ DELETE   │ 1.372 │ 1.434 │ 1.568 │         │
  ├──────────────┼─────────┼──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ TRUNCATE │17.485 │18.413 │18.978 │         │
  │ MySQL        │    0    │──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ DELETE   │ 0.311 │ 0.341 │ 0.356 │  53.6x  │
  ├──────────────┼─────────┼──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ TRUNCATE │16.892 │18.281 │18.845 │         │
  │ MySQL        │   100   │──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ DELETE   │ 0.534 │ 1.406 │ 2.003 │  13.0x  │
  ├──────────────┼─────────┼──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ TRUNCATE │16.723 │17.939 │18.544 │         │
  │ MySQL        │  1000   │──────────┼───────┼───────┼───────┼─────────┤
  │              │         │ DELETE   │ 3.789 │ 6.635 │ 8.400 │  2.70x  │
  └──────────────┴─────────┴──────────┴───────┴───────┴───────┴─────────┘
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
