### PR TITLE
Ensure generated yml files do not have extra blank lines

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -20,7 +20,6 @@ test:
   <<: *default
   database: storage/test.sqlite3
 
-
 <%- if options.skip_kamal? -%>
 # SQLite3 write its data on the local filesystem, as such it requires
 # persistent disks. If you are deploying to a managed service, you should

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -90,7 +90,6 @@ volumes:
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
 asset_path: /rails/public/assets
-
 <% end -%>
 
 # Configure the image builder.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1771,6 +1771,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file(".devcontainer/compose.yaml")
   end
 
+  def test_generated_yml_files_format
+    generator [destination_root]
+    run_generator_instance
+
+    Dir["**/*.yml"].each do |yml_file|
+      assert_file yml_file do |content|
+        assert_no_match(/\n\n\n/, content, "File `#{yml_file}` should not have double empty lines")
+      end
+    end
+  end
+
   private
     def assert_load_defaults
       assert_file "config/application.rb", /\s+config\.load_defaults #{Rails::VERSION::STRING.to_f}/


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when generating a Rails `8.1.1` app, the `deploy.yml` and `database.yml` files have unneeded extra blank lines that were introduced in https://github.com/rails/rails/pull/55646 and https://github.com/rails/rails/pull/50463.

While PR reviewers catch most extra-line issues, they sometimes slip through, which results in odd-looking files in released Rails versions, and follow-up cleanups like https://github.com/rails/rails/pull/55940 and this current PR.

### Detail

This Pull Request fixes extra blank lines in `deploy.yml` and `database.yml`, and adds a test to ensure that most issues like these don't happen again.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
