### PR TITLE
Fix TimeWithZone#xmlschema when wrapping DateTime local time

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -152,11 +152,15 @@ module ActiveSupport
     #
     #   Time.zone.now.xmlschema  # => "2014-12-04T11:02:37-05:00"
     def xmlschema(fraction_digits = 0)
+      precision = fraction_digits || 0
+
       if @is_utc
-        utc.iso8601(fraction_digits || 0)
+        utc.iso8601(precision)
       else
-        str = time.iso8601(fraction_digits || 0)
-        str[-1] = formatted_offset(true, "Z")
+        str = time.iso8601(precision)
+        offset = formatted_offset(true, "Z")
+
+        str.sub!(/(Z|[+-]\d{2}:\d{2})\z/, offset)
         str
       end
     end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -172,6 +172,13 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal "1999-12-31T19:00:00-05:00", @twz.xmlschema(nil)
   end
 
+  def test_xmlschema_with_datetime_local_time
+    tz = ActiveSupport::TimeZone["America/New_York"]
+    twz = ActiveSupport::TimeWithZone.new(nil, tz, DateTime.new(2025, 11, 7, 12))
+
+    assert_equal "2025-11-07T12:00:00-05:00", twz.xmlschema
+  end
+
   def test_iso8601_with_fractional_seconds
     @twz += Rational(1, 8)
     assert_equal "1999-12-31T19:00:00.125-05:00", @twz.iso8601(3)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because of issue: https://github.com/rails/rails/issues/56112

It fixes a regression where `ActiveSupport::TimeWithZone#xmlschema` produced invalid ISO-8601 strings when instantiated with a `DateTime` used as a local time.

Example:
```ruby
tz  = ActiveSupport::TimeZone["America/New_York"]
twz = ActiveSupport::TimeWithZone.new(nil, tz, DateTime.new(2025, 11, 7, 12))

twz.xmlschema
# => "2025-11-07T12:00:00+00:0-05:00"
```

Expected:
```ruby
"2025-11-07T12:00:00-05:00"
```

This happens because the implementation assumed that `time.iso8601` always ends with `"Z"`, which is not true for `DateTime`. This PR ensures correct ISO-8601 output regardless of whether the wrapped value is a `Time` or `DateTime`.

### Detail

This Pull Request changes:
- Updates `ActiveSupport::TimeWithZone#xmlschema` to replace the entire timezone suffix (`Z` or `±HH:MM`) instead of the final character
- Ensures correct calculation of the timezone offset for both Time and DateTime instances
- Adds a regression `test test_xmlschema_with_datetime_local_time`, which reproduces the issue and confirms the fix

Implementation change:
```ruby
str.sub(/(Z|[+-]\d{2}:\d{2})\z/, formatted_offset(true, "Z"))
```

### Additional information

It does not introduce behavioral changes outside of the reported bug

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to a single change.
* [x] Commit message contains a detailed description and references the issue.
* [x] Tests were added and pass successfully.
* [x] No CHANGELOG is needed, this is a minor bug fix.
