### PR TITLE
Active Support notifications for CSRF warnings

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Active Support notifications for CSRF warnings.
+
+    Switches from direct logging to event-driven logging, allowing others to
+    subscribe to and act on CSRF events:
+
+    - `csrf_token_fallback.action_controller`
+    - `csrf_request_blocked.action_controller`
+    - `csrf_javascript_blocked.action_controller`
+
+    *Jeremy Daer*
+
 *   Modern header-based CSRF protection.
 
     Modern browsers send the `Sec-Fetch-Site` header to indicate the relationship

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -87,6 +87,30 @@ module ActionController
     end
     event_log_level :unpermitted_parameters, :debug
 
+    def csrf_token_fallback(event)
+      return unless ActionController::Base.log_warning_on_csrf_failure
+
+      warn do
+        payload = event[:payload]
+        "Falling back to CSRF token verification for #{payload[:controller]}##{payload[:action]}"
+      end
+    end
+    event_log_level :csrf_token_fallback, :info
+
+    def csrf_request_blocked(event)
+      return unless ActionController::Base.log_warning_on_csrf_failure
+
+      warn { event[:payload][:message] }
+    end
+    event_log_level :csrf_request_blocked, :info
+
+    def csrf_javascript_blocked(event)
+      return unless ActionController::Base.log_warning_on_csrf_failure
+
+      warn { event[:payload][:message] }
+    end
+    event_log_level :csrf_javascript_blocked, :info
+
     def fragment_cache(event)
       return unless ActionController::Base.enable_fragment_cache_logging
 

--- a/actionpack/lib/action_controller/structured_event_subscriber.rb
+++ b/actionpack/lib/action_controller/structured_event_subscriber.rb
@@ -91,6 +91,26 @@ module ActionController
     end
     debug_only :unpermitted_parameters
 
+    def csrf_token_fallback(event)
+      emit_csrf_event "action_controller.csrf_token_fallback", event.payload
+    end
+
+    def csrf_request_blocked(event)
+      emit_csrf_event "action_controller.csrf_request_blocked", event.payload
+    end
+
+    def csrf_javascript_blocked(event)
+      emit_csrf_event "action_controller.csrf_javascript_blocked", event.payload
+    end
+
+    private def emit_csrf_event(name, payload)
+      emit_event name,
+        controller: payload[:controller],
+        action: payload[:action],
+        sec_fetch_site: payload[:sec_fetch_site],
+        message: payload[:message]
+    end
+
     def write_fragment(event)
       fragment_cache(__method__, event)
     end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -536,9 +536,9 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_block_post_with_origin_checking_and_wrong_origin
-    old_logger = ActionController::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    ActionController::Base.logger = logger
+    old_logger = ActionController::LogSubscriber.logger
+    ActionController::LogSubscriber.logger = logger
 
     forgery_protection_origin_check do
       initialize_csrf_token
@@ -555,14 +555,14 @@ module RequestForgeryProtectionTests
       logger.logged(:warn).last
     )
   ensure
-    ActionController::Base.logger = old_logger
+    ActionController::LogSubscriber.logger = old_logger
   end
 
 
   def test_should_warn_on_missing_csrf_token
-    old_logger = ActionController::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    ActionController::Base.logger = logger
+    old_logger = ActionController::LogSubscriber.logger
+    ActionController::LogSubscriber.logger = logger
 
     begin
       assert_blocked { post :index }
@@ -571,14 +571,14 @@ module RequestForgeryProtectionTests
       assert_match(/Falling back to CSRF token/, logger.logged(:warn).first)
       assert_match(/CSRF token authenticity/, logger.logged(:warn).last)
     ensure
-      ActionController::Base.logger = old_logger
+      ActionController::LogSubscriber.logger = old_logger
     end
   end
 
   def test_should_not_warn_if_csrf_logging_disabled
-    old_logger = ActionController::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    ActionController::Base.logger = logger
+    old_logger = ActionController::LogSubscriber.logger
+    ActionController::LogSubscriber.logger = logger
     ActionController::Base.log_warning_on_csrf_failure = false
 
     begin
@@ -586,7 +586,7 @@ module RequestForgeryProtectionTests
 
       assert_equal 0, logger.logged(:warn).size
     ensure
-      ActionController::Base.logger = old_logger
+      ActionController::LogSubscriber.logger = old_logger
       ActionController::Base.log_warning_on_csrf_failure = true
     end
   end
@@ -613,9 +613,9 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_warn_on_not_same_origin_js
-    old_logger = ActionController::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    ActionController::Base.logger = logger
+    old_logger = ActionController::LogSubscriber.logger
+    ActionController::LogSubscriber.logger = logger
 
     begin
       assert_cross_origin_blocked { get :same_origin_js }
@@ -623,14 +623,14 @@ module RequestForgeryProtectionTests
       assert_equal 1, logger.logged(:warn).size
       assert_match(/<script> tag on another site requested protected JavaScript/, logger.logged(:warn).last)
     ensure
-      ActionController::Base.logger = old_logger
+      ActionController::LogSubscriber.logger = old_logger
     end
   end
 
   def test_should_not_warn_if_csrf_logging_disabled_and_not_same_origin_js
-    old_logger = ActionController::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
-    ActionController::Base.logger = logger
+    old_logger = ActionController::LogSubscriber.logger
+    ActionController::LogSubscriber.logger = logger
     ActionController::Base.log_warning_on_csrf_failure = false
 
     begin
@@ -638,7 +638,7 @@ module RequestForgeryProtectionTests
 
       assert_equal 0, logger.logged(:warn).size
     ensure
-      ActionController::Base.logger = old_logger
+      ActionController::LogSubscriber.logger = old_logger
       ActionController::Base.log_warning_on_csrf_failure = true
     end
   end
@@ -884,7 +884,7 @@ end
 class CustomAuthenticityParamControllerTest < ActionController::TestCase
   def setup
     super
-    @old_logger = ActionController::Base.logger
+    @old_logger = ActionController::LogSubscriber.logger
     @logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
     @token = Base64.urlsafe_encode64(SecureRandom.random_bytes(32))
     @old_request_forgery_protection_token = ActionController::Base.request_forgery_protection_token
@@ -897,7 +897,7 @@ class CustomAuthenticityParamControllerTest < ActionController::TestCase
   end
 
   def test_should_not_warn_if_form_authenticity_param_matches_form_authenticity_token
-    ActionController::Base.logger = @logger
+    ActionController::LogSubscriber.logger = @logger
     begin
       @controller.stub :valid_authenticity_token?, :true do
         post :index, params: { custom_token_name: "foobar" }
@@ -906,12 +906,12 @@ class CustomAuthenticityParamControllerTest < ActionController::TestCase
         assert_match(/Falling back to CSRF token/, @logger.logged(:warn).first)
       end
     ensure
-      ActionController::Base.logger = @old_logger
+      ActionController::LogSubscriber.logger = @old_logger
     end
   end
 
   def test_should_warn_if_form_authenticity_param_does_not_match_form_authenticity_token
-    ActionController::Base.logger = @logger
+    ActionController::LogSubscriber.logger = @logger
 
     begin
       post :index, params: { custom_token_name: "bazqux" }
@@ -920,7 +920,7 @@ class CustomAuthenticityParamControllerTest < ActionController::TestCase
       assert_match(/Falling back to CSRF token/, @logger.logged(:warn).first)
       assert_match(/CSRF token authenticity/, @logger.logged(:warn).last)
     ensure
-      ActionController::Base.logger = @old_logger
+      ActionController::LogSubscriber.logger = @old_logger
     end
   end
 end


### PR DESCRIPTION
Switches from direct logging to event-driven logging, allowing others to subscribe to and act on CSRF events.

New notification events:
* csrf_token_fallback.action_controller
* csrf_request_blocked.action_controller
* csrf_javascript_blocked.action_controller

StructuredEventSubscriber transforms these to EventReporter format (action_controller.* namespace) for LogSubscriber.

References https://github.com/rails/rails/pull/56350#discussion_r2615540783
References #56350

/cc @bdewater @rosa