### PR TITLE
More `InsertAll` performance improvements

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -17,11 +17,11 @@ module ActiveRecord
         def cast(value)
           return if value.nil?
 
-          if value.is_a?(Hash)
+          if value.is_a?(::Hash)
             set_time_zone_without_conversion(super)
           elsif value.respond_to?(:in_time_zone)
             begin
-              result = super(user_input_in_time_zone(value)) || super
+              result = super(__getobj__.user_input_in_time_zone(value)) || super
               if result && type == :time
                 result = result.change(year: 2000, month: 1, day: 1)
               end

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -34,7 +34,6 @@ module ActiveRecord
 
       @scope_attributes = relation.scope_for_create.except(@model.inheritance_column)
       @keys |= @scope_attributes.keys
-      @keys = @keys.to_set
 
       @returning = (connection.supports_insert_returning? ? primary_keys : false) if @returning.nil?
       @returning = false if @returning == []
@@ -95,9 +94,9 @@ module ActiveRecord
     # TODO: Consider renaming this method, as it only conditionally extends keys, not always
     def keys_including_timestamps
       @keys_including_timestamps ||= if record_timestamps?
-        keys + model.all_timestamp_attributes_in_model
+        (keys | model.all_timestamp_attributes_in_model).sort!
       else
-        keys
+        keys.sort!
       end
     end
 
@@ -208,7 +207,7 @@ module ActiveRecord
 
 
       def verify_attributes(attributes)
-        if keys_including_timestamps != attributes.keys.to_set
+        if keys_including_timestamps != attributes.keys.sort!
           raise ArgumentError, "All objects being inserted must have the same keys"
         end
       end


### PR DESCRIPTION
[Remove hash allocations from InsertAll](https://github.com/rails/rails/commit/e34c573d1c88e144606cd998086746ff422e61d4) 

stringify_keys already happens in initialize, so its not necessary.

reverse_merge!(timestamps_for_create) was allocating two hashes per
call, so it was replaced with a simpler iteration over an array which
may be allocated outside the loop.

```
=== Running benchmark-ips comparison ===
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin23]
Warming up --------------------------------------
         insert_all!     1.000 i/100ms
Calculating -------------------------------------
         insert_all!      5.622 (± 0.0%) i/s  (177.86 ms/i) -     29.000 in   5.162262s

Comparison:
  insert_all! before:        5.2 i/s
             raw_sql:       14.1 i/s - 2.73x  faster
         insert_all!:        5.6 i/s - 1.09x  faster
```

---

[Remove set usage from InsertAll](https://github.com/rails/rails/commit/b936830de3328184aa9f232729ff34c9add1a021) 

The set served two purposes: ensuring keys_including_timestamps didn't
have duplicate keys, and providing an easy way to compare each insert's
attribute keys to ensure they are all the same.

However, instantiating the set for each insert is actually much more
expensive than just sorting the keys (and attributes.keys.to_set doesn't
benefit from Set's uniqueness because hash keys are necesarily unique).
Additionally, the uniqueness requirement for keys_including_timestamps
can be satisfied using | (simiar to how scope_attributes are added to
keys).

```
=== Running benchmark-ips comparison ===
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin23]
Warming up --------------------------------------
         insert_all!     1.000 i/100ms
Calculating -------------------------------------
         insert_all!      6.404 (± 0.0%) i/s  (156.16 ms/i) -     32.000 in   5.002871s

Comparison:
  insert_all! before:        5.5 i/s
             raw_sql:       13.3 i/s - 2.41x  faster
         insert_all!:        6.4 i/s - 1.15x  faster
```

---

[Avoid {const,method}_missing in TimeZoneConversion](https://github.com/rails/rails/commit/02b6a5e43af4c20f32cf42c40782209410e8ad79) 

Since they are delegated, they are even slower than normal.

```
=== Running benchmark-ips comparison ===
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin23]
Warming up --------------------------------------
         insert_all!     1.000 i/100ms
Calculating -------------------------------------
         insert_all!      6.764 (± 0.0%) i/s  (147.84 ms/i) -     34.000 in   5.031003s

Comparison:
  insert_all! before:        6.4 i/s
             raw_sql:       13.8 i/s - 2.14x  faster
         insert_all!:        6.8 i/s - 1.05x  faster
```