### PR TITLE
add deep compact methods to hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "hash/conversions"
+require_relative "hash/deep_compact"
 require_relative "hash/deep_merge"
 require_relative "hash/deep_transform_values"
 require_relative "hash/except"

--- a/activesupport/lib/active_support/core_ext/hash/deep_compact.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_compact.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+class Hash
+  # Returns a new hash with all nil values removed recursively.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays.
+  #
+  #   hash = { a: 1, b: nil, c: { d: 2, e: nil } }
+  #
+  #   hash.deep_compact
+  #   # => { a: 1, c: { d: 2 } }
+  def deep_compact
+    _deep_compact_in_object(self)
+  end
+
+  # Destructively removes all nil values recursively.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays.
+  def deep_compact!
+    _deep_compact_in_object!(self)
+  end
+
+  # Returns a new hash with all blank values removed recursively.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays. Uses Object#blank? for determining
+  # if a value is blank.
+  #
+  #   hash = { a: 1, b: "", c: nil, d: [], e: false, f: { g: "", h: 2 } }
+  #
+  #   hash.deep_compact_blank
+  #   # => { a: 1, f: { h: 2 } }
+  def deep_compact_blank
+    _deep_compact_blank_in_object(self)
+  end
+
+  # Destructively removes all blank values recursively.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays. Uses Object#blank? for determining
+  # if a value is blank.
+  def deep_compact_blank!
+    _deep_compact_blank_in_object!(self)
+  end
+
+  private
+    # Support methods for deep compacting nested hashes and arrays.
+    def _deep_compact_in_object(object)
+      case object
+      when Hash
+        object.each_with_object({}) do |(key, value), result|
+          compacted_value = _deep_compact_in_object(value)
+          result[key] = compacted_value unless compacted_value.nil?
+        end
+      when Array
+        object.map { |e| _deep_compact_in_object(e) }
+      else
+        object
+      end
+    end
+
+    def _deep_compact_in_object!(object)
+      case object
+      when Hash
+        object.delete_if do |_key, value|
+          _deep_compact_in_object!(value)
+          value.nil?
+        end
+      when Array
+        object.map! { |e| _deep_compact_in_object!(e) }
+      else
+        object
+      end
+    end
+
+    def _deep_compact_blank_in_object(object)
+      case object
+      when Hash
+        object.each_with_object({}) do |(key, value), result|
+          compacted_value = _deep_compact_blank_in_object(value)
+          result[key] = compacted_value unless compacted_value.blank?
+        end
+      when Array
+        object.map { |e| _deep_compact_blank_in_object(e) }
+      else
+        object
+      end
+    end
+
+    def _deep_compact_blank_in_object!(object)
+      case object
+      when Hash
+        object.delete_if do |_key, value|
+          _deep_compact_blank_in_object!(value)
+          value.blank?
+        end
+      when Array
+        object.map! { |e| _deep_compact_blank_in_object!(e) }
+      else
+        object
+      end
+    end
+end
+

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -36,6 +36,10 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :deep_transform_keys!
     assert_respond_to h, :deep_transform_values
     assert_respond_to h, :deep_transform_values!
+    assert_respond_to h, :deep_compact
+    assert_respond_to h, :deep_compact!
+    assert_respond_to h, :deep_compact_blank
+    assert_respond_to h, :deep_compact_blank!
     assert_respond_to h, :symbolize_keys
     assert_respond_to h, :symbolize_keys!
     assert_respond_to h, :deep_symbolize_keys
@@ -103,6 +107,74 @@ class HashExtTest < ActiveSupport::TestCase
     transformed_hash.deep_transform_values! { |value| value.to_s }
     assert_equal({ "a" => { b: { "c" => "3" } } }, transformed_hash)
     assert_equal({ "a" => { b: { "c" => 3 } } }, @nested_mixed)
+  end
+
+  def test_deep_compact
+    hash_with_nil_values = { a: 1, b: nil, c: { d: 2, e: nil, f: { g: nil, h: 3 } } }
+    expected = { a: 1, c: { d: 2, f: { h: 3 } } }
+    assert_equal expected, hash_with_nil_values.deep_compact
+
+    hash_with_array = { a: [{ b: 1, c: nil }, { d: nil, e: 2 }] }
+    expected_with_array = { a: [{ b: 1 }, { e: 2 }] }
+    assert_equal expected_with_array, hash_with_array.deep_compact
+  end
+
+  def test_deep_compact_not_mutates
+    hash_with_nil_values = { a: 1, b: nil, c: { d: 2, e: nil } }
+    original = hash_with_nil_values.deep_dup
+    hash_with_nil_values.deep_compact
+    assert_equal original, hash_with_nil_values
+  end
+
+  def test_deep_compact!
+    hash_with_nil_values = { a: 1, b: nil, c: { d: 2, e: nil, f: { g: nil, h: 3 } } }
+    expected = { a: 1, c: { d: 2, f: { h: 3 } } }
+    assert_equal expected, hash_with_nil_values.deep_compact!
+
+    hash_with_array = { a: [{ b: 1, c: nil }, { d: nil, e: 2 }] }
+    expected_with_array = { a: [{ b: 1 }, { e: 2 }] }
+    assert_equal expected_with_array, hash_with_array.deep_compact!
+  end
+
+  def test_deep_compact_with_bang_mutates
+    hash_with_nil_values = { a: 1, b: nil, c: { d: 2, e: nil } }
+    hash_with_nil_values.deep_compact!
+    expected = { a: 1, c: { d: 2 } }
+    assert_equal expected, hash_with_nil_values
+  end
+
+  def test_deep_compact_blank
+    hash_with_blank_values = { a: 1, b: "", c: nil, d: [], e: {}, f: false, g: { h: "", i: 2 } }
+    expected = { a: 1, g: { i: 2 } }
+    assert_equal expected, hash_with_blank_values.deep_compact_blank
+
+    hash_with_array = { a: [{ b: 1, c: "" }, { d: nil, e: 2 }] }
+    expected_with_array = { a: [{ b: 1 }, { e: 2 }] }
+    assert_equal expected_with_array, hash_with_array.deep_compact_blank
+  end
+
+  def test_deep_compact_blank_not_mutates
+    hash_with_blank_values = { a: 1, b: "", c: nil, d: [] }
+    original = hash_with_blank_values.deep_dup
+    hash_with_blank_values.deep_compact_blank
+    assert_equal original, hash_with_blank_values
+  end
+
+  def test_deep_compact_blank!
+    hash_with_blank_values = { a: 1, b: "", c: nil, d: [], e: {}, f: false, g: { h: "", i: 2 } }
+    expected = { a: 1, g: { i: 2 } }
+    assert_equal expected, hash_with_blank_values.deep_compact_blank!
+
+    hash_with_array = { a: [{ b: 1, c: "" }, { d: nil, e: 2 }] }
+    expected_with_array = { a: [{ b: 1 }, { e: 2 }] }
+    assert_equal expected_with_array, hash_with_array.deep_compact_blank!
+  end
+
+  def test_deep_compact_blank_with_bang_mutates
+    hash_with_blank_values = { a: 1, b: "", c: nil, d: [] }
+    hash_with_blank_values.deep_compact_blank!
+    expected = { a: 1 }
+    assert_equal expected, hash_with_blank_values
   end
 
   def test_symbolize_keys


### PR DESCRIPTION
## Motivation / Background

While Ruby's `Hash#compact` removes nil values from a hash, it only operates at the top level. When working with nested hashes (common in Rails applications, especially with params, JSON responses, and nested attributes), there's no built-in way to remove nil or blank values recursively.

This PR adds four new methods to Hash that recursively remove nil or blank values from nested structures.

## Detail

This PR introduces four new methods to `Hash`:

- **`deep_compact`**: Returns a new hash with all nil values removed recursively
- **`deep_compact!`**: Destructive version of `deep_compact`
- **`deep_compact_blank`**: Returns a new hash with all blank values removed recursively (using `Object#blank?`)
- **`deep_compact_blank!`**: Destructive version of `deep_compact_blank`

All methods handle nested hashes and arrays containing hashes.

## Examples

# deep_compact - removes nil values recursively
hash = { a: 1, b: nil, c: { d: 2, e: nil, f: { g: nil, h: 3 } } }
hash.deep_compact
# => { a: 1, c: { d: 2, f: { h: 3 } } }

# deep_compact_blank - removes blank values recursively
hash = { a: 1, b: "", c: nil, d: [], e: {}, f: false, g: { h: "", i: 2 } }
hash.deep_compact_blank
# => { a: 1, g: { i: 2 } }

# Works with arrays of hashes
hash = { a: [{ b: 1, c: nil }, { d: nil, e: 2 }] }
hash.deep_compact
# => { a: [{ b: 1 }, { e: 2 }] }## Use Cases

- Cleaning up API responses before sending to clients
- Removing blank nested attributes before validation
- Sanitizing form params with nested structures
- Data cleanup in JSON serialization

## Implementation Details

The implementation follows the same pattern as existing deep methods like `deep_transform_values` and `deep_transform_keys`:
- Uses private helper methods for recursion
- Handles both Hash and Array types
- Non-destructive versions create new objects
- Destructive versions (with `!`) modify in place

## Additional Information

⚠️ **Note**: According to Rails contributing guidelines, changes to Active Support core extensions are generally discouraged to avoid conflicts with future Ruby versions. This PR is being submitted for discussion and consideration by the core team. If accepted here, a similar proposal could be made to Ruby core, or this could be considered for Rails-specific use cases where the functionality is particularly valuable.

## Checklist

- [x] Implementation follows existing Rails patterns
- [x] Tests added for all new methods
- [x] Tests cover edge cases (nested hashes, arrays, empty values)
- [x] Both destructive and non-destructive variants implemented
- [x] Documentation includes clear examples
- [x] No linter errors