### PR TITLE
Add SecureRandom.base32

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `SecureRandom.base32` for generating case-insensitive keys that are unambiguous to humans.
+
+    *Stanko Krtalic Rusendic & Miha Rekar*
+
 *   Add a fast failure mode to `ActiveSupport::ContinuousIntegration` that stops the rest of
     the run after a step fails. Invoke by running `bin/ci --fail-fast` or `bin/ci -f`.
 

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -5,6 +5,7 @@ require "securerandom"
 module SecureRandom
   BASE58_ALPHABET = ("0".."9").to_a + ("A".."Z").to_a + ("a".."z").to_a - ["0", "O", "I", "l"]
   BASE36_ALPHABET = ("0".."9").to_a + ("a".."z").to_a
+  BASE32_ALPHABET = ("0".."9").to_a + ("A".."Z").to_a - ["I", "L", "O", "U"]
 
   # SecureRandom.base58 generates a random base58 string.
   #
@@ -51,6 +52,31 @@ module SecureRandom
         idx = byte % 64
         idx = SecureRandom.random_number(36) if idx >= 36
         BASE36_ALPHABET[idx]
+      end.join
+    end
+  end
+
+  # SecureRandom.base32 generates a random Crockford base32 string in uppercase.
+  #
+  # The argument _n_ specifies the length of the random string to be generated.
+  #
+  # If _n_ is not specified or is +nil+, 16 is assumed. It may be larger in the future.
+  # This method can be used over +base58+ if a case-insensitive key that's unambiguous to humans is necessary.
+  #
+  # The result may contain alphanumeric characters in uppercase except I, L, O, and U.
+  #
+  #   p SecureRandom.base32 # => "PAK1NG78CM1HJ44A"
+  #   p SecureRandom.base32(24) # => "BN9EAB8RG9BNTTC9BX7P5JGJ"
+  if SecureRandom.method(:alphanumeric).parameters.size == 2 # Remove check when Ruby 3.3 is the minimum supported version
+    def self.base32(n = 16)
+      alphanumeric(n, chars: BASE32_ALPHABET)
+    end
+  else
+    def self.base32(n = 16)
+      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
+        idx = byte % 64
+        idx = SecureRandom.random_number(32) if idx >= 32
+        BASE32_ALPHABET[idx]
       end.join
     end
   end

--- a/activesupport/test/core_ext/secure_random_test.rb
+++ b/activesupport/test/core_ext/secure_random_test.rb
@@ -69,4 +69,40 @@ class SecureRandomTest < ActiveSupport::TestCase
     assert_match(/^[a-z0-9]+$/, s1)
     assert_match(/^[a-z0-9]+$/, s2)
   end
+
+  def test_base32
+    s1 = SecureRandom.base32
+    s2 = SecureRandom.base32
+
+    assert_not_equal s1, s2
+    assert_equal 16, s1.length
+    assert_match(/^[A-Z0-9]+$/, s1)
+    assert_match(/^[A-Z0-9]+$/, s2)
+    assert_match(/^[^ILOU]+$/, s1)
+    assert_match(/^[^ILOU]+$/, s2)
+  end
+
+  def test_base32_with_length
+    s1 = SecureRandom.base32(24)
+    s2 = SecureRandom.base32(24)
+
+    assert_not_equal s1, s2
+    assert_equal 24, s1.length
+    assert_match(/^[A-Z0-9]+$/, s1)
+    assert_match(/^[A-Z0-9]+$/, s2)
+    assert_match(/^[^ILOU]+$/, s1)
+    assert_match(/^[^ILOU]+$/, s2)
+  end
+
+  def test_base32_with_nil
+    s1 = SecureRandom.base32(nil)
+    s2 = SecureRandom.base32(nil)
+
+    assert_not_equal s1, s2
+    assert_equal 16, s1.length
+    assert_match(/^[A-Z0-9]+$/, s1)
+    assert_match(/^[A-Z0-9]+$/, s2)
+    assert_match(/^[^ILOU]+$/, s1)
+    assert_match(/^[^ILOU]+$/, s2)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

For one-time codes that are meant to be typed in by hand, we want to generate codes that are easy to read, easy to say out loud, and hard to confuse.

Crockford's Base32 gives us a case insensitive alphabet that avoids characters ambiguous to humans. This makes it a good fit for short codes that people can copy from an email into a form or read over the phone, such as two factor authentication codes.

Implementing a similar code generator is trivial in Ruby. Implementing it in a *cryptographically safe* way is less intuitive, as [I learned while working on Fizzy](https://github.com/basecamp/fizzy/pull/1868). By upstreaming this, I want to provide a helper that produces human-friendly codes that can safely be used for magic links or 2FA, so individual apps don’t need to re-solve the same problem.

### Detail

- Adds a new alphabet to `SecureRandom::BASE32_ALPHABET`
- Reuses the existing pattern for generating keys in different bases

Note: Base32 can mean different things, look at the Wikipedia article below, I went with `base32` because I saw that `base58` uses the Bitcoin version without specifically calling it out.

### Additional information

- [Crockford's Base32 definition](https://www.crockford.com/base32.html)
- [Base32 wikipedia article](https://en.wikipedia.org/wiki/Base32#Crockford's_Base32)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
