### PR TITLE
Fix text overflow in interstitial notes on mobile

### DIFF
--- a/guides/assets/stylesrc/components/_code-container.scss
+++ b/guides/assets/stylesrc/components/_code-container.scss
@@ -31,6 +31,7 @@ dl dd .interstitial {
   spurious blank area below with the box background. */
   p {
     margin-bottom: 0.75em;
+    overflow: hidden;
 
     &:last-child {
       margin-bottom: 0;


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because on mobile viewports, notes containing long `<code>` elements (like `bin/rails generate model Book title:string author:string`) overflow their container, causing horizontal scrolling and clipped text.

### Detail
#### Before
The .interstitial container uses display: flex, but paragraphs inside had min-width: auto which prevented them from shrinking below their content size. This caused long code snippets to overflow on mobile devices.

<img width="535" height="628" alt="Screenshot 2025-12-06 at 7 15 04 PM" src="https://github.com/user-attachments/assets/97b7a96d-8ee8-4a46-94dc-11421b0a0c4c" />

#### After
Adding overflow: hidden establishes a block formatting context, which changes how min-width: auto is computed in flexbox, allowing the paragraph to shrink properly.

<img width="535" height="628" alt="Screenshot 2025-12-06 at 7 15 43 PM" src="https://github.com/user-attachments/assets/ed165504-914a-4831-a366-413e8c501e4f" />

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
This can be checked on this URL in mobile view: https://guides.rubyonrails.org/active_record_basics.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
