### PR TITLE
Fix QueryIntent RangeError handling breaking affected_rows

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -316,8 +316,8 @@ module ActiveRecord
 
         def run_query!
           adapter.execute_intent(self)
-        rescue ::RangeError
-          @cast_result = ActiveRecord::Result.empty
+        rescue ::RangeError => error
+          @error = error
           @raw_result_available = true
         end
     end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -270,6 +270,14 @@ module ActiveRecord
 
         assert_not_nil error.cause
       end
+
+      def test_range_error_is_raised_for_out_of_range_integer_on_create
+        error = assert_raises(ActiveRecord::RangeError) do
+          Book.create!(author_id: 9223372036854775808)
+        end
+
+        assert_kind_of RangeError, error.cause
+      end
     end
 
     def test_exceptions_from_notifications_are_not_translated


### PR DESCRIPTION
### Summary

Fixes a regression introduced in #55897 where `RangeError` during write queries causes a `RuntimeError` instead of propagating the original error.

When a `RangeError` occurred during query execution, `QueryIntent#run_query!` was setting `@cast_result = ActiveRecord::Result.empty`. This broke the state machine for write queries because:

1. Write queries (INSERT/UPDATE) call `affected_rows()` to check success
2. `affected_rows()` raises `RuntimeError` if `@cast_result` is already defined
3. This caused: `"Cannot call affected_rows after cast_result has been called"`

### The Problem

```ruby
# Before: This broke the state machine
rescue ::RangeError
  @cast_result = ActiveRecord::Result.empty  # <-- Sets cast_result
  @raw_result_available = true
```

When calling `save!` with an out-of-range integer:
- Expected: `ActiveModel::RangeError`
- Actual: `RuntimeError: "Cannot call affected_rows after cast_result has been called"`

### The Fix

Store the error in `@error` instead, which gets properly raised to the caller via `ensure_result()`. This follows the same pattern as other error handling in the class (see `execute_or_skip` and `execute_or_wait`).

```ruby
# After: Follows existing error handling pattern
rescue ::RangeError => error
  @error = error
  @raw_result_available = true
```

### Test Case

```ruby
test "error on excessive integer input" do
  max_integer = (2**31) - 1
  setting = Setting.first
  setting.some_integer_field = max_integer + 1
  
  # Before fix: RuntimeError
  # After fix: ActiveModel::RangeError (as expected)
  assert_raise ActiveModel::RangeError do
    setting.save!
  end
end
```