### PR TITLE
Add setting for requiring explicit SELECT column names

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Add `ActiveRecord::Base.require_explicit_select` configuration option.
+
+    When set to `true`, raises `ActiveRecord::ExplicitSelectRequired` when a query
+    is executed without an explicit `select` clause. This encourages developers to
+    be explicit about which columns to fetch, improving performance by reducing
+    memory usage and data transfer.
+
+    ```ruby
+    # config/application.rb
+    config.active_record.require_explicit_select = true
+
+    # Or per-model
+    class User < ApplicationRecord
+      self.require_explicit_select = true
+    end
+
+    User.all
+    # => raises ActiveRecord::ExplicitSelectRequired
+
+    User.select(:id, :name, :email).all
+    # => works fine
+
+    # Aggregate methods are not affected
+    User.count  # => works
+    User.pluck(:id)  # => works
+    ```
+
+    *Said Kaldybaev*
+
 *   Fix bug when `current_transaction.isolation` would not have been reset in test env.
 
     Additionally, extending the change in [#55549](https://github.com/rails/rails/pull/55549)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -85,6 +85,28 @@ module ActiveRecord
       # to the database while the app is running.
       class_attribute :enumerate_columns_in_select_statements, instance_accessor: false, default: false
 
+      ##
+      # :singleton-method:
+      # When set to +true+, raises an +ActiveRecord::ExplicitSelectRequired+ error
+      # when a query is executed without an explicit +select+ clause.
+      #
+      # This encourages developers to be explicit about which columns to fetch,
+      # which can improve performance by reducing memory usage and data transfer.
+      #
+      #   class ApplicationRecord < ActiveRecord::Base
+      #     self.require_explicit_select = true
+      #   end
+      #
+      #   User.all
+      #   # => raises ActiveRecord::ExplicitSelectRequired
+      #
+      #   User.select(:id, :name).all
+      #   # => works fine
+      #
+      # Note: This does not affect aggregate queries like +count+, +sum+, +pluck+, etc.
+      # as they already specify their own columns.
+      class_attribute :require_explicit_select, instance_accessor: false, default: false
+
       class_attribute :belongs_to_required_by_default, instance_accessor: false
 
       class_attribute :strict_loading_by_default, instance_accessor: false, default: false

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -417,6 +417,37 @@ module ActiveRecord
   class StrictLoadingViolationError < ActiveRecordError
   end
 
+  # Raised when a query is executed without an explicit +select+ clause and
+  # +require_explicit_select+ is enabled on the model or globally.
+  #
+  # This error encourages developers to be explicit about which columns to fetch,
+  # which can improve performance by reducing memory usage and data transfer.
+  #
+  # To resolve this error, add an explicit +select+ clause to your query:
+  #
+  #   # Instead of:
+  #   User.all
+  #
+  #   # Use:
+  #   User.select(:id, :name, :email).all
+  #
+  # See {Selecting Specific Fields}[https://guides.rubyonrails.org/active_record_querying.html#selecting-specific-fields]
+  # for more information.
+  class ExplicitSelectRequired < ActiveRecordError
+    attr_reader :model
+
+    def initialize(model = nil)
+      @model = model
+      if model
+        super("Query on #{model.name} is missing an explicit `select` clause. " \
+              "Use `select` to specify the columns you need, " \
+              "or disable `require_explicit_select` to allow SELECT *.")
+      else
+        super("Query is missing an explicit `select` clause.")
+      end
+    end
+  end
+
   # {ActiveRecord::Base.transaction}[rdoc-ref:Transactions::ClassMethods#transaction]
   # uses this exception to distinguish a deliberate rollback from other exceptional situations.
   # Normally, raising an exception will cause the

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1898,6 +1898,8 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values))
+        elsif model.require_explicit_select
+          raise ExplicitSelectRequired.new(model)
         elsif model.ignored_columns.any? || model.enumerate_columns_in_select_statements
           arel.project(*model.column_names.map { |field| table[field] })
         else

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1421,6 +1421,20 @@ is `nil`, purge jobs are sent to the default Active Job queue (see
 
 When `true`, will always include column names in `SELECT` statements, and avoid wildcard `SELECT * FROM ...` queries. This avoids prepared statement cache errors when adding columns to a PostgreSQL database for example. Defaults to `false`.
 
+#### `config.active_record.require_explicit_select`
+
+When `true`, raises `ActiveRecord::ExplicitSelectRequired` when a query is executed without an explicit `select` clause. This encourages developers to be explicit about which columns to fetch, improving performance by reducing memory usage and data transfer. Defaults to `false`.
+
+```ruby
+# With require_explicit_select = true
+User.all                          # => raises ActiveRecord::ExplicitSelectRequired
+User.select(:id, :name, :email)   # => works fine
+
+# Aggregate methods are not affected
+User.count      # => works
+User.pluck(:id) # => works
+```
+
 #### `config.active_record.verify_foreign_keys_for_fixtures`
 
 Ensures all foreign key constraints are valid after fixtures are loaded in tests. Supported by PostgreSQL and SQLite only.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Add a new configuration setting `ActiveRecord::Base.require_explicit_select`. When truthy, ActiveRecord will raise an `ActiveRecord::ExplicitSelectRequired` error when a query is executed without an explicit select clause, forcing developers to be explicit about which columns to fetch.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

Using SELECT * can cause several issues in production applications:
- Increased memory usage by loading unnecessary data into Ruby objects
- Slower queries by transferring mode data than needed from the database

Currently, there's no way easy way to enforece explicit `select` usage accross the app. Teams that care about this end up:
- Adding custom rubocop rules to lint for missing `select` calls
- Doing manual code reviews to catch `select *` queries
- Building custom query wrappers that require column specs

Adding a config option to enforce this behaviour all the time seems cleaner, and makes it easier to opt-in on per-model or per-environment basis.
```ruby
# config/application.rb
module MyApp
  class Application < Rails::Application
    config.active_record.require_explicit_select = true
  end
end
```
Or on a per-model basis:
```ruby
# app/models/user.rb
class User < ApplicationRecord
  self.require_explicit_select = true
end
```

Note: This does not affect aggregate queries like `count`, `sum`, `pluck`, `exists`?, `ids`, etc. as they already specify their own columns internally.


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
