### PR TITLE
Allow disabling transactional callbacks on a model

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -10,6 +10,8 @@ module ActiveRecord
       define_callbacks :commit, :rollback,
                        :before_commit,
                        scope: [:kind, :name]
+
+      class_attribute :transactional_callbacks, instance_writer: false, default: true
     end
 
     attr_accessor :_new_record_before_last_commit, :_last_transaction_return_status # :nodoc:
@@ -425,6 +427,10 @@ module ActiveRecord
     # This method is available within the context of an ActiveRecord::Base
     # instance.
     def with_transaction_returning_status # :nodoc:
+      unless self.class.transactional_callbacks
+        return yield
+      end
+
       self.class.with_connection do |connection|
         connection.pool.with_pool_transaction_isolation_level(ActiveRecord.default_transaction_isolation_level, connection.transaction_open?) do
           status = nil

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1525,6 +1525,56 @@ class TransactionTest < ActiveRecord::TestCase
     assert_array_match expected_queries, actual_queries
   end
 
+  class TopicWithoutCallbacks < ActiveRecord::Base
+    self.table_name = "topics"
+    self.transactional_callbacks = false
+  end
+
+  def test_save_without_callbacks_does_not_materialize_transaction
+    topic = TopicWithoutCallbacks.find(topics(:fifth).id)
+    actual_queries = capture_sql do
+      topic.title = "foo"
+      topic.save!
+    end
+
+    assert_array_match [/UPDATE/i], actual_queries
+  end
+
+  def test_update_without_callbacks_does_not_materialize_transaction
+    topic = TopicWithoutCallbacks.find(topics(:fifth).id)
+    actual_queries = capture_sql do
+      topic.update!(title: "foo")
+    end
+
+    assert_array_match [/UPDATE/i], actual_queries
+  end
+
+  def test_destroy_without_callbacks_does_not_materialize_transaction
+    topic = TopicWithoutCallbacks.find(topics(:fifth).id)
+    actual_queries = capture_sql do
+      topic.destroy
+    end
+
+    assert_array_match [/DELETE/i], actual_queries
+  end
+
+  def test_touch_without_callbacks_does_not_materialize_transaction
+    topic = TopicWithoutCallbacks.find(topics(:fifth).id)
+    actual_queries = capture_sql do
+      topic.touch
+    end
+
+    assert_array_match [/UPDATE/i], actual_queries
+  end
+
+  def test_create_without_callbacks_does_not_materialize_transaction
+    actual_queries = capture_sql do
+      TopicWithoutCallbacks.create!(title: "foo")
+    end
+
+    assert_array_match [/INSERT/i], actual_queries
+  end
+
   def test_nested_transactions_after_disable_lazy_transactions
     Topic.lease_connection.disable_lazy_transactions!
 


### PR DESCRIPTION
All validations and model callbacks are wrapped into `BEGIN` / `COMMIT` for transactional consistency.

However, in a large-scale apps with high concurrency and high DB connections usage, that brings the downside of that `BEGIN` holding the connection from being reused by another workers.

On top of that, in a large scale app, you'd run in isolation level like `READ COMMITTED` where keeping callbacks part of the same txn doesn't give you much.

I've tried to write a version of this PR that would automatically kick in if the model has no callbacks, but then I've realized that validations are also part of this. And there's no good way to check whether validations are pure Ruby (`validates :author_id, presence: true`) or actual database (`validates :author, presence: true`).

So I've opted to make this a manual thing per model.

This would already help us at Shopify to save some connections usage across some very hot paths.