### PR TITLE
Add support for PostgreSQL index `WITH (...)` options

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow PostgreSQL index storage parameters to be managed via the `with:` option
+    on `add_index`, and include them in schema dumps and `index_exists?` lookups.
+
+    *Danila Poyarkov*
+
 *   Fix inconsistency in PostgreSQL handling of unbounded time range types
 
     Use `-infinity` rather than `NULL` for the lower value of PostgreSQL time

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -117,6 +117,9 @@ module ActiveRecord
           sql << "(#{quoted_columns(index)})"
           sql << "INCLUDE (#{quoted_include_columns(index.include)})" if supports_index_include? && index.include
           sql << "NULLS NOT DISTINCT" if supports_nulls_not_distinct? && index.nulls_not_distinct
+          if clause = index_with_clause(index)
+            sql << clause
+          end
           sql << "WHERE #{index.where}" if supports_partial_index? && index.where
 
           sql.join(" ")
@@ -137,6 +140,8 @@ module ActiveRecord
         def supports_index_using?
           true
         end
+
+        def index_with_clause(index); end
 
         def add_table_options!(create_sql, o)
           create_sql << " #{o.options}" if o.options

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
     class IndexDefinition # :nodoc:
-      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :include, :nulls_not_distinct, :comment, :valid
+      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :include, :nulls_not_distinct, :comment, :valid, :with
 
       def initialize(
         table, name,
@@ -21,7 +21,8 @@ module ActiveRecord
         include: nil,
         nulls_not_distinct: nil,
         comment: nil,
-        valid: true
+        valid: true,
+        with: nil
       )
         @table = table
         @name = name
@@ -37,6 +38,7 @@ module ActiveRecord
         @nulls_not_distinct = nulls_not_distinct
         @comment = comment
         @valid = valid
+        @with = with
       end
 
       def valid?
@@ -51,14 +53,15 @@ module ActiveRecord
         }
       end
 
-      def defined_for?(columns = nil, name: nil, unique: nil, valid: nil, include: nil, nulls_not_distinct: nil, **options)
+      def defined_for?(columns = nil, name: nil, unique: nil, valid: nil, include: nil, nulls_not_distinct: nil, with: nil, **options)
         columns = options[:column] if columns.blank?
         (columns.nil? || Array(self.columns) == Array(columns).map(&:to_s)) &&
           (name.nil? || self.name == name.to_s) &&
           (unique.nil? || self.unique == unique) &&
           (valid.nil? || self.valid == valid) &&
           (include.nil? || Array(self.include) == Array(include).map(&:to_s)) &&
-          (nulls_not_distinct.nil? || self.nulls_not_distinct == nulls_not_distinct)
+          (nulls_not_distinct.nil? || self.nulls_not_distinct == nulls_not_distinct) &&
+          (with.nil? || self.with == with)
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -146,6 +146,18 @@ module ActiveRecord
             String === o ? o : quoted_include_columns_for_index(o)
           end
 
+          def index_with_clause(index)
+            return unless index.with.present?
+
+            unless index.with.is_a?(Hash)
+              raise ArgumentError, "Index storage options must be a hash, got #{index.with.class.name}"
+            end
+
+            clauses = index.with.map { |key, value| "#{key} = #{value}" }
+
+            "WITH (#{clauses.join(', ')})" if clauses.any?
+          end
+
           # Returns any SQL string to go between CREATE and TABLE. May be nil.
           def table_modifier_in_create(o)
             # A table cannot be both TEMPORARY and UNLOGGED, since all TEMPORARY

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -275,6 +275,7 @@ module ActiveRecord
         index_parts << "using: #{index.using.inspect}" if !@connection.default_index_type?(index)
         index_parts << "include: #{index.include.inspect}" if index.include
         index_parts << "nulls_not_distinct: #{index.nulls_not_distinct.inspect}" if index.nulls_not_distinct
+        index_parts << "with: #{format_index_parts(index.with)}" if index.with
         index_parts << "type: #{index.type.inspect}" if index.type
         index_parts << "comment: #{index.comment.inspect}" if index.comment
         index_parts << "enabled: #{index.enabled.inspect}" if @connection.supports_disabling_indexes? && index.disabled?

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -82,6 +82,16 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
       assert_equal expected, add_index(:people, :last_name, nulls_not_distinct: true)
     end
 
+    expected = %(CREATE INDEX "index_people_on_last_name" ON "people" ("last_name") WITH (fillfactor = 70))
+    assert_equal expected, add_index(:people, :last_name, with: { fillfactor: 70 })
+
+    expected = %(CREATE INDEX "index_people_on_last_name" ON "people" ("last_name") WITH (fillfactor = 70, deduplicate_items = on))
+    assert_equal expected, add_index(:people, :last_name, with: { fillfactor: 70, deduplicate_items: :on })
+
+    assert_raise ArgumentError do
+      add_index(:people, :last_name, with: "fillfactor = 70")
+    end
+
     assert_raise ArgumentError do
       add_index(:people, :last_name, algorithm: :copy)
     end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -321,6 +321,26 @@ module ActiveRecord
         assert_not connection.index_exists?("testings", "last_name", nulls_not_distinct: true)
       end
 
+      def test_add_index_with_with_option_assert_exists_with_same_values
+        skip("current adapter doesn't support index storage parameters") unless current_adapter?(:PostgreSQLAdapter)
+
+        connection.add_index("testings", "last_name", with: { fillfactor: 80 })
+        assert connection.index_exists?("testings", "last_name", with: { fillfactor: 80 })
+
+        connection.remove_index("testings", column: "last_name", with: { fillfactor: 80 })
+        assert_not connection.index_exists?("testings", "last_name", with: { fillfactor: 80 })
+      end
+
+      def test_add_index_with_with_option_assert_exists_with_different_values
+        skip("current adapter doesn't support index storage parameters") unless current_adapter?(:PostgreSQLAdapter)
+
+        connection.add_index("testings", "last_name", with: { fillfactor: 80 })
+        assert_not connection.index_exists?("testings", "last_name", with: { fillfactor: 70 })
+
+        connection.remove_index("testings", column: "last_name")
+        assert_not connection.index_exists?("testings", "last_name", with: { fillfactor: 80 })
+      end
+
       if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
         def test_index_visibility_through_add_index
           connection.add_index(:testings, :foo, enabled: false)

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       end
 
       def invalid_add_index_option_exception_message(key)
-        default_keys = [":unique", ":length", ":order", ":opclass", ":where", ":type", ":using", ":comment", ":algorithm", ":include", ":nulls_not_distinct"]
+        default_keys = [":unique", ":length", ":order", ":opclass", ":where", ":type", ":using", ":comment", ":algorithm", ":include", ":nulls_not_distinct", ":with"]
 
         if connection.supports_disabling_indexes?
           default_keys.concat([":enabled"])

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -206,6 +206,7 @@ _SQL
   end
 
   add_index(:companies, [:firm_id, :type], name: "company_include_index", include: [:name, :account_id])
+  add_index(:companies, :firm_id, name: "company_with_fillfactor_index", with: { fillfactor: 70 })
 
   if supports_insert_returning?
     create_table :pk_autopopulated_by_a_trigger_records, force: true, id: false do |t|


### PR DESCRIPTION
### Motivation / Background

PostgreSQL’s `WITH (...)` storage parameters are required by some extensions and index types. ParadeDB’s `bm25` search index, for example, must include a `WITH` clause that defines tokenizers, stemmers, and other schema details. Without DSL support, these indexes can’t be expressed in migrations, inspected via `index_exists?`, or round-tripped through schema dumps.

Closes #56116.

### Detail

- `IndexDefinition` now records a `with` hash for storage parameters.
- `add_index` / `index_exists?` accept `with:` hash and normalize it, ensuring migrations, checks, and schema dumps stay consistent.
- PostgreSQL adapter parses `WITH (...)` into the new `with` attribute and emits the clause when generating SQL.
- `SchemaDumper` includes `with:` in schema.rb, completing the round trip.

### Additional Information

- ParadeDB `bm25` example: https://docs.paradedb.com/v2/indexing/create-index#create-an-index
- PostgreSQL reference: https://www.postgresql.org/docs/current/sql-createindex.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
