### PR TITLE
Add support for configuring migration strategy on a per-adapter basis.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add support for configuring migration strategy on a per-adapter basis.
+
+    `migration_strategy` can now be set on on individual adapter classes, overriding
+    the global `ActiveRecord.migration_strategy`. This allows individual databases to
+    customize migration execution logic:
+
+    ```ruby
+    class CustomPostgresStrategy < ActiveRecord::Migration::DefaultStrategy
+      def drop_table(*)
+        # Custom logic specific to PostgreSQL
+      end
+    end
+
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.migration_strategy = CustomPostgresStrategy
+    ```
+
+    *Adrianna Chang*
+
 *   Allow either explain format syntax for EXPLAIN queries.
 
     MySQL uses FORMAT=JSON whereas Postgres uses FORMAT JSON. We should be

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -406,7 +406,8 @@ module ActiveRecord
 
   ##
   # :singleton-method: migration_strategy
-  # Specify strategy to use for executing migrations.
+  # Specify the global default strategy to use for executing migrations.
+  # Individual adapter classes can override this by setting their own migration_strategy.
   singleton_class.attr_accessor :migration_strategy
   self.migration_strategy = Migration::DefaultStrategy
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -30,6 +30,19 @@ module ActiveRecord
     # notably, the instance methods provided by SchemaStatements are very useful.
     class AbstractAdapter
       ADAPTER_NAME = "Abstract"
+
+      ##
+      # :singleton-method: migration_strategy
+      #
+      # Allows configuration of migration strategy per adapter type.
+      # When set on a specific adapter class (e.g., PostgreSQLAdapter),
+      # all migrations using that adapter will use the specified strategy
+      # instead of the global ActiveRecord.migration_strategy.
+      #
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.migration_strategy = CustomPostgresStrategy
+      #   ActiveRecord::ConnectionAdapters::Mysql2Adapter.migration_strategy = CustomMySQLStrategy
+      class_attribute :migration_strategy, instance_writer: false
+
       include ActiveSupport::Callbacks
       define_callbacks :checkout, :checkin
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -810,7 +810,7 @@ module ActiveRecord
     end
 
     def execution_strategy
-      @execution_strategy ||= ActiveRecord.migration_strategy.new(self)
+      @execution_strategy ||= (connection.migration_strategy || ActiveRecord.migration_strategy).new(self)
     end
 
     self.verbose = true

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1188,6 +1188,23 @@ end
 config.active_record.migration_strategy = CustomMigrationStrategy
 ```
 
+You can also configure migration strategies on a per-adapter basis by setting the `migration_strategy` class on the adapter itself.
+This is useful when you want to customize migration behavior for a specific database type.
+
+For example, to use a custom migration strategy for PostgreSQL:
+
+```ruby
+class CustomPostgresStrategy < ActiveRecord::Migration::DefaultStrategy
+  def drop_table(*)
+    # Custom logic specific to PostgreSQL
+  end
+end
+
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.migration_strategy = CustomPostgresStrategy
+```
+
+By assigning to the adapter class, all migrations run through connections using that adapter will use the specified strategy.
+
 #### `config.active_record.schema_versions_formatter`
 
 Controls the formatter class used by schema dumper to format versions information. Custom class can be provided


### PR DESCRIPTION
### Motivation / Background

This allows individual databases to customize migration execution logic, rather than only allowing overrides at the global level. This is useful for multi-db applications that may be using different DB drivers, with different requirements for migration behaviour.

For example, to use a custom migration strategy for PostgreSQL:

```ruby
class CustomPostgresStrategy < ActiveRecord::Migration::DefaultStrategy
  def drop_table(*)
    # Custom logic specific to PostgreSQL
  end
end

ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.migration_strategy = CustomPostgresStrategy
```

### Detail

Add a `class_attribute` for `migration_strategy` to `AbstractAdapter`. When we set the `execution_strategy` inside the migration, we first check whether the adapter has a strategy configured, otherwise we use the global value.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
