### PR TITLE
Combine rather than overwrite tag content supplied via both parameter and block

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix tag parameter content being overwritten instead of combined with tag block content.
+    Before `tag.div("Hello ") { "World" }` would just return `<div>World</div>`, now it returns `<div>Hello World</div>`.
+
+    *DHH*
+
 *   Add ability to pass a block when rendering collection. The block will be executed for each rendered element in the collection.
 
     *Vincent Robert*

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -276,7 +276,11 @@ module ActionView
 
         private
           def tag_string(name, content = nil, options, escape: true, &block)
-            content = @view_context.capture(self, &block) if block
+            if content && block_given?
+              content += @view_context.capture(self, &block)
+            elsif block_given?
+              content = @view_context.capture(self, &block)
+            end
 
             content_tag_string(name, content, options, escape)
           end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -521,6 +521,10 @@ class TagHelperTest < ActionView::TestCase
       content_tag("p", "limelight", data: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"' })
   end
 
+  def test_content_tag_with_both_argument_and_block
+    assert_dom_equal '<p>limelight shines!</p>', tag.p("limelight") { " shines!" }
+  end
+
   def test_tag_builder_with_data_attributes
     assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
       tag.p("limelight", data: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"' })

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -522,7 +522,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_with_both_argument_and_block
-    assert_dom_equal '<p>limelight shines!</p>', tag.p("limelight") { " shines!" }
+    assert_dom_equal "<p>limelight shines!</p>", tag.p("limelight") { " shines!" }
   end
 
   def test_tag_builder_with_data_attributes


### PR DESCRIPTION
Before this, we'd silently just overwrite the parameter content with the block content, so `tag.div("Hello ") { "World" }` would just return `<div>World</div>`. With this fix, it's going to return `<div>Hello World</div>`.