### PR TITLE
Use a modern approach for cross-site request forgery protection

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   Modern header-based CSRF protection.
+
+    Modern browsers send the `Sec-Fetch-Site` header to indicate the relationship
+    between request initiator and target origins. Rails now uses this header to
+    verify same-origin requests without requiring authenticity tokens.
+
+    Two verification strategies are available via `protect_from_forgery using:`:
+
+    * `:header_only` - Uses `Sec-Fetch-Site` header only. Rejects requests
+      without a valid header. Default for new Rails 8.2 applications.
+
+    * `:header_or_legacy_token` - Uses `Sec-Fetch-Site` header when present,
+      falls back to authenticity token verification for older browsers.
+
+    Configure trusted origins for legitimate cross-site requests (OAuth callbacks,
+    third-party embeds) with `trusted_origins:`:
+
+    ```ruby
+    protect_from_forgery trusted_origins: %w[ https://accounts.google.com ]
+    ```
+
+    `InvalidAuthenticityToken` is deprecated in favor of `InvalidCrossOriginRequest`.
+
+    *Rosa Gutierrez*
+
 *   Fix `action_dispatch_request` early load hook call when building
     Rails app middleware.
 

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -119,7 +119,7 @@ module ActionController # :nodoc:
       # * :token_fallback - Combined approach: Sec-Fetch-Site with fallback to token
       singleton_class.delegate :forgery_protection_verification_strategy, :forgery_protection_verification_strategy=, to: :config
       delegate :forgery_protection_verification_strategy, :forgery_protection_verification_strategy=, to: :config
-      self.forgery_protection_verification_strategy = :fetch_metadata
+      self.forgery_protection_verification_strategy = :token_fallback
 
       # Origins allowed for cross-site requests, such as OAuth/SSO callbacks,
       # third-party embeds, and legitimate remote form submission.

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -566,8 +566,6 @@ module ActionController # :nodoc:
       # For all strategies, GET and HEAD requests are allowed without verification.
       #
       def verified_request? # :doc:
-        return true if request.get? || request.head? || !protect_against_forgery?
-
         request.get? || request.head? || !protect_against_forgery? ||
           (valid_request_origin? && verified_request_for_forgery_protection?)
       end

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -7,11 +7,13 @@ require "action_controller/metal/exceptions"
 require "active_support/security_utils"
 
 module ActionController # :nodoc:
-  class InvalidAuthenticityToken < ActionControllerError # :nodoc:
-  end
-
   class InvalidCrossOriginRequest < ActionControllerError # :nodoc:
   end
+
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+  deprecate_constant "InvalidAuthenticityToken", "ActionController::InvalidCrossOriginRequest",
+    deprecator: ActionController.deprecator,
+    message: "ActionController::InvalidAuthenticityToken has been deprecated and will be removed in Rails 9.0. Use ActionController::InvalidCrossOriginRequest instead."
 
   # # Action Controller Request Forgery Protection
   #

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -228,24 +228,23 @@ module ActionController # :nodoc:
       #
       # *   `:using` - Set the verification strategy for CSRF protection.
       #
+      #     Built-in verification strategies are:
       #
-      # Built-in verification strategies are:
+      #     *   `:header_only` - Uses the `Sec-Fetch-Site` header sent by modern
+      #         browsers to verify that requests originate from the same site. This
+      #         approach does not require authenticity tokens but only works with
+      #         browsers that support the Fetch Metadata Request Headers. Requests
+      #         without a valid `Sec-Fetch-Site` header will be rejected. This is
+      #         the default.
       #
-      # *   `:header_only` - Uses the `Sec-Fetch-Site` header sent by modern
-      #     browsers to verify that requests originate from the same site. This
-      #     approach does not require authenticity tokens but only works with
-      #     browsers that support the Fetch Metadata Request Headers. Requests
-      #     without a valid `Sec-Fetch-Site` header will be rejected. This is the
-      #     default, as Rails only supports modern browsers by default (see
-      #     `allow_browser`).
-      #
-      # *   `:header_or_legacy_token` - A hybrid approach that first checks the `Sec-Fetch-Site`
-      #     header. If the header indicates same-site or same-origin, the request is
-      #     allowed. Requests with a cross-site value are rejected. When the header is
-      #     missing or "none", it falls back to checking the authenticity token.
-      #     This mode logs when falling back to authenticity token to help identify
-      #     requests that should be fixed to work with `:header_only`. Use this
-      #     if you need to support older browsers that don't send the `Sec-Fetch-Site` header.
+      #     *   `:header_or_legacy_token` - A hybrid approach that first checks the
+      #         `Sec-Fetch-Site` header. If the header indicates same-site or
+      #         same-origin, the request is allowed. Requests with a cross-site
+      #         value are rejected. When the header is missing or "none", it falls
+      #         back to checking the authenticity token. This mode logs when
+      #         falling back to help identify requests that should be fixed to work
+      #         with `:header_only`. Use this if you need to support older browsers
+      #         that don't send the `Sec-Fetch-Site` header.
       #
       # *   `:trusted_origins` - Array of origins to allow for cross-site requests,
       #     such as OAuth/SSO callbacks, third-party embeds, and legitimate remote

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1802,3 +1802,26 @@ class TrustedOriginsTokenFallbackControllerTest < ActionController::TestCase
     end
   end
 end
+
+class InvalidAuthenticityTokenDeprecationTest < ActiveSupport::TestCase
+  test "InvalidAuthenticityToken is deprecated" do
+    assert_deprecated("ActionController::InvalidAuthenticityToken has been deprecated", ActionController.deprecator) do
+      ActionController::InvalidAuthenticityToken
+    end
+  end
+
+  test "InvalidAuthenticityToken resolves to InvalidCrossOriginRequest" do
+    assert_deprecated(ActionController.deprecator) do
+      assert_equal ActionController::InvalidCrossOriginRequest, ActionController::InvalidAuthenticityToken
+    end
+  end
+
+  test "can rescue InvalidCrossOriginRequest with deprecated InvalidAuthenticityToken" do
+    assert_deprecated(ActionController.deprecator) do
+      assert_nothing_raised do
+        raise ActionController::InvalidCrossOriginRequest
+      rescue ActionController::InvalidAuthenticityToken
+      end
+    end
+  end
+end

--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -51,7 +51,7 @@ end
 ```
 
 NOTE: All subclasses of `ActionController::Base` are protected by default and
-will raise an `ActionController::InvalidAuthenticityToken` error on unverified
+will raise an `ActionController::InvalidCrossOriginRequest` error on unverified
 requests.
 
 ### Authenticity Token in Forms

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.2
 
+- [`config.action_controller.forgery_protection_verification_strategy`](#config-action-controller-forgery-protection-verification-strategy): `:header_only`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 - [`config.active_storage.analyze`](#config-active-storage-analyze): `:immediately`
@@ -1984,6 +1985,27 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 5.0                   | `true`               |
+
+#### `config.action_controller.forgery_protection_verification_strategy`
+
+Configures how Rails verifies requests for CSRF protection. Available strategies are:
+
+* `:header_only` - Uses the `Sec-Fetch-Site` header sent by modern browsers to verify
+  that requests originate from the same site. Requests without a valid header are rejected.
+  This is simpler and more secure but only works with browsers that support the
+  [Fetch Metadata Request Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site).
+
+* `:header_or_legacy_token` - A hybrid approach that checks the `Sec-Fetch-Site` header first.
+  If the header indicates same-origin or same-site, the request is allowed. When the
+  header is missing or has the value "none", it falls back to checking the authenticity
+  token. This supports older browsers while logging when fallback occurs.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is         |
+| --------------------- | ---------------------------- |
+| (original)            | `:header_or_legacy_token`    |
+| 8.2                   | `:header_only`               |
 
 #### `config.action_controller.default_protect_from_forgery`
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -551,7 +551,7 @@ document.head.querySelector("meta[name=csrf-token]")?.content
 It is common to use persistent cookies to store user information, with `cookies.permanent` for example. In this case, the cookies will not be cleared and the out of the box CSRF protection will not be effective. If you are using a different cookie store than the session for this information, you must handle what to do with it yourself:
 
 ```ruby
-rescue_from ActionController::InvalidAuthenticityToken do |exception|
+rescue_from ActionController::InvalidCrossOriginRequest do |exception|
   sign_out_user # Example method that will destroy the user cookies
 end
 ```

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -372,7 +372,7 @@ module Rails
           load_defaults "8.1"
 
           if respond_to?(:action_controller)
-            action_controller.forgery_protection_verification_strategy = :fetch_metadata
+            action_controller.forgery_protection_verification_strategy = :header_only
           end
 
           if respond_to?(:active_record)

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -371,6 +371,10 @@ module Rails
         when "8.2"
           load_defaults "8.1"
 
+          if respond_to?(:action_controller)
+            action_controller.forgery_protection_verification_strategy = :fetch_metadata
+          end
+
           if respond_to?(:active_record)
             active_record.postgresql_adapter_decode_bytea = true
             active_record.postgresql_adapter_decode_money = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -16,15 +16,16 @@
 # between request initiator and target origins. Rails can use this header to
 # reject cross-site requests without requiring authenticity tokens.
 #
-# When set to :fetch_metadata, requests without a valid Sec-Fetch-Site header
+# When set to :header_only, requests without a valid Sec-Fetch-Site header
 # (same-origin or same-site) will be rejected. This is more secure and simpler
 # than token-based protection, but only works with modern browsers.
 #
-# When set to :token_fallback (pre-8.2 default), Rails checks the Sec-Fetch-Site
-# header first, but falls back to authenticity token verification for requests
-# without the header. This supports older browsers while logging fallback usage.
+# When set to :header_or_legacy_token (pre-8.2 default), Rails checks the
+# Sec-Fetch-Site header first, but falls back to authenticity token verification
+# for requests without the header. This supports older browsers while logging
+# fallback usage.
 #++
-# Rails.application.config.action_controller.forgery_protection_verification_strategy = :fetch_metadata
+# Rails.application.config.action_controller.forgery_protection_verification_strategy = :header_only
 
 ###
 # Controls whether the PostgresqlAdapter should decode bytea and money columns automatically with manual queries.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -10,6 +10,23 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 ###
+# Use Sec-Fetch-Site header for CSRF protection instead of tokens.
+#
+# Modern browsers send the Sec-Fetch-Site header to indicate the relationship
+# between request initiator and target origins. Rails can use this header to
+# reject cross-site requests without requiring authenticity tokens.
+#
+# When set to :fetch_metadata, requests without a valid Sec-Fetch-Site header
+# (same-origin or same-site) will be rejected. This is more secure and simpler
+# than token-based protection, but only works with modern browsers.
+#
+# When set to :token_fallback (pre-8.2 default), Rails checks the Sec-Fetch-Site
+# header first, but falls back to authenticity token verification for requests
+# without the header. This supports older browsers while logging fallback usage.
+#++
+# Rails.application.config.action_controller.forgery_protection_verification_strategy = :fetch_metadata
+
+###
 # Controls whether the PostgresqlAdapter should decode bytea and money columns automatically with manual queries.
 #
 # Example:

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1823,7 +1823,7 @@ module ApplicationTests
     test "config.action_controller.default_protect_from_forgery is true by default" do
       app "development"
 
-      assert_includes ActionController::Base.__callbacks[:process_action].map(&:filter), :verify_authenticity_token
+      assert_includes ActionController::Base.__callbacks[:process_action].map(&:filter), :verify_request_for_forgery_protection
     end
 
     test "config.action_controller.permit_all_parameters can be configured in an initializer" do

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1020,7 +1020,7 @@ module ApplicationTests
 
       output = run_test_command("-n test_should_create_user")
 
-      assert_match "ActionController::InvalidAuthenticityToken", output
+      assert_match "ActionController::InvalidCrossOriginRequest", output
     end
 
     def test_raise_error_when_specified_file_does_not_exist


### PR DESCRIPTION
### Motivation / Background

CSRF protection has always been a source of issues related to cached pages, stale tokens, the session being somehow cleared, all resulting in false positives. We still get these in our apps. 

This PR proposes to modernise this, with the goal of eventually deprecating and getting rid of CSRF tokens completely. It takes advantage of the `Sec-Fetch-Site` header, which is a fetch metadata request header that modern browsers send, and that indicates whether a request for a resource is coming from the same origin, the same site or a different site. The server can use this to decide whether the request should be allowed or not.

In this PR, this approach is used by default, in a very conservative and strict way: only requests with a `Sec-Fetch-Site` value of `same-site` or `same-origin` are allowed. Requests with a value of `cross-site` are rejected unless they come from a configured trusted origin (see below, in the Detail section). Requests that don't include a `Sec-Fetch-Site` header or that have it set to `none` are rejected as well. Assuming a modern browser, user-initiated requests (like direct navigation or clicking a bookmark) shouldn't cause a non-GET/HEAD request, so these wouldn't be subject to the CSRF check in any case. Requests that don't include the header could be:
- Not from a browser, in which case they wouldn't include the authenticity token either. These would be excluded from the check in another way.
- From a browser, but having the header stripped by some middle proxy or firewall (we've seen this in the wild). In this case, we can't allow the request without making the user vulnerable to CSRF.

This is what we're currently using in HEY, with a custom strategy class for unverified request handling. 

For apps that can't use this approach yet because they need to support older browsers that don't send the `Sec-Fetch-Site` header, the usual authenticity token approach is kept as a fallback. When a decision can't be clearly made with the header value because it's missing or 'none', the token is checked as before.

The `Origin` check is not changed; it continues to work in the same way, combined with the `Sec-Fetch-Site `or authenticity token checks.

### Detail
This PR introduces a new option, `using`, that can be passed to `protect_from_forgery`, to indicate the approach used for verifying requests. The possible values are `header_only`, which relies exclusively on the `Sec-Fetch-Site` header, or `header_or_legacy_token`, which uses the authenticity token when a decision can't be made with the header alone. The default would be `header_only` for Rails 8.2. Example: 

```ruby
class ApplicationController < ActionController::Base
  protect_from_forgery using: :header_or_legacy_token, with: :exception
```

When using the `header_or_legacy_token` approach, a warning is logged when the fallback is necessary. In this way, developers can check which requests don't include valid `Sec-Fetch-Site` headers and progressively fix them so that they can eventually stop using the CSRF token. 

A new option, `trusted_origins`, is also added to set trusted origins for legitimate cross-site requests (OAuth callbacks, third-party embeds):
 
```ruby
protect_from_forgery trusted_origins: %w[ https://accounts.google.com ]
```

I'll include some comments in the PR to point out other important details. 

### Additional information
Some references about this: 
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site
- https://web.dev/articles/fetch-metadata
- https://github.com/golang/go/issues/73626
- https://www.alexedwards.net/blog/preventing-csrf-in-go

### Open questions
Besides the obvious question of whether this is an acceptable approach for Rails and whether this makes sense with the current implementation, a possible open question is: should the values allowed for `Sec-Fetch-Site` be configurable? This would allow for an even stricter policy where `same-site` requests aren't allowed, only `same-origin`. This would prevent requests coming from a different subdomain, for example. It would also allow for a more relaxed policy where `none` or missing values are allowed because the risk of people running older browsers or some kind of proxy is deemed acceptable. 


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
