### PR TITLE
Make schema cache backward compatible with the changes in column

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -104,7 +104,7 @@ module ActiveRecord
         def deduplicated
           @name = -name
           @sql_type_metadata = sql_type_metadata.deduplicate if sql_type_metadata
-          @default = -default if default
+          @default = -default if String === default
           @default_function = -default_function if default_function
           @collation = -collation if collation
           @comment = -comment if comment

--- a/activerecord/test/assets/schema_dump_8_1.yml
+++ b/activerecord/test/assets/schema_dump_8_1.yml
@@ -1,0 +1,40 @@
+--- !ruby/object:ActiveRecord::ConnectionAdapters::SchemaCache
+columns:
+  posts:
+  - &1 !ruby/object:ActiveRecord::ConnectionAdapters::Column
+    name: id
+    table_name: posts
+    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      sql_type: INTEGER
+      type: :integer
+      limit:
+      precision:
+      scale:
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  - &2 !ruby/object:ActiveRecord::ConnectionAdapters::Column
+    name: published
+    table_name: posts
+    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      sql_type: boolean
+      type: :boolean
+      limit:
+      precision:
+      scale:
+    'null': true
+    default: true
+    default_function:
+    collation:
+    comment:
+columns_hash:
+  posts:
+    id: *1
+    published: *2
+primary_keys:
+  posts: id
+data_sources:
+  posts: true
+version: 0

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -121,6 +121,17 @@ module ActiveRecord
         tempfile.unlink
       end
 
+      def test_yaml_loads_8_1_dump
+        cache = load_bound_reflection("#{ASSETS_ROOT}/schema_dump_8_1.yml")
+
+        assert_no_queries do
+          assert_equal 2, cache.columns("posts").size
+          assert_equal 2, cache.columns_hash("posts").size
+          assert cache.data_source_exists?("posts")
+          assert_equal "id", cache.primary_keys("posts")
+        end
+      end
+
       def test_yaml_loads_5_1_dump
         cache = load_bound_reflection(schema_dump_path)
 


### PR DESCRIPTION
### Motivation / Background

We recently rolled out Rails 8.1 to production and encountered a backward compatibility issue when older Rails 8.0 processes load a schema cache generated under Rails 8.1.

### Detail

In Rails 8.1, the default value for a column is now assigned like this (see https://github.com/rails/rails/commit/205cdd50ba626325b26ce2919d5e961c6df50df0):

```ruby
@default = default.nil? || cast_type.mutable? ? default : cast_type.deserialize(default)
```

This means that when default is `nil`, `@default` is set to `true`. Later on, during deduplication, Rails handles this case correctly within 8.1 https://github.com/rails/rails/blob/205cdd50ba626325b26ce2919d5e961c6df50df0/activerecord/lib/active_record/connection_adapters/column.rb#L120

However, if a schema cache produced by 8.1 is deserialized by Rails 8.0, the `default = true` value is processed by Rails 8.0 code that expects default to always be either a `string` or `nil`
https://github.com/rails/rails/blob/433c70c470c2bbaddfc29cde40966b9700cccfe7/activerecord/lib/active_record/connection_adapters/column.rb#L107

Since `default` is now `true`, this triggers:

```
NoMethodError: undefined method `-@' for true:TrueClass
```

To fix it, I propose to backport @byroot's changes in `Column#deduplicated`.  It should restore backward compatibility, with no impact on 8.0 application.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
