### PR TITLE
Fix foreign key test for MariaDB 12.1.1+ error message format

### DIFF
--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -860,7 +860,7 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
 
             if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
               if ActiveRecord::Base.lease_connection.mariadb?
-                assert_match(/Duplicate key on write or update/, error.message)
+                assert_match(/Duplicate key on write or update|Duplicate FOREIGN KEY/, error.message)
               elsif ActiveRecord::Base.lease_connection.database_version < "8.0"
                 assert_match(/Can't write; duplicate key in table/, error.message)
               else


### PR DESCRIPTION
### Motivation / Background
This commit addresses the following failure with MariaDB 12.1.1.

### Detail

```ruby
$ ARCONN=mysql2 bin/test test/cases/migration/foreign_key_test.rb:863
Using mysql2
Run options: --seed 34393

F

Failure:
ActiveRecord::Migration::ForeignKeyTest#test_add_foreign_key_with_if_not_exists_not_set [test/cases/migration/foreign_key_test.rb:863]:
Expected /Duplicate key on write or update/ to match "Mysql2::Error: Duplicate FOREIGN KEY constraint name ''".

bin/test test/cases/migration/foreign_key_test.rb:848

Finished in 0.474266s, 2.1085 runs/s, 8.4341 assertions/s.
1 runs, 4 assertions, 1 failures, 0 errors, 0 skips
$
```

since MariaDB 12.1.1 introduced per-table unique FOREIGN KEY constraint names (MDEV-28933), which changed the error message format for duplicate foreign key constraints.

### Additional information

References
https://mariadb.com/docs/release-notes/community-server/12.1/12.1.1#miscellaneous
> Per-table unique FOREIGN KEY constraint names (MDEV-28933)

https://jira.mariadb.org/browse/MDEV-28933
https://github.com/MariaDB/server/pull/3960

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
