### PR TITLE
Fix false deprecation warnings when using `protect_from_forgery` with `prepend: true`

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -272,7 +272,12 @@ module ActionController # :nodoc:
         self.forgery_protection_verification_strategy = verification_strategy(options[:using] || forgery_protection_verification_strategy)
         self.forgery_protection_trusted_origins = Array(options[:trusted_origins]) if options.key?(:trusted_origins)
 
-        before_action :verify_authenticity_token, :verify_request_for_forgery_protection, options
+        if options[:prepend]
+          prepend_before_action :verify_request_for_forgery_protection, options
+          prepend_before_action :verify_authenticity_token, options
+        else
+          before_action :verify_authenticity_token, :verify_request_for_forgery_protection, options
+        end
         append_after_action :verify_same_origin_request
         append_after_action :append_sec_fetch_site_to_vary_header, options
       end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -139,6 +139,10 @@ class PrependProtectForgeryBaseController < ActionController::Base
       add_called_callback("custom_action")
     end
 
+    def verify_authenticity_token
+      add_called_callback("verify_authenticity_token")
+    end
+
     def verify_request_for_forgery_protection
       add_called_callback("verify_request_for_forgery_protection")
     end
@@ -828,24 +832,24 @@ class PrependProtectForgeryBaseControllerTest < ActionController::TestCase
     protect_from_forgery
   end
 
-  def test_verify_request_for_forgery_protection_is_prepended
+  def test_forgery_protection_callbacks_are_prepended_in_correct_order
     @controller = PrependTrueController.new
     get :index
-    expected_callback_order = ["verify_request_for_forgery_protection", "custom_action"]
+    expected_callback_order = ["verify_authenticity_token", "verify_request_for_forgery_protection", "custom_action"]
     assert_equal(expected_callback_order, @controller.called_callbacks)
   end
 
-  def test_verify_request_for_forgery_protection_is_not_prepended
+  def test_forgery_protection_callbacks_are_not_prepended
     @controller = PrependFalseController.new
     get :index
-    expected_callback_order = ["custom_action", "verify_request_for_forgery_protection"]
+    expected_callback_order = ["custom_action", "verify_authenticity_token", "verify_request_for_forgery_protection"]
     assert_equal(expected_callback_order, @controller.called_callbacks)
   end
 
-  def test_verify_request_for_forgery_protection_is_not_prepended_by_default
+  def test_forgery_protection_callbacks_are_not_prepended_by_default
     @controller = PrependDefaultController.new
     get :index
-    expected_callback_order = ["custom_action", "verify_request_for_forgery_protection"]
+    expected_callback_order = ["custom_action", "verify_authenticity_token", "verify_request_for_forgery_protection"]
     assert_equal(expected_callback_order, @controller.called_callbacks)
   end
 end


### PR DESCRIPTION
## Context

PR #56369 registers two callbacks for backwards compatibility: `before_action :verify_authenticity_token, :verify_request_for_forgery_protection, options`

When `prepend: true` is used,

this results in:
```
[]
[:verify_authenticity_token] <- first prepend
[:verify_request_for_forgery_protection, :verify_authenticity_token] <- second prepend
```

causing a false deprecation warning to emit when `:verify_request_for_forgery_protection` runs as `:verify_authenticity_token` has not ran and set the `@_verify_authenticity_token_ran` flag.

This affects any controller using this [protect_from_forgery "..." prepend: true](https://github.com/search?q=protect_from_forgery+prepend%3A+true+language%3Aruby&type=code) pattern.

## The Fix

Prepend both callbacks so they are executed in the correct order.

```
    prepend_before_action :verify_request_for_forgery_protection, options
    prepend_before_action :verify_authenticity_token, options
```

Result (correct order): `[:verify_authenticity_token, :verify_request_for_forgery_protection]`

This also handles custom callbacks being prepended/not prepended correctly as updated in the tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
