### PR TITLE
Fix MySQL test_table_options DefaultEngineOptionTest#test_legacy_migrations_contain_default_ENGINE=InnoDB_option

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
@@ -88,15 +88,15 @@ class DefaultEngineOptionTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def setup
-    @logger_was  = ActiveRecord::Base.logger
+    @logger_was  = ActiveRecord::LogSubscriber.logger
     @log         = StringIO.new
     @verbose_was = ActiveRecord::Migration.verbose
-    ActiveRecord::Base.logger = ActiveSupport::Logger.new(@log)
+    ActiveRecord::LogSubscriber.logger = ActiveSupport::Logger.new(@log)
     ActiveRecord::Migration.verbose = false
   end
 
   def teardown
-    ActiveRecord::Base.logger = @logger_was
+    ActiveRecord::LogSubscriber.logger = @logger_was
     ActiveRecord::Migration.verbose = @verbose_was
     ActiveRecord::Base.lease_connection.drop_table "mysql_table_options", if_exists: true
     ActiveRecord::Base.connection_pool.schema_migration.delete_all_versions rescue nil


### PR DESCRIPTION
Fixes #56142

Previously, this test would fail because the log subscriber was being reset to a file logger:

```
 #<ActiveSupport::Logger:0x00007f42c3c1c138
 @default_formatter=#<Logger::Formatter:0x00007f42c38e9858 @datetime_format=nil>,
 @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x00007f42c38e91c8 @datetime_format=nil>,
 @level=0,
 @level_override={},
 @local_level_key=:logger_thread_safe_level_2936,
 @logdev=
  #<Logger::LogDevice:0x00007f42c3c1bc38
   @binmode=false,
   @dev=#<File:debug.log>,
   @filename="debug.log",
   @mon_data=#<Monitor:0x00007f42c38e9678>,
   @mon_data_owner_object_id=2928,
   @reraise_write_errors=[],
   @shift_age=1,
   @shift_period_suffix="%Y%m%d",
   @shift_size=104857600,
   @skip_header=false>,
 @progname=nil>
```

Somewhere it becomes a StringIO logger which is what this test expects:

```
 @default_formatter=#<Logger::Formatter:0x00007f79d6326f48 @datetime_format=nil>,
 @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x00007f79d6326b10 @datetime_format=nil>,
 @level=0,
 @level_override={},
 @local_level_key=:logger_thread_safe_level_3176,
 @logdev=
  #<Logger::LogDevice:0x00007f79d56c83f0
   @binmode=false,
   @dev=#<StringIO:0x00007f79d63273d0>,
   @filename=nil,
   @mon_data=#<Monitor:0x00007f79d6326d90>,
   @mon_data_owner_object_id=3168,
   @reraise_write_errors=[],
   @shift_age=nil,
   @shift_period_suffix=nil,
   @shift_size=nil,
   @skip_header=false>,
 @progname=nil>
```

It might be worth finding out which test is mutating the log subscriber which this test passes with, but that is out of scope here. There are possibly multiple places this happens, and we could do something like leak detector to check for logger mutations in the future.

/cc @yahonda 