### PR TITLE
Fix detection of cssbundling-rails usage in the app generator

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -537,7 +537,7 @@ module Rails
       end
 
       def using_css_bundling?
-        options[:skip_asset_pipeline] || options[:css]
+        css_gemfile_entry&.name == "cssbundling-rails"
       end
 
       def capture_command(command, pattern = nil)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1149,8 +1149,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "importmap-rails"
   end
 
-  def test_css_option_uses_application_stylesheet_link_tag
-    run_generator [destination_root, "--css=tailwind"]
+  def test_css_option_with_cssbundling_uses_application_stylesheet_link_tag
+    run_generator [destination_root, "--css=bootstrap"]
 
     assert_file "app/views/layouts/application.html.erb" do |content|
       assert_match(/stylesheet_link_tag\s+"application"/, content)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because #56086 added a conditional to use `application` as the main entrypoint for the CSS stylesheet when using `cssbundling-rails`. However, the helper added to check this does not correctly detect the presence of the cssbundling-rails gem, as it assumes that passing the `css` option is enough for this to be true, which is incorrect. If the value of the `css` option argument is `tailwind` or `sass`, `cssbundling-rails` is not used by default, unless you are using a JS runtime, but rather the `tailwindcss-rails` or `dartsass-rails` gem is used.

### Detail

This pull request changes the way `cssbundling-rails` usage is detected in the app generator. It simply checks whether the gem used for CSS is `cssbundling-rails`, rather than making another inference. Existing conditions are reused.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
