### PR TITLE
Fix update, insert, and delete to raise IrreversibleMigration on roll…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2,6 +2,13 @@
 
     *Ngan Pham*
 
+*   Fix `update`, `insert`, and `delete` in migrations to raise `ActiveRecord::IrreversibleMigration` on rollback.
+
+    Previously, these methods would silently execute during rollback instead of
+    raising an error like `execute` does.
+
+    *Said Kaldybaev*
+
 *   Fix bug when `current_transaction.isolation` would not have been reset in test env.
 
     Additionally, extending the change in [#55549](https://github.com/rails/rails/pull/55549)

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -61,7 +61,8 @@ module ActiveRecord
         :create_enum, :drop_enum, :rename_enum, :add_enum_value, :rename_enum_value,
         :create_schema, :drop_schema,
         :create_virtual_table, :drop_virtual_table,
-        :enable_index, :disable_index
+        :enable_index, :disable_index,
+        :update, :insert, :delete
       ]
       include JoinTable
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -54,6 +54,42 @@ module ActiveRecord
         end
       end
 
+      def test_inverse_of_raise_exception_on_update
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :update, ["UPDATE users SET name = 'test'"]
+        end
+      end
+
+      def test_inverse_of_raise_exception_on_insert
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :insert, ["INSERT INTO users (name) VALUES ('test')"]
+        end
+      end
+
+      def test_inverse_of_raise_exception_on_delete
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :delete, ["DELETE FROM users WHERE id = 1"]
+        end
+      end
+
+      def test_irreversible_update_raises_exception
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.revert { @recorder.update "UPDATE users SET name = 'test'" }
+        end
+      end
+
+      def test_irreversible_insert_raises_exception
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.revert { @recorder.insert "INSERT INTO users (name) VALUES ('test')" }
+        end
+      end
+
+      def test_irreversible_delete_raises_exception
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.revert { @recorder.delete "DELETE FROM users WHERE id = 1" }
+        end
+      end
+
       def test_record
         @recorder.record :create_table, [:system_settings]
         assert_equal 1, @recorder.commands.length


### PR DESCRIPTION
Fixes #51570

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

`update`, `insert`, and `delete` statements in migrations were silently being executed during rollback when used in a change method. This is inconsistent with `execute`, which correctly `raises ActiveRecord::IrreversibleMigration`.

For example:
```ruby
class ResetUsersUpdatedAt < ActiveRecord::Migration[8.0]
  def change
    update("UPDATE users SET updated_at = NOW()")
  end
end
```
When rolling back this migration, the `UPDATE` statement would execute silently (potentially corrupting data) instead of raising an error.


<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

This PR adds `:update`, `:insert`, and `:delete` to `ReversibleAndIrreversibleMethods` in `CommandRecorder`.
This ensures these methods are recorded by the `CommandRecorder` and checked for reversibility when rolling back. Since they have no inverse operation defined, they now correctly raise `ActiveRecord::IrreversibleMigration` on rollback.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
