### PR TITLE
Handle closed PostgreSQL connections in retryable_query_error?

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -867,8 +867,12 @@ module ActiveRecord
         def retryable_query_error?(exception)
           # We cannot retry anything if we're inside a broken transaction; we need to at
           # least raise until the innermost savepoint is rolled back
-          @raw_connection&.transaction_status != ::PG::PQTRANS_INERROR &&
-            super
+          in_transaction = begin
+            @raw_connection&.transaction_status == ::PG::PQTRANS_INERROR
+          rescue PG::ConnectionBad
+            false
+          end
+          !in_transaction && super
         end
 
         def get_oid_type(oid, fmod, column_name, sql_type = "")

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -539,6 +539,14 @@ module ActiveRecord
         end
       end
 
+      def test_retryable_query_error_handles_closed_connection
+        @connection.raw_connection.close
+
+        assert_raises ActiveRecord::ConnectionNotEstablished do
+          @connection.execute("SELECT 1")
+        end
+      end
+
       def test_translate_no_connection_exception_to_not_established
         pid = @connection.execute("SELECT pg_backend_pid()").to_a[0]["pg_backend_pid"]
         @connection.pool.checkout.execute("SELECT pg_terminate_backend(#{pid})")


### PR DESCRIPTION
## What is this?

When a PG connection dies unexpectedly, before reconnection can happen, `retryable_query_error?` calls `@raw_connection.transaction_status` which raises `PG::ConnectionBad` on a closed connection.

Currently, PostgreSQL adapter's retryable_query_error? handles two cases (connection is nil, connection is alive) but misses a third case (connection object exists but is closed). This PR adds this third case (rescues `PG::ConnectionBad` and falls back to super, allowing the retry to proceed)

We discovered this case while migrating our MySQL app to PG and encountering a failing test which tested this exact connection disconnection ordering.

<details><summary> ♽ Reproduction script </summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "main"
  gem "pg"
end

require "active_record"

DATABASE_URL = ENV["DATABASE_URL"] || "postgres://localhost/postgres"

ActiveRecord::Base.establish_connection(DATABASE_URL)
connection = ActiveRecord::Base.lease_connection
raw_conn = connection.raw_connection

puts "=== Setup ==="
puts "Connection alive: #{raw_conn.status == PG::CONNECTION_OK}"
puts "transaction_status: #{raw_conn.transaction_status}"

raw_conn.close
puts "Connection closed (but object still exists)"

puts "\n=== Bug: transaction_status on closed connection ==="
begin
  raw_conn.transaction_status
rescue PG::ConnectionBad => e
  puts "PG::ConnectionBad: #{e.message}"
end

puts "\n=== Current Implementation ==="
begin
  connection.execute("SELECT 1")
  puts "Query succeeded"
rescue PG::ConnectionBad => e
  puts "BUG: PG::ConnectionBad crashed retry mechanism"
rescue ActiveRecord::ConnectionNotEstablished
  puts "ConnectionNotEstablished (expected after fix)"
end

puts "\n=== With Fix Applied ==="

connection.class.class_eval do
  def retryable_query_error?(exception)
    # We cannot retry anything if we're inside a broken transaction; we need to at
    # least raise until the innermost savepoint is rolled back
    in_transaction = begin
      @raw_connection&.transaction_status == ::PG::PQTRANS_INERROR
    rescue PG::ConnectionBad
      false
    end
    !in_transaction && super
  end
end

connection.reconnect!
connection.raw_connection.close

begin
  connection.execute("SELECT 1")
  puts "Query succeeded (connection was restored)"
rescue PG::ConnectionBad => e
  puts "FAILED: #{e.message}"
rescue ActiveRecord::ConnectionNotEstablished
  puts "SUCCESS: ConnectionNotEstablished raised (retry mechanism worked)"
end
```

</details>


Result:
```
=== Setup ===
Connection alive: true
transaction_status: 0
Connection closed (but object still exists)

=== Bug: transaction_status on closed connection ===
PG::ConnectionBad: connection is closed

=== Current Implementation ===
BUG: PG::ConnectionBad crashed retry mechanism

=== With Fix Applied ===
SUCCESS: ConnectionNotEstablished raised (retry mechanism worked)
```