### PR TITLE
[Guides] Add an upgrade note about the request forgery callback rename

### DIFF
--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1729,6 +1729,22 @@ class InvalidVerificationStrategyTest < ActionController::TestCase
   end
 end
 
+class SkipVerifyAuthenticityTokenDeprecationTest < ActiveSupport::TestCase
+  test "skip_before_action :verify_authenticity_token skips forgery protection callback and is deprecated" do
+    controller_class = nil
+
+    assert_deprecated("skip_before_action :verify_authenticity_token has been deprecated", ActionController.deprecator) do
+      controller_class = Class.new(ActionController::Base) do
+        protect_from_forgery with: :exception
+        skip_before_action :verify_authenticity_token
+      end
+    end
+
+    before_filters = controller_class._process_action_callbacks.select { |cb| cb.kind == :before }.map(&:filter)
+    assert_not_includes before_filters, :verify_request_for_forgery_protection
+  end
+end
+
 
 class TrustedOriginsHeaderOnlyController < ActionController::Base
   include RequestForgeryProtectionActions

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -82,6 +82,30 @@ Upgrading from Rails 8.1 to Rails 8.2
 
 For more information on changes made to Rails 8.2 please see the [release notes](8_2_release_notes.html).
 
+### CSRF verification callback has been renamed
+
+If you were skipping CSRF protection by skipping the `:verify_authenticity_token` callback, you may see errors like:
+
+```text
+Before process_action callback :verify_authenticity_token has not been defined
+```
+
+To fix this, prefer using the dedicated API:
+
+```ruby
+class WebhooksController < ApplicationController
+  skip_forgery_protection
+end
+```
+
+If you need to keep using `skip_before_action`, update it to the new callback name:
+
+```ruby
+class WebhooksController < ApplicationController
+  skip_before_action :verify_request_for_forgery_protection
+end
+```
+
 ### The negative scopes for enums now include records with `nil` values.
 
 Active Record negative scopes for enums now include records with `nil` values.


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/56350/ ( [Comment](https://github.com/rails/rails/pull/56350/changes#r2616298971) )

There was  kind of a breaking change ( renaming `verify_authenticity_token` to `verify_request_for_forgery_protection`)  , I've just realized it in my application. I know developers can just use `skip_forgery_protection` to fix it. But `verify_authenticity_token` is referenced quited a bit in the documentation, and I believe in many applications ( as well as many Rails articles ) use it frequently in the `Rails API only` sphere.

I had this error by running: `bin/rails zeitwerk:check` ( aka eager loading the application )

<img width="1252" height="163" alt="Image" src="https://github.com/user-attachments/assets/9362f702-28c4-4f7d-8361-d09c164f25c6" />

I couldn't figure out an easy way to handle both foreward and backward compatibility, so I'm opening a documentation PR with an upgrade note to help developers upgrade  their applications from Rails 8.1 to 8.2

references across Github can be found here: https://github.com/search?q=skip_before_action+%3Averify_authenticity_token&type=code&p=1


cc @jeremy @rosa 