### PR TITLE
[skip ci] DOCS / PostgreSQL / Add missing configuration for timestamptz 

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -539,6 +539,8 @@ To configure `timestamp with time zone` as your new timestamp default data type,
 # config/application.rb
 ActiveSupport.on_load(:active_record_postgresqladapter) do
   self.datetime_type = :timestamptz
+  # If you are adding this to an existing application with an existing database, add this line:
+  ActiveRecord::Base.time_zone_aware_types << :timestamp
 end
 ```
 


### PR DESCRIPTION
More info: https://github.com/rails/rails/pull/41084#issuecomment-3541856880

By setting `timestamptz`, `timestamp` is no longer time zone aware which breaks existing application that relied on this behavior. `timestamp` used to be converted to `datetime` which is time zone aware.

Related to : 
- https://github.com/rails/rails/pull/53687
- https://github.com/rails/rails/pull/41084

cc @ghiculescu @andyatkinson 