### PR TITLE
fix(activesupport): handle syntax errors in debug views when using editor

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -917,6 +917,18 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "editor can handle syntax errors" do
+    @app = DevelopmentApp
+    ActiveSupport::Editor.stub(:current, ActiveSupport::Editor.find("atom")) do
+      get "/syntax_error_into_view"
+
+      assert_response 500
+      assert_select "#Application-Trace-0" do
+        assert_select "code", /syntax error, unexpected|syntax errors found/
+      end
+    end
+  end
+
   test "shows a buttons for every action in an actionable error" do
     @app = DevelopmentApp
     Rails.stub :root, Pathname.new(".") do

--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -21,6 +21,10 @@ module ActiveSupport
 
       def base_label
       end
+
+      def absolute_path
+        path
+      end
     end
 
     class BacktraceLocationProxy < ActiveSupport::Delegation::DelegateClass(Thread::Backtrace::Location) # :nodoc:


### PR DESCRIPTION
fixes #56284

hitting syntax error with `RAILS_EDITOR` env variable after #55295

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When using `RAILS_EDITOR`, syntax errors in ERB templates are not handled correctly.

### Detail

Provide `ActiveSupport::SyntaxErrorProxy::BacktraceLocation#absolute_path` as it is used to retrieve the `editor_url` [here](https://github.com/markokajzer/rails/blob/fd7518be46f830b96bc89801b9558a17b8faf123/actionpack/lib/action_dispatch/middleware/debug_view.rb#L61)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
