### PR TITLE
Use event reporter for active_record.deprecated_association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add structured event `active_record.deprecated_association` when mode is set to `:notify`.
+
+    ```
+    config.active_record.deprecated_associations_options = { mode: :notify }
+    ```
+
+    *zzak*
+
 *   On MySQL parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
 
     Truncating on MySQL is very slow even on empty or nearly empty tables.

--- a/activerecord/test/cases/structured_event_subscriber_test.rb
+++ b/activerecord/test/cases/structured_event_subscriber_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "active_support/testing/event_reporter_assertions"
 require "active_record/structured_event_subscriber"
+require "models/dats"
 require "models/developer"
 require "models/binary"
 

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -659,23 +659,6 @@ In practice, you cannot do much with the transaction object, but it may still be
 helpful for tracing database activity. For example, by tracking
 `transaction.uuid`.
 
-#### `deprecated_association.active_record`
-
-This event is emitted when a deprecated association is accessed, and the
-configured deprecated associations mode is `:notify`.
-
-| Key                  | Value                                                |
-| -------------------- | ---------------------------------------------------- |
-| `:reflection`        | The reflection of the association                    |
-| `:message`           | A descriptive message about the access               |
-| `:location`          | The application-level location of the access         |
-| `:backtrace`         | Only present if the option `:backtrace` is true      |
-
-The `:location` is a `Thread::Backtrace::Location` object, and `:backtrace`, if
-present, is an array of `Thread::Backtrace::Location` objects. These are
-computed using the Active Record backtrace cleaner. In Rails applications, this
-is the same as `Rails.backtrace_cleaner`.
-
 ### Active Storage
 
 #### `preview.active_storage`

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1843,7 +1843,7 @@ If no mapping is found, the protocol is used as the adapter name.
 If present, this has to be a hash with keys `:mode` and/or `:backtrace`:
 
 ```ruby
-config.active_record.deprecated_associations_options = { mode: :notify, backtrace: true }
+config.active_record.deprecated_associations_options = { mode: :event, backtrace: true }
 ```
 
 * In `:warn` mode, accessing the deprecated association is reported by the
@@ -1852,9 +1852,10 @@ config.active_record.deprecated_associations_options = { mode: :notify, backtrac
 * In `:raise` mode, usage raises an `ActiveRecord::DeprecatedAssociationError`
   with a similar message and a clean backtrace in the exception object.
 
-* In `:notify` mode, a `deprecated_association.active_record` Active Support
-  notification is published. Please, see details about its payload in the
-  [Active Support Instrumentation guide](active_support_instrumentation.html).
+* In `:event` mode, an `active_record.deprecated_association` Active Support
+  event is reported. Please, see details about the [Event
+  Reporter](https://edgeapi.rubyonrails.org/classes/ActiveSupport/EventReporter.html)
+  on how to use it.
 
 Backtraces are disabled by default. If `:backtrace` is true, warnings include a
 clean backtrace in the message, and notifications have a `:backtrace` key in the


### PR DESCRIPTION
Replaces the existing notification and deprecates `:notify` option.

Based on feedback: https://github.com/rails/rails/pull/56170#issuecomment-3536213783

> When I implemented deprecated associations, I emitted an AS notification because that is what we had, but I did not like it.
> 
> The fact that this patch uses a subscriber is an implementation detail, no? The patch that I would like is that the core of the deprecated associations feature directly emits a structured event.

This is an alternative to #56170 that uses event reporter directly to emit a structured event for deprecated associations.

The benefits to this approach are simpler, and less overhead than going through notifications and structured event subscribers.

My concern is that this introduces a new pattern for emitting events in the framework, where the other PR follows the established pattern of (emit notification -> event subscribers -> reporter). Is this a one-off, or are there other cases where we would replace existing business specific notifications with events.

The other concern is how neatly this fits in to existing event subscribers, but since everything flows through the reporter (there should only be one) then it's probably fine -- I just wanted to note that as a possible concern even if it's lower risk. In theory, event subscribers will emit it like any other event, or can filter if necessary.

I think this feature also sits separately from the other notifications, for example `active_record.sql` or `active_job.completed` are more _framework-level_ telling us what's happening in the system. But associations are very much apart of the business domain of the application, not an internal event or side-effect of something Rails did, like process a request. So I can see the argument for not using notifications.

That said, I would like to get feedback from @gmcgibbon, @adrianna-chang-shopify, and @rafaelfranca on this.

/cc @fxn

