### PR TITLE
Remove unused test fixtures from ActionView

### DIFF
--- a/actionview/test/fixtures/test/dont_pick_me
+++ b/actionview/test/fixtures/test/dont_pick_me
@@ -1,1 +1,0 @@
-non-template file

--- a/actionview/test/fixtures/test/hello_world.erb~
+++ b/actionview/test/fixtures/test/hello_world.erb~
@@ -1,1 +1,0 @@
-Don't pick me!


### PR DESCRIPTION
While reviewing the ActionView test suite, I discovered a couple of fixture files that are not referenced anywhere in the tests. 

### Detail

This Pull Request removes two unused file from the ActionView test suite.