### PR TITLE
Add controller action source location to routes inspector

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add controller action source location to routes inspector.
+
+    The routes inspector now shows where controller actions are defined.
+    In `rails routes --expanded`, a new "Action Location" field displays
+    the file and line number of each action method.
+
+    On the routing error page, when `RAILS_EDITOR` or `EDITOR` is set,
+    a clickable ✏️ icon appears next to each Controller#Action that opens
+    the action directly in the editor.
+
+    *Guillermo Iguaran*
+
 *   Active Support notifications for CSRF warnings.
 
     Switches from direct logging to event-driven logging, allowing others to

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_route.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_route.html.erb
@@ -11,7 +11,15 @@
     <%= route[:path] %>
   </td>
   <td>
-    <%=simple_format route[:reqs] %>
+    <%
+      editor = ActiveSupport::Editor.current
+      action_file = route[:action_source_file]
+      action_line = route[:action_source_line]
+    %>
+    <% if editor && action_file && action_line %>
+      <%= link_to("✏️", editor.url_for(action_file, action_line), class: "edit-icon") %>
+    <% end %>
+    <%= route[:reqs] %>
   </td>
   <td>
     <%=simple_format route[:source_location] %>

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -66,6 +66,10 @@
     padding: 4px 30px;
   }
 
+  #route_table .edit-icon {
+    text-decoration: none;
+  }
+
   @media (prefers-color-scheme: dark) {
     #route_table tbody tr:nth-child(odd) {
       background: #282828;

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -261,138 +261,161 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
       URI               | /rails/action_mailbox/postmark/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/postmark/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb:XX
       --[ Route 3 ]--------------
       Prefix            | rails_relay_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/relay/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/relay/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/relay/inbound_emails_controller.rb:XX
       --[ Route 4 ]--------------
       Prefix            | rails_sendgrid_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/sendgrid/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/sendgrid/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb:XX
       --[ Route 5 ]--------------
       Prefix            | rails_mandrill_inbound_health_check
       Verb              | GET
       URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#health_check
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb:XX
       --[ Route 6 ]--------------
       Prefix            | rails_mandrill_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb:XX
       --[ Route 7 ]--------------
       Prefix            | rails_mailgun_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
       Controller#Action | action_mailbox/ingresses/mailgun/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb:XX
       --[ Route 8 ]--------------
       Prefix            | rails_conductor_inbound_emails
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#index
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
       --[ Route 9 ]--------------
       Prefix            |#{" "}
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
       --[ Route 10 ]-------------
       Prefix            | new_rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#new
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
       --[ Route 11 ]-------------
       Prefix            | rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#show
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
       --[ Route 12 ]-------------
       Prefix            | new_rails_conductor_inbound_email_source
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#new
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb:XX
       --[ Route 13 ]-------------
       Prefix            | rails_conductor_inbound_email_sources
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb:XX
       --[ Route 14 ]-------------
       Prefix            | rails_conductor_inbound_email_reroute
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)
       Controller#Action | rails/conductor/action_mailbox/reroutes#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/reroutes_controller.rb:XX
       --[ Route 15 ]-------------
       Prefix            | rails_conductor_inbound_email_incinerate
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/incinerate(.:format)
       Controller#Action | rails/conductor/action_mailbox/incinerates#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/incinerates_controller.rb:XX
       --[ Route 16 ]-------------
       Prefix            | rails_service_blob
       Verb              | GET
       URI               | /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb:XX
       --[ Route 17 ]-------------
       Prefix            | rails_service_blob_proxy
       Verb              | GET
       URI               | /rails/active_storage/blobs/proxy/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/proxy#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb:XX
       --[ Route 18 ]-------------
       Prefix            |#{" "}
       Verb              | GET
       URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb:XX
       --[ Route 19 ]-------------
       Prefix            | rails_blob_representation
       Verb              | GET
       URI               | /rails/active_storage/representations/redirect/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/representations/redirect_controller.rb:XX
       --[ Route 20 ]-------------
       Prefix            | rails_blob_representation_proxy
       Verb              | GET
       URI               | /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/proxy#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/representations/proxy_controller.rb:XX
       --[ Route 21 ]-------------
       Prefix            |#{" "}
       Verb              | GET
       URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/representations/redirect_controller.rb:XX
       --[ Route 22 ]-------------
       Prefix            | rails_disk_service
       Verb              | GET
       URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
       Controller#Action | active_storage/disk#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/disk_controller.rb:XX
       --[ Route 23 ]-------------
       Prefix            | update_rails_disk_service
       Verb              | PUT
       URI               | /rails/active_storage/disk/:encoded_token(.:format)
       Controller#Action | active_storage/disk#update
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/disk_controller.rb:XX
       --[ Route 24 ]-------------
       Prefix            | rails_direct_uploads
       Verb              | POST
       URI               | /rails/active_storage/direct_uploads(.:format)
       Controller#Action | active_storage/direct_uploads#create
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
+      Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/direct_uploads_controller.rb:XX
     MESSAGE
   end
 


### PR DESCRIPTION
### Motivation / Background

The routes inspector now shows where controller actions are defined. In `rails routes --expanded`, a new "Action Location" field displays the file and line number of each action method.

On the routing error page, when `RAILS_EDITOR` or `EDITOR` is set, a clickable ✏️ icon appears next to each Controller#Action that opens the action directly in the editor.


### Detail

- Add \`action_source_location\` method to RouteWrapper that uses
    \`instance_method(:action).source_location\` to find where actions are defined
- Display \"Action Location\" in \`rails routes --expanded\` output
- Add clickable editor link (✏️) next to Controller#Action in the routing
    error page when `RAILS_EDITOR` or `EDITOR` environment variable is set
- Works with namespaced controllers and gracefully handles missing
    controllers/actions, Rack apps, and dynamic routes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
