### PR TITLE
Return parsed JSON for JSON formatted `EXPLAIN` queries.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Return hash for json formatted `EXPLAIN` queries.
+
+    Previously, `format: :json` option in `EXPLAIN` queries returns a string of the json result.
+    The json format now returns a parsed hash.
+
+    *Jenny Shen*
+
 *   Add support for configuring migration strategy on a per-adapter basis.
 
     `migration_strategy` can now be set on on individual adapter classes, overriding

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -30,7 +30,14 @@ module ActiveRecord
           result  = internal_exec_query(sql, "EXPLAIN", binds)
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
 
+          return JSON.parse(result.first["EXPLAIN"]) if explain_json_format?(options)
+
           MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
+        end
+
+
+        def explain_json_format?(options)
+          options.any? { |opt| opt.is_a?(Hash) && opt[:format] == :json }
         end
 
         def build_explain_clause(options = [])

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -7,7 +7,14 @@ module ActiveRecord
         def explain(arel, binds = [], options = [])
           sql    = build_explain_clause(options) + " " + to_sql(arel, binds)
           result = internal_exec_query(sql, "EXPLAIN", binds)
+
+          return JSON.parse(result.first["QUERY PLAN"]).first if explain_json_format?(options)
+
           PostgreSQL::ExplainPrettyPrinter.new.pp(result)
+        end
+
+        def explain_json_format?(options)
+          options.any? { |opt| opt.is_a?(Hash) && opt[:format] == :json }
         end
 
         # Queries the database and returns the results in an Array-like object

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -21,6 +21,10 @@ module ActiveRecord
           SQLite3::ExplainPrettyPrinter.new.pp(result)
         end
 
+        def explain_json_format?(options)
+          false
+        end
+
         def begin_deferred_transaction(isolation = nil) # :nodoc:
           internal_begin_transaction(:deferred, isolation)
         end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
@@ -40,7 +40,7 @@ class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
   def test_explain_format_option
     explain = Author.all.explain(format: :json).inspect
 
-    assert_match(/\{.*\}/m, explain)
+    assert_instance_of Hash, explain.first
   end
 
   private

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -42,6 +42,6 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
   def test_explain_format_option
     explain = Author.all.explain(format: :json).inspect
 
-    assert_match(/\{.*\}/m, explain)
+    assert_instance_of Hash, explain.first
   end
 end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -153,6 +153,23 @@ if ActiveRecord::Base.lease_connection.supports_explain?
       end
     end
 
+    def test_exec_explain_with_json_format
+      sqls    = %w(foo bar)
+      binds   = [[], []]
+      queries = sqls.zip(binds)
+      results = ["query plan foo", "query plan bar"]
+
+      stub_explain_for_query_plans(results) do
+        result = base.exec_explain(queries, [{ format: :json }])
+
+        if current_adapter?(:SQLite3Adapter)
+          assert_instance_of String, result
+        else
+          assert_equal results, result
+        end
+      end
+    end
+
     private
       def stub_explain_for_query_plans(query_plans = ["query plan foo", "query plan bar"])
         explain_called = 0


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I wanted to utilize the newly introduced json format option for explain queries https://github.com/rails/rails/pull/56198. However, I noticed that I needed to use a regex to extract the json from the returned string. I would have wanted the result to be a parsed hash.

### Detail

If the `format: :json` option is passed, return a hash instead.

#### Before
```
EXPLAIN FORMAT=JSON SELECT `authors`.* FROM `authors`
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| EXPLAIN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| {
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "0.55"
    },
    "table": {
      "table_name": "authors",
      "access_type": "ALL",
      "rows_examined_per_scan": 3,
      "rows_produced_per_join": 3,
      "filtered": "100.00",
      "cost_info": {
        "read_cost": "0.25",
        "eval_cost": "0.30",
        "prefix_cost": "0.55",
        "data_read_per_join": "9K"
      },
      "used_columns": [
        "id",
        "name",
        "author_address_id",
        "author_address_extra_id",
        "organization_id",
        "owned_essay_id"
      ]
    }
  }
} |
```

#### After
```ruby
[{"query_block" =>
   {"select_id" => 1,
    "cost_info" => {"query_cost" => "0.55"},
    "table" =>
     {"table_name" => "authors",
      "access_type" => "ALL",
      "rows_examined_per_scan" => 3,
      "rows_produced_per_join" => 3,
      "filtered" => "100.00",
      "cost_info" => {"read_cost" => "0.25", "eval_cost" => "0.30", "prefix_cost" => "0.55", "data_read_per_join" => "9K"},
      "used_columns" => ["id", "name", "author_address_id", "author_address_extra_id", "organization_id", "owned_essay_id"]}}}]
``` 

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
