### PR TITLE
Allow setting errors with symbol messages on custom attributes

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Changes `ActiveModel::Validations#read_attribute_for_validation` to return `nil` if the record doesn't
+    respond to the attribute instead of raising an error.
+
+    This change allows adding errors to custom attributes with symbol messages.
+
+    ```ruby
+    user = User.new # User model has no `address` attribute
+
+    user.errors.add(:address, :invalid)
+
+    user.errors.messages
+    ```
+
+    Previously, calling `messages` would raise an error because `address` attribute can't be read.
+    Now it returns the localized error message.
+
+    *Lovro Bikić*
+
 *   Add built-in Argon2 support for `has_secure_password`.
 
     `has_secure_password` now supports Argon2 as a built-in algorithm:

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -425,9 +425,9 @@ module ActiveModel
     end
 
     # Hook method defining how an attribute value should be retrieved. By default
-    # this is assumed to be an instance named after the attribute. Override this
-    # method in subclasses should you need to retrieve the value for a given
-    # attribute differently:
+    # this is assumed to be an instance named after the attribute. If the attribute
+    # does not exist, nil is returned. Override this method in subclasses should you
+    # need to retrieve the value for a given attribute differently:
     #
     #   class MyClass
     #     include ActiveModel::Validations
@@ -440,7 +440,9 @@ module ActiveModel
     #       @data[key]
     #     end
     #   end
-    alias :read_attribute_for_validation :send
+    def read_attribute_for_validation(attribute)
+      send(attribute) if respond_to?(attribute, true)
+    end
 
     # Returns the context when running validations.
     def validation_context

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -101,6 +101,22 @@ class ValidationsTest < ActiveModel::TestCase
     assert_equal 2, r.errors.count
   end
 
+  def test_errors_on_custom_attribute
+    r = Reply.new
+
+    r.errors.add(:foo_bar, "is invalid")
+
+    assert_equal ["Foo bar is invalid"], r.errors.full_messages
+  end
+
+  def test_errors_on_custom_attribute_with_symbol_message
+    r = Reply.new
+
+    r.errors.add(:foo_bar, :invalid)
+
+    assert_equal ["Foo bar is invalid"], r.errors.full_messages
+  end
+
   def test_errors_empty_after_errors_on_check
     t = Topic.new
     assert_empty t.errors[:id]


### PR DESCRIPTION
### Motivation / Background

Currently, `errors.add` with an attribute that **can't** be read works only if the error message is a string. If the error message is a symbol — meaning it has to be localized by I18n — calling `errors.messages` or `errors.full_messages` fails because of how `ActiveModel::Validations#read_attribute_for_validation` is implemented. This prevents adding localizable errors for custom attributes.

To give an example, take the following model:
```ruby
class User < ApplicationRecord
  # `users` table has columns `address_street`, `address_city` and `address_postal_code`

  validate :address_columns_all_present_or_all_blank

  private

  def address_columns_all_present_or_all_blank
    values = [address_street, address_city, address_postal_code]

    return if values.all?(&:present?) || values.all?(&:blank?)

    errors.add(:address, :invalid)
  end
end
```

The model has a custom validation which checks that the three address columns are either all present or all blank (meaning e.g. you can't set a street, but not a city; they must all be present if you want to set an address, or all blank if you want to unset it).

The validation adds the error message to attribute `address` which does not exist on the model; there's no column or method for it. It does this because in the view we only want to present one error message for all three fields, e.g. (simple_form example):
```ruby
.
  = f.label :address
  = f.full_error :address
.
  = f.input_field :address_street
  = f.input_field :address_city
  = f.input_field :address_postal_code
```
In this case, we don't want to attach the error to `:base` because we'd like it to be shown next to the address inputs, but still not attached to any particular input.

Unfortunately, generating messages for custom attributes fails because `read_attribute_for_validation` calls `send(attribute_name)`, which raises `NoMethodError` for non-existent attributes.

Note that, currently, if the model passes a string instead of a symbol as the error message in the validation:
```ruby
errors.add(:address, 'is invalid')
```
this works as expected and `errors.[full_]messages` does not fail.

### Detail

`read_attribute_for_validation` has been changed to return `nil` if the record doesn't respond to attribute name.

### Additional information

When the error message is generated in `ActiveModel::Error`, `I18n.translate` will receive `nil` as the `value` option for the translation of a non-existent attribute:
https://github.com/rails/rails/blob/a9b4f5f638fbfc908dc4e657915278cc2451810c/activemodel/lib/active_model/error.rb#L65-L72
I think this makes sense since there's no value in such cases.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
