### PR TITLE
Make explain accept hash format syntax

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Allow either explain format syntax for EXPLAIN queries.
+
+    MySQL uses FORMAT=JSON whereas Postgres uses FORMAT JSON. We should be
+    able to accept both formats as options.
+
+    *Gannon McGibbon*
+
 *   On MySQL parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
 
     Truncating on MySQL is very slow even on empty or nearly empty tables.

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -36,6 +36,10 @@ module ActiveRecord
         def build_explain_clause(options = [])
           return "EXPLAIN" if options.empty?
 
+          options = options.flat_map do |option|
+            option.is_a?(Hash) ? option.to_a.map { |nested| nested.join("=") } : option
+          end
+
           explain_clause = "EXPLAIN #{options.join(" ").upcase}"
 
           if analyze_without_explain? && explain_clause.include?("ANALYZE")

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -96,6 +96,10 @@ module ActiveRecord
         def build_explain_clause(options = [])
           return "EXPLAIN" if options.empty?
 
+          options = options.flat_map do |option|
+            option.is_a?(Hash) ? option.to_a.map { |nested| nested.join(" ") } : option
+          end
+
           "EXPLAIN (#{options.join(", ").upcase})"
         end
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
@@ -37,6 +37,12 @@ class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
     assert_match %(#{expected_analyze_clause} SELECT `posts`.* FROM `posts` WHERE `posts`.`author_id` = 1), explain
   end
 
+  def test_explain_format_option
+    explain = Author.all.explain(format: :json).inspect
+
+    assert_match(/\{.*\}/m, explain)
+  end
+
   private
     def explain_option
       supports_analyze? || supports_explain_analyze? ? :analyze : :extended

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -38,4 +38,10 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
     assert_match %r(EXPLAIN \(ANALYZE\) SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %r(EXPLAIN \(ANALYZE\) SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\$1 \[\["author_id", 1\]\]|1)), explain
   end
+
+  def test_explain_format_option
+    explain = Author.all.explain(format: :json).inspect
+
+    assert_match(/\{.*\}/m, explain)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Active Record currently requires adapter specific syntax for explain queries when using the FORMAT option. MySQL uses `FORMAT=JSON` whereas Postgres uses `FORMAT JSON`. We should be able to accept a hash that maps to the right format syntax as an option.

### Detail

This Pull Request changes explain clause building for mysql and postgres to map hashes to the correct syntax. Example:
```rb
Car.all.explain(format: :json)
# or
Car.connection.explain(query, [], [{format: :json}]
```

### Additional information

I previously tried gsub-ing the SQL string but I think this approach with hashes is cleaner.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
