### PR TITLE
Fix preload for scoped has_one associations with LIMIT

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `preload` and `includes` applying `LIMIT` globally for `has_one` associations with `limit` in scope.
+
+    When preloading a `has_one` association defined with a `limit` scope like
+    `has_one :last_comment, -> { order(id: :desc).limit(1) }`, the `LIMIT` was
+    incorrectly applied to the entire batch query instead of per-parent-record.
+    This caused some parent records to incorrectly return `nil` for the association.
+
+    *Dmytro Rymar*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -304,6 +304,8 @@ module ActiveRecord
               scope.merge!(preload_scope)
             end
 
+            scope.limit!(nil) if !reflection.collection? && scope.limit_value
+
             cascade_strict_loading(scope)
           end
 

--- a/activerecord/test/cases/associations/preload_has_one_limit_test.rb
+++ b/activerecord/test/cases/associations/preload_has_one_limit_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+
+class PreloadHasOneLimitTest < ActiveRecord::TestCase
+  fixtures :posts, :comments
+
+  def test_preload_has_one_with_limit_returns_correct_record_per_parent
+    posts = Post.where(id: [posts(:welcome).id, posts(:thinking).id])
+                .order(:id)
+                .preload(:limited_last_comment)
+                .to_a
+
+    assert_equal comments(:more_greetings), posts[0].limited_last_comment
+    assert_equal comments(:does_it_hurt), posts[1].limited_last_comment
+  end
+
+  def test_preload_has_one_with_limit_does_not_cause_n_plus_one
+    posts = Post.where(id: [posts(:welcome).id, posts(:thinking).id])
+                .preload(:limited_last_comment)
+                .to_a
+
+    assert_no_queries { posts.each(&:limited_last_comment) }
+  end
+
+  def test_preload_has_one_with_limit_alongside_other_associations
+    expected_comment_1 = comments(:more_greetings)
+    expected_comment_2 = comments(:does_it_hurt)
+
+    posts = Post.where(id: [posts(:welcome).id, posts(:thinking).id])
+                .order(:id)
+                .preload(:limited_last_comment, :comments)
+                .to_a
+
+    assert_no_queries do
+      assert_equal expected_comment_1, posts[0].limited_last_comment
+      assert_equal 2, posts[0].comments.size
+      assert_equal expected_comment_2, posts[1].limited_last_comment
+      assert_equal 1, posts[1].comments.size
+    end
+  end
+
+  def test_preload_has_one_with_limit_with_no_matching_records
+    posts = Post.where(id: posts(:authorless).id)
+                .preload(:limited_last_comment)
+                .to_a
+
+    assert_nil posts.first.limited_last_comment
+  end
+
+  def test_includes_has_one_with_limit_returns_correct_record_per_parent
+    posts = Post.where(id: [posts(:welcome).id, posts(:thinking).id])
+                .order(:id)
+                .includes(:limited_last_comment)
+                .to_a
+
+    assert_equal comments(:more_greetings), posts[0].limited_last_comment
+    assert_equal comments(:does_it_hurt), posts[1].limited_last_comment
+  end
+
+  def test_includes_has_one_with_limit_does_not_cause_n_plus_one
+    posts = Post.where(id: [posts(:welcome).id, posts(:thinking).id])
+                .includes(:limited_last_comment)
+                .to_a
+
+    assert_no_queries { posts.each(&:limited_last_comment) }
+  end
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -58,6 +58,7 @@ class Post < ActiveRecord::Base
   end
   has_one :first_comment, -> { order("id ASC") }, class_name: "Comment"
   has_one :last_comment, -> { order("id desc") }, class_name: "Comment"
+  has_one :limited_last_comment, -> { order(id: :desc).limit(1) }, class_name: "Comment"
 
   scope :no_comments, -> { left_joins(:comments).where(comments: { id: nil }) }
   scope :with_special_comments, -> { joins(:comments).where(comments: { type: "SpecialComment" }) }


### PR DESCRIPTION
### Motivation / Background

This Pull Request addresses issue: https://github.com/rails/rails/issues/56276

Rails currently applies `LIMIT` incorrectly when preloading a `has_one` association where the scope contains `.limit(1)`. Because `preload` performs a single query for all parent records, the LIMIT is applied globally rather than per parent record.

Example:
```ruby
class Account < ApplicationRecord
  has_one :last_payment, -> { order(created_on: :desc).limit(1) }
end

Account.preload(:last_payment)
```

Generates SQL similar to:
```sql
SELECT * FROM payments
WHERE account_id IN (1, 2)
ORDER BY created_on DESC
LIMIT 1
```

Only one associated record is loaded for all accounts, causing incorrect results(one account receives `nil`).

### Detail

This PR fixes the issue by stripping the LIMIT clause from the preload scope for has_one (non-collection) associations.

  The key insight is that for `has_one` associations, the "one record per parent" filtering is already handled in Ruby code within `Preloader::Association#load_records`, which only assigns the first matching record to each owner. The `LIMIT` in the scope is therefore redundant for preloading and harmful when applied globally.

The fix(in `preloader/association.rb`):
```ruby
scope.limit!(nil) if !reflection.collection? && scope.limit_value
```

This approach:
  - Preserves `preload`'s efficient batch loading (single query for all parents)
  - Removes only the problematic global `LIMIT`
  - Lets existing Ruby code handle per-parent record assignment
  - Does not affect `has_many` or other collection associations

Additional Information
  - This change does not modify behavior of `has_many`, `belongs_to`, or `has_one` associations without `LIMIT` in scope
  - The fix applies to both preload and includes (when using preload strategy)
  - eager_load was already working correctly (uses JOINs, not affected by this issue)
  - The fix is backward-compatible and minimal

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] No CHANGELOG is needed, this is a small bug fix.
