### PR TITLE
[Fix #56260] Include `env_name` and `name` in `configuration_hash` and respect them in `establish_connection`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `establish_connection` to preserve environment and database name when using configuration hash.
+
+    `ActiveRecord::DatabaseConfigurations::DatabaseConfig#configuration_hash` now includes
+    `env_name` and `name`, and `ActiveRecord::Base.establish_connection` respects these
+    values from the hash before defaulting to the Rails environment and "primary". This
+    allows programmatic database switching using configuration hashes.
+
+    *Joshua Young*
+
 *   Add support for configuring migration strategy on a per-adapter basis.
 
     `migration_strategy` can now be set on individual adapter classes, overriding

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       #
       def initialize(env_name, name, configuration_hash)
         super(env_name, name)
-        @configuration_hash = configuration_hash.symbolize_keys.freeze
+        @configuration_hash = configuration_hash.symbolize_keys.merge(env_name: env_name, name: name).freeze
         validate_configuration!
       end
 

--- a/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [adapter: "mysql2", database: nil])
+      mock.expect(:call, nil, [env_name: "default_env", name: "primary", adapter: "mysql2", database: nil])
       mock.expect(:call, nil, [db_config])
 
       ActiveRecord::Base.stub(:lease_connection, @connection) do

--- a/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
@@ -23,7 +23,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+      mock.expect(:call, nil, [{ env_name: "default_env", name: "primary", adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
       mock.expect(:call, nil, [db_config])
 
       ActiveRecord::Base.stub(:lease_connection, @connection) do
@@ -40,7 +40,7 @@ module ActiveRecord
         assert_called_with(
           @connection,
           :create_database,
-          ["my-app-db", @configuration.symbolize_keys.merge(encoding: "utf8")]
+          ["my-app-db", @configuration.symbolize_keys.merge(env_name: "test", name: "primary", encoding: "utf8")]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create @configuration
         end
@@ -52,7 +52,7 @@ module ActiveRecord
         assert_called_with(
           @connection,
           :create_database,
-          ["my-app-db", @configuration.symbolize_keys.merge(encoding: "latin")]
+          ["my-app-db", @configuration.symbolize_keys.merge(env_name: "test", name: "primary", encoding: "latin")]
         ) do
           ActiveRecord::Tasks::DatabaseTasks.create @configuration.
             merge("encoding" => "latin")
@@ -68,6 +68,8 @@ module ActiveRecord
           [
             "my-app-db",
             @configuration.symbolize_keys.merge(
+              env_name: "test",
+              name: "primary",
               encoding: "utf8",
               collation: "ja_JP.UTF8",
               ctype: "ja_JP.UTF8"
@@ -84,7 +86,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+      mock.expect(:call, nil, [{ env_name: "default_env", name: "primary", adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
       mock.expect(:call, nil, [db_config])
 
       ActiveRecord::Base.stub(:lease_connection, @connection) do
@@ -155,6 +157,8 @@ module ActiveRecord
           ActiveRecord::Base,
           :establish_connection,
           [
+            env_name: "test",
+            name: "primary",
             adapter: "postgresql",
             database: "postgres",
             schema_search_path: "public"
@@ -219,7 +223,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+      mock.expect(:call, nil, [{ env_name: "default_env", name: "primary", adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
       mock.expect(:call, nil, [db_config])
 
       with_stubbed_connection do
@@ -247,7 +251,7 @@ module ActiveRecord
           assert_called_with(
             @connection,
             :create_database,
-            ["my-app-db", @configuration.symbolize_keys.merge(encoding: "utf8")]
+            ["my-app-db", @configuration.symbolize_keys.merge(env_name: "test", name: "primary", encoding: "utf8")]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.purge @configuration
           end
@@ -259,7 +263,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+      mock.expect(:call, nil, [{ env_name: "default_env", name: "primary", adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
       mock.expect(:call, nil, [db_config])
 
       with_stubbed_connection do

--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -60,7 +60,7 @@ module ActiveRecord
         ActiveRecord::Tasks::DatabaseTasks.create @configuration, "/rails/root"
       end
 
-      assert_equal [@configuration.symbolize_keys], calls.map { |c| c.first.configuration_hash }
+      assert_equal [@configuration.symbolize_keys.merge(env_name: "test", name: "primary")], calls.map { |c| c.first.configuration_hash }
     end
 
     def test_db_create_with_error_prints_message

--- a/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [adapter: "trilogy", database: nil])
+      mock.expect(:call, nil, [env_name: "default_env", name: "primary", adapter: "trilogy", database: nil])
       mock.expect(:call, nil, [db_config])
 
       ActiveRecord::Base.stub(:lease_connection, @connection) do

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -181,7 +181,7 @@ module ActiveRecord
           assert_equal handler, ActiveRecord::Base.connection_handler
 
           assert_not_nil pool = handler.retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal({ adapter: "postgresql", database: "bar", host: "localhost" }, pool.db_config.configuration_hash)
+          assert_equal({ env_name: "default_env", name: "primary", adapter: "postgresql", database: "bar", host: "localhost" }, pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
@@ -200,7 +200,7 @@ module ActiveRecord
           assert_equal handler, ActiveRecord::Base.connection_handler
 
           assert_not_nil pool = handler.retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal(config, pool.db_config.configuration_hash)
+          assert_equal(config.merge(env_name: "default_env", name: "primary"), pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
@@ -232,7 +232,7 @@ module ActiveRecord
           assert_equal handler, ActiveRecord::Base.connection_handler
 
           assert_not_nil pool = handler.retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal(config["default_env"]["animals"], pool.db_config.configuration_hash)
+          assert_equal(config["default_env"]["animals"].merge(env_name: "default_env", name: "animals"), pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -258,7 +258,7 @@ module ActiveRecord
           assert_equal handler, ActiveRecord::Base.connection_handler
 
           assert_not_nil pool = handler.retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal(config["default_env"]["primary"], pool.db_config.configuration_hash)
+          assert_equal(config["default_env"]["primary"].merge(env_name: "default_env", name: "primary"), pool.db_config.configuration_hash)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -51,7 +51,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config = { "not_production" => {  "adapter" => "abstract", "database" => "not_foo" } }
         actual = resolve_db_config(:default_env, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+        expected = { env_name: "default_env", name: "primary", adapter: "postgresql", database: "foo", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -62,7 +62,7 @@ module ActiveRecord
 
         config = { "not_production" => { "adapter" => "abstract", "database" => "not_foo" } }
         actual = resolve_db_config(:foo, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+        expected = { env_name: "foo", name: "primary", adapter: "postgresql", database: "foo", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -71,7 +71,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "foo"
         config = { "foo" => { "adapter" => "postgresql", "url" => ENV["DATABASE_URL"] } }
         actual = resolve_db_config(:foo, config)
-        expected_config = { adapter: "postgresql" }
+        expected_config = { env_name: "foo", name: "primary", adapter: "postgresql" }
 
         assert_equal expected_config, actual.configuration_hash
       end
@@ -82,7 +82,7 @@ module ActiveRecord
 
         config = { "not_production" => { "adapter" => "abstract", "database" => "not_foo" } }
         actual = resolve_db_config(:foo, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+        expected = { env_name: "foo", name: "primary", adapter: "postgresql", database: "foo", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -91,7 +91,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config = { "production" => { "adapter" => "abstract", "database" => "not_foo", "host" => "localhost" } }
         actual = resolve_db_config(:production, config)
-        expected = { adapter: "abstract", database: "not_foo", host: "localhost" }
+        expected = { env_name: "production", name: "primary", adapter: "abstract", database: "not_foo", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -102,7 +102,7 @@ module ActiveRecord
 
         config = { "production" => { "adapter" => "postgresql", "database" => "foo_prod" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
         actual = resolve_db_config(:test, config)
-        expected = { adapter: "postgresql", database: "foo_test", host: "localhost" }
+        expected = { env_name: "test", name: "primary", adapter: "postgresql", database: "foo_test", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -119,7 +119,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "abstract://not-localhost/not_foo"
         config = { "production" => {  "adapter" => "abstract", "database" => "also_not_foo" } }
         actual = resolve_db_config("postgres://localhost/foo", config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost" }
+        expected = { env_name: "default_env", name: "primary", adapter: "postgresql", database: "foo", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -130,7 +130,7 @@ module ActiveRecord
 
         config = { "test" => { "adapter" => "postgres", "database" => "not_foo", "host" => "localhost" } }
         actual = resolve_db_config(:test, config)
-        expected = { adapter: "postgres", database: "foo", host: "localhost" }
+        expected = { env_name: "test", name: "primary", adapter: "postgres", database: "foo", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -138,19 +138,19 @@ module ActiveRecord
       def test_jdbc_url
         config   = { "production" => { "adapter" => "abstract", "url" => "jdbc:postgres://localhost/foo" } }
         actual   = resolve_config(config, "production")
-        assert_equal config["production"].symbolize_keys, actual
+        assert_equal config["production"].symbolize_keys.merge(env_name: "production", name: "primary"), actual
       end
 
       def test_http_url
         config   = { "production" => { "adapter" => "abstract", "url" => "http://example.com/path" } }
         actual   = resolve_config(config, "production")
-        assert_equal config["production"].symbolize_keys, actual
+        assert_equal config["production"].symbolize_keys.merge(env_name: "production", name: "primary"), actual
       end
 
       def test_https_url
         config   = { "production" => { "adapter" => "abstract", "url" => "https://example.com" } }
         actual   = resolve_config(config, "production")
-        assert_equal config["production"].symbolize_keys, actual
+        assert_equal config["production"].symbolize_keys.merge(env_name: "production", name: "primary"), actual
       end
 
       def test_environment_does_not_exist_in_config_url_does_exist
@@ -158,6 +158,8 @@ module ActiveRecord
         config      = { "not_default_env" => { "adapter" => "abstract", "database" => "not_foo" } }
         actual      = resolve_config(config, "default_env")
         expect_prod = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost"
@@ -171,7 +173,7 @@ module ActiveRecord
         ENV["DATABASE_URL"] = "ibm-db://localhost/foo"
         config = { "default_env" => { "adapter" => "abstract", "database" => "not_foo", "host" => "localhost" } }
         actual = resolve_db_config(:default_env, config)
-        expected = { adapter: "ibm_db", database: "foo", host: "localhost" }
+        expected = { env_name: "default_env", name: "primary", adapter: "ibm_db", database: "foo", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -180,6 +182,8 @@ module ActiveRecord
         config   = { "default_env" => "postgres://localhost/foo" }
         actual   = resolve_config(config, "default_env")
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost"
@@ -192,6 +196,8 @@ module ActiveRecord
         config   = { "default_env" => { "url" => "postgres://localhost/foo" } }
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost"
@@ -210,14 +216,14 @@ module ActiveRecord
       def test_url_with_equals_in_query_value
         config   = { "default_env" => { "url" => "postgresql://localhost/foo?options=-cmyoption=on" } }
         actual   = resolve_config(config)
-        expected = { options: "-cmyoption=on", adapter: "postgresql", database: "foo", host: "localhost" }
+        expected = { env_name: "default_env", name: "primary", adapter: "postgresql", database: "foo", host: "localhost", options: "-cmyoption=on" }
         assert_equal expected, actual
       end
 
       def test_hash
         config = { "production" => { "adapter" => "postgresql", "database" => "foo" } }
         actual = resolve_config(config, "production")
-        assert_equal config["production"].symbolize_keys, actual
+        assert_equal config["production"].symbolize_keys.merge(env_name: "production", name: "primary"), actual
       end
 
       def test_blank
@@ -232,6 +238,8 @@ module ActiveRecord
         config   = {}
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost"
@@ -247,6 +255,8 @@ module ActiveRecord
         config   = {}
         actual   = resolve_config(config)
         expected = {
+          env_name: "not_production",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost"
@@ -262,6 +272,8 @@ module ActiveRecord
         config   = {}
         actual   = resolve_config(config)
         expected = {
+          env_name: "not_production",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost"
@@ -276,6 +288,8 @@ module ActiveRecord
         config   = {}
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "::1",
@@ -291,6 +305,8 @@ module ActiveRecord
         config   = { "default_env" => { "url" => "postgres://localhost/foo" } }
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost"
@@ -305,11 +321,15 @@ module ActiveRecord
         config   = { "default_env" => { "adapter" => "abstract", "database" => "foo" }, "other_env" => { "url" => "postgres://foohost/bardb" } }
         expected = {
           default_env: {
+            env_name: "default_env",
+            name: "primary",
             database: "baz",
             adapter: "postgresql",
             host: "localhost"
           },
           other_env: {
+            env_name: "other_env",
+            name: "primary",
             adapter: "postgresql",
             database: "bardb",
             host: "foohost"
@@ -326,6 +346,8 @@ module ActiveRecord
         config   = { "default_env" => { "adapter" => "abstract", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
@@ -341,6 +363,8 @@ module ActiveRecord
         config   = { "default_env" => { "adapter" => "abstract", "database" => "NOT-FOO", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
@@ -356,6 +380,8 @@ module ActiveRecord
         config   = { "default_env" => { "adapter" => "postgresql", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
@@ -371,6 +397,8 @@ module ActiveRecord
         config   = { "default_env" => { "adapter" => "abstract", "max_connections" => 5 } }
         actual   = resolve_config(config)
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
@@ -393,6 +421,8 @@ module ActiveRecord
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         actual = configs.configs_for(env_name: "default_env", name: "primary").configuration_hash
         expected = {
+          env_name: "default_env",
+          name: "primary",
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
@@ -403,7 +433,7 @@ module ActiveRecord
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         actual = configs.configs_for(env_name: "default_env", name: "animals").configuration_hash
-        expected = { adapter: "abstract", max_connections: 5 }
+        expected = { env_name: "default_env", name: "animals", adapter: "abstract", max_connections: 5 }
 
         assert_equal expected, actual
       end
@@ -437,11 +467,13 @@ module ActiveRecord
         config = { "production" => { "adapter" => "abstract", "database" => "not_foo", "host" => "localhost" }, "default_env" => {} }
 
         actual = resolve_db_config(:production, config)
-        assert_equal config["production"].symbolize_keys, actual.configuration_hash
+        assert_equal config["production"].symbolize_keys.merge(env_name: "production", name: "primary"), actual.configuration_hash
 
         actual = resolve_db_config(:default_env, config)
 
         assert_equal({
+          env_name: "default_env",
+          name: "primary",
           host: "localhost",
           database: "foo",
           adapter: "postgresql",
@@ -453,7 +485,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "production"
 
         actual = resolve_db_config(:production, {})
-        expected = { adapter: "mysql2", database: "exampledb", host: "localhost" }
+        expected = { env_name: "production", name: "primary", adapter: "mysql2", database: "exampledb", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -463,7 +495,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "production"
 
         actual = resolve_db_config(:production, {})
-        expected = { adapter: "unknown", database: "exampledb", host: "localhost" }
+        expected = { env_name: "production", name: "primary", adapter: "unknown", database: "exampledb", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -474,7 +506,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "production"
 
         actual = resolve_db_config(:production, {})
-        expected = { adapter: "postgresql", database: "exampledb", host: "localhost" }
+        expected = { env_name: "production", name: "primary", adapter: "postgresql", database: "exampledb", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -485,7 +517,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "production"
 
         actual = resolve_db_config(:production, {})
-        expected = { adapter: "postgresql", database: "exampledb", host: "localhost" }
+        expected = { env_name: "production", name: "primary", adapter: "postgresql", database: "exampledb", host: "localhost" }
 
         assert_equal expected, actual.configuration_hash
       end
@@ -496,7 +528,7 @@ module ActiveRecord
         ENV["RAILS_ENV"] = "production"
 
         actual = resolve_db_config(:production, {})
-        expected = { adapter: "sqlite3", database: "/path/to/db.sqlite3" }
+        expected = { env_name: "production", name: "primary", adapter: "sqlite3", database: "/path/to/db.sqlite3" }
 
         assert_equal expected, actual.configuration_hash
       end

--- a/activerecord/test/cases/database_configurations/resolver_test.rb
+++ b/activerecord/test/cases/database_configurations/resolver_test.rb
@@ -26,6 +26,8 @@ module ActiveRecord
           pool_config = resolve_db_config :production, "production" => "abstract://foo?encoding=utf8"
 
           assert_equal({
+            env_name: "production",
+            name: "primary",
             adapter:  "abstract",
             host:     "foo",
             encoding: "utf8"
@@ -36,6 +38,8 @@ module ActiveRecord
           pool_config = resolve_db_config :production, "production" => { "url" => "abstract://foo?encoding=utf8" }
 
           assert_equal({
+            env_name: "production",
+            name: "primary",
             adapter:  "abstract",
             host:     "foo",
             encoding: "utf8"
@@ -47,6 +51,8 @@ module ActiveRecord
           pool_config = resolve_db_config :production, "production" => hash
 
           assert_equal({
+            env_name: "production",
+            name: "primary",
             adapter:         "abstract",
             host:            "foo",
             encoding:        "utf8",
@@ -59,6 +65,8 @@ module ActiveRecord
           pool_config = resolve_db_config :production, "production" => hash
 
           assert_equal({
+            env_name: "production",
+            name: "primary",
             adapter:  "abstract",
             user:     "user",
             password: "passwd",
@@ -69,6 +77,8 @@ module ActiveRecord
         def test_url_host_no_db
           pool_config = resolve_db_config "abstract://foo?encoding=utf8"
           assert_equal({
+            env_name: "test",
+            name: "primary",
             adapter:  "abstract",
             host:     "foo",
             encoding: "utf8"
@@ -84,6 +94,8 @@ module ActiveRecord
         def test_url_host_db
           pool_config = resolve_db_config "abstract://foo/bar?encoding=utf8"
           assert_equal({
+            env_name: "test",
+            name: "primary",
             adapter:  "abstract",
             database: "bar",
             host:     "foo",
@@ -95,6 +107,8 @@ module ActiveRecord
           pool_config = resolve_db_config "abstract://foo:123?encoding=utf8"
 
           assert_equal({
+            env_name: "test",
+            name: "primary",
             adapter:  "abstract",
             port:     123,
             host:     "foo",
@@ -137,6 +151,8 @@ module ActiveRecord
           pool_config = resolve_db_config :production, "production" => { "url" => "sqlite3:foo?encoding=utf8" }
 
           assert_equal({
+            env_name: "production",
+            name: "primary",
             adapter:  "sqlite3",
             database: "foo",
             encoding: "utf8"

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -53,6 +53,80 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     assert_equal "primary", config.name
   end
 
+  def test_configuration_hash_includes_env_name_and_name
+    configs = ActiveRecord::DatabaseConfigurations.new({
+      "development" => {
+        "primary" => {
+          "adapter" => "sqlite3",
+          "database" => "db/development.sqlite3"
+        }
+      },
+      "production" => {
+        "secondary" => {
+          "adapter" => "sqlite3",
+          "database" => "db/production_secondary.sqlite3"
+        }
+      }
+    })
+
+    config = configs.configs_for(env_name: "production", name: "secondary")
+    hash = config.configuration_hash
+
+    assert_equal "production", hash[:env_name]
+    assert_equal "secondary", hash[:name]
+  end
+
+  def test_resolve_with_configuration_hash_preserves_env_name_and_name
+    configs = ActiveRecord::DatabaseConfigurations.new({
+      "development" => {
+        "primary" => {
+          "adapter" => "sqlite3",
+          "database" => "db/development.sqlite3"
+        }
+      },
+      "production" => {
+        "secondary" => {
+          "adapter" => "sqlite3",
+          "database" => "db/production_secondary.sqlite3"
+        }
+      }
+    })
+
+    config = configs.configs_for(env_name: "production", name: "secondary")
+    hash = config.configuration_hash
+
+    resolved = configs.resolve(hash)
+
+    assert_equal "production", resolved.env_name
+    assert_equal "secondary", resolved.name
+  end
+
+  def test_initialize_with_configuration_hash_preserves_env_name_and_name
+    configs = ActiveRecord::DatabaseConfigurations.new({
+      "development" => {
+        "primary" => {
+          "adapter" => "sqlite3",
+          "database" => "db/development.sqlite3"
+        }
+      },
+      "production" => {
+        "secondary" => {
+          "adapter" => "sqlite3",
+          "database" => "db/production_secondary.sqlite3"
+        }
+      }
+    })
+
+    config = configs.configs_for(env_name: "production", name: "secondary")
+    hash = config.configuration_hash
+
+    new_configs = ActiveRecord::DatabaseConfigurations.new({ "production" => hash })
+    new_config = new_configs.configs_for(env_name: "production", name: "secondary")
+
+    assert_equal "production", new_config.env_name
+    assert_equal "secondary", new_config.name
+  end
+
   def test_find_db_config_returns_first_config_for_env
     config = ActiveRecord::DatabaseConfigurations.new({
         "test" => {

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -23,6 +23,8 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   def test_config_with_db_config_only
     config_sample = {
       "test" => {
+        "env_name" => "test",
+        "name" => "primary",
         "adapter" => "sqlite3",
         "host" => "localhost",
         "port" => "9000",
@@ -49,6 +51,8 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   def test_config_with_database_url_only
     ENV["DATABASE_URL"] = "postgresql://foo:bar@localhost:9000/foo_test?max_connections=5&timeout=3000"
     expected = {
+      env_name:        "test",
+      name:            "primary",
       adapter:         "postgresql",
       host:            "localhost",
       port:            9000,


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Closes https://github.com/rails/rails/issues/56260.

When passing a hash to `ActiveRecord::Base.establish_connection` (e.g., from `configuration_hash`), the connection always defaults to the primary database instead of preserving the original database name and environment. This makes it impossible to programmatically switch between shards or non-primary databases using configuration hashes like you can with `DatabaseConfig`/`HashConfig` objects.

### Detail

This Pull Request changes two things:

1. `DatabaseConfig#configuration_hash` now includes `env_name` and `name` so the configuration state is preserved when re-establishing connections
2. `DatabaseConfigurations#build_configs` (used by `#initialize`) and `#resolve`  now check for `name` in the hash first before defaulting to "primary", and the latter also checks for `env_name` in the  hash first before defaulting to the Rails environment.

This ensures that `establish_connection(db_config.configuration_hash)` behaves identically to `establish_connection(db_config)` for non-primary databases.

<!-- ### Additional information -->

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.