### PR TITLE
Bump `bundler-audit` version 0.9.3 to support Ruby/Bundler 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,8 +143,7 @@ group :test do
 
   # Needed for Railties tests because it is included in generated apps.
   gem "brakeman"
-  # Skip bundler-audit until https://github.com/rubysec/bundler-audit/issues/405 is resolved for Ruby 3.5.0dev
-  gem "bundler-audit" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.5.0")
+  gem "bundler-audit"
 end
 
 platforms :ruby, :windows do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,8 +153,8 @@ GEM
     brakeman (7.0.0)
       racc
     builder (3.3.0)
-    bundler-audit (0.9.2)
-      bundler (>= 1.2.0, < 3)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
       thor (~> 1.0)
     bunny (2.23.0)
       amq-protocol (~> 2.3, >= 2.3.1)


### PR DESCRIPTION
### Motivation / Background

This commit bumps `bundler-audit` version 0.9.3 to support Ruby/Bundler 4

### Detail
None

### Additional information
Follow up #55883
https://github.com/rubysec/bundler-audit/issues/405
https://github.com/rubysec/bundler-audit/pull/409

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
