### PR TITLE
[DOCS] Fix schematized json has_json example

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -8,7 +8,7 @@
 
     a = Account.new
     a.settings.restrict_creation_to_admins? # => true
-    a.max_invites = "100" # => Set to integer 100
+    a.settings.max_invites = "100" # => Set to integer 100
     a.settings = { "restrict_creation_to_admins" => "false", "max_invites" => "500", "greeting" => "goodbye" }
     a.settings.greeting # => "goodbye"
     a.staff # => nil

--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -24,7 +24,7 @@ module ActiveModel
       #
       #   a = Account.new
       #   a.settings.restrict_creation_to_admins? # => true
-      #   a.max_invites = "100" # => Set to integer 100
+      #   a.settings.max_invites = "100" # => Set to integer 100
       #   a.settings = { "restrict_creation_to_admins" => "false", "max_invites" => "500", "greeting" => "goodbye" }
       #   a.settings.greeting # => "goodbye"
       #   a.flags.staff # => nil


### PR DESCRIPTION
The `has_json :settings` doesn't add store accessors (we have `has_delegated_json` for that), so there is no `account.max_invites = `.

