### PR TITLE
Make ActionCable unsubscribe idempotent

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -44,6 +44,12 @@ module ActionCable
         end
       end
 
+      class MissingIdentifier < Error
+        def initialize
+          super "Identifier is required"
+        end
+      end
+
       def initialize(connection)
         @connection = connection
         @subscriptions = {}
@@ -78,8 +84,11 @@ module ActionCable
       end
 
       def remove(data)
+        raise MissingIdentifier unless data["identifier"].present?
+
         logger.info "Unsubscribing from channel: #{data['identifier']}"
-        remove_subscription find(data)
+        subscription = find(data)
+        remove_subscription(subscription) if subscription
       end
 
       def remove_subscription(subscription)
@@ -88,7 +97,9 @@ module ActionCable
       end
 
       def perform_action(data)
-        find(data).perform_action ActiveSupport::JSON.decode(data["data"])
+        subscription = find(data)
+        raise UnknownSubscription.new(data["identifier"]) unless subscription
+        subscription.perform_action ActiveSupport::JSON.decode(data["data"])
       end
 
       def identifiers
@@ -104,11 +115,7 @@ module ActionCable
         delegate :logger, to: :connection
 
         def find(data)
-          if subscription = subscriptions[data["identifier"]]
-            subscription
-          else
-            raise UnknownSubscription, data["identifier"]
-          end
+          subscriptions[data["identifier"]]
         end
 
         def subscription_from_identifier(id_key)

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -99,11 +99,35 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
   test "unsubscribe command without an identifier" do
     setup_connection
 
-    assert_raises ActionCable::Connection::Subscriptions::UnknownSubscription do
+    assert_raises ActionCable::Connection::Subscriptions::MissingIdentifier do
       @subscriptions.execute_command "command" => "unsubscribe"
     end
 
     assert_empty @subscriptions.identifiers
+  end
+
+  test "unsubscribe from non-existent subscription" do
+    run_in_eventmachine do
+      setup_connection
+
+      assert_nothing_raised do
+        @subscriptions.remove("identifier" => @chat_identifier)
+      end
+      assert_empty @subscriptions.identifiers
+    end
+  end
+
+  test "perform action on non-existent subscription" do
+    run_in_eventmachine do
+      setup_connection
+
+      data = { "content" => "Hello World!", "action" => "speak" }
+
+      error = assert_raises ActionCable::Connection::Subscriptions::UnknownSubscription do
+        @subscriptions.perform_action("identifier" => @chat_identifier, "data" => ActiveSupport::JSON.encode(data))
+      end
+      assert_match(/Unable to find subscription/, error.message)
+    end
   end
 
   test "message command" do

--- a/actionpack/test/dispatch/content_disposition_test.rb
+++ b/actionpack/test/dispatch/content_disposition_test.rb
@@ -41,5 +41,15 @@ module ActionDispatch
 
       assert_equal "inline", disposition.to_s
     end
+
+    test ".format builds the header string" do
+      expected = Http::ContentDisposition.new(disposition: :inline, filename: "racecar.jpg").to_s
+
+      assert_equal expected, Http::ContentDisposition.format(disposition: :inline, filename: "racecar.jpg")
+    end
+
+    test ".format without filename" do
+      assert_equal "inline", Http::ContentDisposition.format(disposition: :inline, filename: nil)
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

`ActionCable` currently raises a `RuntimeError` when a client attempts to unsubscribe from a subscription that no longer exists on the server. This commonly occurs due to race conditions: reconnects, server restarts, or rapid subscribe/unsubscribe cycles (especially with Turbo Streams).

The error is caught by `execute_command`'s rescue block, which calls `rescue_with_handler`. This triggers any `rescue_from` handlers defined in the application's connection class, commonly used to report exceptions to error monitoring services like Sentry, creating noise in production error tracking. It also represents incorrect semantics, as unsubscribe should be idempotent.

Related to #25381 and #30702.

### Detail

This Pull Request changes `find` to return `nil` instead of raising and moves the error handling to the callers. Currently, `find` is only called in two places:

- `remove` now checks for nil and returns early (idempotent no-op)
- `perform_action` still raises if subscription not found (this indicates a real client bug)

This distinction is important: unsubscribing from something that doesn't exist is a successful no-op, while trying to perform an action on a non-existent subscription indicates a real client bug that should still raise.

### Additional information

One issue #25381 was opened in 2016. PR #30702 improved the error message but preserved the raising behavior. This PR completes the fix by making unsubscribe truly idempotent while preserving the error for `perform_action`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.