### PR TITLE
Analyze attachments before validation

### DIFF
--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -55,6 +55,7 @@ module ActiveStorage
 
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers,  default: []
+  mattr_accessor :analyze,    default: :later
 
   mattr_accessor :paths, default: {}
 

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -101,11 +101,24 @@ module ActiveStorage
       #     has_one_attached :avatar, strict_loading: true
       #   end
       #
+      # Pass the +analyze:+ option to control when analysis is performed:
+      #
+      #   class User < ApplicationRecord
+      #     has_one_attached :avatar, analyze: :immediately
+      #   end
+      #
+      # Valid values are:
+      # - +:immediately+ - Analyze before validation, making metadata available for validations
+      # - +:later+ (default) - Analyze in a background job after attachment
+      # - +:lazily+ - Skip automatic analysis; analyze on-demand when metadata is accessed
+      #
+      # The default can be changed globally with <tt>config.active_storage.analyze = :immediately</tt>.
+      #
       # Note: Active Storage relies on polymorphic associations, which in turn store class names in the database.
       # When renaming classes that use <tt>has_one_attached</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false, analyze: nil)
         Attached::Model.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -149,7 +162,7 @@ module ActiveStorage
           :has_one_attached,
           name,
           nil,
-          { dependent: dependent, service_name: service },
+          { dependent: dependent, service_name: service, analyze: analyze },
           self
         )
         yield reflection if block_given?
@@ -205,11 +218,19 @@ module ActiveStorage
       #     has_many_attached :photos, strict_loading: true
       #   end
       #
+      # Pass the +analyze:+ option to control when analysis is performed:
+      #
+      #   class Gallery < ApplicationRecord
+      #     has_many_attached :photos, analyze: :immediately
+      #   end
+      #
+      # See +has_one_attached+ for available values and details.
+      #
       # Note: Active Storage relies on polymorphic associations, which in turn store class names in the database.
       # When renaming classes that use <tt>has_many</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false, analyze: nil)
         Attached::Model.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -255,7 +276,7 @@ module ActiveStorage
           :has_many_attached,
           name,
           nil,
-          { dependent: dependent, service_name: service },
+          { dependent: dependent, service_name: service, analyze: analyze },
           self
         )
         yield reflection if block_given?

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -149,6 +149,7 @@ module ActiveStorage
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
         ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
+        ActiveStorage.analyze = app.config.active_storage.analyze || :later
       end
     end
 

--- a/activestorage/test/controllers/representations/redirect_controller_test.rb
+++ b/activestorage/test/controllers/representations/redirect_controller_test.rb
@@ -107,9 +107,7 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsTest < Actio
       signed_blob_id: @blob.signed_id,
       variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
-    # One additional SELECT is expected from touch_attachments callback when
-    # persisting immediate analysis metadata on the preview image blob.
-    assert_equal 1, variant_record_loaded_count
+    assert_equal 0, variant_record_loaded_count
   ensure
     ActiveSupport::Notifications.unsubscribe(query_subscriber) if query_subscriber
   end

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -15,6 +15,9 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
 
     reflection = User.reflect_on_attachment(:avatar_with_variants)
     assert_instance_of Hash, reflection.named_variants
+
+    reflection = User.reflect_on_attachment(:avatar_with_immediate_analysis)
+    assert_equal :immediately, reflection.options[:analyze]
   end
 
   test "reflection on a singular attachment with the same name as an attachment on another model" do
@@ -39,8 +42,8 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "reflecting on all attachments" do
     reflections = User.reflect_on_all_attachments.sort_by(&:name)
     assert_equal [ User ], reflections.collect(&:active_record).uniq
-    assert_equal [ :avatar, :avatar_with_conditional_preprocessed, :avatar_with_immediate_variants, :avatar_with_later_variants, :avatar_with_lazy_variants, :avatar_with_preprocessed, :avatar_with_variants, :cover_photo, :highlights, :highlights_with_conditional_preprocessed, :highlights_with_immediate_variants, :highlights_with_preprocessed, :highlights_with_variants, :intro_video, :name_pronunciation_audio, :resume, :resume_with_preprocessing, :vlogs ], reflections.collect(&:name)
-    assert_equal [ :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_many_attached ], reflections.collect(&:macro)
-    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
+    assert_equal [ :avatar, :avatar_with_conditional_preprocessed, :avatar_with_immediate_analysis, :avatar_with_immediate_variants, :avatar_with_later_analysis, :avatar_with_later_variants, :avatar_with_lazy_analysis, :avatar_with_lazy_variants, :avatar_with_preprocessed, :avatar_with_variants, :cover_photo, :highlights, :highlights_with_conditional_preprocessed, :highlights_with_immediate_variants, :highlights_with_preprocessed, :highlights_with_variants, :intro_video, :name_pronunciation_audio, :resume, :resume_with_preprocessing, :vlogs ], reflections.collect(&:name)
+    assert_equal [ :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_many_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_one_attached, :has_many_attached ], reflections.collect(&:macro)
+    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
   end
 end

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -300,14 +300,13 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
       # More queries here because we are creating a different variant.
       # The second time we load this variant, we are back down to just 3 queries.
 
-      assert_queries_match(/SELECT/i, count: 14) do
-        # 14 queries:
+      assert_queries_match(/SELECT/i, count: 10) do
+        # 10 queries:
         # attachments (vlogs) initial load x 1
         # blob x 1 (gets both records)
         # variant record x 1 (gets both records)
         # preview_image_attachments for non-images
         # 2x get blob, attachment, variant records again, this happens when loading the new blob inside `VariantWithRecord#key`
-        # 2x (touch_attachments + update_service_metadata) queries per variant from immediate analysis
         user.vlogs.with_all_variant_records.each do |vlog|
           rep = vlog.representation(resize_to_limit: [200, 200])
           rep.processed

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -152,6 +152,9 @@ class User < ActiveRecord::Base
   end
   has_one_attached :intro_video
   has_one_attached :name_pronunciation_audio
+  has_one_attached :avatar_with_immediate_analysis, analyze: :immediately
+  has_one_attached :avatar_with_later_analysis, analyze: :later
+  has_one_attached :avatar_with_lazy_analysis, analyze: :lazily
 
   has_many_attached :highlights
   has_many_attached :vlogs, dependent: false, service: :local

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -872,9 +872,56 @@ It's important to know that the file is not yet available in the `after_create` 
 Analyzing Files
 ---------------
 
-Active Storage analyzes files once they've been uploaded by queuing a job in Active Job. Analyzed files will store additional information in the metadata hash, including `analyzed: true`. You can check whether a blob has been analyzed by calling [`analyzed?`][] on it.
+Active Storage analyzes files to extract metadata like image dimensions, video duration, and audio bit rate. Analyzed files store this information in their metadata hash, including `analyzed: true`. You can check whether a blob has been analyzed by calling [`analyzed?`][] on it.
 
 Image analysis provides `width` and `height` attributes. Video analysis provides these, as well as `duration`, `angle`, `display_aspect_ratio`, and `video` and `audio` booleans to indicate the presence of those channels. Audio analysis provides `duration` and `bit_rate` attributes.
+
+### Validating Attachment Metadata
+
+As of Rails 8.2, attachments are analyzed before validation by default, making metadata available for model validations:
+
+```ruby
+class User < ApplicationRecord
+  has_one_attached :avatar
+
+  validate :validate_avatar_dimensions, if: -> { avatar.attached? }
+
+  private
+    def validate_avatar_dimensions
+      if avatar.metadata[:width] < 200 || avatar.metadata[:height] < 200
+        errors.add(:avatar, "must be at least 200x200 pixels")
+      end
+    end
+end
+```
+
+NOTE: [Direct uploads](#direct-uploads) bypass the server so the file isn't locally available for analysis. In this case, `:immediately` falls back to `:later`, analyzing via background job after upload completes. Metadata isn't available for validation; validate on the client side using JavaScript instead.
+
+### Controlling When Analysis is Performed
+
+Pass the `analyze:` option to control when analysis is performed:
+
+```ruby
+class User < ApplicationRecord
+  # Analyze before validation (default in 8.2)
+  has_one_attached :avatar, analyze: :immediately
+
+  # Analyze after upload from local IO or via background job for direct uploads
+  has_one_attached :document, analyze: :later
+
+  # Skip automatic analysis - analyze on-demand when metadata is accessed
+  has_many_attached :files, analyze: :lazily
+end
+```
+
+NOTE: Attachments with `process: :immediately` variants automatically analyze immediately to ensure metadata is available before processing.
+
+You can set the global default in your application configuration:
+
+```ruby
+# config/application.rb
+config.active_storage.analyze = :later  # restore pre-8.2 behavior
+```
 
 [`analyzed?`]: https://api.rubyonrails.org/classes/ActiveStorage/Blob/Analyzable.html#method-i-analyzed-3F
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -375,6 +375,10 @@ module Rails
             active_record.postgresql_adapter_decode_bytea = true
             active_record.postgresql_adapter_decode_money = true
           end
+
+          if respond_to?(:active_storage)
+            active_storage.analyze = :immediately
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -20,3 +20,25 @@
 #++
 # Rails.application.config.active_record.postgresql_adapter_decode_bytea = true
 # Rails.application.config.active_record.postgresql_adapter_decode_money = true
+
+###
+# Analyze attachments immediately, making metadata available for validations.
+#
+# When enabled, attachment metadata (image dimensions, video duration, etc.) is extracted
+# before validation, allowing you to validate file properties:
+#
+#   has_one_attached :avatar
+#   validate :validate_avatar_dimensions, if: -> { avatar.attached? }
+#
+#   def validate_avatar_dimensions
+#     if avatar.metadata[:width] < 200 || avatar.metadata[:height] < 200
+#       errors.add(:avatar, "must be at least 200x200")
+#     end
+#   end
+#
+# Valid options:
+#  - :immediately - Analyze before validation (new default)
+#  - :later - Analyze after upload from local IO or via background job for direct uploads
+#  - :lazily - Skip automatic analysis; analyze on-demand
+#++
+# Rails.application.config.active_storage.analyze = :immediately


### PR DESCRIPTION
Attachment metadata (width, height, duration, etc.) is now available for model validations:

```ruby
    class User < ApplicationRecord
      has_one_attached :avatar

      validate :validate_avatar_dimensions, if: -> { avatar.attached? }

      def validate_avatar_dimensions
        if avatar.metadata[:width] < 200 || avatar.metadata[:height] < 200
          errors.add(:avatar, "must be at least 200x200")
        end
      end
    end
```

Configure when analysis is performed:

* `analyze: :immediately` (default in 8.2) - Analyze before validation
* `analyze: :later` - Analyze after upload from local IO or via background job
* `analyze: :lazily` - Skip automatic analysis; analyze on-demand

```ruby
    has_one_attached :document, analyze: :later
    has_many_attached :files, analyze: :lazily

    # Or set the global default:
    config.active_storage.analyze = :later
```

Direct uploads bypass the server so the file isn't locally available for analysis. In this case, :immediately falls back to :later, analyzing via background job after upload completes. Metadata isn't available for validation; validate on the client side instead.

/cc @tomrossi7 