### PR TITLE
Make Rails.error.unexpected always report

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `ActiveSupport::ErrorReporter#unexpected` always report the error.
+
+    *Matteo Glock*
+
 *   Add a detailed failure summary to `ActiveSupport::ContinuousIntegration`.
 
     *Mike Dalessio*

--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -125,8 +125,8 @@ module ActiveSupport
     # When called in production, after the error is reported, this method will return
     # nil and execution will continue.
     #
-    # When called in development, the original error is wrapped in a different error class to ensure
-    # it's not being rescued higher in the stack and will be surfaced to the developer.
+    # When called in development, after the error is reported, the original error is wrapped in a different
+    # error class to ensure it's not being rescued higher in the stack and will be surfaced to the developer.
     #
     # This method is intended for reporting violated assertions about preconditions, or similar
     # cases that can and should be gracefully handled in production, but that aren't supposed to happen.
@@ -145,12 +145,11 @@ module ActiveSupport
     #
     def unexpected(error, severity: :warning, context: {}, source: DEFAULT_SOURCE)
       error = RuntimeError.new(error) if error.is_a?(String)
+      report(error, handled: true, severity: severity, context: context, source: source)
 
       if @debug_mode
         ensure_backtrace(error)
         raise UnexpectedError, "#{error.class.name}: #{error.message}", error.backtrace, cause: error
-      else
-        report(error, handled: true, severity: severity, context: context, source: source)
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

I love `Rails.error.unexpected`. I treat it like an `assert`, sprinkling it throughout the codebase to catch any strange behavior in dev or prod. Being able to attach custom context is useful for debugging production issues.

In development, it is not modular at all: when an unexpected case happens, we get an exception and a stack trace. All the benefits of the context hash and custom dev error subscribers are lost.

A simple fix would be to have it call `report` before raising the error.

### Detail

This Pull Request changes `ActiveSupport::ErrorReporter#unexpected` to always calls `report` before raising the error.

### Additional information

- [Original discussion](https://discuss.rubyonrails.org/t/activesupport-error-reporter-make-unexpected-call-report-before-raising-the-error/89911)