### PR TITLE
Wrap console command with an executor by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Wrap console command with an executor by default
+
+    This can be disabled with `-w` or `--skip_executor`, same as runner.
+
+    *zzak*
+
 *   Add a new internal route in development to respond to chromium devtools GET request.
 
     This allows the app folder to be easily connected as a workspace in chromium-based browsers.

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -32,7 +32,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     assert_output prompt, @primary
   end
 
-  def spawn_console(options, wait_for_prompt: true, env: {})
+  def spawn_console(options = nil, wait_for_prompt: true, env: {})
     # Test should not depend on user's irbrc file
     home_tmp_dir = Dir.mktmpdir
 
@@ -177,6 +177,18 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     spawn_console("-e development")
 
     write_prompt "new_session.class.name", "ActionDispatch::Integration::Session"
+  end
+
+  def test_console_with_conditional_executor_enabled_by_default
+    spawn_console
+
+    write_prompt "Rails.application.executor.active?", "true"
+  end
+
+  def test_console_with_conditional_executor_can_be_disabled
+    spawn_console "--skip-executor"
+
+    write_prompt "Rails.application.executor.active?", "false"
   end
 
   def test_app_helper_method


### PR DESCRIPTION
This can be disabled with `-w` or `--skip_executor`, same as runner.

Fixes #56277