### PR TITLE
Deprecate PreviewImageJob

### DIFF
--- a/activestorage/app/jobs/active_storage/preview_image_job.rb
+++ b/activestorage/app/jobs/active_storage/preview_image_job.rb
@@ -6,11 +6,20 @@ class ActiveStorage::PreviewImageJob < ActiveStorage::BaseJob
   discard_on ActiveRecord::RecordNotFound, ActiveStorage::UnrepresentableError
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
+  def initialize(*arguments)
+    ActiveStorage.deprecator.warn(<<~MSG.squish)
+      ActiveStorage::PreviewImageJob is no longer used by Rails.
+      It is deprecated and will be removed in Rails 9.0.
+      Use the ActiveStorage::CreateVariantsJob instead.
+    MSG
+    super
+  end
+
   def perform(blob, variations)
     blob.preview({}).processed
 
     variations.each do |transformations|
-      blob.preprocessed(transformations)
+      ActiveStorage::TransformJob.perform_later(blob, transformations) if blob.representable?
     end
   end
 end

--- a/activestorage/test/jobs/preview_image_job_test.rb
+++ b/activestorage/test/jobs/preview_image_job_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::PreviewImageJobTest < ActiveJob::TestCase
+  setup do
+    @blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    @transformation = { resize_to_limit: [ 100, 100 ] }
+  end
+
+  test "creates preview" do
+    ActiveStorage.deprecator.silence do
+      assert_changes -> { @blob.preview_image.attached? }, from: false, to: true do
+        ActiveStorage::PreviewImageJob.perform_now @blob, [ @transformation ]
+      end
+    end
+  end
+
+  test "enqueues transform variant jobs" do
+    ActiveStorage.deprecator.silence do
+      assert_enqueued_with job: ActiveStorage::TransformJob, args: [ @blob, @transformation ] do
+        ActiveStorage::PreviewImageJob.perform_now @blob, [ @transformation ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
PreviewImageJob is no longer called by Rails but it is a documented
class making it public API that requires deprecation.

Another option is to just delete it but maybe there are code bases that subclass it or call it in tests.

The preprocessed method no longer exist so inline the original implementation instead.

This was missed in #51951.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
