### PR TITLE
fix cached_queries_count on ActiveRecord RuntimeRegistry

### DIFF
--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -33,6 +33,7 @@ module ActiveRecord
       record(
         payload[:name],
         (finish - start) * 1_000.0,
+        cached: payload[:cached],
         async: payload[:async],
         lock_wait: payload[:lock_wait],
       )


### PR DESCRIPTION
### Motivation / Background

After the refactoring of `ActiveRecord::RuntimeRegistry` the `cached_queries_count` stopped to be incremented when a query hits the cache.

Fix #56137

### Detail

Fix `cached` parameter not being passed when registering a query execution on `RuntimeRegistry`.
