### PR TITLE
fix: Reset the schema_search_path during pg reconnect and reset

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -314,7 +314,9 @@ module ActiveRecord
 
         # Returns the active schema search path.
         def schema_search_path
-          @schema_search_path ||= query_value("SHOW search_path")
+          @schema_search_path ||=
+            with_raw_connection { |conn| conn.parameter_status("search_path") } ||
+            query_value("SHOW search_path")
         end
 
         # Returns the current client message level.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -413,6 +413,11 @@ module ActiveRecord
         end
       end
 
+      def clear_cache!(new_connection: false)
+        super
+        @schema_search_path = nil if new_connection
+      end
+
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!
@@ -1038,6 +1043,8 @@ module ActiveRecord
 
           add_pg_encoders
           add_pg_decoders
+
+          schema_search_path # populate cache
 
           reload_type_map
         end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -173,6 +173,25 @@ module ActiveRecord
         connection&.disconnect!
       end
 
+      def test_schema_search_path_uses_parameter_status_on_pg18
+        skip "parameter_status('search_path') requires PostgreSQL 18+" unless @connection.database_version >= 18_00_00
+
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+        begin
+          log = capture_sql(include_schema: true) do
+            connection.connect!
+            connection.schema_search_path
+          end
+
+          assert_not log.any? { |sql| sql.include?("SHOW search_path") },
+                     "Expected no 'SHOW search_path' query, but found one in: #{log.inspect}"
+        ensure
+          connection.disconnect!
+        end
+      end
+
       def test_database_exists_returns_false_when_the_database_does_not_exist
         config = { database: "non_extant_database", adapter: "postgresql" }
         assert_not ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(config),

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -137,6 +137,42 @@ module ActiveRecord
         end
       end
 
+      def test_schema_search_path_is_reapplied_after_reconnect
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(schema_search_path: "public,foo")
+        )
+
+        connection.connect!
+
+        assert_equal "public, foo", connection.select_value("SHOW search_path")
+
+        connection.reconnect!
+
+        assert_equal "public, foo", connection.select_value("SHOW search_path")
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_schema_search_path_is_reapplied_after_reset
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(schema_search_path: "public,foo")
+        )
+
+        connection.connect!
+
+        assert_equal "public, foo", connection.select_value("SHOW search_path")
+
+        connection.reset!
+
+        assert_equal "public, foo", connection.select_value("SHOW search_path")
+      ensure
+        connection&.disconnect!
+      end
+
       def test_database_exists_returns_false_when_the_database_does_not_exist
         config = { database: "non_extant_database", adapter: "postgresql" }
         assert_not ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(config),


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to fix a PostgreSQL adapter bug where the configured `schema_search_path` is not reapplied after a connection is reset or reconnected.

In Rails 8.1, calling `ActiveRecord::Base.connection.reconnect!` (or triggering a connection reset via the pool) creates a new PostgreSQL session, which resets all session-level state such as `search_path`. However, `PostgreSQLAdapter` caches the previously applied `@schema_search_path`, causing `schema_search_path=` to incorrectly short-circuit and skip reapplying the configured search path.

This results in PostgreSQL falling back to its default `"$user", public` search path, breaking applications that rely on multiple schemas.

**Fixes #56378; closes #56382**

---

### Detail

This Pull Request clears the cached `@schema_search_path` whenever PostgreSQL session state is invalidated:

* When reconnecting via `PG::Connection#reset`
* When resetting the session via `DISCARD ALL`

By resetting the cached value in these code paths, `configure_connection` correctly reapplies the configured `schema_search_path` on the new session.

This preserves existing guard logic and avoids unnecessary `SET search_path` calls during normal operation, while ensuring correctness after reconnects and resets.

---

### Additional information

* This issue affects both the `postgresql` and `postgis` adapters
* The behavior is reproducible with a minimal standalone Active Record script (see linked issue)
* Setting the search path at the database or role level works as a workaround, but `database.yml` configuration should be sufficient
* The fix is PostgreSQL-specific and does not affect other adapters

---

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes are not included.
- [x] Commit message includes a detailed description and references the issue.
- [x] Tests are added / updated to cover reconnect and reset behavior.
- [x] CHANGELOG update not required for a bug fix.
