### PR TITLE
Restore missing Postgres type decoding

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Decode PostgreSQL money columns to BigDecimal instead of String when they
+    appear in direct query results.
+
+    ```ruby
+    ActiveRecord::Base.connection
+         .select_value("select '12.34'::money").class #=> BigDecimal
+    ```
+
+    *Matthew Draper*
+
 *   Add support for configuring migration strategy on a per-adapter basis.
 
     `migration_strategy` can now be set on individual adapter classes, overriding

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,13 @@
-*   Decode PostgreSQL money columns to BigDecimal instead of String when they
-    appear in direct query results.
+*   Decode PostgreSQL bytea and money columns when they appear in direct
+    query results.
+
+    bytea columns are now decoded to binary-encoded Strings, and money columns
+    are decoded to BigDecimal instead of String.
 
     ```ruby
+    ActiveRecord::Base.connection
+         .select_value("select '\\x48656c6c6f'::bytea").encoding #=> Encoding::BINARY
+
     ActiveRecord::Base.connection
          .select_value("select '12.34'::money").class #=> BigDecimal
     ```

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -8,6 +8,7 @@ module ActiveRecord
           def deserialize(value)
             return if value.nil?
             return value.to_s if value.is_a?(Type::Binary::Data)
+            return super if value.is_a?(String) && value.encoding == Encoding::BINARY
             PG::Connection.unescape_bytea(super)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -6,10 +6,38 @@ module ActiveRecord
       module OID # :nodoc:
         class Bytea < Type::Binary # :nodoc:
           def deserialize(value)
-            return if value.nil?
-            return value.to_s if value.is_a?(Type::Binary::Data)
-            return super if value.is_a?(String) && value.encoding == Encoding::BINARY
-            PG::Connection.unescape_bytea(super)
+            case value
+            when nil
+              return
+
+            when Type::Binary::Data
+              result = value.to_s
+              if result.instance_variable_defined?(:@ar_pg_bytea_decoded)
+                result = result.dup
+                result.remove_instance_variable(:@ar_pg_bytea_decoded)
+              end
+              return result
+
+            when String
+              if value.instance_variable_get(:@ar_pg_bytea_decoded)
+                result = value.dup
+                result.remove_instance_variable(:@ar_pg_bytea_decoded)
+                return result
+
+              elsif value.encoding == Encoding::BINARY &&
+                  !value.instance_variable_defined?(:@ar_pg_bytea_decoded)
+
+                ActiveRecord.deprecator.warn(<<~MSG.squish)
+                  bytea column received a binary string for unescaping. In Rails 8.3, binary strings
+                  will be treated as already unescaped.
+                MSG
+              end
+
+            else
+              value = super
+            end
+
+            PG::Connection.unescape_bytea(value)
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1176,7 +1176,7 @@ module ActiveRecord
           }
           coders_by_name["date"] = PG::TextDecoder::Date if decode_dates
           coders_by_name["money"] = MoneyDecoder if decode_money
-          coders_by_name["bytea"] = PG::TextDecoder::Bytea if decode_bytea
+          coders_by_name["bytea"] = decode_bytea ? ByteaDecoder : ByteaMarker
 
           known_coder_types = coders_by_name.keys.map { |n| quote(n) }
           query = <<~SQL % known_coder_types.join(", ")
@@ -1216,6 +1216,23 @@ module ActiveRecord
           end
         end
 
+        class ByteaMarker < PG::SimpleDecoder # :nodoc:
+          def decode(value, tuple = nil, field = nil)
+            return if value.nil?
+            value.instance_variable_set(:@ar_pg_bytea_decoded, false) if value.encoding == Encoding::BINARY
+            value
+          end
+        end
+
+        class ByteaDecoder < PG::SimpleDecoder # :nodoc:
+          def decode(value, tuple = nil, field = nil)
+            return if value.nil?
+            decoded = PG::Connection.unescape_bytea(value)
+            decoded.instance_variable_set(:@ar_pg_bytea_decoded, true)
+            decoded
+          end
+        end
+
         ActiveRecord::Type.add_modifier({ array: true }, OID::Array, adapter: :postgresql)
         ActiveRecord::Type.add_modifier({ range: true }, OID::Range, adapter: :postgresql)
         ActiveRecord::Type.register(:bit, OID::Bit, adapter: :postgresql)
@@ -1236,7 +1253,30 @@ module ActiveRecord
         ActiveRecord::Type.register(:uuid, OID::Uuid, adapter: :postgresql)
         ActiveRecord::Type.register(:vector, OID::Vector, adapter: :postgresql)
         ActiveRecord::Type.register(:xml, OID::Xml, adapter: :postgresql)
+
+        module ByteaDecodeDetection # :nodoc:
+          def unescape_bytea(string)
+            if string.instance_variable_get(:@ar_pg_bytea_decoded) == true
+              ActiveRecord.deprecator.warn(<<~MSG.squish)
+                unescape_bytea called on a query result value that has already been
+                automatically unescaped due to `config.active_record.postgresql_adapter_decode_bytea`.
+                In a future Rails release, this will double-unescape the value as
+                instructed, which could cause data corruption.
+              MSG
+
+              result = string.dup
+              result.remove_instance_variable(:@ar_pg_bytea_decoded)
+              return result
+            end
+
+            super
+          end
+        end
+
+        ::PG::Connection.singleton_class.prepend(ByteaDecodeDetection)
+        ::PG::Connection.prepend(ByteaDecodeDetection)
     end
+
     ActiveSupport.run_load_hooks(:active_record_postgresqladapter, PostgreSQLAdapter)
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -131,6 +131,15 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '2024-01-01'::date").class #=> Date
       class_attribute :decode_dates, default: false
 
+      ##
+      # :singleton-method:
+      # Toggles automatic decoding of money columns.
+      #
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '12.34'::money").class #=> String
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_money = true
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '12.34'::money").class #=> BigDecimal
+      class_attribute :decode_money, default: false
+
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigserial primary key",
         string:      { name: "character varying" },
@@ -1157,6 +1166,7 @@ module ActiveRecord
             "timestamptz" => PG::TextDecoder::TimestampWithTimeZone,
           }
           coders_by_name["date"] = PG::TextDecoder::Date if decode_dates
+          coders_by_name["money"] = MoneyDecoder if decode_money
 
           known_coder_types = coders_by_name.keys.map { |n| quote(n) }
           query = <<~SQL % known_coder_types.join(", ")

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -140,6 +140,15 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '12.34'::money").class #=> BigDecimal
       class_attribute :decode_money, default: false
 
+      ##
+      # :singleton-method:
+      # Toggles automatic decoding of bytea columns.
+      #
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '\\x48656c6c6f'::bytea").class #=> String
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea = true
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '\\x48656c6c6f'::bytea").encoding #=> Encoding::BINARY
+      class_attribute :decode_bytea, default: false
+
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigserial primary key",
         string:      { name: "character varying" },
@@ -1167,6 +1176,7 @@ module ActiveRecord
           }
           coders_by_name["date"] = PG::TextDecoder::Date if decode_dates
           coders_by_name["money"] = MoneyDecoder if decode_money
+          coders_by_name["bytea"] = PG::TextDecoder::Bytea if decode_bytea
 
           known_coder_types = coders_by_name.keys.map { |n| quote(n) }
           query = <<~SQL % known_coder_types.join(", ")

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -197,22 +197,16 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
-    initializer "active_record.postgresql_adapter_decode_dates" do
+    initializer "active_record.postgresql_adapter_decodes" do
       config.after_initialize do
-        if config.active_record.postgresql_adapter_decode_dates
-          ActiveSupport.on_load(:active_record_postgresqladapter) do
-            self.decode_dates = true
-          end
-        end
-      end
-    end
+        decode_bytea = config.active_record.postgresql_adapter_decode_bytea
+        decode_dates = config.active_record.postgresql_adapter_decode_dates
+        decode_money = config.active_record.postgresql_adapter_decode_money
 
-    initializer "active_record.postgresql_adapter_decode_money" do
-      config.after_initialize do
-        if config.active_record.postgresql_adapter_decode_money
-          ActiveSupport.on_load(:active_record_postgresqladapter) do
-            self.decode_money = true
-          end
+        ActiveSupport.on_load(:active_record_postgresqladapter) do
+          self.decode_bytea = true if decode_bytea
+          self.decode_dates = true if decode_dates
+          self.decode_money = true if decode_money
         end
       end
     end
@@ -248,6 +242,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :use_schema_cache_dump,
           :postgresql_adapter_decode_dates,
           :postgresql_adapter_decode_money,
+          :postgresql_adapter_decode_bytea,
           :use_legacy_signed_id_verifier,
         )
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -207,6 +207,16 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+    initializer "active_record.postgresql_adapter_decode_money" do
+      config.after_initialize do
+        if config.active_record.postgresql_adapter_decode_money
+          ActiveSupport.on_load(:active_record_postgresqladapter) do
+            self.decode_money = true
+          end
+        end
+      end
+    end
+
     initializer "active_record.set_configs" do |app|
       configs = app.config.active_record
 
@@ -237,6 +247,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :check_schema_cache_dump_version,
           :use_schema_cache_dump,
           :postgresql_adapter_decode_dates,
+          :postgresql_adapter_decode_money,
           :use_legacy_signed_id_verifier,
         )
 

--- a/activerecord/test/cases/adapters/postgresql/binary_with_decoder_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/binary_with_decoder_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "cases/binary_test"
+
+# Run the binary tests with PostgreSQL bytea decoder enabled
+class BinaryWithDecoderTest < BinaryTest
+  def setup
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea = true
+    ActiveRecord::Base.connection_pool.disconnect!
+    super
+  end
+
+  def teardown
+    super
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea = false
+    ActiveRecord::Base.connection_pool.disconnect!
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -47,8 +47,32 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_type_cast_binary_value
-    data = (+"\u001F\x8B").force_encoding("BINARY")
-    assert_equal(data, @type.deserialize(data))
+    encoded = "\\x414243".b
+    assert_deprecated(ActiveRecord.deprecator) do
+      result = @type.deserialize(encoded)
+      assert_equal "ABC", result
+      assert_equal Encoding::BINARY, result.encoding
+    end
+  end
+
+  def test_type_cast_marked_true_value
+    decoded = "\\x414243".b
+    decoded.instance_variable_set(:@ar_pg_bytea_decoded, true)
+
+    result = @type.deserialize(decoded)
+    assert_equal "\\x414243", result  # Should stay as-is, not become "ABC"
+    assert_equal Encoding::BINARY, result.encoding
+    assert_not result.instance_variable_defined?(:@ar_pg_bytea_decoded)
+  end
+
+  def test_type_cast_marked_false_value
+    encoded = "\\x414243".b
+    encoded.instance_variable_set(:@ar_pg_bytea_decoded, false)
+
+    result = @type.deserialize(encoded)
+    assert_equal "ABC", result
+    assert_equal Encoding::BINARY, result.encoding
+    assert_not result.instance_variable_defined?(:@ar_pg_bytea_decoded)
   end
 
   def test_type_case_nil

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -132,4 +132,12 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
     assert_match %r{t\.binary\s+"payload"$}, output
     assert_match %r{t\.binary\s+"serialized"$}, output
   end
+
+  def test_write_and_read_binary_data
+    data = "\\x414243"
+    record = ByteaDataType.create(payload: data)
+    assert_not_predicate record, :new_record?
+    assert_equal(data, record.payload)
+    assert_equal(data, ByteaDataType.where(id: record.id).first.payload)
+  end
 end

--- a/activerecord/test/cases/adapters/postgresql/bytea_with_decoder_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_with_decoder_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "cases/adapters/postgresql/bytea_test"
+
+class PostgresqlByteaWithDecoderTest < PostgresqlByteaTest
+  def setup
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea = true
+    ActiveRecord::Base.connection_pool.disconnect!
+    super
+  end
+
+  def teardown
+    super
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea = false
+    ActiveRecord::Base.connection_pool.disconnect!
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -10,7 +10,8 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     validates :depth, numericality: true
   end
 
-  setup do
+  def setup
+    super
     @connection = ActiveRecord::Base.lease_connection
     @connection.execute("set lc_monetary = 'C'")
     @connection.create_table("postgresql_moneys", force: true) do |t|
@@ -19,8 +20,9 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
-  teardown do
+  def teardown
     @connection.drop_table "postgresql_moneys", if_exists: true
+    super
   end
 
   def test_column

--- a/activerecord/test/cases/adapters/postgresql/money_with_decoder_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_with_decoder_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "cases/adapters/postgresql/money_test"
+
+class PostgresqlMoneyWithDecoderTest < PostgresqlMoneyTest
+  def setup
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_money = true
+    ActiveRecord::Base.connection_pool.disconnect!
+    super
+  end
+
+  def teardown
+    super
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_money = false
+    ActiveRecord::Base.connection_pool.disconnect!
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -818,6 +818,98 @@ module ActiveRecord
         assert_equal Encoding::UTF_8, bytea.encoding
       end
 
+      def test_bytea_unescape_after_decode_prevents_corruption
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+
+        PostgreSQLAdapter.with(decode_bytea: true) do
+          # Need fresh connection after changing decode_bytea setting
+          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+
+          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+          assert_equal "Hello", bytea
+          assert_equal Encoding::BINARY, bytea.encoding
+
+          # Attempting to unescape already-decoded data should prevent corruption
+          assert_deprecated(ActiveRecord.deprecator) do
+            unescaped = PG::Connection.unescape_bytea(bytea)
+            # Should return the already-decoded value, not corrupt it
+            assert_equal "Hello", unescaped
+            assert_equal Encoding::BINARY, unescaped.encoding
+          end
+        end
+      end
+
+      def test_bytea_unescape_normal_usage_still_works
+        encoded = "\\x48656c6c6f"
+
+        unescaped = PG::Connection.unescape_bytea(encoded)
+        assert_equal "Hello", unescaped
+        assert_equal Encoding::BINARY, unescaped.encoding
+      end
+
+      def test_bytea_marker_removed_by_type_system
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+
+        PostgreSQLAdapter.with(decode_bytea: true) do
+          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+
+          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+          assert bytea.instance_variable_defined?(:@ar_pg_bytea_decoded)
+
+          type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+          processed = type.deserialize(bytea)
+
+          assert_not processed.instance_variable_defined?(:@ar_pg_bytea_decoded)
+        end
+      end
+
+      def test_bytea_warns_on_unmarked_binary_string
+        type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+
+        encoded = "\\x48656c6c6f".b
+        assert_deprecated(ActiveRecord.deprecator, /Bytea column received a binary-encoded string/) do
+          result = type.deserialize(encoded)
+          assert_equal "Hello", result
+          assert_equal Encoding::BINARY, result.encoding
+        end
+      end
+
+      def test_bytea_marked_true_skips_decode
+        type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+
+        decoded = "\\x48656c6c6f".b
+        decoded.instance_variable_set(:@ar_pg_bytea_decoded, true)
+
+        result = type.deserialize(decoded)
+        assert_equal "\\x48656c6c6f", result  # Should stay as-is, not become "Hello"
+        assert_equal Encoding::BINARY, result.encoding
+        assert_not result.instance_variable_defined?(:@ar_pg_bytea_decoded)
+      end
+
+      def test_bytea_marked_false_decodes_without_warning
+        type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+
+        encoded = "\\x48656c6c6f".b
+        encoded.instance_variable_set(:@ar_pg_bytea_decoded, false)
+
+        result = type.deserialize(encoded)
+        assert_equal "Hello", result
+        assert_equal Encoding::BINARY, result.encoding
+        assert_not result.instance_variable_defined?(:@ar_pg_bytea_decoded)
+      end
+
+      def test_bytea_binary_data_marker_removed
+        type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+
+        marked = "\\x48656c6c6f".b
+        marked.instance_variable_set(:@ar_pg_bytea_decoded, true)
+        data = ActiveModel::Type::Binary::Data.new(marked)
+
+        result = type.deserialize(data)
+        assert_equal "\\x48656c6c6f", result  # Should stay as-is, not become "Hello"
+        assert_not result.instance_variable_defined?(:@ar_pg_bytea_decoded)
+      end
+
       def test_disable_extension_with_schema
         @connection.execute("CREATE SCHEMA custom_schema")
         @connection.execute("DROP EXTENSION IF EXISTS hstore")

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,8 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.2
 
+- [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
+
 #### Default Values for Target Version 8.1
 
 - [`config.action_controller.action_on_path_relative_redirect`](#config-action-controller-action-on-path-relative-redirect): `:raise`
@@ -1584,6 +1586,23 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.2                   | `true`               |
+
+#### `config.active_record.postgresql_adapter_decode_money`
+
+Specifies whether the PostgresqlAdapter should decode money columns.
+
+```ruby
+ActiveRecord::Base.connection
+     .select_value("select '12.34'::money").class #=> BigDecimal
+```
+
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 8.2                   | `true`               |
 
 
 #### `config.active_record.async_query_executor`

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.2
 
+- [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 
 #### Default Values for Target Version 8.1
@@ -1569,6 +1570,23 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.1                   | `true`               |
+
+#### `config.active_record.postgresql_adapter_decode_bytea`
+
+Specifies whether the PostgresqlAdapter should decode bytea columns.
+
+```ruby
+ActiveRecord::Base.connection
+     .select_value("select '\\x48656c6c6f'::bytea").encoding #=> Encoding::BINARY
+```
+
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 8.2                   | `true`               |
 
 #### `config.active_record.postgresql_adapter_decode_dates`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -372,6 +372,7 @@ module Rails
           load_defaults "8.1"
 
           if respond_to?(:active_record)
+            active_record.postgresql_adapter_decode_bytea = true
             active_record.postgresql_adapter_decode_money = true
           end
         else

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -370,6 +370,10 @@ module Rails
           end
         when "8.2"
           load_defaults "8.1"
+
+          if respond_to?(:active_record)
+            active_record.postgresql_adapter_decode_money = true
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -8,3 +8,15 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# Controls whether the PostgresqlAdapter should decode bytea and money columns automatically with manual queries.
+#
+# Example:
+#   ActiveRecord::Base.connection.select_value("select '\\x48656c6c6f'::bytea").encoding #=> Encoding::BINARY
+#   ActiveRecord::Base.connection.select_value("select '12.34'::money").class #=> BigDecimal
+#
+# When false, these queries return UTF-8 `String` values.
+#++
+# Rails.application.config.active_record.postgresql_adapter_decode_bytea = true
+# Rails.application.config.active_record.postgresql_adapter_decode_money = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3068,6 +3068,40 @@ module ApplicationTests
       assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates
     end
 
+    test "PostgresqlAdapter.decode_money is true by default for new apps" do
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_money
+    end
+
+    test "PostgresqlAdapter.decode_money is false by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal false, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_money
+    end
+
+    test "PostgresqlAdapter.decode_money can be configured via config.active_record.postgresql_adapter_decode_money" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config "config.active_record.postgresql_adapter_decode_money = true"
+
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_money
+    end
+
     test "SQLite3Adapter.strict_strings_by_default is true by default for new apps" do
       app_file "config/initializers/active_record.rb", <<~RUBY
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3102,6 +3102,40 @@ module ApplicationTests
       assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_money
     end
 
+    test "PostgresqlAdapter.decode_bytea is true by default for new apps" do
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea
+    end
+
+    test "PostgresqlAdapter.decode_bytea is false by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal false, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea
+    end
+
+    test "PostgresqlAdapter.decode_bytea can be configured via config.active_record.postgresql_adapter_decode_bytea" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config "config.active_record.postgresql_adapter_decode_bytea = true"
+
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea
+    end
+
     test "SQLite3Adapter.strict_strings_by_default is true by default for new apps" do
       app_file "config/initializers/active_record.rb", <<~RUBY
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")


### PR DESCRIPTION
We've had support for typecasting `money` and `bytea` on the purely-internal `query` method forever: https://github.com/rails/rails/blob/077c3ad60db4c43cccb8f4637b53b8d8eb7a3c19/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L1167-L1168

... but `select_value` and friends (up to `exec_query` -- all the public query-running API methods) lost this behaviour in a92af3fbf0 (shipped in 4.0).

For model-layer behaviour, this does not create any change: the value will be decoded slightly earlier as it's loaded from the query, but model attribute typecasting is already handling these values, so the user-visible effect is only in situations that attribute typecasting doesn't apply (direct queries; `pluck` with non-attribute SQL expressions).

As a safety measure, this PR adds a monkey-patch to `PG::Connection.unescape_bytea` so that existing code of the form `unescape_bytea(select_value("SELECT bytea_value"))` will not double-unescape even when the config is enabled and `select_value` starts correctly returning the already-decoded binary value.