### PR TITLE
Lift primary_keys out of loop

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -237,11 +237,12 @@ module ActiveRecord
 
         def values_list
           types = extract_types_for(keys_including_timestamps)
+          pks = primary_keys
 
           values_list = insert_all.map_key_with_value do |key, value|
             if Arel::Nodes::SqlLiteral === value
               value
-            elsif primary_keys.include?(key) && value.nil?
+            elsif pks.include?(key) && value.nil?
               connection.default_insert_value(model.columns_hash[key])
             else
               ActiveModel::Type::SerializeCastValue.serialize(type = types[key], type.cast(value))


### PR DESCRIPTION
It's not particularly expensive, but the loop is O(MN), so it ends up getting called a ton.

Benchmark:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "."
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
  gem "vernier"
  gem "benchmark-ips"
end

require "active_record/railtie"
require "minitest/autorun"
require "vernier"
require "benchmark/ips"

# This connection will do for database-independent bug reports.
ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :items, force: true do |t|
    t.integer :parent_id
    t.integer :external_id
    t.timestamps
    t.integer :status_flag
    t.datetime :archived_at
    t.integer :group_id
    t.integer :enabled
    t.integer :quantity
    t.integer :owner_id
    t.integer :client_id
  end
end

class Item < ActiveRecord::Base
end

INSERT_COLUMNS = %i[parent_id external_id created_at updated_at status_flag archived_at group_id enabled quantity owner_id client_id].freeze

module BulkInsertMethods
  def self.generate_payload(rows_count)
    rows_count.times.map do |i|
      {
        parent_id: 1,
        external_id: i,
        created_at: Time.current,
        updated_at: Time.current,
        status_flag: 1,
        archived_at: nil,
        group_id: i,
        enabled: 1,
        quantity: i + 10,
        owner_id: nil,
        client_id: nil
      }
    end
  end

  def self.insert_all_method(payload)
    Item.insert_all!(payload)
  end

  def self.raw_sql_method(payload)
    all_attr_values = payload.map do |item|
      INSERT_COLUMNS.map { |col| item[col] }
    end

    insert_manager = Arel::InsertManager.new(Item)
    arel_table = Item.arel_table
    insert_manager.into(arel_table)
    insert_manager.columns.concat(INSERT_COLUMNS.map { |col| arel_table[col] })
    insert_manager.values = insert_manager.create_values_list(all_attr_values)
    sql = insert_manager.to_sql
    Item.connection.exec_query(sql, "Item Bulk Insert")
  end
end

class BugReproducerTest < ActiveSupport::TestCase
  def test_simple_reproduction
    # Simple test to verify everything works
    payload = BulkInsertMethods.generate_payload(10)
    assert_difference -> { Item.count }, +10 do
      BulkInsertMethods.insert_all_method(payload)
    end
    assert_difference -> { Item.count }, +10 do
      BulkInsertMethods.raw_sql_method(payload)
    end
  end
end

# Benchmark and profiling code - run after tests complete
rows_count = 10_000
payload = BulkInsertMethods.generate_payload(rows_count)

BulkInsertMethods.insert_all_method(payload)
BulkInsertMethods.raw_sql_method(payload)

# Disable Active Record logging to reduce noise during benchmarking
original_logger = ActiveRecord::Base.logger
ActiveRecord::Base.logger = nil

puts "\n=== Running benchmark-ips comparison ==="
Benchmark.ips do |x|
  x.report("insert_all!") do
    BulkInsertMethods.insert_all_method(payload)
  end

  x.report("raw_sql") do
    BulkInsertMethods.raw_sql_method(payload)
  end

  x.compare!
end

Vernier.profile(out: "insert_all_profile.json") do
  BulkInsertMethods.insert_all_method(payload)
end

Vernier.profile(out: "raw_sql_profile.json") do
  BulkInsertMethods.raw_sql_method(payload)
end

# Restore original logger
ActiveRecord::Base.logger = original_logger
```

Baseline (`Time.now.utc`):

```
=== Running benchmark-ips comparison ===
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin23]
Warming up --------------------------------------
         insert_all!     1.000 i/100ms
             raw_sql     1.000 i/100ms
Calculating -------------------------------------
         insert_all!      3.366 (± 0.0%) i/s  (297.06 ms/i) -     17.000 in   5.052899s
             raw_sql     14.437 (± 0.0%) i/s   (69.27 ms/i) -     73.000 in   5.059633s

Comparison:
             raw_sql:       14.4 i/s
         insert_all!:        3.4 i/s - 4.29x  slower
```

Switching to `Time.current`

```
=== Running benchmark-ips comparison ===
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin23]
Warming up --------------------------------------
         insert_all!     1.000 i/100ms
             raw_sql     1.000 i/100ms
Calculating -------------------------------------
         insert_all!      4.020 (± 0.0%) i/s  (248.77 ms/i) -     21.000 in   5.227394s
             raw_sql     13.476 (± 0.0%) i/s   (74.20 ms/i) -     68.000 in   5.048847s

Comparison:
             raw_sql:       13.5 i/s
         insert_all!:        4.0 i/s - 3.35x  slower
```

After:

```
=== Running benchmark-ips comparison ===
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin23]
Warming up --------------------------------------
         insert_all!     1.000 i/100ms
             raw_sql     1.000 i/100ms
Calculating -------------------------------------
         insert_all!      4.503 (± 0.0%) i/s  (222.06 ms/i) -     23.000 in   5.113995s
             raw_sql     13.374 (± 0.0%) i/s   (74.77 ms/i) -     67.000 in   5.013000s

Comparison:
             raw_sql:       13.4 i/s
         insert_all!:        4.5 i/s - 2.97x  slower
```
