### PR TITLE
Add configuration option for negative scopes to include records with nil values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -6,6 +6,11 @@
     When set to `false` (8.2 default), negative scopes will include records with `nil`
     values. When set to `true`, negative scopes will exclude records with `nil` values.
 
+    This configuration is deprecated and will be removed in a future version of Rails.
+    It is intended as a temporary measure to ease upgrades. Setting this to `true` will
+    trigger a deprecation warning. Applications should instead manually override the
+    negative scope in their models if they need to maintain the old behavior.
+
     *QWYNG*
 
 *   Fix bug when `current_transaction.isolation` would not have been reset in test env.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `deprecated_negative_enum_scopes_exclude_nil` configuration option.
+
+    This allows applications to choose whether negative scopes for enums should
+    include records with `nil` values or exclude them.
+
+    When set to `false` (8.2 default), negative scopes will include records with `nil`
+    values. When set to `true`, negative scopes will exclude records with `nil` values.
+
+    *QWYNG*
+
 *   Fix bug when `current_transaction.isolation` would not have been reset in test env.
 
     Additionally, extending the change in [#55549](https://github.com/rails/rails/pull/55549)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -103,6 +103,20 @@ module ActiveRecord
       class_attribute :shard_selector, instance_accessor: false, default: nil
 
       class_attribute :deprecated_negative_enum_scopes_exclude_nil, instance_accessor: false, default: true
+      module DeprecatedNegativeEnumScopesExcludeNil
+        def deprecated_negative_enum_scopes_exclude_nil=(value)
+          if value
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Setting `config.active_record.deprecated_negative_enum_scopes_exclude_nil` to `true` is deprecated.
+              This configuration is intended as a temporary measure to ease upgrades and will be removed in a future version of Rails.
+              If you need to keep the old behavior (excluding `nil` values), manually override the negative scope in your model.
+            MSG
+          end
+
+          super
+        end
+      end
+      singleton_class.prepend DeprecatedNegativeEnumScopesExcludeNil
 
       ##
       # :singleton-method:

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -102,6 +102,8 @@ module ActiveRecord
 
       class_attribute :shard_selector, instance_accessor: false, default: nil
 
+      class_attribute :deprecated_negative_enum_scopes_exclude_nil, instance_accessor: false, default: true
+
       ##
       # :singleton-method:
       #

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -318,7 +318,12 @@ module ActiveRecord
 
               # scope :not_active, -> { where.not(status: 0) }
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where(predicate_builder[name, value, :is_distinct_from]) }
+
+              if klass.deprecated_negative_enum_scopes_exclude_nil
+                klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              else
+                klass.scope "not_#{value_method_name}", -> { where(predicate_builder[name, value, :is_distinct_from]) }
+              end
             end
           end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -87,13 +87,28 @@ class EnumTest < ActiveRecord::TestCase
   test "find via negative scope" do
     assert Book.not_published.exclude?(@book)
     assert Book.not_proposed.include?(@book)
+  end
 
-    assert Book.not_forgotten.exclude?(books(:ddd))
-
-    # Should include records with nils in the column.
+  test "deprecated_negative_enum_scopes_exclude_nil" do
     rfr = books(:rfr)
     rfr.update!(status: nil)
-    assert Book.not_published.include?(rfr)
+
+    model1 = Class.new(Book) do
+      self.deprecated_negative_enum_scopes_exclude_nil = false
+      enum :status, [:proposed, :written, :published]
+      enum :last_read, { unread: 0, reading: 2, read: 3, forgotten: nil }
+    end
+
+    assert model1.not_published.include?(rfr.becomes(model1))
+    assert model1.not_forgotten.exclude?(books(:ddd).becomes(model1))
+
+    model2 = Class.new(Book) do
+      self.deprecated_negative_enum_scopes_exclude_nil = true
+      enum :status, [:proposed, :written, :published]
+      enum :last_read, { unread: 0, reading: 2, read: 3, forgotten: nil }
+    end
+
+    assert model2.not_published.exclude?(rfr.becomes(model2))
   end
 
   test "find via where with values" do

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -102,13 +102,15 @@ class EnumTest < ActiveRecord::TestCase
     assert model1.not_published.include?(rfr.becomes(model1))
     assert model1.not_forgotten.exclude?(books(:ddd).becomes(model1))
 
-    model2 = Class.new(Book) do
-      self.deprecated_negative_enum_scopes_exclude_nil = true
-      enum :status, [:proposed, :written, :published]
-      enum :last_read, { unread: 0, reading: 2, read: 3, forgotten: nil }
-    end
+    assert_deprecated(ActiveRecord.deprecator) do
+      model2 = Class.new(Book) do
+        self.deprecated_negative_enum_scopes_exclude_nil = true
+        enum :status, [:proposed, :written, :published]
+        enum :last_read, { unread: 0, reading: 2, read: 3, forgotten: nil }
+      end
 
-    assert model2.not_published.exclude?(rfr.becomes(model2))
+      assert model2.not_published.exclude?(rfr.becomes(model2))
+    end
   end
 
   test "find via where with values" do

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1246,6 +1246,8 @@ Controls the format of the timestamp value in the cache key. Default is `:usec`.
 
 Is a boolean value that controls whether negative scopes for enums include records with `nil` values. When set to `true`, negative scopes will exclude records where the enum column is `nil`. When set to `false`, negative scopes will include records with `nil` values.
 
+This configuration is deprecated and will be removed in a future version of Rails. It is intended as a temporary measure to ease upgrades. Setting this to `true` will trigger a deprecation warning. If you need to keep the old behavior (excluding `nil` values), you should manually override the negative scope in your model instead of relying on this configuration.
+
 The default value depends on the `config.load_defaults` target version:
 
 | Starting with version | The default value is |

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.2
 
+- [`config.active_record.deprecated_negative_enum_scopes_exclude_nil`](#config-active-record-deprecated-negative-enum-scopes-exclude-nil): `false`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 
@@ -1240,6 +1241,17 @@ Controls whether Active Record will use optimistic locking and is `true` by defa
 #### `config.active_record.cache_timestamp_format`
 
 Controls the format of the timestamp value in the cache key. Default is `:usec`.
+
+#### `config.active_record.deprecated_negative_enum_scopes_exclude_nil`
+
+Is a boolean value that controls whether negative scopes for enums include records with `nil` values. When set to `true`, negative scopes will exclude records where the enum column is `nil`. When set to `false`, negative scopes will include records with `nil` values.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- |----------------------|
+| (original)            | `true`               |
+| 8.2                   | `false`              |
 
 #### `config.active_record.record_timestamps`
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -104,7 +104,17 @@ Book.not_published # => [book2]
 Book.not_published # => [book2, book3]
 ```
 
-If you want to maintain the previous behavior (excluding `nil` values), you can set the following configuration:
+If you want to maintain the previous behavior (excluding `nil` values), you should manually override the negative scope in your model:
+
+```ruby
+class Book < ApplicationRecord
+  enum :status, [:proposed, :written, :published]
+  # Override to exclude nil values
+  scope :not_published, -> { where.not(status: :published) }
+end
+```
+
+Alternatively, as a temporary measure during the upgrade, you can set the following configuration. Note that this configuration is deprecated and will be removed in a future version of Rails.
 
 ```ruby
 config.active_record.deprecated_negative_enum_scopes_exclude_nil = true

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -104,6 +104,12 @@ Book.not_published # => [book2]
 Book.not_published # => [book2, book3]
 ```
 
+If you want to maintain the previous behavior (excluding `nil` values), you can set the following configuration:
+
+```ruby
+config.active_record.deprecated_negative_enum_scopes_exclude_nil = true
+```
+
 Upgrading from Rails 8.0 to Rails 8.1
 -------------------------------------
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -374,6 +374,7 @@ module Rails
           if respond_to?(:active_record)
             active_record.postgresql_adapter_decode_bytea = true
             active_record.postgresql_adapter_decode_money = true
+            active_record.deprecated_negative_enum_scopes_exclude_nil = false
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -28,6 +28,16 @@
 # would exclude records where the enum column is `nil`. Starting in Rails 8.2, negative scopes
 # will include records with `nil` values by default.
 #
-# To restore the previous behavior, set this to `true`:
+# This configuration is deprecated and will be removed in a future version of Rails.
+# If you need to keep the old behavior (excluding `nil` values), manually override the
+# negative scope in your model instead:
+#
+#   class MyModel < ApplicationRecord
+#     enum :status, [:active, :inactive]
+#     scope :not_active, -> { where.not(status: :active) }
+#   end
+#
+# To temporarily restore the previous behavior during upgrade, uncomment the line below.
+# Note: Setting this to `true` will trigger a deprecation warning.
 #++
-# Rails.application.config.active_record.deprecated_negative_enum_scopes_exclude_nil = false
+# Rails.application.config.active_record.deprecated_negative_enum_scopes_exclude_nil = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -20,3 +20,14 @@
 #++
 # Rails.application.config.active_record.postgresql_adapter_decode_bytea = true
 # Rails.application.config.active_record.postgresql_adapter_decode_money = true
+
+###
+# Change negative scopes for enums to include records with `nil` values.
+#
+# Previously, negative scopes for enums (e.g., `not_active` for an enum with `active` status)
+# would exclude records where the enum column is `nil`. Starting in Rails 8.2, negative scopes
+# will include records with `nil` values by default.
+#
+# To restore the previous behavior, set this to `true`:
+#++
+# Rails.application.config.active_record.deprecated_negative_enum_scopes_exclude_nil = false

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -5207,6 +5207,13 @@ module ApplicationTests
       assert_not output.include?("Processing by Rails::WelcomeController#index as HTML")
     end
 
+    test "active_record.deprecated_negative_enum_scopes_exclude_nil can be configured" do
+      add_to_config "config.active_record.deprecated_negative_enum_scopes_exclude_nil = true"
+      app "development"
+      assert_equal true, Rails.application.config.active_record.deprecated_negative_enum_scopes_exclude_nil
+      assert_equal true, ActiveRecord::Base.deprecated_negative_enum_scopes_exclude_nil
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

In #55912 and c08989565fc7119ada007f8a20621db8df6f50a7, the behavior of negative scopes for enums was changed to include records with `nil` values using `IS DISTINCT FROM` operator. 
While this is a more correct SQL behavior, it's a breaking change for existing applications that may rely on the previous behavior of excluding `nil` values.

This Pull Request provides a configuration option to allow applications to choose between the new behavior (including `nil` values) and the old behavior (excluding `nil` values), giving developers control over this behavior change.

### Detail

This Pull Request adds a new configuration option `config.active_record.deprecated_negative_enum_scopes_exclude_nil`:

- When set to `false` (default for Rails 8.2+), negative scopes for enums will include records with `nil` values using `IS DISTINCT FROM`
- When set to `true`, negative scopes will exclude records with `nil` values using `WHERE.NOT`

```ruby
class Book < ApplicationRecord
  enum :status, [:proposed, :written, :published]
end

book1 = Book.create!(status: :published)
book2 = Book.create!(status: :written)
book3 = Book.create!(status: nil)

# With deprecated_negative_enum_scopes_exclude_nil = false (8.2 default)
Book.not_published # => [book2, book3]

# With deprecated_negative_enum_scopes_exclude_nil = true
Book.not_published # => [book2]
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
