### PR TITLE
Skip all system test files on app generation

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -255,9 +255,10 @@ module Rails
     end
 
     def system_test
-      empty_directory_with_keep_file "test/system"
-
-      template "test/application_system_test_case.rb"
+      if devcontainer? && depends_on_system_test?
+        empty_directory_with_keep_file "test/system"
+        template "test/application_system_test_case.rb"
+      end
     end
 
     def tmp
@@ -475,7 +476,7 @@ module Rails
       end
 
       def create_system_test_files
-        build(:system_test) if depends_on_system_test?
+        build(:system_test)
       end
 
       def create_storage_files

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -26,6 +26,10 @@ module TestUnit # :nodoc:
         # Generate system tests if this isn't an API only app and the system
         # tests option is true
         if !options.api? && options[:system_tests] == "true"
+          if !File.exist?(File.join("test/application_system_test_case.rb"))
+            template "application_system_test_case.rb", File.join("test", "application_system_test_case.rb")
+          end
+
           template "system_test.rb", File.join("test/system", class_path, "#{file_name.pluralize}_test.rb")
         end
       end

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/application_system_test_case.rb.tt
@@ -1,0 +1,5 @@
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1192,6 +1192,8 @@ module ApplicationTests
     end
 
     def test_reset_sessions_before_rollback_on_system_tests
+      generate_application_system_test_case_file
+
       app_file "test/system/reset_session_before_rollback_test.rb", <<-RUBY
         require "application_system_test_case"
         require "selenium/webdriver"
@@ -1221,6 +1223,8 @@ module ApplicationTests
     end
 
     def test_reset_sessions_on_failed_system_test_screenshot
+      generate_application_system_test_case_file
+
       app_file "test/system/reset_sessions_on_failed_system_test_screenshot_test.rb", <<~RUBY
         require "application_system_test_case"
         require "selenium/webdriver"
@@ -1247,6 +1251,8 @@ module ApplicationTests
     end
 
     def test_failed_system_test_screenshot_should_be_taken_before_other_teardown
+      generate_application_system_test_case_file
+
       app_file "test/system/failed_system_test_screenshot_should_be_taken_before_other_teardown_test.rb", <<~RUBY
         require "application_system_test_case"
         require "selenium/webdriver"
@@ -1273,6 +1279,8 @@ module ApplicationTests
     end
 
     def test_system_tests_are_not_run_with_the_default_test_command
+      generate_application_system_test_case_file
+
       app_file "test/system/dummy_test.rb", <<-RUBY
         require "application_system_test_case"
 
@@ -1289,6 +1297,8 @@ module ApplicationTests
     end
 
     def test_system_tests_are_not_run_through_rake_test
+      generate_application_system_test_case_file
+
       app_file "test/system/dummy_test.rb", <<-RUBY
         require "application_system_test_case"
 
@@ -1304,6 +1314,8 @@ module ApplicationTests
     end
 
     def test_system_tests_are_run_through_rake_test_when_given_in_TEST
+      generate_application_system_test_case_file
+
       app_file "test/system/dummy_test.rb", <<-RUBY
         require "application_system_test_case"
         require "selenium/webdriver"
@@ -1427,6 +1439,16 @@ module ApplicationTests
               puts "#{name.camelize}Test" if #{print}
               assert #{pass}, 'wups!'
             end
+          end
+        RUBY
+      end
+
+      def generate_application_system_test_case_file
+        app_file "test/application_system_test_case.rb", <<-RUBY
+          require "test_helper"
+
+          class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+            driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
           end
         RUBY
       end

--- a/railties/test/commands/devcontainer_test.rb
+++ b/railties/test/commands/devcontainer_test.rb
@@ -14,6 +14,14 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
     require "solid_cable"
     require "solid_queue"
 
+    app_file "test/application_system_test_case.rb", <<~RUBY
+      require "test_helper"
+
+      class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+        driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+      end
+    RUBY
+
     output = rails "devcontainer"
 
     assert_match "app_name: app_template", output

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -75,14 +75,12 @@ DEFAULT_APP_FILES = %w(
   public/robots.txt
   script/.keep
   storage/.keep
-  test/application_system_test_case.rb
   test/controllers/.keep
   test/fixtures/files/.keep
   test/helpers/.keep
   test/integration/.keep
   test/mailers/.keep
   test/models/.keep
-  test/system/.keep
   test/test_helper.rb
   tmp/.keep
   tmp/pids/.keep
@@ -1391,13 +1389,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file ".dockerignore"
     assert_no_file "Dockerfile"
     assert_no_file "bin/docker-entrypoint"
-  end
-
-  def test_system_tests_directory_generated
-    run_generator
-
-    assert_directory("test/system")
-    assert_file("test/system/.keep")
   end
 
   unless Gem.win_platform?


### PR DESCRIPTION
When I updated the scaffold to skip system test generation in rails/rails##55743 I missed that the app generation still creates `application_system_test_case.rb`. This change no longer generates that file unless you are generating a system test and it doesn't yet exist.

Found via https://github.com/rails/rails/pull/56252