### PR TITLE
Only emit logs if logger is defined

### DIFF
--- a/activesupport/lib/active_support/event_reporter/log_subscriber.rb
+++ b/activesupport/lib/active_support/event_reporter/log_subscriber.rb
@@ -42,6 +42,7 @@ module ActiveSupport
       class_attribute :log_levels, default: {} # :nodoc:
 
       def emit(event)
+        return unless logger
         name = event[:name]
         event_method = name[name.index(".") + 1, name.length]
         public_send(event_method, event) if LEVEL_CHECKS[log_levels[event_method]]&.call(logger)

--- a/activesupport/test/event_reporter/log_subscriber_test.rb
+++ b/activesupport/test/event_reporter/log_subscriber_test.rb
@@ -73,6 +73,18 @@ class ActiveSupport::EventReporter::LogSubscriberTest < ActiveSupport::TestCase
     assert_instance_of(ActiveSupport::LogSubscriber::TestHelper::MockLogger, subclass.logger)
   end
 
+  test "nil logger" do
+    MyLogSubscriber.logger = nil
+
+    subclass = Class.new(MyLogSubscriber) do
+      def self.default_logger
+        nil
+      end
+    end
+
+    assert_nothing_raised { subclass.new.emit(name: "test.debug_only") }
+  end
+
   test ".subscription_filter" do
     event_reporter_raise_on_error do
       ActiveSupport.event_reporter.notify("other_namespace_that_shouldnt_work.info_only")


### PR DESCRIPTION
See https://github.com/rails/rails/pull/56213#issuecomment-3642535238

Fixes the following error on main:

1. First generate a new Rails app:

```sh
rails/railties/exe/rails new issue56230 --dev
cd issue56230/
RAILS_ENV=production RAILS_LOG_LEVEL=debug bin/rails server
```

Then edit config/environments/production.rb replacing these lines:

```diff
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true

+  config.action_view.logger = nil
```

Then open http://localhost:3000/up in the browser: the error is there

```
NoMethodError (undefined method 'debug?' for nil)
Caused by: NoMethodError (undefined method 'debug?' for nil)
Information for: NoMethodError (undefined method 'debug?' for nil):
/rails/activesupport/lib/active_support/event_reporter/log_subscriber.rb:9:in 'block in '
/rails/activesupport/lib/active_support/event_reporter/log_subscriber.rb:47:in 'ActiveSupport::EventReporter::LogSubscriber#emit'
```
