### PR TITLE
Do not disable prepared statements when query log tags are enabled

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Do not disable prepared statements by default when query log tags are enabled.
+
+    *Ali Ismayilov*
+
 *   On MySQL parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
 
     Truncating on MySQL is very slow even on empty or nearly empty tables.

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -63,6 +63,9 @@ module ActiveRecord
   #       },
   #     ]
   #
+  # WARNING: Avoid adding high cardinality tags (like request ID), since this will cause each prepared statement to be unique.
+  # Consider disabling prepared_statements in config/database.yml.
+  #
   # By default the name of the application, the name and action of the controller, or the name of the job are logged
   # using the {SQLCommenter}[https://open-telemetry.github.io/opentelemetry-sqlcommenter/] format. This can be changed
   # via {config.active_record.query_log_tags_format}[https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-format]

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -399,7 +399,6 @@ To keep using the current cache store, you can turn off cache versioning entirel
             database:     ->(context) { context[:connection].pool.db_config.database },
             source_location: -> { QueryLogs.query_source_location }
           )
-          ActiveRecord.disable_prepared_statements = true
 
           if app.config.active_record.query_log_tags.present?
             ActiveRecord::QueryLogs.tags = app.config.active_record.query_log_tags

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -415,6 +415,10 @@ To keep using the current cache store, you can turn off cache versioning entirel
           if app.config.active_record.query_log_tags_prepend_comment
             ActiveRecord::QueryLogs.prepend_comment = true
           end
+
+          if app.config.active_record.disable_prepared_statements
+            ActiveRecord.disable_prepared_statements = true
+          end
         end
       end
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,8 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.2
 
+- [`ActiveRecord.disable_prepared_statements`](#activerecord.disable-prepared-statements): `false`
+
 #### Default Values for Target Version 8.1
 
 - [`config.action_controller.action_on_path_relative_redirect`](#config-action-controller-action-on-path-relative-redirect): `:raise`
@@ -1484,7 +1486,14 @@ The default value depends on the `config.load_defaults` target version:
 Specifies whether or not to enable adapter-level query comments. Defaults to
 `false`, but is set to `true` in the default generated `config/environments/development.rb` file.
 
-NOTE: When this is set to `true` database prepared statements will be automatically disabled.
+#### `ActiveRecord.disable_prepared_statements`
+
+Disables prepared statements. `false` has no effect.
+
+| Starting with version | The default value is                          |
+| --------------------- | --------------------------------------------- |
+| (original)            | `!config.active_record.query_log_tags_enabled`|
+| 8.2                   | `false`                                       |
 
 #### `config.active_record.query_log_tags`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -319,6 +319,10 @@ module Rails
             require "action_view/helpers"
             action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
           end
+
+          if respond_to?(:active_record)
+            active_record.disable_prepared_statements = true
+          end
         when "7.2"
           load_defaults "7.1"
 
@@ -370,6 +374,10 @@ module Rails
           end
         when "8.2"
           load_defaults "8.1"
+
+          if respond_to?(:active_record)
+            active_record.disable_prepared_statements = false
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -78,26 +78,6 @@ module ApplicationTests
       assert_includes ActiveRecord.query_transformers, ActiveRecord::QueryLogs
     end
 
-    test "disables prepared statements when enabled" do
-      add_to_config "config.active_record.query_log_tags_enabled = true"
-
-      boot_app
-
-      assert_predicate ActiveRecord, :disable_prepared_statements
-    end
-
-    test "controller and job tags are defined by default" do
-      add_to_config "config.active_record.query_log_tags_enabled = true"
-      app_file "config/initializers/active_record.rb", <<-RUBY
-        raise "Expected prepared_statements to be enabled" unless ActiveRecord::Base.lease_connection.prepared_statements
-        ActiveRecord::Base.lease_connection.execute("SELECT 1")
-      RUBY
-
-      boot_app
-
-      assert_equal [ :application, :controller, :action, :job ], ActiveRecord::QueryLogs.tags
-    end
-
     test "controller actions have tagging filters enabled by default" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       add_to_config "config.active_record.query_log_tags_format = :legacy"


### PR DESCRIPTION
### Motivation / Background

The earliest discussion I found on this topic is from here: https://github.com/rails/rails/issues/48398

It is true that SQL comments are stored in the prepared statements and adding a tag with high cardinality would generate an extra statement per tag. But I'd like to make a case for keeping the prepared statements even when query log tags are enabled.

Default query log tags are `[:application, :job, :controller, :action]`. There's a high chance that any non-basic query has only one or few combination of the these tags. Which means that the prepared statements will be mostly the same and useful.

It's much trickier to reenable the prepared statements, given the rails's initialization process. I might be missing something, but I end up every time having to write the following code to reenable the prepared statements which feels like fighting against the framework:
```ruby
config.active_record.query_log_tags_enabled = true
initializer "reenable_prepared_statements", after: "active_record.query_log_tags_config" do
  config.after_initialize do
    ActiveRecord.disable_prepared_statements = false
  end
end
```

On the other hand, disabling prepared statments can easily be done in database.yml file.

Prepared statements is a good default for for saving time parsing queries and filtering sensitive information when SQL logging is enabled.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
