### PR TITLE
Fix validation context regression for unchanged associations

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -296,7 +296,7 @@ module ActiveRecord
       # or saved. If +autosave+ is +false+ only new records will be returned,
       # unless the parent is/was a new record itself.
       def associated_records_to_validate_or_save(association, new_record, autosave)
-        if new_record || custom_validation_context?
+        if new_record
           association && association.target
         elsif autosave
           association.target.find_all(&:changed_for_autosave?)
@@ -329,7 +329,7 @@ module ActiveRecord
       def validate_has_one_association(reflection)
         association = association_instance_get(reflection.name)
         record      = association && association.reader
-        return unless record && (record.changed_for_autosave? || custom_validation_context?)
+        return unless record && record.changed_for_autosave?
 
         inverse_association = reflection.inverse_of && record.association(reflection.inverse_of.name)
         return if inverse_association && (record.validating_belongs_to_for?(inverse_association) ||
@@ -343,7 +343,7 @@ module ActiveRecord
       def validate_belongs_to_association(reflection)
         association = association_instance_get(reflection.name)
         record      = association && association.reader
-        return unless record && (record.changed_for_autosave? || custom_validation_context?)
+        return unless record && record.changed_for_autosave?
 
         begin
           @validating_belongs_to_for ||= {}

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -2272,11 +2272,18 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
     assert_equal(book_count_before_save, Book.count)
   end
 
-  def test_validations_still_fire_on_unchanged_association_with_custom_validation_context
+  test "validations still fire on unchanged association with validates_associated and custom validation context" do
     pirate = FamousPirate.create!(catchphrase: "Avast Ye!")
-    pirate.famous_ships.create!
+    FamousPirate.validates_associated :famous_ships
+    ship = pirate.famous_ships.new
+    ship.save(validate: false)
 
-    assert_predicate pirate, :valid?
+    pirate.reload
+    assert pirate.valid?
+    assert_not pirate.valid?(:conference)
+
+    pirate.famous_ships.load
+    assert pirate.valid?
     assert_not pirate.valid?(:conference)
   end
 end
@@ -2318,13 +2325,6 @@ class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::
     assert_predicate @pirate, :valid?
     @pirate.non_validated_parrot = Parrot.new(name: "")
     assert_predicate @pirate, :valid?
-  end
-
-  def test_validations_still_fire_on_unchanged_association_with_custom_validation_context
-    firm_with_low_credit = Firm.create!(name: "Something", account: Account.new(credit_limit: 50))
-
-    assert_predicate firm_with_low_credit, :valid?
-    assert_not firm_with_low_credit.valid?(:bank_loan)
   end
 end
 

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -118,4 +118,20 @@ class AssociationValidationTest < ActiveRecord::TestCase
     assert_predicate t, :valid?
     assert_predicate r, :valid?
   end
+
+  def test_should_not_validate_invalid_children_saved_with_validate_false_when_using_custom_context
+    Reply.validates :content, length: { minimum: 10 }
+
+    topic = Topic.create!("title" => "A topic", "content" => "Some content")
+    reply = topic.replies.new("title" => "A reply", "content" => "short")
+    reply.save(validate: false)
+
+    topic.reload
+    assert topic.valid?
+    assert topic.valid?(:custom)
+
+    topic.replies.load
+    assert topic.valid?
+    assert topic.valid?(:custom)
+  end
 end


### PR DESCRIPTION
This PR fixes a regression where calling `valid?(context)` with a custom validation context incorrectly validates unchanged, persisted association records that were previously saved with `validate: false`.

## The Problem
When you save an invalid association record using `validate: false` and then later call `valid?(custom_context)` on the parent, the parent becomes invalid even though: 
1. The association record hasn't changed
2. The parent record itself is valid
3. The default `valid?` call (without context) correctly passes

## Root Cause
The regression was introduced in #37295, which added `|| custom_validation_context?` checks in three places:
* `#validate_has_one_association` (line 332)
* `#validate_belongs_to_association` (line 346)
* `#associated_records_to_validate_or_save` (line 299)

The intent of #37295 was to ensure validations fire when using custom contexts because validation logic might be context-dependent. However, this made the assumption too broad - any custom validation context now causes all loaded association records to be validated, including unchanged, persisted records. This breaks the principle established in #36671 that associations should only be validated if they've actually changed (`changed_for_autosave?`).


## The Solution
Remove the `|| custom_validation_context?` condition from all three validation methods. This restores the behavior where associations are only validated if they have been modified, regardless of whether a custom validation context is being used.
While this means we lose the ability to re-validate unchanged associations when their validation logic might depend on the parent's state (the original motivation for #37295), that edge case should *be handled explicitly by the application*, rather than assuming all custom contexts require full re-validation of unchanged records.
Changes
Remove `|| custom_validation_context?` from `#validate_has_one_association`
Remove `|| custom_validation_context?` from `#validate_belongs_to_association`
Remove `|| custom_validation_context?` from `#associated_records_to_validate_or_save`
Add regression test in test/cases/validations/association_validation_test.rb

## Related Issues
Fixes #38036
Partially reverts #37295 (which was fixing #37192 and #36822)
Restores behavior from #36671