### PR TITLE
Add to_h to SchematizedJson

### DIFF
--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -76,6 +76,10 @@ module ActiveModel
         new_data.each { |k, v| public_send "#{k}=", v }
       end
 
+      def to_h
+        @data
+      end
+
       private
         def method_missing(method_name, *args, **kwargs)
           key = method_name.to_s.remove(/(\?|=)/)

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -106,4 +106,14 @@ class SchematizedJsonTest < ActiveModel::TestCase
     assert_equal 20, hash["max_invites"]
     assert_equal "Hi there!", hash["greeting"]
   end
+
+  test "to_h works with has_delegated_json" do
+    assert_equal({ "premium" => false }, @account.flags.to_h)
+  end
+
+  test "to_h works with has_delegated_json after direct assignment" do
+    @account.flags = { "premium" => "true" }
+
+    assert_equal({ "premium" => true }, @account.flags.to_h)
+  end
 end

--- a/activemodel/test/cases/schematized_json_test.rb
+++ b/activemodel/test/cases/schematized_json_test.rb
@@ -85,4 +85,25 @@ class SchematizedJsonTest < ActiveModel::TestCase
       @account.broken.nesting = { not: :valid }
     end
   end
+
+  test "to_h returns the underlying hash" do
+    assert_equal({ "restricts_access" => true, "max_invites" => 10, "greeting" => "Hello!", "beta" => nil }, @account.settings.to_h)
+  end
+
+  test "to_h does not compact nil values" do
+    hash = @account.settings.to_h
+
+    assert_includes hash, "beta"
+    assert_nil hash["beta"]
+  end
+
+  test "to_h reflects changes made to the data" do
+    @account.settings.max_invites = 20
+    @account.settings.greeting = "Hi there!"
+
+    hash = @account.settings.to_h
+
+    assert_equal 20, hash["max_invites"]
+    assert_equal "Hi there!", hash["greeting"]
+  end
 end


### PR DESCRIPTION
### Motivation / Background

I'm migrating a model from `store_accessor` to the new `has_json` API, and found out that there's no easy way to list all the keys and values from the underlying column. I currently have to do something like `user.preferences.as_json['schema'].each_key`. 

the context is that I have to show this information on an internal dashboard.

### Detail

This PR adds a `to_h` method to the attribute, returning the value as a Hash

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
