### PR TITLE
Fix request load leak when building middleware stack

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `action_dispatch_request` early load hook call when building
+    Rails app middleware.
+
+    *Gannon McGibbon*
+
 *   Emit a structured event when `action_on_open_redirect` is set to `:notify`
     in addition to the existing Active Support Notification.
 

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -312,7 +312,7 @@ module ActionDispatch
     def self.new(app) app; end
   end
 
-  class Request
+  ActiveSupport.on_load(:action_dispatch_request) do
     prepend Flash::RequestMethods
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -6,7 +6,6 @@ require "rack/utils"
 require "rack/request"
 require "rack/session/abstract/id"
 require "action_dispatch/middleware/cookies"
-require "action_dispatch/request/session"
 
 module ActionDispatch
   module Session


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when building middleware during initialization, we don't need to load `ActionDispatch::Request`. The initialized app may not need requests. Discovered in https://github.com/rails/rails/pull/56201.

### Detail

This Pull Request changes flash request patching and a require in abstract store to not eagerly load `ActionDispatch::Request` (it is autoloaded, so we can use load hooks and omit requires).

### Additional information

When an application has a heavier load hook setup on `action_dispatch_request`, we shouldn't have to pay that on boot. This allows the load hook to be unloaded on startup and loaded later when requests are actually necessary.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
