### PR TITLE
Document how to enable Rate Limiting in tests

### DIFF
--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -77,6 +77,10 @@ module ActionController # :nodoc:
       #       rate_limit to: 3, within: 2.seconds, name: "short-term"
       #       rate_limit to: 10, within: 5.minutes, name: "long-term"
       #     end
+      #
+      # For testing with rate limits, you may need to switch the cache store to
+      # ActiveSupport::Cache::MemoryStore (`config.cache_store = :memory_store`)
+      # or any store that will persist data.
       def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { raise TooManyRequests }, store: cache_store, name: nil, scope: nil, **options)
         before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store, name: name, scope: scope || controller_path) }, **options
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I had trouble finding this information.

Rails applications are generated to use the `ActiveSupport::Cache::NullStore` in the test environment by default. This means `rate_limit` doesn't work without intervention. This was a surprising foot gun when I tried covering the controllers generated by the Rails 8 authentication generator.

I brought this up at https://github.com/rails/rails/pull/33773#issuecomment-3538502849 and @zzak requested I send a PR.

### Detail

This Pull Request adds a paragraph to the documentation of [`rate_limit` method in `ActionController::RateLimiting::ClassMethods`](https://api.rubyonrails.org/classes/ActionController/RateLimiting/ClassMethods.html#method-i-rate_limit). I placed it immediately after the existing paragraph about backing cache stores. I added it as a separate paragraph because it would've been quite long together, and it is a separate (though related) topic.