### PR TITLE
[Bug] Fix input[type=file] accept attribute array value separator as `,`

### DIFF
--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -6,6 +6,9 @@ module ActionView
       class FileField < TextField # :nodoc:
         def render
           include_hidden = @options.delete(:include_hidden)
+          if @options[:accept].is_a?(Array)
+            @options[:accept] = @options[:accept].join(",")
+          end
           options = @options.stringify_keys
           add_default_name_and_field(options)
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -628,6 +628,11 @@ class FormHelperTest < ActionView::TestCase
     assert_equal({ class: "pix", direct_upload: true }, original_options)
   end
 
+  def test_file_field_with_accept_attribute
+    expected = '<input accept="image/*,video/*" type="file" name="import[file]" />'
+    assert_dom_equal expected, file_field("import", "file", { accept: ["image/*", "video/*"], id: nil })
+  end
+
   def test_hidden_field
     assert_dom_equal(
       '<input id="post_title" name="post[title]" type="hidden" value="Hello World" autocomplete="off" />',


### PR DESCRIPTION



### Motivation / Background

It is great when all bugs are fixed.

### Detail

This Pull Request changes `input[type=file]` `accept` attribute to join multiple values as `,` instead of ` ` as per specification:

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/accept


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
