### PR TITLE
Fix call to colorize when trapping INT

### DIFF
--- a/activesupport/lib/active_support/continuous_integration.rb
+++ b/activesupport/lib/active_support/continuous_integration.rb
@@ -114,7 +114,7 @@ module ActiveSupport
 
     # :nodoc:
     def report(title, &block)
-      Signal.trap("INT") { abort colorize(:error, "\n❌ #{title} interrupted") }
+      Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
 
       ci = self.class.new
       elapsed = timing { ci.instance_eval(&block) }


### PR DESCRIPTION
This fixes the arguments in the call to `colorize` when you ctrl-c the bin/ci job. The color/type should come last.

https://github.com/rails/rails/blob/a39e20bdcbca64bcaa1c06e99d3f236dc2144f96/activesupport/lib/active_support/continuous_integration.rb#L159-L161

Before:

```
❯ bin/ci
Continuous Integration
Running tests, style checks, and security audits


Tests: Rails
bundle exec rspec

^C
RSpec is shutting down and will print the summary report... Interrupt again to force quit (warning: at_exit hooks will be skipped if you force quit).
/Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:160:in 'Hash#fetch': key not found: "\n❌ Tests: Rails interrupted" (KeyError)
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:160:in 'ActiveSupport::ContinuousIntegration#colorize'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:117:in 'block in ActiveSupport::ContinuousIntegration#report'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:77:in 'Kernel#system'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:77:in 'block in ActiveSupport::ContinuousIntegration#step'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:120:in 'BasicObject#instance_eval'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:120:in 'block in ActiveSupport::ContinuousIntegration#report'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:154:in 'ActiveSupport::ContinuousIntegration#timing'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:120:in 'ActiveSupport::ContinuousIntegration#report'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:77:in 'ActiveSupport::ContinuousIntegration#step'
        from /Users/dennis/Code/tourbrain/web/config/ci.rb:6:in 'block in <compiled>'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:120:in 'BasicObject#instance_eval'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:120:in 'block in ActiveSupport::ContinuousIntegration#report'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:154:in 'ActiveSupport::ContinuousIntegration#timing'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:120:in 'ActiveSupport::ContinuousIntegration#report'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:59:in 'block in ActiveSupport::ContinuousIntegration.run'
        from <internal:kernel>:91:in 'Kernel#tap'
        from /Users/dennis/Code/rails/activesupport/lib/active_support/continuous_integration.rb:56:in 'ActiveSupport::ContinuousIntegration.run'
        from /Users/dennis/Code/tourbrain/web/config/ci.rb:5:in '<compiled>'
        from bin/ci:6:in 'Kernel#require_relative'
        from bin/ci:6:in '<main>'
```

After:

```
❯ bin/ci
Continuous Integration
Running tests, style checks, and security audits


Tests: Rails
bundle exec rspec

^C
RSpec is shutting down and will print the summary report... Interrupt again to force quit (warning: at_exit hooks will be skipped if you force quit).

❌ Tests: Rails interrupted
```
