### PR TITLE
Optimize `String#strip_heredoc`

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -20,8 +20,32 @@ class String
   # Technically, it looks for the least indented non-empty line
   # in the whole string, and removes that amount of leading whitespace.
   def strip_heredoc
-    gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, "").tap do |stripped|
-      stripped.freeze if frozen?
+    scanner = StringScanner.new("")
+
+    min_indent_len = nil
+    lines = self.lines
+
+    lines.each do |line|
+      scanner.string = line
+      indent_len = scanner.skip(/[ \t]*/)
+
+      next unless scanner.match?(/[^\r\n]/)
+
+      min_indent_len = indent_len if indent_len < (min_indent_len || Float::INFINITY)
     end
+
+
+    if min_indent_len.nil? || min_indent_len.zero?
+      return frozen? ? self : dup
+    end
+
+    lines.each do |line|
+      line[0, min_indent_len] = "" unless line == "\n"
+    end
+
+    result = lines.join
+
+    result.freeze if frozen?
+    result
   end
 end


### PR DESCRIPTION
Speed up `String#strip_heredoc` by 1.5x to 5x when yjit is enabled. It's still faster on 2/3 cases without yjit enabled.

New version doesn't allocate any strings to find the `minimum_indent` to be stripped. Instead uses `StringScanner#skip` per each line to count whitespace char length.

<details markdown="1">

<summary>Benchmark script</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

require "strscan"

def strip_heredoc(str)
  str.gsub(/^#{str.scan(/^[ \t]*(?=\S)/).min}/, "").tap do |stripped|
    stripped.freeze if str.frozen?
  end
end

def fast_strip_heredoc(str)
  scanner = StringScanner.new(str)
  min_indent_len = Float::INFINITY

  until scanner.eos?
    indent_len = scanner.skip(/[ \t]*/)

    min_indent_len = [min_indent_len, indent_len].min if scanner.match?(/[^\r\n]/)

    scanner.skip_until(/\n/) || scanner.terminate
  end

  return str if min_indent_len.zero? || min_indent_len.infinite?

  scanner.reset
  result = +""
  indent_pattern = /[ \t]{#{min_indent_len}}/.freeze

  until scanner.eos?
    scanner.skip(indent_pattern)
    line_rest = scanner.scan_until(/\n/)
    result << (line_rest || scanner.rest)

    scanner.terminate if line_rest.nil?
  end

  result.tap { |stripped| stripped.freeze if str.frozen? }
end

# https://gitlab.com/gitlab-org/gitlab/-/blob/master/ee/spec/requests/api/graphql/mutations/boards/issues/issue_move_list_spec.rb#L112
gitlab_scenario = <<-GRAPQL
                       clientMutationId
                       issue {
                         iid,
                         relativePosition
                         epic {
                           id
                         }
                         labels {
                           nodes {
                             title
                           }
                         }
                       }
                       errors
GRAPQL

# https://github.com/mastodon/mastodon/blob/main/lib/mastodon/migration_helpers.rb#L458
mastodon_scenario = <<-SQL
           select m.relname as src_table,
            (select a.attname
              from pg_attribute a
              where a.attrelid = m.oid
                and a.attnum = o.conkey[1]
                and a.attisdropped = false) as src_col,
            o.conname as name,
            o.confdeltype as on_delete
          from pg_constraint o
          left join pg_class f on f.oid = o.confrelid
          left join pg_class c on c.oid = o.conrelid
          left join pg_class m on m.oid = o.conrelid
          where o.contype = 'f'
            and o.conrelid in (
              select oid from pg_class c where c.relkind = 'r')
            and f.relname = 'table';
SQL

fifty_lines_mixed_indents = Array.new(50) { |i| "#{'  ' * ((i % 3) + 3)} puts 123" }.join('\n')

SCENARIOS = {
  "gitlab" => gitlab_scenario,
  "mastodon" => mastodon_scenario,
  "fifty_lines_mixed_indents" => fifty_lines_mixed_indents,
}

SCENARIOS.each_pair do |name, value|
  puts "*" * 80
  puts name

  puts "Speed"
  Benchmark.ips do |x|
    x.report("strip_heredoc")      { strip_heredoc(value) }
    x.report("fast_strip_heredoc") { fast_strip_heredoc(value) }
    x.compare!
  end

  puts "MEMORY"
  Benchmark.memory do |x|
    x.report("strip_heredoc")      { strip_heredoc(value) }
    x.report("fast_strip_heredoc") { fast_strip_heredoc(value) }

    x.compare!
  end
end
```
</details>

```
********************************************************************************
gitlab
Speed
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
       strip_heredoc     4.747k i/100ms
  fast_strip_heredoc     8.553k i/100ms
Calculating -------------------------------------
       strip_heredoc     59.183k (± 5.5%) i/s   (16.90 μs/i) -    299.061k in   5.067798s
  fast_strip_heredoc     89.778k (± 3.9%) i/s   (11.14 μs/i) -    453.309k in   5.057238s

Comparison:
  fast_strip_heredoc:    89778.0 i/s
       strip_heredoc:    59182.7 i/s - 1.52x  slower

MEMORY
Calculating -------------------------------------
       strip_heredoc     3.469k memsize (     0.000  retained)
                        27.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)
  fast_strip_heredoc     1.788k memsize (     0.000  retained)
                        25.000  objects (     0.000  retained)
                        18.000  strings (     0.000  retained)

Comparison:
  fast_strip_heredoc:       1788 allocated
       strip_heredoc:       3469 allocated - 1.94x more
********************************************************************************
mastodon
Speed
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
       strip_heredoc     4.656k i/100ms
  fast_strip_heredoc    10.135k i/100ms
Calculating -------------------------------------
       strip_heredoc     47.692k (± 5.1%) i/s   (20.97 μs/i) -    242.112k in   5.088318s
  fast_strip_heredoc    103.835k (± 3.0%) i/s    (9.63 μs/i) -    527.020k in   5.080055s

Comparison:
  fast_strip_heredoc:   103835.5 i/s
       strip_heredoc:    47692.2 i/s - 2.18x  slower

MEMORY
Calculating -------------------------------------
       strip_heredoc     2.928k memsize (     0.000  retained)
                        28.000  objects (     0.000  retained)
                         8.000  strings (     0.000  retained)
  fast_strip_heredoc     2.812k memsize (     0.000  retained)
                        27.000  objects (     0.000  retained)
                        21.000  strings (     0.000  retained)

Comparison:
  fast_strip_heredoc:       2812 allocated
       strip_heredoc:       2928 allocated - 1.04x more
********************************************************************************
fifty_lines_mixed_indents
Speed
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
       strip_heredoc     5.880k i/100ms
  fast_strip_heredoc    31.145k i/100ms
Calculating -------------------------------------
       strip_heredoc     52.562k (± 9.6%) i/s   (19.03 μs/i) -    264.600k in   5.088349s
  fast_strip_heredoc    283.722k (±11.7%) i/s    (3.52 μs/i) -      1.402M in   5.013711s

Comparison:
  fast_strip_heredoc:   283721.5 i/s
       strip_heredoc:    52562.1 i/s - 5.40x  slower

MEMORY
Calculating -------------------------------------
       strip_heredoc     2.358k memsize (     0.000  retained)
                        13.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
  fast_strip_heredoc     3.024k memsize (     0.000  retained)
                        12.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)

Comparison:
       strip_heredoc:       2358 allocated
  fast_strip_heredoc:       3024 allocated - 1.28x more
```
