### PR TITLE
Fix ERB strict locals parsing when comment spans multiple lines

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -7,7 +7,7 @@ module ActionView
   class Template
     extend ActiveSupport::Autoload
 
-    STRICT_LOCALS_REGEX = /\#\s+locals:\s+\((.*)\)/
+    STRICT_LOCALS_REGEX = /\#\s+locals:\s+\((.*?)\)(?=\s*-?%>|\s*$)/m
 
     # === Encodings in ActionView::Template
     #

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -220,6 +220,28 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal "Hello", render
   end
 
+  def test_locals_with_parentheses
+    @template = new_template("<%# locals: (message: '(Hello)') -%>\n<%= message %>")
+    assert_equal "(Hello)", render
+
+    @template = new_template("<%# locals: (message: '(Hello') -%>\n<%= message %>")
+    assert_equal "(Hello", render
+
+    @template = new_template("<%# locals: (message: 'Hello)') -%>\n<%= message %>")
+    assert_equal "Hello)", render
+  end
+
+  def test_locals_can_spread_to_multiple_lines
+    template = <<~ERB.chomp
+        <%# locals: (arg_1:,
+                     arg_2: nil,
+                     arg_3: []) -%>
+        <%= arg_1 %><%= arg_2 %><%= arg_3 %>
+    ERB
+    @template = new_template(template)
+    assert_equal "First[]", render(arg_1: "First")
+  end
+
   def test_required_locals_must_be_specified
     error = assert_raises(ActionView::Template::Error) do
       @template = new_template("<%# locals: (message:) -%>")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #56239

This PR has been created because ERB partial locals parsing fails when the locals: magic comment spans multiple lines. 
For example, this works:

```ruby
<%# locals: (arg_1:, arg_2: nil, arg_3: []) %>
```
But this raises `ActionView::Template::Error: undefined local variable or method 'arg_2'`:
```ruby
<%# locals: (arg_1:,
             arg_2: nil,
             arg_3: []) %>
```

### Additional information

Now, the below script passes:
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
end

require "action_controller/railtie"
require "action_view/railtie"
require "minitest/autorun"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end

Rails.application.initialize!

class MultilineLocalsTest < ActionView::TestCase
  def test_partial_with_single_line_strict_locals
    tmp_dir = Dir.mktmpdir
    tmp_path = Pathname(tmp_dir)

    # Single line magic comment (this is working)
    File.write(tmp_path.join("_partial.html.erb"), <<~HTML)
      <%# locals: (arg_1:, arg_2: nil, arg_3: []) %>
      <p class="arg1"><%= arg_1 %></p>
      <p class="arg2"><%= arg_2 %></p>
      <p class="arg3"><%= arg_3 %></p>
    HTML

    File.write(tmp_path.join("main.html.erb"), <<~ERB)
      <div>
        <%= render partial: "partial", locals: { arg_1: "First" } %>
      </div>
    ERB

    ActionController::Base.prepend_view_path tmp_path

    render template: "main"

    assert_equal "First", rendered.html.at_css(".arg1").text
    assert_equal "", rendered.html.at_css(".arg2").text
    assert_equal "[]", rendered.html.at_css(".arg3").text
  ensure
    FileUtils.rm_rf tmp_dir
  end

  def test_partial_with_multiline_strict_locals
    tmp_dir = Dir.mktmpdir
    tmp_path = Pathname(tmp_dir)

    # Multiline magic comment (this is not working)
    File.write(tmp_path.join("_partial.html.erb"), <<~HTML)
      <%# locals: (arg_1:,
                   arg_2: nil,
                   arg_3: []) %>
      <p class="arg1"><%= arg_1 %></p>
      <p class="arg2"><%= arg_2 %></p>
      <p class="arg3"><%= arg_3 %></p>
    HTML

    File.write(tmp_path.join("main.html.erb"), <<~ERB)
      <div>
        <%= render partial: "partial", locals: { arg_1: "First" } %>
      </div>
    ERB

    ActionController::Base.prepend_view_path tmp_path

    render template: "main"

    assert_equal "First", rendered.html.at_css(".arg1").text
    assert_equal "", rendered.html.at_css(".arg2").text
    assert_equal "[]", rendered.html.at_css(".arg3").text
  ensure
    FileUtils.rm_rf tmp_dir
  end
end
```

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
