### PR TITLE
Introduce DevToolsController for chrome workspaces

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add a new internal route in development to respond to chromium devtools GET request.
+
+    This allows the app folder to be easily connected as a workspace in chromium-based browsers.
+
+    *coorasse*
+
 *   Set `config.rake_eager_load` in generated test environment to match `config.eager_load` behavior in CI.
 
     This ensures eager loading works consistently in CI when rake tasks invoke the `:environment` task before tests run.

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -30,6 +30,7 @@ module Rails
   autoload :InfoController
   autoload :MailersController
   autoload :WelcomeController
+  autoload :DevtoolsController
 
   eager_autoload do
     autoload :HealthController

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -144,6 +144,7 @@ module Rails
             get "/rails/info/routes"     => "rails/info#routes",     internal: true
             get "/rails/info/notes"      => "rails/info#notes",      internal: true
             get "/rails/info"            => "rails/info#index",      internal: true
+            get ".well-known/appspecific/com.chrome.devtools.json" => "rails/devtools#show",      internal: true
           end
 
           routes_reloader.run_after_load_paths = -> do

--- a/railties/lib/rails/devtools_controller.rb
+++ b/railties/lib/rails/devtools_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Rails::DevtoolsController < ActionController::Base # :nodoc:
+  def show
+    root_path = Rails.root.to_s
+    hash = Digest::SHA1.hexdigest(root_path)
+    uuid = "#{hash[0..7]}-#{hash[8..11]}-#{hash[12..15]}-#{hash[16..19]}-#{hash[20..31]}"
+
+    render json: {
+      "workspace": {
+        "root": root_path,
+        "uuid": uuid
+      }
+    }
+  end
+end

--- a/railties/test/rails_devtools_controller_test.rb
+++ b/railties/test/rails_devtools_controller_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class DevtoolsControllerTest < ActionController::TestCase
+  tests Rails::DevtoolsController
+
+  def setup
+    Rails.application.routes.draw do
+      get ".well-known/appspecific/com.chrome.devtools.json" => "rails/devtools#show", internal: true
+    end
+    @routes = Rails.application.routes
+  end
+
+  test "devtools controller renders JSON with workspace root and uuid" do
+    get :show
+    assert_response :success
+    assert_match(/application\/json/, @response.content_type)
+
+    json_response = JSON.parse(@response.body)
+    assert json_response.key?("workspace")
+    assert json_response["workspace"].key?("root")
+    assert json_response["workspace"].key?("uuid")
+    assert_equal Rails.root.to_s, json_response["workspace"]["root"]
+  end
+end


### PR DESCRIPTION
### Motivation / Background

[Chromium is able to automatically detect workspace folders](https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md). In order to do that, performs a call to `.well-known/appspecific/com.chrome.devtools.json`.

This PR introduces a default controller to respond to this call.

### Detail

A Rails::DevtoolsController is provided by the Rails engine and a path is added (commented out) to the routes.rb file:

```ruby
get ".well-known/appspecific/com.chrome.devtools.json", to: "rails/devtools#show"
```

The controller returns the `Rails.root` path and a uuid that changes only if the Rails.root path changes.

### Additional information

There's plenty of other ways we can implement this:
* a middleware
* a non-modifiable route
* clone the controller in the project

I think this implementation is a good trade-off: it provides a good default, which can be easily enabled/disabled also in new apps. It can be easily overridden if the functionality changes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
