### PR TITLE
Use explicit block parameter to avoid breaking private API signature

### DIFF
--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -167,10 +167,10 @@ module ActionView
 
           collection_body = if template
             cache_collection_render(payload, view, template, collection) do |filtered_collection|
-              collection_with_template(view, template, layout, filtered_collection, block)
+              collection_with_template(view, template, layout, filtered_collection, &block)
             end
           else
-            collection_with_template(view, nil, layout, collection, block)
+            collection_with_template(view, nil, layout, collection, &block)
           end
 
           return RenderedCollection.empty(@lookup_context.formats.first) if collection_body.empty?
@@ -179,7 +179,7 @@ module ActionView
         end
       end
 
-      def collection_with_template(view, template, layout, collection, block)
+      def collection_with_template(view, template, layout, collection, &block)
         locals = @locals
         cache = {}
 


### PR DESCRIPTION
Follow up to #56044

This broke `jbuilder` here: https://github.com/rails/jbuilder/blob/38339adaa9d44ba89c0dde2a795338a886941e6f/lib/jbuilder/collection_renderer.rb#L47

Tested with jbuilder main:

```
~/code/jbuilder => git df
diff --git a/gemfiles/rails_head.gemfile b/gemfiles/rails_head.gemfile
index e030a84..b7724f3 100644
--- a/gemfiles/rails_head.gemfile
+++ b/gemfiles/rails_head.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "rake"
 gem "mocha", require: false
 gem "appraisal"
-gem "rails", github: "rails/rails", branch: "main"
+gem "rails", path: "~/code/rails"

 gemspec path: "../"
~/code/jbuilder => bundle exec appraisal rails-head rake test
>> BUNDLE_GEMFILE=/home/zzak/code/jbuilder/gemfiles/rails_head.gemfile bundle exec rake test
/home/zzak/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0+0/gems/i18n-1.14.7/lib/i18n/exceptions.rb:3: warning: CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
Run options: --seed 25158

# Running:

....................................................................................................................................

Finished in 0.210961s, 625.7090 runs/s, 1834.4652 assertions/s.
132 runs, 387 assertions, 0 failures, 0 errors, 0 skips
```

<details>
<summary>Before:</summary>

```
~/code/jbuilder => bundle exec appraisal rails-head rake test
>> BUNDLE_GEMFILE=/home/zzak/code/jbuilder/gemfiles/rails_head.gemfile bundle exec rake test
/home/zzak/.rbenv/versions/4.0.0/lib/ruby/gems/4.0.0+0/gems/i18n-1.14.7/lib/i18n/exceptions.rb:3: warning: CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
Run options: --seed 39608

# Running:

.................................................................................................E

Error:
JbuilderTemplateTest#test_array_of_partials_under_key:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:240:in 'block in JbuilderTemplate#_set_inline_partial'
    lib/jbuilder.rb:355:in 'Jbuilder#_scope'
    lib/jbuilder/jbuilder_template.rb:238:in 'JbuilderTemplate#_set_inline_partial'
    lib/jbuilder/jbuilder_template.rb:138:in 'JbuilderTemplate#set!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:140:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:139

E

Error:
JbuilderTemplateTest#test_partial_collection_by_name_with_symbol_local:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:60:in 'JbuilderTemplate#partial!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:80:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:79

.......E

Error:
JbuilderTemplateTest#test_partial_collection_by_name_with_string_local:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:60:in 'JbuilderTemplate#partial!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:96:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:95

E

Error:
JbuilderTemplateTest#test_partial_collection_by_name_with_caching:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:60:in 'JbuilderTemplate#partial!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:88:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:87

.E

Error:
JbuilderTemplateTest#test_supports_the_cached:_true_option:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:128:in 'JbuilderTemplate#array!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:344:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:343

..E

Error:
JbuilderTemplateTest#test_supports_the_cached:_->()_{}_option:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:128:in 'JbuilderTemplate#array!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:371:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:370

.......E

Error:
JbuilderTemplateTest#test_array_of_partials:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:128:in 'JbuilderTemplate#array!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:122:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:121

....E

Error:
JbuilderTemplateTest#test_partial_collection_by_options:
ActionView::Template::Error: wrong number of arguments (given 5, expected 4)
    lib/jbuilder/collection_renderer.rb:47:in 'Jbuilder::CollectionRenderer#collection_with_template'
    lib/jbuilder/jbuilder_template.rb:170:in 'JbuilderTemplate#_render_partial_with_options'
    lib/jbuilder/jbuilder_template.rb:60:in 'JbuilderTemplate#partial!'
    test/jbuilder_template_test.rb:420:in 'JbuilderTemplateTest#render_without_parsing'
    test/jbuilder_template_test.rb:415:in 'JbuilderTemplateTest#render'
    test/jbuilder_template_test.rb:104:in 'block in <class:JbuilderTemplateTest>'


bin/rails test test/jbuilder_template_test.rb:103

......

Finished in 0.205744s, 641.5741 runs/s, 1676.8413 assertions/s.
132 runs, 345 assertions, 0 failures, 8 errors, 0 skips
rake aborted!
Command failed with status (1)
/home/zzak/.rbenv/versions/4.0.0/bin/bundle:25:in '<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
[ble: exit 1]
```
</details>

/cc @chaadow @genezys 