### PR TITLE
Adds template-file rendering examples in the bug report test-template for ActionView

### DIFF
--- a/guides/bug_report_templates/action_view.rb
+++ b/guides/bug_report_templates/action_view.rb
@@ -23,13 +23,40 @@ end
 Rails.application.initialize!
 
 class BugTest < ActionView::TestCase
+  setup do
+    @view_path = Pathname.new(Dir.mktmpdir)
+    ActionController::Base.prepend_view_path @view_path
+  end
+
+  teardown do
+    @view_path.rmtree
+  end
+
   helper do
     def upcase(value)
       value.upcase
     end
   end
 
-  def test_stuff
+  def test_action_view_render_template
+    view_file "posts/index.html.erb", <<~ERB
+      <h1>Posts</h1>
+
+      <% posts.each do |post| %>
+        <%= render partial: "posts/post", locals: { post: post } %>
+      <% end %>
+    ERB
+
+    view_file "posts/_post.html.erb", <<~ERB
+      <p><%= upcase(post) %></p>
+    ERB
+
+    render template: "posts/index", locals: { posts: ["hello world"] }
+
+    assert_equal "HELLO WORLD", rendered.html.at("p").text
+  end
+
+  def test_action_view_render_inline
     render inline: <<~ERB, locals: { key: "value" }
       <p><%= upcase(key) %></p>
     ERB
@@ -38,4 +65,11 @@ class BugTest < ActionView::TestCase
 
     assert_equal element.text, "VALUE"
   end
+
+  private
+    def view_file(filename, contents)
+      pathname = @view_path.join(filename)
+      pathname.dirname.mkpath
+      pathname.write(contents.chomp)
+    end
 end


### PR DESCRIPTION
## Motivation

When developers report view-template rendering issues, they often struggle to provide reproducible code. As a result, many issue descriptions are unclear or incomplete, making them difficult to understand or reproduce. This is largely because we do not currently provide a predefined template for such reports.

## Details

This PR enhances the existing bug report test template for Action View by adding clearer guidance and structure for issues related to template file rendering. The updated template helps contributors create executable, reproducible test cases, improving the quality and efficiency of issue triage and resolution.
