### PR TITLE
Remove imprecise wording in the testing guides

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1019,8 +1019,7 @@ CRUD application you'll be using `post`, `get`, `put`, and `delete` most
 often.
 
 NOTE: Functional tests do not verify whether the specified request type is
-accepted by the action; instead, they focus on the result. For testing the
-request type, request tests are available, making your tests more purposeful.
+accepted by the action; instead, they focus on the result.
 
 ### Testing XHR (AJAX) Requests
 


### PR DESCRIPTION
I was confused about a small note in the testing guides today.

I may be wrong, but I'm not aware of any `request tests` and I'm not sure what the original intent of the sentence was. In my mind, it would be less confusing to just delete the sentence.