### PR TITLE
Add a top-level switch for has_secure_password algorithm and default to argon2

### DIFF
--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -13,9 +13,10 @@ module ActiveModel
       app.deprecators[:active_model] = ActiveModel.deprecator
     end
 
-    initializer "active_model.secure_password" do
+    initializer "active_model.secure_password" do |app|
       ActiveSupport.on_load(:active_model_secure_password) do
         ActiveModel::SecurePassword.min_cost = Rails.env.test?
+        ActiveModel::SecurePassword.algorithm = app.config.active_model.secure_password_algorithm
       end
     end
 

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -13,6 +13,9 @@ module ActiveModel
     class << self
       attr_accessor :min_cost # :nodoc:
 
+      # The default algorithm to use for has_secure_password.
+      attr_accessor :algorithm
+
       # Returns the registry of password algorithms
       def algorithm_registry
         @algorithm_registry ||= {}
@@ -193,6 +196,8 @@ module ActiveModel
       #
       def has_secure_password(attribute = :password, validations: true, reset_token: true, algorithm: nil)
         # Resolve algorithm: can be a Symbol (for registry lookup), an instance, or default to BCrypt
+        algorithm ||= ActiveModel::SecurePassword.algorithm
+
         algorithm = case algorithm
         when Symbol
           algorithm_class = ActiveModel::SecurePassword.lookup_algorithm(algorithm)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,8 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.2
 
+- [`config.active_model.secure_password_algorithm`](#config-active-model-secure-password-algorithm): `:argon2`
+
 #### Default Values for Target Version 8.1
 
 - [`config.action_controller.action_on_path_relative_redirect`](#config-action-controller-action-on-path-relative-redirect): `:raise`
@@ -959,6 +961,19 @@ Sets fallback behavior for missing translations. Here are 3 usage examples for t
     ```
 
 ### Configuring Active Model
+
+#### `config.active_model.secure_password_algorithm`
+
+Set the default algorithm used by [`has_secure_password`][]. Supported algorithms are `:bcrypt` (default) and `:argon2`.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `nil`                |
+| 8.2                   | `argon2`             |
+
+[`has_secure_password`]: https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password
 
 #### `config.active_model.i18n_customize_full_message`
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add top-level flag for `has_secure_password` algorithm and default to `:argon2`
+
+    If your application uses `bcrypt` you need to explicitly set the config:
+
+    ```ruby
+    Rails.application.config.active_model.has_secure_password_algorithm = :bcrypt
+    ```
+
+    This is only necessary after updating `config.load_defaults(8.2)`.
+
+    *zzak*
+
 *   Update the `.node-version` file conditionally generated for new applications to 22.21.1
 
     *Taketo Takashima*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -370,6 +370,10 @@ module Rails
           end
         when "8.2"
           load_defaults "8.1"
+
+          if respond_to?(:active_model)
+            active_model.secure_password_algorithm = :argon2
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 <% unless options.minimal? -%>
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+# gem "argon2"
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -8,3 +8,9 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+
+###
+# Set the default algorithm for has_secure_password to Argon2.
+#++
+# Rails.application.config.active_model.secure_password_algorithm = :argon2

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -42,12 +42,12 @@ module Rails
         route "resource :session"
       end
 
-      def enable_bcrypt
-        if File.read(File.expand_path("Gemfile", destination_root)).include?('gem "bcrypt"')
-          uncomment_lines "Gemfile", /gem "bcrypt"/
+      def enable_argon2
+        if File.read(File.expand_path("Gemfile", destination_root)).include?('gem "argon2"')
+          uncomment_lines "Gemfile", /gem "argon2"/
           bundle_command("install --quiet")
         else
-          bundle_command("add bcrypt", {}, quiet: true)
+          bundle_command("add argon2", {}, quiet: true)
         end
       end
 

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
@@ -1,4 +1,6 @@
-<%% password_digest = BCrypt::Password.create("password") %>
+<%% algorithm = Rails.application.config.active_model.secure_password_algorithm || :argon2 %>
+<%% password_algorithm = ActiveModel::SecurePassword.lookup_algorithm(algorithm).new %>
+<%% password_digest = password_algorithm.hash_password("password") %>
 
 one:
   email_address: one@example.com

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
@@ -4,7 +4,9 @@
 <%= name %>:
 <% attributes.each do |attribute| -%>
   <%- if attribute.password_digest? -%>
-  password_digest: <%= BCrypt::Password.create("secret") %>  # Generated with BCrypt::Password.create("secret")
+  <%- algorithm = Rails.application.config.active_model.secure_password_algorithm || :argon2 -%>
+  <%- password_algorithm = ActiveModel::SecurePassword.lookup_algorithm(algorithm).new -%>
+  password_digest: <%= password_algorithm.hash_password("secret") %>  # Generated with <%= password_algorithm.class.name %>.new.hash_password("secret")
   <%- elsif attribute.reference? -%>
   <%= yaml_key_value(attribute.column_name.delete_suffix("_id"), attribute.default || name) %>
   <%- elsif !attribute.virtual? -%>

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -48,7 +48,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "Gemfile" do |content|
-      assert_match(/\ngem "bcrypt"/, content)
+      assert_match(/\ngem "argon2"/, content)
     end
 
     assert_file "config/routes.rb" do |content|
@@ -71,14 +71,14 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_authentication_generator_without_bcrypt_in_gemfile
-    File.write("#{destination_root}/Gemfile", File.read("#{destination_root}/Gemfile").sub(/# gem "bcrypt".*\n/, ""))
+  def test_authentication_generator_without_argon2_in_gemfile
+    File.write("#{destination_root}/Gemfile", File.read("#{destination_root}/Gemfile").sub(/# gem "argon2".*\n/, ""))
 
     generator([destination_root])
 
     run_generator_instance
 
-    assert_includes @bundle_commands, ["add bcrypt", {}, { quiet: true }]
+    assert_includes @bundle_commands, ["add argon2", {}, { quiet: true }]
   end
 
   def test_authentication_generator_with_api_flag
@@ -101,7 +101,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "Gemfile" do |content|
-      assert_match(/\ngem "bcrypt"/, content)
+      assert_match(/\ngem "argon2"/, content)
     end
 
     assert_file "config/routes.rb" do |content|

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -3,7 +3,7 @@
 require "plugin_helpers"
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
-require "bcrypt"
+require "argon2"
 
 class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include PluginHelpers
@@ -565,7 +565,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "test/fixtures/users.yml" do |content|
       assert_match(/password_digest: (.+)$/, content)
       digest = content.match(/password_digest: ([^#\s]+)/)[1].strip
-      assert BCrypt::Password.new(digest) == "secret"
+      assert Argon2::Password.verify_password("secret", digest)
     end
   end
 


### PR DESCRIPTION
Follow up to #56057 per:
https://github.com/rails/rails/pull/48993#issuecomment-2266154188

> the bigger value would be if we added support for argon2id as an alternative, and then had a top-level switch to set the default algorithm, so it can be set for new apps to be argon2id