### PR TITLE
Remove explicit `--config` from rubocop binstub templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/rubocop.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rubocop.tt
@@ -1,7 +1,4 @@
 require "rubygems"
 require "bundler/setup"
 
-# Explicit RuboCop config increases performance slightly while avoiding config confusion.
-ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
-
 load Gem.bin_path("rubocop", "rubocop")

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rubocop.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rubocop.tt
@@ -1,7 +1,4 @@
 require "rubygems"
 require "bundler/setup"
 
-# explicit rubocop config increases performance slightly while avoiding config confusion.
-ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
-
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
## Summary

Removes the explicit `--config .rubocop.yml` argument from the rubocop binstub templates. This change allows RuboCop's cascading config feature to work properly, enabling subdirectory-specific configurations.

## Motivation

The current rubocop binstub templates pass `--config .rubocop.yml` explicitly to RuboCop. While this was intended to increase performance and avoid config confusion, it has an unintended side effect: **it prevents RuboCop from loading subdirectory-specific config files**.

RuboCop supports per-directory configuration through [cascading config files](https://docs.rubocop.org/rubocop/configuration.html#config-file-locations):

> RuboCop will start looking for the configuration file in the directory where the inspected file is and continue its way up to the root directory.

However, the documentation explicitly states:

> All the previous logic does not apply if a specific configuration file is passed on the command line through the --config flag. In that case, the resolved configuration file will be the one passed to the CLI.

For example, a project might have:
- `.rubocop.yml` for general Ruby code
- `test/.rubocop.yml` to enable/disable specific cops for test files  
- `scripts/.rubocop.yml` for one-off scripts with relaxed rules
- `sorbet/rbi/.rubocop.yml` for RBI files with Sorbet-specific rules

When the binstub explicitly passes `--config .rubocop.yml`, RuboCop only uses that config file and ignores any subdirectory configs. This breaks the cascading config feature entirely.

## Changes

- Removed the `ARGV.unshift("--config", ...)` line from `railties/lib/rails/generators/rails/app/templates/bin/rubocop.tt`
- Removed the same line from `railties/lib/rails/generators/rails/plugin/templates/bin/rubocop.tt`

## Impact

By removing the explicit `--config` argument, RuboCop will use its default behavior: start from the current working directory and search for config files, properly merging configs as it walks up the directory tree. This allows subdirectory-specific configs to work as intended while still loading the project's main `.rubocop.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)