### PR TITLE
Fix typos in comments

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -37,7 +37,7 @@ module ActionCable
       def with_subscriptions_connection(&block) # :nodoc:
         # Action Cable is taking ownership over this database connection, and will
         # perform the necessary cleanup tasks.
-        # We purposedly avoid #checkout to not end up with a pinned connection
+        # We purposely avoid #checkout to not end up with a pinned connection
         ar_conn = ActiveRecord::Base.connection_pool.new_connection
         pg_conn = ar_conn.raw_connection
 

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -274,7 +274,7 @@ module ActionController
       end
 
       def _enforce_open_redirect_protection(location, allow_other_host:)
-        # Explictly allowed other host or host is in allow list allow redirect
+        # Explicitly allowed other host or host is in allow list allow redirect
         if allow_other_host || _url_host_allowed?(location)
           location
         # Explicitly disallowed other host


### PR DESCRIPTION
### Summary

Fix typos found by codespell:
- `Explictly` -> `Explicitly` in Action Controller
- `purposedly` -> `purposely` in Action Cable

### Additional Information

These are comment-only changes with no functional impact.
