### PR TITLE
Remove unnecessary backslash before "Rails" in Action Mailbox README

### DIFF
--- a/actionmailbox/README.md
+++ b/actionmailbox/README.md
@@ -1,6 +1,6 @@
 # Action Mailbox
 
-Action Mailbox routes incoming emails to controller-like mailboxes for processing in \Rails. It ships with ingresses for Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
+Action Mailbox routes incoming emails to controller-like mailboxes for processing in Rails. It ships with ingresses for Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
 
 The inbound emails are turned into `InboundEmail` records using Active Record and feature lifecycle tracking, storage of the original email on cloud storage via Active Storage, and responsible data handling with on-by-default incineration.
 


### PR DESCRIPTION
### Summary

This PR removes unnecessary backslashes before "Rails" in `actionmailbox/README.md`. The escape character is not needed in Markdown and makes the text look odd.

### Motivation

Improves readability and consistency across Rails documentation.

### Changes

- Removed `\Rails` → `Rails` in `actionmailbox/README.md`

### Notes

No functional changes. Documentation only.
