### PR TITLE
Allow create_join_table to accept a primary key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Allow `create_join_table` to accept a primary key.
+
+    This is useful for databases like PostgreSQL where logical replication requires primary
+    keys on all tables.
+
+    ```ruby
+    create_join_table :assemblies, :parts, primary_key: [:assembly_id, :part_id]
+    ```
+
+    This generates a join table with a composite primary key on both foreign key columns.
+
+    *Genadi Samokovarov*
+
 *   Fix Active Record Pool Reaper thread leak after `Parallelization#shutdown`.
 
     After parallelized test runs, the parent process leaked the Active Record Pool

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -184,7 +184,7 @@ module ActiveRecord
       # The +options+ hash can include the following keys:
       # [<tt>:id</tt>]
       #   Whether to automatically add a primary key column. Defaults to true.
-      #   Join tables for {ActiveRecord::Base.has_and_belongs_to_many}[rdoc-ref:Associations::ClassMethods#has_and_belongs_to_many] should set it to false.
+      #   Join tables for {ActiveRecord::Base.has_and_belongs_to_many}[rdoc-ref:Associations::ClassMethods#has_and_belongs_to_many] set it to false by default.
       #
       #   A Symbol can be used to specify the type of the generated primary key column.
       #
@@ -379,6 +379,9 @@ module ActiveRecord
       # [<tt>:force</tt>]
       #   Set to true to drop the table before creating it.
       #   Defaults to false.
+      # [<tt>:primary_key</tt>]
+      #   By default no primary key is added for join tables. Use this option to set the primary key
+      #   and it's name. If an array is passed, a composite primary key will be created.
       #
       # Note that #create_join_table does not create any indices by default; you can use
       # its block form to do so yourself:
@@ -412,14 +415,29 @@ module ActiveRecord
       #     part_id bigint NOT NULL,
       #   ) ENGINE=InnoDB DEFAULT CHARSET=utf8
       #
+      # ====== Add a composite primary key
+      #
+      #   create_join_table(:assemblies, :parts, primary_key: [:assembly_id, :part_id])
+      #
+      # generates:
+      #
+      #   CREATE TABLE assemblies_parts (
+      #     assembly_id bigint NOT NULL,
+      #     part_id bigint NOT NULL,
+      #   );
+      #
+      #  ALTER TABLE ONLY "assemblies_parts"
+      #      ADD CONSTRAINT assemblies_parts_pkey PRIMARY KEY (assembly_id, part_id);
+      #
       def create_join_table(table_1, table_2, column_options: {}, **options)
         join_table_name = find_join_table_name(table_1, table_2, options)
 
         column_options.reverse_merge!(null: false, index: false)
+        options.reverse_merge!(id: options[:primary_key] ? :primary_key : false)
 
         t1_ref, t2_ref = [table_1, table_2].map { |t| reference_name_for_table(t) }
 
-        create_table(join_table_name, **options.merge!(id: false)) do |td|
+        create_table(join_table_name, **options) do |td|
           td.references t1_ref, **column_options
           td.references t2_ref, **column_options
           yield td if block_given?
@@ -434,10 +452,11 @@ module ActiveRecord
       def build_create_join_table_definition(table_1, table_2, column_options: {}, **options) # :nodoc:
         join_table_name = find_join_table_name(table_1, table_2, options)
         column_options.reverse_merge!(null: false, index: false)
+        options.reverse_merge!(id: options[:primary_key] ? :primary_key : false)
 
         t1_ref, t2_ref = [table_1, table_2].map { |t| reference_name_for_table(t) }
 
-        build_create_table_definition(join_table_name, **options.merge!(id: false)) do |td|
+        build_create_table_definition(join_table_name, **options) do |td|
           td.references t1_ref, **column_options
           td.references t2_ref, **column_options
           yield td if block_given?

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -91,6 +91,12 @@ module ActiveRecord
         assert_equal video_id.sql_type, music_id.sql_type
       end
 
+      def test_create_join_table_can_set_primary_key
+        connection.create_join_table :artists, :musics, primary_key: [:artist_id, :music_id]
+
+        assert_equal %w(artist_id music_id), connection.primary_key(:artists_musics)
+      end
+
       def test_drop_join_table
         connection.create_join_table :artists, :musics
         connection.drop_join_table :artists, :musics
@@ -136,6 +142,13 @@ module ActiveRecord
       def test_drop_join_table_with_column_options
         connection.create_join_table :artists, :musics, column_options: { null: true }
         connection.drop_join_table :artists, :musics, column_options: { null: true }
+
+        assert_not connection.table_exists?("artists_musics")
+      end
+
+      def test_drop_join_table_with_primary_key
+        connection.create_join_table :artists, :musics, primary_key: [:artist_id, :music_id]
+        connection.drop_join_table :artists, :musics, primary_key: [:artist_id, :music_id]
 
         assert_not connection.table_exists?("artists_musics")
       end


### PR DESCRIPTION
### Motivation / Background

Historically, `create_join_table` did not allow setting primary keys because it hard-coded id: false when calling the underlying `create_table` method. This meant that even if you passed the `:primary_key` option, it would be ignored since `id: false` took precedence and prevented any primary key from being added.

Postgres logical replication requires all tables to have primary keys for it to work correctly, and in this case, it's handy to be able to specify a primary key, such as a composite one.

At work (Dext), we are using Postgres replication, and we cannot use `create_join_table` in its current form. We have to rely on `create_table` for join tables, or define a custom migration method and deal with its reversibility, which is not pretty to say the least.

### Detail

The `id: false` option is no longer hard-coded and passed to the underlying `create_table` call, but it remains false by default to maintain backwards compatibility. When the `:primary_key`
option is provided, `:id` is automatically set to `:primary_key`, allowing primary keys to be configured. 

Here is a usage example:

```ruby
create_join_table :assemblies, :parts, primary_key: [:assembly_id, :part_id]
```

I could have left the interface to be:

```ruby
create_join_table :assemblies, :parts, id: :primary_key, primary_key: [:assembly_id, :part_id]
```

But the former is more concise, which is what we want when setting primary keys on the join tables, in my opinion.
    
### Additional information

While working on this PR, I stumbled on the `build_create_tjoin_table_definition` method, which is a `:nodoc` method invoked only in Rails' test suite. Do you think I can just remove it? It's not public by Rails API standards, and a simple [GH search](https://github.com/search?q=build_create_join_table_definition&type=code&p=1) does not show it being used in anything serious – type declaration projects, Rails forks, and the likes.