### PR TITLE
Update Configurable deprecaton warning

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -3,7 +3,7 @@
 ActiveSupport.deprecator.warn <<~MSG
   ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.
 
-  You can emulate the previous behavior with `class_attribute`.
+  The previous behavior can be emulated with `attr_accessor`s, `class_attribute`s, or combinations of `class_attribute` and `InheritableOptions` depending on requirements.
 MSG
 
 require "active_support/concern"


### PR DESCRIPTION
Ref https://github.com/rails/rails/pull/53970

The blanket suggestion to use class_attribute can be misleading, and I've seen gems default to using class_attribute because of this warning instead of plain attr_accessors.

This commit tries to be less prescriptive of how to replace Configurable by suggesting multiple alternatives, since different usages of Configurable will require different replacements.