### PR TITLE
Add support for parameterized tests

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add parameterized tests via `ActiveSupport::TestCase#test`
+
+    ```ruby
+    test "greater than 0", each: [1, 2, 3] do |value|
+      assert_operator value, :>, 0
+    end
+    ```
+
+    *Joseph Hale*
+
 *   Make flaky parallel tests easier to diagnose by deterministically assigning
     tests to workers.
 

--- a/activesupport/lib/active_support/testing/declarative.rb
+++ b/activesupport/lib/active_support/testing/declarative.rb
@@ -10,18 +10,36 @@ module ActiveSupport
         #   test "verify something" do
         #     ...
         #   end
-        def test(name, &block)
+        #
+        # Also supports parameterized tests.
+        #
+        #   test "verify something", each: [ ... ] do |value|
+        #     ...
+        #   end
+        def test(name, each: [], &block)
           test_name = "test_#{name.gsub(/\s+/, '_')}".to_sym
-          defined = method_defined? test_name
-          raise "#{test_name} is already defined in #{self}" if defined
-          if block_given?
-            define_method(test_name, &block)
-          else
-            define_method(test_name) do
-              flunk "No implementation provided for #{name}"
+          test_with_name(test_name, each: each, &block)
+        end
+
+        private
+          def test_with_name(test_name, each: [], &block)
+            if each.any?
+              each.each do |value|
+                parameterized_test_name = "#{test_name} |#{value.inspect}|".to_sym
+                test_with_name(parameterized_test_name) { instance_exec(value, &block) }
+              end
+            else
+              defined = method_defined? test_name
+              raise "#{test_name} is already defined in #{self}" if defined
+              if block_given?
+                define_method(test_name, &block)
+              else
+                define_method(test_name) do
+                  flunk "No implementation provided for #{test_name}"
+                end
+              end
             end
           end
-        end
       end
     end
   end

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -19,25 +19,32 @@ class BlankTest < ActiveSupport::TestCase
   BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {} ]
   NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now ]
 
-  def test_blank
-    BLANK.each { |v| assert_equal true, v.blank?,  "#{v.inspect} should be blank" }
-    NOT.each   { |v| assert_equal false, v.blank?, "#{v.inspect} should not be blank" }
+  test "blank", each: BLANK do |value|
+    assert_equal true, value.blank?
   end
 
-  def test_blank_with_bundled_string_encodings
-    Encoding.list.reject(&:dummy?).each do |encoding|
-      assert_predicate " ".encode(encoding), :blank?
-      assert_not_predicate "a".encode(encoding), :blank?
-    end
+  test "not blank", each: NOT do |value|
+    assert_equal false, value.blank?
   end
 
-  def test_present
-    BLANK.each { |v| assert_equal false, v.present?, "#{v.inspect} should not be present" }
-    NOT.each   { |v| assert_equal true, v.present?,  "#{v.inspect} should be present" }
+  test "blank with bundled string encodings", each: Encoding.list.reject(&:dummy?) do |encoding|
+    assert_predicate " ".encode(encoding), :blank?
+    assert_not_predicate "a".encode(encoding), :blank?
   end
 
-  def test_presence
-    BLANK.each { |v| assert_nil v.presence, "#{v.inspect}.presence should return nil" }
-    NOT.each   { |v| assert_equal v,   v.presence, "#{v.inspect}.presence should return self" }
+  test "present", each: NOT do |value|
+    assert_equal true, value.present?
+  end
+
+  test "not present", each: BLANK do |value|
+    assert_equal false, value.present?
+  end
+
+  test "presence is self", each: NOT do |value|
+    assert_equal value, value.presence
+  end
+
+  test "presence is nil", each: BLANK do |value|
+    assert_nil value.presence
   end
 end

--- a/activesupport/test/core_ext/object/with_test.rb
+++ b/activesupport/test/core_ext/object/with_test.rb
@@ -92,12 +92,7 @@ class WithTest < ActiveSupport::TestCase
     assert_equal "1", @object.with(public_attr: "1", &:public_attr)
   end
 
-  test "basic immediates don't respond to #with" do
-    assert_not_respond_to nil, :with
-    assert_not_respond_to true, :with
-    assert_not_respond_to false, :with
-    assert_not_respond_to 1, :with
-    assert_not_respond_to 1.0, :with
-    assert_not_respond_to :sym, :with
+  test "basic immediates don't respond to #with", each: [nil, true, false, 1, 1.0, :sym] do |value|
+    assert_not_respond_to value, :with
   end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -56,16 +56,20 @@ class StringInflectionsTest < ActiveSupport::TestCase
     EOS
   end
 
-  def test_pluralize
-    SingularToPlural.each do |singular, plural|
-      assert_equal(plural, singular.pluralize)
-    end
+  test "pluralize", each: SingularToPlural do |singular, plural|
+    assert_equal(plural, singular.pluralize)
+  end
 
+  test "pluralize already pluralized word" do
     assert_equal("plurals", "plurals".pluralize)
+  end
 
-    assert_equal("blargles", "blargle".pluralize(0))
-    assert_equal("blargle", "blargle".pluralize(1))
-    assert_equal("blargles", "blargle".pluralize(2))
+  test "pluralize with count", each: [
+    ["blargle", 0, "blargles"],
+    ["blargle", 1, "blargle"],
+    ["blargle", 2, "blargles"]
+  ] do |singular, count, plural|
+    assert_equal plural, singular.pluralize(count)
   end
 
   test "pluralize with count = 1 still returns new string" do
@@ -73,22 +77,16 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_not_same name.pluralize(1), name
   end
 
-  def test_singularize
-    SingularToPlural.each do |singular, plural|
-      assert_equal(singular, plural.singularize)
-    end
+  test "singularize", each: SingularToPlural do |singular, plural|
+    assert_equal(singular, plural.singularize)
   end
 
-  def test_titleize
-    MixtureToTitleCase.each do |before, titleized|
-      assert_equal(titleized, before.titleize)
-    end
+  test "titleize", each: MixtureToTitleCase do |before, titleized|
+    assert_equal(titleized, before.titleize)
   end
 
-  def test_titleize_with_keep_id_suffix
-    MixtureToTitleCaseWithKeepIdSuffix.each do |before, titleized|
-      assert_equal(titleized, before.titleize(keep_id_suffix: true))
-    end
+  test "titleize with keep_id_suffix", each: MixtureToTitleCaseWithKeepIdSuffix do |before, titleized|
+    assert_equal(titleized, before.titleize(keep_id_suffix: true))
   end
 
   def test_downcase_first
@@ -117,10 +115,8 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_not_predicate "".upcase_first, :frozen?
   end
 
-  def test_camelize
-    CamelToUnderscore.each do |camel, underscore|
-      assert_equal(camel, underscore.camelize)
-    end
+  test "camelize", each: CamelToUnderscore do |camel, underscore|
+    assert_equal(camel, underscore.camelize)
   end
 
   def test_camelize_lower
@@ -138,25 +134,23 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal("Invalid option, use either :upper or :lower.", e.message)
   end
 
-  def test_dasherize
-    UnderscoresToDashes.each do |underscored, dasherized|
-      assert_equal(dasherized, underscored.dasherize)
-    end
+  test "dasherize", each: UnderscoresToDashes do |underscored, dasherized|
+    assert_equal(dasherized, underscored.dasherize)
   end
 
-  def test_underscore
-    CamelToUnderscore.each do |camel, underscore|
-      assert_equal(underscore, camel.underscore)
-    end
-
-    assert_equal "html_tidy", "HTMLTidy".underscore
-    assert_equal "html_tidy_generator", "HTMLTidyGenerator".underscore
+  test "underscore", each: CamelToUnderscore do |camel, underscore|
+    assert_equal(underscore, camel.underscore)
   end
 
-  def test_underscore_to_lower_camel
-    UnderscoreToLowerCamel.each do |underscored, lower_camel|
-      assert_equal(lower_camel, underscored.camelize(:lower))
-    end
+  test "underscore acronyms", each: [
+    ["HTMLTidy", "html_tidy"],
+    ["HTMLTidyGenerator", "html_tidy_generator"]
+  ] do |acronym, underscored|
+    assert_equal underscored, acronym.underscore
+  end
+
+  test "underscore to lower camel", each: UnderscoreToLowerCamel do |underscored, lower_camel|
+    assert_equal(lower_camel, underscored.camelize(:lower))
   end
 
   def test_demodulize
@@ -167,62 +161,44 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "MyApplication::Billing", "MyApplication::Billing::Account".deconstantize
   end
 
-  def test_foreign_key
-    ClassNameToForeignKeyWithUnderscore.each do |klass, foreign_key|
-      assert_equal(foreign_key, klass.foreign_key)
-    end
-
-    ClassNameToForeignKeyWithoutUnderscore.each do |klass, foreign_key|
-      assert_equal(foreign_key, klass.foreign_key(false))
-    end
+  test "foreign_key", each: ClassNameToForeignKeyWithUnderscore do |klass, foreign_key|
+    assert_equal(foreign_key, klass.foreign_key)
   end
 
-  def test_tableize
-    ClassNameToTableName.each do |class_name, table_name|
-      assert_equal(table_name, class_name.tableize)
-    end
+  test "foreign_key", each: ClassNameToForeignKeyWithoutUnderscore do |klass, foreign_key|
+    assert_equal(foreign_key, klass.foreign_key(false))
   end
 
-  def test_classify
-    ClassNameToTableName.each do |class_name, table_name|
-      assert_equal(class_name, table_name.classify)
-    end
+  test "tableize", each: ClassNameToTableName do |class_name, table_name|
+    assert_equal(table_name, class_name.tableize)
   end
 
-  def test_string_parameterized_normal
-    StringToParameterized.each do |normal, slugged|
-      assert_equal(slugged, normal.parameterize)
-    end
+  test "classify", each: ClassNameToTableName do |class_name, table_name|
+    assert_equal(class_name, table_name.classify)
   end
 
-  def test_string_parameterized_normal_preserve_case
-    StringToParameterizedPreserveCase.each do |normal, slugged|
-      assert_equal(slugged, normal.parameterize(preserve_case: true))
-    end
+  test "string parameterized normal", each: StringToParameterized do |normal, slugged|
+    assert_equal(slugged, normal.parameterize)
   end
 
-  def test_string_parameterized_no_separator
-    StringToParameterizeWithNoSeparator.each do |normal, slugged|
-      assert_equal(slugged, normal.parameterize(separator: ""))
-    end
+  test "string parameterized normal preserve_case", each: StringToParameterizedPreserveCase do |normal, slugged|
+    assert_equal(slugged, normal.parameterize(preserve_case: true))
   end
 
-  def test_string_parameterized_no_separator_preserve_case
-    StringToParameterizePreserveCaseWithNoSeparator.each do |normal, slugged|
-      assert_equal(slugged, normal.parameterize(separator: "", preserve_case: true))
-    end
+  test "string parameterized no separator", each: StringToParameterizeWithNoSeparator do |normal, slugged|
+    assert_equal(slugged, normal.parameterize(separator: ""))
   end
 
-  def test_string_parameterized_underscore
-    StringToParameterizeWithUnderscore.each do |normal, slugged|
-      assert_equal(slugged, normal.parameterize(separator: "_"))
-    end
+  test "string parameterized no separator preserve_case", each: StringToParameterizePreserveCaseWithNoSeparator do |normal, slugged|
+    assert_equal(slugged, normal.parameterize(separator: "", preserve_case: true))
   end
 
-  def test_string_parameterized_underscore_preserve_case
-    StringToParameterizePreserveCaseWithUnderscore.each do |normal, slugged|
-      assert_equal(slugged, normal.parameterize(separator: "_", preserve_case: true))
-    end
+  test "string parameterized underscore", each: StringToParameterizeWithUnderscore do |normal, slugged|
+    assert_equal(slugged, normal.parameterize(separator: "_"))
+  end
+
+  test "string parameterized underscore preserve_case", each: StringToParameterizePreserveCaseWithUnderscore do |normal, slugged|
+    assert_equal(slugged, normal.parameterize(separator: "_", preserve_case: true))
   end
 
   def test_parameterize_with_locale
@@ -231,31 +207,24 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal("fuenf-autos", word.parameterize(locale: :de))
   end
 
-  def test_humanize
-    UnderscoreToHuman.each do |underscore, human|
-      assert_equal(human, underscore.humanize)
-    end
+  test "humanize", each: UnderscoreToHuman do |underscore, human|
+    assert_equal(human, underscore.humanize)
   end
 
-  def test_humanize_without_capitalize
-    UnderscoreToHumanWithoutCapitalize.each do |underscore, human|
-      assert_equal(human, underscore.humanize(capitalize: false))
-    end
+  test "humanize without capitalize", each: UnderscoreToHumanWithoutCapitalize do |underscore, human|
+    assert_equal(human, underscore.humanize(capitalize: false))
   end
 
-  def test_humanize_with_keep_id_suffix
-    UnderscoreToHumanWithKeepIdSuffix.each do |underscore, human|
-      assert_equal(human, underscore.humanize(keep_id_suffix: true))
-    end
+  test "humanize with keep_id_suffix", each: UnderscoreToHumanWithKeepIdSuffix do |underscore, human|
+    assert_equal(human, underscore.humanize(keep_id_suffix: true))
   end
 
   def test_humanize_with_html_escape
     assert_equal "Hello", ERB::Util.html_escape("hello").humanize
   end
 
-  def test_ord
-    assert_equal 97, "a".ord
-    assert_equal 97, "abc".ord
+  test "ord", each: ["a", "abc"] do |str|
+    assert_equal 97, str.ord
   end
 
   def test_starts_ends_with_alias
@@ -1146,13 +1115,11 @@ class StringExcludeTest < ActiveSupport::TestCase
 end
 
 class StringIndentTest < ActiveSupport::TestCase
-  test "does not indent strings that only contain newlines (edge cases)" do
-    ["", "\n", "\n" * 7].each do |string|
-      str = string.dup
-      assert_nil str.indent!(8)
-      assert_equal str, str.indent(8)
-      assert_equal str, str.indent(1, "\t")
-    end
+  test "does not indent strings that only contain newlines (edge case)", each: ["", "\n", "\n" * 7] do |string|
+    str = string.dup
+    assert_nil str.indent!(8)
+    assert_equal str, str.indent(8)
+    assert_equal str, str.indent(1, "\t")
   end
 
   test "by default, indents with spaces if the existing indentation uses them" do

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -79,12 +79,10 @@ class InflectorTest < ActiveSupport::TestCase
     ActiveSupport::Inflector.inflections.uncountables.pop
   end
 
-  ActiveSupport::Inflector.inflections.uncountable.each do |word|
-    define_method "test_uncountability_of_#{word}" do
-      assert_equal word, ActiveSupport::Inflector.singularize(word)
-      assert_equal word, ActiveSupport::Inflector.pluralize(word)
-      assert_equal ActiveSupport::Inflector.pluralize(word), ActiveSupport::Inflector.singularize(word)
-    end
+  test "uncountability of", each: ActiveSupport::Inflector.inflections.uncountable do |word|
+    assert_equal word, ActiveSupport::Inflector.singularize(word)
+    assert_equal word, ActiveSupport::Inflector.pluralize(word)
+    assert_equal ActiveSupport::Inflector.pluralize(word), ActiveSupport::Inflector.singularize(word)
   end
 
   def test_uncountable_word_is_not_greedy
@@ -102,30 +100,24 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal "sponsor", ActiveSupport::Inflector.singularize(ActiveSupport::Inflector.pluralize(countable_word))
   end
 
-  SingularToPlural.each do |singular, plural|
-    define_method "test_pluralize_singular_#{singular}" do
-      assert_equal(plural, ActiveSupport::Inflector.pluralize(singular))
-      assert_equal(plural.capitalize, ActiveSupport::Inflector.pluralize(singular.capitalize))
-    end
+  test "pluralize singular", each: SingularToPlural do |singular, plural|
+    assert_equal(plural, ActiveSupport::Inflector.pluralize(singular))
+    assert_equal(plural.capitalize, ActiveSupport::Inflector.pluralize(singular.capitalize))
   end
 
-  SingularToPlural.each do |singular, plural|
-    define_method "test_singularize_plural_#{plural}" do
-      assert_equal(singular, ActiveSupport::Inflector.singularize(plural))
-      assert_equal(singular.capitalize, ActiveSupport::Inflector.singularize(plural.capitalize))
-    end
+  test "singularize plural", each: SingularToPlural do |singular, plural|
+    assert_equal(singular, ActiveSupport::Inflector.singularize(plural))
+    assert_equal(singular.capitalize, ActiveSupport::Inflector.singularize(plural.capitalize))
   end
 
-  SingularToPlural.each do |singular, plural|
-    define_method "test_pluralize_plural_#{plural}" do
-      assert_equal(plural, ActiveSupport::Inflector.pluralize(plural))
-      assert_equal(plural.capitalize, ActiveSupport::Inflector.pluralize(plural.capitalize))
-    end
+  test "pluralize plural", each: SingularToPlural do |singular, plural|
+    assert_equal(plural, ActiveSupport::Inflector.pluralize(plural))
+    assert_equal(plural.capitalize, ActiveSupport::Inflector.pluralize(plural.capitalize))
+  end
 
-    define_method "test_singularize_singular_#{singular}" do
-      assert_equal(singular, ActiveSupport::Inflector.singularize(singular))
-      assert_equal(singular.capitalize, ActiveSupport::Inflector.singularize(singular.capitalize))
-    end
+  test "singularize singular", each: SingularToPlural do |singular, plural|
+    assert_equal(singular, ActiveSupport::Inflector.singularize(singular))
+    assert_equal(singular.capitalize, ActiveSupport::Inflector.singularize(singular.capitalize))
   end
 
   def test_overwrite_previous_inflectors
@@ -134,49 +126,38 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("serie", ActiveSupport::Inflector.singularize("series"))
   end
 
-  MixtureToTitleCase.each_with_index do |(before, titleized), index|
-    define_method "test_titleize_mixture_to_title_case_#{index}" do
-      assert_equal(titleized, ActiveSupport::Inflector.titleize(before), "mixture \
-        to TitleCase failed for #{before}")
-    end
+  test "titleize mixture to title case", each: MixtureToTitleCase do |before, titleized|
+    assert_equal(titleized, ActiveSupport::Inflector.titleize(before), "mixture \
+      to TitleCase failed for #{before}")
   end
 
-  MixtureToTitleCaseWithKeepIdSuffix.each_with_index do |(before, titleized), index|
-    define_method "test_titleize_with_keep_id_suffix_mixture_to_title_case_#{index}" do
-      assert_equal(titleized, ActiveSupport::Inflector.titleize(before, keep_id_suffix: true),
-        "mixture to TitleCase with keep_id_suffix failed for #{before}")
-    end
+  test "titleize with keep_id_suffix mixture to title case", each: MixtureToTitleCaseWithKeepIdSuffix do |before, titleized|
+    assert_equal(titleized, ActiveSupport::Inflector.titleize(before, keep_id_suffix: true),
+      "mixture to TitleCase with keep_id_suffix failed for #{before}")
   end
 
-  def test_camelize
-    CamelToUnderscore.each do |camel, underscore|
-      assert_equal(camel, ActiveSupport::Inflector.camelize(underscore))
-    end
+  test "camelize", each: CamelToUnderscore do |camel, underscore|
+    assert_equal(camel, ActiveSupport::Inflector.camelize(underscore))
   end
 
-  def test_camelize_with_true_upcases_the_first_letter
-    assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", true))
-    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", true))
+  test "camelize with true upcases the first letter", each: ["Capital", "capital"] do |input|
+    assert_equal("Capital", ActiveSupport::Inflector.camelize(input, true))
   end
 
-  def test_camelize_with_upper_upcases_the_first_letter
-    assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", :upper))
-    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", :upper))
+  test "camelize with upper upcases the first letter", each: ["Capital", "capital"] do |input|
+    assert_equal("Capital", ActiveSupport::Inflector.camelize(input, :upper))
   end
 
-  def test_camelize_with_false_downcases_the_first_letter
-    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", false))
-    assert_equal("capital", ActiveSupport::Inflector.camelize("capital", false))
+  test "camelize with false downcases the first letter", each: ["Capital", "capital"] do |input|
+    assert_equal("capital", ActiveSupport::Inflector.camelize(input, false))
   end
 
-  def test_camelize_with_nil_downcases_the_first_letter
-    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", nil))
-    assert_equal("capital", ActiveSupport::Inflector.camelize("capital", nil))
+  test "camelize with nil downcases the first letter", each: ["Capital", "capital"] do |input|
+    assert_equal("capital", ActiveSupport::Inflector.camelize(input, nil))
   end
 
-  def test_camelize_with_lower_downcases_the_first_letter
-    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", :lower))
-    assert_equal("capital", ActiveSupport::Inflector.camelize("capital", :lower))
+  test "camelize with lower downcases the first letter", each: ["Capital", "capital"] do |input|
+    assert_equal("capital", ActiveSupport::Inflector.camelize(input, :lower))
   end
 
   def test_camelize_with_any_other_arg_upcases_the_first_letter
@@ -285,25 +266,20 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("json_html_api", ActiveSupport::Inflector.underscore("JSONHTMLAPI"))
   end
 
-  def test_underscore
-    CamelToUnderscore.each do |camel, underscore|
-      assert_equal(underscore, ActiveSupport::Inflector.underscore(camel))
-    end
-    CamelToUnderscoreWithoutReverse.each do |camel, underscore|
-      assert_equal(underscore, ActiveSupport::Inflector.underscore(camel))
-    end
+  test "underscore", each: CamelToUnderscore do |camel, underscore|
+    assert_equal(underscore, ActiveSupport::Inflector.underscore(camel))
   end
 
-  def test_camelize_with_module
-    CamelWithModuleToUnderscoreWithSlash.each do |camel, underscore|
-      assert_equal(camel, ActiveSupport::Inflector.camelize(underscore))
-    end
+  test "underscore", each: CamelToUnderscoreWithoutReverse do |camel, underscore|
+    assert_equal(underscore, ActiveSupport::Inflector.underscore(camel))
   end
 
-  def test_underscore_with_slashes
-    CamelWithModuleToUnderscoreWithSlash.each do |camel, underscore|
-      assert_equal(underscore, ActiveSupport::Inflector.underscore(camel))
-    end
+  test "camelize with module", each: CamelWithModuleToUnderscoreWithSlash do |camel, underscore|
+    assert_equal(camel, ActiveSupport::Inflector.camelize(underscore))
+  end
+
+  test "underscore with slashes", each: CamelWithModuleToUnderscoreWithSlash do |camel, underscore|
+    assert_equal(underscore, ActiveSupport::Inflector.underscore(camel))
   end
 
   def test_demodulize
@@ -325,44 +301,32 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal "", ActiveSupport::Inflector.deconstantize("")
   end
 
-  def test_foreign_key
-    ClassNameToForeignKeyWithUnderscore.each do |klass, foreign_key|
-      assert_equal(foreign_key, ActiveSupport::Inflector.foreign_key(klass))
-    end
-
-    ClassNameToForeignKeyWithoutUnderscore.each do |klass, foreign_key|
-      assert_equal(foreign_key, ActiveSupport::Inflector.foreign_key(klass, false))
-    end
+  test "foreign_key", each: ClassNameToForeignKeyWithUnderscore do |klass, foreign_key|
+    assert_equal(foreign_key, ActiveSupport::Inflector.foreign_key(klass))
   end
 
-  def test_tableize
-    ClassNameToTableName.each do |class_name, table_name|
-      assert_equal(table_name, ActiveSupport::Inflector.tableize(class_name))
-    end
+  test "foreign_key", each: ClassNameToForeignKeyWithoutUnderscore do |klass, foreign_key|
+    assert_equal(foreign_key, ActiveSupport::Inflector.foreign_key(klass, false))
   end
 
-  def test_parameterize
-    StringToParameterized.each do |some_string, parameterized_string|
-      assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
-    end
+  test "tableize", each: ClassNameToTableName do |class_name, table_name|
+    assert_equal(table_name, ActiveSupport::Inflector.tableize(class_name))
   end
 
-  def test_parameterize_and_normalize
-    StringToParameterizedAndNormalized.each do |some_string, parameterized_string|
-      assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
-    end
+  test "parameterize", each: StringToParameterized do |some_string, parameterized_string|
+    assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
   end
 
-  def test_parameterize_with_custom_separator
-    StringToParameterizeWithUnderscore.each do |some_string, parameterized_string|
-      assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string, separator: "_"))
-    end
+  test "parameterize and normalize", each: StringToParameterizedAndNormalized do |some_string, parameterized_string|
+    assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string))
   end
 
-  def test_parameterize_with_multi_character_separator
-    StringToParameterized.each do |some_string, parameterized_string|
-      assert_equal(parameterized_string.gsub("-", "__sep__"), ActiveSupport::Inflector.parameterize(some_string, separator: "__sep__"))
-    end
+  test "parameterize with custom separator", each: StringToParameterizeWithUnderscore do |some_string, parameterized_string|
+    assert_equal(parameterized_string, ActiveSupport::Inflector.parameterize(some_string, separator: "_"))
+  end
+
+  test "parameterize with multi-character separator", each: StringToParameterized do |some_string, parameterized_string|
+    assert_equal(parameterized_string.gsub("-", "__sep__"), ActiveSupport::Inflector.parameterize(some_string, separator: "__sep__"))
   end
 
   def test_parameterize_with_locale
@@ -371,11 +335,9 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("fuenf-autos", ActiveSupport::Inflector.parameterize(word, locale: :de))
   end
 
-  def test_classify
-    ClassNameToTableName.each do |class_name, table_name|
-      assert_equal(class_name, ActiveSupport::Inflector.classify(table_name))
-      assert_equal(class_name, ActiveSupport::Inflector.classify("table_prefix." + table_name))
-    end
+  test "classify", each: ClassNameToTableName do |class_name, table_name|
+    assert_equal(class_name, ActiveSupport::Inflector.classify(table_name))
+    assert_equal(class_name, ActiveSupport::Inflector.classify("table_prefix." + table_name))
   end
 
   def test_classify_with_symbol
@@ -388,26 +350,20 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal "FooBar", ActiveSupport::Inflector.classify("schema.foo_bar")
   end
 
-  def test_humanize
-    UnderscoreToHuman.each do |underscore, human|
-      assert_equal(human, ActiveSupport::Inflector.humanize(underscore))
-    end
+  test "humanize", each: UnderscoreToHuman do |underscore, human|
+    assert_equal(human, ActiveSupport::Inflector.humanize(underscore))
   end
 
   def test_humanize_nil
     assert_equal("", ActiveSupport::Inflector.humanize(nil))
   end
 
-  def test_humanize_without_capitalize
-    UnderscoreToHumanWithoutCapitalize.each do |underscore, human|
-      assert_equal(human, ActiveSupport::Inflector.humanize(underscore, capitalize: false))
-    end
+  test "humanize without capitalize", each: UnderscoreToHumanWithoutCapitalize do |underscore, human|
+    assert_equal(human, ActiveSupport::Inflector.humanize(underscore, capitalize: false))
   end
 
-  def test_humanize_with_keep_id_suffix
-    UnderscoreToHumanWithKeepIdSuffix.each do |underscore, human|
-      assert_equal(human, ActiveSupport::Inflector.humanize(underscore, keep_id_suffix: true))
-    end
+  test "humanize with keep id suffix", each: UnderscoreToHumanWithKeepIdSuffix do |underscore, human|
+    assert_equal(human, ActiveSupport::Inflector.humanize(underscore, keep_id_suffix: true))
   end
 
   def test_humanize_by_rule
@@ -457,52 +413,51 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
-  def test_ordinal
-    OrdinalNumbers.each do |number, ordinalized|
-      assert_equal(ordinalized, number + ActiveSupport::Inflector.ordinal(number))
-    end
+  test "ordinal", each: OrdinalNumbers do |number, ordinalized|
+    assert_equal(ordinalized, number + ActiveSupport::Inflector.ordinal(number))
   end
 
-  def test_ordinalize
-    OrdinalNumbers.each do |number, ordinalized|
-      assert_equal(ordinalized, ActiveSupport::Inflector.ordinalize(number))
-    end
+  test "ordinalize", each: OrdinalNumbers do |number, ordinalized|
+    assert_equal(ordinalized, ActiveSupport::Inflector.ordinalize(number))
   end
 
-  def test_dasherize
-    UnderscoresToDashes.each do |underscored, dasherized|
-      assert_equal(dasherized, ActiveSupport::Inflector.dasherize(underscored))
-    end
+  test "dasherize", each: UnderscoresToDashes do |underscored, dasherized|
+    assert_equal(dasherized, ActiveSupport::Inflector.dasherize(underscored))
   end
 
-  def test_underscore_as_reverse_of_dasherize
-    UnderscoresToDashes.each_key do |underscored|
-      assert_equal(underscored, ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.dasherize(underscored)))
-    end
+  test "underscore as reverse of dasherize", each: UnderscoresToDashes do |underscored, dasherized|
+    assert_equal(underscored, ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.dasherize(underscored)))
   end
 
-  def test_underscore_to_lower_camel
-    UnderscoreToLowerCamel.each do |underscored, lower_camel|
-      assert_equal(lower_camel, ActiveSupport::Inflector.camelize(underscored, false))
-    end
+  test "underscore to lower camel", each: UnderscoreToLowerCamel do |underscored, lower_camel|
+    assert_equal(lower_camel, ActiveSupport::Inflector.camelize(underscored, false))
   end
 
-  def test_symbol_to_lower_camel
-    SymbolToLowerCamel.each do |symbol, lower_camel|
-      assert_equal(lower_camel, ActiveSupport::Inflector.camelize(symbol, false))
-    end
+  test "symbol to lower camel", each: SymbolToLowerCamel do |symbol, lower_camel|
+    assert_equal(lower_camel, ActiveSupport::Inflector.camelize(symbol, false))
   end
 
-  %w{plurals singulars uncountables humans}.each do |inflection_type|
-    class_eval <<-RUBY, __FILE__, __LINE__ + 1
-      def test_clear_#{inflection_type}
-        ActiveSupport::Inflector.inflections.clear :#{inflection_type}
-        assert ActiveSupport::Inflector.inflections.#{inflection_type}.empty?, \"#{inflection_type} inflections should be empty after clear :#{inflection_type}\"
-      end
-    RUBY
+  test "clear plurals" do
+    ActiveSupport::Inflector.inflections.clear :plurals
+    assert ActiveSupport::Inflector.inflections.plurals.empty?
   end
 
-  def test_clear_acronyms_resets_to_reusable_state
+  test "clear singulars" do
+    ActiveSupport::Inflector.inflections.clear :singulars
+    assert ActiveSupport::Inflector.inflections.singulars.empty?
+  end
+
+  test "clear uncountables" do
+    ActiveSupport::Inflector.inflections.clear :uncountables
+    assert ActiveSupport::Inflector.inflections.uncountables.empty?
+  end
+
+  test "clear humans" do
+    ActiveSupport::Inflector.inflections.clear :humans
+    assert ActiveSupport::Inflector.inflections.humans.empty?
+  end
+
+  test "clear acronyms resets to reusable state" do
     ActiveSupport::Inflector.inflections.clear(:acronyms)
 
     assert_empty ActiveSupport::Inflector.inflections.acronyms
@@ -604,7 +559,7 @@ class InflectorTest < ActiveSupport::TestCase
   end
 
   Irregularities.each do |singular, plural|
-    define_method("test_irregularity_between_#{singular}_and_#{plural}") do
+    test "irregularity between #{singular} and #{plural}" do
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.irregular(singular, plural)
         assert_equal singular, ActiveSupport::Inflector.singularize(plural)
@@ -614,7 +569,7 @@ class InflectorTest < ActiveSupport::TestCase
   end
 
   Irregularities.each do |singular, plural|
-    define_method("test_pluralize_of_irregularity_#{plural}_should_be_the_same") do
+    test "pluralize of irregularity #{plural} should be the same" do
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.irregular(singular, plural)
         assert_equal plural, ActiveSupport::Inflector.pluralize(plural)
@@ -623,7 +578,7 @@ class InflectorTest < ActiveSupport::TestCase
   end
 
   Irregularities.each do |singular, plural|
-    define_method("test_singularize_of_irregularity_#{singular}_should_be_the_same") do
+    test "singularize of irregularity #{singular} should be the same" do
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.irregular(singular, plural)
         assert_equal singular, ActiveSupport::Inflector.singularize(singular)
@@ -631,38 +586,33 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
-  [ :all, [] ].each do |scope|
+  test "clear inflections with", each: [[], :all] do |scope|
     ActiveSupport::Inflector.inflections do |inflect|
-      define_method("test_clear_inflections_with_#{scope.kind_of?(Array) ? "no_arguments" : scope}") do
-        # save all the inflections
-        singulars, plurals, uncountables = inflect.singulars, inflect.plurals, inflect.uncountables
+      # save all the inflections
+      singulars, plurals, uncountables = inflect.singulars, inflect.plurals, inflect.uncountables
 
-        # clear all the inflections
-        inflect.clear(*scope)
+      # clear all the inflections
+      inflect.clear(*scope)
 
-        assert_equal [], inflect.singulars
-        assert_equal [], inflect.plurals
-        assert_equal [], inflect.uncountables.to_a
+      assert_equal [], inflect.singulars
+      assert_equal [], inflect.plurals
+      assert_equal [], inflect.uncountables.to_a
 
-        # restore all the inflections
-        singulars.reverse_each { |singular| inflect.singular(*singular) }
-        plurals.reverse_each   { |plural|   inflect.plural(*plural) }
-        inflect.uncountable(uncountables)
+      # restore all the inflections
+      singulars.reverse_each { |singular| inflect.singular(*singular) }
+      plurals.reverse_each   { |plural|   inflect.plural(*plural) }
+      inflect.uncountable(uncountables)
 
-        assert_equal singulars, inflect.singulars
-        assert_equal plurals, inflect.plurals
-        assert_equal uncountables, inflect.uncountables
-      end
+      assert_equal singulars, inflect.singulars
+      assert_equal plurals, inflect.plurals
+      assert_equal uncountables, inflect.uncountables
     end
   end
 
-  %i(plurals singulars uncountables humans).each do |scope|
-    define_method("test_clear_inflections_with_#{scope}") do
-      # clear the inflections
-      ActiveSupport::Inflector.inflections do |inflect|
-        inflect.clear(scope)
-        assert_equal [], inflect.public_send(scope)
-      end
+  test "clear inflections with", each: %i(plurals singulars uncountables humans) do |scope|
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.clear(scope)
+      assert_equal [], inflect.public_send(scope)
     end
   end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to add an additional way to make writing tests more expressive, particularly when making identical actions/assertions about varying inputs.

Consider some of the existing approaches to writing parameterized tests in the ActiveSupport test suite...

**Inlining** https://github.com/rails/rails/blob/217d6a4a8614ac5ac22a5f8f12cb66bd0f6d2de2/activesupport/test/core_ext/string_ext_test.rb#L76-L80

**Metaprogramming**  https://github.com/rails/rails/blob/217d6a4a8614ac5ac22a5f8f12cb66bd0f6d2de2/activesupport/test/inflector_test.rb#L127-L132

Personally, I prefer how the inline test keeps the test method declaration at the root level of the containing class, but here are two things I greatly value about the metaprogramming version that I don't think are possible with the inline version.

1. Every test case is always executed, even if one or more fail.
	
	By contrast, with inlining, if an early test case fails, none of the later cases are executed (because iteration aborts on the first assertion failure). If multiple test cases would have failed, only the first failure is shown, potentially obfuscating a problem.

2. Test failure messages are automatically more detailed/helpful

	With metaprogramming, each test case is literally a separate test. When one fails, the failure message includes both the assertion failure and the detailed test case in the test name. Running the tests in verbose mode clearly shows the variety of test cases being evaluated.

	By contrast, with inlining, there's one single test with a generic test name. When it fails, there's only the assertion failure which doesn't indicate the specific failing test case (unless an explicit message is added to the assertion).

What if we could have the best of both worlds?

### Detail

This Pull Request adds an `each: <iterable>` paremeter to the `ActiveSupport::TestCase#test` helper, which will generate a new test method per item in the iterable.

For example, this code
```ruby
test "greater than 0", each: [1, 2, 3] do |value|
  assert_operator value, :>, 0
end
```

Produces the following tests
```ruby
$ bin/rails test --verbose

...
test_greater_than_0 |1|
test_greater_than_0 |2|
test_greater_than_0 |3|
...
```

> [!NOTE]
> Notice how the parameterized test method name places the value within `|pipes|` to mirror how the value is passed to the test block.

Using this syntax, the previous examples from the ActiveSupport test suite now look like this:

```ruby
test "singularize", each: SingularToPlural do |singular, plural|
  assert_equal singular, plural.singularize
end
```

```ruby
test "titleize mixture to title case", each: MixtureToTitleCase do |before, titleized|
  assert_equal titleized, ActiveSupport::Inflector.titleize(before)
end
```

Multiple portions of the test suite have been updated to use these parameterized tests to improve readability. These updates are in distinct commits so they can be accepted/rejected independent of the core addition to `ActiveSupport::TestCase#test`

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Testing tools in other languages/frameworks include this kind of feature under the name ["parameterized tests"](https://docs.pytest.org/en/stable/how-to/parametrize.html), ["subtests"](https://docs.python.org/3/library/unittest.html#distinguishing-test-iterations-using-subtests), or "table driven tests" ([JavaScript](https://jestjs.io/docs/api#testeachtablename-fn-timeout), [Go](https://go.dev/wiki/TableDrivenTests))

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.