### PR TITLE
Use pattern matching on sql instead of string match event payload name

### DIFF
--- a/activestorage/test/controllers/representations/redirect_controller_test.rb
+++ b/activestorage/test/controllers/representations/redirect_controller_test.rb
@@ -93,9 +93,11 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsTest < Actio
     variant_record_loaded_count = 0
 
     query_subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-      if event.payload[:name] == "ActiveStorage::VariantRecord Create"
+      case event.payload[:sql]
+      when /INSERT INTO "active_storage_variant_records"/
         variant_record_created = true
-      elsif event.payload[:name] == "ActiveStorage::VariantRecord Load" && variant_record_created
+      when /SELECT "active_storage_variant_records".* FROM "active_storage_variant_records"/
+        next unless variant_record_created
         variant_record_loaded_count += 1
       end
     end


### PR DESCRIPTION
Follow up to #56225

I think string matching the event name could be brittle if the notification changes the format of that message this test will fail for no reason, so instead we can match on the SQL which is less-likely to change.

/cc @jeremy @rosa 