### PR TITLE
Add support for inverse_of association with query_constraints, fixes #56192

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add support for inverse_of association with query_constraints, fixes #56192
+
+    Fixes `NoMethodError` when using query_constraints macro with sharded inverse_of association
+
+    *Tahsin Hasan*
+
 *   Add support for configuring migration strategy on a per-adapter basis.
 
     `migration_strategy` can now be set on individual adapter classes, overriding

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -574,9 +574,9 @@ module ActiveRecord
           if active_record.has_query_constraints?
             derived_fk = derive_fk_query_constraints(derived_fk)
           end
-
+          Logger.new($stdout).info("Derived foreign key for #{active_record}.#{name} is #{derived_fk.inspect}")
           if derived_fk.is_a?(Array)
-            derived_fk.map! { |fk| -fk.freeze }
+            derived_fk.map! { |fk| -fk.to_s.freeze }
             derived_fk.freeze
           else
             -derived_fk.freeze
@@ -875,13 +875,13 @@ module ActiveRecord
           end
 
           return foreign_key if primary_query_constraints.include?(foreign_key)
-
+          Logger.new($stdout).info("Deriving foreign key query constraints for #{active_record}.#{name} with primary_query_constraints=#{primary_query_constraints.inspect} and foreign_key=#{foreign_key.inspect}")
           first_key, last_key = primary_query_constraints
 
           if first_key == owner_pk
-            [foreign_key, last_key.to_s]
+            [foreign_key, last_key.to_s].flatten
           elsif last_key == owner_pk
-            [first_key.to_s, foreign_key]
+            [first_key.to_s, foreign_key].flatten
           else
             raise ArgumentError, <<~MSG.squish
               Active Record couldn't correctly interpret the query constraints

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -574,7 +574,7 @@ module ActiveRecord
           if active_record.has_query_constraints?
             derived_fk = derive_fk_query_constraints(derived_fk)
           end
-          Logger.new($stdout).info("Derived foreign key for #{active_record}.#{name} is #{derived_fk.inspect}")
+
           if derived_fk.is_a?(Array)
             derived_fk.map! { |fk| -fk.to_s.freeze }
             derived_fk.freeze
@@ -875,7 +875,7 @@ module ActiveRecord
           end
 
           return foreign_key if primary_query_constraints.include?(foreign_key)
-          Logger.new($stdout).info("Deriving foreign key query constraints for #{active_record}.#{name} with primary_query_constraints=#{primary_query_constraints.inspect} and foreign_key=#{foreign_key.inspect}")
+
           first_key, last_key = primary_query_constraints
 
           if first_key == owner_pk

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -711,6 +711,8 @@ class AssociationProxyTest < ActiveRecord::TestCase
 end
 
 class TestShardedQueryConstraintAssociationWithInverse < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
   setup do
     @connection = ActiveRecord::Base.lease_connection
     @connection.create_table :shard_companies, force: true do |t|


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it fixes #56192

### Detail

With this Pull Request now we can use `query_constraints` macro with sharded inverse_of associations without any errors.

Now the below script passes:

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  gem 'rails'
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem 'sqlite3'
end

require 'active_record/railtie'
require 'minitest/autorun'

# This connection will do for database-independent bug reports.
ENV['DATABASE_URL'] = 'sqlite3::memory:'

class TestApp < Rails::Application
  config.load_defaults(Rails::VERSION::STRING.to_f)
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = 'secret_key_base'

  config.active_record.encryption.primary_key = 'primary_key'
  config.active_record.encryption.deterministic_key = 'deterministic_key'
  config.active_record.encryption.key_derivation_salt = 'key_derivation_salt'
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :companies, force: true do |t|
    t.string(:name)
  end

  create_table :posts, force: true do |t|
    t.references(:company, foreign_key: true)
    t.index(%i[company_id id])
  end

  create_table :comments, force: true do |t|
    t.references(:post, foreign_key: true)
    t.references(:company, foreign_key: true)
    t.index(%i[company_id id])
  end
end

class Company < ActiveRecord::Base
  has_many :posts
  has_many :comments
end

class Post < ActiveRecord::Base
  query_constraints :company_id, :id
  belongs_to :company, inverse_of: :posts
  has_many :comments, inverse_of: :post
end

class Comment < ActiveRecord::Base
  query_constraints :company_id, :id

  belongs_to :company, inverse_of: :comments
  belongs_to :post, inverse_of: :comments
end

class BugTest < ActiveSupport::TestCase
  def test_query_constraints_on_associated_model
    organization = Company.create!(name: 'Example Inc.')
    post = organization.posts.create!
    assert_empty post.comments # Throws NoMethodError
  end
end
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
