### PR TITLE
Fixed bin/rails notes command to work with CSS /**/ comments

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -107,8 +107,12 @@ module Rails
         PatternExtractor.new(/#\s*(#{tag}):?\s*(.*)$/)
       end
 
-      register_extensions("css", "js") do |tag|
+      register_extensions("js") do |tag|
         PatternExtractor.new(/\/\/\s*(#{tag}):?\s*(.*)$/)
+      end
+
+      register_extensions("css") do |tag|
+        PatternExtractor.new(/\/\*\s*(#{tag}):?\s*(.*?)(?:\*\/)?$/)
       end
 
       register_extensions("erb") do |tag|
@@ -205,7 +209,7 @@ module Rails
       results.keys.sort.each do |file|
         puts "#{file}:"
         results[file].each do |note|
-          puts "  * #{note.to_s(options)}"
+          puts "  * #{note.to_s(options).strip}"
         end
         puts
       end

--- a/railties/test/commands/notes_test.rb
+++ b/railties/test/commands/notes_test.rb
@@ -13,12 +13,20 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
     app_file "db/some_seeds.rb", "# FIXME: note in db directory"
     app_file "lib/some_file.rb", "# TODO: note in lib directory"
     app_file "test/some_test.rb", "\n" * 100 + "# FIXME: note in test directory"
+    app_file "app/assets/stylesheets/some_styles.css", "/* FIXME: CSS note in app/assets/stylesheets directory */"
+    app_file "app/javascripts/controllers/some_file.js", "// TODO: note in app/javascripts directory"
 
     app_file "some_other_dir/blah.rb", "# TODO: note in some_other directory"
 
     assert_equal <<~OUTPUT, run_notes_command
+      app/assets/stylesheets/some_styles.css:
+        * [  1] [FIXME] CSS note in app/assets/stylesheets directory
+
       app/controllers/some_controller.rb:
         * [  1] [OPTIMIZE] note in app directory
+
+      app/javascripts/controllers/some_file.js:
+        * [  1] [TODO] note in app/javascripts directory
 
       config/initializers/some_initializer.rb:
         * [  1] [TODO] note in config directory


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the `bin/rails notes` command fails to pick up any `TODO`, `FIXME`, `OPTIMIZE` notes inside .css files due to looking for JavaScript style `//` comments instead of CSS style `/**/` comments.

I'm fairly certain this is a bug as I couldn't see any reason CSS and JavaScript would be using the same comments style or understand why my `TODO` notes in my stylesheets aren't showing up.

### Detail

This Pull Request changes the comment lookup Regex for CSS in `railties/lib/rails/source_annotation_extractor.rb` to: `/\/\*\s*(#{tag}):?\s*(.*?)(?:\*\/)?$/` to accurately pickup notes in CSS files. It optionally ignores the ending comment `*/` if it exists from display in the command line. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
