### PR TITLE
avoid schema conflicts by dumping enum types with fully qualified name in PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Avoid schema conflicts by dumping enum types with fully qualified name in PostgreSQL.
+
+    *Alex Robbin*
+
 *   Add support for configuring migration strategy on a per-adapter basis.
 
     `migration_strategy` can now be set on individual adapter classes, overriding

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -108,7 +108,17 @@ module ActiveRecord
               spec = { type: schema_type(column).inspect }.merge!(spec)
             end
 
-            spec[:enum_type] = column.sql_type.inspect if column.enum?
+            if column.enum?
+              # If only dumping one schema, or the enum type is already schema-qualified,
+              # use the enum type as is. Otherwise, qualify it with the current schema name.
+              enum_type = if @dump_schemas.size == 1 || column.sql_type.include?(".")
+                column.sql_type
+              else
+                "#{schema_name}.#{column.sql_type}"
+              end
+
+              spec[:enum_type] = enum_type.inspect
+            end
 
             spec
           end


### PR DESCRIPTION
If there are multiple enum types with the same name, but in different schemas, the `:enum_type` option dumped as part of `db:schema:dump` will be ambiguous, potentially resulting in the wrong type being used when loading the schema.

Now, if the enum type is not already fully qualified, and multiple schemas are being dumped, the type includes the schema name.