### PR TITLE
Reset relations after delete_by/destroy_by, resolves #55664

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Reset relations after `delete_by`/`destroy_by`.
+
+    Methods `delete_by` and `destroy_by` which are shortcuts for `where(…).delete_all` and `where(…).destroy_all` will
+    now call `reset` at the end, like it is done for delete_all/destroy_all without condition. See
+    [#55664](https://github.com/rails/rails/issues/55664) for the issue and
+    [#45943](https://github.com/rails/rails/pull/45943) for change to `insert_all`, `insert_all!` and `upsert_all`.
+
+    *Ivan Kuchin*
+
 *   Yield the transaction object to the block when using `with_lock`.
 
     *Ngan Pham*

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1124,7 +1124,7 @@ module ActiveRecord
     #   Person.destroy_by(name: 'Spartacus', rating: 4)
     #   Person.destroy_by("published_at < ?", 2.weeks.ago)
     def destroy_by(*args)
-      where(*args).destroy_all
+      where(*args).destroy_all.tap { reset }
     end
 
     # Finds and deletes all records matching the specified conditions.
@@ -1137,7 +1137,7 @@ module ActiveRecord
     #   Person.delete_by(name: 'Spartacus', rating: 4)
     #   Person.delete_by("published_at < ?", 2.weeks.ago)
     def delete_by(*args)
-      where(*args).delete_all
+      where(*args).delete_all.tap { reset }
     end
 
     # Schedule the query to be performed from a background thread pool.

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -163,6 +163,26 @@ module ActiveRecord
       assert_not_equal cache_key, developers.cache_key
     end
 
+    test "delete_by will update cache_key" do
+      Developer.create!(name: "Ivan")
+      developers = Developer.all
+      cache_key = developers.cache_key
+
+      developers.delete_by(name: "Ivan")
+
+      assert_not_equal cache_key, developers.cache_key
+    end
+
+    test "destroy_by will update cache_key" do
+      Developer.create!(name: "Ivan")
+      developers = Developer.all
+      cache_key = developers.cache_key
+
+      developers.destroy_by(name: "Ivan")
+
+      assert_not_equal cache_key, developers.cache_key
+    end
+
     test "it triggers at most one query" do
       developers = Developer.where(name: "David")
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2055,6 +2055,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [david], destroyed
   end
 
+  def test_delete_by_resets_association
+    david = authors(:david)
+
+    assert_difference("david.posts.length", -3) { david.posts.delete_by(body: "hello") }
+  end
+
+  def test_destroy_by_resets_association
+    david = authors(:david)
+
+    assert_difference("david.posts.length", -3) { david.posts.destroy_by(body: "hello") }
+  end
+
   test "find_by with hash conditions returns the first matching record" do
     assert_equal posts(:eager_other), Post.order(:id).find_by(author_id: 2)
   end


### PR DESCRIPTION
Methods `delete_by` and `destroy_by` which are shortcuts for `where(…).delete_all` and `where(…).destroy_all` will call `reset` at the end, like it is done for delete_all/destroy_all without condition.
Resolves #55664
