### PR TITLE
Add minitest-mock as run-time dependency of AS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ PATH
       json
       logger (>= 1.4.2)
       minitest (>= 5.1)
+      minitest-mock
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
@@ -365,6 +366,7 @@ GEM
       path_expander (~> 1.1)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
+    minitest-mock (5.27.0.beta.1.beta.1)
     minitest-retry (0.2.3)
       minitest (>= 5.0)
     minitest-server (1.0.9)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.3.1"
   s.add_dependency "connection_pool", ">= 2.2.5"
   s.add_dependency "minitest",        ">= 5.1"
+  s.add_dependency "minitest-mock"
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "bigdecimal"


### PR DESCRIPTION
It's used in ActiveSupport::Testing::MethodCallAssertions:
https://github.com/rails/rails/blob/61b5c7e2953fd0ccfab151b233ce69283c567a34/activesupport/lib/active_support/testing/method_call_assertions.rb#L3

This might explain why my builds are failing, but why not all builds are affected :shrug: 
https://buildkite.com/rails/rails/builds/124759#019b3073-e2ce-4883-b4eb-212f6e3dea86/L1482