### PR TITLE
ActiveJob.perform_all_later should respect `job_class.enqueue_after_transaction_commit`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `ActiveJob.perform_all_later` to respect `job_class.enqueue_after_transaction_commit`.
+
+    Previously, `perform_all_later` would enqueue all jobs immediately, even if
+    they had `enqueue_after_transaction_commit = true`. Now it correctly defers
+    jobs with this setting until after transaction commits, matching the behavior
+    of `perform_later`.
+
+    *OuYangJinTing*
+
 *   Fix using custom serializers with `ActiveJob::Arguments.serialize` when
     `ActiveJob::Base` hasn't been loaded.
 

--- a/activejob/lib/active_job/enqueue_after_transaction_commit.rb
+++ b/activejob/lib/active_job/enqueue_after_transaction_commit.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 module ActiveJob
+  class << self
+    # Ensures perform_all_later respects each job's enqueue_after_transaction_commit configuration.
+    # Jobs with enqueue_after_transaction_commit set to true are deferred and enqueued only after the transaction commits;
+    # other jobs are enqueued immediately. This ensures enqueuing timing matches the per-job setting.
+    alias _perform_all_later_skip_transaction perform_all_later
+    def perform_all_later(*jobs)
+      jobs.flatten!
+      deferred_jobs, immediate_jobs = jobs.partition { |job| job.class.enqueue_after_transaction_commit }
+      _perform_all_later_skip_transaction(immediate_jobs) if immediate_jobs.any?
+      ActiveRecord.after_all_transactions_commit { _perform_all_later_skip_transaction(deferred_jobs) } if deferred_jobs.any?
+      nil
+    end
+  end
+
   module EnqueueAfterTransactionCommit # :nodoc:
     private
       def raw_enqueue


### PR DESCRIPTION
### Motivation / Background

Previously, `ActiveJob.perform_all_later` did not respect the `enqueue_after_transaction_commit` setting on individual job classes. This meant that even if a job class had `enqueue_after_transaction_commit = true`, it would still be enqueued immediately when passed to `perform_all_later`, rather than being deferred until after the transaction commits.

This is inconsistent with the behavior of `perform_later`, which correctly respects the `enqueue_after_transaction_commit` setting. This inconsistency could lead to unexpected behavior when using `perform_all_later` with jobs that need to wait for transaction commits.

### Detail

This Pull Request changes `ActiveJob.perform_all_later` to:

1. Partition jobs into two groups based on their `enqueue_after_transaction_commit` setting:
   - Jobs with `enqueue_after_transaction_commit = true` are deferred until after transaction commits
   - Jobs with `enqueue_after_transaction_commit = false` are enqueued immediately

2. Alias the original method `perform_all_later` to the new method `_perform_all_later_skip_transaction`, then redefine `perform_all_later` to separate transaction jobs

3. Add comprehensive tests to verify:
   - Jobs with `enqueue_after_transaction_commit = true` are deferred
   - Mixed scenarios with both immediate and deferred jobs work correctly

### Additional information

The implementation follows the same pattern used in `perform_later` for individual jobs, ensuring consistency across the ActiveJob API. The change maintains backward compatibility for jobs that don't set `enqueue_after_transaction_commit` (defaults to `false`).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.