### PR TITLE
Make minitest-mock a hard dependency again

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  gem "minitest-mock"
-  require "minitest/mock"
-rescue LoadError
-  warn <<~WARN
-    minitest-mock gem is not available. Method call assertions including `assert_called_with` will not work.
-    Please add it to your Gemfile: `gem "minitest-mock"`
-  WARN
-  raise
-end
+require "minitest/mock"
 
 module ActiveSupport
   module Testing


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/56207
Revert c5c678a67a09b1b83f0f7616290512b48bf2d071

It makes no sense to make it a soft dependency, this is not code exposed to users, it's only loaded inside Rails own test suite.

FYI @zenspider @guilleiguaran 