### PR TITLE
Add PostgreSQL service setup for Arch Linux

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -131,7 +131,8 @@ To install all run:
 ```bash
 $ sudo pacman -S sqlite mariadb libmariadbclient mariadb-clients postgresql postgresql-libs redis memcached imagemagick ffmpeg mupdf mupdf-tools poppler yarn libxml2 libvips
 $ sudo mariadb-install-db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
-$ sudo systemctl start redis mariadb memcached
+$ sudo -u postgres initdb -D /var/lib/postgres/data
+$ sudo systemctl start redis mariadb memcached postgresql
 ```
 
 NOTE: If you are running Arch Linux, MySQL isn't supported anymore so you will need to


### PR DESCRIPTION
### Motivation / Background

This commit updates installing PostgreSQL on Arch Linux for Rails development.

### Detail
- Without this commit
`postgresql` service needs start manually
`sudo systemctl start postgresql fails as follows

```
$ sudo systemctl start postgresql
Job for postgresql.service failed because the control process exited with error code.
See "systemctl status postgresql.service" and "journalctl -xeu postgresql.service" for details.
[yahonda@myarch activestorage]$ sudo systemctl status postgresql
× postgresql.service - PostgreSQL database server
     Loaded: loaded (/usr/lib/systemd/system/postgresql.service; disabled; preset: disabled)
     Active: failed (Result: exit-code) since Sun 2025-11-16 05:44:20 UTC; 5s ago
   Duration: 35.911s
 Invocation: 8c4e6f9657584108b15ae25813957fbf
       Docs: man:postgres(1)
    Process: 103605 ExecStartPre=/usr/bin/postgresql-check-db-dir ${PGROOT}/data (code=exited, status=1/FAILURE)
   Mem peak: 2M
        CPU: 47ms

Nov 16 05:44:20 myarch systemd[1]: Starting PostgreSQL database server...
Nov 16 05:44:20 myarch postgres[103605]: "/var/lib/postgres/data" is missing or empty. Use a command like
Nov 16 05:44:20 myarch postgres[103605]:   su -l postgres -c "initdb --locale=C.UTF-8 --encoding=UTF8 -D '/var/lib/postgres/data'"
Nov 16 05:44:20 myarch postgres[103605]: with relevant options, to initialize the database cluster.
Nov 16 05:44:20 myarch systemd[1]: postgresql.service: Control process exited, code=exited, status=1/FAILURE
Nov 16 05:44:20 myarch systemd[1]: postgresql.service: Failed with result 'exit-code'.
Nov 16 05:44:20 myarch systemd[1]: Failed to start PostgreSQL database server.
$
```

- With this commit

```
$ sudo -u postgres initdb -D /var/lib/postgres/data
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.UTF-8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are enabled.

fixing permissions on existing directory /var/lib/postgres/data ... ok
creating subdirectories ... ok
selecting dynamic shared memory implementation ... posix
selecting default "max_connections" ... 100
selecting default "shared_buffers" ... 128MB
selecting default time zone ... UTC
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok

initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    pg_ctl -D /var/lib/postgres/data -l logfile start

$ sudo systemctl start postgresql
$ pg_isready
/run/postgresql:5432 - accepting connections
```

- Environment

```
$ cat /etc/os-release
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo
$
```

### Additional information
Rerfer to https://wiki.archlinux.org/title/PostgreSQL

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
