### PR TITLE
Add a top level bin/test

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+raw_directory = ARGV.first.split("/").first
+directory = File.join(raw_directory, "/")
+args = ARGV.filter_map do |arg|
+  if arg == raw_directory
+    nil
+  else
+    arg.delete_prefix(directory)
+  end
+end
+
+Dir.chdir(directory)
+exec("bin/test", *args)

--- a/bin/test
+++ b/bin/test
@@ -11,5 +11,6 @@ args = ARGV.filter_map do |arg|
   end
 end
 
+ENV["RAILS_TEST_PWD"] = Dir.pwd
 Dir.chdir(directory)
 exec("bin/test", *args)

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -4,9 +4,10 @@ require "minitest"
 
 module Rails
   class TestUnitReporter < Minitest::StatisticsReporter
+    @app_root = ENV["RAILS_TEST_PWD"]
     singleton_class.attr_accessor :app_root
 
-    @executable = "bin/rails test"
+    @executable = ENV.fetch("RAILS_TEST_EXECUTABLE", "bin/rails test")
     singleton_class.attr_accessor :executable
 
     def prerecord(test_class, test_name)
@@ -92,10 +93,14 @@ module Rails
 
       def app_root
         @app_root ||= self.class.app_root ||
-          if defined?(ENGINE_ROOT)
+          if ENV["RAILS_TEST_PWD"]
+            ENV["RAILS_TEST_PWD"]
+          elsif defined?(ENGINE_ROOT)
             ENGINE_ROOT
           elsif Rails.respond_to?(:root)
             Rails.root
+          else
+            Dir.pwd
           end
       end
 

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -11,7 +11,7 @@ require "active_support"
 require "active_support/test_case"
 
 ActiveSupport::TestCase.extend Rails::LineFiltering
-Rails::TestUnitReporter.app_root = COMPONENT_ROOT
+Rails::TestUnitReporter.app_root ||= COMPONENT_ROOT
 Rails::TestUnitReporter.executable = "bin/test"
 
 Rails::TestUnit::Runner.parse_options(ARGV)

--- a/tools/test_common.rb
+++ b/tools/test_common.rb
@@ -2,6 +2,8 @@
 
 ActiveSupport::TestCase.alias_method :force_skip, :skip
 
+ENV["RAILS_TEST_EXECUTABLE"] = "bin/test"
+
 if ENV["BUILDKITE"]
   require "minitest-ci"
   ENV.delete("CI") # CI has affect on the applications, and we don't want it applied to the apps.


### PR DESCRIPTION
Just a bit of quality of life for contributors.

I constantly have to cd into various subdirectories to run tests, and that gets annoying.

This new script allows to directly run a test file from the root:

```bash
$ bin/test activemodel
...
$ bin/test activemodel/test/cases/dirty_test.rb
...
$ bin/test activemodel/test/cases/dirty_test.rb activemodel/test/cases/error_test.rb -v
...
```

Running tests in multiple subprojects in a single invocation isn't supported though.

In addition, previously the rerun command printed when running Rails own
test suite was unusable, e.g.:

```bash
bin/rails test /rails/activerecord/test/cases/adapters/postgresql/connection_test.rb:187
```

Now it prints a command you can directly copy paste at the repo root:

```bash
bin/test activerecord/test/cases/adapters/postgresql/connection_test.rb:187
```

See: https://buildkite.com/rails/rails/builds/124229#019ade2f-ecf0-485f-ba07-5e26f23fa3e9/1245-1259
