### PR TITLE
Fix PARALLEL_WORKERS ignoring test parallelization threshold

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `PARALLEL_WORKERS` environment variable bypassing the parallelization threshold.
+
+    Previously, setting `PARALLEL_WORKERS` would enable parallelization regardless of
+    the test count threshold. Now parallelization only occurs when the number of tests
+    exceeds the configured threshold.
+
+    *Justin Ko*
+
 *   Make flaky parallel tests easier to diagnose by deterministically assigning
     tests to workers.
 

--- a/activesupport/lib/active_support/testing/parallelize_executor.rb
+++ b/activesupport/lib/active_support/testing/parallelize_executor.rb
@@ -58,7 +58,7 @@ module ActiveSupport
         end
 
         def should_parallelize?
-          (ENV["PARALLEL_WORKERS"] || tests_count > threshold) && many_workers?
+          tests_count > threshold && many_workers?
         end
 
         def many_workers?


### PR DESCRIPTION
Previously, setting PARALLEL_WORKERS would enable test parallelization regardless of whether the test count exceeded the threshold. Now parallelization is only enabled when tests_count > threshold.

I was fiddling with the threshold argument and noticed parallelization was always activating, causing a 4 second slowdown for running a single test. I have PARALLEL_WORKERS set in my `.env.test.local` and that was the cause. 

I can't think of a reason why we would ever want PARALLEL_WORKERS to override the behavior of threshold. 