### PR TITLE
Fix ActiveRecord::SoleRecordExceeded#record to return the relation

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -148,7 +148,7 @@ module ActiveRecord
       elsif undesired.nil?
         found
       else
-        raise ActiveRecord::SoleRecordExceeded.new(model)
+        raise ActiveRecord::SoleRecordExceeded.new(self)
       end
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -795,6 +795,16 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_sole_record_exceeded_record_accessor
+    relation = Topic.where("author_name = 'Carl'")
+    error = assert_raises ActiveRecord::SoleRecordExceeded, match: "Wanted only one Topic" do
+      relation.sole
+    end
+
+    assert_kind_of ActiveRecord::Relation, error.record
+    assert_equal relation.count, error.record.count
+  end
+
   def test_sole_on_loaded_relation
     relation = Topic.where("title = 'The First Topic'").load
     expected_topic = topics(:first)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/56281

This inadvertently regressed in https://github.com/rails/rails/pull/50396
