### PR TITLE
ActiveRecord log to STDOUT on console

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -73,6 +73,7 @@ module ActiveRecord
       end
       ActiveRecord.verbose_query_logs = false
       ActiveRecord::Base.attributes_for_inspect = :all
+      ActiveRecord::Base.logger = Logger.new(STDOUT)
     end
 
     runner do


### PR DESCRIPTION
### Motivation / Background

Every time I set up a new Rails app, I find myself configuring the following:

```
# config/application.rb
console do
  ActiveRecord::Base.logger = Logger.new(STDOUT)
end
```

because I want to see the ActiveRecord logs printed on the console. Working with an ActiveRecord object is the Number 1 reason why I use the rails console.

I wonder if this is the right approach or if we should set this by default in application.rb in new rails apps, but I decided to bring the point nevertheless.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
