### PR TITLE
Support but deprecate `skip_before_action :verify_authenticity_token`

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -319,7 +319,7 @@ module ActionController
     PROTECTED_IVARS = AbstractController::Rendering::DEFAULT_PROTECTED_INSTANCE_VARIABLES + %i(
       @_params @_response @_request @_config @_url_options @_action_has_layout @_view_context_class
       @_view_renderer @_lookup_context @_routes @_view_runtime @_db_runtime @_helper_proxy
-      @_marked_for_same_origin_verification @_rendered_format
+      @_marked_for_same_origin_verification @_verify_authenticity_token_ran @_rendered_format
     )
 
     def _protected_ivars

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -195,6 +195,13 @@ class SkipProtectionWhenUnprotectedController < ActionController::Base
   skip_forgery_protection
 end
 
+# Controller using the deprecated skip_before_action :verify_authenticity_token
+class DeprecatedSkipVerifyAuthenticityTokenController < ActionController::Base
+  include RequestForgeryProtectionActions
+  protect_from_forgery with: :exception
+  skip_before_action :verify_authenticity_token
+end
+
 class CookieCsrfTokenStorageStrategyController < ActionController::Base
   include RequestForgeryProtectionActions
 
@@ -1277,6 +1284,29 @@ class SkipProtectionWhenUnprotectedControllerTest < ActionController::TestCase
   def assert_not_blocked(&block)
     assert_nothing_raised(&block)
     assert_response :success
+  end
+end
+
+class DeprecatedSkipVerifyAuthenticityTokenControllerTest < ActionController::TestCase
+  def test_should_allow_post_without_token_with_deprecation_warning
+    assert_deprecated(ActiveSupport.deprecator) do
+      post :index
+    end
+    assert_response :success
+  end
+
+  def test_deprecation_message_suggests_skip_forgery_protection
+    assert_deprecated(/skip_forgery_protection/, ActiveSupport.deprecator) do
+      post :index
+    end
+  end
+
+  def test_should_not_raise_exception_when_skipped
+    assert_deprecated(ActiveSupport.deprecator) do
+      assert_nothing_raised do
+        post :index
+      end
+    end
   end
 end
 


### PR DESCRIPTION
In #56350, `verify_authenticity_token` was renamed to `verify_request_for_forgery_protection`, to more accurately reflect its purpose, now that  an authenticity token is not necessarily verified.

However, because many people rely on `skip_before_action :verify_authenticity_token`, to opt out of forgery protection, we need to keep this working and deprecate it.  We simply mark it as having ran, as part of `protect_from_forgery`, and when verifying the request, we check if the method ran. If it didn't, it's because it was skipped on its own and not via `skip_forgery_protection`, so we can emit the deprecation warning.

cc @chaadow

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
