### PR TITLE
Schedule a single job per Blob that schedules preprocessing variants jobs

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Schedule a single job per blob for creating variants
+
+    *Petrik de Heus, Tom Rossi <tom@higherpixels.com>*
+
 *   `ActiveStorage::Blob#open` can now be used without passing a block, like `Tempfile.open`. When using this form the
     returned temporary file must be unlinked manually.
 

--- a/activestorage/app/jobs/active_storage/variants_job.rb
+++ b/activestorage/app/jobs/active_storage/variants_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ActiveStorage::VariantsJob < ActiveStorage::BaseJob
+  queue_as { ActiveStorage.queues[:transform] }
+
+  discard_on ActiveRecord::RecordNotFound, ActiveStorage::UnrepresentableError
+  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
+
+  def perform(blob, variations)
+    variations.each do |transformations|
+      blob.preprocessed(transformations)
+    end
+  end
+end

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -137,14 +137,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
           named_variant.transformations
         end
       }
-
-      if blob.preview_image_needed_before_processing_variants? && preprocessed_variations.any?
-        blob.create_preview_image_later(preprocessed_variations)
-      else
-        preprocessed_variations.each do |transformations|
-          blob.preprocessed(transformations)
-        end
-      end
+      blob.transform_variants_later(preprocessed_variations) if preprocessed_variations.any?
     end
 
     def purge_dependent_blob_later

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -168,6 +168,18 @@ module ActiveStorage::Blob::Representable
     previewable? && !preview_image.attached?
   end
 
+  def transform_variants_later(variations) # :nodoc:
+    if preview_image_needed_before_processing_variants?
+      create_preview_image_later(variations)
+    else
+      create_variants_later(variations)
+    end
+  end
+
+  def create_variants_later(variations) # :nodoc:
+    ActiveStorage::VariantsJob.perform_later(self, variations) if representable?
+  end
+
   def create_preview_image_later(variations) # :nodoc:
     ActiveStorage::PreviewImageJob.perform_later(self, variations) if representable?
   end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -919,33 +919,33 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "transforms variants later" do
     blob = create_file_blob(filename: "racecar.jpg")
 
-    assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [1, 1]] do
+    assert_enqueued_with job: ActiveStorage::VariantsJob, args: [blob, [{ resize_to_limit: [1, 1] }]] do
       @user.highlights_with_preprocessed.attach blob
     end
   end
 
   test "transforms variants later conditionally via proc" do
-    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
+    assert_no_enqueued_jobs only: [ ActiveStorage::VariantsJob, ActiveStorage::PreviewImageJob ] do
       @user.highlights_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
     blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via proc")
 
-    assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [2, 2]] do
+    assert_enqueued_with job: ActiveStorage::VariantsJob, args: [blob, [{ resize_to_limit: [2, 2] }]] do
       @user.highlights_with_conditional_preprocessed.attach blob
     end
   end
 
   test "transforms variants later conditionally via method" do
-    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
+    assert_no_enqueued_jobs only: [ ActiveStorage::VariantsJob, ActiveStorage::PreviewImageJob ] do
       @user.highlights_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
     blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via method")
 
-    assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [3, 3]] do
+    assert_enqueued_with job: ActiveStorage::VariantsJob, args: [blob, [{ resize_to_limit: [3, 3] }]] do
       assert_no_enqueued_jobs only: ActiveStorage::PreviewImageJob do
         @user.highlights_with_conditional_preprocessed.attach blob
       end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -861,33 +861,33 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "transforms variants later" do
     blob = create_file_blob(filename: "racecar.jpg")
 
-    assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [1, 1]] do
+    assert_enqueued_with job: ActiveStorage::VariantsJob, args: [blob, [{ resize_to_limit: [1, 1] }]] do
       @user.avatar_with_preprocessed.attach blob
     end
   end
 
   test "transforms variants later conditionally via proc" do
-    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
+    assert_no_enqueued_jobs only: [ ActiveStorage::VariantsJob, ActiveStorage::PreviewImageJob ] do
       @user.avatar_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
     blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via proc")
 
-    assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [2, 2]] do
+    assert_enqueued_with job: ActiveStorage::VariantsJob, args: [blob, [{ resize_to_limit: [2, 2] }]] do
       @user.avatar_with_conditional_preprocessed.attach blob
     end
   end
 
   test "transforms variants later conditionally via method" do
-    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
+    assert_no_enqueued_jobs only: [ ActiveStorage::VariantsJob, ActiveStorage::PreviewImageJob ] do
       @user.avatar_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
     blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via method")
 
-    assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [3, 3]] do
+    assert_enqueued_with job: ActiveStorage::VariantsJob, args: [blob, [{ resize_to_limit: [3, 3] }]] do
       @user.avatar_with_conditional_preprocessed.attach blob
     end
   end
@@ -895,7 +895,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "avoids enqueuing transform later job or preview image job when blob is not representable" do
     unrepresentable_blob = create_blob(filename: "hello.txt")
 
-    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ]  do
+    assert_no_enqueued_jobs only: [ ActiveStorage::VariantsJob, ActiveStorage::PreviewImageJob ]  do
       @user.avatar_with_preprocessed.attach unrepresentable_blob
     end
   end
@@ -903,7 +903,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "avoids enqueuing transform later job or preview later job if there aren't any variants to preprocess" do
     blob = create_file_blob(filename: "report.pdf")
 
-    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
+    assert_no_enqueued_jobs only: [ ActiveStorage::VariantsJob, ActiveStorage::PreviewImageJob ] do
       @user.resume.attach blob
     end
   end
@@ -912,7 +912,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "report.pdf")
 
     assert_enqueued_with job: ActiveStorage::PreviewImageJob, args: [blob, [resize_to_fill: [400, 400]]] do
-      assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+      assert_no_enqueued_jobs only: ActiveStorage::VariantsJob do
         @user.resume_with_preprocessing.attach blob
       end
     end


### PR DESCRIPTION
Similar to `PreviewImageJob`, instead of scheduling jobs for processing each variant, schedule a single job that schedules jobs for processing each variant.

This makes things more performant as less jobs get scheduled in a single request. It also makes things more consistent, as for previewable blobs we do the same thing.

# Details 

### For attachments we schedule a job for each variant

If an ActiveStorage attachment has multiple preprocessed variants, currently a job gets created for each variant, resulting in a lot of jobs when multiple blobs are attached with multiple variants in a single request.
A request with 10 uploads with 5 variants each, schedules 50 jobs.

```mermaid
flowchart TD
    A[Attachment] -->|transform_variants_later| B@{shape: processes, label: TransformJob}
```

This is done in `transform_variants_later` where `blob.preprocessed` schedules a `TransformJob` for each variation:
https://github.com/rails/rails/blob/4c53863e354ad94dbfaf0643d9cdc99393a1a583/activestorage/app/models/active_storage/attachment.rb#L144-L146

### For previewable attachments we schedule a single job

For a previewable blob, for example a PDF has a image preview, all variants are based on the preview.
As the variants require the preview, we create a single `PreviewImageJob` that creates the preview and then schedules all the variants.

```mermaid
flowchart TD
    C[Attachment] -->|transform_variants_later| D[ImagePreviewJob]
    D -->|perform| E@{shape: processes, label: TransformJob}
```

`create_preview_image_later` schedules a `PreviewimageJob` for the blob:

https://github.com/rails/rails/blob/4c53863e354ad94dbfaf0643d9cdc99393a1a583/activestorage/app/models/active_storage/attachment.rb#L142

`PreviewImageJob` processes the required image preview and schedules jobs for all preprocessed variants:

https://github.com/rails/rails/blob/4c53863e354ad94dbfaf0643d9cdc99393a1a583/activestorage/app/jobs/active_storage/preview_image_job.rb#L10-L14

### Schedule a single job for all variant processing

For non-previewable blobs we can do the same: schedule a single job that schedules jobs for all preprocessed variants.

```mermaid
flowchart TD
    C[Attachment] -->|transform_variants_later| D[VariantsJob]
    D -->|perform| E@{shape: processes, label: TransformJob}
```

This moves some logic (with feature envy on the Blob) from Attachment to a single method on Blob.
This is similar to other methods defined on Attachment that delegate to the Blob instead, like `analyze_blob_later`, `mirror_blob_later` and `purge_later`.

This reuses some code from: https://github.com/rails/rails/pull/51951

Co-authored-by: Tom Rossi <tom@higherpixels.com>

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
