### PR TITLE
Respect config.log_level to emit debug events

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -73,7 +73,7 @@ module Rails
 
       initializer :initialize_event_reporter, group: :all do
         Rails.event.raise_on_error = config.consider_all_requests_local
-        Rails.event.debug_mode = Rails.env.development?
+        Rails.event.debug_mode = config.log_level.to_s == "debug"
       end
 
       # Initialize cache early in the stack so railties can make use of it.


### PR DESCRIPTION
This is a follow-up to #55657, a PR that enables debug events in development only.

The problem is that some users might want to see debug events also in test or in production. 
A real-world example is detailed in https://github.com/rails/rails/pull/55900#issuecomment-3445390380

---

This PR slightly changes the behavior replacing `Rails.env.development?` with `config.log_level == "debug"`. 
As explained in [Rails documentation](https://guides.rubyonrails.org/debugging_rails_applications.html#log-levels):

> The default Rails log level is :debug. However, it is set to :info for the production environment
> in the default generated config/environments/production.rb.

As a result, this PR maintains the existing behavior when defaults are applied, but opens up the possibility to see debug events in production for those who want to do so: they simply have to set `RAILS_LOG_LEVEL=debug`.
