### PR TITLE
[Docs] Document swappable migration backend behaviour

### DIFF
--- a/activerecord/lib/active_record/migration/default_strategy.rb
+++ b/activerecord/lib/active_record/migration/default_strategy.rb
@@ -2,9 +2,54 @@
 
 module ActiveRecord
   class Migration
-    # The default strategy for executing migrations. Delegates method calls
-    # to the connection adapter.
-    class DefaultStrategy < ExecutionStrategy # :nodoc:
+    # = Default Strategy
+    #
+    # DefaultStrategy is the default execution strategy for migrations.
+    # It delegates all method calls directly to the connection adapter,
+    # which is the standard behavior for executing migration commands.
+    #
+    # This class is the recommended base class for custom migration strategies.
+    # By inheriting from DefaultStrategy, you can override specific methods
+    # while retaining the default behavior for all other migration operations.
+    #
+    # == Example: Creating a Custom Strategy
+    #
+    #   class AuditingStrategy < ActiveRecord::Migration::DefaultStrategy
+    #     def create_table(table_name, **options)
+    #       Rails.logger.info "Creating table: #{table_name}"
+    #       super
+    #     end
+    #
+    #     def drop_table(table_name, **options)
+    #       Rails.logger.warn "Dropping table: #{table_name}"
+    #       super
+    #     end
+    #   end
+    #
+    #   # Apply globally
+    #   config.active_record.migration_strategy = AuditingStrategy
+    #
+    #   # Or apply to a specific adapter
+    #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.migration_strategy = AuditingStrategy
+    #
+    # == Available Methods
+    #
+    # DefaultStrategy responds to all methods available on the connection adapter,
+    # including but not limited to:
+    #
+    # * +create_table+
+    # * +drop_table+
+    # * +add_column+
+    # * +remove_column+
+    # * +add_index+
+    # * +remove_index+
+    # * +add_foreign_key+
+    # * +remove_foreign_key+
+    # * +execute+
+    #
+    # See ActiveRecord::ConnectionAdapters::SchemaStatements for the complete
+    # list of available schema modification methods.
+    class DefaultStrategy < ExecutionStrategy
       private
         def method_missing(method, ...)
           connection.send(method, ...)

--- a/activerecord/lib/active_record/migration/execution_strategy.rb
+++ b/activerecord/lib/active_record/migration/execution_strategy.rb
@@ -2,12 +2,44 @@
 
 module ActiveRecord
   class Migration
-    # ExecutionStrategy is used by the migration to respond to any method calls
-    # that the migration class does not implement directly. This is the base strategy.
-    # All strategies should inherit from this class.
+    # = Execution Strategy
     #
-    # The ExecutionStrategy receives the current +migration+ when initialized.
-    class ExecutionStrategy # :nodoc:
+    # ExecutionStrategy is the base class for migration execution strategies.
+    # A migration execution strategy handles method calls made by migrations
+    # that the migration class does not implement directly.
+    #
+    # When a migration calls methods like +create_table+, +add_column+, or
+    # +add_index+, these calls are delegated to the execution strategy, which
+    # determines how they should be executed.
+    #
+    # == Customizing Migration Execution
+    #
+    # You can create custom execution strategies by subclassing ExecutionStrategy
+    # (or more commonly, ActiveRecord::Migration::DefaultStrategy) and overriding
+    # methods to customize migration behavior. For example:
+    #
+    #   class MyCustomStrategy < ActiveRecord::Migration::DefaultStrategy
+    #     def create_table(table_name, **options)
+    #       # Custom logic before creating a table
+    #       puts "Creating table: #{table_name}"
+    #       super
+    #     end
+    #
+    #     def drop_table(table_name, **options)
+    #       # Custom logic for dropping tables
+    #       super
+    #     end
+    #   end
+    #
+    #   # Apply globally
+    #   config.active_record.migration_strategy = MyCustomStrategy
+    #
+    #   # Or apply to a specific adapter
+    #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.migration_strategy = MyCustomStrategy
+    #
+    # The strategy receives the current migration instance when initialized,
+    # accessible via the +migration+ attribute.
+    class ExecutionStrategy
       def initialize(migration)
         @migration = migration
       end

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -15,6 +15,7 @@ After reading this guide, you will know:
 * How to change existing migrations and update your schema.
 * How migrations relate to `schema.rb`.
 * How to maintain referential integrity.
+* How to customize migration behavior with swappable strategies.
 
 --------------------------------------------------------------------------------
 
@@ -1816,3 +1817,124 @@ Instead, consider using the
 gem provides a framework for creating and managing data migrations and other
 maintenance tasks in a way that is safe and easy to manage without interfering
 with schema migrations.
+
+Customizing Migration Behavior with Swappable Strategies
+--------------------------------------------------------
+
+Rails allows you to customize how migrations execute by using **migration
+strategies**. A migration strategy is an object that sits between your migration
+and the connection, giving you control over how schema changes are applied to
+the database.
+
+By default, Rails uses [`ActiveRecord::Migration::DefaultStrategy`][], which
+executes migrations by sending method calls directly to the connection.
+However, you can replace this with your own strategy to modify, validate,
+or even prevent certain migration operations. Migration strategies are
+especially useful when you need different migration behavior across
+environments. For example, production migrations may require:
+
+* **Safety and Validation**: Prevent dangerous operations like dropping tables
+  or removing columns in production environments.
+* **Online Schema Changes**: Integrate with tools that perform schema
+  changes without downtime (e.g., `pt-online-schema-change`, `gh-ost`).
+* **Centralized Management**: Submit migrations to a centralized service
+  rather than executing them directly, useful in large-scale deployments.
+
+### Configuring a Global Migration Strategy
+
+To customize how migrations are executed, you can define your own migration
+strategy by subclassing [`ActiveRecord::Migration::DefaultStrategy`][]. This
+default class automatically forwards all migration methods to the underlying
+database connection, so you only need to override the methods you want to
+customize.
+
+For example, to prevent dropping tables in production:
+
+```ruby
+class CustomMigrationStrategy < ActiveRecord::Migration::DefaultStrategy
+  def drop_table(table_name, **options)
+    raise "Dropping tables is not allowed in production!"
+  end
+end
+```
+
+You can override any schema statement method your application needs, such as:
+
+- `create_table`
+- `drop_table`
+- `add_column`
+- `remove_column`
+- `add_index`
+- `remove_index`
+- Or any other method from
+  [`ActiveRecord::ConnectionAdapters::SchemaStatements`][]
+
+You can also subclass [`ActiveRecord::Migration::ExecutionStrategy`][], the base
+strategy class. This is useful if you want to define all migration behavior from
+scratch, without having any methods forwarded to the connection.
+
+Once you've defined your custom strategy, make it the default for migrations across
+all database connections by setting [`config.active_record.migration_strategy`][].
+For example, to set a custom strategy in production:
+
+```ruby
+# config/environments/production.rb
+Rails.application.configure do
+  config.active_record.migration_strategy = CustomMigrationStrategy
+end
+```
+
+All migrations methods will be sent to your custom strategy in production.
+
+### Configuring Per-Adapter Migration Strategies
+
+If you're working with multiple database systems, a single global strategy is
+likely insufficient: you may need to tailor migration behavior according to the
+database. Active Record allows you to configure migration strategies on a
+per-adapter basis. For example, suppose your application has a MySQL database,
+`primary`, and a PostgreSQL database, `animals`:
+
+```yaml
+  primary:
+    database: my_primary_database
+    username: root
+    password: <%= ENV['ROOT_PASSWORD'] %>
+    adapter: trilogy
+  animals:
+    database: my_animals_database
+    username: animals_root
+    password: <%= ENV['ANIMALS_ROOT_PASSWORD'] %>
+    adapter: postgresql
+    migrations_paths: db/animals_migrate
+```
+
+You can configure a `migration_strategy` on each adapter class:
+
+```ruby
+# config/initializers/migration_strategies.rb
+if Rails.env.production?
+  ActiveSupport.on_load(:active_record_trilogyadapter) do
+    ActiveRecord::ConnectionAdapters::Trilogy.migration_strategy =
+      MySQLMigrationStrategy
+  end
+
+  ActiveSupport.on_load(:active_record_postgresqladapter) do
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.migration_strategy =
+      PostgreSQLMigrationStrategy
+  end
+end
+```
+
+Migrations running against `primary` will use `MySQLMigrationStrategy`, and
+migrations running against `animals` will use `PostgreSQLMigrationStrategy`.
+The adapter-specific strategy takes precedence over any globally-configured
+stategy.
+
+[`ActiveRecord::Migration::DefaultStrategy`]:
+    https://api.rubyonrails.org/classes/ActiveRecord/Migration/DefaultStrategy.html
+[`ActiveRecord::Migration::ExecutionStrategy`]:
+    https://api.rubyonrails.org/classes/ActiveRecord/Migration/ExecutionStrategy.html
+[`config.active_record.migration_strategy`]:
+    configuring.html#config-active-record-migration-strategy
+[`ActiveRecord::ConnectionAdapters::SchemaStatements`]:
+    https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html


### PR DESCRIPTION
### Motivation / Background

This PR was created to add more comprehensive documentation on "Swappable Migration Strategies" to the guides + API docs. We added this to Rails in https://github.com/rails/rails/pull/45324, and more recently extended the feature to support per-adapter strategies in https://github.com/rails/rails/pull/56204. I wrote a [blog post](https://railsatscale.com/2025-12-08-swappable-migration-backends-in-rails/) about how we use this at Shopify to power our production migration system, but realized Rails itself contains very little documentation about this feature.

### Detail

Added a section to the _Active Record Migrations_ guide, and properly documented the `ActiveRecord::Migration::ExecutionStrategy` and `ActiveRecord::Migration::DefaultStrategy` classes.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
