### PR TITLE
Fix protect_from_forgery to use the default value from config

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -269,7 +269,7 @@ module ActionController # :nodoc:
         self.request_forgery_protection_token ||= :authenticity_token
 
         self.csrf_token_storage_strategy = storage_strategy(options[:store] || SessionStore.new)
-        self.forgery_protection_verification_strategy = verification_strategy(options[:using] || :header_only)
+        self.forgery_protection_verification_strategy = verification_strategy(options[:using] || forgery_protection_verification_strategy)
         self.forgery_protection_trusted_origins = Array(options[:trusted_origins]) if options.key?(:trusted_origins)
 
         before_action :verify_request_for_forgery_protection, options


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/56350/
and this [discussion](https://github.com/rails/rails/pull/56350/changes#r2615865992)

When using
```ruby
config.action_controller.forgery_protection_verification_strategy = :header_or_legacy_token
```

We expect that this will be used in controllers by default. But in actuality, `header_only` is used as a fallback

cc @rosa @jeremy  