### PR TITLE
Fix AudioAnalyzerTest for ffmpeg 7 and ffmpeg 8

### DIFF
--- a/activestorage/test/analyzer/audio_analyzer_test.rb
+++ b/activestorage/test/analyzer/audio_analyzer_test.rb
@@ -10,7 +10,8 @@ class ActiveStorage::Analyzer::AudioAnalyzerTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
     metadata = extract_metadata_from(blob)
 
-    assert_equal 0.914286, metadata[:duration]
+    assert (0.863379..0.914286).include?(metadata[:duration])
+
     assert_equal 128000, metadata[:bit_rate]
     assert_equal 44100, metadata[:sample_rate]
     assert_not_nil metadata[:tags]


### PR DESCRIPTION
```
ffmpeg -acodec mp3 -i test/fixtures/files/audio.mp3 -hide_banner

Input #0, mp3, from 'test/fixtures/files/audio.mp3':
  Metadata:
    major_brand     : M4A
    minor_version   : 0
    compatible_brands: M4A mp42isom
    iTunSMPB        :  00000000 00000F45 00000269 0000000000009252 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
    encoder         : Lavf57.56.100
  Duration: 00:00:00.91, start: 0.025057, bitrate: 132 kb/s
  Stream #0:0: Audio: mp3, 44100 Hz, stereo, s16p, 128 kb/s
    Metadata:
      encoder         : Lavc57.64
```

---

```
~/ffmpeg8/bin/ffmpeg -acodec mp3 -i test/fixtures/files/audio.mp3 -hide_banner

Input #0, mp3, from 'test/fixtures/files/audio.mp3':
  Metadata:
    major_brand     : M4A
    minor_version   : 0
    compatible_brands: M4A mp42isom
    iTunSMPB        :  00000000 00000F45 00000269 0000000000009252 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
    encoder         : Lavf57.56.100
  Duration: 00:00:00.86, start: 0.025057, bitrate: 140 kb/s
  Stream #0:0: Audio: mp3, 44100 Hz, stereo, s16p, 128 kb/s, start 0.025057
    Metadata:
      encoder         : Lavc57.64
```

---

```diff
- Duration: 00:00:00.91, start: 0.025057, bitrate: 132 kb/s
+ Duration: 00:00:00.86, start: 0.025057, bitrate: 140 kb/s
```

If I had to guess it might be this commit: FFmpeg/FFmpeg@5a526fd but I think we don't expect the analyzer to touch the duration, only return the value from `ffmpeg` so accepting both values seems reasonable here.

Fixes #56069 /cc @voxik @rathann
