### PR TITLE
Add schematized json for has_json

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -5,7 +5,7 @@
       has_json :settings, restrict_creation_to_admins: true, max_invites: 10, greeting: "Hello!"
       has_delegated_json :flags, beta: false, staff: :boolean
     end
-    
+
     a = Account.new
     a.settings.restrict_creation_to_admins? # => true
     a.max_invites = "100" # => Set to integer 100

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add +has_json+ and +has_delegated_json+ to provide schema-enforced access to JSON attributes.
+
+    ```ruby
+    class Account < ApplicationRecord
+      has_json :settings, restrict_creation_to_admins: true, max_invites: 10, greeting: "Hello!"
+      has_delegated_json :flags, beta: false, staff: :boolean
+    end
+    
+    a = Account.new
+    a.settings.restrict_creation_to_admins? # => true
+    a.max_invites = "100" # => Set to integer 100
+    a.settings = { "restrict_creation_to_admins" => "false", "max_invites" => "500", "greeting" => "goodbye" }
+    a.settings.greeting # => "goodbye"
+    a.staff # => nil
+    a.staff = true
+    a.staff? # => true
+    ```
+
+    *DHH*
+
 *   Changes `ActiveModel::Validations#read_attribute_for_validation` to return `nil` if the record doesn't
     respond to the attribute instead of raising an error.
 

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -49,6 +49,7 @@ module ActiveModel
   autoload :Model
   autoload :Name, "active_model/naming"
   autoload :Naming
+  autoload :SchematizedJson
   autoload :SecurePassword
   autoload :Serialization
   autoload :Translation

--- a/activemodel/lib/active_model/api.rb
+++ b/activemodel/lib/active_model/api.rb
@@ -61,6 +61,7 @@ module ActiveModel
     include ActiveModel::AttributeAssignment
     include ActiveModel::Validations
     include ActiveModel::Conversion
+    include ActiveModel::SchematizedJson
 
     included do
       extend ActiveModel::Naming

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -12,13 +12,16 @@ module ActiveModel
       # directly from the UI as strings, and still have them set with the correct JSON type in the database.
       def has_json(attr, **schema)
         define_method(attr) do
+          # Ensure the attribute is set if nil, so we can pass the reference to the accessor for defaults.
           _write_attribute(attr.to_s, {}) if attribute(attr.to_s).nil?
+
+          # No memoizationen used in order to stay compatible with #reload (and because it's such a thin accessor)
           ActiveModel::SchematizedJson::DataAccessor.new(schema, data: attribute(attr.to_s))
         end
 
         define_method("#{attr}=") { |data| public_send(attr).assign_data_with_type_casting(data) }
 
-        # Ensure default values are set before saving
+        # Ensure default values are set before saving by relying on DataAccessor instantiation to do it.
         before_save -> { send(attr) } if respond_to?(:before_save)
       end
     end
@@ -71,6 +74,8 @@ module ActiveModel
           end
         end
 
+        # Types that are declared using real values, like true/false, 5, or "hello", will be used as defaults.
+        # Types that are declared using symbols, like :boolean, :integer, :string, will be nulled out.
         def update_data_with_schema_defaults
           @data.reverse_merge!(@schema.to_h { |attr, type| [ attr.to_s, type.is_a?(Symbol) ? nil : type ] })
         end

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/hash/reverse_merge"
+require "active_support/core_ext/symbol/starts_ends_with"
+
+module ActiveModel
+  module SchematizedJson
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def has_json(attr, schema:, delegate: false)
+        define_method(attr) do
+          attribute_name = attr.to_s
+          _write_attribute(attribute_name, {}) if attribute(attribute_name).nil?
+          ActiveModel::SchematizedJson::DataAccessor.new(schema, data: attribute(attribute_name))
+        end
+
+        define_method("#{attr}=") { |data| public_send(attr).assign_data_with_type_casting(data) }
+
+        schema.keys.each do |schema_key|
+          define_method(schema_key)       { public_send(attr).public_send(schema_key) }
+          define_method("#{schema_key}?") { public_send(attr).public_send("#{schema_key}?") }
+          define_method("#{schema_key}=") { |value| send(attr).public_send("#{schema_key}=", value) }
+        end if delegate
+
+        # Ensure default values are set before saving
+        before_save -> { send(attr) } if respond_to?(:before_save)
+      end
+    end
+
+    class DataAccessor
+      def initialize(schema, data:)
+        @schema, @data = schema, data
+        update_data_with_schema_defaults
+      end
+
+      def assign_data_with_type_casting(new_data)
+        new_data.each { |k, v| public_send "#{k}=", v }
+      end
+
+      private
+        def method_missing(method_name, *args, **kwargs)
+          key = method_name.to_s.remove(/(\?|=)/)
+
+          if @schema.key? key.to_sym
+            if method_name.ends_with?("?")
+              @data[key].present?
+            elsif method_name.ends_with?("=")
+              value = args.first
+              @data[key] = lookup_schema_type_for(key).cast(value)
+            else
+              @data[key]
+            end
+          else
+            super
+          end
+        end
+
+        def respond_to_missing?(method_name, include_private = false)
+          @schema.key?(method_name.to_s.remove(/[?=]/).to_sym) || super
+        end
+
+        def lookup_schema_type_for(key)
+          type_or_default_value = @schema[key.to_sym]
+
+          case type_or_default_value
+          when :boolean, :integer, :string
+            ActiveModel::Type.lookup(type_or_default_value)
+          when TrueClass, FalseClass
+            ActiveModel::Type.lookup(:boolean)
+          when Integer
+            ActiveModel::Type.lookup(:integer)
+          when String
+            ActiveModel::Type.lookup(:string)
+          else
+            raise "Only boolean, integer, or strings are allowed as JSON schema types"
+          end
+        end
+
+        def update_data_with_schema_defaults
+          @data.reverse_merge!(@schema.to_h { |k, v| [ k.to_s, v.is_a?(Symbol) ? nil : v ] })
+        end
+    end
+  end
+end

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -77,7 +77,7 @@ module ActiveModel
         end
 
         def update_data_with_schema_defaults
-          @data.reverse_merge!(@schema.to_h { |k, v| [ k.to_s, v.is_a?(Symbol) ? nil : v ] })
+          @data.reverse_merge!(@schema.to_h { |attr, type| [ attr.to_s, type.is_a?(Symbol) ? nil : type ] })
         end
     end
   end

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -70,7 +70,7 @@ module ActiveModel
           when String
             ActiveModel::Type.lookup :string
           else
-            raise "Only boolean, integer, or strings are allowed as JSON schema types"
+            raise ArgumentError, "Only boolean, integer, or strings are allowed as JSON schema types"
           end
         end
 

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -8,6 +8,8 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     module ClassMethods
+      # Provides a schema-enforced access layer for a JSON attribute. This allows you to assign values
+      # directly from the UI as strings, and still have them set with the correct JSON type in the database.
       def has_json(attr, schema:, delegate: false)
         define_method(attr) do
           _write_attribute(attr.to_s, {}) if attribute(attr.to_s).nil?

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -10,19 +10,13 @@ module ActiveModel
     module ClassMethods
       # Provides a schema-enforced access layer for a JSON attribute. This allows you to assign values
       # directly from the UI as strings, and still have them set with the correct JSON type in the database.
-      def has_json(attr, schema:, delegate: false)
+      def has_json(attr, **schema)
         define_method(attr) do
           _write_attribute(attr.to_s, {}) if attribute(attr.to_s).nil?
           ActiveModel::SchematizedJson::DataAccessor.new(schema, data: attribute(attr.to_s))
         end
 
         define_method("#{attr}=") { |data| public_send(attr).assign_data_with_type_casting(data) }
-
-        schema.keys.each do |schema_key|
-          define_method(schema_key)       { public_send(attr).public_send(schema_key) }
-          define_method("#{schema_key}?") { public_send(attr).public_send("#{schema_key}?") }
-          define_method("#{schema_key}=") { |value| send(attr).public_send("#{schema_key}=", value) }
-        end if delegate
 
         # Ensure default values are set before saving
         before_save -> { send(attr) } if respond_to?(:before_save)

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -10,9 +10,8 @@ module ActiveModel
     module ClassMethods
       def has_json(attr, schema:, delegate: false)
         define_method(attr) do
-          attribute_name = attr.to_s
-          _write_attribute(attribute_name, {}) if attribute(attribute_name).nil?
-          ActiveModel::SchematizedJson::DataAccessor.new(schema, data: attribute(attribute_name))
+          _write_attribute(attr.to_s, {}) if attribute(attr.to_s).nil?
+          ActiveModel::SchematizedJson::DataAccessor.new(schema, data: attribute(attr.to_s))
         end
 
         define_method("#{attr}=") { |data| public_send(attr).assign_data_with_type_casting(data) }

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -65,13 +65,13 @@ module ActiveModel
 
           case type_or_default_value
           when :boolean, :integer, :string
-            ActiveModel::Type.lookup(type_or_default_value)
+            ActiveModel::Type.lookup type_or_default_value
           when TrueClass, FalseClass
-            ActiveModel::Type.lookup(:boolean)
+            ActiveModel::Type.lookup :boolean
           when Integer
-            ActiveModel::Type.lookup(:integer)
+            ActiveModel::Type.lookup :integer
           when String
-            ActiveModel::Type.lookup(:string)
+            ActiveModel::Type.lookup :string
           else
             raise "Only boolean, integer, or strings are allowed as JSON schema types"
           end

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -41,8 +41,7 @@ module ActiveModel
             if method_name.ends_with?("?")
               @data[key].present?
             elsif method_name.ends_with?("=")
-              value = args.first
-              @data[key] = lookup_schema_type_for(key).cast(value)
+              @data[key] = lookup_schema_type_for(key).cast(args.first)
             else
               @data[key]
             end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -58,4 +58,11 @@ class SchematizedJsonTest < ActiveModel::TestCase
     @account.staff = false
     assert_not @account.staff?
   end
+
+  test "mass assignment" do
+    @account.settings = { "restricts_access" => "false", "max_invites" => "5", "greeting" => "goodbye" }
+    assert_not @account.settings.restricts_access?
+    assert_equal 5, @account.settings.max_invites
+    assert_equal "goodbye", @account.settings.greeting
+  end
 end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -11,6 +11,9 @@ class Account
 
   attribute :settings
   has_json :settings, schema: { restricts_access: true, max_invites: 10, greeting: "Hello!", beta: :boolean }
+
+  attribute :flags
+  has_json :flags, schema: { staff: true, early_adopter: false }, delegate: true
 end
 
 class SchematizedJsonTest < ActiveModel::TestCase
@@ -47,5 +50,12 @@ class SchematizedJsonTest < ActiveModel::TestCase
     assert_equal "Hello!", @account.settings.greeting
     @account.settings.greeting = 100
     assert_equal "100", @account.settings.greeting
+  end
+
+  test "delegated methods" do
+    assert @account.staff?
+    assert_equal true, @account.staff
+    @account.staff = false
+    assert_not @account.staff?
   end
 end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -12,6 +12,9 @@ class Account
   attribute :settings
   has_json :settings, restricts_access: true, max_invites: 10, greeting: "Hello!", beta: :boolean
 
+  attribute :flags
+  has_delegated_json :flags, premium: false
+
   attribute :flags_with_defaults, default: { "staff" => false, "early_adopter" => true }
   has_json :flags_with_defaults, staff: true, early_adopter: false
 
@@ -53,6 +56,12 @@ class SchematizedJsonTest < ActiveModel::TestCase
     assert_equal "Hello!", @account.settings.greeting
     @account.settings.greeting = 100
     assert_equal "100", @account.settings.greeting
+  end
+
+  test "delegated accessors" do
+    assert_not @account.premium?
+    @account.premium = true
+    assert @account.premium?
   end
 
   test "mass assignment" do

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class Account
+  extend ActiveModel::Callbacks
+  include ActiveModel::Attributes
+  include ActiveModel::SchematizedJson
+
+  define_model_callbacks :save
+
+  attribute :settings
+  has_json :settings, schema: { restricts_access: true, max_invites: 10, greeting: "Hello!", beta: :boolean }
+end
+
+class SchematizedJsonTest < ActiveModel::TestCase
+  setup do
+    @account = Account.new
+  end
+
+  test "boolean" do
+    assert @account.settings.restricts_access?
+
+    @account.settings.restricts_access = false
+    assert_not @account.settings.restricts_access?
+
+    @account.settings.restricts_access = "true"
+    assert @account.settings.restricts_access?
+  end
+
+  test "boolean without default" do
+    assert_nil @account.settings.beta
+    assert_not @account.settings.beta?
+  end
+
+  test "integer" do
+    assert_equal 10, @account.settings.max_invites
+
+    @account.settings.max_invites = 15
+    assert_equal 15, @account.settings.max_invites
+
+    @account.settings.max_invites = "100"
+    assert_equal 100, @account.settings.max_invites
+  end
+
+  test "string" do
+    assert_equal "Hello!", @account.settings.greeting
+    @account.settings.greeting = 100
+    assert_equal "100", @account.settings.greeting
+  end
+end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -14,6 +14,9 @@ class Account
 
   attribute :flags
   has_json :flags, schema: { staff: true, early_adopter: false }, delegate: true
+
+  attribute :flags_with_defaults, default: { "staff" => false, "early_adopter" => true }
+  has_json :flags_with_defaults, schema: { staff: true, early_adopter: false }
 end
 
 class SchematizedJsonTest < ActiveModel::TestCase
@@ -64,5 +67,11 @@ class SchematizedJsonTest < ActiveModel::TestCase
     assert_not @account.settings.restricts_access?
     assert_equal 5, @account.settings.max_invites
     assert_equal "goodbye", @account.settings.greeting
+  end
+
+  test "schema defaults will not overwrite attribute defaults" do
+    a = Account.new
+    assert_not @account.flags_with_defaults.staff?
+    assert @account.flags_with_defaults.early_adopter?
   end
 end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -60,7 +60,6 @@ class SchematizedJsonTest < ActiveModel::TestCase
   end
 
   test "schema defaults will not overwrite attribute defaults" do
-    a = Account.new
     assert_not @account.flags_with_defaults.staff?
     assert @account.flags_with_defaults.early_adopter?
   end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -14,6 +14,9 @@ class Account
 
   attribute :flags_with_defaults, default: { "staff" => false, "early_adopter" => true }
   has_json :flags_with_defaults, staff: true, early_adopter: false
+
+  attribute :broken
+  has_json :broken, creation: :datetime, nesting: {}
 end
 
 class SchematizedJsonTest < ActiveModel::TestCase
@@ -62,5 +65,15 @@ class SchematizedJsonTest < ActiveModel::TestCase
   test "schema defaults will not overwrite attribute defaults" do
     assert_not @account.flags_with_defaults.staff?
     assert @account.flags_with_defaults.early_adopter?
+  end
+
+  test "only standard json types are acceptable schema types" do
+    assert_raises(ArgumentError) do
+      @account.broken.creation = DateTime.now
+    end
+
+    assert_raises(ArgumentError) do
+      @account.broken.nesting = { not: :valid }
+    end
   end
 end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -10,13 +10,10 @@ class Account
   define_model_callbacks :save
 
   attribute :settings
-  has_json :settings, schema: { restricts_access: true, max_invites: 10, greeting: "Hello!", beta: :boolean }
-
-  attribute :flags
-  has_json :flags, schema: { staff: true, early_adopter: false }, delegate: true
+  has_json :settings, restricts_access: true, max_invites: 10, greeting: "Hello!", beta: :boolean
 
   attribute :flags_with_defaults, default: { "staff" => false, "early_adopter" => true }
-  has_json :flags_with_defaults, schema: { staff: true, early_adopter: false }
+  has_json :flags_with_defaults, staff: true, early_adopter: false
 end
 
 class SchematizedJsonTest < ActiveModel::TestCase
@@ -53,13 +50,6 @@ class SchematizedJsonTest < ActiveModel::TestCase
     assert_equal "Hello!", @account.settings.greeting
     @account.settings.greeting = 100
     assert_equal "100", @account.settings.greeting
-  end
-
-  test "delegated methods" do
-    assert @account.staff?
-    assert_equal true, @account.staff
-    @account.staff = false
-    assert_not @account.staff?
   end
 
   test "mass assignment" do


### PR DESCRIPTION
Provides a schema-enforced access object for a JSON attribute. This allows you to assign values
directly from the UI as strings, and still have them set with the correct JSON type in the database.

Only the three basic JSON types are supported: boolean, integer, and string. No nesting either.
These types can either be set by referring to them by their symbol or by setting a default value.
Default values are set when a new model is instantiated and on +before_save+ (if defined).

Examples:

```ruby
class Account < ApplicationRecord
  has_json :settings, restrict_creation_to_admins: true, max_invites: 10, greeting: "Hello!"
  has_delegated_json :flags, beta: false, staff: :boolean
end

a = Account.new
a.settings.restrict_creation_to_admins? # => true
a.settings.max_invites = "100" # => Set to integer 100
a.settings = { "restrict_creation_to_admins" => "false", "max_invites" => "500", "greeting" => "goodbye" }
a.settings.greeting # => "goodbye"
a.staff # => nil
a.staff = true
a.staff? # => true
```