### PR TITLE
ActionView Strict Locals: Adds support for case when closing parenthesis is on next line

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -366,7 +366,7 @@ module ActionView
     def strict_locals!
       if @strict_locals == NONE
         self.source.sub!(STRICT_LOCALS_REGEX, "")
-        @strict_locals = $1
+        @strict_locals = $1&.rstrip
 
         return if @strict_locals.nil? # Magic comment not found
 

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -242,6 +242,19 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal "First[]", render(arg_1: "First")
   end
 
+  def test_locals_can_spread_to_multiple_lines_with_closing_parenthesis_on_diff_line
+    template = <<~ERB.chomp
+        <%# locals: (
+                      arg_1:,
+                      arg_2: nil,
+                      arg_3: []
+                     ) -%>
+        <%= arg_1 %><%= arg_2 %><%= arg_3 %>
+    ERB
+    @template = new_template(template)
+    assert_equal "First[]", render(arg_1: "First")
+  end
+
   def test_required_locals_must_be_specified
     error = assert_raises(ActionView::Template::Error) do
       @template = new_template("<%# locals: (message:) -%>")


### PR DESCRIPTION
## Motivation / Background

A recent issue with strict locals parsing—specifically when the locals comment spans multiple lines—was fixed in https://github.com/rails/rails/pull/56270.

```erb
<%# locals: (arg_1:,
             arg_2: nil,
             arg_3: []) -%>

<%= arg_1 %><%= arg_2 %><%= arg_3 %>
```

### Missing variant
However, one variant was not covered: when the closing parenthesis is placed on the next line for alignment/formatting purposes. 

For example:

```erb
<%# locals: (
              arg_1:,
              arg_2: nil,
              arg_3: []
             ) -%>

<%= arg_1 %><%= arg_2 %><%= arg_3 %>

```

This PR contains support for the missing part. 

## Effects on HAML & SLIM
I have tested this behavior in Slim and confirmed that it works as expected. While I have not explicitly tested Haml, the logic should apply similarly.

**Example Code For SLim**

```slim
/# locals: (
           arg_1_req:,
           arg_2: 'default2Multi',
           arg_3: 'default3multi'
           )
p With a partial with strict locals!
p = arg_1_req
p = arg_2
p = arg_3
```


