### PR TITLE
Empty all tables with delete for trilogy

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -13,18 +13,6 @@ module ActiveRecord
           end
         end
 
-        def empty_all_tables # :nodoc:
-          table_names = tables - [pool.schema_migration.table_name, pool.internal_metadata.table_name]
-          return if table_names.empty?
-
-          statements = build_delete_from_statements(table_names)
-
-          # Deleting is generally much faster than truncating in MySQL
-          disable_referential_integrity do
-            execute_batch(statements, "Delete Tables")
-          end
-        end
-
         private
           def execute_batch(statements, name = nil, **kwargs)
             combine_multi_statements(statements).each do |statement|

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/empty_all_tables_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/empty_all_tables_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+require "models/author"
+require "models/bulb"
+require "models/car"
+
+class MySQLEmptyTablesTest < ActiveRecord::AbstractMysqlTestCase
+  self.use_transactional_tests = false
+
+  def setup
+    @conn = ActiveRecord::Base.lease_connection
+  end
+
+  def test_empty_all_tables_uses_delete_not_truncate
+    queries = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+      queries << event.payload[:sql] if event.payload[:name] == "Delete Tables"
+    end
+
+    @conn.empty_all_tables
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+
+    assert queries.any? { |q| q.include?("DELETE FROM") }, "Expected DELETE statements to be used"
+    assert queries.none? { |q| q.include?("TRUNCATE") }, "Expected TRUNCATE statements to NOT be used"
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -352,25 +352,3 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       super(@conn, "ex", definition, &block)
     end
 end
-
-class Mysql2AdapterEmptyAllTablesTest < ActiveRecord::Mysql2TestCase
-  self.use_transactional_tests = false
-
-  def setup
-    @conn = ActiveRecord::Base.lease_connection
-  end
-
-  def test_empty_all_tables_uses_delete_not_truncate
-    queries = []
-    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-      queries << event.payload[:sql] if event.payload[:name] == "Delete Tables"
-    end
-
-    @conn.empty_all_tables
-
-    ActiveSupport::Notifications.unsubscribe(subscriber)
-
-    assert queries.any? { |q| q.include?("DELETE FROM") }, "Expected DELETE statements to be used"
-    assert queries.none? { |q| q.include?("TRUNCATE") }, "Expected TRUNCATE statements to NOT be used"
-  end
-end


### PR DESCRIPTION
Following on from https://github.com/rails/rails/pull/56097, move the `empty_all_tables` implementation into the abstract MySQL adapter so that it is also used with the `trilogy` adapter.
