### PR TITLE
Consolidate use of Ruby versions in templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -101,7 +101,7 @@ builder:
   #
   # # Pass arguments and secrets to the Docker build process
   # args:
-  #   RUBY_VERSION: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+  #   RUBY_VERSION: <%= Gem.ruby_version %>
   # secrets:
   #   - GITHUB_TOKEN
   #   - RAILS_MASTER_KEY

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      RUBY_VERSION: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+      RUBY_VERSION: <%= version_manager_ruby_version %>
       RUBOCOP_CACHE_ROOT: tmp/rubocop
     steps:
       - name: Checkout code
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+          ruby-version: <%= version_manager_ruby_version %>
           bundler-cache: true
       <%- if using_bun? -%>
 


### PR DESCRIPTION
Make templates consistent:

- Use [`version_manager_ruby_version`](https://github.com/rails/rails/blob/89dac2ad4d8ae10abd9419eb2bb0caf654e3b21e/railties/lib/rails/generators/app_base.rb#L774)  introduced in PR [#56365](https://github.com/rails/rails/pull/56365) when using a ruby version in a qualified ruby-build format
- Use `Gem.ruby_version` in `deploy.yml.tt` comment overriding the  `RUBY_VERSION` Docker `ARG` to be consistent with the Dockerfile:
https://github.com/rails/rails/blob/0bbf296e1e74cf3c2042dbbd467b8219780a6a2d/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt#L11
    (`Gem.ruby_version` is used in those cases because qualified ruby version formats wouldn't work, as they are not part of the names of Ruby docker images)