### PR TITLE
Do not clean directories directly under the application root with `Rails::BacktraceCleaner`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Do not clean directories directly under the application root with `Rails::BacktraceCleaner`
+
+    Improved `Rails.backtrace_cleaner` so that most paths located directly under the application's root directory are no longer silenced.
+
+    *alpaca-tc*
+
 *   Add `Rails::CodeStatistics#register_extension` to register file extensions for `rails stats`
 
     ```ruby

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -5,7 +5,6 @@ require "active_support/core_ext/string/access"
 
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner # :nodoc:
-    APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w+(?:-\w+)*\))/
     RENDER_TEMPLATE_PATTERN = /:in [`'].*_\w+_{2,3}\d+_\d+'/
 
     def initialize
@@ -23,7 +22,10 @@ module Rails
           line
         end
       end
-      add_silencer { |line| !APP_DIRS_PATTERN.match?(line) }
+
+      add_silencer do |line|
+        line.start_with?(File::SEPARATOR, "vendor/", "bin/")
+      end
     end
 
     def clean(backtrace, kind = :silent)


### PR DESCRIPTION
### Motivation / Background

- We run ad-hoc scripts under `./script` via `bin/rails runner ./script/<file>`.
  - I think it's common to run files as temporary scripts when you want to avoid putting complex data patches into DB migrations.
- When debugging, we need accurate backtraces and query call locations, but `Rails.backtrace_cleaner` hides frames outside the fixed "application code" paths.
- As a result, useful frames from `./script` (and similar custom dirs) are removed.

*Problem Example*

```
# ./script/verbose_logs.rb
User.where(id: 1).load
```

```
# On main, frames under `./script` are cleaned, so their backtraces don't appear.
$ bundle exec rails runner ./script/verbose_logs.rb
  User Load (1.0ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1
```

```
# Backtrace includes gem internals but omits our script frames we actually want.
$ BACKTRACE=1 bundle exec rails runner ./script/verbose_logs.rb
  User Load (1.0ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1
  ↳ activerecord (7.2.3) lib/active_record/log_subscriber.rb:122:in 'ActiveRecord::LogSubscriber#log_query_source'
```

### Detail

I updated `Rails::BacktraceCleaner` it so that directories directly under the application root - except for vendor - are not cleaned, based on the advice in https://github.com/rails/rails/pull/56333#issuecomment-3635662172.

```
# This PR
$ bundle exec rails runner ./script/verbose_logs.rb
  User Load (1.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 1
  ↳ script/verbose_logs.rb:1:in '<top (required)>'
```

### Additional information

Who benefits

- Teams that keep runnable utilities in user-defined dirs, or modular-monolith setups that store app code in `./packs`, can keep those paths visible in backtraces for debugging.
- `ActiveSupport::BacktraceCleaner#remove_filters!` isn't a viable alternative because it strips out the useful default filters.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.