### PR TITLE
Fix typo in comments: exisiting → existing

### DIFF
--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -105,7 +105,7 @@ module ActiveRecord
         # Problem is, messages may have a "c" header that is present or not
         # depending on whether compression was applied on encryption. If this
         # threshold was modified, the message generated for lookup could vary
-        # for the same clear text, and searches on exisiting data could fail.
+        # for the same clear text, and searches on existing data could fail.
         THRESHOLD_TO_JUSTIFY_COMPRESSION = 140.bytes
 
         def default_key_provider

--- a/activerecord/test/models/dats.rb
+++ b/activerecord/test/models/dats.rb
@@ -3,7 +3,7 @@
 # DATS = Deprecated Associations Test Suite.
 #
 # Minimal models defined ad-hoc for the test suite of deprecated associations.
-# They are persisted in exisiting tables for simplicity.
+# They are persisted in existing tables for simplicity.
 module DATS
   def self.table_name_prefix = ""
 


### PR DESCRIPTION
### Summary

This PR fixes a typo in code comments where "exisiting" was misspelled as "existing".

### Motivation / Background

While running codespell to find typos in the codebase, I found this spelling error in two comment lines.

### Details

Fixed "exisiting" → "existing" in:
- `activerecord/lib/active_record/encryption/encryptor.rb:108` - Comment about searches on existing data
- `activerecord/test/models/dats.rb:6` - Comment about persisting in existing tables

This is a comment-only change with no functional impact.
