### PR TITLE
Fix typos in documentation for clarity and consistency [ci skip]

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -126,14 +126,14 @@ module ActiveRecord
       # other than the writer method.
       #
       # The immutable requirement is enforced by Active Record by freezing any object assigned as a value
-      # object. Attempting to change it afterwards will result in a +RuntimeError+.
+      # object. Attempting to change it afterward will result in a +RuntimeError+.
       #
       # Read more about value objects on http://c2.com/cgi/wiki?ValueObject and on the dangers of not
       # keeping value objects immutable on http://c2.com/cgi/wiki?ValueObjectsShouldBeImmutable
       #
       # == Custom constructors and converters
       #
-      # By default value objects are initialized by calling the <tt>new</tt> constructor of the value
+      # By default, value objects are initialized by calling the <tt>new</tt> constructor of the value
       # class passing each of the mapped attributes, in the order specified by the <tt>:mapping</tt>
       # option, as arguments. If the value class doesn't support this convention then #composed_of allows
       # a custom constructor to be specified.
@@ -144,7 +144,7 @@ module ActiveRecord
       #
       # For example, the +NetworkResource+ model has +network_address+ and +cidr_range+ attributes that should be
       # aggregated using the +NetAddr::CIDR+ value class (https://www.rubydoc.info/gems/netaddr/1.5.0/NetAddr/CIDR).
-      # The constructor for the value class is called +create+ and it expects a CIDR address string as a parameter.
+      # The constructor for the value class is called,+create+ and it expects a CIDR address string as a parameter.
       # New values can be assigned to the value object using either another +NetAddr::CIDR+ object, a string
       # or an array. The <tt>:constructor</tt> and <tt>:converter</tt> options can be used to meet
       # these requirements:
@@ -199,7 +199,7 @@ module ActiveRecord
         #   mapped attributes.
         #   This defaults to +false+.
         # * <tt>:constructor</tt> - A symbol specifying the name of the constructor method or a Proc that
-        #   is called to initialize the value object. The constructor is passed all of the mapped attributes,
+        #   is called to initialize the value object. The constructor is passed to all the mapped attributes,
         #   in the order that they are defined in the <tt>:mapping option</tt>, as arguments and uses them
         #   to instantiate a <tt>:class_name</tt> object.
         #   The default is <tt>:new</tt>.

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -162,7 +162,7 @@ module ActiveRecord # :nodoc:
   # you can call <tt>account.balance_before_type_cast</tt> or <tt>account.id_before_type_cast</tt>.
   #
   # This is especially useful in validation situations where the user might supply a string for an
-  # integer field and you want to display the original string back in an error message. Accessing the
+  # integer field, and you want to display the original string back in an error message. Accessing the
   # attribute normally would typecast the string to 0, which isn't what you want.
   #
   # == Dynamic attribute-based finders

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -79,7 +79,7 @@ module ActiveRecord
   #
   # *IMPORTANT:* In order for inheritance to work for the callback queues, you must specify the
   # callbacks before specifying the associations. Otherwise, you might trigger the loading of a
-  # child before the parent has registered the callbacks and they won't be inherited.
+  # child before the parent has registered the callbacks, and they won't be inherited.
   #
   # == Types of callbacks
   #
@@ -173,7 +173,7 @@ module ActiveRecord
   #
   # If a <tt>before_*</tt> callback throws +:abort+, all the later callbacks and
   # the associated action are cancelled.
-  # \Callbacks are generally run in the order they are defined, with the exception of callbacks defined as
+  # \Callbacks are generally run in the order they are defined, with an exception to callbacks defined as
   # methods on the model, which are called last.
   #
   # == Ordering callbacks
@@ -236,7 +236,7 @@ module ActiveRecord
   # In this case the +log_children+ is executed before +do_something_else+.
   # This applies to all non-transactional callbacks, and to +before_commit+.
   #
-  # For transactional +after_+ callbacks (+after_commit+, +after_rollback+, etc), the order
+  # For transactional +after_+ callbacks (+after_commit+, +after_rollback+, etc.), the order
   # can be set via configuration.
   #
   #   config.active_record.run_after_transaction_callbacks_in_order_defined = false

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -8,7 +8,7 @@ module ActiveRecord
 
     # Establishes the connection to the database. Accepts a hash as input where
     # the <tt>:adapter</tt> key must be specified with the name of a database adapter (in lower-case)
-    # example for regular databases (MySQL, PostgreSQL, etc):
+    # example for regular databases (MySQL, PostgreSQL, etc.):
     #
     #   ActiveRecord::Base.establish_connection(
     #     adapter:  "mysql2",
@@ -128,7 +128,7 @@ module ActiveRecord
     # shard is passed, an +ActiveRecord::ConnectionNotEstablished+ error will be
     # raised.
     #
-    # When a shard and role is passed, Active Record will first lookup the role,
+    # When a shard and role is passed, Active Record will first look up the role,
     # and then look up the connection by shard key.
     #
     #   ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one_replica) do

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       ##
       # :singleton-method:
       #
-      # Accepts a logger conforming to the interface of Log4r or the default
+      # Accepts a logger conforming to the interface of +Log4r+ or the default
       # Ruby +Logger+ class, which is then passed on to any new database
       # connections made. You can retrieve this logger by calling +logger+ on
       # either an Active Record model class or an Active Record model instance.

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -219,7 +219,7 @@ module ActiveRecord
     #   the default <tt>:foreign_type</tt>.
     # [+:primary_key+]
     #   Specify the method that returns the primary key of associated object used for the convenience methods.
-    #   By default this is +id+.
+    #   By default, this is +id+.
     #
     # Option examples:
     #   class Entry < ApplicationRecord

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -64,7 +64,7 @@ module ActiveRecord
   #     enum :status, active: 0, archived: 1
   #   end
   #
-  # Finally it's also possible to use a string column to persist the enumerated value.
+  # Finally, it's also possible to use a string column to persist the enumerated value.
   # Note that this will likely lead to slower database queries:
   #
   #   class Conversation < ActiveRecord::Base

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -28,7 +28,7 @@ module ActiveRecord
           msg << c.explain(sql, binds, options)
         end.join("\n")
       end
-      # Overriding inspect to be more human readable, especially in the console.
+      # Overriding inspect to be more human-readable, especially in the console.
       def str.inspect
         self
       end

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -354,7 +354,7 @@ module ActiveRecord
       # Sets the attribute used for single table inheritance to this class name if this is not the
       # ActiveRecord::Base descendant.
       # Considering the hierarchy Reply < Message < ActiveRecord::Base, this makes it possible to
-      # do Reply.new without having to set <tt>Reply[Reply.inheritance_column] = "Reply"</tt> yourself.
+      # do <tt>Reply.new</tt> without having to set <tt>Reply[Reply.inheritance_column] = "Reply"</tt> yourself.
       # No such attribute would be set for objects of the Message class in that example.
       def ensure_proper_type
         klass = self.class


### PR DESCRIPTION
This PR addresses several documentation issues across the project’s RDoc files. 

It corrects grammatical mistakes, fixes typos, and improves formatting to enhance clarity and consistency. 

These changes aim to make the documentation easier to read for contributors and users without altering any functional behavior.