### PR TITLE
Fix Inflector fallback to :en locale

### DIFF
--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -84,6 +84,7 @@ module ActiveSupport
         return @__en_instance__ ||= new if locale == :en
 
         I18n.fallbacks[locale].each do |k|
+          return @__en_instance__ if k == :en && @__en_instance__
           return @__instance__[k] if @__instance__.key?(k)
         end
         instance(locale)

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -84,7 +84,7 @@ module ActiveSupport
         return @__en_instance__ ||= new if locale == :en
 
         I18n.fallbacks[locale].each do |k|
-          return @__en_instance__ if k == :en && @__en_instance__
+          return @__en_instance__ ||= new if k == :en
           return @__instance__[k] if @__instance__.key?(k)
         end
         instance(locale)


### PR DESCRIPTION
The `instance_or_fallback `method didn't check `@__en_instance__` when falling back to :en, causing locales like en-GB to create empty inflection instances instead of using :en rules.

### Motivation / Background

The `ActiveSupport::Inflector.inflections` fallback mechanism (`instance_or_fallback`) doesn't work correctly when the fallback locale is `:en`. This is because `:en` uses a special singleton instance (`@__en_instance__`) instead of being stored in `@__instance__[:en]`.

When a locale like `en-GB` falls back to `:en` through `I18n.fallbacks`, the method checks `@__instance__[:en]` which doesn't exist, causing it to create an empty inflection instance instead of using the `:en` rules. This results in incorrect pluralization (e.g., `'problem'.pluralize(:'en-GB')` returns `"problem"` instead of `"problems"`).

This affects any application using compound English locales (`en-GB`, `en-US`, etc.) with `I18n.fallbacks` configured.

### Detail

This Pull Request fixes the `instance_or_fallback` method in `lib/active_support/inflector/inflections.rb` to check `@__en_instance__` when the fallback locale is `:en`.

**Before:**
```ruby
def self.instance_or_fallback(locale)
  return @__en_instance__ ||= new if locale == :en

  I18n.fallbacks[locale].each do |k|
    return @__instance__[k] if @__instance__.key?(k)  # ❌ Never finds :en
  end
  instance(locale)
end
```

**After:**
```ruby
def self.instance_or_fallback(locale)
  return @__en_instance__ ||= new if locale == :en

  I18n.fallbacks[locale].each do |k|
    return @__en_instance__ ||= new if k == :en  # ✅ Check and initialize @__en_instance__
    return @__instance__[k] if @__instance__.key?(k)
  end
  instance(locale)
end
```

Added test `test_inflections_fallback_to_en_locale` that verifies:
- `en-GB` falls back to `:en` correctly
- Pluralization rules are shared between `:en` and `en-GB`
- The same instance is returned when falling back
- `'problem'.pluralize(:'en-GB')` correctly returns `"problems"`

### Additional information

**Reproduction case:**
```ruby
# Set up I18n fallbacks
I18n.fallbacks.map("en-GB": :en)

# Access :en (populates @__en_instance__)
en_inflections = ActiveSupport::Inflector.inflections(:en)
puts en_inflections.plurals.size  # => 33
puts 'problem'.pluralize(:en)     # => "problems" (correct)

# Access :en-GB (should fallback to :en, but creates empty instance)
en_gb_inflections = ActiveSupport::Inflector.inflections(:'en-GB')
puts en_gb_inflections.plurals.size  # => 0 (WRONG - should be 33)
puts 'problem'.pluralize(:'en-GB')   # => "problem" (WRONG - should be "problems")
```

This appears to be a regression introduced in Rails 8.0 or 8.1, as it worked correctly in Rails 7.2.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.

* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

* [x] Tests are added or updated if you fix a bug or add a feature.

* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

