### PR TITLE
Ensure Rails::TestUnitRailtie is defined and `config.generators.system_tests` is set when generating a system test

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Ensure `Rails::TestUnitRailtie` is defined and
+    `config.generators.system_tests` is set when generating a system test.
+
+    For integration tests we added check for `Rails::TestUnitRailtie`.
+
+    *zzak*
+
 *   Do not clean directories directly under the application root with `Rails::BacktraceCleaner`
 
     Improved `Rails.backtrace_cleaner` so that most paths located directly under the application's root directory are no longer silenced.

--- a/railties/lib/rails/generators/rails/integration_test/integration_test_generator.rb
+++ b/railties/lib/rails/generators/rails/integration_test/integration_test_generator.rb
@@ -3,6 +3,14 @@
 module Rails
   module Generators
     class IntegrationTestGenerator < NamedBase # :nodoc:
+      def check_if_test_unit_loaded!
+        unless defined?(Rails::TestUnitRailtie)
+          raise <<~ERR
+            Please ensure `require "rails/test_unit/railtie"` is added to `config/application.rb`.
+          ERR
+        end
+      end
+
       hook_for :integration_tool, as: :integration
     end
   end

--- a/railties/lib/rails/generators/rails/system_test/system_test_generator.rb
+++ b/railties/lib/rails/generators/rails/system_test/system_test_generator.rb
@@ -3,6 +3,14 @@
 module Rails
   module Generators
     class SystemTestGenerator < NamedBase # :nodoc:
+      def check_if_system_tests_enabled!
+        unless defined?(Rails::TestUnitRailtie) && Rails.application.config.generators.system_tests
+          raise <<~ERR
+            Please ensure `require "rails/test_unit/railtie"` is added to `config/application.rb` and `Rails.application.config.generators.system_tests` is set to `:test_unit` (default).
+          ERR
+        end
+      end
+
       hook_for :system_tests, as: :system
     end
   end

--- a/railties/test/generators/integration_test_generator_test.rb
+++ b/railties/test/generators/integration_test_generator_test.rb
@@ -22,4 +22,15 @@ class IntegrationTestGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/integration/integration_test_test.rb"
     assert_file "test/integration/integration_test.rb"
   end
+
+  def test_rails_test_unit_railtie_is_undefined
+    original_const = Rails.send(:remove_const, :TestUnitRailtie)
+
+    assert_raises(RuntimeError) do
+      run_generator %w(integration)
+    end
+    assert_no_file "test/integration/integration_test.rb"
+  ensure
+    Rails.const_set(:TestUnitRailtie, original_const)
+  end
 end

--- a/railties/test/generators/system_test_generator_test.rb
+++ b/railties/test/generators/system_test_generator_test.rb
@@ -30,4 +30,24 @@ class SystemTestGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/system/users_test_test.rb"
     assert_file "test/system/users_test.rb"
   end
+
+  def test_system_tests_is_disabled
+    Rails.application.config.generators.with(system_tests: nil) do
+      assert_raises(RuntimeError) do
+        run_generator
+      end
+      assert_no_file "test/system/users_test.rb"
+    end
+  end
+
+  def test_rails_test_unit_railtie_is_undefined
+    original_const = Rails.send(:remove_const, :TestUnitRailtie)
+
+    assert_raises(RuntimeError) do
+      run_generator
+    end
+    assert_no_file "test/system/users_test.rb"
+  ensure
+    Rails.const_set(:TestUnitRailtie, original_const)
+  end
 end


### PR DESCRIPTION
Fixes #56022

When `rails new --skip-test` is called, we put `config.generators.system_tests = nil` in `config/application.rb`:
https://github.com/rails/rails/blob/61b5c7e2953fd0ccfab151b233ce69283c567a34/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt#L36-L39

If the user then tries to run `bin/rails g system_test Whatever` or `bin/rails g integration_test Whatever` it will do nothing.

This change will now raise an exception in that case to give the user some feedback.

---

Originally I was going to leave out the const check because it creates a dependency on `Rails::TestUnit`, but I checked and `rspec-rails` is not using this generator -- they provide their own `bin/rails g rspec:integration` and `bin/rails g rspec:system`.

So the behavior is the same if you are using `rspec-rails` or not, if `rails/test_unit/railtie` is not loaded.

I couldn't find any other uses of the generator in the wilds, and I'm unaware of other test frameworks that could be affected by this change.