### PR TITLE
Deduplicate logic for internal params handling in Action Controller log subscriber

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -2,18 +2,13 @@
 
 module ActionController
   class LogSubscriber < ActiveSupport::EventReporter::LogSubscriber # :nodoc:
-    INTERNAL_PARAMS = %w(controller action format _method only_path)
-
     class_attribute :backtrace_cleaner, default: ActiveSupport::BacktraceCleaner.new
 
     self.namespace = "action_controller"
 
     def request_started(event)
       payload = event[:payload]
-      params = {}
-      payload[:params].each_pair do |k, v|
-        params[k] = v unless INTERNAL_PARAMS.include?(k)
-      end
+      params  = payload[:params]
       format  = payload[:format]
       format  = format.to_s.upcase if format.is_a?(Symbol)
       format  = "*/*" if format.nil?


### PR DESCRIPTION
While reviewing the code for new [structured events](https://github.com/rails/rails/pull/55334), I noticed that there's duplicated logic for removing internal params from the logs. Previously, this logic was in `ActionController::LogSubscriber`, but now it lives in `ActionController::StructuredEventSubscriber`: https://github.com/rails/rails/blob/1e1d8497a0fdad1f4bd3a6efbe7453217b4e56c5/actionpack/lib/action_controller/structured_event_subscriber.rb#L9-L12
which emits a `request_started` event handled in `LogSubscriber`: https://github.com/rails/rails/blob/1e1d8497a0fdad1f4bd3a6efbe7453217b4e56c5/actionpack/lib/action_controller/structured_event_subscriber.rb#L17-L22
so the params received by `request_started` method are already a hash and have the internal keys excluded.

This PR removes the duplicated logic so that only `StructuredEventSubscriber#start_processing` handles the internal keys.