### PR TITLE
Enhance rate limiting to support dynamic `to:` and `within:` options

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Support dynamic `to:` and `within:` options in `rate_limit`.
+
+    The `to:` and `within:` options now accept callables (lambdas or procs) and
+    method names (as symbols), in addition to static values. This allows for
+    dynamic rate limiting based on user attributes or other runtime conditions.
+
+    ```ruby
+    class APIController < ApplicationController
+      rate_limit to: :max_requests, within: :time_window, by: -> { current_user.id }
+
+      private
+        def max_requests
+          current_user.premium? ? 1000 : 100
+        end
+
+        def time_window
+          current_user.premium? ? 1.hour : 1.minute
+        end
+    end
+    ```
+
+    *Murilo Duarte*
+
 *   Define `ActionController::Parameters#deconstruct_keys` to support pattern matching
 
     ```ruby


### PR DESCRIPTION
### Motivation / Background

The `rate_limit` API already supports method names for `:by` and `:with`, bringing parity with callback declarations like `before_action`. Extending this to `:to` and `:within` allows applications to express dynamic limits (per-user, per-plan, per-tenant) without boilerplate conditionals in controllers. This improves flexibility while keeping existing static usages untouched. Related prior work: support for method names on `:by` and `:with` (see commit `63166fe`) [link](https://github.com/muriloduarte/rails/commit/63166fe6233527ddbe16f741a5a49d8b0854cdc3).

### Detail

Changes `ActionController::RateLimiting` so that `to:` and `within:` accept:
- Static values (unchanged behavior), e.g. `to: 10`, `within: 1.minute`.
- Instance method names (symbols), evaluated in the controller context via `send`.
- Callables (lambdas/procs), evaluated in the controller context via `instance_exec`.

Resolution logic:
- If value is a Symbol → `send(value)`
- Else if it responds to `call` → `instance_exec(&value)`
- Else → use as-is

### Additional information

- Aligns with earlier change to allow method names for `:by` and `:with` (commit `63166fe`) [link](https://github.com/muriloduarte/rails/commit/63166fe6233527ddbe16f741a5a49d8b0854cdc3).
- Negligible overhead (a couple of conditional checks) on the rate-limited path.
- Considered edge case: objects that respond to `call` but are intended as literals; current approach mirrors existing conventions in the codebase.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
