### PR TITLE
Allow compose override for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 // For format details, see https://containers.dev/implementors/json_reference/.
 {
 	"name": "Rails project development",
-	"dockerComposeFile": "compose.yaml",
+	"dockerComposeFile": [
+		"compose.yaml",
+		"compose.override.yaml"
+	],
 	"service": "rails",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pkg/
 /tmp/
 /yarn-error.log
 /test-reports/
+/.devcontainer/compose.override.*


### PR DESCRIPTION
Most time I don't use the `rails` container for development, and prefer to use my host with all of the tools I need. But I still need to connect to databases to run tests.

Until now, I've been using buildkite-config compose (with override) because it's closer to what runs in CI and easier to debug.

I want to use devcontainer more, and try the `rails` container sometimes, like for pairing, etc.

This change allows me to run rails code on my host but still leverage the devcontainer services.

For example, I have this in my `.devcontainer/compose.override.yaml`:

```yaml
services:
  postgres:
    ports:
      - "5432:5432"

  mysql:
    ports:
      - "3306:3306"

  redis:
    ports:
      - "6379:6379"

  memcached:
    ports:
      - "11211:11211"
```

This means I don't need to have unstaged changes to use the config, and shouldn't impact other people's workflow. :pray: