### PR TITLE
Make bin/ci call db:test:prepare instead of db:seed:replant

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `bin/ci` call `db:test:prepare` instead of `db:seed:replant` to make it consistent with `.github/workflows/ci.yml`
+
+    *Matthew Nguyen*
+
 *   Do not clean directories directly under the application root with `Rails::BacktraceCleaner`
 
     Improved `Rails.backtrace_cleaner` so that most paths located directly under the application's root directory are no longer silenced.

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -20,13 +20,10 @@ CI.run do
 <% end -%>
 <% unless options[:skip_test] -%>
 <% if options[:api] || options[:skip_system_test] -%>
-  step "Tests: Rails", "bin/rails test"
+  step "Tests: Rails", "bin/rails <%= "db:test:prepare " unless options.skip_active_record? %>test"
 <% else %>
-  step "Tests: Rails", "bin/rails test"
-  step "Tests: System", "bin/rails test:system"
-<% end -%>
-<% unless options.skip_active_record? -%>
-  step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+  step "Tests: Rails", "bin/rails <%= "db:test:prepare " unless options.skip_active_record? %>test"
+  step "Tests: System", "bin/rails <%= "db:test:prepare " unless options.skip_active_record? %>test:system"
 <% end -%>
 <% end -%>
 

--- a/railties/test/application/bin_ci_test.rb
+++ b/railties/test/application/bin_ci_test.rb
@@ -20,9 +20,8 @@ module ApplicationTests
         assert_match(/bin\/rubocop/, content)
         assert_match(/bin\/brakeman/, content)
         assert_match(/bin\/bundler-audit/, content)
-        assert_match(/"bin\/rails test"$/, content)
-        assert_match(/"bin\/rails test:system"$/, content)
-        assert_match(/bin\/rails db:seed:replant/, content)
+        assert_match(/"bin\/rails db:test:prepare test"$/, content)
+        assert_match(/"bin\/rails db:test:prepare test:system"$/, content)
 
         # Node-specific steps excluded by default
         assert_no_match(/yarn audit/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -689,11 +689,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_config_ci_includes_seed_step_by_default
+  def test_config_ci_includes_db_test_prepare_step_by_default
     run_generator [destination_root]
 
     assert_file "config/ci.rb" do |content|
-      assert_match(/step "Tests: Seeds", "env RAILS_ENV=test bin\/rails db:seed:replant"/, content)
+      assert_match(/step "Tests: Rails", "bin\/rails db:test:prepare test"/, content)
+      assert_match(/step "Tests: System", "bin\/rails db:test:prepare test:system"/, content)
     end
   end
 
@@ -703,17 +704,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/ci.rb" do |content|
       assert_no_match(/step "Tests: Rails"/, content)
       assert_no_match(/step "Tests: System"/, content)
-      assert_no_match(/step "Tests: Seeds"/, content)
-      assert_no_match(/bin\/rails db:seed:replant/, content)
     end
   end
 
-  def test_config_ci_does_not_include_seed_step_when_skip_active_record_is_given
+  def test_config_ci_does_not_include_db_test_prepare_when_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
 
     assert_file "config/ci.rb" do |content|
-      assert_no_match(/step "Tests: Seeds"/, content)
-      assert_no_match(/bin\/rails db:seed:replant/, content)
+      assert_no_match(/db:test:prepare/, content)
+      assert_match(/bin\/rails test/, content)
+      assert_match(/bin\/rails test:system/, content)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

`bin/ci` uses seeds while `ci.yml` doesn't and starts with an empty database.  
This results in potentially different outputs when running CI locally and on github.

### Detail

I replaced `db:seed:replant` with `db:test:prepare` in `bin/ci`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
