### PR TITLE
Fix devcontainer volumes for PostgreSQL 18

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -26,7 +26,7 @@ services:
     image: postgres:latest
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -174,10 +174,10 @@ module Rails
 
         def service
           {
-            "image" => "postgres:16.1",
+            "image" => "postgres:18",
             "restart" => "unless-stopped",
             "networks" => ["default"],
-            "volumes" => ["postgres-data:/var/lib/postgresql/data"],
+            "volumes" => ["postgres-data:/var/lib/postgresql"],
             "environment" => {
               "POSTGRES_USER" => "postgres",
               "POSTGRES_PASSWORD" => "postgres"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1568,10 +1568,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_includes compose_config["services"]["rails-app"]["depends_on"], "postgres"
 
       expected_postgres_config = {
-        "image" => "postgres:16.1",
+        "image" => "postgres:18",
         "restart" => "unless-stopped",
         "networks" => ["default"],
-        "volumes" => ["postgres-data:/var/lib/postgresql/data"],
+        "volumes" => ["postgres-data:/var/lib/postgresql"],
         "environment" => {
           "POSTGRES_USER" => "postgres",
           "POSTGRES_PASSWORD" => "postgres"

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -61,10 +61,10 @@ module Rails
               assert_includes compose_config["services"]["rails-app"]["depends_on"], "postgres"
 
               expected_postgres_config = {
-                "image" => "postgres:16.1",
+                "image" => "postgres:18",
                 "restart" => "unless-stopped",
                 "networks" => ["default"],
-                "volumes" => ["postgres-data:/var/lib/postgresql/data"],
+                "volumes" => ["postgres-data:/var/lib/postgresql"],
                 "environment" => {
                   "POSTGRES_USER" => "postgres",
                   "POSTGRES_PASSWORD" => "postgres"

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -178,10 +178,10 @@ module Rails
 
         assert_compose_file do |compose|
           expected_postgres_config = {
-            "image" => "postgres:16.1",
+            "image" => "postgres:18",
             "restart" => "unless-stopped",
             "networks" => ["default"],
-            "volumes" => ["postgres-data:/var/lib/postgresql/data"],
+            "volumes" => ["postgres-data:/var/lib/postgresql"],
             "environment" => {
               "POSTGRES_USER" => "postgres",
               "POSTGRES_PASSWORD" => "postgres"

--- a/tools/devcontainer
+++ b/tools/devcontainer
@@ -52,4 +52,7 @@ when "run-user-commands"
 when "sh"
   service_id, _, _ = Open3.capture3("#{DOCKER} ps -q -f name=#{info["service"]}")
   system "#{DOCKER} exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash"
+when "down"
+  compose_file = File.expand_path(".devcontainer/#{info["dockerComposeFile"]}")
+  system DOCKER, "compose", "-f", compose_file, "down", "-v"
 end


### PR DESCRIPTION
The current configuration prints a warning when using the version 18 image:

```
Important Change: the PGDATA environment variable of the image was
changed to be version specific in PostgreSQL 18 and above. For 18 it is
/var/lib/postgresql/18/docker. Later versions will replace 18 with their
respective major version (e.g., /var/lib/postgresql/19/docker for
PostgreSQL 19.x). The defined VOLUME was changed in 18 and above to
/var/lib/postgresql. Mounts and volumes should be targeted at the
updated location. This will allow users upgrading between PostgreSQL
major releases to use the faster --link when running pg_upgrade and
mounting /var/lib/postgresql.
```

The recommendation is now to mount the entire `/var/lib/postgresql` folder so that it will hold multiple, versioned data dirs inside it.
