### PR TITLE
In MT6, test_order -> run_order. Add AS::TC#run_order as needed

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -62,6 +62,12 @@ module ActiveSupport
         ActiveSupport.test_order ||= :random
       end
 
+      if Minitest.respond_to? :run_order # MT6 API change
+        def run_order # :nodoc:
+          test_order
+        end
+      end
+
       # Parallelizes the test suite.
       #
       # Takes a +workers+ argument that controls how many times the process


### PR DESCRIPTION
Rather than rename everything on the rails side, only provide a bridge
from AS::TC#test_order to MT6's MT::Test#run_order if AS::TC responds
to it.
