### PR TITLE
Remove custom TimeWithZone#respond_to?

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -532,14 +532,6 @@ module ActiveSupport
       initialize(variables[0].utc, ::Time.find_zone(variables[1]), variables[2].utc)
     end
 
-    # respond_to_missing? is not called in some cases, such as when type conversion is
-    # performed with Kernel#String
-    def respond_to?(sym, include_priv = false)
-      # ensure that we're not going to throw and rescue from NoMethodError in method_missing which is slow
-      return false if sym.to_sym == :to_str
-      super
-    end
-
     # Ensure proxy class responds to all methods that underlying time instance
     # responds to.
     def respond_to_missing?(sym, include_priv)


### PR DESCRIPTION
Ref https://github.com/rails/rails/pull/15313

It was added to make `String(twz)` faster, but the performance is now _slower_ than without the custom `#respond_to?`.

Benchmark:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "."
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"
  gem "benchmark-ips"
end

require "active_support/all"

class MyTimeWithZone < ActiveSupport::TimeWithZone
  def respond_to?(sym, include_priv = false)
    # ensure that we're not going to throw and rescue from NoMethodError in method_missing which is slow
    return false if sym.to_sym == :to_str
    super
  end
end

Time.zone_default = Time.find_zone!("UTC")

t = Time.now.utc

mtz = MyTimeWithZone.new(t, Time.zone)
tz = ActiveSupport::TimeWithZone.new(t, Time.zone)

raise unless mtz == tz

krt = Kernel.instance_method(:respond_to?)
raise "MyTimeWithZone uses Kernel#respond_to?" if MyTimeWithZone.instance_method(:respond_to?) == krt
raise "TimeWithZone overrides Kernel#respond_to?" unless ActiveSupport::TimeWithZone.instance_method(:respond_to?) == krt

Benchmark.ips do |x|
  x.report("custom respond_to?")      { String(mtz) }
  x.report("default respond_to?") { String(tz) }
  x.compare!
end
```

Results:

```
❯ ruby twzrt.rb
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin23]
Warming up --------------------------------------
  custom respond_to?   131.392k i/100ms
 default respond_to?   129.653k i/100ms
Calculating -------------------------------------
  custom respond_to?      1.337M (± 1.6%) i/s  (747.91 ns/i) -      6.701M in   5.013086s
 default respond_to?      1.400M (± 0.8%) i/s  (714.41 ns/i) -      7.001M in   5.002137s

Comparison:
 default respond_to?:  1399748.8 i/s
  custom respond_to?:  1337063.0 i/s - 1.05x  slower
```
