### PR TITLE
Fix has_many through find_or_initialize FK

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1705,6 +1705,19 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal(chapter.book, book)
   end
 
+  def test_find_or_initialize_by_sets_foreign_key_when_through_not_loaded
+    client = companies(:first_client)
+
+    expected_firm_id = client.client_of
+    assert_not_nil expected_firm_id
+
+    assert_not client.association(:firm).loaded?
+    new_account = client.accounts.find_or_initialize_by(credit_limit: 123_456)
+
+    assert_not client.association(:firm).loaded?
+    assert_equal expected_firm_id, new_account.firm_id
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR fixes [#55609](https://github.com/rails/rails/issues/55609) where `find_or_initialize_by` on `has_many :through` associations was not setting foreign keys correctly when the through association was not loaded. This caused newly initialized records to have `nil` foreign key values, leading to potential database constraint violations or incorrect associations.

### Detail

This Pull Request changes the `build_record` method in `ThroughAssociation` to handle the case where the through association target is not loaded. Previously, foreign keys were only set when the through association target was already loaded. Now, when the through reflection is a `belongs_to` association and the foreign key is present on the owner, the foreign key value is extracted directly from the owner record instead of requiring the through association to be loaded. A test case has been added to verify that `find_or_initialize_by` correctly sets foreign keys even when the through association is not loaded.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
