### PR TITLE
Address `Lint/UselessAssignment: Useless assignment to variable - sql.`

### DIFF
--- a/activestorage/test/controllers/representations/redirect_controller_test.rb
+++ b/activestorage/test/controllers/representations/redirect_controller_test.rb
@@ -93,7 +93,6 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsTest < Actio
     variant_record_loaded_count = 0
 
     query_subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-      sql = event.payload[:sql]
       if event.payload[:name] == "ActiveStorage::VariantRecord Create"
         variant_record_created = true
       elsif event.payload[:name] == "ActiveStorage::VariantRecord Load" && variant_record_created


### PR DESCRIPTION
### Motivation / Background

This commit addresses the `Lint/UselessAssignment: Useless assignment to variable - sql.`

### Detail
Offense without this commit:
```ruby
$ bundle exec rubocop test/controllers/representations/redirect_controller_test.rb
Inspecting 1 file
W

Offenses:

test/controllers/representations/redirect_controller_test.rb:96:7: W: [Correctable] Lint/UselessAssignment: Useless assignment to variable - sql.
      sql = event.payload[:sql]
      ^^^

1 file inspected, 1 offense detected, 1 offense autocorrectable
$
```

This sql is not used, removing this line should pass the test.

### Additional information
Follow up #56225

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
