### PR TITLE
Update GitHub Actions/Checkout to v6 in CI templates

### DIFF
--- a/.github/workflows/devcontainer-shellcheck.yml
+++ b/.github/workflows/devcontainer-shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (GitHub)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Lint Devcontainer Scripts
         run: |

--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout (GitHub)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/rail_inspector.yml
+++ b/.github/workflows/rail_inspector.yml
@@ -16,7 +16,7 @@ jobs:
     name: rail_inspector tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Remove Gemfile.lock
         run: rm -f Gemfile.lock
       - name: Set up Ruby

--- a/.github/workflows/rails-new-docker.yml
+++ b/.github/workflows/rails-new-docker.yml
@@ -14,7 +14,7 @@ jobs:
   rails-new-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Remove Gemfile.lock
       run: rm -f Gemfile.lock
     - name: Set up Ruby

--- a/.github/workflows/rails_releaser_tests.yml
+++ b/.github/workflows/rails_releaser_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -54,7 +54,7 @@ jobs:
       RUBOCOP_CACHE_ROOT: tmp/rubocop
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -121,7 +121,7 @@ jobs:
 
       <%- end -%>
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -194,7 +194,7 @@ jobs:
 
       <%- end -%>
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -14,7 +14,7 @@ jobs:
       RUBOCOP_CACHE_ROOT: tmp/rubocop
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -77,7 +77,7 @@ jobs:
     <%- end -%>
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
### Motivation / Background
Fixes #56320 

When creating new Rails 8.1.1 app with GitHub Actions CI & Dependabot flags enabled & pushing the code to GitHub -> Dependabot immediately opens pull request: Bump actions/checkout from 5 to 6. This issue might be confusing to new Rails users.

<img width="1924" height="1128" alt="image" src="https://github.com/user-attachments/assets/b0a7beee-f146-4c68-84a6-8f9b080f22bb" />
<img width="1116" height="794" alt="image" src="https://github.com/user-attachments/assets/875d517b-26dc-4800-b9cc-f01937cbc878" />

### Detail
This Pull Request updates the GitHub Actions CI template generated by new Rails applications to use `actions/checkout@v6` instead of `@v5`.

Newly generated Rails 8.1.1 applications currently trigger an immediate Dependabot PR to upgrade actions/checkout because the template still uses version 5. This change brings the template in line with the latest stable release and prevents unnecessary Dependabot noise in freshly initialized repositories.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
