### PR TITLE
Add structured event `active_record.deprecated_association` when mode is set to `:notify`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add structured event `active_record.deprecated_association` when mode is set to `:notify`.
+
+    ```
+    config.active_record.deprecated_associations_options = { mode: :notify }
+    ```
+
+    *zzak*
+
 *   On MySQL parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
 
     Truncating on MySQL is very slow even on empty or nearly empty tables.

--- a/activerecord/lib/active_record/structured_event_subscriber.rb
+++ b/activerecord/lib/active_record/structured_event_subscriber.rb
@@ -56,6 +56,18 @@ module ActiveRecord
     end
     debug_only :sql
 
+    def deprecated_association(event)
+      payload = {
+        reflection: event.payload[:reflection],
+        message: event.payload[:message],
+        location: event.payload[:location],
+      }
+
+      payload[:backtrace] = event.payload[:backtrace] if event.payload.key?(:backtrace)
+
+      emit_event("active_record.deprecated_association", payload)
+    end
+
     private
       def type_casted_binds(casted_binds)
         casted_binds.respond_to?(:call) ? casted_binds.call : casted_binds


### PR DESCRIPTION
Currently, mode can only be configured by global config:

```
config.active_record.deprecated_associations_options = { mode: :notify }
```

The default is `:warn`:
<https://edgeguides.rubyonrails.org/configuring.html#config-active-record-deprecated-associations-options>

/cc @gmcgibbon @adrianna-chang-shopify @fxn 