### PR TITLE
Fix typos in test descriptions & code for clarity

### DIFF
--- a/railties/test/application/active_record_railtie_test.rb
+++ b/railties/test/application/active_record_railtie_test.rb
@@ -41,10 +41,10 @@ module ApplicationTests
       assert_includes ActiveRecord::Base.filter_attributes, :special_param
     end
 
-    test "filter_paramenters include filter_attributes for an AR::Base subclass" do
+    test "filter_parameters include filter_attributes for an AR::Base subclass" do
       app "development"
 
-      assert_not_includes ActiveRecord::Base.filter_attributes, "messsage.special_attr"
+      assert_not_includes ActiveRecord::Base.filter_attributes, "message.special_attr"
 
       class Message < ActiveRecord::Base
         self.table_name = "messages"
@@ -54,7 +54,7 @@ module ApplicationTests
       assert_includes Rails.application.config.filter_parameters, "message.special_attr"
     end
 
-    test "filter_paramenters include filter_attributes for AR::Base subclasses" do
+    test "filter_parameters include filter_attributes for AR::Base subclasses" do
       app "development"
 
       assert_not_includes ActiveRecord::Base.filter_attributes, "special_attr"


### PR DESCRIPTION
### Motivation / Background

```ruby
assert_not_includes ActiveRecord::Base.filter_attributes, "messsage.special_attr"
```

Test uses "messsage.special_attr" (with a typo), which caused the test to assert against an unintended string. 

This made the test misleading because it appeared to validate filtering behavior, but the assertion was actually checking for a misspelled attribute, not the intended `"message.special_attr"` key.