### PR TITLE
Active Support: remove stale deprecation assertions from TimeWithZone YAML tests

### DIFF
--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -198,10 +198,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
       time: 1999-12-31 19:00:00.000000000 Z
     EOF
 
-    # TODO: Remove assertion in Rails 7.1
-    assert_not_deprecated(ActiveSupport.deprecator) do
-      assert_equal(yaml, @twz.to_yaml)
-    end
+    assert_equal(yaml, @twz.to_yaml)
   end
 
   def test_ruby_to_yaml
@@ -214,10 +211,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
         time: 1999-12-31 19:00:00.000000000 Z
     EOF
 
-    # TODO: Remove assertion in Rails 7.1
-    assert_not_deprecated(ActiveSupport.deprecator) do
-      assert_equal(yaml, { "twz" => @twz }.to_yaml)
-    end
+    assert_equal(yaml, { "twz" => @twz }.to_yaml)
   end
 
   def test_yaml_load


### PR DESCRIPTION
### Motivation / Background

The `ActiveSupport::TimeWithZone` YAML serialization tests were still wrapped in `assert_not_deprecated` with a TODO to “Remove assertion in Rails 7.1”. Since we’re well past that version and the behavior no longer emits a deprecation, the TODO/wrapper are now just noise.

### Detail

This Pull Request removes the stale TODO comments and simplifies `test_to_yaml` / `test_ruby_to_yaml` to assert the YAML output directly.

### Additional information

Ran: `bundle exec ruby activesupport/test/core_ext/time_with_zone_test.rb`

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
