### PR TITLE
Fix DelegateClass defining ... signatures

### DIFF
--- a/activesupport/lib/active_support/delegation.rb
+++ b/activesupport/lib/active_support/delegation.rb
@@ -226,11 +226,12 @@ module ActiveSupport
         delegated_methods.each do |method_name|
           if method_name.match?(/\A[a-zA-Z]\w+[!?]?\z/)
             parameters = superclass.instance_method(method_name).parameters
-            if parameters.empty?
-              signature = ""
+
+            signature = if parameters.empty?
+              ""
             elsif parameters.all? { |type, _name| type == :req || type == :keyreq || type == :block }
               anonymous = 0
-              signature = parameters.map do |type, name|
+              parameters.map do |type, name|
                 case type
                 when :req
                   name || "__anonymous_arg_#{anonymous += 1}"


### PR DESCRIPTION
Ref #56171

Previously, the `signature` variable was only getting set in the first two branches, but not the third. This caused methods that _should_ have been defined with triple dot delegation to instead have no arguments defined.

This commit fixes the issue by pulling the `signature =` assignment out of the condition so that it always happens.