### PR TITLE
[ci skip][docs] PARALLEL_WORKERS threshold bypass behavior

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -74,7 +74,9 @@ module ActiveSupport
       # If <tt>ENV["PARALLEL_WORKERS"]</tt> is set the workers argument will be ignored
       # and the environment variable will be used instead. This is useful for CI
       # environments, or other environments where you may need more workers than
-      # you do for local testing.
+      # you do for local testing. Note that setting <tt>PARALLEL_WORKERS</tt> will
+      # also bypass the +threshold+ check, enabling parallelization regardless of
+      # test count.
       #
       # If the number of workers is set to +1+ or fewer, the tests will not be
       # parallelized.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -2805,6 +2805,9 @@ class ActiveSupport::TestCase
 end
 ```
 
+NOTE: Setting the `PARALLEL_WORKERS` environment variable will bypass the
+threshold check, enabling parallelization regardless of test count.
+
 Testing Eager Loading
 ---------------------
 


### PR DESCRIPTION
For reasoning, please see this pull: https://github.com/rails/rails/pull/56352

Guides change:
https://9696f494.rails-docs-preview.pages.dev/guides/testing#threshold-to-parallelize-tests

<img width="896" height="409" alt="image" src="https://github.com/user-attachments/assets/5595aac7-38d7-48a7-98de-d43cd94c782f" />

---

API docs change:
https://9696f494.rails-docs-preview.pages.dev/api/classes/ActiveSupport/TestCase.html#method-c-parallelize
