### PR TITLE
Make `delegate` and `delegate_missing_to` work in BasicObject subclasses

### DIFF
--- a/activesupport/lib/active_support/delegation.rb
+++ b/activesupport/lib/active_support/delegation.rb
@@ -151,11 +151,11 @@ module ActiveSupport
               "def #{method_name}(#{definition})" <<
               "  _ = #{receiver}" <<
               "  _.#{method}(#{definition})" <<
-              "rescue NoMethodError => e" <<
+              "rescue ::NoMethodError => e" <<
               "  if _.nil? && e.name == :#{method}" <<
-              "    raise ::ActiveSupport::DelegationError.nil_target(:#{method_name}, :'#{receiver}')" <<
+              "    ::Kernel.raise ::ActiveSupport::DelegationError.nil_target(:#{method_name}, :'#{receiver}')" <<
               "  else" <<
-              "    raise" <<
+              "    ::Kernel.raise" <<
               "  end" <<
               "end"
           end
@@ -202,7 +202,7 @@ module ActiveSupport
             def method_missing(method, ...)
               __target = #{target}
               if __target.nil? && !nil.respond_to?(method)
-                raise ::ActiveSupport::DelegationError.nil_target(method, :'#{target}')
+                ::Kernel.raise ::ActiveSupport::DelegationError.nil_target(method, :'#{target}')
               elsif __target.respond_to?(method)
                 __target.public_send(method, ...)
               else

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -56,6 +56,16 @@ Event = Struct.new(:case) do
   delegate :foo, to: :case
 end
 
+class BasicEvent < BasicObject
+  delegate :foo, to: :case
+
+  attr_reader :case
+
+  def initialize(kase)
+    @case = kase
+  end
+end
+
 Tester = Struct.new(:client) do
   delegate :name, to: :client, prefix: false
 
@@ -138,6 +148,16 @@ class Cavern
 
   def target
     @maze.passages = :twisty
+  end
+end
+
+class BasicCavern < BasicObject
+  delegate_missing_to :target
+
+  attr_reader :target
+
+  def initialize(target)
+    @target = target
   end
 end
 
@@ -490,6 +510,22 @@ class ModuleTest < ActiveSupport::TestCase
     deserialized_array = Marshal.load(serialized_array)
 
     assert_nil deserialized_array[1]
+  end
+
+  def test_delegate_to_missing_raises_delegation_error_on_basic_object
+    cavern = BasicCavern.new(nil)
+
+    assert_raises(Module::DelegationError) do
+      cavern.some_method
+    end
+  end
+
+  def test_delegate_raises_delegation_error_on_basic_object
+    cavern = BasicEvent.new(nil)
+
+    assert_raises(Module::DelegationError) do
+      cavern.foo
+    end
   end
 
   def test_delegate_with_case


### PR DESCRIPTION
When those features are used in `BasicObject` subclasses, the generated code must use `::Kernel.raise` to raise exceptions, because `BasicObject` does not have a built-in raise method. Similarly, references to exception classes like `NoMethodError` must be fully qualified with the `::` prefix to ensure they are resolved correctly.

Without this, `delegate_to_missing` would raise a `SystemStackError` when attempting to raise a `DelegationError` from a `BasicObject` subclass, due to infinite recursion in `method_missing`.