### PR TITLE
QueryIntent#execute!

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -119,6 +119,10 @@ module ActiveRecord
         internal_exec_query(sql, name, allow_retry:, materialize_transactions:).rows
       end
 
+      def query_command(sql, name = nil, allow_retry: false, materialize_transactions: true) # :nodoc:
+        affected_rows(internal_execute(sql, name, allow_retry: allow_retry, materialize_transactions: materialize_transactions))
+      end
+
       # Determines whether the SQL statement is a write query.
       def write_query?(sql)
         raise NotImplementedError

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -142,7 +142,7 @@ module ActiveRecord
         query_all(...).rows
       end
 
-      def query_all(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
+      def query_all(sql, name = "SCHEMA", allow_retry: true, materialize_transactions: false) # :nodoc:
         intent = internal_build_intent(sql, name, allow_retry:, materialize_transactions:)
         intent.execute!
         intent.cast_result

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -79,9 +79,28 @@ module ActiveRecord
           allow_retry: allow_retry
         )
 
-        select(intent, async: async && FutureResult::SelectAll)
-      rescue ::RangeError
-        ActiveRecord::Result.empty(async: async)
+        if async && async_enabled?
+          if current_transaction.joinable?
+            raise AsynchronousQueryInsideTransactionError, "Asynchronous queries are not allowed inside transactions"
+          end
+
+          future_result = FutureResult::SelectAll.new(pool, intent)
+          future_result.schedule!(ActiveRecord::Base.asynchronous_queries_session)
+          future_result
+        else
+          begin
+            intent.execute!
+            result = intent.cast_result
+          rescue ::RangeError
+            result = ActiveRecord::Result.empty
+          end
+
+          if async
+            FutureResult.wrap(result)
+          else
+            result
+          end
+        end
       end
 
       # Returns a record hash with the column names as keys and column values
@@ -120,7 +139,9 @@ module ActiveRecord
       end
 
       def query_command(sql, name = nil, allow_retry: false, materialize_transactions: true) # :nodoc:
-        affected_rows(internal_execute(sql, name, allow_retry: allow_retry, materialize_transactions: materialize_transactions))
+        intent = internal_build_intent(sql, name, allow_retry: allow_retry, materialize_transactions: materialize_transactions)
+        intent.execute!
+        intent.finish
       end
 
       # Determines whether the SQL statement is a write query.
@@ -143,7 +164,9 @@ module ActiveRecord
       # method may be manually memory managed. Consider using #exec_query
       # wrapper instead.
       def execute(sql, name = nil, allow_retry: false)
-        internal_execute(sql, name, allow_retry: allow_retry)
+        intent = internal_build_intent(sql, name, allow_retry: allow_retry)
+        intent.execute!
+        intent.raw_result
       end
 
       # Executes +sql+ statement in the context of this connection using
@@ -174,21 +197,26 @@ module ActiveRecord
         intent.raw_sql = sql
         intent.binds = binds
 
-        raw_exec_query(intent)
+        intent.execute!
+        intent.cast_result
       end
 
       # Executes delete +sql+ statement in the context of this connection using
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.
       def exec_delete(sql, name = nil, binds = [])
-        affected_rows(internal_execute(sql, name, binds))
+        intent = internal_build_intent(sql, name, binds)
+        intent.execute!
+        intent.affected_rows
       end
 
       # Executes update +sql+ statement in the context of this connection using
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.
       def exec_update(sql, name = nil, binds = [])
-        affected_rows(internal_execute(sql, name, binds))
+        intent = internal_build_intent(sql, name, binds)
+        intent.execute!
+        intent.affected_rows
       end
 
       deprecate :exec_insert, :exec_delete, :exec_update, deprecator: ActiveRecord.deprecator
@@ -227,14 +255,16 @@ module ActiveRecord
       def update(arel, name = nil, binds = [])
         intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
 
-        affected_rows(raw_execute(intent))
+        intent.execute!
+        intent.affected_rows
       end
 
       # Executes the delete statement and returns the number of rows affected.
       def delete(arel, name = nil, binds = [])
         intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
 
-        affected_rows(raw_execute(intent))
+        intent.execute!
+        intent.affected_rows
       end
 
       # Executes the truncate statement.
@@ -562,14 +592,11 @@ module ActiveRecord
         HIGH_PRECISION_CURRENT_TIMESTAMP
       end
 
-      # Same as raw_execute but returns an ActiveRecord::Result object.
-      def raw_exec_query(intent) # :nodoc:
-        cast_result(raw_execute(intent))
-      end
-
       # Execute a query and returns an ActiveRecord::Result
       def internal_exec_query(...) # :nodoc:
-        cast_result(internal_execute(...))
+        intent = internal_build_intent(...)
+        intent.execute!
+        intent.cast_result
       end
 
       def default_insert_value(column) # :nodoc:
@@ -591,21 +618,23 @@ module ActiveRecord
         sql
       end
 
+      # Lowest-level abstract execution of a query, called only from the intent itself.
+      # Final wrapper around the subclass-specific +perform_query+. Populates the calling
+      # intent's raw_result.
+      def execute_intent(intent) # :nodoc:
+        log(intent) do |notification_payload|
+          intent.notification_payload = notification_payload
+          with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: intent.materialize_transactions) do |conn|
+            result = perform_query(conn, intent)
+            intent.raw_result = result
+            handle_warnings(result, intent.processed_sql)
+          end
+        end
+      end
+
       private
         DEFAULT_INSERT_VALUE = Arel.sql("DEFAULT").freeze
         private_constant :DEFAULT_INSERT_VALUE
-
-        # Lowest level way to execute a query. Doesn't check for illegal writes, doesn't annotate queries, yields a native result object.
-        def raw_execute(intent)
-          log(intent) do |notification_payload|
-            intent.notification_payload = notification_payload
-            with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: intent.materialize_transactions) do |conn|
-              result = perform_query(conn, intent)
-              handle_warnings(result, intent.processed_sql)
-              result
-            end
-          end
-        end
 
         def perform_query(raw_connection, intent)
           raise NotImplementedError
@@ -623,19 +652,17 @@ module ActiveRecord
           raise NotImplementedError
         end
 
-        # Same as #internal_exec_query, but yields a native adapter result
-        def internal_execute(sql, name = "SQL", binds = [], prepare: false, async: false, allow_retry: false, materialize_transactions: true, &block)
-          intent = QueryIntent.new(
+        # Same as #internal_exec_query, but returns a QueryIntent without executing
+        def internal_build_intent(sql, name = "SQL", binds = [], prepare: false, allow_retry: false, materialize_transactions: true, &block)
+          QueryIntent.new(
             adapter: self,
             raw_sql: sql,
             name: name,
             binds: binds,
             prepare: prepare,
-            async: async,
             allow_retry: allow_retry,
             materialize_transactions: materialize_transactions
           )
-          raw_execute(intent, &block)
         end
 
         def execute_batch(statements, name = nil, **kwargs)
@@ -646,12 +673,12 @@ module ActiveRecord
               name: name,
               binds: kwargs[:binds] || [],
               prepare: kwargs[:prepare] || false,
-              async: kwargs[:async] || false,
               allow_retry: kwargs[:allow_retry] || false,
               materialize_transactions: kwargs[:materialize_transactions] != false,
               batch: kwargs[:batch] || false
             )
-            raw_execute(intent)
+            intent.execute!
+            intent.finish
           end
         end
 
@@ -722,26 +749,6 @@ module ActiveRecord
 
         def combine_multi_statements(total_sql)
           total_sql.join(";\n")
-        end
-
-        # Returns an ActiveRecord::Result instance.
-        def select(intent, async: false)
-          if async && async_enabled?
-            if current_transaction.joinable?
-              raise AsynchronousQueryInsideTransactionError, "Asynchronous queries are not allowed inside transactions"
-            end
-
-            future_result = async.new(pool, intent)
-            future_result.schedule!(ActiveRecord::Base.asynchronous_queries_session)
-            future_result
-          else
-            result = raw_exec_query(intent)
-            if async
-              FutureResult.wrap(result)
-            else
-              result
-            end
-          end
         end
 
         def sql_for_insert(sql, pk, binds, returning) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -610,21 +610,6 @@ module ActiveRecord
         DEFAULT_INSERT_VALUE
       end
 
-      def preprocess_query(sql) # :nodoc:
-        if write_query?(sql)
-          ensure_writes_are_allowed(sql)
-        end
-
-        # We call tranformers after the write checks so we don't add extra parsing work.
-        # This means we assume no transformer whille change a read for a write
-        # but it would be insane to do such a thing.
-        ActiveRecord.query_transformers&.each do |transformer|
-          sql = transformer.call(sql, self)
-        end
-
-        sql
-      end
-
       # Lowest-level abstract execution of a query, called only from the intent itself.
       # Final wrapper around the subclass-specific +perform_query+. Populates the calling
       # intent's raw_result.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -127,15 +127,25 @@ module ActiveRecord
       end
 
       def query_value(...) # :nodoc:
-        single_value_from_rows(query(...))
+        single_value_from_rows(query_rows(...))
       end
 
       def query_values(...) # :nodoc:
-        query(...).map(&:first)
+        query_rows(...).map(&:first)
       end
 
-      def query(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
-        internal_exec_query(sql, name, allow_retry:, materialize_transactions:).rows
+      def query_one(...) # :nodoc:
+        query_all(...).first
+      end
+
+      def query_rows(...) # :nodoc:
+        query_all(...).rows
+      end
+
+      def query_all(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
+        intent = internal_build_intent(sql, name, allow_retry:, materialize_transactions:)
+        intent.execute!
+        intent.cast_result
       end
 
       def query_command(sql, name = nil, allow_retry: false, materialize_transactions: true) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -81,6 +81,7 @@ module ActiveRecord
       def select_all(arel, name = nil, binds = [], preparable: nil, async: false, allow_retry: false)
         arel = arel_from_relation(arel)
         intent = QueryIntent.new(
+          adapter: self,
           arel: arel,
           name: name,
           binds: binds,
@@ -169,7 +170,7 @@ module ActiveRecord
       # `nil` is the default value and maintains default behavior. If an array of column names is passed -
       # the result will contain values of the specified columns from the inserted row.
       def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil)
-        intent = QueryIntent.new(raw_sql: sql, name: name, binds: binds)
+        intent = QueryIntent.new(adapter: self, raw_sql: sql, name: name, binds: binds)
 
         _exec_insert(intent, pk, sequence_name, returning: returning)
       end
@@ -218,7 +219,7 @@ module ActiveRecord
       # `nil` is the default value and maintains default behavior. If an array of column names is passed -
       # an array of is returned from the method representing values of the specified columns from the inserted row.
       def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
-        intent = QueryIntent.new(arel: arel, name: name, binds: binds)
+        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
 
         # Compile Arel before calling exec_insert
         compile_arel_in_intent(intent)
@@ -233,7 +234,7 @@ module ActiveRecord
 
       # Executes the update statement and returns the number of rows affected.
       def update(arel, name = nil, binds = [])
-        intent = QueryIntent.new(arel: arel, name: name, binds: binds)
+        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
 
         # Compile Arel to get SQL
         compile_arel_in_intent(intent)
@@ -243,7 +244,7 @@ module ActiveRecord
 
       # Executes the delete statement and returns the number of rows affected.
       def delete(arel, name = nil, binds = [])
-        intent = QueryIntent.new(arel: arel, name: name, binds: binds)
+        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
 
         # Compile Arel to get SQL
         compile_arel_in_intent(intent)
@@ -646,6 +647,7 @@ module ActiveRecord
         # Same as #internal_exec_query, but yields a native adapter result
         def internal_execute(sql, name = "SQL", binds = [], prepare: false, async: false, allow_retry: false, materialize_transactions: true, &block)
           intent = QueryIntent.new(
+            adapter: self,
             raw_sql: sql,
             name: name,
             binds: binds,
@@ -660,6 +662,7 @@ module ActiveRecord
         def execute_batch(statements, name = nil, **kwargs)
           statements.each do |statement|
             intent = QueryIntent.new(
+              adapter: self,
               processed_sql: statement,
               name: name,
               binds: kwargs[:binds] || [],

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -422,13 +422,6 @@ module ActiveRecord
                :disable_lazy_transactions!, :enable_lazy_transactions!, :dirty_current_transaction,
                to: :transaction_manager
 
-      def mark_transaction_written # :nodoc:
-        transaction = current_transaction
-        if transaction.open?
-          transaction.written ||= true
-        end
-      end
-
       def transaction_open?
         current_transaction.open?
       end
@@ -638,7 +631,6 @@ module ActiveRecord
         def preprocess_query(sql)
           if write_query?(sql)
             ensure_writes_are_allowed(sql)
-            mark_transaction_written
           end
 
           # We call tranformers after the write checks so we don't add extra parsing work.

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -215,16 +215,15 @@ module ActiveRecord
         type_map.lookup(sql_type)
       end
 
-      private
-        def type_casted_binds(binds)
-          binds&.map do |value|
-            if ActiveModel::Attribute === value
-              type_cast(value.value_for_database)
-            else
-              type_cast(value)
-            end
+      def type_casted_binds(binds) # :nodoc:
+        binds&.map do |value|
+          if ActiveModel::Attribute === value
+            type_cast(value.value_for_database)
+          else
+            type_cast(value)
           end
         end
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
@@ -9,15 +9,15 @@ module ActiveRecord
       end
 
       def create_savepoint(name = current_savepoint_name)
-        internal_execute("SAVEPOINT #{name}", "TRANSACTION")
+        query_command("SAVEPOINT #{name}", "TRANSACTION")
       end
 
       def exec_rollback_to_savepoint(name = current_savepoint_name)
-        internal_execute("ROLLBACK TO SAVEPOINT #{name}", "TRANSACTION")
+        query_command("ROLLBACK TO SAVEPOINT #{name}", "TRANSACTION")
       end
 
       def release_savepoint(name = current_savepoint_name)
-        internal_execute("RELEASE SAVEPOINT #{name}", "TRANSACTION")
+        query_command("RELEASE SAVEPOINT #{name}", "TRANSACTION")
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -33,7 +33,7 @@ module ActiveRecord
       # Returns the relation names usable to back Active Record models.
       # For most adapters this means all #tables and #views.
       def data_sources
-        query_values(data_source_sql, "SCHEMA")
+        query_values(data_source_sql)
       rescue NotImplementedError
         tables | views
       end
@@ -43,14 +43,14 @@ module ActiveRecord
       #   data_source_exists?(:ebooks)
       #
       def data_source_exists?(name)
-        query_values(data_source_sql(name), "SCHEMA").any? if name.present?
+        query_values(data_source_sql(name)).any? if name.present?
       rescue NotImplementedError
         data_sources.include?(name.to_s)
       end
 
       # Returns an array of table names defined in the database.
       def tables
-        query_values(data_source_sql(type: "BASE TABLE"), "SCHEMA")
+        query_values(data_source_sql(type: "BASE TABLE"))
       end
 
       # Checks to see if the table +table_name+ exists on the database.
@@ -58,14 +58,14 @@ module ActiveRecord
       #   table_exists?(:developers)
       #
       def table_exists?(table_name)
-        query_values(data_source_sql(table_name, type: "BASE TABLE"), "SCHEMA").any? if table_name.present?
+        query_values(data_source_sql(table_name, type: "BASE TABLE")).any? if table_name.present?
       rescue NotImplementedError
         tables.include?(table_name.to_s)
       end
 
       # Returns an array of view names defined in the database.
       def views
-        query_values(data_source_sql(type: "VIEW"), "SCHEMA")
+        query_values(data_source_sql(type: "VIEW"))
       end
 
       # Checks to see if the view +view_name+ exists on the database.
@@ -73,7 +73,7 @@ module ActiveRecord
       #   view_exists?(:ebooks)
       #
       def view_exists?(view_name)
-        query_values(data_source_sql(view_name, type: "VIEW"), "SCHEMA").any? if view_name.present?
+        query_values(data_source_sql(view_name, type: "VIEW")).any? if view_name.present?
       rescue NotImplementedError
         views.include?(view_name.to_s)
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -148,7 +148,6 @@ module ActiveRecord
       end
 
       attr_reader :connection, :state, :savepoint_name, :isolation_level, :user_transaction
-      attr_accessor :written
 
       delegate :invalidate!, :invalidated?, to: :@state
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -203,12 +203,6 @@ module ActiveRecord
         end
       end
 
-      def ensure_writes_are_allowed(sql) # :nodoc:
-        if preventing_writes?
-          raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
-        end
-      end
-
       MAX_JITTER = 0.0..1.0 # :nodoc:
       def max_jitter
         (@config[:pool_jitter] || 0.2).to_f.clamp(MAX_JITTER)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -494,7 +494,7 @@ module ActiveRecord
         scope = quoted_scope(table_name)
 
         # MySQL returns 1 row for each column of composite foreign keys.
-        fk_info = internal_exec_query(<<~SQL, "SCHEMA")
+        fk_info = query_all(<<~SQL, "SCHEMA")
           SELECT fk.referenced_table_name AS 'to_table',
                  fk.referenced_column_name AS 'primary_key',
                  fk.column_name AS 'column',
@@ -549,7 +549,7 @@ module ActiveRecord
           SQL
           sql += " AND cc.table_name = #{scope[:name]}" if mariadb?
 
-          chk_info = internal_exec_query(sql, "SCHEMA")
+          chk_info = query_all(sql, "SCHEMA")
 
           chk_info.map do |row|
             options = {
@@ -913,7 +913,7 @@ module ActiveRecord
             comment: column.comment
           }
 
-          current_type = internal_exec_query("SHOW COLUMNS FROM #{quote_table_name(table_name)} LIKE #{quote(column_name)}", "SCHEMA").first["Type"]
+          current_type = query_one("SHOW COLUMNS FROM #{quote_table_name(table_name)} LIKE #{quote(column_name)}", "SCHEMA")["Type"]
           td = create_table_definition(table_name)
           cd = td.new_column_definition(new_column_name, current_type, **options)
           schema_creation.accept(ChangeColumnDefinition.new(cd, column.name))
@@ -1008,11 +1008,11 @@ module ActiveRecord
         end
 
         def column_definitions(table_name) # :nodoc:
-          internal_exec_query("SHOW FULL FIELDS FROM #{quote_table_name(table_name)}", "SCHEMA", allow_retry: true)
+          query_all("SHOW FULL FIELDS FROM #{quote_table_name(table_name)}", "SCHEMA")
         end
 
         def create_table_info(table_name) # :nodoc:
-          internal_exec_query("SHOW CREATE TABLE #{quote_table_name(table_name)}", "SCHEMA").first["Create Table"]
+          query_one("SHOW CREATE TABLE #{quote_table_name(table_name)}", "SCHEMA")["Create Table"]
         end
 
         def arel_visitor

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -999,6 +999,7 @@ module ActiveRecord
 
           # ...and send them all in one query
           intent = QueryIntent.new(
+            adapter: self,
             processed_sql: "SET #{encoding} #{sql_mode_assignment} #{variable_assignments}",
             name: "SCHEMA"
           )

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -233,7 +233,7 @@ module ActiveRecord
       #++
 
       def begin_db_transaction # :nodoc:
-        internal_execute("BEGIN", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+        query_command("BEGIN", "TRANSACTION", allow_retry: true, materialize_transactions: false)
       end
 
       def begin_isolated_db_transaction(isolation) # :nodoc:
@@ -248,15 +248,15 @@ module ActiveRecord
       end
 
       def commit_db_transaction # :nodoc:
-        internal_execute("COMMIT", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+        query_command("COMMIT", "TRANSACTION", allow_retry: false, materialize_transactions: true)
       end
 
       def exec_rollback_db_transaction # :nodoc:
-        internal_execute("ROLLBACK", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+        query_command("ROLLBACK", "TRANSACTION", allow_retry: false, materialize_transactions: true)
       end
 
       def exec_restart_db_transaction # :nodoc:
-        internal_execute("ROLLBACK AND CHAIN", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+        query_command("ROLLBACK AND CHAIN", "TRANSACTION", allow_retry: false, materialize_transactions: true)
       end
 
       def empty_insert_statement_value(primary_key = nil) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1003,7 +1003,8 @@ module ActiveRecord
             processed_sql: "SET #{encoding} #{sql_mode_assignment} #{variable_assignments}",
             name: "SCHEMA"
           )
-          raw_execute(intent)
+          intent.execute!
+          intent.finish
         end
 
         def column_definitions(table_name) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         def explain(arel, binds = [], options = [])
           sql     = build_explain_clause(options) + " " + to_sql(arel, binds)
           start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          result  = internal_exec_query(sql, "EXPLAIN", binds)
+          result  = select_all(sql, "EXPLAIN", binds)
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 
           MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -66,7 +66,7 @@ module ActiveRecord
             if column.collation
               @table_collation_cache ||= {}
               @table_collation_cache[table_name] ||=
-                @connection.query_one("SHOW TABLE STATUS LIKE #{@connection.quote(table_name)}", "SCHEMA")["Collation"]
+                @connection.query_one("SHOW TABLE STATUS LIKE #{@connection.quote(table_name)}")["Collation"]
               column.collation.inspect if column.collation != @table_collation_cache[table_name]
             end
           end
@@ -88,7 +88,7 @@ module ActiveRecord
               # Calling .inspect leads into issues with the query result
               # which already returns escaped quotes.
               # We remove the escape sequence from the result in order to deal with double escaping issues.
-              @connection.query_value(sql, "SCHEMA").gsub("\\'", "'").inspect
+              @connection.query_value(sql).gsub("\\'", "'").inspect
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -66,7 +66,7 @@ module ActiveRecord
             if column.collation
               @table_collation_cache ||= {}
               @table_collation_cache[table_name] ||=
-                @connection.internal_exec_query("SHOW TABLE STATUS LIKE #{@connection.quote(table_name)}", "SCHEMA").first["Collation"]
+                @connection.query_one("SHOW TABLE STATUS LIKE #{@connection.quote(table_name)}", "SCHEMA")["Collation"]
               column.collation.inspect if column.collation != @table_collation_cache[table_name]
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         def indexes(table_name)
           indexes = []
           current_index = nil
-          query_all("SHOW KEYS FROM #{quote_table_name(table_name)}", "SCHEMA").each do |row|
+          query_all("SHOW KEYS FROM #{quote_table_name(table_name)}").each do |row|
             if current_index != row["Key_name"]
               next if row["Key_name"] == "PRIMARY" # skip the primary key
               current_index = row["Key_name"]

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         def indexes(table_name)
           indexes = []
           current_index = nil
-          internal_exec_query("SHOW KEYS FROM #{quote_table_name(table_name)}", "SCHEMA").each do |row|
+          query_all("SHOW KEYS FROM #{quote_table_name(table_name)}", "SCHEMA").each do |row|
             if current_index != row["Key_name"]
               next if row["Key_name"] == "PRIMARY" # skip the primary key
               current_index = row["Key_name"]

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -17,6 +17,7 @@ module ActiveRecord
           def execute_batch(statements, name = nil, **kwargs)
             combine_multi_statements(statements).each do |statement|
               intent = QueryIntent.new(
+                adapter: self,
                 processed_sql: statement,
                 name: name,
                 batch: true,

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -60,7 +60,7 @@ module ActiveRecord
             raw_connection.query_options[:database_timezone] = default_timezone
 
             result = nil
-            if intent.binds.nil? || intent.binds.empty?
+            if !intent.has_binds?
               result = raw_connection.query(intent.processed_sql)
               # Ref: https://github.com/brianmario/mysql2/pull/1383
               # As of mysql2 0.5.6 `#affected_rows` might raise Mysql2::Error if a prepared statement

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -27,7 +27,8 @@ module ActiveRecord
                 allow_retry: kwargs[:allow_retry] || false,
                 materialize_transactions: kwargs[:materialize_transactions] != false
               )
-              raw_execute(intent)
+              intent.execute!
+              intent.finish
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -203,6 +203,7 @@ module ActiveRecord
 
           def execute_batch(statements, name = nil, **kwargs)
             intent = QueryIntent.new(
+              adapter: self,
               processed_sql: combine_multi_statements(statements),
               name: name,
               batch: true,

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -11,7 +11,7 @@ module ActiveRecord
         end
 
         # Queries the database and returns the results in an Array-like object
-        def query(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
+        def query_rows(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
           intent = internal_build_intent(sql, name, allow_retry:, materialize_transactions:)
           intent.execute!
           result = intent.raw_result

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -163,10 +163,10 @@ module ActiveRecord
 
                 raise
               end
-            elsif intent.binds.nil? || intent.binds.empty?
-              raw_connection.async_exec(intent.processed_sql)
-            else
+            elsif intent.has_binds?
               raw_connection.exec_params(intent.processed_sql, intent.type_casted_binds)
+            else
+              raw_connection.async_exec(intent.processed_sql)
             end
 
             verified!

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       module DatabaseStatements
         def explain(arel, binds = [], options = [])
           sql    = build_explain_clause(options) + " " + to_sql(arel, binds)
-          result = internal_exec_query(sql, "EXPLAIN", binds)
+          result = select_all(sql, "EXPLAIN", binds)
           PostgreSQL::ExplainPrettyPrinter.new.pp(result)
         end
 
@@ -59,7 +59,8 @@ module ActiveRecord
               end
               return result unless sequence_name
             end
-            last_insert_id_result(sequence_name)
+
+            query_all("SELECT currval(#{quote(sequence_name)})", "SQL")
           end
         end
 
@@ -222,11 +223,6 @@ module ActiveRecord
 
           def build_truncate_statements(table_names)
             ["TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"]
-          end
-
-          # Returns the current ID of a table's sequence.
-          def last_insert_id_result(sequence_name)
-            internal_exec_query("SELECT currval(#{quote(sequence_name)})", "SQL")
           end
 
           def returning_column_values(result)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -62,27 +62,27 @@ module ActiveRecord
 
         # Begins a transaction.
         def begin_db_transaction # :nodoc:
-          internal_execute("BEGIN", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+          query_command("BEGIN", "TRANSACTION", allow_retry: true, materialize_transactions: false)
         end
 
         def begin_isolated_db_transaction(isolation) # :nodoc:
-          internal_execute("BEGIN ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+          query_command("BEGIN ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}", "TRANSACTION", allow_retry: true, materialize_transactions: false)
         end
 
         # Commits a transaction.
         def commit_db_transaction # :nodoc:
-          internal_execute("COMMIT", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+          query_command("COMMIT", "TRANSACTION", allow_retry: false, materialize_transactions: true)
         end
 
         # Aborts a transaction.
         def exec_rollback_db_transaction # :nodoc:
           cancel_any_running_query
-          internal_execute("ROLLBACK", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+          query_command("ROLLBACK", "TRANSACTION", allow_retry: false, materialize_transactions: true)
         end
 
         def exec_restart_db_transaction # :nodoc:
           cancel_any_running_query
-          internal_execute("ROLLBACK AND CHAIN", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+          query_command("ROLLBACK AND CHAIN", "TRANSACTION", allow_retry: false, materialize_transactions: true)
         end
 
         # From https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -11,7 +11,7 @@ module ActiveRecord
         end
 
         # Queries the database and returns the results in an Array-like object
-        def query_rows(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
+        def query_rows(sql, name = "SCHEMA", allow_retry: true, materialize_transactions: false) # :nodoc:
           intent = internal_build_intent(sql, name, allow_retry:, materialize_transactions:)
           intent.execute!
           result = intent.raw_result

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -189,7 +189,7 @@ module ActiveRecord
 
         # TODO: Make this method private after we release 8.1.
         def lookup_cast_type(sql_type) # :nodoc:
-          super(query_value("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").to_i)
+          super(query_value("SELECT #{quote(sql_type)}::regtype::oid").to_i)
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -73,7 +73,7 @@ module ActiveRecord
 
         # Returns true if schema exists.
         def schema_exists?(name)
-          query_value("SELECT COUNT(*) FROM pg_namespace WHERE nspname = #{quote(name)}", "SCHEMA").to_i > 0
+          query_value("SELECT COUNT(*) FROM pg_namespace WHERE nspname = #{quote(name)}").to_i > 0
         end
 
         # Verifies existence of an index with a given name.
@@ -81,7 +81,7 @@ module ActiveRecord
           table = quoted_scope(table_name)
           index = quoted_scope(index_name)
 
-          query_value(<<~SQL, "SCHEMA").to_i > 0
+          query_value(<<~SQL).to_i > 0
             SELECT COUNT(*)
             FROM pg_class t
             INNER JOIN pg_index d ON t.oid = d.indrelid
@@ -98,7 +98,7 @@ module ActiveRecord
         def indexes(table_name) # :nodoc:
           scope = quoted_scope(table_name)
 
-          result = query_rows(<<~SQL, "SCHEMA")
+          result = query_rows(<<~SQL)
             SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid),
                             pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid,
                             ARRAY(
@@ -191,7 +191,7 @@ module ActiveRecord
         def table_comment(table_name) # :nodoc:
           scope = quoted_scope(table_name, type: "BASE TABLE")
           if scope[:name]
-            query_value(<<~SQL, "SCHEMA")
+            query_value(<<~SQL)
               SELECT pg_catalog.obj_description(c.oid, 'pg_class')
               FROM pg_catalog.pg_class c
                 LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -206,7 +206,7 @@ module ActiveRecord
         def table_partition_definition(table_name) # :nodoc:
           scope = quoted_scope(table_name, type: "BASE TABLE")
 
-          query_value(<<~SQL, "SCHEMA")
+          query_value(<<~SQL)
             SELECT pg_catalog.pg_get_partkeydef(c.oid)
             FROM pg_catalog.pg_class c
               LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -220,7 +220,7 @@ module ActiveRecord
         def inherited_table_names(table_name) # :nodoc:
           scope = quoted_scope(table_name, type: "BASE TABLE")
 
-          query_values(<<~SQL, "SCHEMA")
+          query_values(<<~SQL)
             SELECT parent.relname
             FROM pg_catalog.pg_inherits i
               JOIN pg_catalog.pg_class child ON i.inhrelid = child.oid
@@ -234,40 +234,40 @@ module ActiveRecord
 
         # Returns the current database name.
         def current_database
-          query_value("SELECT current_database()", "SCHEMA")
+          query_value("SELECT current_database()")
         end
 
         # Returns the current schema name.
         def current_schema
-          query_value("SELECT current_schema", "SCHEMA")
+          query_value("SELECT current_schema")
         end
 
         # Returns an array of the names of all schemas presently in the effective search path,
         # in their priority order.
         def current_schemas # :nodoc:
-          schemas = query_value("SELECT current_schemas(false)", "SCHEMA")
+          schemas = query_value("SELECT current_schemas(false)")
           decoder = PG::TextDecoder::Array.new
           decoder.decode(schemas)
         end
 
         # Returns the current database encoding format.
         def encoding
-          query_value("SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = current_database()", "SCHEMA")
+          query_value("SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = current_database()")
         end
 
         # Returns the current database collation.
         def collation
-          query_value("SELECT datcollate FROM pg_database WHERE datname = current_database()", "SCHEMA")
+          query_value("SELECT datcollate FROM pg_database WHERE datname = current_database()")
         end
 
         # Returns the current database ctype.
         def ctype
-          query_value("SELECT datctype FROM pg_database WHERE datname = current_database()", "SCHEMA")
+          query_value("SELECT datctype FROM pg_database WHERE datname = current_database()")
         end
 
         # Returns an array of schema names.
         def schema_names
-          query_values(<<~SQL, "SCHEMA")
+          query_values(<<~SQL)
             SELECT nspname
               FROM pg_namespace
              WHERE nspname !~ '^pg_.*'
@@ -307,19 +307,19 @@ module ActiveRecord
         def schema_search_path=(schema_csv)
           return if schema_csv == @schema_search_path
           if schema_csv
-            query_command("SET search_path TO #{schema_csv}")
+            query_command("SET search_path TO #{schema_csv}", "SCHEMA")
             @schema_search_path = schema_csv
           end
         end
 
         # Returns the active schema search path.
         def schema_search_path
-          @schema_search_path ||= query_value("SHOW search_path", "SCHEMA")
+          @schema_search_path ||= query_value("SHOW search_path")
         end
 
         # Returns the current client message level.
         def client_min_messages
-          query_value("SHOW client_min_messages", "SCHEMA")
+          query_value("SHOW client_min_messages")
         end
 
         # Set the client message level.
@@ -339,7 +339,7 @@ module ActiveRecord
         end
 
         def serial_sequence(table, column)
-          query_value("SELECT pg_get_serial_sequence(#{quote(table)}, #{quote(column)})", "SCHEMA")
+          query_value("SELECT pg_get_serial_sequence(#{quote(table)}, #{quote(column)})")
         end
 
         # Sets the sequence of a table's primary key to the specified value.
@@ -350,7 +350,7 @@ module ActiveRecord
             if sequence
               quoted_sequence = quote_table_name(sequence)
 
-              query_command("SELECT setval(#{quote(quoted_sequence)}, #{value})", "SCHEMA")
+              query_command("SELECT setval(#{quote(quoted_sequence)}, #{value})")
             else
               @logger.warn "#{table} has primary key #{pk} with no default sequence." if @logger
             end
@@ -372,16 +372,16 @@ module ActiveRecord
 
           if pk && sequence
             quoted_sequence = quote_table_name(sequence)
-            max_pk = query_value("SELECT MAX(#{quote_column_name pk}) FROM #{quote_table_name(table)}", "SCHEMA")
+            max_pk = query_value("SELECT MAX(#{quote_column_name pk}) FROM #{quote_table_name(table)}")
             if max_pk.nil?
               if database_version >= 10_00_00
-                minvalue = query_value("SELECT seqmin FROM pg_sequence WHERE seqrelid = #{quote(quoted_sequence)}::regclass", "SCHEMA")
+                minvalue = query_value("SELECT seqmin FROM pg_sequence WHERE seqrelid = #{quote(quoted_sequence)}::regclass")
               else
-                minvalue = query_value("SELECT min_value FROM #{quoted_sequence}", "SCHEMA")
+                minvalue = query_value("SELECT min_value FROM #{quoted_sequence}")
               end
             end
 
-            query_command("SELECT setval(#{quote(quoted_sequence)}, #{max_pk || minvalue}, #{max_pk ? true : false})", "SCHEMA")
+            query_command("SELECT setval(#{quote(quoted_sequence)}, #{max_pk || minvalue}, #{max_pk ? true : false})")
           end
         end
 
@@ -389,7 +389,7 @@ module ActiveRecord
         def pk_and_sequence_for(table) # :nodoc:
           # First try looking for a sequence with a dependency on the
           # given table's primary key.
-          result = query_rows(<<~SQL, "SCHEMA")[0]
+          result = query_rows(<<~SQL)[0]
             SELECT attr.attname, nsp.nspname, seq.relname
             FROM pg_class      seq,
                  pg_attribute  attr,
@@ -409,7 +409,7 @@ module ActiveRecord
           SQL
 
           if result.nil? || result.empty?
-            result = query_rows(<<~SQL, "SCHEMA")[0]
+            result = query_rows(<<~SQL)[0]
               SELECT attr.attname, nsp.nspname,
                 CASE
                   WHEN pg_get_expr(def.adbin, def.adrelid) !~* 'nextval' THEN NULL
@@ -440,7 +440,7 @@ module ActiveRecord
         end
 
         def primary_keys(table_name) # :nodoc:
-          query_values(<<~SQL, "SCHEMA")
+          query_values(<<~SQL)
             SELECT a.attname
             FROM pg_index i
             JOIN pg_attribute a
@@ -610,7 +610,7 @@ module ActiveRecord
 
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
-          fk_info = query_all(<<~SQL, "SCHEMA", materialize_transactions: false)
+          fk_info = query_all(<<~SQL)
             SELECT t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid,
               (
                 SELECT array_agg(a.attname ORDER BY idx)
@@ -663,17 +663,17 @@ module ActiveRecord
         end
 
         def foreign_tables
-          query_values(data_source_sql(type: "FOREIGN TABLE"), "SCHEMA")
+          query_values(data_source_sql(type: "FOREIGN TABLE"))
         end
 
         def foreign_table_exists?(table_name)
-          query_values(data_source_sql(table_name, type: "FOREIGN TABLE"), "SCHEMA").any? if table_name.present?
+          query_values(data_source_sql(table_name, type: "FOREIGN TABLE")).any? if table_name.present?
         end
 
         def check_constraints(table_name) # :nodoc:
           scope = quoted_scope(table_name)
 
-          check_info = query_all(<<-SQL, "SCHEMA", materialize_transactions: false)
+          check_info = query_all(<<-SQL)
             SELECT conname, pg_get_constraintdef(c.oid, true) AS constraintdef, c.convalidated AS valid
             FROM pg_constraint c
             JOIN pg_class t ON c.conrelid = t.oid
@@ -699,7 +699,7 @@ module ActiveRecord
         def exclusion_constraints(table_name)
           scope = quoted_scope(table_name)
 
-          exclusion_info = query_all(<<-SQL, "SCHEMA")
+          exclusion_info = query_all(<<-SQL)
             SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef, c.condeferrable, c.condeferred
             FROM pg_constraint c
             JOIN pg_class t ON c.conrelid = t.oid
@@ -733,7 +733,7 @@ module ActiveRecord
         def unique_constraints(table_name)
           scope = quoted_scope(table_name)
 
-          unique_info = query_all(<<~SQL, "SCHEMA", materialize_transactions: false)
+          unique_info = query_all(<<~SQL)
             SELECT c.conname, c.conrelid, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef,
             (
               SELECT array_agg(a.attname ORDER BY idx)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -610,7 +610,7 @@ module ActiveRecord
 
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
-          fk_info = internal_exec_query(<<~SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)
+          fk_info = query_all(<<~SQL, "SCHEMA", materialize_transactions: false)
             SELECT t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid,
               (
                 SELECT array_agg(a.attname ORDER BY idx)
@@ -673,7 +673,7 @@ module ActiveRecord
         def check_constraints(table_name) # :nodoc:
           scope = quoted_scope(table_name)
 
-          check_info = internal_exec_query(<<-SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)
+          check_info = query_all(<<-SQL, "SCHEMA", materialize_transactions: false)
             SELECT conname, pg_get_constraintdef(c.oid, true) AS constraintdef, c.convalidated AS valid
             FROM pg_constraint c
             JOIN pg_class t ON c.conrelid = t.oid
@@ -699,7 +699,7 @@ module ActiveRecord
         def exclusion_constraints(table_name)
           scope = quoted_scope(table_name)
 
-          exclusion_info = internal_exec_query(<<-SQL, "SCHEMA")
+          exclusion_info = query_all(<<-SQL, "SCHEMA")
             SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef, c.condeferrable, c.condeferred
             FROM pg_constraint c
             JOIN pg_class t ON c.conrelid = t.oid
@@ -733,7 +733,7 @@ module ActiveRecord
         def unique_constraints(table_name)
           scope = quoted_scope(table_name)
 
-          unique_info = internal_exec_query(<<~SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)
+          unique_info = query_all(<<~SQL, "SCHEMA", materialize_transactions: false)
             SELECT c.conname, c.conrelid, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef,
             (
               SELECT array_agg(a.attname ORDER BY idx)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -307,7 +307,7 @@ module ActiveRecord
         def schema_search_path=(schema_csv)
           return if schema_csv == @schema_search_path
           if schema_csv
-            internal_execute("SET search_path TO #{schema_csv}")
+            query_command("SET search_path TO #{schema_csv}")
             @schema_search_path = schema_csv
           end
         end
@@ -324,7 +324,7 @@ module ActiveRecord
 
         # Set the client message level.
         def client_min_messages=(level)
-          internal_execute("SET client_min_messages TO '#{level}'", "SCHEMA")
+          query_command("SET client_min_messages TO '#{level}'", "SCHEMA")
         end
 
         # Returns the sequence name for a table's primary key or some other specified key.
@@ -350,7 +350,7 @@ module ActiveRecord
             if sequence
               quoted_sequence = quote_table_name(sequence)
 
-              internal_execute("SELECT setval(#{quote(quoted_sequence)}, #{value})", "SCHEMA")
+              query_command("SELECT setval(#{quote(quoted_sequence)}, #{value})", "SCHEMA")
             else
               @logger.warn "#{table} has primary key #{pk} with no default sequence." if @logger
             end
@@ -381,7 +381,7 @@ module ActiveRecord
               end
             end
 
-            internal_execute("SELECT setval(#{quote(quoted_sequence)}, #{max_pk || minvalue}, #{max_pk ? true : false})", "SCHEMA")
+            query_command("SELECT setval(#{quote(quoted_sequence)}, #{max_pk || minvalue}, #{max_pk ? true : false})", "SCHEMA")
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -98,7 +98,7 @@ module ActiveRecord
         def indexes(table_name) # :nodoc:
           scope = quoted_scope(table_name)
 
-          result = query(<<~SQL, "SCHEMA")
+          result = query_rows(<<~SQL, "SCHEMA")
             SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid),
                             pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid,
                             ARRAY(
@@ -389,7 +389,7 @@ module ActiveRecord
         def pk_and_sequence_for(table) # :nodoc:
           # First try looking for a sequence with a dependency on the
           # given table's primary key.
-          result = query(<<~SQL, "SCHEMA")[0]
+          result = query_rows(<<~SQL, "SCHEMA")[0]
             SELECT attr.attname, nsp.nspname, seq.relname
             FROM pg_class      seq,
                  pg_attribute  attr,
@@ -409,7 +409,7 @@ module ActiveRecord
           SQL
 
           if result.nil? || result.empty?
-            result = query(<<~SQL, "SCHEMA")[0]
+            result = query_rows(<<~SQL, "SCHEMA")[0]
               SELECT attr.attname, nsp.nspname,
                 CASE
                   WHEN pg_get_expr(def.adbin, def.adrelid) !~* 'nextval' THEN NULL

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1060,7 +1060,7 @@ module ActiveRecord
         #  - format_type includes the column size constraint, e.g. varchar(50)
         #  - ::regclass is a function that gives the id for a table name
         def column_definitions(table_name)
-          query(<<~SQL, "SCHEMA")
+          query_rows(<<~SQL, "SCHEMA")
               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                      pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
                      c.collname, col_description(a.attrelid, a.attnum) AS comment,

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -521,7 +521,7 @@ module ActiveRecord
           JOIN pg_namespace n ON pg_extension.extnamespace = n.oid
         SQL
 
-        internal_exec_query(query, "SCHEMA", allow_retry: true, materialize_transactions: false).cast_values.map do |row|
+        query_all(query, "SCHEMA", materialize_transactions: false).cast_values.map do |row|
           name, schema = row[0], row[1]
           schema = nil if schema == current_schema
           [schema, name].compact.join(".")
@@ -543,7 +543,7 @@ module ActiveRecord
           GROUP BY type.OID, n.nspname, type.typname;
         SQL
 
-        internal_exec_query(query, "SCHEMA", allow_retry: true, materialize_transactions: false).cast_values.each_with_object({}) do |row, memo|
+        query_all(query, "SCHEMA", materialize_transactions: false).cast_values.each_with_object({}) do |row, memo|
           name, schema = row[0], row[2]
           schema = nil if schema == current_schema
           full_name = [schema, name].compact.join(".")

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1027,10 +1027,10 @@ module ActiveRecord
           # If using Active Record's time zone support configure the connection
           # to return TIMESTAMP WITH ZONE types in UTC.
           if default_timezone == :utc
-            intent = QueryIntent.new(processed_sql: "SET SESSION timezone TO 'UTC'", name: "SCHEMA")
+            intent = QueryIntent.new(adapter: self, processed_sql: "SET SESSION timezone TO 'UTC'", name: "SCHEMA")
             raw_execute(intent)
           else
-            intent = QueryIntent.new(processed_sql: "SET SESSION timezone TO DEFAULT", name: "SCHEMA")
+            intent = QueryIntent.new(adapter: self, processed_sql: "SET SESSION timezone TO DEFAULT", name: "SCHEMA")
             raw_execute(intent)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -5,14 +5,15 @@ module ActiveRecord
     class QueryIntent # :nodoc:
       attr_reader :arel, :name, :prepare, :allow_retry,
                   :materialize_transactions, :batch
-      attr_accessor :raw_sql, :binds, :async, :processed_sql, :type_casted_binds, :notification_payload
+      attr_accessor :adapter, :raw_sql, :binds, :async, :processed_sql, :type_casted_binds, :notification_payload
 
-      def initialize(arel: nil, raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, async: false,
+      def initialize(adapter:, arel: nil, raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, async: false,
                      allow_retry: false, materialize_transactions: true, batch: false)
         if arel.nil? && raw_sql.nil? && processed_sql.nil?
           raise ArgumentError, "One of arel, raw_sql, or processed_sql must be provided"
         end
 
+        @adapter = adapter
         @arel = arel
         @raw_sql = raw_sql
         @name = name

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -140,7 +140,7 @@ module ActiveRecord
           end
 
           def affected_rows(result)
-            result.affected_rows
+            result&.affected_rows
           end
 
           def execute_batch(statements, name = nil, **kwargs)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         def explain(arel, binds = [], _options = [])
           sql    = "EXPLAIN QUERY PLAN " + to_sql(arel, binds)
-          result = query(sql, "EXPLAIN")
+          result = query_rows(sql, "EXPLAIN")
           SQLite3::ExplainPrettyPrinter.new.pp(result)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -98,7 +98,7 @@ module ActiveRecord
                 raw_connection.prepare(intent.processed_sql)
               end
               begin
-                unless intent.binds.nil? || intent.binds.empty?
+                if intent.has_binds?
                   stmt.bind_params(intent.type_casted_binds)
                 end
                 result = if stmt.column_count.zero? # No return

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -146,6 +146,7 @@ module ActiveRecord
           def execute_batch(statements, name = nil, **kwargs)
             sql = combine_multi_statements(statements)
             intent = QueryIntent.new(
+              adapter: self,
               processed_sql: sql,
               name: name,
               batch: true,

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -78,7 +78,7 @@ module ActiveRecord
 
             query_command("BEGIN #{mode} TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
             if isolation
-              @previous_read_uncommitted = query_value("PRAGMA read_uncommitted")
+              @previous_read_uncommitted = query_value("PRAGMA read_uncommitted", "TRANSACTION")
               query_command("PRAGMA read_uncommitted=ON", "TRANSACTION", allow_retry: true, materialize_transactions: false)
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -156,7 +156,8 @@ module ActiveRecord
               allow_retry: kwargs[:allow_retry] || false,
               materialize_transactions: kwargs[:materialize_transactions] != false
             )
-            raw_execute(intent)
+            intent.execute!
+            intent.finish
           end
 
           def build_truncate_statement(table_name)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         def explain(arel, binds = [], _options = [])
           sql    = "EXPLAIN QUERY PLAN " + to_sql(arel, binds)
-          result = internal_exec_query(sql, "EXPLAIN", [])
+          result = query(sql, "EXPLAIN")
           SQLite3::ExplainPrettyPrinter.new.pp(result)
         end
 
@@ -34,11 +34,11 @@ module ActiveRecord
         end
 
         def commit_db_transaction # :nodoc:
-          internal_execute("COMMIT TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+          query_command("COMMIT TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
         end
 
         def exec_rollback_db_transaction # :nodoc:
-          internal_execute("ROLLBACK TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+          query_command("ROLLBACK TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
         end
 
         # https://stackoverflow.com/questions/17574784
@@ -57,7 +57,7 @@ module ActiveRecord
         end
 
         def reset_isolation_level # :nodoc:
-          internal_execute("PRAGMA read_uncommitted=#{@previous_read_uncommitted}", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+          query_command("PRAGMA read_uncommitted=#{@previous_read_uncommitted}", "TRANSACTION", allow_retry: true, materialize_transactions: false)
           @previous_read_uncommitted = nil
         end
 
@@ -76,10 +76,10 @@ module ActiveRecord
               raise StandardError, "You need to enable the shared-cache mode in SQLite mode before attempting to change the transaction isolation level" unless shared_cache?
             end
 
-            internal_execute("BEGIN #{mode} TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+            query_command("BEGIN #{mode} TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
             if isolation
               @previous_read_uncommitted = query_value("PRAGMA read_uncommitted")
-              internal_execute("PRAGMA read_uncommitted=ON", "TRANSACTION", allow_retry: true, materialize_transactions: false)
+              query_command("PRAGMA read_uncommitted=ON", "TRANSACTION", allow_retry: true, materialize_transactions: false)
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/explain_pretty_printer.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/explain_pretty_printer.rb
@@ -11,7 +11,7 @@ module ActiveRecord
         #   0|1|1|SCAN TABLE posts (~100000 rows)
         #
         def pp(result)
-          result.rows.map do |row|
+          result.map do |row|
             row.join("|")
           end.join("\n") + "\n"
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       module SchemaStatements # :nodoc:
         # Returns an array of indexes for the given table.
         def indexes(table_name)
-          internal_exec_query("PRAGMA index_list(#{quote_table_name(table_name)})", "SCHEMA").filter_map do |row|
+          query_all("PRAGMA index_list(#{quote_table_name(table_name)})", "SCHEMA").filter_map do |row|
             # Indexes SQLite creates implicitly for internal use start with "sqlite_".
             # See https://www.sqlite.org/fileformat2.html#intschema
             next if row["name"].start_with?("sqlite_")
@@ -23,7 +23,7 @@ module ActiveRecord
 
             /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+))?(?:\s*\/\*.*\*\/)?\z/i =~ index_sql
 
-            columns = internal_exec_query("PRAGMA index_info(#{quote(row['name'])})", "SCHEMA").map do |col|
+            columns = query_all("PRAGMA index_info(#{quote(row['name'])})", "SCHEMA").map do |col|
               col["name"]
             end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -6,12 +6,12 @@ module ActiveRecord
       module SchemaStatements # :nodoc:
         # Returns an array of indexes for the given table.
         def indexes(table_name)
-          query_all("PRAGMA index_list(#{quote_table_name(table_name)})", "SCHEMA").filter_map do |row|
+          query_all("PRAGMA index_list(#{quote_table_name(table_name)})").filter_map do |row|
             # Indexes SQLite creates implicitly for internal use start with "sqlite_".
             # See https://www.sqlite.org/fileformat2.html#intschema
             next if row["name"].start_with?("sqlite_")
 
-            index_sql = query_value(<<~SQL, "SCHEMA")
+            index_sql = query_value(<<~SQL)
               SELECT sql
               FROM sqlite_master
               WHERE name = #{quote(row['name'])} AND type = 'index'
@@ -23,7 +23,7 @@ module ActiveRecord
 
             /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+))?(?:\s*\/\*.*\*\/)?\z/i =~ index_sql
 
-            columns = query_all("PRAGMA index_info(#{quote(row['name'])})", "SCHEMA").map do |col|
+            columns = query_all("PRAGMA index_info(#{quote(row['name'])})").map do |col|
               col["name"]
             end
 
@@ -75,11 +75,11 @@ module ActiveRecord
         end
 
         def virtual_table_exists?(table_name)
-          query_values(data_source_sql(table_name, type: "VIRTUAL TABLE"), "SCHEMA").any?
+          query_values(data_source_sql(table_name, type: "VIRTUAL TABLE")).any?
         end
 
         def check_constraints(table_name)
-          table_sql = query_value(<<-SQL, "SCHEMA")
+          table_sql = query_value(<<-SQL)
             SELECT sql
             FROM sqlite_master
             WHERE name = #{quote(table_name)} AND type = 'table'

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -307,8 +307,8 @@ module ActiveRecord
       # REFERENTIAL INTEGRITY ====================================
 
       def disable_referential_integrity # :nodoc:
-        old_foreign_keys = query_value("PRAGMA foreign_keys")
-        old_defer_foreign_keys = query_value("PRAGMA defer_foreign_keys")
+        old_foreign_keys = query_value("PRAGMA foreign_keys", nil)
+        old_defer_foreign_keys = query_value("PRAGMA defer_foreign_keys", nil)
 
         begin
           execute("PRAGMA defer_foreign_keys = ON")
@@ -353,7 +353,7 @@ module ActiveRecord
           SELECT name, sql FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL %';
         SQL
 
-        query_rows(query, "SCHEMA").each_with_object({}) do |(table_name, sql), memo|
+        query_rows(query).each_with_object({}) do |(table_name, sql), memo|
           _, module_name, arguments = sql.match(VIRTUAL_TABLE_REGEX).to_a
           memo[table_name] = [module_name, arguments]
         end.to_a
@@ -469,7 +469,7 @@ module ActiveRecord
       DEFERRABLE_REGEX = /DEFERRABLE INITIALLY (\w+)/
       def foreign_keys(table_name)
         # SQLite returns 1 row for each column of composite foreign keys.
-        fk_info = query_all("PRAGMA foreign_key_list(#{quote(table_name)})", "SCHEMA")
+        fk_info = query_all("PRAGMA foreign_key_list(#{quote(table_name)})")
         # Deferred or immediate foreign keys can only be seen in the CREATE TABLE sql
         fk_defs = table_structure_sql(table_name)
                     .select do |column_string|
@@ -527,7 +527,7 @@ module ActiveRecord
       end
 
       def get_database_version # :nodoc:
-        SQLite3Adapter::Version.new(query_value("SELECT sqlite_version(*)", "SCHEMA"))
+        SQLite3Adapter::Version.new(query_value("SELECT sqlite_version(*)"))
       end
 
       def check_version # :nodoc:
@@ -829,7 +829,7 @@ module ActiveRecord
           #                       "password_digest" varchar COLLATE "NOCASE",
           #                       "o_id" integer,
           #                       CONSTRAINT "fk_rails_78146ddd2e" FOREIGN KEY ("o_id") REFERENCES "os" ("id"));
-          result = query_value(sql, "SCHEMA")
+          result = query_value(sql)
 
           return [] unless result
 
@@ -846,9 +846,9 @@ module ActiveRecord
 
         def table_info(table_name)
           if supports_virtual_columns?
-            query_all("PRAGMA table_xinfo(#{quote_table_name(table_name)})", "SCHEMA")
+            query_all("PRAGMA table_xinfo(#{quote_table_name(table_name)})")
           else
-            query_all("PRAGMA table_info(#{quote_table_name(table_name)})", "SCHEMA")
+            query_all("PRAGMA table_info(#{quote_table_name(table_name)})")
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -469,7 +469,7 @@ module ActiveRecord
       DEFERRABLE_REGEX = /DEFERRABLE INITIALLY (\w+)/
       def foreign_keys(table_name)
         # SQLite returns 1 row for each column of composite foreign keys.
-        fk_info = internal_exec_query("PRAGMA foreign_key_list(#{quote(table_name)})", "SCHEMA")
+        fk_info = query_all("PRAGMA foreign_key_list(#{quote(table_name)})", "SCHEMA")
         # Deferred or immediate foreign keys can only be seen in the CREATE TABLE sql
         fk_defs = table_structure_sql(table_name)
                     .select do |column_string|
@@ -846,9 +846,9 @@ module ActiveRecord
 
         def table_info(table_name)
           if supports_virtual_columns?
-            internal_exec_query("PRAGMA table_xinfo(#{quote_table_name(table_name)})", "SCHEMA", allow_retry: true)
+            query_all("PRAGMA table_xinfo(#{quote_table_name(table_name)})", "SCHEMA")
           else
-            internal_exec_query("PRAGMA table_info(#{quote_table_name(table_name)})", "SCHEMA", allow_retry: true)
+            query_all("PRAGMA table_info(#{quote_table_name(table_name)})", "SCHEMA")
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -353,8 +353,7 @@ module ActiveRecord
           SELECT name, sql FROM sqlite_master WHERE sql LIKE 'CREATE VIRTUAL %';
         SQL
 
-        exec_query(query, "SCHEMA").cast_values.each_with_object({}) do |row, memo|
-          table_name, sql = row[0], row[1]
+        query_rows(query, "SCHEMA").each_with_object({}) do |(table_name, sql), memo|
           _, module_name, arguments = sql.match(VIRTUAL_TABLE_REGEX).to_a
           memo[table_name] = [module_name, arguments]
         end.to_a

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -429,7 +429,7 @@ module ActiveRecord
         validate_change_column_null_argument!(null)
 
         unless null || default.nil?
-          internal_exec_query("UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote(default)} WHERE #{quote_column_name(column_name)} IS NULL")
+          query_command("UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote(default)} WHERE #{quote_column_name(column_name)} IS NULL")
         end
         alter_table(table_name) do |definition|
           definition[column_name].null = null
@@ -741,7 +741,7 @@ module ActiveRecord
           quoted_columns = columns.map { |col| quote_column_name(col) } * ","
           quoted_from_columns = from_columns_to_copy.map { |col| quote_column_name(col) } * ","
 
-          internal_exec_query("INSERT INTO #{quote_table_name(to)} (#{quoted_columns})
+          query_command("INSERT INTO #{quote_table_name(to)} (#{quoted_columns})
                      SELECT #{quoted_from_columns} FROM #{quote_table_name(from)}")
         end
 

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -67,6 +67,7 @@ module ActiveRecord
           def execute_batch(statements, name = nil, **kwargs)
             combine_multi_statements(statements).each do |statement|
               intent = QueryIntent.new(
+                adapter: self,
                 processed_sql: statement,
                 name: name,
                 batch: true,

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -9,9 +9,10 @@ module ActiveRecord
           intent.raw_sql = sql
           intent.binds = binds
 
-          # AbstractAdapter calls raw_exec_query (returning an AR::Result), but
+          # AbstractAdapter calls cast_result (returning an AR::Result), but
           # our last_inserted_id needs the raw Trilogy result object
-          raw_execute(intent)
+          intent.execute!
+          intent.raw_result
         end
 
         private
@@ -77,7 +78,8 @@ module ActiveRecord
                 allow_retry: kwargs[:allow_retry] || false,
                 materialize_transactions: kwargs[:materialize_transactions] != false
               )
-              raw_execute(intent)
+              intent.execute!
+              intent.finish
             end
           end
       end

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -85,6 +85,7 @@ module ActiveRecord
 
     def schedule!(session)
       @session = session
+      @intent.adapter = nil  # Orphan intent while in queue
       @pool.schedule_query(self)
     end
 
@@ -160,17 +161,18 @@ module ActiveRecord
       end
 
       def execute_query(connection, async: false)
-        @result = exec_query(connection, @intent, async: async)
+        # Update intent with actual executing adapter and async mode for accurate logging
+        @intent.adapter = connection
+        @intent.async = async
+
+        @result = exec_query(connection, @intent)
       rescue => error
         @error = error
       ensure
         @pending = false
       end
 
-      def exec_query(connection, intent, async: false)
-        # Update intent with actual async execution mode for accurate logging
-        intent.async = async
-
+      def exec_query(connection, intent)
         connection.raw_exec_query(intent)
       end
 

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -85,7 +85,7 @@ module ActiveRecord
 
     def schedule!(session)
       @session = session
-      @intent.adapter = nil  # Orphan intent while in queue
+      @intent.schedule!  # Preprocess query, then detach adapter
       @pool.schedule_query(self)
     end
 

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -173,7 +173,8 @@ module ActiveRecord
       end
 
       def exec_query(connection, intent)
-        connection.raw_exec_query(intent)
+        intent.execute!
+        intent.cast_result
       end
 
       class SelectAll < FutureResult # :nodoc:

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -99,16 +99,16 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
       assert_equal "cp932_japanese_ci", connection.show_variable("collation_connection")
 
       expected = "こんにちは".encode(Encoding::CP932)
-      assert_equal expected, connection.query_value("SELECT 'こんにちは'")
+      assert_equal expected, connection.select_value("SELECT 'こんにちは'")
     end
   end
 
   def test_collation_connection_is_configured
     assert_equal "utf8mb4_unicode_ci", @connection.show_variable("collation_connection")
-    assert_equal 1, @connection.query_value("SELECT 'こんにちは' = 'コンニチハ'")
+    assert_equal 1, @connection.select_value("SELECT 'こんにちは' = 'コンニチハ'")
 
     assert_equal "utf8mb4_general_ci", ARUnit2Model.lease_connection.show_variable("collation_connection")
-    assert_equal 0, ARUnit2Model.lease_connection.query_value("SELECT 'こんにちは' = 'コンニチハ'")
+    assert_equal 0, ARUnit2Model.lease_connection.select_value("SELECT 'こんにちは' = 'コンニチハ'")
   end
 
   def test_mysql_default_in_strict_mode

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
@@ -62,7 +62,7 @@ class TableOptionsTest < ActiveRecord::AbstractMysqlTestCase
   test "schema dump works with NO_TABLE_OPTIONS sql mode" do
     skip "As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated. It will be removed in a future version of MySQL." if @connection.database_version >= "5.7.22"
 
-    old_sql_mode = @connection.query_value("SELECT @@SESSION.sql_mode")
+    old_sql_mode = @connection.select_value("SELECT @@SESSION.sql_mode")
     new_sql_mode = old_sql_mode + ",NO_TABLE_OPTIONS"
 
     begin

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
@@ -133,7 +133,7 @@ module ActiveRecord
             latch.count_down
             sleep(0.5)
             conn = Sample.lease_connection
-            pid = conn.query_value("SELECT id FROM information_schema.processlist WHERE info LIKE '% FOR UPDATE'")
+            pid = conn.select_value("SELECT id FROM information_schema.processlist WHERE info LIKE '% FOR UPDATE'")
             conn.execute("KILL QUERY #{pid}")
           end
         end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -309,7 +309,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_warnings_do_not_change_returned_value_of_exec_update
     previous_logger = ActiveRecord::Base.logger
-    old_sql_mode = @conn.query_value("SELECT @@SESSION.sql_mode")
+    old_sql_mode = @conn.select_value("SELECT @@SESSION.sql_mode")
 
     with_db_warnings_action(:log) do
       ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)
@@ -329,7 +329,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_warnings_do_not_change_returned_value_of_exec_delete
     previous_logger = ActiveRecord::Base.logger
-    old_sql_mode = @conn.query_value("SELECT @@SESSION.sql_mode")
+    old_sql_mode = @conn.select_value("SELECT @@SESSION.sql_mode")
 
     with_db_warnings_action(:log) do
       ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -81,7 +81,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
     data = "'\u001F\\"
     ByteaDataType.create(payload: data)
     sql = ByteaDataType.where(payload: data).select(:payload).to_sql
-    result = @connection.query_rows(sql)
+    result = @connection.query_rows(sql, nil)
     assert_equal([[data]], result)
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -81,7 +81,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
     data = "'\u001F\\"
     ByteaDataType.create(payload: data)
     sql = ByteaDataType.where(payload: data).select(:payload).to_sql
-    result = @connection.query(sql)
+    result = @connection.query_rows(sql)
     assert_equal([[data]], result)
   end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -53,41 +53,41 @@ module ActiveRecord
       NonExistentTable.establish_connection(params)
 
       # Verify the connection param has been applied.
-      expect = NonExistentTable.lease_connection.query("show geqo").first.first
-      assert_equal "off", expect
+      actual = NonExistentTable.lease_connection.query_value("show geqo")
+      assert_equal "off", actual
     ensure
       NonExistentTable.remove_connection
     end
 
     def test_reset
-      @connection.query("ROLLBACK")
-      @connection.query("SET geqo TO off")
+      @connection.query_command("ROLLBACK")
+      @connection.query_command("SET geqo TO off")
 
       # Verify the setting has been applied.
-      expect = @connection.query("show geqo").first.first
-      assert_equal "off", expect
+      actual = @connection.query_value("show geqo")
+      assert_equal "off", actual
 
       @connection.reset!
 
       # Verify the setting has been cleared.
-      expect = @connection.query("show geqo").first.first
-      assert_equal "on", expect
+      actual = @connection.query_value("show geqo")
+      assert_equal "on", actual
     end
 
     def test_reset_with_transaction
-      @connection.query("ROLLBACK")
-      @connection.query("SET geqo TO off")
+      @connection.query_command("ROLLBACK")
+      @connection.query_command("SET geqo TO off")
 
       # Verify the setting has been applied.
-      expect = @connection.query("show geqo").first.first
-      assert_equal "off", expect
+      actual = @connection.query_value("show geqo")
+      assert_equal "off", actual
 
-      @connection.query("BEGIN")
+      @connection.query_command("BEGIN")
       @connection.reset!
 
       # Verify the setting has been cleared.
-      expect = @connection.query("show geqo").first.first
-      assert_equal "on", expect
+      actual = @connection.query_value("show geqo")
+      assert_equal "on", actual
     end
 
     def test_tables_logs_name
@@ -203,8 +203,7 @@ module ActiveRecord
     def test_get_and_release_advisory_lock
       lock_id = 5295901941911233559
       list_advisory_locks = <<~SQL
-        SELECT locktype,
-              (classid::bigint << 32) | objid::bigint AS lock_id
+        SELECT (classid::bigint << 32) | objid::bigint AS lock_id
         FROM pg_locks
         WHERE locktype = 'advisory'
       SQL
@@ -212,15 +211,15 @@ module ActiveRecord
       got_lock = @connection.get_advisory_lock(lock_id)
       assert got_lock, "get_advisory_lock should have returned true but it didn't"
 
-      advisory_lock = @connection.query(list_advisory_locks).find { |l| l[1] == lock_id }
-      assert advisory_lock,
+      advisory_locks = @connection.query_values(list_advisory_locks)
+      assert_includes advisory_locks, lock_id,
         "expected to find an advisory lock with lock_id #{lock_id} but there wasn't one"
 
       released_lock = @connection.release_advisory_lock(lock_id)
       assert released_lock, "expected release_advisory_lock to return true but it didn't"
 
-      advisory_locks = @connection.query(list_advisory_locks).select { |l| l[1] == lock_id }
-      assert_empty advisory_locks,
+      advisory_locks = @connection.query_values(list_advisory_locks)
+      assert_not_includes advisory_locks, lock_id,
         "expected to have released advisory lock with lock_id #{lock_id} but it was still held"
     end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       NonExistentTable.establish_connection(params)
 
       # Verify the connection param has been applied.
-      actual = NonExistentTable.lease_connection.query_value("show geqo")
+      actual = NonExistentTable.lease_connection.select_value("show geqo")
       assert_equal "off", actual
     ensure
       NonExistentTable.remove_connection
@@ -64,13 +64,13 @@ module ActiveRecord
       @connection.query_command("SET geqo TO off")
 
       # Verify the setting has been applied.
-      actual = @connection.query_value("show geqo")
+      actual = @connection.select_value("show geqo")
       assert_equal "off", actual
 
       @connection.reset!
 
       # Verify the setting has been cleared.
-      actual = @connection.query_value("show geqo")
+      actual = @connection.select_value("show geqo")
       assert_equal "on", actual
     end
 
@@ -79,14 +79,14 @@ module ActiveRecord
       @connection.query_command("SET geqo TO off")
 
       # Verify the setting has been applied.
-      actual = @connection.query_value("show geqo")
+      actual = @connection.select_value("show geqo")
       assert_equal "off", actual
 
       @connection.query_command("BEGIN")
       @connection.reset!
 
       # Verify the setting has been cleared.
-      actual = @connection.query_value("show geqo")
+      actual = @connection.select_value("show geqo")
       assert_equal "on", actual
     end
 
@@ -196,7 +196,7 @@ module ActiveRecord
     def test_set_session_timezone
       run_without_connection do |orig_connection|
         ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { timezone: "America/New_York" }))
-        assert_equal "America/New_York", ActiveRecord::Base.lease_connection.query_value("SHOW TIME ZONE")
+        assert_equal "America/New_York", ActiveRecord::Base.lease_connection.select_value("SHOW TIME ZONE")
       end
     end
 
@@ -211,14 +211,14 @@ module ActiveRecord
       got_lock = @connection.get_advisory_lock(lock_id)
       assert got_lock, "get_advisory_lock should have returned true but it didn't"
 
-      advisory_locks = @connection.query_values(list_advisory_locks)
+      advisory_locks = @connection.select_values(list_advisory_locks)
       assert_includes advisory_locks, lock_id,
         "expected to find an advisory lock with lock_id #{lock_id} but there wasn't one"
 
       released_lock = @connection.release_advisory_lock(lock_id)
       assert released_lock, "expected release_advisory_lock to return true but it didn't"
 
-      advisory_locks = @connection.query_values(list_advisory_locks)
+      advisory_locks = @connection.select_values(list_advisory_locks)
       assert_not_includes advisory_locks, lock_id,
         "expected to have released advisory lock with lock_id #{lock_id} but it was still held"
     end

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -48,8 +48,8 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     second_money = PostgresqlMoney.find(2)
     assert_equal 567.89, first_money.wealth
     assert_equal(-567.89, second_money.wealth)
-    assert_equal 567.89, @connection.query_value("SELECT wealth FROM postgresql_moneys WHERE id = 1")
-    assert_equal(-567.89, @connection.query_value("SELECT wealth FROM postgresql_moneys WHERE id = 2"))
+    assert_equal 567.89, @connection.query_value("SELECT wealth FROM postgresql_moneys WHERE id = 1", nil)
+    assert_equal(-567.89, @connection.query_value("SELECT wealth FROM postgresql_moneys WHERE id = 2", nil))
   end
 
   def test_money_type_cast

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -175,7 +175,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
         end
-        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
+        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -184,7 +184,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
         end
-        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
+        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -193,7 +193,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
         end
-        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
+        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -202,7 +202,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
         end
-        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
+        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -773,11 +773,11 @@ module ActiveRecord
         @connection.execute("CREATE SCHEMA custom_schema")
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
         @connection.execute("CREATE EXTENSION hstore SCHEMA custom_schema")
-        result = @connection.query_values("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
+        result = @connection.select_values("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
         assert_equal ["hstore"], result
 
         @connection.disable_extension "custom_schema.hstore"
-        result = @connection.query_values("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
+        result = @connection.select_values("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
         assert_equal [], result
       ensure
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
@@ -787,11 +787,11 @@ module ActiveRecord
       def test_disable_extension_without_schema
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
         @connection.execute("CREATE EXTENSION hstore")
-        result = @connection.query_values("SELECT extname FROM pg_extension")
+        result = @connection.select_values("SELECT extname FROM pg_extension")
         assert_includes result, "hstore"
 
         @connection.disable_extension "hstore"
-        result = @connection.query_values("SELECT extname FROM pg_extension")
+        result = @connection.select_values("SELECT extname FROM pg_extension")
         assert_not_includes result, "hstore"
       ensure
         @connection.execute("DROP EXTENSION IF EXISTS hstore")

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -175,7 +175,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
         end
-        expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
+        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -184,7 +184,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
         end
-        expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
+        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -193,7 +193,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
         end
-        expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
+        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -202,7 +202,7 @@ module ActiveRecord
         result = assert_deprecated(ActiveRecord.deprecator) do
           connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
         end
-        expect = connection.query("select max(id) from postgresql_partitioned_table_parent").first.first
+        expect = connection.query_value("select max(id) from postgresql_partitioned_table_parent")
         assert_equal expect.to_i, result.rows.first.first
       end
 
@@ -773,12 +773,12 @@ module ActiveRecord
         @connection.execute("CREATE SCHEMA custom_schema")
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
         @connection.execute("CREATE EXTENSION hstore SCHEMA custom_schema")
-        result = @connection.query("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
-        assert_equal [["hstore"]], result.to_a
+        result = @connection.query_values("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
+        assert_equal ["hstore"], result
 
         @connection.disable_extension "custom_schema.hstore"
-        result = @connection.query("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
-        assert_equal [], result.to_a
+        result = @connection.query_values("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
+        assert_equal [], result
       ensure
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
         @connection.execute("DROP SCHEMA IF EXISTS custom_schema CASCADE")
@@ -787,12 +787,12 @@ module ActiveRecord
       def test_disable_extension_without_schema
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
         @connection.execute("CREATE EXTENSION hstore")
-        result = @connection.query("SELECT extname FROM pg_extension")
-        assert_includes result.to_a, ["hstore"]
+        result = @connection.query_values("SELECT extname FROM pg_extension")
+        assert_includes result, "hstore"
 
         @connection.disable_extension "hstore"
-        result = @connection.query("SELECT extname FROM pg_extension")
-        assert_not_includes result.to_a, ["hstore"]
+        result = @connection.query_values("SELECT extname FROM pg_extension")
+        assert_not_includes result, "hstore"
       ensure
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
       end

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -164,7 +164,7 @@ module ActiveRecord
             latch.count_down
             sleep(0.5)
             conn = Sample.lease_connection
-            pid = conn.query_value("SELECT pid FROM pg_stat_activity WHERE query LIKE '% FOR UPDATE'")
+            pid = conn.select_value("SELECT pid FROM pg_stat_activity WHERE query LIKE '% FOR UPDATE'")
             conn.execute("SELECT pg_cancel_backend(#{pid})")
           end
         end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -543,7 +543,7 @@ module ActiveRecord
           result = assert_deprecated(ActiveRecord.deprecator) do
             @conn.exec_insert("insert into ex (number) VALUES ('foo')", nil, [], "id")
           end
-          expect = @conn.query_value("select max(id) from ex")
+          expect = @conn.select_value("select max(id) from ex")
           assert_equal expect.to_i, result.rows.first.first
         end
         @conn = original_conn
@@ -560,7 +560,7 @@ module ActiveRecord
           result = assert_deprecated(ActiveRecord.deprecator) do
             @conn.exec_insert("insert into ex DEFAULT VALUES", nil, [], "id")
           end
-          expect = @conn.query_value("select max(id) from ex")
+          expect = @conn.select_value("select max(id) from ex")
           assert_equal expect.to_i, result.rows.first.first
         end
         @conn = original_conn

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -543,7 +543,7 @@ module ActiveRecord
           result = assert_deprecated(ActiveRecord.deprecator) do
             @conn.exec_insert("insert into ex (number) VALUES ('foo')", nil, [], "id")
           end
-          expect = @conn.query("select max(id) from ex").first.first
+          expect = @conn.query_value("select max(id) from ex")
           assert_equal expect.to_i, result.rows.first.first
         end
         @conn = original_conn
@@ -560,7 +560,7 @@ module ActiveRecord
           result = assert_deprecated(ActiveRecord.deprecator) do
             @conn.exec_insert("insert into ex DEFAULT VALUES", nil, [], "id")
           end
-          expect = @conn.query("select max(id) from ex").first.first
+          expect = @conn.query_value("select max(id) from ex")
           assert_equal expect.to_i, result.rows.first.first
         end
         @conn = original_conn

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -319,7 +319,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   test "#begin_db_transaction raises error" do
     error = Class.new(Exception)
     assert_raises error do
-      @conn.stub(:raw_execute, -> (*) { raise error }) do
+      @conn.stub(:perform_query, -> (*) { raise error }) do
         @conn.begin_db_transaction
       end
     end
@@ -331,7 +331,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   test "#commit_db_transaction raises error" do
     error = Class.new(Exception)
     assert_raises error do
-      @conn.stub(:raw_execute, -> (*) { raise error }) do
+      @conn.stub(:perform_query, -> (*) { raise error }) do
         @conn.commit_db_transaction
       end
     end
@@ -340,7 +340,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   test "#rollback_db_transaction raises error" do
     error = Class.new(Exception)
     assert_raises error do
-      @conn.stub(:raw_execute, -> (*) { raise error }) do
+      @conn.stub(:perform_query, -> (*) { raise error }) do
         @conn.rollback_db_transaction
       end
     end

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -316,14 +316,6 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     assert_equal [], @conn.indexes("users")
   end
 
-  test "#begin_db_transaction answers empty result" do
-    result = @conn.begin_db_transaction
-    assert_equal [], result.rows
-
-    # rollback transaction so it doesn't bleed into other tests
-    @conn.rollback_db_transaction
-  end
-
   test "#begin_db_transaction raises error" do
     error = Class.new(Exception)
     assert_raises error do
@@ -334,11 +326,6 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
 
     # rollback transaction so it doesn't bleed into other tests
     @conn.rollback_db_transaction
-  end
-
-  test "#commit_db_transaction answers empty result" do
-    result = @conn.commit_db_transaction
-    assert_equal [], result.rows
   end
 
   test "#commit_db_transaction raises error" do

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -145,16 +145,16 @@ module ActiveRecord
           assert_equal "primary_shard_one_replica", pool.db_config.name
 
           IntegerKeysBase.connected_to(shard: 1) do
-            assert_includes IntegerKeysBase.lease_connection.query_value("SELECT file FROM pragma_database_list;"), "primary_shard_one.sqlite3"
+            assert_includes IntegerKeysBase.lease_connection.select_value("SELECT file FROM pragma_database_list;"), "primary_shard_one.sqlite3"
           end
 
           IntegerKeysBase.connected_to(role: :reading, shard: 1) do
-            assert_includes IntegerKeysBase.lease_connection.query_value("SELECT file FROM pragma_database_list;"), "primary_shard_one_replica.sqlite3"
+            assert_includes IntegerKeysBase.lease_connection.select_value("SELECT file FROM pragma_database_list;"), "primary_shard_one_replica.sqlite3"
           end
 
           assert_raises(ActiveRecord::ConnectionNotDefined) do
             IntegerKeysBase.connected_to(shard: 2) do
-              IntegerKeysBase.lease_connection.query_value("SELECT file FROM pragma_database_list;")
+              IntegerKeysBase.lease_connection.select_value("SELECT file FROM pragma_database_list;")
             end
           end
         ensure

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -215,7 +215,7 @@ module ActiveRecord
 
           child = Thread.new do
             conn = pool.checkout
-            conn.query_rows("SELECT 1") # ensure connected
+            conn.select_rows("SELECT 1") # ensure connected
             event.set
             Thread.stop
           end

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -215,7 +215,7 @@ module ActiveRecord
 
           child = Thread.new do
             conn = pool.checkout
-            conn.query("SELECT 1") # ensure connected
+            conn.query_rows("SELECT 1") # ensure connected
             event.set
             Thread.stop
           end

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -33,7 +33,7 @@ module ActiveRecord
 
     test "statement and binds are set on select" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
-      binds = [Minitest::Mock.new, Minitest::Mock.new]
+      binds = [123, 456]
       connection = Book.lease_connection
       intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(adapter: connection, processed_sql: sql, name: Book.name, binds: binds)
       error = assert_raises(ActiveRecord::StatementInvalid) do

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -19,10 +19,11 @@ module ActiveRecord
 
     test "message contains no sql" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
-      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(processed_sql: sql, name: Book.name)
+      connection = Book.lease_connection
+      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(adapter: connection, processed_sql: sql, name: Book.name)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        Book.lease_connection.send(:log, intent) do
-          Book.lease_connection.send(:with_raw_connection) do
+        connection.send(:log, intent) do
+          connection.send(:with_raw_connection) do
             raise MockDatabaseError
           end
         end
@@ -33,10 +34,11 @@ module ActiveRecord
     test "statement and binds are set on select" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       binds = [Minitest::Mock.new, Minitest::Mock.new]
-      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(processed_sql: sql, name: Book.name, binds: binds)
+      connection = Book.lease_connection
+      intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(adapter: connection, processed_sql: sql, name: Book.name, binds: binds)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        Book.lease_connection.send(:log, intent) do
-          Book.lease_connection.send(:with_raw_connection) do
+        connection.send(:log, intent) do
+          connection.send(:with_raw_connection) do
             raise MockDatabaseError
           end
         end

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -142,7 +142,7 @@ module AdapterHelper
       connection.instance_variable_get(:@raw_connection).async_exec("set idle_in_transaction_session_timeout = '10ms'")
       sleep 0.05
     elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      connection.send(:internal_execute, "set @@wait_timeout=1", materialize_transactions: false)
+      connection.query_command("set @@wait_timeout=1", materialize_transactions: false)
       sleep 1.2
     else
       skip("remote_disconnect unsupported")


### PR DESCRIPTION
Follow-up to #55897

QueryIntent now knows which adapter instance it belongs to (with the exception of the async queue, which needs a little extra handling, QueryIntent instances live and die all within a single `select_all`-or-similar method call on an adapter, so there's no lifetime issue).

That means QueryIntent can now ask the adapter to do work for it, and therefore is able to take the driver's seat for process steps where it was previously a passive container, like query preprocessing.

And all of the above sets us up to allow QueryIntent to `execute!`, storing the result for the caller to then request in whichever raw/cast form they prefer. 


Before:

<img width="2119" height="1438" alt="mermaid-diagram-2025-10-29-175554" src="https://github.com/user-attachments/assets/1b86ea09-2dcc-4447-b1dd-023bed7fd60e" />


Now:

<img width="2480" height="1682" alt="mermaid-diagram-2025-11-12-040028" src="https://github.com/user-attachments/assets/fa215405-b580-44d5-ba42-6f58f435057f" />

