### PR TITLE
Clarify that SOLID_QUEUE_IN_PUMA needs to be removed to run Solid Queue separately

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -54,6 +54,8 @@ env:
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
+    # To run the Supervisor separately, you need to remove the env variable below completely,
+    # as setting it to "false" will still make it run within Puma.
     SOLID_QUEUE_IN_PUMA: true
 
     # Set number of processes dedicated to Solid Queue (default: 1)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to clarify the behaviour of `SOLID_QUEUE_IN_PUMA` variable.

### Detail

Setting it to `false` does nothing because of how we check the variable:
https://github.com/Jay0921/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt#L39
`"false"`  is still truthy.

My first though was to update the check within Puma,
but I see that a similar PR was closed: https://github.com/rails/rails/pull/53340
so going to just document it, hopefully saves other people time.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
