### PR TITLE
ActionView#content_for uses keyword argument to replace options hash

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate invalid options passed to `content_for`. Invalid options were previously silently
+    ignored. For example, `content_for :foo, fluhs: true { "bar" }` (note the typo) would not
+    flush content, with no indication of the mistake.
+
+    *Jeroen Versteeg*
+
 *   Fix tag parameter content being overwritten instead of combined with tag block content.
     Before `tag.div("Hello ") { "World" }` would just return `<div>World</div>`, now it returns `<div>Hello World</div>`.
 

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -148,7 +148,7 @@ module ActionView
       #
       #   <ul><%= content_for :navigation %></ul>
       #
-      # If the flush parameter is +true+ <tt>content_for</tt> replaces the blocks it is given. For example:
+      # If the flush parameter is +true+, <tt>content_for</tt> replaces the blocks it is given. For example:
       #
       #   <% content_for :navigation do %>
       #     <li><%= link_to 'Home', action: 'index' %></li>
@@ -175,8 +175,15 @@ module ActionView
             options = content if content
             content = capture(&block)
           end
+          flush = options.delete(:flush) { false }
+          if options.any?
+            ActionView.deprecator.warn(<<-MSG.squish)
+              Passing invalid options to content_for is deprecated.
+              Options #{options.keys.join(', ')} will be ignored.
+            MSG
+          end
           if content
-            options[:flush] ? @view_flow.set(name, content) : @view_flow.append(name, content)
+            flush ? @view_flow.set(name, content) : @view_flow.append(name, content)
           end
           nil
         else

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -178,6 +178,14 @@ class CaptureHelperTest < ActionView::TestCase
     assert_predicate content_for(:title), :html_safe?
   end
 
+  def test_content_for_deprecates_invalid_options
+    assert_deprecated(/Passing invalid options to content_for is deprecated/, ActionView.deprecator) do
+      content_for :name, invalid: true do
+        "foo"
+      end
+    end
+  end
+
   def test_provide
     assert_not content_for?(:title)
     provide :title, "hi"

--- a/guides/source/8_2_release_notes.md
+++ b/guides/source/8_2_release_notes.md
@@ -94,6 +94,15 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 ### Deprecations
 
+*   Deprecate invalid options (i.e., anything other than `flush:`) passed to `content_for`.
+
+    ```ruby
+    content_for(:foo, invalid: true) { "foo" }
+    ```
+
+    Invalid options were previously silently ignored. This will now emit deprecation warnings.
+    In the next major release, this will instead `raise ArgumentError`.
+
 ### Notable changes
 
 *   Add ability to pass a block when rendering a collection. The block is executed


### PR DESCRIPTION
# Motivation / Background

This PR improves the signature for `content_for` by replacing the `options` hash with a modern keyword argument.

The benefits are:
* Invalid arguments will eventually (see below) `raise ArgumentError` instead of being silently ignored.
  (e.g., `content_for :foo, fluhs: true { "whoops" }`)
* Keyword arguments are documented in the method's signature instead of in its body.
  Better for humans, IDEs and LLMs.
* Remove confusing argument shifting (`options = content if content` 🤨).

## Update
Based on seanpdoyle's review, the scope of this change was reduced to maintain backwards compatibility.

The only change now is that options other than `flush` will trigger a deprecation warning.

# Backwards-compatibility
The current behavior is kept but deprecated. The added warning will not only warn users of a future change, it will also alert them to bugs in their code. (Any invalid option is almost guaranteed to be a typo!)

~~Note that I've added the BC-keeping code in the second commit. If this is deemed overkill ("progress over stability" 😉), I can easily drop it. Otherwise, I'd be more than happy to squash the two commits.~~

# Checklist

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
