### PR TITLE
ActionText: Validate `RemoteImage` URLs

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,2 +1,10 @@
+*   Validate `RemoteImage` URLs at creation time.
+
+    `RemoteImage.from_node` now validates the URL before creating a `RemoteImage` object, using the
+    same regex that `AssetUrlHelper` uses during rendering. URLs like "image.png" that would
+    previously have been passed to the asset pipeline and raised a `ActionView::Template::Error` are
+    rejected early, and gracefully fail by resulting in a `MissingAttachable`.
+
+    *Mike Dalessio*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actiontext/CHANGELOG.md) for previous changes.

--- a/actiontext/lib/action_text/attachables/remote_image.rb
+++ b/actiontext/lib/action_text/attachables/remote_image.rb
@@ -9,12 +9,16 @@ module ActionText
 
       class << self
         def from_node(node)
-          if node["url"] && content_type_is_image?(node["content-type"])
+          if remote_url?(node["url"]) && content_type_is_image?(node["content-type"])
             new(attributes_from_node(node))
           end
         end
 
         private
+          def remote_url?(url)
+            url && ActionView::Helpers::AssetUrlHelper::URI_REGEXP.match?(url)
+          end
+
           def content_type_is_image?(content_type)
             content_type.to_s.match?(/^image(\/.+|$)/)
           end

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -55,6 +55,16 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_equal "100", attachable.height
   end
 
+  test "treats image attachments with non-URL paths as missing" do
+    html = '<action-text-attachment content-type="image/*" url="image.png" width="100" height="100"></action-text-attachment>'
+
+    content = content_from_html(html)
+    assert_equal 1, content.attachments.size
+
+    attachable = content.attachments.first.attachable
+    assert_kind_of ActionText::Attachables::MissingAttachable, attachable
+  end
+
   test "identifies destroyed attachables as missing" do
     file = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{file.attachable_sgid}"></action-text-attachment>)


### PR DESCRIPTION
### Motivation / Background

If an image is attached to rich text with a URL like `image.png`, the rendering pipeline will attempt to ask Propshaft to resolve it as a local asset, which will either then:

- raise `ActionView::Template::Error: The asset 'image.png' was not found in the load path.`
- or potentially resolve to something with the same name that is in the asset load path.

The first leads to a 500 error unless the application developer adds code to rescue the exception. The second is bad behavior at best, and a potential exploit vector at worst.

### Detail

RemoteImage.from_node now validates the URL before creating a RemoteImage object, using the same regex that AssetUrlHelper uses during rendering. URLs like "image.png" that would previously have been passed to the asset pipeline are rejected and fall through to MissingAttachable.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
