### PR TITLE
Dispatch `direct-upload:success` event with `detail.hiddenInput`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Dispatch `direct-upload:success` with `blob` and `hiddenInput`
+
+    The `direct-upload:success` event is dispatched after the final
+    `direct-upload:progress` and before `direct-upload:end`. The `blob` is the
+    response from `ActiveStorage::DirectUploadsController#create`. The `hiddenInput`
+    is the `<input type="hidden">` element created by the upload.
+
+    *Sean Doyle*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -1124,12 +1124,16 @@ class DirectUploadController {
     hiddenInput.name = this.input.name;
     this.input.insertAdjacentElement("beforebegin", hiddenInput);
     this.dispatch("start");
-    this.directUpload.create(((error, attributes) => {
+    this.directUpload.create(((error, blob) => {
       if (error) {
         hiddenInput.parentNode.removeChild(hiddenInput);
         this.dispatchError(error);
       } else {
-        hiddenInput.value = attributes.signed_id;
+        hiddenInput.value = blob.signed_id;
+        this.dispatch("success", {
+          blob: blob,
+          hiddenInput: hiddenInput
+        });
       }
       this.dispatch("end");
       callback(error);

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -1107,12 +1107,16 @@
       hiddenInput.name = this.input.name;
       this.input.insertAdjacentElement("beforebegin", hiddenInput);
       this.dispatch("start");
-      this.directUpload.create(((error, attributes) => {
+      this.directUpload.create(((error, blob) => {
         if (error) {
           hiddenInput.parentNode.removeChild(hiddenInput);
           this.dispatchError(error);
         } else {
-          hiddenInput.value = attributes.signed_id;
+          hiddenInput.value = blob.signed_id;
+          this.dispatch("success", {
+            blob: blob,
+            hiddenInput: hiddenInput
+          });
         }
         this.dispatch("end");
         callback(error);

--- a/activestorage/app/javascript/activestorage/direct_upload_controller.js
+++ b/activestorage/app/javascript/activestorage/direct_upload_controller.js
@@ -18,12 +18,13 @@ export class DirectUploadController {
 
     this.dispatch("start")
 
-    this.directUpload.create((error, attributes) => {
+    this.directUpload.create((error, blob) => {
       if (error) {
         hiddenInput.parentNode.removeChild(hiddenInput)
         this.dispatchError(error)
       } else {
-        hiddenInput.value = attributes.signed_id
+        hiddenInput.value = blob.signed_id
+        this.dispatch("success", { blob, hiddenInput })
       }
 
       this.dispatch("end")

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1588,6 +1588,7 @@ The JavaScript library supports events that can be used for the upload form:
 | `direct-upload:before-blob-request` | `<input>` | `{id, file, xhr}` | Before making a request to your application for direct upload metadata. |
 | `direct-upload:before-storage-request` | `<input>` | `{id, file, xhr}` | Before making a request to store a file. |
 | `direct-upload:progress` | `<input>` | `{id, file, progress}` | As requests to store files progress. |
+| `direct-upload:success` | `<input>` | `{id, file, blob, hiddenInput}` | A request succeeded. The `blob` contains upload metadata. The `hiddenInput` is an `<input type="hidden">` element whose `value` stores the signed id. |
 | `direct-upload:error` | `<input>` | `{id, file, error}` | An error occurred. An `alert` will display unless this event is canceled. |
 | `direct-upload:end` | `<input>` | `{id, file}` | A direct upload has ended. |
 | `direct-uploads:end` | `<form>` | None | All direct uploads have ended. |
@@ -1633,6 +1634,13 @@ addEventListener("direct-upload:error", event => {
   const element = document.getElementById(`direct-upload-${id}`)
   element.classList.add("direct-upload--error")
   element.setAttribute("title", error)
+})
+
+addEventListener("direct-upload:success", event => {
+  const { id, blob } = event.detail
+  const element = document.getElementById(`direct-upload-${id}`)
+  element.classList.add("direct-upload--success")
+  element.setAttribute("title", `Uploaded ${blob.signed_id}`)
 })
 
 addEventListener("direct-upload:end", event => {


### PR DESCRIPTION
### Motivation / Background

The issue
---

The [direct-upload:end][] event is dispatched when a `DirectUploadController` finishes a file upload. At that point, the upload has either succeeded or failed. On success, the `<form>` element has a new `<input type="hidden">` element with the signed Blob response from the Rails server. However, listeners cannot access the signed value reliably, nor can they access other metadata from the response.


### Detail

The proposal
---

Introduce the `direct-upload:success` event dispatched after the final `direct-upload:progress` and before `direct-upload:end`. The `event.detail` object has two properties:

* `hiddenInput` the `<input type="hidden">` element that stores the Blob's signed id in its `[value]` and `.value` property
* `blob` the entire Blob metadata response object

[direct-upload:end]: https://guides.rubyonrails.org/active_storage_overview.html#direct-uploads

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
