### PR TITLE
Allow `schema_dump` configuration to be an absolute path.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Allow `schema_dump` configuration to be an absolute path.
+
+    Previously, the `schema_dump` configuration was always joined with the
+    `db_dir` path. Now, if an absolute path is provided, it will be used as-is.
+
+    *Mike Dalessio*
+
 *   Decode PostgreSQL bytea and money columns when they appear in direct
     query results.
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -481,7 +481,7 @@ module ActiveRecord
         filename = db_config.schema_dump(format)
         return unless filename
 
-        if File.dirname(filename) == ActiveRecord::Tasks::DatabaseTasks.db_dir
+        if Pathname.new(filename).absolute? || File.dirname(filename) == ActiveRecord::Tasks::DatabaseTasks.db_dir
           filename
         else
           File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1753,6 +1753,17 @@ module ActiveRecord
       end
     end
 
+    def test_schema_dump_path_with_absolute_path
+      ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, "db") do
+        configurations = {
+          "development" => { "primary" => { "adapter" => "abstract", "database" => "dev-db", "schema_dump" => "/absolute/path/to/schema.rb" } },
+        }
+        with_stubbed_configurations(configurations) do
+          assert_equal "/absolute/path/to/schema.rb", ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(config_for("development", "primary"))
+        end
+      end
+    end
+
     def test_check_dump_filename_with_schema_env_with_non_primary_databases
       schema = ENV["SCHEMA"]
       ENV["SCHEMA"] = "schema_path"


### PR DESCRIPTION
### Motivation / Background

I'm maintaining a Rails engine that has some models that are intended to be in a separate database from the application's `primary` database. Rails provides lots of hooks (like ERB support in `config/database.yml` and absolute path support for the `:migrations_paths` db config param) to make this separation of concerns _mostly_ straightforward.

However, Rails currently makes it hard to maintain a schema dump file outside of the Rails application's source tree. `ActiveRecord::Tasks::DatabaseTasks.schema_dump_path` allows an absolute path to be set via the `SCHEMA` environment variable, but any path set in the database configuration is assumed to be in `DatabaseTasks.db_dir` and treated as a relative path.

This constraint makes it challenging for an engine to maintain its own schema file.

If specifics are helpful, I'm referring here to https://github.com/basecamp/fizzy which is an open-source Rails application, and https://github.com/basecamp/fizzy-saas which is the engine we're using for the SaaS-specific bits (like deployment configuration, proprietary customer signup, and telemetry integration). Users of the open-source app have no use for a schema file that belongs to the (optional) engine, and so I'd prefer to not add it to the application (see https://github.com/basecamp/fizzy-saas/pull/20 for more details).

### Detail

This pull request will allow developers to extend their database configuration to include the separate engine-specific database like this:

```database.yml
<% gem_path = Gem::Specification.find_by_name("fizzy-saas").gem_dir %>
production:
  primary:
    # ...
  saas:
    database: saas_production
    host: <%= mysql_database_host %>
    username: <%= mysql_app_user %>
    password: <%= mysql_app_password %>
    # migrations_paths already works!
    migrations_paths: <%= File.join(gem_path, "db", "migrate") %>
    # schema_dump is the subject of this PR
    schema_dump: <%= File.join(gem_path, "db", "saas_schema.rb") %>
```

The change is to `ActiveRecord::Tasks::DatabaseTasks.schema_dump_path` to check if the path is absolute using `Pathname#absolute?` and if so to return it unmodified.

### Additional information

Perhaps it's worth noting that `migrations_paths` has no such constraint -- absolute paths work fine for that config parameter.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
