### PR TITLE
Include MRI prerelease string in generated `.ruby-version`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -771,6 +771,19 @@ module Rails
         defined?(JRUBY_VERSION)
       end
 
+      def version_manager_ruby_version
+        return ENV["RBENV_VERSION"] if ENV["RBENV_VERSION"]
+        return ENV["rvm_ruby_string"] if ENV["rvm_ruby_string"]
+
+        version = if RUBY_ENGINE == "ruby"
+          Gem.ruby_version.to_s.sub(/\.([a-zA-Z])/, '-\1')
+        else
+          RUBY_ENGINE_VERSION
+        end
+
+        "#{RUBY_ENGINE}-#{version}"
+      end
+
       def empty_directory_with_keep_file(destination, config = {})
         empty_directory(destination, config)
         keep_file(destination)

--- a/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/ruby-version.tt
@@ -1,1 +1,1 @@
-<%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+<%= version_manager_ruby_version %>

--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -2,11 +2,15 @@
 
 require "active_support/test_case"
 require "active_support/testing/autorun"
+require "env_helpers"
+require "minitest/mock"
 require "rails/generators/app_base"
 
 module Rails
   module Generators
     class GeneratorTest < ActiveSupport::TestCase
+      include EnvHelpers
+
       def make_builder_class
         Class.new(AppBase) do
           add_shared_options_for "application"
@@ -37,6 +41,57 @@ module Rails
         assert_equal ["~> 4.1.7", ">= 4.1.7.1.rc2"], specifier_for["4.1.7.1.rc2"]
         assert_equal "~> 4.2.0.beta1", specifier_for["4.2.0.beta1"]
         assert_equal "~> 5.0.0.beta1", specifier_for["5.0.0.beta1"]
+      end
+
+      def test_version_manager_ruby_version_with_rbenv_env_var
+        klass = make_builder_class
+        generator = klass.start(["new", "blah"])
+
+        switch_env "RBENV_VERSION", "3.4.0" do
+          assert_equal "3.4.0", generator.send(:version_manager_ruby_version)
+        end
+      end
+
+      def test_version_manager_ruby_version_with_rvm_env_var
+        klass = make_builder_class
+        generator = klass.start(["new", "blah"])
+
+        switch_env "rvm_ruby_string", "ruby-3.4.0" do
+          assert_equal "ruby-3.4.0", generator.send(:version_manager_ruby_version)
+        end
+      end
+
+      def test_version_manager_ruby_version_with_mri_ruby
+        klass = make_builder_class
+        generator = klass.start(["new", "blah"])
+
+        stub_const(Object, :RUBY_ENGINE, "ruby") do
+          Gem.stub(:ruby_version, Gem::Version.new("3.4.0")) do
+            assert_equal "ruby-3.4.0", generator.send(:version_manager_ruby_version)
+          end
+        end
+      end
+
+      def test_version_manager_ruby_version_with_mri_ruby_prerelease
+        klass = make_builder_class
+        generator = klass.start(["new", "blah"])
+
+        stub_const(Object, :RUBY_ENGINE, "ruby") do
+          Gem.stub(:ruby_version, Gem::Version.new("4.0.0.preview2")) do
+            assert_equal "ruby-4.0.0-preview2", generator.send(:version_manager_ruby_version)
+          end
+        end
+      end
+
+      def test_version_manager_ruby_version_with_non_mri_ruby
+        klass = make_builder_class
+        generator = klass.start(["new", "blah"])
+
+        stub_const(Object, :RUBY_ENGINE, "jruby") do
+          stub_const(Object, :RUBY_ENGINE_VERSION, "10.0.2.0") do
+            assert_equal "jruby-10.0.2.0", generator.send(:version_manager_ruby_version)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/55644.

### Motivation / Background

This Pull Request has been created because when using a Ruby prerelease like `4.0.0-preview2`, `rails new` generates a `.ruby-version` that only contains `4.0.0` without the `-preview2` suffix. This can make Ruby version managers like `asdf` or `mise` error out when the release version does not exist locally or remotely.

### Detail

This Pull Request changes `ruby-version.tt` to include the prerelease suffix (for example `-preview2`) for MRI Ruby.

### Additional information

- For non-MRI Rubies, the old behavior is kept, since in practice `RUBY_ENGINE_VERSION` seems to contain the full version with alphanumeric characters. For example, TruffleRuby 23.0.0-preview1 has a `RUBY_ENGINE_VERSION` that directly returns `"23.0.0-preview1"`.
- Unit tests have been added with real-world mocked values that I copy/pasted from my own manual testing of different Ruby version managers (rbenv, rvm, asdf, and mise) and Ruby versions (MRI release, MRI prerelease, JRuby release, TruffleRuby release, and TruffleRuby release with alphanumeric characters).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
