### PR TITLE
Stub bundle install for ApiAppGeneratorTest

### DIFF
--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -144,6 +144,9 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     generator [destination_root], ["--api"]
     run_generator_instance
 
+    assert_equal 1, @bundle_commands.count("binstubs kamal")
+    assert_equal 1, @bundle_commands.count("exec kamal init")
+
     assert_file "config/deploy.yml" do |content|
       assert_no_match(/asset_path:/, content)
       assert_no_match(/public\/assets/, content)
@@ -151,6 +154,15 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
   end
 
   private
+    def run_generator_instance
+      @bundle_commands = []
+      bundle_command_stub = -> (command, *) { @bundle_commands << command }
+
+      generator.stub :bundle_command, bundle_command_stub do
+        super
+      end
+    end
+
     def default_files
       %w(.gitignore
         .ruby-version


### PR DESCRIPTION
This commit removes the dependency on `bundle install` to test the Api generator for the kamal test in this file.

Follows the establish pattern in other tests, like PluginGeneratorTest and ActionTest::Generators::InstallGeneratorTest.

Prior to this change, the test would pass but takes ~2s longer to finish on my machine, and outputs many logs.

```
bin/test test/generators/api_app_generator_test.rb:143
Run options: --seed 19606

 # Running:

Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.0.10
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.1.6
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-7.2.3
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.0.4
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
  * rails-8.1.1
Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.0.10
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.1.6
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-7.2.3
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.0.4
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
  * rails-8.1.1
Could not find gem 'rails (~> 8.2.0.alpha)' in locally installed gems.
bundler: failed to load command: kamal (/home/zzak/.rbenv/versions/3.4.7/bin/kamal)
/home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/resolver.rb:356:in 'Bundler::Resolver#raise_not_found!': Could not find gem 'rails (~> 8.2.0.alpha)' in locally installed gems. (Bundler::GemNotFound)
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/resolver.rb:450:in 'block in Bundler::Resolver#prepare_dependencies'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/resolver.rb:425:in 'Hash#each'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/resolver.rb:425:in 'Enumerable#filter_map'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/resolver.rb:425:in 'Bundler::Resolver#prepare_dependencies'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/resolver.rb:63:in 'Bundler::Resolver#setup_solver'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/resolver.rb:28:in 'Bundler::Resolver#start'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/definition.rb:744:in 'Bundler::Definition#start_resolution'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/definition.rb:344:in 'Bundler::Definition#resolve'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/definition.rb:653:in 'Bundler::Definition#materialize'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/definition.rb:239:in 'Bundler::Definition#specs'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/definition.rb:306:in 'Bundler::Definition#specs_for'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/runtime.rb:18:in 'Bundler::Runtime#setup'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler.rb:166:in 'Bundler.setup'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/setup.rb:32:in 'block in <top (required)>'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/ui/shell.rb:173:in 'Bundler::UI::Shell#with_level'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/ui/shell.rb:119:in 'Bundler::UI::Shell#silence'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/setup.rb:32:in '<top (required)>'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/cli/exec.rb:57:in 'Kernel#require_relative'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/cli/exec.rb:57:in 'Bundler::CLI::Exec#kernel_load'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/cli.rb:456:in 'Bundler::CLI#exec'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/exe/bundle:28:in 'block in <main>'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
        from /home/zzak/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/exe/bundle:20:in '<main>'
.

Finished in 2.966518s, 0.3371 runs/s, 2.0226 assertions/s.
1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

After:

```
bin/test test/generators/api_app_generator_test.rb:143
Run options: --seed 19429

 # Running:

.

Finished in 1.164370s, 0.8588 runs/s, 6.8707 assertions/s.
1 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```