### PR TITLE
Yield the transaction for Model#with_lock

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Yield the transaction object to the block when using `with_lock`.
+
+    *Ngan Pham*
+
 *   Fix bug when `current_transaction.isolation` would not have been reset in test env.
 
     Additionally, extending the change in [#55549](https://github.com/rails/rails/pull/55549)

--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -97,9 +97,9 @@ module ActiveRecord
       def with_lock(*args)
         transaction_opts = args.extract_options!
         lock = args.present? ? args.first : true
-        transaction(**transaction_opts) do
+        transaction(**transaction_opts) do |transaction|
           lock!(lock)
-          yield
+          yield transaction
         end
       end
     end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -814,6 +814,13 @@ class PessimisticLockingTest < ActiveRecord::TestCase
           end
         end
       end
+
+      def test_with_lock_yields_transaction
+        person = Person.find 1
+        person.with_lock do |transaction|
+          assert_equal Person.current_transaction, transaction
+        end
+      end
     end
 
     def test_no_locks_no_wait


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I'd like a nicer way of getting the current transaction when using `AR#with_lock`. This is similar to https://github.com/rails/rails/pull/51474 which yields the transaction when calling `AR.transaction`.

### Detail

This Pull Request changes `ActiveRecord::Base#with_lock` to yield the transaction.
```ruby
person.with_lock do |transaction|
  transaction.after_commit { puts "hello" }
end
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
