### PR TITLE
Bump minitest to V6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@
 source "https://rubygems.org"
 gemspec
 
-gem "minitest", "< 6"
+gem "minitest", "~> 6.0"
+gem "minitest-mock"
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 13"
@@ -132,7 +133,6 @@ local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
-  gem "minitest-bisect", require: false
   gem "minitest-ci", require: false
   gem "minitest-retry"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,17 +359,13 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
-    minitest-bisect (1.7.0)
-      minitest-server (~> 1.0)
-      path_expander (~> 1.1)
+    minitest (6.0.0)
+      prism (~> 1.5)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
+    minitest-mock (5.27.0)
     minitest-retry (0.2.3)
       minitest (>= 5.0)
-    minitest-server (1.0.9)
-      drb (~> 2.0)
-      minitest (> 5.16)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
@@ -415,7 +411,6 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
-    path_expander (1.1.3)
     pg (1.6.2)
     pg (1.6.2-aarch64-linux)
     pg (1.6.2-arm64-darwin)
@@ -424,7 +419,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
+    prism (1.7.0)
     propshaft (1.3.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -728,9 +723,9 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   mdl (!= 0.13.0)
-  minitest (< 6)
-  minitest-bisect
+  minitest (~> 6.0)
   minitest-ci
+  minitest-mock
   minitest-retry
   msgpack (>= 1.7.0)
   mysql2 (~> 0.5, < 0.5.7)

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
-require "minitest/mock"
+begin
+  gem "minitest-mock"
+  require "minitest/mock"
+rescue LoadError
+  warn <<~WARN
+    minitest-mock gem is not available. Method call assertions including `assert_called_with` will not work.
+    Please add it to your Gemfile: `gem "minitest-mock"`
+  WARN
+  raise
+end
 
 module ActiveSupport
   module Testing

--- a/activesupport/lib/active_support/testing/parallelization/thread_pool_executor.rb
+++ b/activesupport/lib/active_support/testing/parallelization/thread_pool_executor.rb
@@ -39,7 +39,11 @@ module ActiveSupport
               klass, method, reporter = job
 
               reporter.synchronize { reporter.prerecord klass, method }
-              result = Minitest.run_one_method klass, method
+              result = if Minitest.respond_to? :run_one_method then
+                Minitest.run_one_method klass, method
+              else
+                klass.new(method).run
+              end
               reporter.synchronize { reporter.record result }
             end
           end

--- a/guides/test/test_helper.rb
+++ b/guides/test/test_helper.rb
@@ -7,3 +7,4 @@ $LOAD_PATH.unshift File.expand_path("..", __dir__)
 require "rails_guides"
 
 require "minitest/autorun"
+Minitest.load :rails if Minitest.respond_to? :load


### PR DESCRIPTION
This bumps the dependency on minitest to 6.0+ and adds minitest-mock. 

Also found a couple new failures that my preemptive fixin' PRs didn't see for some reason. All fixed up.