### PR TITLE
Implement LocalCache strategy on MemoryStore

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Implement LocalCache strategy on `ActiveSupport::Cache::MemoryStore`. The memory store
+    needs to respond to the same interface as other cache stores (e.g. `ActiveSupport::NullStore`).
+
+    *Mikey Gough*
+
 *   Add a detailed failure summary to `ActiveSupport::ContinuousIntegration`.
 
     *Mike Dalessio*

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -26,6 +26,8 @@ module ActiveSupport
     #
     # +MemoryStore+ is thread-safe.
     class MemoryStore < Store
+      prepend Strategy::LocalCache
+
       module DupCoder # :nodoc:
         extend self
 

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -214,4 +214,26 @@ class MemoryStorePruningTest < StoreTest
     assert_not_equal item.object_id, read_item.object_id
     assert_not_equal read_item.object_id, @cache.read(key).object_id
   end
+
+  def test_local_store_strategy
+    @cache.with_local_cache do
+      @cache.write("name", "value")
+      assert_equal "value", @cache.read("name")
+      @cache.delete("name")
+      assert_nil @cache.read("name")
+      puts @cache.method(:write)
+      @cache.write("name", "value")
+    end
+    assert_equal "value", @cache.read("name")
+  end
+
+  def test_local_store_repeated_reads
+    @cache.with_local_cache do
+      @cache.read("foo")
+      assert_nil @cache.read("foo")
+
+      @cache.read_multi("foo", "bar")
+      assert_equal({}, @cache.read_multi("foo", "bar"))
+    end
+  end
 end

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -315,10 +315,10 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
   end
 
   test "Rails.cache does not respond to middleware" do
-    add_to_config "config.cache_store = :memory_store, { timeout: 10 }"
+    add_to_config "config.cache_store = :file_store, '/tmp/cache'"
     boot!
     assert_equal "Rack::Runtime", middleware[5]
-    assert_instance_of ActiveSupport::Cache::MemoryStore, Rails.cache
+    assert_instance_of ActiveSupport::Cache::FileStore, Rails.cache
   end
 
   test "Rails.cache does respond to middleware" do


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the `ActiveSupport::Cache::MemoryStore` currently doesn't implement the local cache strategy. It should respond to the same interface as other cache stores (e.g. `ActiveSupport::Cache::NullStore`). While the backing cache in this case is just another memory cache, I think we can guarantee the same behaviour the easiest way using the local cache strategy module.

### Detail

This Pull Request simply prepends `Strategy::LocalCache` to `MemoryStore` which adds common behavior for cache stores. I've added two tests to accompany these changes.

### Additional information

N.A.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
