### PR TITLE
Fast failure mode for local CI

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add a fast failure mode to `ActiveSupport::ContinuousIntegration` that stops the rest of
+    the run after a step fails. Invoke by running `bin/ci --fail-fast` or `bin/ci -f`.
+
+    *Dennis Paagman*
+
 *   Implement LocalCache strategy on `ActiveSupport::Cache::MemoryStore`. The memory store
     needs to respond to the same interface as other cache stores (e.g. `ActiveSupport::NullStore`).
 

--- a/activesupport/lib/active_support/continuous_integration.rb
+++ b/activesupport/lib/active_support/continuous_integration.rb
@@ -38,6 +38,8 @@ module ActiveSupport
     #
     # Sets the CI environment variable to "true" to allow for conditional behavior in the app, like enabling eager loading and disabling logging.
     #
+    # A 'fail fast' option can be passed as a CLI argument (-f or --fail-fast). This exits with a non-zero status directly after a step fails.
+    #
     # Example:
     #
     #   ActiveSupport::ContinuousIntegration.run do
@@ -124,6 +126,8 @@ module ActiveSupport
       else
         echo "\n❌ #{title} failed in #{elapsed}", type: :error
 
+        abort if ci.fail_fast?
+
         if ci.multiple_results?
           ci.failures.each do |success, title|
             unless success
@@ -146,6 +150,11 @@ module ActiveSupport
     # :nodoc:
     def multiple_results?
       results.size > 1
+    end
+
+    # :nodoc:
+    def fail_fast?
+      ARGV.include?("-f") || ARGV.include?("--fail-fast")
     end
 
     private


### PR DESCRIPTION
### Motivation / Background

I find myself manually cancelling a `bin/ci` run a lot when a step fails before the end. For example if Rubocop fails as the first step, I want to go in and fix that first, and don't really care about brakeman or my tests yet. The incoming lines from the other steps also impede with me reading the error and will scroll the screen.

### Detail

This PR introduces a cli argument `--fail-fast` (or `-f`), as commonly used by for example minitest and RSpec.

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
