### PR TITLE
Fix devcontainer MySQL/Trilogy config to use host instead of socket

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -15,7 +15,7 @@ default: &default
   max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-<% if database.socket -%>
+<% if !devcontainer? && database.socket -%>
   socket: <%= database.socket %>
 <% else -%>
   host: <%%= ENV.fetch("DB_HOST") { "<%= database.host %>" } %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -15,13 +15,14 @@ default: &default
   max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
+<% if !devcontainer? && database.socket -%>
+  socket: <%= database.socket %>
+<% else -%>
   host: <%%= ENV.fetch("DB_HOST") { "<%= database.host %>" } %>
+<% end -%>
 
 development:
   <<: *default
-<% if database.socket -%>
-  socket: <%= database.socket %>
-<% end -%>
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
@@ -29,9 +30,6 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-<% if database.socket -%>
-  socket: <%= database.socket %>
-<% end -%>
   database: <%= app_name %>_test
 
 # As with config/credentials.yml, you never want to store sensitive information,


### PR DESCRIPTION
When generating a new Rails app with `--devcontainer` and MySQL/Trilogy database options, the generator would incorrectly use socket-based configuration if MySQL was installed locally on the host machine. This breaks devcontainer setups which require network-based `host:` configuration to connect to the containerized MySQL service.

The generator now skips local socket detection when `--devcontainer` is specified, ensuring the generated database.yml uses `host:` with the DB_HOST environment variable for proper container networking.

Additionally, unified the socket/host logic in trilogy.yml.tt by moving it to the default section, matching the mysql.yml.tt pattern. This ensures only socket OR host is present (never both), avoiding confusion since socket takes precedence when both are specified.

[Fix #56134]

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
