### PR TITLE
Prepping rails for minitest 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,9 +367,9 @@ GEM
       minitest (>= 5.0.6)
     minitest-retry (0.2.3)
       minitest (>= 5.0)
-    minitest-server (1.0.8)
+    minitest-server (1.0.9)
       drb (~> 2.0)
-      minitest (~> 5.16)
+      minitest (> 5.16)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -20,13 +20,13 @@ module ActionDispatch
       end
 
       test "not being empty when route is added" do
-        assert_predicate self, :empty?
+        assert_empty @set
 
         draw do
           get "foo", to: SimpleApp.new("foo#index")
         end
 
-        assert_not empty?
+        assert_not_empty @set
       end
 
       test "URL helpers are added when route is added" do

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -124,7 +124,8 @@ module ActiveSupport
           actual = exp.call
           rich_message = -> do
             code_string = code.respond_to?(:call) ? _callable_to_source_string(code) : code
-            error = "`#{code_string}` didn't change by #{diff}, but by #{actual - before_value}"
+            error = "`#{code_string}` didn't change by #{diff}, but by #{actual - before_value}."
+            error = "#{error}\n#{diff before_value + diff, actual}" if Minitest::VERSION > "6"
             error = "#{message}.\n#{error}" if message
             error
           end
@@ -228,7 +229,7 @@ module ActiveSupport
         rich_message = -> do
           code_string = expression.respond_to?(:call) ? _callable_to_source_string(expression) : expression
           error = "`#{code_string}` didn't change"
-          error = "#{error}. It was already #{to.inspect}" if before == to
+          error = "#{error}. It was already #{to.inspect}." if before == to
           error = "#{message}.\n#{error}" if message
           error
         end
@@ -296,8 +297,9 @@ module ActiveSupport
 
         rich_message = -> do
           code_string = expression.respond_to?(:call) ? _callable_to_source_string(expression) : expression
-          error = "`#{code_string}` changed"
+          error = "`#{code_string}` changed."
           error = "#{message}.\n#{error}" if message
+          error = "#{error}\n#{diff before, after}" if Minitest::VERSION > "6"
           error
         end
 

--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -2,4 +2,11 @@
 
 require "minitest"
 
+##
+# I shouldn't need this respond_to check but some tests are running
+# sub-process tests in an unbundled environment, causing MT5 to be
+# used in some cases. This conditional can probably go after the bump
+# is complete? ... but could still fail for developers working w/
+# multiple versions installed.
+Minitest.load :rails if Minitest.respond_to? :load
 Minitest.autorun

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -49,7 +49,11 @@ module ActiveSupport
           set_process_title("#{klass}##{method}")
 
           result = klass.with_info_handler reporter do
-            Minitest.run_one_method(klass, method)
+            if Minitest.respond_to?(:run_one_method) then
+              Minitest.run_one_method(klass, method)
+            else
+              klass.new(method).run
+            end
           end
 
           safe_record(reporter, result)

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -243,7 +243,7 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "`@object.num` didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
+    assert_match "`@object.num` didn't change. It was already 0.", error.message
   end
 
   def test_assert_changes_message_with_lambda
@@ -255,7 +255,7 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "`@object.num` didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
+    assert_match "`@object.num` didn't change. It was already 0.", error.message
   end
 
   def test_assert_changes_with_wrong_to_option

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -105,6 +105,13 @@ module Minitest
       options[:fail_fast] = true
     end
 
+    if Minitest::VERSION > "6" then
+      opts.on "-n", "--name PATTERN", "Include /regexp/ or string for run." do |a|
+        warn "Please switch from -n/--name to -i/--include"
+        options[:include] = a
+      end
+    end
+
     opts.on("-c", "--[no-]color", "Enable color in the output") do |value|
       options[:color] = value
     end

--- a/railties/lib/rails/test_unit/line_filtering.rb
+++ b/railties/lib/rails/test_unit/line_filtering.rb
@@ -4,10 +4,31 @@ require "rails/test_unit/runner"
 
 module Rails
   module LineFiltering # :nodoc:
-    def run(reporter, options = {})
-      options = options.merge(filter: Rails::TestUnit::Runner.compose_filter(self, options[:filter]))
+    def self.extended(obj)
+      require "minitest"
 
-      super
+      case Minitest::VERSION
+      when /^5/ then
+        obj.extend MT5
+      when /^6/ then
+        obj.extend MT6
+      end
+    end
+
+    module MT5
+      def run(reporter, options = {})
+        options = options.merge(filter: Rails::TestUnit::Runner.compose_filter(self, options[:filter]))
+
+        super
+      end
+    end
+
+    module MT6
+      def run_suite(reporter, options = {})
+        options = options.merge(include: Rails::TestUnit::Runner.compose_filter(self, options[:include]))
+
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
This branch contains all the fixes needed for minitest 6 to work smoothly with rails. I've now tested extensively on MT5 as well as MT6. 

I have another branch testing out the actual MT6 bump and it still has some sort of flaky going on that I'm investigating.