### PR TITLE
Suppress unnecessary output in railties tests

### DIFF
--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -28,8 +28,10 @@ module ApplicationTests
 
     test "/rails/mailers is not accessible in production" do
       app("production")
-      get("/rails/mailers", {}, { "HTTPS" => "on" })
-      assert_equal 404, last_response.status
+      quietly do
+        get("/rails/mailers", {}, { "HTTPS" => "on" })
+        assert_equal 404, last_response.status
+      end
     end
 
     test "/rails/mailers is accessible with correct configuration" do
@@ -634,9 +636,11 @@ module ApplicationTests
     end
 
     test "preview does not leak I18n global setting changes" do
-      I18n.with_locale(:en) do
-        get "/rails/mailers/notifier/foo.txt?locale=ja"
-        assert_equal :en, I18n.locale
+      quietly do
+        I18n.with_locale(:en) do
+          get "/rails/mailers/notifier/foo.txt?locale=ja"
+          assert_equal :en, I18n.locale
+        end
       end
     end
 

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -49,13 +49,17 @@ module ApplicationTests
         end
       RUBY
 
-      get "/foo", {}, { "HTTPS" => "on" }
-      assert_equal 404, last_response.status
+      quietly do
+        get "/foo", {}, { "HTTPS" => "on" }
+        assert_equal 404, last_response.status
+      end
     end
 
     test "renders unknown http methods as 405" do
-      request("/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD", "HTTPS" => "on" })
-      assert_equal 405, last_response.status
+      quietly do
+        request("/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD", "HTTPS" => "on" })
+        assert_equal 405, last_response.status
+      end
     end
 
     test "renders unknown http methods as 405 when routes are used as the custom exceptions app" do
@@ -65,8 +69,10 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :all
 
-      request "/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD", "HTTPS" => "on" }
-      assert_equal 405, last_response.status
+      quietly do
+        request "/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD", "HTTPS" => "on" }
+        assert_equal 405, last_response.status
+      end
     end
 
     test "renders unknown http formats as 406 when routes are used as the custom exceptions app" do
@@ -92,21 +98,23 @@ module ApplicationTests
       add_to_config "config.action_dispatch.show_exceptions = :all"
       add_to_config "config.consider_all_requests_local = false"
 
-      get "/foo", {}, { "HTTP_ACCEPT" => "invalid", "HTTPS" => "on" }
-      assert_equal 406, last_response.status
-      assert_not_equal "rendering index!", last_response.body
+      quietly do
+        get "/foo", {}, { "HTTP_ACCEPT" => "invalid", "HTTPS" => "on" }
+        assert_equal 406, last_response.status
+        assert_not_equal "rendering index!", last_response.body
 
-      get "/foo", {}, { "CONTENT_TYPE" => "invalid", "HTTPS" => "on" }
-      assert_equal 406, last_response.status
-      assert_not_equal "rendering index!", last_response.body
+        get "/foo", {}, { "CONTENT_TYPE" => "invalid", "HTTPS" => "on" }
+        assert_equal 406, last_response.status
+        assert_not_equal "rendering index!", last_response.body
 
-      get "/foo", {}, { "HTTP_ACCEPT" => "invalid", "CONTENT_TYPE" => "invalid", "HTTPS" => "on" }
-      assert_equal 406, last_response.status
-      assert_not_equal "rendering index!", last_response.body
+        get "/foo", {}, { "HTTP_ACCEPT" => "invalid", "CONTENT_TYPE" => "invalid", "HTTPS" => "on" }
+        assert_equal 406, last_response.status
+        assert_not_equal "rendering index!", last_response.body
 
-      post "/foo", {}, { "HTTP_ACCEPT" => "invalid", "CONTENT_TYPE" => "invalid", "HTTPS" => "on" }
-      assert_equal 406, last_response.status
-      assert_not_equal "rendering index!", last_response.body
+        post "/foo", {}, { "HTTP_ACCEPT" => "invalid", "CONTENT_TYPE" => "invalid", "HTTPS" => "on" }
+        assert_equal 406, last_response.status
+        assert_not_equal "rendering index!", last_response.body
+      end
     end
 
     test "uses custom exceptions app" do
@@ -118,9 +126,11 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :all
 
-      get("/foo", {}, "HTTPS" => "on")
-      assert_equal 404, last_response.status
-      assert_equal "YOU FAILED", last_response.body
+      quietly do
+        get("/foo", {}, "HTTPS" => "on")
+        assert_equal 404, last_response.status
+        assert_equal "YOU FAILED", last_response.body
+      end
     end
 
     test "URL generation error when action_dispatch.show_exceptions is set raises an exception" do
@@ -137,8 +147,10 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :all
 
-      get("/foo", {}, "HTTPS" => "on")
-      assert_equal 500, last_response.status
+      quietly do
+        get("/foo", {}, "HTTPS" => "on")
+        assert_equal 500, last_response.status
+      end
     end
 
     test "unspecified route when action_dispatch.show_exceptions is not set raises an exception" do
@@ -152,9 +164,11 @@ module ApplicationTests
     test "unspecified route when action_dispatch.show_exceptions is set shows 404" do
       app.config.action_dispatch.show_exceptions = :all
 
-      assert_nothing_raised do
-        get("/foo", {}, "HTTPS" => "on")
-        assert_match "The page you were looking for doesn't exist.", last_response.body
+      quietly do
+        assert_nothing_raised do
+          get("/foo", {}, "HTTPS" => "on")
+          assert_match "The page you were looking for doesn't exist.", last_response.body
+        end
       end
     end
 
@@ -162,9 +176,11 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :all
       app.config.consider_all_requests_local = true
 
-      assert_nothing_raised do
-        get("/foo", {}, "HTTPS" => "on")
-        assert_match "No route matches", last_response.body
+      quietly do
+        assert_nothing_raised do
+          get("/foo", {}, "HTTPS" => "on")
+          assert_match "No route matches", last_response.body
+        end
       end
     end
 
@@ -176,8 +192,10 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :all
       app.config.consider_all_requests_local = true
 
-      get("/articles", {}, "HTTPS" => "on")
-      assert_match "<title>Action Controller: Exception caught</title>", last_response.body
+      quietly do
+        get("/articles", {}, "HTTPS" => "on")
+        assert_match "<title>Action Controller: Exception caught</title>", last_response.body
+      end
     end
 
     test "displays diagnostics message when exception raised in template that contains UTF-8" do
@@ -199,9 +217,11 @@ module ApplicationTests
         ✓測試テスト시험
       ERB
 
-      get("/foo", { utf8: "✓" }, { "HTTPS" => "on" })
-      assert_match(/boooom/, last_response.body)
-      assert_match(/測試テスト시험/, last_response.body)
+      quietly do
+        get("/foo", { utf8: "✓" }, { "HTTPS" => "on" })
+        assert_match(/boooom/, last_response.body)
+        assert_match(/測試テスト시험/, last_response.body)
+      end
     end
 
     test "displays diagnostics message when malformed query parameters are provided" do
@@ -219,9 +239,11 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :all
       app.config.consider_all_requests_local = true
 
-      get "/foo?x[y]=1&x[y][][w]=2", {}, "HTTPS" => "on"
-      assert_equal 400, last_response.status
-      assert_match "Invalid query parameters", last_response.body
+      quietly do
+        get "/foo?x[y]=1&x[y][][w]=2", {}, "HTTPS" => "on"
+        assert_equal 400, last_response.status
+        assert_match "Invalid query parameters", last_response.body
+      end
     end
 
     test "displays diagnostics message when too deep query parameters are provided" do
@@ -241,9 +263,11 @@ module ApplicationTests
       limit = ActionDispatch::ParamBuilder.default.param_depth_limit + 1
       malicious_url = "/foo?#{'[test]' * limit}=test"
 
-      get(malicious_url, {}, "HTTPS" => "on")
-      assert_equal 400, last_response.status
-      assert_match "Invalid query parameters", last_response.body
+      quietly do
+        get(malicious_url, {}, "HTTPS" => "on")
+        assert_equal 400, last_response.status
+        assert_match "Invalid query parameters", last_response.body
+      end
     end
 
     test "displays statement invalid template correctly" do
@@ -261,15 +285,17 @@ module ApplicationTests
       app.config.consider_all_requests_local = true
       app.config.action_dispatch.ignore_accept_header = false
 
-      get("/foo", {}, "HTTPS" => "on")
-      assert_equal 500, last_response.status
-      assert_match "<title>Action Controller: Exception caught</title>", last_response.body
-      assert_match "ActiveRecord::StatementInvalid", last_response.body
+      quietly do
+        get("/foo", {}, "HTTPS" => "on")
+        assert_equal 500, last_response.status
+        assert_match "<title>Action Controller: Exception caught</title>", last_response.body
+        assert_match "ActiveRecord::StatementInvalid", last_response.body
 
-      get "/foo", {}, { "HTTP_ACCEPT" => "text/plain", "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest", "HTTPS" => "on" }
-      assert_equal 500, last_response.status
-      assert_equal "text/plain", last_response.media_type
-      assert_match "ActiveRecord::StatementInvalid", last_response.body
+        get "/foo", {}, { "HTTP_ACCEPT" => "text/plain", "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest", "HTTPS" => "on" }
+        assert_equal 500, last_response.status
+        assert_equal "text/plain", last_response.media_type
+        assert_match "ActiveRecord::StatementInvalid", last_response.body
+      end
     end
 
     test "show_exceptions :rescuable with a rescuable error" do
@@ -286,8 +312,10 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :rescuable
 
-      get "/foo", {}, { "HTTPS" => "on" }
-      assert_equal 404, last_response.status
+      quietly do
+        get "/foo", {}, { "HTTPS" => "on" }
+        assert_equal 404, last_response.status
+      end
     end
 
     test "show_exceptions :rescuable with a non-rescuable error" do

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -30,14 +30,18 @@ module ApplicationTests
 
     test "rails/info/routes in development" do
       app("development")
-      get "/rails/info/routes"
-      assert_equal 200, last_response.status
+      quietly do
+        get "/rails/info/routes"
+        assert_equal 200, last_response.status
+      end
     end
 
     test "rails/info/properties in development" do
       app("development")
-      get "/rails/info/properties"
-      assert_equal 200, last_response.status
+      quietly do
+        get "/rails/info/properties"
+        assert_equal 200, last_response.status
+      end
     end
 
     test "/rails/info routes are accessible with globbing route present" do
@@ -108,26 +112,34 @@ module ApplicationTests
 
     test "rails/welcome in production" do
       app("production")
-      get("/", {}, "HTTPS" => "on")
-      assert_equal 404, last_response.status
+      quietly do
+        get("/", {}, "HTTPS" => "on")
+        assert_equal 404, last_response.status
+      end
     end
 
     test "rails/info in production" do
       app("production")
-      get("/rails/info", {}, "HTTPS" => "on")
-      assert_equal 404, last_response.status
+      quietly do
+        get("/rails/info", {}, "HTTPS" => "on")
+        assert_equal 404, last_response.status
+      end
     end
 
     test "rails/info/routes in production" do
       app("production")
-      get("/rails/info/routes", {}, "HTTPS" => "on")
-      assert_equal 404, last_response.status
+      quietly do
+        get("/rails/info/routes", {}, "HTTPS" => "on")
+        assert_equal 404, last_response.status
+      end
     end
 
     test "rails/info/properties in production" do
       app("production")
-      get("/rails/info/properties", {}, "HTTPS" => "on")
-      assert_equal 404, last_response.status
+      quietly do
+        get("/rails/info/properties", {}, "HTTPS" => "on")
+        assert_equal 404, last_response.status
+      end
     end
 
     test "rails/health in production" do

--- a/railties/test/application/sprockets_assets_test.rb
+++ b/railties/test/application/sprockets_assets_test.rb
@@ -371,8 +371,10 @@ module ApplicationTests
       # Load app env
       app "production"
 
-      get("/assets/demo.js", {}, "HTTPS" => "on")
-      assert_equal 404, last_response.status
+      quietly do
+        get("/assets/demo.js", {}, "HTTPS" => "on")
+        assert_equal 404, last_response.status
+      end
     end
 
     test "does not stream session cookies back" do

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -391,10 +391,12 @@ module SharedGeneratorTests
   def test_generated_files_have_no_rubocop_warnings
     run_generator
 
-    Dir.chdir(destination_root) do
-      output = `./bin/rubocop`
+    quietly do
+      Dir.chdir(destination_root) do
+        output = `./bin/rubocop`
 
-      assert_predicate $?, :success?, "bin/rubocop did not exit successfully:\n#{output}"
+        assert_predicate $?, :success?, "bin/rubocop did not exit successfully:\n#{output}"
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This commit wraps HTTP request tests and RuboCop output with `quietly` blocks to suppress output during test execution.

### Detail
Here are examples without this commit:

- HTTP request without this commit
```ruby
$ bin/test test/application/mailer_previews_test.rb:29 -v
Run options: -v --seed 45319

# Running:

ApplicationTests::MailerPreviewsTest#test_/rails/mailers_is_not_accessible_in_production = [3635ef3a-33d8-4c40-aecc-d81361ef0008]   
[3635ef3a-33d8-4c40-aecc-d81361ef0008] ActionController::RoutingError (No route matches [GET] "/rails/mailers"):
[3635ef3a-33d8-4c40-aecc-d81361ef0008]   
1.02 s = .

Finished in 1.038007s, 0.9634 runs/s, 0.9634 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
$
``` 

- RuboCop without this commit
```ruby
$ bin/test test/generators/plugin_generator_test.rb -n test_generated_files_have_no_rubocop_warnings
Run options: -n test_generated_files_have_no_rubocop_warnings --seed 51891

# Running:

The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that you can opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable
Minitest/AssertInDelta: # new in 0.10
  Enabled: true
Minitest/AssertKindOf: # new in 0.10
  Enabled: true
Minitest/AssertOperator: # new in 0.32
  Enabled: true
Minitest/AssertOutput: # new in 0.10
  Enabled: true
Minitest/AssertPathExists: # new in 0.10
  Enabled: true
Minitest/AssertPredicate: # new in 0.18
  Enabled: true
Minitest/AssertRaisesCompoundBody: # new in 0.21
  Enabled: true
Minitest/AssertRaisesWithRegexpArgument: # new in 0.22
  Enabled: true
Minitest/AssertSame: # new in 0.26
  Enabled: true
Minitest/AssertSilent: # new in 0.10
  Enabled: true
Minitest/AssertWithExpectedArgument: # new in 0.11
  Enabled: true
Minitest/AssertionInLifecycleHook: # new in 0.10
  Enabled: true
Minitest/DuplicateTestRun: # new in 0.19
  Enabled: true
Minitest/EmptyLineBeforeAssertionMethods: # new in 0.23
  Enabled: true
Minitest/Focus: # new in 0.35
  Enabled: true
Minitest/LifecycleHooksOrder: # new in 0.28
  Enabled: true
Minitest/LiteralAsActualArgument: # new in 0.10
  Enabled: true
Minitest/MultipleAssertions: # new in 0.10
  Enabled: true
Minitest/NonExecutableTestMethod: # new in 0.34
  Enabled: true
Minitest/NonPublicTestMethod: # new in 0.27
  Enabled: true
Minitest/RedundantMessageArgument: # new in 0.34
  Enabled: true
Minitest/RefuteInDelta: # new in 0.10
  Enabled: true
Minitest/RefuteKindOf: # new in 0.10
  Enabled: true
Minitest/RefuteOperator: # new in 0.32
  Enabled: true
Minitest/RefutePathExists: # new in 0.10
  Enabled: true
Minitest/RefutePredicate: # new in 0.18
  Enabled: true
Minitest/RefuteSame: # new in 0.26
  Enabled: true
Minitest/ReturnInTestMethod: # new in 0.31
  Enabled: true
Minitest/SkipEnsure: # new in 0.20
  Enabled: true
Minitest/SkipWithoutReason: # new in 0.24
  Enabled: true
Minitest/TestFileName: # new in 0.26
  Enabled: true
Minitest/TestMethodName: # new in 0.10
  Enabled: true
Minitest/UnreachableAssertion: # new in 0.14
  Enabled: true
Minitest/UnspecifiedException: # new in 0.10
  Enabled: true
Minitest/UselessAssertion: # new in 0.26
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
.

Finished in 1.003901s, 0.9961 runs/s, 0.9961 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
$
``` 

- HTTP request with this commit

```ruby
$ bin/test test/application/mailer_previews_test.rb:29 -v
Run options: -v --seed 9909

# Running:

ApplicationTests::MailerPreviewsTest#test_/rails/mailers_is_not_accessible_in_production = 1.01 s = .

Finished in 1.017556s, 0.9827 runs/s, 0.9827 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

- RuboCop with this commit
```ruby
$ bin/test test/generators/plugin_generator_test.rb -n test_generated_files_have_no_rubocop_warnings
Run options: -n test_generated_files_have_no_rubocop_warnings --seed 59171

# Running:

.

Finished in 0.999844s, 1.0002 runs/s, 1.0002 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
$
``` 

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
