### PR TITLE
Generate correct CTE while using merge with with_recursive modifier, fixes #56145

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Generate correct CTE while using merge with with_recursive modifier, fixes #56145.
+
+    Using `Post.merge(Post.with_recursive(...))` preserves `RECURSIVE` modifier.
+
+    *Tahsin Hasan*
+
 *   On MySQL parallel test database table reset to use `DELETE` instead of `TRUNCATE`.
 
     Truncating on MySQL is very slow even on empty or nearly empty tables.

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -63,7 +63,11 @@ module ActiveRecord
           # `false.blank?` returns `true`, so there needs to be an extra check so that explicit `false` values
           # don't fall through the cracks.
           unless value.nil? || (value.blank? && false != value)
-            relation.public_send(:"#{name}!", *value)
+            if name == :with && !other.instance_variable_get(:@with_is_recursive).nil? && other.to_sql.start_with?("WITH RECURSIVE")
+              relation.public_send(:with_recursive!, *value)
+            else
+              relation.public_send(:"#{name}!", *value)
+            end
           end
         end
 

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -115,6 +115,19 @@ module ActiveRecord
         assert_match "WITH RECURSIVE", relation.to_sql
       end
 
+      def test_merge_with_recursive
+        relation = Company.with_recursive(
+          top_companies_and_children: [
+            Company.where(firm_id: nil),
+            Company.joins("JOIN top_companies_and_children ON companies.firm_id = top_companies_and_children.id"),
+          ]
+        )
+        with_recursive = relation.to_sql
+        merge_with_recursive = Company.merge(relation).to_sql
+
+        assert_equal with_recursive, merge_with_recursive
+      end
+
       def test_with_joins
         relation = Post
           .with(commented_posts: Comment.select(:post_id).distinct)


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it fixes #56145. 

### Detail

With this PR using `merge` with `with_recursive` modifier generates correct CTE - it outputs `WITH RECURSIVE posts_with_replies AS (...)`.

The below script now passes:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

# This connection will do for database-independent bug reports.
ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :reply_to_id
    t.boolean :archived
  end
end

class Post < ActiveRecord::Base
  scope :with_replies, -> {
    with_recursive(
      posts_with_replies: [
        Post.where(archived: false),
        Post.joins("JOIN posts_and_replies ON posts.reply_to_id = posts_and_replies.id")
      ]
    )
  }
end

class BugTest < ActiveSupport::TestCase
  def test_merge_with_recursive
    with_recursive = Post.with_replies.to_sql
    merge_with_recursive = Post.merge(Post.with_replies).to_sql
    
    assert_equal with_recursive, merge_with_recursive
  end
end
```

We have also added a test case for `merge` using `with_recursive` modifier.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
