### PR TITLE
Add tests for `Arel::Nodes::UnqualifiedColumn`

### DIFF
--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -200,6 +200,23 @@ module Arel
           }
         end
       end
+
+      describe "Nodes::UnqualifiedColumn" do
+        it "compiles qualified columns" do
+          attribute = Nodes::UnqualifiedColumn.new(Attributes::Attribute.new(Table.new(:users), "name"))
+          _(compile(attribute)).must_be_like %{ "users"."name" }
+        end
+
+        it "compiles aliased columns" do
+          attribute = Nodes::UnqualifiedColumn.new(Attributes::Attribute.new(Table.new(:users).alias("zomgusers"), "name"))
+          _(compile(attribute)).must_be_like %{ "zomgusers"."name" }
+        end
+
+        it "compiles unqualified columns" do
+          attribute = Nodes::UnqualifiedColumn.new(Attributes::Attribute.new(Table.new(""), "name"))
+          _(compile(attribute)).must_be_like %{ "name" }
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -1056,6 +1056,23 @@ module Arel
             _(compile(sql)).must_be_like "SELECT foo, bar FROM customers GROUP BY foo"
           end
         end
+
+        describe "Nodes::UnqualifiedColumn" do
+          it "compiles qualified columns" do
+            attribute = Nodes::UnqualifiedColumn.new(Attributes::Attribute.new(Table.new(:users), "name"))
+            _(compile(attribute)).must_be_like %{ "name" }
+          end
+
+          it "compiles aliased columns" do
+            attribute = Nodes::UnqualifiedColumn.new(Attributes::Attribute.new(Table.new(:users).alias("zomgusers"), "name"))
+            _(compile(attribute)).must_be_like %{ "name" }
+          end
+
+          it "compiles unqualified columns" do
+            attribute = Nodes::UnqualifiedColumn.new(Attributes::Attribute.new(Table.new(""), "name"))
+            _(compile(attribute)).must_be_like %{ "name" }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/8e123847e8ba0a59aafa708950a4887a669311b4, the `Arel::Visitors::Mysql` visitor handles `Arel::Nodes::UnqualifiedColumn` differently from `Arel::Visitor::ToSql`.

This has made it impossible to compile an Arel tree with an actually unqualified column for MySQL. I don't know if this is the intended behaviour or an oversight but, at least for the case where a table with an empty `name` string, it seems appropriate to return `"column_name"` instead of `""."column_name"`.

```ruby
attribute = Nodes::UnqualifiedColumn.new(Attributes::Attribute.new(Table.new(""), "name"))
_(compile(attribute)).must_be_like %{ "name" }
```

In its current state, this PR adds only some test cases to show the problem but with some guidance to the expected solution, I am available to submit a fix.