### PR TITLE
Add slice/except helpers to ActiveModel::Errors

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActiveModel::Errors#slice` and `#except` to filter errors by attribute.
+
+    ```ruby
+    user.errors.slice(:email, :name)
+    user.errors.except(:base, :admin)
+    ```
+
+    *Said Kaldybaev*
+
 *   Add `has_json` and `has_delegated_json` to provide schema-enforced access to JSON attributes.
 
     ```ruby

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -190,6 +190,20 @@ module ActiveModel
       }
     end
 
+    # Returns a new +Errors+ containing only the errors for the given attributes.
+    #
+    #   person.errors.slice(:name, :email)
+    def slice(*attributes)
+      filter_errors(attributes.flatten.map!(&:to_sym), keep: true)
+    end
+
+    # Returns a new +Errors+ excluding errors for the given attributes.
+    #
+    #   person.errors.except(:email)
+    def except(*attributes)
+      filter_errors(attributes.flatten.map!(&:to_sym), keep: false)
+    end
+
     # Returns +true+ if the error messages include an error for the given key
     # +attribute+, +false+ otherwise.
     #
@@ -499,6 +513,19 @@ module ActiveModel
         end
 
         [attribute.to_sym, type, options]
+      end
+
+      def filter_errors(attributes, keep:)
+        filtered = self.class.new(@base)
+
+        @errors.each do |error|
+          included = attributes.include?(error.attribute)
+          next unless keep ? included : !included
+
+          filtered.import(error)
+        end
+
+        filtered
       end
   end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -677,6 +677,32 @@ class ErrorsTest < ActiveModel::TestCase
     assert(person.errors.added?(:name, :blank))
   end
 
+  test "slice returns errors only for requested attributes" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors.add(:email, :blank)
+    errors.add(:base, :invalid)
+
+    sliced = errors.slice(:email)
+
+    assert sliced.added?(:email, :blank)
+    assert_not sliced.added?(:name, :invalid)
+    assert_not sliced.added?(:base, :invalid)
+  end
+
+  test "except returns errors excluding requested attributes" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors.add(:email, :blank)
+    errors.add(:base, :invalid)
+
+    excluded = errors.except(:name)
+
+    assert excluded.added?(:email, :blank)
+    assert excluded.added?(:base, :invalid)
+    assert_not excluded.added?(:name, :invalid)
+  end
+
   test "merge does not import errors when merging with self" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -690,6 +690,19 @@ class ErrorsTest < ActiveModel::TestCase
     assert_not sliced.added?(:base, :invalid)
   end
 
+  test "slice accepts arrays and string attributes" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors.add(:email, :blank)
+    errors.add(:city, :invalid)
+
+    sliced = errors.slice([:email, "city"])
+
+    assert sliced.added?(:email, :blank)
+    assert sliced.added?(:city, :invalid)
+    assert_not sliced.added?(:name, :invalid)
+  end
+
   test "except returns errors excluding requested attributes" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)
@@ -701,6 +714,19 @@ class ErrorsTest < ActiveModel::TestCase
     assert excluded.added?(:email, :blank)
     assert excluded.added?(:base, :invalid)
     assert_not excluded.added?(:name, :invalid)
+  end
+
+  test "except accepts arrays and string attributes" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors.add(:email, :blank)
+    errors.add(:city, :invalid)
+
+    excluded = errors.except(["name", :city])
+
+    assert excluded.added?(:email, :blank)
+    assert_not excluded.added?(:name, :invalid)
+    assert_not excluded.added?(:city, :invalid)
   end
 
   test "merge does not import errors when merging with self" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

We often need to scope errors for specific contexts (sectioned forms, partial PATCH responses, logging). Today, doing that requires manual filtering over errors. E.g:
```ruby
err = ActiveModel::Errors.new(user)
user.errors.each do |error|
  err.import(error) if [:billing_address, :billing_city, :billing_zip].include?(error.attribute)
end
logger.warn(err.details)
render json: err.full_messages
```
With a helper, this would become simpler and clearer:
```ruby
err= user.errors.slice(:billing_address, :billing_city, :billing_zip)
logger.warn(err.details)
render json: err.full_messages
```

If these helpers make sense to merge, I can also update the changelog.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

This PR adds two helpers to `ActiveModel::Errors`:
- `slice(*attributes)`: returns a new `Errors` with only the given attributes’ errors.
- `except(*attributes)`: returns a new `Errors` without the given attributes’ errors.

Keeping this on `Errors` preserves full semantics (types, metadata/options, nested/NestedError wrapping, and downstream helpers like messages, full_messages, details, serialization).

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
