### PR TITLE
Add password manager support for Rails Credentials keys

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `key_command` option to `EncryptedFile` and `EncryptedConfiguration` to
+    fetch encryption keys from shell commands (e.g., password managers).
+
+    *Jordan Brough*
+
 *   Make flaky parallel tests easier to diagnose by deterministically assigning
     tests to workers.
 

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -51,9 +51,9 @@ module ActiveSupport
 
     delegate_missing_to :options
 
-    def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:)
-      super content_path: config_path, key_path: key_path,
-        env_key: env_key, raise_if_missing_key: raise_if_missing_key
+    def initialize(config_path:, env_key:, key_command: nil, key_path:, raise_if_missing_key:)
+      super content_path: config_path, env_key: env_key, key_command: key_command,
+        key_path: key_path, raise_if_missing_key: raise_if_missing_key
       @config = nil
       @options = nil
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -322,6 +322,20 @@ Defaults to `config/credentials/#{Rails.env}.yml.enc` if it exists, or
 NOTE: In order for the `bin/rails credentials` commands to recognize this value,
 it must be set in `config/application.rb` or `config/environments/#{Rails.env}.rb`.
 
+#### `config.credentials.key_command`
+
+A shell command to execute to retrieve the encryption key. This is useful for
+integrating with password managers like 1Password, LastPass, and Bitwarden.
+
+```ruby
+config.credentials.key_command = "op read op://vault/my_app/master_key"
+config.credentials.key_command = "lpass show --password my_app_master_key"
+config.credentials.key_command = "bw get password my_app_master_key"
+```
+
+NOTE: In order for the `bin/rails credentials` commands to recognize this value,
+it must be set in `config/application.rb` or `config/environments/#{Rails.env}.rb`.
+
 #### `config.credentials.key_path`
 
 The path of the encrypted credentials key file.

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1655,7 +1655,13 @@ It is beyond the scope of this guide to inform you on how to secure your applica
 
 ### Custom Credentials
 
-Rails stores secrets in `config/credentials.yml.enc`, which is encrypted and hence cannot be edited directly. Rails uses `config/master.key` or alternatively looks for the environment variable `ENV["RAILS_MASTER_KEY"]` to encrypt the credentials file. Because the credentials file is encrypted, it can be stored in version control, as long as the master key is kept safe.
+Rails stores secrets in `config/credentials.yml.enc`, which is encrypted and hence cannot be edited directly. The encryption key can be provided via:
+
+* `ENV["RAILS_MASTER_KEY"]` environment variable
+* `config.credentials.key_command` shell command (e.g., for password managers)
+* `config/master.key` file
+
+Because the credentials file is encrypted, it can be stored in version control, as long as the master key is kept safe.
 
 By default, the credentials file contains the application's
 `secret_key_base`. It can also be used to store other secrets such as access keys for external APIs.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `config.credentials.key_command` to fetch the credentials encryption key
+    from a shell command. This enables integration with password managers like
+    1Password, LastPass, and Bitwarden.
+
+    ```ruby
+    # config/environments/production.rb
+    config.credentials.key_command = "op read op://vault/my_app/master_key"
+    ```
+
+    *Jordan Brough*
+
 *   Add `Rails.app` as alias for `Rails.application`. Particularly helpful when accessing nested accessors inside application code,
     like when using `Rails.app.credentials`.
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -489,18 +489,24 @@ module Rails
     # +production+ environment), or +config/credentials.yml.enc+ if that file
     # does not exist.
     #
-    # The encryption key is taken from either <tt>ENV["RAILS_MASTER_KEY"]</tt>,
-    # or from the file specified by +config.credentials.key_path+. By default,
-    # +config.credentials.key_path+ will point to either
+    # The encryption key is taken from <tt>ENV["RAILS_MASTER_KEY"]</tt>,
+    # the shell command specified by +config.credentials.key_command+,
+    # or the file specified by +config.credentials.key_path+.
+    # By default, +config.credentials.key_path+ will point to either
     # <tt>config/credentials/#{environment}.key</tt> for the current
     # environment, or +config/master.key+ if that file does not exist.
     def credentials
-      @credentials ||= encrypted(config.credentials.content_path, key_path: config.credentials.key_path)
+      @credentials ||= encrypted(
+        config.credentials.content_path,
+        key_path: config.credentials.key_path,
+        key_command: config.credentials.key_command
+      )
     end
 
     # Returns an ActiveSupport::EncryptedConfiguration instance for an encrypted
-    # file. By default, the encryption key is taken from either
-    # <tt>ENV["RAILS_MASTER_KEY"]</tt>, or from the +config/master.key+ file.
+    # file. By default, the encryption key is taken from
+    # <tt>ENV["RAILS_MASTER_KEY"]</tt>, the +key_command+ shell command,
+    # or the +config/master.key+ file.
     #
     #   my_config = Rails.application.encrypted("config/my_config.enc")
     #
@@ -513,11 +519,12 @@ module Rails
     # Encrypted files can be edited with the <tt>bin/rails encrypted:edit</tt>
     # command. (See the output of <tt>bin/rails encrypted:edit --help</tt> for
     # more information.)
-    def encrypted(path, key_path: "config/master.key", env_key: "RAILS_MASTER_KEY")
+    def encrypted(path, env_key: "RAILS_MASTER_KEY", key_command: nil, key_path: "config/master.key")
       ActiveSupport::EncryptedConfiguration.new(
         config_path: Rails.root.join(path),
-        key_path: Rails.root.join(key_path),
         env_key: env_key,
+        key_command: key_command,
+        key_path: Rails.root.join(key_path),
         raise_if_missing_key: config.require_master_key
       )
     end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -665,7 +665,7 @@ module Rails
           key_path = root.join("config/credentials/#{Rails.env}.key")
           key_path = root.join("config/master.key") if !key_path.exist?
 
-          { content_path: content_path, key_path: key_path }
+          { content_path: content_path, key_command: nil, key_path: key_path }
         end
 
         def generate_local_secret

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -91,7 +91,7 @@ module Rails
         end
 
         def credentials
-          @credentials ||= Rails.application.encrypted(content_path, key_path: key_path)
+          @credentials ||= Rails.application.encrypted(content_path, key_command: config.key_command, key_path: key_path)
         end
 
         def ensure_encryption_key_has_been_added


### PR DESCRIPTION
### Motivation / Background

When using per-environment credentials files, I'd like to be able to use a lazily-invoked password manager when:

1. **Editing or viewing credentials** for my production environment, in particular.
2. **Viewing git diffs** with changes to `config/credentials/production.yml.enc`.
3. **Deploying** e.g. via Kamal. (This isn't addressed in the current PR, though)

### Detail

This PR adds `config.credentials.key_command`, similar to the existing `config.credentials.key_path`.

If present, `config.credentials.key_command` is executed as a shell command, e.g.:
```ruby
config.credentials.key_command = "op read op://vault/my_app/master_key"
```

### Additional information

This approach seems convenient and flexible to me, but some alternative options could be:

- Re-use `config.credentials.key_path` by detecting when it's a shell command instead of a path and executing it.
- Have `key_command` be a callable object instead of a shell command.
- Allow `RAILS_<ENVIRONMENT>_MASTER_KEY` env vars, and leave it to the user to set the appropriate environment values.  I think this might end up being eagerly loaded locally though, which I don't love for speed or for production keys.
- Provide explicit integrations with password managers, similar to what Kamal does. E.g.:
    ```ruby
    config.credentials.key_provider = {
      adapter: "1password",
      account: "myaccount",
      vault: "myvault",
      item: "myitem",
      key: "rails_master_key",
    }
    ```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
