### PR TITLE
Make flaky parallel tests easier to diagnose by deterministically assigning tests to workers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Make flaky parallel tests easier to diagnose by deterministically assigning
+    tests to workers.
+
+    Rails assigns tests to workers in round-robin order so the same `--seed`
+    and worker count will result in the same sequence of tests running on each
+    worker (whether processes or threads) increasing the odds of reproducing
+    test failures caused by test interdependence.
+
+    This can make test runtime slower and spikier when one worker gets most of
+    the slow tests. Enable `work_stealing: true` to allow idle workers to steal
+    tests from busy workers in deterministic order, smoothing out runtime at the
+    cost of less reproducible flaky-test failures.
+
+    *Jeremy Daer*
+
 *   Make `ActiveSupport::EventReporter#debug_mode?` true by default to emit debug events
     outside of Rails application contexts.
 

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -96,6 +96,19 @@ module ActiveSupport
       # number of tests to run is above the +threshold+ param. The default value is
       # 50, and it's configurable via +config.active_support.test_parallelization_threshold+.
       #
+      # Parallelization shuffles tests and distributes them to workers in
+      # round-robin order, so given the same seed value and worker count, the
+      # same sequence of tests will run on each worker. This makes flaky tests
+      # caused by parallel test interdependence somewhat easier to reproduce,
+      # though it is not a guarantee of deterministic test execution.
+      #
+      # This can make test runtime slower and spikier when one worker gets most
+      # of the slow tests. Enable +work_stealing+ to allow idle workers to steal
+      # tests from busy workers, smoothing out runtime at the cost of less
+      # reproducible flaky-test failures:
+      #
+      #   parallelize(workers: :number_of_processors, work_stealing: true)
+      #
       # If you want to skip Rails default creation of one database per process in favor of
       # writing your own implementation, you can set +parallelize_databases+, or configure it
       # via +config.active_support.parallelize_test_databases+.
@@ -104,7 +117,7 @@ module ActiveSupport
       #
       # Note that your test suite may deadlock if you attempt to use only one database
       # with multiple processes.
-      def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold, parallelize_databases: ActiveSupport.parallelize_test_databases)
+      def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold, parallelize_databases: ActiveSupport.parallelize_test_databases, work_stealing: false)
         case
         when ENV["PARALLEL_WORKERS"]
           workers = ENV["PARALLEL_WORKERS"].to_i
@@ -116,7 +129,7 @@ module ActiveSupport
           ActiveSupport.parallelize_test_databases = parallelize_databases
         end
 
-        Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)
+        Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold, work_stealing: work_stealing)
       end
 
       # Before fork hook for parallel testing. This can be used to run anything

--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -3,6 +3,8 @@
 require "drb"
 require "drb/unix" unless Gem.win_platform?
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/testing/parallelization/test_distributor"
+require "active_support/testing/parallelization/thread_pool_executor"
 require "active_support/testing/parallelization/server"
 require "active_support/testing/parallelization/worker"
 
@@ -33,9 +35,13 @@ module ActiveSupport
 
       cattr_reader :run_cleanup_hooks
 
-      def initialize(worker_count)
+      def initialize(worker_count, work_stealing: false)
         @worker_count = worker_count
-        @queue_server = Server.new
+
+        distributor = (work_stealing ? RoundRobinWorkStealingDistributor : RoundRobinDistributor).new \
+          worker_count: worker_count
+
+        @queue_server = Server.new(distributor: distributor)
         @worker_pool = []
         @url = DRb.start_service("drbunix:", @queue_server).uri
       end

--- a/activesupport/lib/active_support/testing/parallelization/test_distributor.rb
+++ b/activesupport/lib/active_support/testing/parallelization/test_distributor.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Testing
+    class Parallelization # :nodoc:
+      # Abstract base class for test distribution strategies.
+      # Subclasses implement different ways of assigning tests to workers.
+      class TestDistributor
+        # Add a test to be distributed to workers.
+        # @param test [Array] Test tuple: [class, method, reporter]
+        def add_test(test)
+          raise NotImplementedError
+        end
+
+        # Retrieve the next test for a specific worker.
+        # @param worker_id [Integer] The worker requesting work
+        # @return [Array, nil] Test tuple or nil if no work available
+        def take(worker_id:)
+          raise NotImplementedError
+        end
+
+        # Clear all pending work (called on interrupt).
+        def interrupt
+          # Optional
+        end
+
+        # Check if there is pending work.
+        # @return [Boolean] true if work is pending
+        def pending?
+          raise NotImplementedError
+        end
+
+        # Close the distributor. No more work will be accepted.
+        def close
+          # Optional
+        end
+      end
+
+      # Shared queue distributor - workers compete for tests (work stealing).
+      # Internal/testing helper; not exposed as a public distribution mode.
+      class SharedQueueDistributor < TestDistributor
+        def initialize
+          @queue = Queue.new
+        end
+
+        def add_test(test)
+          @queue << test
+        end
+
+        def take(...)
+          @queue.pop
+        end
+
+        def interrupt
+          @queue.clear
+        end
+
+        def pending?
+          !@queue.empty?
+        end
+
+        def close
+          @queue.close
+        end
+      end
+
+      # Round-robin distributor - tests are assigned to workers as they arrive.
+      #
+      # Tests arrive already shuffled by Minitest based on the seed. Since the arrival
+      # order is deterministic for a given seed, round-robin assignment produces
+      # reproducible test-to-worker distribution.
+      #
+      # This is much simpler than buffering and re-shuffling: tests can start executing
+      # immediately as they arrive, and we avoid complex synchronization.
+      class RoundRobinDistributor < TestDistributor
+        WORK_WAIT_TIMEOUT = 0.1
+
+        def initialize(worker_count:)
+          @worker_count = worker_count
+          @queues = Array.new(@worker_count) { Queue.new }
+          @next_worker = 0
+          @mutex = Mutex.new
+          @cv = ConditionVariable.new
+          @closed = false
+        end
+
+        def add_test(test)
+          @mutex.synchronize do
+            return if @closed || !@queues
+
+            worker_id = @next_worker
+            @next_worker = (@next_worker + 1) % @worker_count
+            queue = @queues[worker_id]
+            queue << test unless queue.closed?
+            @cv.signal  # Wake one waiting worker
+          end
+        end
+
+        def take(worker_id:)
+          job = nil
+
+          until job || exhausted?(worker_id)
+            job = next_job(worker_id)
+            wait(worker_id) unless job || exhausted?(worker_id)
+          end
+
+          job
+        end
+
+        def interrupt
+          @mutex.synchronize do
+            @queues&.each do |q|
+              q.clear
+              q.close
+            end
+            @closed = true
+            @cv.broadcast  # Wake all waiting workers
+          end
+        end
+
+        def pending?
+          @mutex.synchronize do
+            @queues&.any? { |q| !q.empty? }
+          end
+        end
+
+        def close
+          @mutex.synchronize do
+            @queues&.each(&:close)
+            @closed = true
+            @cv.broadcast  # Wake all waiting workers
+          end
+        end
+
+        private
+          def next_job(worker_id)
+            pop_now(worker_id)
+          end
+
+          def pop_now(worker_id)
+            @queues[worker_id].pop(true)
+          rescue ThreadError, ClosedQueueError
+            nil
+          end
+
+          # Waits for work, rechecking exhausted? inside the mutex to handle
+          # the race where close() broadcasts before we start waiting.
+          def wait(worker_id)
+            @mutex.synchronize do
+              @cv.wait(@mutex, WORK_WAIT_TIMEOUT) unless exhausted?(worker_id)
+            end
+          end
+
+          def exhausted?(worker_id)
+            queue = @queues[worker_id]
+            queue.closed? && queue.empty?
+          end
+      end
+
+      # Round-robin distributor with work stealing enabled.
+      # Tests are initially assigned round-robin as they arrive (same as RoundRobinDistributor),
+      # but when a worker exhausts its queue, it can steal work from other workers
+      # to improve load balancing.
+      class RoundRobinWorkStealingDistributor < RoundRobinDistributor
+        private
+          def next_job(worker_id)
+            pop_now(worker_id) || steal(worker_id)
+          end
+
+          def steal(worker_id)
+            # Steal from other workers in a consistent order
+            @worker_count.times do |offset|
+              other_id = (worker_id + offset + 1) % @worker_count
+              if job = pop_now(other_id)
+                return job
+              end
+            end
+
+            nil
+          end
+
+          def exhausted?(...)
+            @queues.all? { |q| q.closed? && q.empty? }
+          end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/testing/parallelization/thread_pool_executor.rb
+++ b/activesupport/lib/active_support/testing/parallelization/thread_pool_executor.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "concurrent/executor/fixed_thread_pool"
+
+module ActiveSupport
+  module Testing
+    class Parallelization # :nodoc:
+      # Thread pool executor using a test distributor strategy.
+      # Provides the same interface as Minitest::Parallel::Executor but
+      # with configurable distribution (round robin vs work stealing).
+      class ThreadPoolExecutor
+        attr_reader :size
+
+        def initialize(size:, distributor:)
+          @size = size
+          @distributor = distributor
+          @pool = Concurrent::FixedThreadPool.new(size, fallback_policy: :abort)
+        end
+
+        def start
+          size.times do |worker_id|
+            @pool.post { worker_loop(worker_id) }
+          end
+        end
+
+        def <<(work)
+          @distributor.add_test(work)
+        end
+
+        def shutdown
+          @distributor.close
+          @pool.shutdown
+          @pool.wait_for_termination
+        end
+
+        private
+          def worker_loop(worker_id)
+            while job = @distributor.take(worker_id: worker_id)
+              klass, method, reporter = job
+
+              reporter.synchronize { reporter.prerecord klass, method }
+              result = Minitest.run_one_method klass, method
+              reporter.synchronize { reporter.record result }
+            end
+          end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -36,7 +36,7 @@ module ActiveSupport
         end
 
         def work_from_queue
-          while job = @queue.pop
+          while job = @queue.pop(@number)
             perform_job(job)
           end
         end

--- a/activesupport/test/parallelization/server_test.rb
+++ b/activesupport/test/parallelization/server_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+
+class ServerTest < ActiveSupport::TestCase
+  test "server tracks active workers" do
+    distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+    server = ActiveSupport::Testing::Parallelization::Server.new(distributor: distributor)
+
+    assert_not server.active_workers?
+
+    server.start_worker("worker-1", 1234)
+    assert server.active_workers?
+
+    server.stop_worker("worker-1", 1234)
+    assert_not server.active_workers?
+  end
+
+  test "server removes dead workers" do
+    distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+    server = ActiveSupport::Testing::Parallelization::Server.new(distributor: distributor)
+
+    server.start_worker("worker-1", 1234)
+    server.start_worker("worker-2", 5678)
+    assert server.active_workers?
+
+    server.remove_dead_workers([1234])
+    assert server.active_workers?  # worker-2 still active
+
+    server.remove_dead_workers([5678])
+    assert_not server.active_workers?  # all workers gone
+  end
+end

--- a/activesupport/test/parallelization/test_distributor_test.rb
+++ b/activesupport/test/parallelization/test_distributor_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+
+class TestDistributorTest < ActiveSupport::TestCase
+  test "distributes tests round-robin as they arrive" do
+    distributor = ActiveSupport::Testing::Parallelization::RoundRobinDistributor.new(
+      worker_count: 2
+    )
+
+    # Add tests and they should be distributed immediately
+    distributor.add_test(["Test1", "test_a", nil])
+    distributor.add_test(["Test2", "test_b", nil])
+    distributor.add_test(["Test3", "test_c", nil])
+
+    # Worker 0 should get Test1 and Test3 (indexes 0 and 2)
+    test1 = distributor.take(worker_id: 0)
+    assert_equal "Test1", test1[0]
+
+    test3 = distributor.take(worker_id: 0)
+    assert_equal "Test3", test3[0]
+
+    # Worker 1 should get Test2 (index 1)
+    test2 = distributor.take(worker_id: 1)
+    assert_equal "Test2", test2[0]
+  end
+
+  test "interrupt clears pending tests" do
+    distributor = ActiveSupport::Testing::Parallelization::RoundRobinDistributor.new(
+      worker_count: 2
+    )
+
+    distributor.add_test(["FooTest", "test_a", nil])
+    distributor.add_test(["BarTest", "test_b", nil])
+    assert distributor.pending?
+
+    distributor.interrupt
+    assert_not distributor.pending?
+  end
+
+  test "close stops accepting tests and closes queues" do
+    distributor = ActiveSupport::Testing::Parallelization::RoundRobinDistributor.new(
+      worker_count: 2
+    )
+
+    distributor.add_test(["FooTest", "test_a", nil])
+    distributor.add_test(["BarTest", "test_b", nil])
+
+    distributor.close
+
+    # After close, adding tests should be ignored
+    distributor.add_test(["Test3", "test_c", nil])
+
+    # Can still drain queued tests
+    test1 = distributor.take(worker_id: 0)
+    assert_equal "FooTest", test1[0]
+
+    # Worker 1 gets its test
+    test2 = distributor.take(worker_id: 1)
+    assert_equal "BarTest", test2[0]
+
+    # No Test3 because it was added after close
+    assert_nil distributor.take(worker_id: 0)
+    assert_nil distributor.take(worker_id: 1)
+  end
+
+  test "work stealing distributor steals work from other workers when queue empty" do
+    distributor = ActiveSupport::Testing::Parallelization::RoundRobinWorkStealingDistributor.new(
+      worker_count: 2
+    )
+
+    # Add 3 tests - with round-robin, worker 0 gets Test1 and Test3, worker 1 gets Test2
+    distributor.add_test(["Test1", "test_a", nil])
+    distributor.add_test(["Test2", "test_b", nil])
+    distributor.add_test(["Test3", "test_c", nil])
+
+    # Close to signal no more tests coming
+    distributor.close
+
+    # Worker 0 takes its tests
+    test1 = distributor.take(worker_id: 0)
+    assert_equal "Test1", test1[0]
+    test3 = distributor.take(worker_id: 0)
+    assert_equal "Test3", test3[0]
+
+    # Worker 1 takes its test
+    test2 = distributor.take(worker_id: 1)
+    assert_equal "Test2", test2[0]
+
+    # Now both queues are empty and closed - workers get nil
+    assert_nil distributor.take(worker_id: 0)
+    assert_nil distributor.take(worker_id: 1)
+  end
+
+  test "work stealing distributor returns nil when no work available anywhere" do
+    distributor = ActiveSupport::Testing::Parallelization::RoundRobinWorkStealingDistributor.new(
+      worker_count: 2
+    )
+
+    distributor.add_test(["Test1", "test_a", nil])
+    distributor.add_test(["Test2", "test_b", nil])
+
+    # Close to signal no more tests
+    distributor.close
+
+    # Drain all tests
+    distributor.take(worker_id: 0)  # Takes Test1
+    distributor.take(worker_id: 1)  # Takes Test2
+
+    # No work left anywhere, queues are closed
+    assert_nil distributor.take(worker_id: 0)
+    assert_nil distributor.take(worker_id: 1)
+  end
+
+  test "SharedQueueDistributor distributes tests to any worker" do
+    distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+
+    distributor.add_test(["Test1", "test_a", nil])
+    distributor.add_test(["Test2", "test_b", nil])
+
+    # Any worker can get any test
+    test1 = distributor.take(worker_id: 0)
+    test2 = distributor.take(worker_id: 1)
+
+    assert_not_nil test1
+    assert_not_nil test2
+    assert_not_equal test1[0], test2[0]
+  end
+
+  test "SharedQueueDistributor pending? reflects queue state" do
+    distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+
+    assert_not distributor.pending?
+
+    distributor.add_test(["Test1", "test_a", nil])
+    assert distributor.pending?
+
+    distributor.take(worker_id: 0)
+    assert_not distributor.pending?
+  end
+end

--- a/activesupport/test/parallelization/thread_pool_executor_test.rb
+++ b/activesupport/test/parallelization/thread_pool_executor_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+
+class ThreadPoolExecutorTest < ActiveSupport::TestCase
+  test "executes tests in thread pool" do
+    results = Concurrent::Array.new
+    reporter = Minitest::CompositeReporter.new
+
+    # Track which tests ran
+    reporter.reporters << Class.new do
+      define_method(:prerecord) { |*| }
+      define_method(:record) { |result| results << result.name }
+    end.new
+
+    mock_test_class = Class.new(Minitest::Test) do
+      def self.name
+        "MockTest"
+      end
+
+      def test_foo
+        assert true
+      end
+
+      def test_bar
+        assert true
+      end
+    end
+
+    distributor = ActiveSupport::Testing::Parallelization::RoundRobinDistributor.new(worker_count: 2)
+
+    distributor.add_test([mock_test_class, "test_foo", reporter])
+    distributor.add_test([mock_test_class, "test_bar", reporter])
+
+    executor = ActiveSupport::Testing::Parallelization::ThreadPoolExecutor.new(
+      size: 2,
+      distributor: distributor
+    )
+
+    executor.start
+    executor.shutdown
+
+    assert_equal 2, results.size
+    assert_includes results, "test_foo"
+    assert_includes results, "test_bar"
+  end
+
+  test "distributes work using round robin distributor" do
+    worker_assignments = Concurrent::Hash.new
+
+    reporter = Minitest::CompositeReporter.new
+    reporter.reporters << Class.new do
+      attr_accessor :worker_assignments
+
+      define_method(:prerecord) { |*| }
+      define_method(:record) do |result|
+        # Track which thread ran which test
+        worker_assignments[Thread.current] ||= []
+        worker_assignments[Thread.current] << result.name
+      end
+    end.new.tap { |r| r.worker_assignments = worker_assignments }
+
+    mock_test_class = Class.new(Minitest::Test) do
+      def self.name
+        "MockTest"
+      end
+
+      def test_a; assert true; end
+      def test_b; assert true; end
+      def test_c; assert true; end
+      def test_d; assert true; end
+    end
+
+    distributor = ActiveSupport::Testing::Parallelization::RoundRobinDistributor.new(worker_count: 2)
+
+    distributor.add_test([mock_test_class, "test_a", reporter])
+    distributor.add_test([mock_test_class, "test_b", reporter])
+    distributor.add_test([mock_test_class, "test_c", reporter])
+    distributor.add_test([mock_test_class, "test_d", reporter])
+
+    executor = ActiveSupport::Testing::Parallelization::ThreadPoolExecutor.new(
+      size: 2,
+      distributor: distributor
+    )
+
+    executor.start
+    executor.shutdown
+
+    # Verify tests were distributed across threads
+    assert_equal 2, worker_assignments.size
+    assert worker_assignments.values.all? { |tests| tests.size > 0 }
+  end
+end

--- a/activesupport/test/parallelization_test.rb
+++ b/activesupport/test/parallelization_test.rb
@@ -35,12 +35,19 @@ class ParallelizationTest < ActiveSupport::TestCase
   end
 
   test "shutdown handles dead workers gracefully" do
+    # Use a blocking queue strategy so workers wait for work
+    blocking_distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+
     parallelization = ActiveSupport::Testing::Parallelization.new(1)
+    server = parallelization.instance_variable_get(:@queue_server)
+
+    # Replace distributor with one that blocks
+    server.instance_variable_set(:@distributor, blocking_distributor)
+
     parallelization.start
 
-    sleep 0.25
+    sleep 0.5
 
-    server = parallelization.instance_variable_get(:@queue_server)
     assert server.active_workers?
 
     worker_pids = parallelization.instance_variable_get(:@worker_pool)
@@ -49,5 +56,220 @@ class ParallelizationTest < ActiveSupport::TestCase
 
     Timeout.timeout(2.5, Minitest::Assertion, "Expected shutdown to not hang") { parallelization.shutdown }
     assert_not server.active_workers?
+  end
+
+  test "seeded distribution assigns tests to workers round-robin" do
+    worker_count = 2
+
+    # Simulate test collection
+    tests = [
+      ["TestClass1", "test_a", nil],
+      ["TestClass1", "test_b", nil],
+      ["TestClass2", "test_c", nil],
+      ["TestClass2", "test_d", nil],
+      ["TestClass3", "test_e", nil],
+      ["TestClass3", "test_f", nil]
+    ]
+
+    # Mock seed and runnables before creating parallelization
+    Minitest.stub :seed, 12345 do
+      mock_runnable = Class.new do
+        def self.runnable_methods
+          ["test_a", "test_b"]
+        end
+      end
+
+      Minitest::Runnable.stub :runnables, [mock_runnable, mock_runnable, mock_runnable] do
+        parallelization = ActiveSupport::Testing::Parallelization.new(worker_count)
+
+        # Access the distributor through the server
+        server = parallelization.instance_variable_get(:@queue_server)
+        distributor = server.instance_variable_get(:@distributor)
+
+        # Verify it's a seeded distributor
+        assert_instance_of ActiveSupport::Testing::Parallelization::RoundRobinDistributor, distributor
+
+        # Enqueue tests - they'll be distributed round-robin immediately
+        tests.each { |test| parallelization << test }
+
+        # Close distributor to signal no more tests will come
+        distributor.close
+
+        # Collect tests from each worker by calling take
+        worker_0_tests = []
+        worker_1_tests = []
+
+        # Drain worker 0's queue - should get tests at indexes 0, 2, 4
+        while test = distributor.take(worker_id: 0)
+          worker_0_tests << test
+        end
+
+        # Drain worker 1's queue - should get tests at indexes 1, 3, 5
+        while test = distributor.take(worker_id: 1)
+          worker_1_tests << test
+        end
+
+        # Verify all tests were distributed
+        assert_equal tests.size, worker_0_tests.size + worker_1_tests.size
+
+        # Verify round-robin distribution (each worker gets 3 tests)
+        assert_equal 3, worker_0_tests.size
+        assert_equal 3, worker_1_tests.size
+      end
+    end
+  end
+
+  test "seeded distribution produces same assignment with same seed" do
+    worker_count = 2
+    tests = [
+      ["TestClass1", "test_a", nil],
+      ["TestClass1", "test_b", nil],
+      ["TestClass2", "test_c", nil],
+      ["TestClass2", "test_d", nil]
+    ]
+
+    mock_runnable = Class.new do
+      def self.runnable_methods
+        ["test_a", "test_b"]
+      end
+    end
+
+    # Run with same seed twice
+    seed = 54321
+    distributions = 2.times.map do
+      Minitest.stub :seed, seed do
+        Minitest::Runnable.stub :runnables, [mock_runnable, mock_runnable] do
+          parallelization = ActiveSupport::Testing::Parallelization.new(worker_count)
+
+          # Enqueue tests in same order (they arrive pre-shuffled from Minitest)
+          tests.each { |test| parallelization << test }
+
+          server = parallelization.instance_variable_get(:@queue_server)
+          distributor = server.instance_variable_get(:@distributor)
+
+          # Close to signal no more tests
+          distributor.close
+
+          # Drain all tests from all workers
+          all_tests = []
+          worker_count.times do |worker_id|
+            while test = distributor.take(worker_id: worker_id)
+              all_tests << [worker_id, test[0..1]]
+            end
+          end
+          all_tests
+        end
+      end
+    end
+
+    # Verify both runs have identical distribution
+    assert_equal distributions[0], distributions[1]
+  end
+
+  test "seeded distribution produces different assignment with different seed" do
+    worker_count = 2
+
+    mock_runnable = Class.new do
+      def self.runnable_methods
+        ["test_a", "test_b"]
+      end
+    end
+
+    # Run with different seeds - this simulates Minitest shuffling tests differently
+    distributions = [12345, 67890].map do |seed|
+      Minitest.stub :seed, seed do
+        Minitest::Runnable.stub :runnables, [mock_runnable, mock_runnable] do
+          parallelization = ActiveSupport::Testing::Parallelization.new(worker_count)
+
+          # Simulate tests arriving in different order based on seed
+          # In reality, Minitest would shuffle these differently
+          tests = [
+            ["TestClass1", "test_a", nil],
+            ["TestClass1", "test_b", nil],
+            ["TestClass2", "test_c", nil],
+            ["TestClass2", "test_d", nil]
+          ].shuffle(random: Random.new(seed))
+
+          tests.each { |test| parallelization << test }
+
+          server = parallelization.instance_variable_get(:@queue_server)
+          distributor = server.instance_variable_get(:@distributor)
+
+          # Close to signal no more tests
+          distributor.close
+
+          # Capture which tests each worker gets, preserving order
+          worker_tests = {}
+          worker_count.times do |worker_id|
+            worker_tests[worker_id] = []
+            while test = distributor.take(worker_id: worker_id)
+              worker_tests[worker_id] << test[0..1]
+            end
+          end
+          worker_tests
+        end
+      end
+    end
+
+    # Verify different seeds produce different test assignments
+    # Different seeds -> different Minitest shuffling -> different round-robin distribution
+    assert_not_equal distributions[0], distributions[1]
+  end
+
+  test "default uses seeded distributor without work stealing" do
+    mock_runnable = Class.new do
+      def self.runnable_methods
+        ["test_a"]
+      end
+    end
+
+    Minitest::Runnable.stub :runnables, [mock_runnable] do
+      parallelization = ActiveSupport::Testing::Parallelization.new(2)
+      server = parallelization.instance_variable_get(:@queue_server)
+      distributor = server.instance_variable_get(:@distributor)
+
+      # Verify it's a seeded distributor
+      assert_instance_of ActiveSupport::Testing::Parallelization::RoundRobinDistributor, distributor
+    end
+  end
+
+  test "work_stealing: true uses seeded distributor with work stealing" do
+    mock_runnable = Class.new do
+      def self.runnable_methods
+        ["test_a"]
+      end
+    end
+
+    Minitest::Runnable.stub :runnables, [mock_runnable] do
+      parallelization = ActiveSupport::Testing::Parallelization.new(2, work_stealing: true)
+      server = parallelization.instance_variable_get(:@queue_server)
+      distributor = server.instance_variable_get(:@distributor)
+
+      # Verify it's a round robin work stealing distributor
+      assert_instance_of ActiveSupport::Testing::Parallelization::RoundRobinWorkStealingDistributor, distributor
+    end
+  end
+
+  test "thread pool executor uses seeded distributor by default" do
+    mock_runnable = Class.new do
+      def self.runnable_methods
+        ["test_a"]
+      end
+    end
+
+    Minitest.stub :seed, 12345 do
+      Minitest::Runnable.stub :runnables, [mock_runnable] do
+        executor = ActiveSupport::Testing::Parallelization::ThreadPoolExecutor.new(
+          size: 2,
+          distributor: ActiveSupport::Testing::Parallelization::RoundRobinDistributor.new(worker_count: 2)
+        )
+
+        # Verify the executor has the right interface
+        assert_respond_to executor, :start
+        assert_respond_to executor, :<<
+        assert_respond_to executor, :shutdown
+        assert_equal 2, executor.size
+      end
+    end
   end
 end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -2682,6 +2682,25 @@ workers a test run should use:
 $ PARALLEL_WORKERS=15 bin/rails test
 ```
 
+#### Reproducing Flaky Parallel Tests
+
+Whether using processes or threads, tests are distributed to workers in
+round-robin order, so given the same `--seed` value and worker count, each
+worker runs the same sequence of tests. This makes flaky tests caused by
+parallel test interdependence easier to reproduce: re-run with the same seed
+and worker count to get the same distribution.
+
+This deterministic assignment can make test runtime uneven when one worker
+happens to get most of the slow tests. Enable `work_stealing` to allow idle
+workers to steal tests from busy workers, improving load balance at the cost
+of less reproducible test distribution:
+
+```ruby
+class ActiveSupport::TestCase
+  parallelize(workers: :number_of_processors, work_stealing: true)
+end
+```
+
 When parallelizing tests, Active Record automatically handles creating a
 database and loading the schema into the database for each process. The
 databases will be suffixed with the number corresponding to the worker. For


### PR DESCRIPTION
Rails assigns tests to workers in round-robin order so the same `--seed` and worker count will result in the same sequence of tests running on each worker (whether processes or threads) increasing the odds of reproducing test failures caused by test interdependence.

This can make test runtime slower and spikier when one worker gets most of the slow tests. Enable `work_stealing: true` to allow idle workers to steal tests from busy workers in deterministic order, smoothing out runtime at the cost of less reproducible flaky-test failures.

(Update: removed concurrent test reportsfor each test failures.)

Performance:
* Seeing statistically insignificant difference in test suite times before/after, and with work stealing enabled/disabled. Too much variance; need more samples.
* See https://github.com/basecamp/fizzy/pull/2037 for validation.