### PR TITLE
Include inbound email context on mailbox exceptions

### DIFF
--- a/actionmailbox/test/unit/mailbox/exception_context_test.rb
+++ b/actionmailbox/test/unit/mailbox/exception_context_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class RaisingMailbox < ActionMailbox::Base
+  def process
+    raise ArgumentError, "boom"
+  end
+end
+
+class ActionMailbox::Base::ExceptionContextTest < ActiveSupport::TestCase
+  test "raised errors include inbound email reference" do
+    inbound_email = create_inbound_email_from_fixture("welcome.eml")
+    reference = inbound_email.to_gid_param || inbound_email.id.to_s
+
+    error = assert_raises(ArgumentError) do
+      RaisingMailbox.receive(inbound_email)
+    end
+
+    assert_includes error.message, reference
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Mailboxes rescue exceptions today without any context about which inbound email failed, making incidents harder to debug. This aligns with the TODO in ActionMailbox::Base to surface the inbound email reference on failures.

### Detail

This Pull Request changes ActionMailbox::Base to attach the inbound email reference to raised exceptions (using the GID/SGID or ID) and adds a unit test to assert the message includes that reference.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
