### PR TITLE
Fix has_one association builder setting readonly FK when unchanged

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `has_one` association builder setting readonly foreign key attribute when it is unchanged.
+
+    When a has_one association with a readonly foreign key was accessed and returned nil, the nil
+    value was cached and the association became loaded. Later when creating the association, the
+    cached nil would cause `set_owner_attributes` to write the foreign key even though it hadn't
+    changed, raising `ActiveRecord::ReadonlyAttributeError`.
+
+    *Rui Santos*
+
 *   Yield the transaction object to the block when using `with_lock`.
 
     *Ngan Pham*

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -29,7 +29,7 @@ module ActiveRecord::Associations
 
         primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
           value = owner._read_attribute(foreign_key)
-          record._write_attribute(primary_key, value)
+          record._write_attribute(primary_key, value) unless record._read_attribute(primary_key) == value
         end
 
         if reflection.type

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -24,6 +24,7 @@ require "models/cpk"
 require "models/room"
 require "models/user"
 require "models/dats"
+require "models/eye"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
@@ -323,6 +324,20 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     firm = Firm.create(name: "GlobalMegaCorp")
     account = firm.create_account(credit_limit: 1000)
     assert_equal account, firm.reload.account
+  end
+
+  def test_create_association_with_readonly_foreign_key
+    eye = Eye.create!
+
+    assert_nothing_raised do
+      eye.iris_with_read_only_foreign_key || eye.create_iris_with_read_only_foreign_key!(color: "blue")
+    end
+
+    iris = eye.iris_with_read_only_foreign_key
+
+    assert_equal "blue", iris.color
+    assert_equal eye.id, iris.eye_id
+    assert iris.persisted?
   end
 
   def test_clearing_an_association_clears_the_associations_inverse


### PR DESCRIPTION
### Motivation / Background

When a `has_one` association with a readonly foreign key is accessed and returns nil, the association becomes loaded with a cached `target = nil`. Later, when creating the association, the cached nil causes `set_owner_attributes` to write the readonly foreign key even though it hasn't changed, raising `ActiveRecord::ReadonlyAttributeError`.

A common use case that triggers this is the `obj.association || obj.create_association` pattern, which follows this sequence of accessing the association first and then creating it if nil.

This PR changes `set_owner_attributes` in `foreign_association.rb` to check if the foreign key value has changed before writing it. It follows the same pattern used in #46759 and #50901.

<details>
<summary>Reproduction script</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout, level: :warn)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name
  end

  create_table :profiles, force: true do |t|
    t.integer :user_id, null: false
    t.string :bio
  end
end

class User < ActiveRecord::Base
  has_one :profile
end

class Profile < ActiveRecord::Base
  belongs_to :user
  attr_readonly :user_id
end

class BugTest < ActiveSupport::TestCase
  def test_has_one_with_readonly_foreign_key
    user = User.create!(name: "John")

    assert_nothing_raised do
      user.profile || user.create_profile!(bio: "Developer")
    end

    profile = user.profile

    assert_equal "Developer", profile.bio
    assert_equal user.id, profile.user_id
  end
end
```

</details>

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
