### PR TITLE
Move async execution into QueryIntent

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -76,7 +76,7 @@ module ActiveRecord
           name: name,
           binds: binds,
           prepare: preparable,
-          async: async,
+          allow_async: async,
           allow_retry: allow_retry
         )
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -83,11 +83,7 @@ module ActiveRecord
         intent.execute!
 
         if async
-          if async_enabled?
-            FutureResult.new(intent)
-          else
-            FutureResult.wrap(intent.cast_result)
-          end
+          intent.future_result
         else
           intent.cast_result
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -84,16 +84,12 @@ module ActiveRecord
             raise AsynchronousQueryInsideTransactionError, "Asynchronous queries are not allowed inside transactions"
           end
 
-          future_result = FutureResult::SelectAll.new(pool, intent)
+          future_result = FutureResult.new(intent)
           future_result.schedule!(ActiveRecord::Base.asynchronous_queries_session)
           future_result
         else
-          begin
-            intent.execute!
-            result = intent.cast_result
-          rescue ::RangeError
-            result = ActiveRecord::Result.empty
-          end
+          intent.execute!
+          result = intent.cast_result
 
           if async
             FutureResult.wrap(result)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1219,7 +1219,7 @@ module ActiveRecord
               name:              intent.name,
               binds:             intent.binds,
               type_casted_binds: intent.type_casted_binds,
-              async:             intent.async,
+              async:             intent.ran_async,
               allow_retry:       intent.allow_retry,
               connection:        self,
               transaction:       current_transaction.user_transaction.presence,

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -23,7 +23,7 @@ module ActiveRecord
                 batch: true,
                 binds: kwargs[:binds] || [],
                 prepare: kwargs[:prepare] || false,
-                async: kwargs[:async] || false,
+                allow_async: kwargs[:async] || false,
                 allow_retry: kwargs[:allow_retry] || false,
                 materialize_transactions: kwargs[:materialize_transactions] != false
               )

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -217,7 +217,7 @@ module ActiveRecord
               batch: true,
               binds: kwargs[:binds] || [],
               prepare: kwargs[:prepare] || false,
-              async: kwargs[:async] || false,
+              allow_async: kwargs[:async] || false,
               allow_retry: kwargs[:allow_retry] || false,
               materialize_transactions: kwargs[:materialize_transactions] != false
             )

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -273,7 +273,7 @@ module ActiveRecord
 
           sql = raw_sql
 
-          # We call tranformers after the write checks so we don't need to parse the
+          # We call transformers after the write checks so we don't need to parse the
           # transformed result (which probably just adds comments we'd need to ignore).
           # This means we assume no transformer will change a read into a write.
           ActiveRecord.query_transformers&.each do |transformer|

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -152,7 +152,7 @@ module ActiveRecord
               batch: true,
               binds: kwargs[:binds] || [],
               prepare: kwargs[:prepare] || false,
-              async: kwargs[:async] || false,
+              allow_async: kwargs[:async] || false,
               allow_retry: kwargs[:allow_retry] || false,
               materialize_transactions: kwargs[:materialize_transactions] != false
             )

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -74,7 +74,7 @@ module ActiveRecord
                 batch: true,
                 binds: kwargs[:binds] || [],
                 prepare: kwargs[:prepare] || false,
-                async: kwargs[:async] || false,
+                allow_async: kwargs[:async] || false,
                 allow_retry: kwargs[:allow_retry] || false,
                 materialize_transactions: kwargs[:materialize_transactions] != false
               )

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -25,31 +25,6 @@ module ActiveRecord
       end
     end
 
-    class EventBuffer
-      def initialize(future_result, instrumenter)
-        @future_result = future_result
-        @instrumenter = instrumenter
-        @events = []
-      end
-
-      def instrument(name, payload = {}, &block)
-        event = @instrumenter.new_event(name, payload)
-        begin
-          event.record(&block)
-        ensure
-          @events << event
-        end
-      end
-
-      def flush
-        events, @events = @events, []
-        events.each do |event|
-          event.payload[:lock_wait] = @future_result.lock_wait
-          ActiveSupport::Notifications.publish_event(event)
-        end
-      end
-    end
-
     Canceled = Class.new(ActiveRecordError)
 
     def self.wrap(result)
@@ -62,21 +37,10 @@ module ActiveRecord
     end
 
     delegate :empty?, :to_a, to: :result
+    delegate :lock_wait, to: :@intent
 
-    attr_reader :lock_wait
-
-    def initialize(pool, intent)
-      @mutex = Mutex.new
-
-      @session = nil
-      @pool = pool
+    def initialize(intent)
       @intent = intent
-
-      @pending = true
-      @error = nil
-      @result = nil
-      @instrumenter = ActiveSupport::Notifications.instrumenter
-      @event_buffer = nil
     end
 
     def then(&block)
@@ -84,106 +48,29 @@ module ActiveRecord
     end
 
     def schedule!(session)
-      @session = session
-      @intent.schedule!  # Preprocess query, then detach adapter
-      @pool.schedule_query(self)
-    end
-
-    def execute!(connection)
-      execute_query(connection)
-    end
-
-    def cancel
-      @pending = false
-      @error = Canceled
-      self
+      @intent.async_schedule!(session)
     end
 
     def execute_or_skip
-      return unless pending?
+      @intent.execute_or_skip
+    end
 
-      @session.synchronize do
-        return unless pending?
-
-        @pool.with_connection do |connection|
-          return unless @mutex.try_lock
-          begin
-            if pending?
-              @event_buffer = EventBuffer.new(self, @instrumenter)
-              ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] = @event_buffer
-
-              execute_query(connection, async: true)
-            end
-          ensure
-            @mutex.unlock
-          end
-        end
-      end
+    def cancel
+      @intent.cancel
     end
 
     def result
-      execute_or_wait
-      @event_buffer&.flush
+      raise Canceled if canceled?
 
-      if canceled?
-        raise Canceled
-      elsif @error
-        raise @error
-      else
-        @result
-      end
+      @intent.cast_result
     end
 
     def pending?
-      @pending && (!@session || @session.active?)
+      @intent.pending?
     end
 
     def canceled?
-      @session && !@session.active?
+      @intent.canceled?
     end
-
-    private
-      def execute_or_wait
-        if pending?
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
-          @mutex.synchronize do
-            if pending?
-              @pool.with_connection do |connection|
-                execute_query(connection)
-              end
-            else
-              @lock_wait = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - start)
-            end
-          end
-        else
-          @lock_wait = 0.0
-        end
-      end
-
-      def execute_query(connection, async: false)
-        # Update intent with actual executing adapter and async mode for accurate logging
-        @intent.adapter = connection
-        @intent.async = async
-
-        @result = exec_query(connection, @intent)
-      rescue => error
-        @error = error
-      ensure
-        @pending = false
-      end
-
-      def exec_query(connection, intent)
-        intent.execute!
-        intent.cast_result
-      end
-
-      class SelectAll < FutureResult # :nodoc:
-        private
-          def exec_query(*, **)
-            super
-          rescue ::RangeError
-            ActiveRecord::Result.empty
-          end
-      end
   end
 end

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -47,14 +47,6 @@ module ActiveRecord
       Promise.new(self, block)
     end
 
-    def schedule!(session)
-      @intent.async_schedule!(session)
-    end
-
-    def execute_or_skip
-      @intent.execute_or_skip
-    end
-
     def cancel
       @intent.cancel
     end

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -169,7 +169,7 @@ module ActiveRecord
         ActiveRecord::Base.connection.singleton_class.undef_method(:log)
 
         ActiveRecord::Base.connection.singleton_class.define_method(:log) do |intent, *args, **kwargs, &block|
-          unless intent.async
+          unless intent.ran_async
             return old_log.call(intent, *args, **kwargs, &block)
           end
 


### PR DESCRIPTION
FutureResult remains as the user-facing object, but is no longer directly involved in the actual execution process: the pool's async queue now contains the QueryIntent instance.

Before:

<img width="2480" height="1682" alt="mermaid-diagram-2025-11-12-040028" src="https://github.com/user-attachments/assets/fa215405-b580-44d5-ba42-6f58f435057f" />


Now:

<img width="1987" height="1438" alt="mermaid-diagram-2025-12-01-201116" src="https://github.com/user-attachments/assets/3dfd2ad9-ff01-4b3b-b642-198a5afda4a4" />

