### PR TITLE
Fix CI eager loading when rake tasks invoke :environment before tests

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Set `config.rake_eager_load` in generated test environment to match `config.eager_load` behavior in CI.
+
+    This ensures eager loading works consistently in CI when rake tasks invoke the `:environment` task before tests run.
+
+    *Trevor Turk*
+
 *   Update the `.node-version` file conditionally generated for new applications to 22.21.1
 
     *Taketo Takashima*

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -14,6 +14,7 @@ Rails.application.configure do
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
+  config.rake_eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with cache-control for performance.
   config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }


### PR DESCRIPTION
### Summary

This PR fixes an issue where `config.eager_load = ENV["CI"].present?` in the test environment doesn't work as expected when gems invoke the `:environment` rake task before tests run.

### The Problem

Related to #56065, which proposes adding `rails zeitwerk:check` to the default CI workflow. While investigating why `CI=1 bin/rails test` passes but `bin/rails zeitwerk:check` fails for apps with Zeitwerk errors, I discovered a deeper issue with the test environment configuration.

When the `:environment` rake task runs (triggered by gems like `tailwindcss-rails` that hook into `test:prepare`), Rails executes:

```ruby
ActiveSupport.on_load(:before_initialize) { config.eager_load = config.rake_eager_load }
```

Since `config.rake_eager_load` defaults to `false`, this overrides the `config.eager_load = ENV["CI"].present?` setting in `config/environments/test.rb`, causing eager loading to be disabled in CI when running `bin/rails test`.

### Reproduction

1. Create a fresh Rails app with `tailwindcss-rails` and a gem that has a Zeitwerk naming error (e.g., `swarm_sdk 2.1.3`)
2. Run `CI=1 bin/rails test` - tests pass (eager loading is disabled)
3. Run `bin/rails zeitwerk:check` - fails with Zeitwerk error (eager loading works)

See https://github.com/trevorturk/issue_56065 for a minimal reproduction case.

### The Fix

Set `config.rake_eager_load = ENV["CI"].present?` in the generated test environment template to match the `config.eager_load` behavior. This ensures eager loading works consistently in CI regardless of whether rake tasks invoke `:environment` before tests run.

### Why This Approach

This is the minimal fix that ensures the intended behavior works correctly. The alternative would be to change how Rails handles the `:environment` task, but that could have broader implications. Setting both config options in the test environment is straightforward and aligns with the documented intent of eager loading in CI.

### History of rake_eager_load via Claude

Here's the history and purpose of rake_eager_load:

The Problem It Was Designed to Solve

Historical issue: Before Rails 5.1, rake tasks always disabled eager loading by hardcoding config.eager_load = false in the :environment task. This was done for "legacy
reasons" - specifically, problems with rake assets:precompile attempting database connections due to eager loading.

The regression: Disabling eager loading in rake tasks caused thread safety problems in production rake tasks. When code isn't eager loaded, classes might be autoloaded at
runtime by multiple threads, leading to race conditions.

What rake_eager_load Does

From PR #28209 (2017, merged 2019):

"I would wish to be able to control that behaviour so regardless how the application is accessed, the load order remains the same."

config.rake_eager_load allows you to opt-in to eager loading for rake tasks, overriding the default behavior where rake tasks never eager load.

Default behavior:
- production mode: eager_load = true
- But when running rake tasks in production: rake_eager_load = false overrides it
- So production rake tasks don't eager load by default

From the autoloading guide (commit 6cbd2c97ed):

"When a Rake task gets executed, config.eager_load is overridden by config.rake_eager_load, which is false by default. So, by default, in production environments Rake tasks 
do not eager load the application."

The Irony

The test environment setting config.eager_load = ENV["CI"].present? was trying to enable eager loading in CI to catch autoloading bugs...but it was being overridden by
rake_eager_load = false whenever any gem triggered the :environment task!

So our fix is actually using rake_eager_load for its intended purpose - to control eager loading behavior in rake tasks, including bin/rails test which runs as a rake task.