### PR TITLE
Fix remove_index to handle custom name with JSONB expression

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Rails 6.1.7.10 (October 23, 2024) ##
 
-*   No changes.
+*   Fix `remove_index` to handle custom name with JSONB expression.
+
+    When removing an index created with a JSONB expression (like `(metadata->>'endpoint')`) and a custom name, `remove_index` would fail with `ArgumentError: No indexes found` because the column-based matching logic couldn't match the generated index name with the custom name.
+
+    The fix skips column-based matching when both a custom name and a complex expression are provided, using only name-based matching instead.
 
 
 ## Rails 6.1.7.9 (October 15, 2024) ##


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When reversing a migration that adds an index with a JSONB expression and a custom name (using `algorithm: :concurrently`), Rails fails to remove the index. The column-based matching logic generates a different index name than the custom one provided, resulting in `ArgumentError: No indexes found`. This PR addresses that bug.

### Detail

This Pull Request updates `index_name_for_remove` to skip column-based matching when both a custom name and a complex expression are provided, relying solely on name-based matching. This ensures that indexes created with custom names and expressions can be reliably removed.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
- Backward compatible; only affects this edge case.
- No breaking changes.
- Affects Rails 6.1+.
- Includes a test that creates and removes such an index, verifying the fix.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
