### PR TITLE
Fix ActiveStorage logging success when blobs failed to upload

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `LogSubscriber` to log error messages instead of success messages when storage operations fail with exceptions
+    (e.g., network errors uploading to S3).
+
+    Previously, operations like upload, download, and delete would log success messages (e.g., "Uploaded file to key: xxx")
+    even when they failed, because `ActiveSupport::Notifications` publishes events in an `ensure` block. Now the
+    `LogSubscriber` checks for exceptions in the event payload and logs appropriate error messages with the exception
+    class and message (e.g., "Failed to upload file to key: xxx (Net::OpenTimeout: execution expired)").
+
+    *Felipe Raul*
+
 *   `ActiveStorage::Blob#open` can now be used without passing a block, like `Tempfile.open`. When using this form the
     returned temporary file must be unlinked manually.
 

--- a/activestorage/lib/active_storage/log_subscriber.rb
+++ b/activestorage/lib/active_storage/log_subscriber.rb
@@ -7,51 +7,87 @@ module ActiveStorage
     self.namespace = "active_storage"
 
     def service_upload(event)
-      message = "Uploaded file to key: #{key_in(event)}"
-      message += " (checksum: #{event[:payload][:checksum]})" if event[:payload][:checksum]
-      info event, color(message, GREEN)
+      if event[:payload][:exception]
+        error event, color("Failed to upload file to key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        message = "Uploaded file to key: #{key_in(event)}"
+        message += " (checksum: #{event[:payload][:checksum]})" if event[:payload][:checksum]
+        info event, color(message, GREEN)
+      end
     end
     event_log_level :service_upload, :info
 
     def service_download(event)
-      info event, color("Downloaded file from key: #{key_in(event)}", BLUE)
+      if event[:payload][:exception]
+        error event, color("Failed to download file from key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        info event, color("Downloaded file from key: #{key_in(event)}", BLUE)
+      end
     end
     event_log_level :service_download, :info
 
     def service_streaming_download(event)
-      info event, color("Downloaded file from key: #{key_in(event)}", BLUE)
+      if event[:payload][:exception]
+        error event, color("Failed to download file from key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        info event, color("Downloaded file from key: #{key_in(event)}", BLUE)
+      end
     end
     event_log_level :service_streaming_download, :info
 
     def preview(event)
-      info event, color("Previewed file from key: #{key_in(event)}", BLUE)
+      if event[:payload][:exception]
+        error event, color("Failed to preview file from key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        info event, color("Previewed file from key: #{key_in(event)}", BLUE)
+      end
     end
     event_log_level :preview, :info
 
     def service_delete(event)
-      info event, color("Deleted file from key: #{key_in(event)}", RED)
+      if event[:payload][:exception]
+        error event, color("Failed to delete file from key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        info event, color("Deleted file from key: #{key_in(event)}", RED)
+      end
     end
     event_log_level :service_delete, :info
 
     def service_delete_prefixed(event)
-      info event, color("Deleted files by key prefix: #{event[:payload][:prefix]}", RED)
+      if event[:payload][:exception]
+        error event, color("Failed to delete files by key prefix: #{event[:payload][:prefix]}#{exception_info(event)}", RED)
+      else
+        info event, color("Deleted files by key prefix: #{event[:payload][:prefix]}", RED)
+      end
     end
     event_log_level :service_delete_prefixed, :info
 
     def service_exist(event)
-      debug event, color("Checked if file exists at key: #{key_in(event)} (#{event[:payload][:exist] ? "yes" : "no"})", BLUE)
+      if event[:payload][:exception]
+        error event, color("Failed to check if file exists at key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        debug event, color("Checked if file exists at key: #{key_in(event)} (#{event[:payload][:exist] ? "yes" : "no"})", BLUE)
+      end
     end
     event_log_level :service_exist, :debug
 
     def service_url(event)
-      debug event, color("Generated URL for file at key: #{key_in(event)} (#{event[:payload][:url]})", BLUE)
+      if event[:payload][:exception]
+        error event, color("Failed to generate URL for file at key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        debug event, color("Generated URL for file at key: #{key_in(event)} (#{event[:payload][:url]})", BLUE)
+      end
     end
     event_log_level :service_url, :debug
 
     def service_mirror(event)
-      message = "Mirrored file at key: #{key_in(event)}"
-      message += " (checksum: #{event[:payload][:checksum]})" if event[:payload][:checksum]
-      debug event, color(message, GREEN)
+      if event[:payload][:exception]
+        error event, color("Failed to mirror file at key: #{key_in(event)}#{exception_info(event)}", RED)
+      else
+        message = "Mirrored file at key: #{key_in(event)}"
+        message += " (checksum: #{event[:payload][:checksum]})" if event[:payload][:checksum]
+        debug event, color(message, GREEN)
+      end
     end
     event_log_level :service_mirror, :debug
 
@@ -68,12 +104,21 @@ module ActiveStorage
         super log_prefix_for_service(event) + colored_message
       end
 
+      def error(event, colored_message)
+        super log_prefix_for_service(event) + colored_message
+      end
+
       def log_prefix_for_service(event)
         color "  #{event[:payload][:service]} Storage (#{event[:payload][:duration_ms].round(1)}ms) ", CYAN
       end
 
       def key_in(event)
         event[:payload][:key]
+      end
+
+      def exception_info(event)
+        exception_class, exception_message = event[:payload][:exception]
+        " (#{exception_class}: #{exception_message})"
       end
   end
 end

--- a/activestorage/lib/active_storage/structured_event_subscriber.rb
+++ b/activestorage/lib/active_storage/structured_event_subscriber.rb
@@ -5,72 +5,90 @@ require "active_support/structured_event_subscriber"
 module ActiveStorage
   class StructuredEventSubscriber < ActiveSupport::StructuredEventSubscriber # :nodoc:
     def service_upload(event)
-      emit_event("active_storage.service_upload",
+      payload = {
         key: event.payload[:key],
         checksum: event.payload[:checksum],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_event("active_storage.service_upload", payload)
     end
 
     def service_download(event)
-      emit_event("active_storage.service_download",
+      payload = {
         key: event.payload[:key],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_event("active_storage.service_download", payload)
     end
 
     def service_streaming_download(event)
-      emit_event("active_storage.service_streaming_download",
+      payload = {
         key: event.payload[:key],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_event("active_storage.service_streaming_download", payload)
     end
 
     def preview(event)
-      emit_event("active_storage.preview",
+      payload = {
         key: event.payload[:key],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_event("active_storage.preview", payload)
     end
 
     def service_delete(event)
-      emit_event("active_storage.service_delete",
+      payload = {
         key: event.payload[:key],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_event("active_storage.service_delete", payload)
     end
 
     def service_delete_prefixed(event)
-      emit_event("active_storage.service_delete_prefixed",
+      payload = {
         prefix: event.payload[:prefix],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_event("active_storage.service_delete_prefixed", payload)
     end
 
     def service_exist(event)
-      emit_debug_event("active_storage.service_exist",
+      payload = {
         key: event.payload[:key],
         exist: event.payload[:exist],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_debug_event("active_storage.service_exist", payload)
     end
     debug_only :service_exist
 
     def service_url(event)
-      emit_debug_event("active_storage.service_url",
+      payload = {
         key: event.payload[:key],
         url: event.payload[:url],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_debug_event("active_storage.service_url", payload)
     end
     debug_only :service_url
 
     def service_mirror(event)
-      emit_debug_event("active_storage.service_mirror",
+      payload = {
         key: event.payload[:key],
         checksum: event.payload[:checksum],
         duration_ms: event.duration.round(2),
-      )
+      }
+      payload[:exception] = event.payload[:exception] if event.payload[:exception]
+      emit_debug_event("active_storage.service_mirror", payload)
     end
     debug_only :service_mirror
   end

--- a/activestorage/test/log_subscriber_test.rb
+++ b/activestorage/test/log_subscriber_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "minitest/mock"
 require "active_support/log_subscriber/test_helper"
 require "active_support/testing/event_reporter_assertions"
 require "active_storage/structured_event_subscriber"
@@ -34,6 +35,20 @@ module ActiveStorage
       assert_match(/Uploaded file/, @logger.logged(:info).first)
     end
 
+    test "service_upload logs failure when exception occurs" do
+      error = StandardError.new("Storage connection failed")
+
+      IO.stub(:copy_stream, ->(*) { raise error }) do
+        assert_raises(StandardError) do
+          User.create!(name: "Test", avatar: { io: StringIO.new("test"), filename: "avatar.jpg" })
+        end
+      end
+
+      assert_no_match(/Uploaded file/, @logger.logged(:info).join)
+      assert_equal 1, @logger.logged(:error).count
+      assert_match(/Failed to upload file/, @logger.logged(:error).first)
+    end
+
     test "service_download" do
       blob = create_blob(filename: "avatar.jpg")
       user = User.create!(name: "Test", avatar: blob)
@@ -44,6 +59,24 @@ module ActiveStorage
       assert_match(/Downloaded file/, @logger.logged(:info).last)
     end
 
+    test "service_download logs failure when exception occurs" do
+      blob = create_blob(filename: "avatar.jpg")
+      user = User.create!(name: "Test", avatar: blob)
+      @logger.clear
+
+      error = StandardError.new("Storage read failed")
+
+      File.stub(:binread, ->(*) { raise error }) do
+        assert_raises(StandardError) do
+          user.avatar.download
+        end
+      end
+
+      assert_no_match(/Downloaded file/, @logger.logged(:info).join)
+      assert_equal 1, @logger.logged(:error).count
+      assert_match(/Failed to download file/, @logger.logged(:error).first)
+    end
+
     test "service_streaming_download" do
       blob = create_blob(filename: "avatar.jpg")
       user = User.create!(name: "Test", avatar: blob)
@@ -52,6 +85,32 @@ module ActiveStorage
 
       assert_equal 2, @logger.logged(:info).count
       assert_match(/Downloaded file/, @logger.logged(:info).last)
+    end
+
+    test "service_streaming_download logs failure when exception occurs" do
+      blob = create_blob(filename: "avatar.jpg")
+      user = User.create!(name: "Test", avatar: blob)
+      @logger.clear
+
+      error = StandardError.new("Storage stream failed")
+
+      # stream method uses File.open inside the instrument block
+      original_open = File.method(:open)
+      File.stub(:open, ->(path, *args, &block) {
+        if path.include?(user.avatar.key)
+          raise error
+        else
+          original_open.call(path, *args, &block)
+        end
+      }) do
+        assert_raises(StandardError) do
+          user.avatar.download { }
+        end
+      end
+
+      assert_no_match(/Downloaded file/, @logger.logged(:info).join)
+      assert_equal 1, @logger.logged(:error).count
+      assert_match(/Failed to download file/, @logger.logged(:error).first)
     end
 
     test "preview" do
@@ -74,6 +133,24 @@ module ActiveStorage
       assert_match(/Deleted file/, @logger.logged(:info).last)
     end
 
+    test "service_delete logs failure when exception occurs" do
+      blob = create_blob(filename: "avatar.jpg")
+      user = User.create!(name: "Test", avatar: blob)
+      @logger.clear
+
+      error = StandardError.new("Storage delete failed")
+
+      File.stub(:delete, ->(*) { raise error }) do
+        assert_raises(StandardError) do
+          user.avatar.service.delete(user.avatar.key)
+        end
+      end
+
+      assert_no_match(/Deleted file/, @logger.logged(:info).join)
+      assert_equal 1, @logger.logged(:error).count
+      assert_match(/Failed to delete file/, @logger.logged(:error).first)
+    end
+
     test "service_delete_prefixed" do
       blob = create_file_blob(fixture: "colors.bmp")
       user = User.create!(name: "Test", avatar: blob)
@@ -82,6 +159,24 @@ module ActiveStorage
 
       assert_equal 3, @logger.logged(:info).count
       assert_match(/Deleted files by key prefix/, @logger.logged(:info).last)
+    end
+
+    test "service_delete_prefixed logs failure when exception occurs" do
+      blob = create_blob(filename: "avatar.jpg")
+      user = User.create!(name: "Test", avatar: blob)
+      @logger.clear
+
+      error = StandardError.new("Storage delete prefixed failed")
+
+      Dir.stub(:glob, ->(*) { raise error }) do
+        assert_raises(StandardError) do
+          user.avatar.service.delete_prefixed("test-prefix/")
+        end
+      end
+
+      assert_no_match(/Deleted files by key prefix/, @logger.logged(:info).join)
+      assert_equal 1, @logger.logged(:error).count
+      assert_match(/Failed to delete files by key prefix/, @logger.logged(:error).first)
     end
 
     test "service_exist" do
@@ -94,6 +189,24 @@ module ActiveStorage
       assert_match(/Checked if file exists/, @logger.logged(:debug).last)
     end
 
+    test "service_exist logs failure when exception occurs" do
+      blob = create_blob(filename: "avatar.jpg")
+      user = User.create!(name: "Test", avatar: blob)
+      @logger.clear
+
+      error = StandardError.new("Storage exist check failed")
+
+      File.stub(:exist?, ->(*) { raise error }) do
+        assert_raises(StandardError) do
+          user.avatar.service.exist?(user.avatar.key)
+        end
+      end
+
+      assert_no_match(/Checked if file exists/, @logger.logged(:debug).join)
+      assert_equal 1, @logger.logged(:error).count
+      assert_match(/Failed to check if file exists/, @logger.logged(:error).first)
+    end
+
     test "service_url" do
       blob = create_blob(filename: "avatar.jpg")
       user = User.create!(name: "Test", avatar: blob)
@@ -102,6 +215,25 @@ module ActiveStorage
 
       assert_equal 1, @logger.logged(:debug).count
       assert_match(/Generated URL for file/, @logger.logged(:debug).last)
+    end
+
+    test "service_url logs failure when exception occurs" do
+      blob = create_blob(filename: "avatar.jpg")
+      user = User.create!(name: "Test", avatar: blob)
+      @logger.clear
+
+      error = StandardError.new("URL generation failed")
+
+      ActiveStorage.stub(:verifier, -> { raise error }) do
+        assert_raises(StandardError) do
+          user.avatar.service.url(user.avatar.key, expires_in: 5.minutes, disposition: :inline,
+            filename: ActiveStorage::Filename.new("test.jpg"), content_type: "image/jpeg")
+        end
+      end
+
+      assert_no_match(/Generated URL for file/, @logger.logged(:debug).join)
+      assert_equal 1, @logger.logged(:error).count
+      assert_match(/Failed to generate URL for file/, @logger.logged(:error).first)
     end
 
     test "service_mirror" do
@@ -124,6 +256,38 @@ module ActiveStorage
 
       assert_equal 4, @logger.logged(:debug).count
       assert_match(/Mirrored file/, @logger.logged(:debug).last)
+    end
+
+    test "service_mirror logs failure when exception occurs" do
+      blob = create_blob(filename: "avatar.jpg")
+      @logger.clear
+
+      mirror_config = (1..3).to_h do |i|
+        [ "mirror_#{i}",
+          service: "Disk",
+          root: Dir.mktmpdir("active_storage_tests_mirror_#{i}") ]
+      end
+
+      config = mirror_config.merge \
+        mirror:  { service: "Mirror", primary: "primary", mirrors: mirror_config.keys },
+        primary: { service: "Disk", root: Dir.mktmpdir("active_storage_tests_primary") }
+
+      service = ActiveStorage::Service.configure :mirror, config
+      service.upload blob.key, StringIO.new(blob.download), checksum: blob.checksum
+      @logger.clear
+
+      error = StandardError.new("Mirror failed")
+
+      # Mirror uses IO.copy_stream inside instrument block
+      IO.stub(:copy_stream, ->(*) { raise error }) do
+        assert_raises(StandardError) do
+          service.mirror blob.key, checksum: blob.checksum
+        end
+      end
+
+      assert_no_match(/Mirrored file/, @logger.logged(:debug).join)
+      assert @logger.logged(:error).count >= 1
+      assert @logger.logged(:error).any? { |msg| msg.include?("Failed to mirror file") }
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Previously, storage operations like upload, download, and delete would log success messages instead of error messages when they failed with exceptions (e.g., network errors uploading to S3). 

Tests were added to make sure we log failure messages in these situations. 

### Detail

This happened because ActiveSupport::Notifications publishes events in an ensure block, so the messages were logged even tough exceptions happened. 

You can easily confirm this by turning off your Wifi and uploading a file to S3. You'll get an exception, but also a success message will be logged.

This can lead to long misleading debugging sessions because the file was never actually uploaded to S3, whilst you try to understand how / when it was deleted. 

This PR ads LogSubscriber checks for exceptions in the event payload and logs appropriate error messages including the exception class and message, e.g., "Failed to upload file to key: xxx (Net::OpenTimeout: execution expired)"

### Checklist

Before submitting the PR make sure the following are checked:

* [x ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x ] Tests are added or updated if you fix a bug or add a feature.
* [x ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
