### PR TITLE
Add tests for InsertAll edge cases

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -104,6 +104,20 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_kind_of ActiveRecord::Result, result
   end
 
+  def test_insert_all_validates_consistent_attributes
+    assert_raises ArgumentError do
+      Book.insert_all [{ name: "Rework" }, {}]
+    end
+
+    assert_nothing_raised do
+      Book.insert_all [{ created_at: Time.current }, {}]
+    end
+
+    assert_nothing_raised do
+      Book.create_with(name: "X").insert_all!([{ name: "Rework" }, {} ])
+    end
+  end
+
   def test_insert_all_returns_primary_key_if_returning_is_supported
     skip unless supports_insert_returning?
 
@@ -787,6 +801,10 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_difference "Book.where(format: 'X').count", +2 do
       Book.create_with(format: "X").insert_all!([ { name: "A" }, { name: "B" } ])
     end
+
+    assert_difference "Book.where(name: 'C').count", +2 do
+      Book.create_with(name: "C").insert_all!([ { name: "A" }, { name: "B" } ])
+    end
   end
 
   def test_insert_all_has_many_through
@@ -842,6 +860,10 @@ class InsertAllTest < ActiveRecord::TestCase
 
     assert_difference "Book.where(format: 'X').count", +2 do
       Book.create_with(format: "X").upsert_all([ { name: "A" }, { name: "B" } ])
+    end
+
+    assert_difference "Book.where(name: 'C').count", +2 do
+      Book.create_with(name: "C").upsert_all([ { name: "A" }, { name: "B" } ])
     end
   end
 


### PR DESCRIPTION
I'd like to refactor InsertAll more to improve performance, but want to validate which behaviors must be kept. This commit demonstrates two that I find unintuitive: record_timestamps and scope attributes both enable inconsistent insert keys, but they apply their defaults differently.

record_timestamps will reverse_merge into the attributes, so it ensures timestamp keys exist for all inserts but doesn't override any that are already set. scope attributes are merge'd into attributes, so they also ensure the keys exist for all inserts but they override the original value (which can hide that the keys weren't initially consistent).

Seems like there are a few options:

- We can make record_timestamps work like scope attributes: always apply them instead of allowing override. We could also add deprecation warnings if a timestamp/scope attribute is specified which will be overridden (and raise in the future). This would be the best for performance because we wouldn't have to do any conditional fallback if some inserts don't specify a timestamp but others do.
-  We can leave record_timestamps and scope_attributes how they are, but warn (and later raise) when an attribute specified in an insert will be overriden by a scope attribute.
- We can make scope attributes work like record_timestamps: allow individual inserts to override the scope attribute. This would make performance worse because we wouldn't be able to `merge!` into the attributes hash any more (instead having to check whether the attribute already exists per insert).