### PR TITLE
Ensure variants are loaded and processed synchronously just once

### DIFF
--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -109,7 +109,7 @@ class ActiveStorage::Preview
     end
 
     def variant
-      image.variant(variation)
+      @variant ||= image.variant(variation)
     end
 
     def variant?

--- a/activestorage/test/controllers/representations/redirect_controller_test.rb
+++ b/activestorage/test/controllers/representations/redirect_controller_test.rb
@@ -88,6 +88,29 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsTest < Actio
     assert_equal 100, image.height
   end
 
+  test "processing and recording variant for preview just once" do
+    variant_record_created = false
+    variant_record_loaded_count = 0
+
+    query_subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+      sql = event.payload[:sql]
+      if event.payload[:name] == "ActiveStorage::VariantRecord Create"
+        variant_record_created = true
+      elsif event.payload[:name] == "ActiveStorage::VariantRecord Load" && variant_record_created
+        variant_record_loaded_count += 1
+      end
+    end
+
+    get rails_blob_representation_url(
+      filename: @blob.filename,
+      signed_blob_id: @blob.signed_id,
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
+
+    assert_equal 0, variant_record_loaded_count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(query_subscriber) if query_subscriber
+  end
+
   test "showing preview with invalid signed blob ID" do
     get rails_blob_representation_url(
       filename: @blob.filename,


### PR DESCRIPTION
### Motivation / Background

Today, while looking into some 500 errors from `GET /rails/active_storage/representations/redirect/` requests, I noticed an unexpected behaviour in our logs. We were computing a variant for a previewable blob (for example, a video or a PDF, whose variants belong to their preview image), and then, after having uploaded it and stored it, we were trying to load it again from the database, failing to find it, then downloading the preview once more and processing the variant again, and finally failing to create the variant record, because it already existed. Turns out, the reason we couldn't find it the second time we tried to load it was that this was happening in the replica, whereas the new variant is created against the primary, by manually connecting to the writer: 
https://github.com/rails/rails/blob/17f6e00bce8c35b6c5355450331da170c768e3e0/activestorage/app/models/active_storage/variant_with_record.rb#L57-L62

This PR avoids loading the record that was created within the request once more just to get the redirect URL.  See below for more details. 

### Detail

Even though we [track and memoize the just-created `@record`](https://github.com/rails/rails/blob/17f6e00bce8c35b6c5355450331da170c768e3e0/activestorage/app/models/active_storage/variant_with_record.rb#L56-L57) in `ActiveStorage::VariantWithRecord` when we call `processed` (which calls [`process`](https://github.com/rails/rails/blob/17f6e00bce8c35b6c5355450331da170c768e3e0/activestorage/app/models/active_storage/variant_with_record.rb#L43-L45)), we always instantiate a new object when we call `ActiveStorage::Blob#variant`. 
https://github.com/rails/rails/blob/17f6e00bce8c35b6c5355450331da170c768e3e0/activestorage/app/models/active_storage/blob/representable.rb#L100-L102


If we only call this once, that's fine, but when processing the variant via `GET /rails/active_storage/representations/redirect`, we call this twice: one when setting the representation and processing it:
https://github.com/rails/rails/blob/17f6e00bce8c35b6c5355450331da170c768e3e0/activestorage/app/controllers/active_storage/representations/base_controller.rb#L13-L14

and another one when calling `@representation.url` for the redirect: 
https://github.com/rails/rails/blob/17f6e00bce8c35b6c5355450331da170c768e3e0/activestorage/app/controllers/active_storage/representations/redirect_controller.rb#L12

which calls `ActiveStorage::Preview#url`, which ultimately calls `ActiveStorage::VariantWithRecord.processed` again, but on a new instance of `ActiveStorage::VariantWithRecord`. This checks whether [the variant record exists](https://github.com/rails/rails/blob/17f6e00bce8c35b6c5355450331da170c768e3e0/activestorage/app/models/active_storage/variant_with_record.rb#L39-L41) (the one we just created in the previous call to `processed`), but does so against the replica, which is unlikely to find it if there's any delay, since these calls are very close together.

With this change, we make sure we reuse the variant instance we just calculated for the preview image.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
