### PR TITLE
Yield key to `ActionController::Parameters#fetch`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Yield key to `ActionController::Parameters#fetch` block
+
+    ```ruby
+    key = params.fetch(:missing) { |missing_key| missing_key }
+    key # => :missing
+
+    key = params.fetch("missing") { |missing_key| missing_key }
+    key # => "missing"
+    ```
+
+    *Sean Doyle*
+
 *   Add `config.action_controller.live.streaming_excluded_keys` to control execution state sharing in ActionController::Live.
 
     When using ActionController::Live, actions are executed in a separate thread that shares

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -812,7 +812,7 @@ module ActionController
     # are several options: With no other arguments, it will raise an
     # ActionController::ParameterMissing error; if a second argument is given, then
     # that is returned (converted to an instance of `ActionController::Parameters`
-    # if possible); if a block is given, then that will be run and its result
+    # if possible); if a block is given, the key is yielded to the block and its result
     # returned.
     #
     #     params = ActionController::Parameters.new(person: { name: "Francesco" })
@@ -820,12 +820,12 @@ module ActionController
     #     params.fetch(:none)                 # => ActionController::ParameterMissing: param is missing or the value is empty or invalid: none
     #     params.fetch(:none, {})             # => #<ActionController::Parameters {} permitted: false>
     #     params.fetch(:none, "Francesco")    # => "Francesco"
-    #     params.fetch(:none) { "Francesco" } # => "Francesco"
+    #     params.fetch(:none) { |key| "Francesco" } # => "Francesco"
     def fetch(key, *args)
       convert_value_to_parameters(
         @parameters.fetch(key) {
           if block_given?
-            yield
+            yield key
           else
             args.fetch(0) { raise ActionController::ParameterMissing.new(key, @parameters.keys) }
           end

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -179,6 +179,18 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params[:person].fetch(:name), :permitted?
   end
 
+  test "fetch yields string key to block when missing" do
+    key = @params.fetch("missing") { |missing_key| missing_key }
+
+    assert_equal "missing", key
+  end
+
+  test "fetch yields symbol key to block when missing" do
+    key = @params.fetch(:missing) { |missing_key| missing_key }
+
+    assert_equal :missing, key
+  end
+
   test "has_key? returns true if the given key is present in the params" do
     assert @params.has_key?(:person)
   end


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, the `ActionController::Parameters#fetch` method did not yield the key to the block when fetching an unknown key. While the `ActionController::Parameters` interface is Hash-like, it **does not** inherit from `Hash` directly.

### Detail

The [Hash#fetch][] method yields the key to the block, so this commit changes the `ActionController::Parameters#fetch` behavior to do the same.

[Hash#fetch]: https://docs.ruby-lang.org/en/master/Hash.html#method-i-fetch

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
