### PR TITLE
Document ActiveStorage Variant Process Option [ci skip]

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -101,6 +101,28 @@ module ActiveStorage
       #     has_one_attached :avatar, strict_loading: true
       #   end
       #
+      # You can configure specific variants per attachment by calling the +variant+ method
+      # on the yielded attachable object. Use the +:process+ option to control when variants
+      # are generated:
+      #
+      #   class User < ApplicationRecord
+      #     has_one_attached :avatar do |attachable|
+      #       # Create immediately when the avatar is attached
+      #       attachable.variant :thumb, resize_to_limit: [100, 100], process: :immediately
+      #
+      #       # Create in a background job after attachment
+      #       attachable.variant :medium, resize_to_limit: [300, 300], process: :later
+      #
+      #       # Create on demand when first requested (default)
+      #       attachable.variant :large, resize_to_limit: [800, 800], process: :lazily
+      #     end
+      #   end
+      #
+      # The +:process+ option accepts:
+      # * +:lazily+ (default) - Variants are created on the fly when first requested
+      # * +:later+ - Variants are created in a background job after the attachment is saved
+      # * +:immediately+ - Variants are created synchronously when the attachment is created
+      #
       # Note: Active Storage relies on polymorphic associations, which in turn store class names in the database.
       # When renaming classes that use <tt>has_one_attached</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
@@ -202,6 +224,18 @@ module ActiveStorage
       #   class Gallery < ApplicationRecord
       #     has_many_attached :photos, strict_loading: true
       #   end
+      #
+      # You can configure specific variants per attachment by calling the +variant+ method
+      # on the yielded attachable object. Use the +:process+ option to control when variants
+      # are generated:
+      #
+      #   class Gallery < ApplicationRecord
+      #     has_many_attached :photos do |attachable|
+      #       attachable.variant :thumb, resize_to_limit: [100, 100], process: :immediately
+      #     end
+      #   end
+      #
+      # See +has_one_attached+ for more details on the +:process+ option.
       #
       # Note: Active Storage relies on polymorphic associations, which in turn store class names in the database.
       # When renaming classes that use <tt>has_many</tt>, make sure to also update the class names in the

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -461,6 +461,8 @@ class User < ApplicationRecord
 end
 ```
 
+NOTE: The `preprocessed: true` option is deprecated in favor of `process: :later`.
+
 NOTE: Since Active Storage relies on polymorphic associations, and [polymorphic associations](./association_basics.html#polymorphic-associations) rely on storing class names in the database, that data must remain synchronized with the class name used by the Ruby code. When renaming classes that use `has_one_attached`, make sure to also update the class names in the `active_storage_attachments.record_type` polymorphic type column of the corresponding rows.
 
 [`has_one_attached`]: https://api.rubyonrails.org/classes/ActiveStorage/Attached/Model.html#method-i-has_one_attached


### PR DESCRIPTION
Document ActiveStorage variant process option and preprocessed deprecation

### Motivation / Background

This Pull Request has been created because PR #51951 introduced the `process` option for ActiveStorage variants with three values (`:lazily`, `:later`, `:immediately`) and deprecated the `preprocessed: true` option. The API documentation for `has_one_attached` and `has_many_attached` methods was missing documentation for this new feature, and the guides needed a deprecation notice for users still using `preprocessed: true`.

### Detail

This Pull Request changes:

1. **API Documentation** (`activestorage/lib/active_storage/attached/model.rb`):
   - Adds comprehensive documentation for the `process` option in `has_one_attached` method, explaining how to configure variants with `:lazily`, `:later`, and `:immediately` options
   - Adds similar documentation for `has_many_attached` method with a reference to `has_one_attached` for details

2. **Guides** (`guides/source/active_storage_overview.md`):
   - Adds a deprecation note about `preprocessed: true` being deprecated in favor of `process: :later`

These changes ensure the API documentation is complete and users are informed about the deprecation.

### Additional information

This PR complements PR #51951 by completing the documentation for the immediate variants feature. The CHANGELOG already documents this feature, so no CHANGELOG updates are needed for this documentation-only PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (N/A - documentation only)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (N/A - documentation only, CHANGELOG already updated in PR #51951)