### PR TITLE
Fix bug when txn isolation would not reset or when requires_new is set

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix bug when `current_transaction.isolation` would not have been reset in test env.
+
+    Additionally, extending the change in [#55549](https://github.com/rails/rails/pull/55549)
+    to handle `requires_new: true`.
+
+    *Kir Shatrov*
+
 *   Allow `schema_dump` configuration to be an absolute path.
 
     Previously, the `schema_dump` configuration was always joined with the

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -321,6 +321,14 @@ class TransactionIsolationWithTransactionalTestsTest < ActiveRecord::TestCase
       Tag.transaction(isolation: :read_committed) do
         assert_equal :read_committed, Tag.lease_connection.current_transaction.isolation
       end
+      assert_nil Tag.lease_connection.current_transaction.isolation
+    end
+
+    test "starting a transaction with isolation and requires_new sets the isolation level" do
+      Tag.transaction(isolation: :read_committed, requires_new: true) do
+        assert_equal :read_committed, Tag.lease_connection.current_transaction.isolation
+      end
+      assert_nil Tag.lease_connection.current_transaction.isolation
     end
 
     test "starting a transaction with a different isolation level raises an error" do


### PR DESCRIPTION
Opening this since it's a smaller change that's perhaps easier to land than https://github.com/rails/rails/pull/55792.

In https://github.com/rails/rails/pull/55549, I've missed:

1) Resetting `current_transaction.isolation` back to its original value
2) Handling `requires_new: true`

This is a trivial fix and this bug is really impacting our isolation workflows at Shopify.

@matthewd @eileencodes @byroot 