### PR TITLE
fix: acronym inflector should give precedence to longer matches

### DIFF
--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -264,9 +264,13 @@ module ActiveSupport
 
       private
         def define_acronym_regex_patterns
-          @acronym_regex             = @acronyms.empty? ? /(?=a)b/ : /#{@acronyms.values.join("|")}/
+          @acronym_regex             = @acronyms.empty? ? /(?=a)b/ : /#{sorted_acronyms.values.join("|")}/
           @acronyms_camelize_regex   = /^(?:#{@acronym_regex}(?=\b|[A-Z_])|\w)/
           @acronyms_underscore_regex = /(?:(?<=([A-Za-z\d]))|\b)(#{@acronym_regex})(?=\b|[^a-z])/
+        end
+
+        def sorted_acronyms
+          @acronyms.sort_by { |_key, acronym| -acronym.length }.to_h
         end
     end
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -265,6 +265,16 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("htmlAPI", ActiveSupport::Inflector.camelize("HTMLAPI", false))
   end
 
+  def test_underscore_acronym_precedence
+    ActiveSupport::Inflector.inflections(:en) do |inflect|
+      inflect.acronym "JWK"
+      inflect.acronym "JWKS"
+    end
+
+    assert_equal "jwks", "JWKS".underscore
+    assert_equal "jwk", "JWK".underscore
+  end
+
   def test_underscore_acronym_sequence
     ActiveSupport::Inflector.inflections do |inflect|
       inflect.acronym("API")


### PR DESCRIPTION
### Motivation / Background

When multiple acronyms are defined where one is a prefix of another (e.g., "JWK" and "JWKS"), the inflector would incorrectly match the shorter acronym first, causing "JWKS".underscore to return "jwk_s" instead of "jwks".

Fixes #56181

### Detail

This PR fixes the issue by sorting acronyms by length in descending order before building the regex pattern, ensuring longest matches take precedence over shorter overlapping ones.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.