### PR TITLE
Load hook guard

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -12,6 +12,11 @@ module ActionCable
     config.action_cable.mount_path = ActionCable::INTERNAL[:default_mount_path]
     config.action_cable.precompile_assets = true
 
+    guard_load_hooks(
+      :action_cable, :action_cable_channel, :action_cable_connection,
+      :action_cable_test_case, :action_cable_connection_test_case,
+    )
+
     initializer "action_cable.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_cable] = ActionCable.deprecator
     end

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -22,6 +22,8 @@ module ActionMailbox
 
     config.action_mailbox.storage_service = nil
 
+    guard_load_hooks(:action_mailbox_inbound_email, :action_mailbox_record, :action_mailbox, :action_mailbox_test_case)
+
     initializer "action_mailbox.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_mailbox] = ActionMailbox.deprecator
     end

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -11,6 +11,8 @@ module ActionMailer
     config.action_mailer.preview_paths = []
     config.eager_load_namespaces << ActionMailer
 
+    guard_load_hooks(:action_mailer, :action_mailer_test_case)
+
     initializer "action_mailer.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_mailer] = ActionMailer.deprecator
     end

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -21,6 +21,8 @@ module ActionController
     config.eager_load_namespaces << AbstractController
     config.eager_load_namespaces << ActionController
 
+    guard_load_hooks(:action_controller, :action_controller_base, :action_controller_api, :action_controller_test_case)
+
     initializer "action_controller.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_controller] = ActionController.deprecator
     end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -50,6 +50,11 @@ module ActionDispatch
 
     config.eager_load_namespaces << ActionDispatch
 
+    guard_load_hooks(
+      :action_dispatch_request, :action_dispatch_response,
+      :action_dispatch_system_test_case, :action_dispatch_integration_test,
+    )
+
     initializer "action_dispatch.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_dispatch] = ActionDispatch.deprecator
     end

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -26,6 +26,11 @@ module ActionText
       #{root}/app/models
     )
 
+    guard_load_hooks(
+      :action_text_record, :action_text_rich_text, :action_text_content,
+      :action_text_encrypted_rich_text,
+    )
+
     initializer "action_text.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_text] = ActionText.deprecator
     end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -17,6 +17,8 @@ module ActionView
 
     config.eager_load_namespaces << ActionView
 
+    guard_load_hooks(:action_view, :action_view_test_case)
+
     config.after_initialize do |app|
       ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
         app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -11,6 +11,8 @@ module ActiveJob
     config.active_job.custom_serializers = []
     config.active_job.log_query_tags_around_perform = true
 
+    guard_load_hooks(:active_job, :active_job_arguments, :active_job_continuable, :active_job_test_case)
+
     initializer "active_job.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_job] = ActiveJob.deprecator
     end

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -9,6 +9,8 @@ module ActiveModel
 
     config.active_model = ActiveSupport::OrderedOptions.new
 
+    guard_load_hooks(:active_model, :active_model_error, :active_model_secure_password, :active_model_translation)
+
     initializer "active_model.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_model] = ActiveModel.deprecator
     end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -46,6 +46,12 @@ module ActiveRecord
 
     config.eager_load_namespaces << ActiveRecord
 
+    guard_load_hooks(
+      :active_record, :active_record_encryption, :active_record_fixture_set, :active_record_fixtures,
+      :active_record_mysql2adapter, :active_record_postgresqladapter, :active_record_sqlite3adapter,
+      :active_record_trilogyadapter,
+    )
+
     rake_tasks do
       namespace :db do
         task :load_config do

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -77,6 +77,8 @@ module ActiveStorage
 
     config.eager_load_namespaces << ActiveStorage
 
+    guard_load_hooks(:active_storage_record, :active_storage_attachment, :active_storage_blob, :active_storage_variant_record)
+
     initializer "active_storage.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_storage] = ActiveStorage.deprecator
     end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -9,6 +9,8 @@ module ActiveSupport
 
     config.eager_load_namespaces << ActiveSupport
 
+    guard_load_hooks(:message_pack, :active_support_test_case)
+
     initializer "active_support.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_support] = ActiveSupport.deprecator
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -183,6 +183,11 @@ Below are the default values associated with each target version. In cases of co
 
 The following configuration methods are to be called on a `Rails::Railtie` object, such as a subclass of `Rails::Engine` or `Rails::Application`.
 
+#### `config.action_on_eary_load_hook`
+
+Controls what happens when a load hook is violated before the Rails application is initialized.
+The value is `:log` by default, which will log when when a load hook is invoked early. The value can alternatively be `raise`, which will raise a `LoadError` instead of logging.
+
 #### `config.add_autoload_paths_to_load_path`
 
 Says whether autoload paths have to be added to `$LOAD_PATH`. It is recommended to be set to `false` in `:zeitwerk` mode early, in `config/application.rb`. Zeitwerk uses absolute paths internally, and applications running in `:zeitwerk` mode do not need `require_dependency`, so models, controllers, jobs, etc. do not need to be in `$LOAD_PATH`. Setting this to `false` saves Ruby from checking these directories when resolving `require` calls with relative paths, and saves Bootsnap work and RAM, since it does not need to build an index for them.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -24,7 +24,7 @@ module Rails
                     :content_security_policy_nonce_auto,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
-                    :dom_testing_default_html_version, :yjit
+                    :dom_testing_default_html_version, :yjit, :action_on_eary_load_hook
 
       attr_reader :encoding, :api_only, :loaded_config_version, :log_level
 
@@ -85,6 +85,7 @@ module Rails
         @server_timing                           = false
         @dom_testing_default_html_version        = :html4
         @yjit                                    = false
+        @action_on_eary_load_hook                = :log
       end
 
       # Loads default configuration values for a target version. This includes

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -4,6 +4,7 @@ require "rails/initializable"
 require "active_support/descendants_tracker"
 require "active_support/inflector"
 require "active_support/core_ext/module/introspection"
+require "active_support/logger"
 
 module Rails
   # +Rails::Railtie+ is the core of the \Rails framework and provides
@@ -216,13 +217,12 @@ module Rails
       # the a lazy loaded component is loaded. The load hook will avise how to use
       # load hooks to defer code until the application is fully loaded.
       def guard_load_hooks(*components)
-        railtie = self
         components.each do |component|
           ActiveSupport.on_load(component) do
             if Rails.try(:application) && !Rails.configuration.eager_load && !Rails.application.initialized?
               case Rails.configuration.action_on_eary_load_hook
               when :log
-                Rails.logger.warn <<~MSG
+                (Rails.logger || ActiveSupport::Logger.new($stdout)).warn <<~MSG
                   #{Railtie.load_hook_guard_message_for(component)}
 
                   Called from:

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -440,11 +440,13 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/active_record.rb", <<-RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-        ActiveRecord::Migration.verbose = false
-        ActiveRecord::Schema.define(version: 1) do
-          create_table :posts do |t|
-            t.string :title
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+          ActiveRecord::Migration.verbose = false
+          ActiveRecord::Schema.define(version: 1) do
+            create_table :posts do |t|
+              t.string :title
+            end
           end
         end
       RUBY
@@ -3036,22 +3038,28 @@ module ApplicationTests
 
     test "PostgresqlAdapter.decode_dates is true by default for new apps" do
       app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "postgresql")
+        end
       RUBY
 
       app "development"
 
+      _ = ActiveRecord::Base
       assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates
     end
 
     test "PostgresqlAdapter.decode_dates is false by default for upgraded apps" do
       remove_from_config '.*config\.load_defaults.*\n'
       app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "postgresql")
+        end
       RUBY
 
       app "development"
 
+      _ = ActiveRecord::Base
       assert_equal false, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates
     end
 
@@ -3060,11 +3068,14 @@ module ApplicationTests
       add_to_config "config.active_record.postgresql_adapter_decode_dates = true"
 
       app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "postgresql")
+        end
       RUBY
 
       app "development"
 
+      _ = ActiveRecord::Base
       assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates
     end
 
@@ -3138,11 +3149,14 @@ module ApplicationTests
 
     test "SQLite3Adapter.strict_strings_by_default is true by default for new apps" do
       app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        end
       RUBY
 
       app "development"
 
+      _ = ActiveRecord::Base
       assert_equal true, ActiveRecord::ConnectionAdapters::SQLite3Adapter.strict_strings_by_default
     end
 
@@ -3154,11 +3168,14 @@ module ApplicationTests
 
       remove_from_config '.*config\.load_defaults.*\n'
       app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        end
       RUBY
 
       app "development"
 
+      _ = ActiveRecord::Base
       assert_equal false, ActiveRecord::ConnectionAdapters::SQLite3Adapter.strict_strings_by_default
 
       Post.lease_connection.create_table :posts
@@ -3172,11 +3189,14 @@ module ApplicationTests
       add_to_config "config.active_record.sqlite3_adapter_strict_strings_by_default = true"
 
       app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        end
       RUBY
 
       app "development"
 
+      _ = ActiveRecord::Base
       assert_equal true, ActiveRecord::ConnectionAdapters::SQLite3Adapter.strict_strings_by_default
     end
 
@@ -3191,11 +3211,14 @@ module ApplicationTests
         Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
       RUBY
       app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        end
       RUBY
 
       app "development"
 
+      _ = ActiveRecord::Base
       assert_equal true, ActiveRecord::ConnectionAdapters::SQLite3Adapter.strict_strings_by_default
 
       Post.lease_connection.create_table :posts
@@ -4098,15 +4121,16 @@ module ApplicationTests
         Rails.application.config.active_record.encryption.primary_key = "dummy_key"
         Rails.application.config.active_record.encryption.previous = [ { key_provider: MyOldKeyProvider.new } ]
 
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-        ActiveRecord::Migration.verbose = false
-        ActiveRecord::Schema.define(version: 1) do
-          create_table :posts do |t|
-            t.string :content
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+          ActiveRecord::Migration.verbose = false
+          ActiveRecord::Schema.define(version: 1) do
+            create_table :posts do |t|
+              t.string :content
+            end
           end
+          ActiveRecord::Base.schema_cache.add("posts")
         end
-
-        ActiveRecord::Base.schema_cache.add("posts")
       RUBY
 
       app_file "app/models/post.rb", <<-RUBY
@@ -4138,7 +4162,9 @@ module ApplicationTests
         Rails.application.config.active_record.encryption.primary_key = "dummy_key"
         Rails.application.config.active_record.encryption.previous = [ { key_provider: MyOldKeyProvider.new } ]
 
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        end
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Schema.define(version: 1) do
           create_table :posts do |t|
@@ -4889,7 +4915,9 @@ module ApplicationTests
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "7.0"'
       app_file "config/initializers/01_configure_database.rb", <<-RUBY
-        ActiveRecord::Base.connected?
+        ActiveSupport.on_load(:axtive_record) do
+          ActiveRecord::Base.connected?
+        end
       RUBY
       app_file "config/initializers/new_framework_defaults_7_1.rb", <<-RUBY
         Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -374,7 +374,9 @@ module ApplicationTests
 
     test "connections checked out during initialization are returned to the pool" do
       app_file "config/initializers/active_record.rb", <<-RUBY
-        ActiveRecord::Base.lease_connection
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.lease_connection
+        end
       RUBY
       app("development")
       assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because load hooks can load early in Rails and cause bugs and performance regressions. Rails has no inherent way to guard against this, but it is possible to implement rudimentary safeguards with some basic scripting:

```rb
require "bundler/setup"
require "active_support/lazy_load_hooks"

ActiveSupport.on_load(:active_record) do # load hook set to raise before the app is booted
  raise "Oops!"
end


require_relative "config/environment" # boot the app
```

Instead of expecting developers to do this, we should bake this into the framework to make developers more aware of components being loaded at the wrong time. All `ActiveSupport.on_load` hooks should only be ran after the application is initialized, and I believe this change will help developers make that happen in their applications.

### Detail

This Pull Request adds a new method `guard_load_hooks` to `Rails::Railtie` that can be used to add load hooks that check if the Rails app is loaded or not when a load hook is called. By default, it logs the early loading, but it can also be configured to raise. This allows any gem with a railtie/engine to add optional guards for its own load hooks.

If the direction of this PR makes sense, I will add changelogs, docs, and plug any further leaks in tests.


### Additional Information

This work is directly inspired by https://github.com/rails/rails/pull/46047. Thanks for talking about this with my during Rails World @p8! ❤️ 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
