### PR TITLE
Fix guides/bug_report_template_test not running with rake

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -4,9 +4,10 @@ require "rake/testtask"
 
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.pattern = "test/**/*_test.rb"
+  t.warning = true
   t.verbose = true
-  t.options = "--profile" if ENV["CI"]
+  t.options = "--profile" if ENV["BUILDKITE"]
 end
 
 namespace :guides do

--- a/guides/test/test_helper.rb
+++ b/guides/test/test_helper.rb
@@ -5,3 +5,5 @@ require_relative "../../tools/strict_warnings"
 $LOAD_PATH.unshift File.expand_path("..", __dir__)
 
 require "rails_guides"
+
+require "minitest/autorun"


### PR DESCRIPTION
This test was running with `bin/test` but `rake test` did not execute any tests since autorun was not loaded.

Also cleaned up the test task to match other test tasks in the framework.
https://github.com/rails/rails/blob/4f4e0acaf558f6adf7df3ac23a51beb470463901/railties/Rakefile#L166-L173

See: https://github.com/rails/rails/pull/55987#issuecomment-3641860716