### PR TITLE
Add delete_in_batches for batch deletions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `delete_in_batches` for deleting records in batches.
+
+    Unlike `in_batches.delete_all`, this does not use cursor tracking or
+    `ORDER BY` since deleted records are excluded from subsequent batches.
+
+    ```ruby
+    Event.where("created_at < ?", 1.year.ago).delete_in_batches
+    Event.where(processed: true).delete_in_batches(of: 5000)
+    ```
+
+    *Shayon Mukherjee*
+
 *   Yield the transaction object to the block when using `with_lock`.
 
     *Ngan Pham*

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,
       :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
-      :find_each, :find_in_batches, :in_batches,
+      :find_each, :find_in_batches, :in_batches, :delete_in_batches,
       :select, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -301,6 +301,32 @@ module ActiveRecord
       end
     end
 
+    # Deletes records in batches. Returns the total number of rows deleted.
+    #
+    #   Person.where("age < 21").delete_in_batches
+    #
+    # ==== Options
+    #
+    # * <tt>:of</tt> - Specifies the size of the batch. Defaults to 1000.
+    #
+    # This method does not instantiate records and does not invoke
+    # callbacks. If you need callbacks to run, use #destroy_all or
+    # <tt>in_batches.destroy_all</tt> instead.
+    #
+    # Unlike other batch methods, this does not use +ORDER BY+ since
+    # deleted records are excluded from subsequent batches.
+    def delete_in_batches(of: 1000)
+      total = 0
+
+      loop do
+        deleted = limit(of).delete_all
+        break if deleted == 0
+        total += deleted
+      end
+
+      total
+    end
+
     private
       def ensure_valid_options_for_batching!(cursor, start, finish, order)
         if start && Array(start).size != cursor.size


### PR DESCRIPTION
### Motivation / Background

Currently, the default option for `order` is `asc` and can also be set to `desc` or passed an array with those values. This works great in most cases, however sometimes forcing the `ORDER` clause for the primary key can result into a sort + heap scan in Postgresql, by passing an index lookup and may cause a performance tax and in those situations where we don't care about order, ~it'd be lovely to continue using `in_batches` with no order instead of having to write custom SQL.~

**Update:** Based on feedback from @jeremy, @p8, and @skipkayhil, this PR now introduces `delete_in_batches` instead of adding `order: nil` support.

### Solution

Add `delete_in_batches` method:

```ruby
Event.where(story_run_id: ids).delete_in_batches
Event.where(processed: true).delete_in_batches(of: 5000)
```

For bulk deletes where order doesn't matter, something like can actually be faster because the lookups just hit the primary key index.

Added context (from the conversations below): This is cleaner than `order: nil` because the intent is explicit (as this is for deletions) and we don't need to modify the order function either. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
