### PR TITLE
Stdlib `blank` core extensions are not loaded for standalone `activemodel`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -197,3 +197,15 @@ class Time # :nodoc:
     true
   end
 end
+
+if defined? DateTime
+  require "active_support/core_ext/date_time/blank"
+end
+
+if defined? Date
+  require "active_support/core_ext/date/blank"
+end
+
+if defined? Pathname
+  require "active_support/core_ext/pathname/blank"
+end


### PR DESCRIPTION
### Motivation / Background

- When `activemodel` is used as a standalone gem, `blank` core extensions for the stdlib classes are not loaded.

- In others words, [Pathname](https://docs.ruby-lang.org/en/3.4/Pathname.html), [Date](https://docs.ruby-lang.org/en/3.4/Date.html) and [DateTime](https://docs.ruby-lang.org/en/3.4/DateTime.html) are using `blank?` implementation inherited from [Object#blank?](https://github.com/rails/rails/blob/v8.1.1/activesupport/lib/active_support/core_ext/object/blank.rb#L18), not from their corresponding monkey-patches: [Pathname#blank?](https://github.com/rails/rails/blob/v8.1.1/activesupport/lib/active_support/core_ext/pathname/blank.rb#L13), [Date#blank?](https://github.com/rails/rails/blob/v8.1.1/activesupport/lib/active_support/core_ext/date/blank.rb#L11) and [DateTime#blank?](https://github.com/rails/rails/blob/v8.1.1/activesupport/lib/active_support/core_ext/date_time/blank.rb).

- While for [Date](https://docs.ruby-lang.org/en/3.4/Date.html) and [DateTime](https://docs.ruby-lang.org/en/3.4/DateTime.html) instances that is not problem, for [Pathname](https://docs.ruby-lang.org/en/3.4/Pathname.html) it leads to the not obvious behaviour.

   <details><summary>Please, review the almost minimal reproducible example (click to collapse/expand).</summary>
  
  ```ruby
  # frozen_string_literal: true
  
  require "bundler/inline"

  gemfile(true) do
    source "https://rubygems.org"

    gem "activemodel", "8.1.1"
  end

  require "active_model"

  class CustomFolder
    include ActiveModel::Validations

    attr_reader :path

    validates :path, presence: true

    def initialize(path:)
      @path = path
    end
  end

  require "minitest/autorun"

  class BeforeRequireTest < ActiveSupport::TestCase
    def test_pathname_blank
      assert_equal true, CustomFolder.new(path: Pathname.new("")).valid? # Should be `false`!
      assert_equal false, CustomFolder.new(path: "").valid?

      assert_equal true, CustomFolder.new(path: Pathname.new("/example")).valid?
      assert_equal true, CustomFolder.new(path: "/example").valid?

      assert_equal false, Pathname.new("").blank? # Should be `true`!
      assert_equal true, "".blank?

      assert_equal false, Pathname.new("/example").blank?
      assert_equal false, "/example".blank?
    end
  end
  ```
</details>

- The `CustomFolder.new(path: Pathname.new("")).valid?` expression from the example should be `false`, but it returns `true` instead.

- The `Pathname.new("").blank?` expresion should be `true`,  but it returns `false` instead, that is not something that is easy to predict. 

### Detail

This PR adds the following lines to the `activesupport/lib/active_support/core_ext/object/blank.rb`.

```ruby
if defined? DateTime
  require "active_support/core_ext/date_time/blank"
end

if defined? Date
  require "active_support/core_ext/date/blank"
end

if defined? Pathname
  require "active_support/core_ext/pathname/blank"
end
```

This way, whenever `activesupport/lib/active_support/core_ext/object/blank.rb` is required, [Pathname](https://docs.ruby-lang.org/en/3.4/Pathname.html), [Date](https://docs.ruby-lang.org/en/3.4/Date.html) and [DateTime](https://docs.ruby-lang.org/en/3.4/DateTime.html) patches are also required if their constants are already in-memory.

### Additional information

<details>
  <summary>One file script to verify the changes (click to collapse/expand).</summary>

  ```ruby
  # frozen_string_literal: true

  require "bundler/inline"

  gemfile(true) do
    source "https://rubygems.org"

    gem "activemodel", github: "marian13/rails", branch: "require_blank_for_stdlib"
  end

  require "active_model"

  class CustomFolder
    include ActiveModel::Validations

    attr_reader :path

    validates :path, presence: true

    def initialize(path:)
      @path = path
    end
  end

  require "minitest/autorun"

  class BeforeRequireTest < ActiveSupport::TestCase
    def test_pathname_blank
      assert_equal false, CustomFolder.new(path: Pathname.new("")).valid? # Fixed. Returns `false` as expected.
      assert_equal false, CustomFolder.new(path: "").valid?

      assert_equal true, CustomFolder.new(path: Pathname.new("/example")).valid?
      assert_equal true, CustomFolder.new(path: "/example").valid?

      assert_equal true, Pathname.new("").blank? # Fixed. Returns `true` as expected.
      assert_equal true, "".blank?

      assert_equal false, Pathname.new("/example").blank?
      assert_equal false, "/example".blank?
    end
  end
  ```
</details>



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
