### PR TITLE
Implement exclude keys for ActionController::Live execution sharing

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `config.action_controller.live.streaming_excluded_keys` to control execution state sharing in ActionController::Live.
+
+    When using ActionController::Live, actions are executed in a separate thread that shares
+    state from the parent thread. This new configuration allows applications to opt-out specific
+    state keys that should not be shared.
+
+    This is useful when streaming inside a `connected_to` block, where you may want
+    the streaming thread to use its own database connection context.
+
+    ```ruby
+    # config/application.rb
+    config.action_controller.live.streaming_excluded_keys = [:active_record_connected_to_stack]
+    ```
+
+    By default, all keys are shared.
+
+    *Eileen M. Uchitelle*
+
 *   Add controller action source location to routes inspector.
 
     The routes inspector now shows where controller actions are defined.

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -53,8 +53,49 @@ module ActionController
   #       response.headers["Last-Modified"] = Time.now.httpdate # Add this line if your Rack version is 2.2.x
   #       ...
   #     end
+  #
+  # ## Streaming and Execution State
+  #
+  # When streaming, the action is executed in a separate thread. By default, this thread
+  # shares execution state from the parent thread.
+  #
+  # You can configure which execution state keys should be excluded from being shared
+  # using the `config.action_controller.live.streaming_excluded_keys` configuration:
+  #
+  #   # config/application.rb
+  #   config.action_controller.live.streaming_excluded_keys = [:active_record_connected_to_stack]
+  #
+  # This is useful when using ActionController::Live inside a `connected_to` block. For example,
+  # if the parent request is reading from a replica using `connected_to(role: :reading)`, you may
+  # want the streaming thread to use its own connection context instead of inheriting the read-only
+  # context:
+  #
+  #   # Without configuration, streaming thread inherits read-only connection
+  #   ActiveRecord::Base.connected_to(role: :reading) do
+  #     @posts = Post.all
+  #     render stream: true # Streaming thread cannot write to database
+  #   end
+  #
+  #   # With configuration, streaming thread gets fresh connection context
+  #   # config.action_controller.live.streaming_excluded_keys = [:active_record_connected_to_stack]
+  #   ActiveRecord::Base.connected_to(role: :reading) do
+  #     @posts = Post.all
+  #     render stream: true # Streaming thread can write to database if needed
+  #   end
+  #
+  # Common keys you might want to exclude:
+  # - `:active_record_connected_to_stack` - Database connection routing and roles
+  # - `:active_record_prohibit_shard_swapping` - Shard swapping restrictions
+  #
+  # By default, no keys are excluded to maintain backward compatibility.
   module Live
     extend ActiveSupport::Concern
+
+    mattr_accessor :live_streaming_excluded_keys, default: []
+
+    included do
+      class_attribute :live_streaming_excluded_keys, instance_accessor: false, default: Live.live_streaming_excluded_keys
+    end
 
     module ClassMethods
       def make_response!(request)
@@ -278,7 +319,8 @@ module ActionController
           # Since we're processing the view in a different thread, copy the thread locals
           # from the main thread to the child thread. :'(
           locals.each { |k, v| t2[k] = v }
-          ActiveSupport::IsolatedExecutionState.share_with(t1) do
+
+          ActiveSupport::IsolatedExecutionState.share_with(t1, except: self.class.live_streaming_excluded_keys) do
             super(name)
           rescue => e
             if @_response.committed?

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -33,6 +33,10 @@ module ActionController
       ActionController::Helpers.helpers_path = app.helpers_paths
     end
 
+    initializer "action_controller.live_streaming_excluded_keys" do |app|
+      ActionController::Live.live_streaming_excluded_keys = app.config.action_controller.live_streaming_excluded_keys
+    end
+
     initializer "action_controller.parameters_config" do |app|
       options = app.config.action_controller
 
@@ -83,6 +87,7 @@ module ActionController
           :action_on_unpermitted_parameters,
           :always_permitted_parameters,
           :wrap_parameters_by_default,
+          :live_streaming_excluded_keys
         )
 
         filtered_options.each do |k, v|

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -246,6 +246,11 @@ module ActionController
         render plain: ActiveSupport::IsolatedExecutionState[:raw_isolated_state].inspect
       end
 
+      def connected_to_stack_not_inherited
+        stack = ActiveSupport::IsolatedExecutionState[:active_record_connected_to_stack]
+        render plain: stack.inspect
+      end
+
       def with_stale
         render plain: "stale" if stale?(etag: "123", template: false)
       end
@@ -568,6 +573,34 @@ module ActionController
       get :isolated_state
       assert_equal nil.inspect, response.body
       assert_stream_closed
+    end
+
+    def test_connected_to_stack_not_inherited
+      original = @controller.class.live_streaming_excluded_keys
+      @controller.class.live_streaming_excluded_keys = [:active_record_connected_to_stack]
+
+      stack = [{ role: :reading, shard: :default, prevent_writes: true, klasses: [] }]
+      ActiveSupport::IsolatedExecutionState[:active_record_connected_to_stack] = stack
+
+      get :connected_to_stack_not_inherited
+
+      assert_equal "nil", response.body
+      assert_stream_closed
+    ensure
+      @controller.class.live_streaming_excluded_keys = original
+      ActiveSupport::IsolatedExecutionState.delete(:active_record_connected_to_stack)
+    end
+
+    def test_live_streaming_doesnt_exclude_by_default
+      stack = [{ role: :reading, shard: :default, prevent_writes: true, klasses: [] }]
+      ActiveSupport::IsolatedExecutionState[:active_record_connected_to_stack] = stack
+
+      get :connected_to_stack_not_inherited
+
+      assert_match(/role.*reading/, response.body)
+      assert_stream_closed
+    ensure
+      ActiveSupport::IsolatedExecutionState.delete(:active_record_connected_to_stack)
     end
 
     def test_live_stream_default_header

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -5207,6 +5207,30 @@ module ApplicationTests
       assert_not output.include?("Processing by Rails::WelcomeController#index as HTML")
     end
 
+    test "config.action_controller.live_streaming_excluded_keys configures ActionController::Live" do
+      app_file "app/controllers/posts_controller.rb", <<-RUBY
+      class PostsController < ActionController::Base
+        include ActionController::Live
+
+        def index
+          render plain: self.class.live_streaming_excluded_keys.inspect
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          resources :posts
+        end
+        config.action_controller.live_streaming_excluded_keys = [:active_record_connected_to_stack, :custom_key]
+      RUBY
+
+      app "development"
+
+      get "/posts"
+      assert_equal "[:active_record_connected_to_stack, :custom_key]", last_response.body
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
When using `ActionController::Live` the execution context is shared across threads. In some cases, like database context switching from a writer to a replica connection, you may not want that context to be shared.

This PR implements a config option for excluding specific keys from the shared execution. By default no keys are shared to support backwards compatibility in order to maintain current behavior while implementing a way for applications experiencing an issue with database connections to opt-out. See #52906.

To exclude a specific key application-wide, set the following config option:

```ruby
config.action_controller.live_streaming_excluded_keys = [:active_record_connected_to_stack]
```

If you want finer-grained control over which controllers exclude these keys you can set `live_streaming_excluded_keys` in the controller itself.

```ruby
class MyController < ApplicationController
  include ActionController::Live
  self.live_streaming_excluded_keys = [:active_record_connected_to_stack]

  def index
    ...
  end
end
```

In the future we may want to default to excluding this key since I'm not sure anyone wants to share database context. However I chose not to do that in this PR because we need to backport this to use as a bug fix, and if it changes behavior that could break applications.

Fixes #52906