### PR TITLE
Enable debug events by default

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `ActiveSupport::EventReporter#debug_mode?` true by default to emit debug events
+    outside of Rails application contexts.
+
+    *Gannon McGibbon*
+
 *   Add `SecureRandom.base32` for generating case-insensitive keys that are unambiguous to humans.
 
     *Stanko Krtalic Rusendic & Miha Rekar*

--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -293,7 +293,7 @@ module ActiveSupport
     def initialize(*subscribers, raise_on_error: false)
       @subscribers = []
       subscribers.each { |subscriber| subscribe(subscriber) }
-      @debug_mode = false
+      @debug_mode = true
       @raise_on_error = raise_on_error
     end
 

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -11,6 +11,12 @@ module ActiveSupport
     setup do
       @subscriber = EventReporter::TestHelper::EventSubscriber.new
       @reporter = EventReporter.new(@subscriber, raise_on_error: true)
+      @old_debug_mode = @reporter.debug_mode?
+      @reporter.debug_mode = false
+    end
+
+    teardown do
+      @reporter.debug_mode = @old_debug_mode
     end
 
     class TestEvent
@@ -290,6 +296,10 @@ module ActiveSupport
         assert_predicate @reporter, :debug_mode?
       end
       assert_not_predicate @reporter, :debug_mode?
+    end
+
+    test "#debug_mode? returns true by default" do
+      assert @old_debug_mode
     end
 
     test "#debug_mode? returns true when debug_mode=true is set" do

--- a/activesupport/test/structured_event_subscriber_test.rb
+++ b/activesupport/test/structured_event_subscriber_test.rb
@@ -25,8 +25,14 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
     debug_only :debug_only_event
   end
 
-  def setup
+  setup do
     @subscriber = TestSubscriber.new
+    @old_debug_mode = ActiveSupport.event_reporter.debug_mode?
+    ActiveSupport.event_reporter.debug_mode = false
+  end
+
+  teardown do
+    ActiveSupport.event_reporter.debug_mode = @old_debug_mode
   end
 
   def test_emit_event_calls_event_reporter_notify


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because debug events don't get emitted by default anymore since we introduced the new log subscribers that use the new event reporter.

### Detail

This Pull Request changes the event reporter to default to debug mode.

Closes https://github.com/rails/rails/issues/56230

Enables debug events when the application hasn't been initialized. This use-case is primarily for test purposes, or when using framework libraries individually outside of Rails. In these cases, we shouldn't assume debug events need to be obfuscated.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
