### PR TITLE
Ensure batched preloaded associations accounts for klass when grouping to avoid issues with STI

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -38,7 +38,13 @@ module ActiveRecord
           attr_reader :loaders
 
           def group_and_load_similar(loaders)
-            loaders.grep_v(ThroughAssociation).group_by(&:loader_query).each_pair do |query, similar_loaders|
+            non_through = loaders.grep_v(ThroughAssociation)
+
+            grouped = non_through.group_by do |loader|
+              [loader.loader_query, loader.klass]
+            end
+
+            grouped.each do |(query, _klass), similar_loaders|
               query.load_records_in_batch(similar_loaders)
             end
           end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1580,6 +1580,17 @@ class PreloaderTest < ActiveRecord::TestCase
       assert_same author, post.author
     end
   end
+
+  def test_preload_group_with_klass
+    published_author = PublishedAuthor.create!(name: "PublishedAuthor")
+    PublishedBook.create!(name: "PublishedBook", author_id: published_author.id, isbn: "12345")
+
+    author = Author.create!(name: "Author", published_author_id: published_author.id)
+    Book.create!(name: "Book", author_id: author.id, isbn: "67890")
+
+    result = Author.includes(books: [], published_author: { books: [] }).last
+    assert_equal [PublishedBook], result.published_author.books.map(&:class)
+  end
 end
 
 class GeneratedMethodsTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -268,7 +268,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
       authors = [@david, @mary]
       encoded = ActiveSupport::JSON.encode(authors, except: [
         :name, :author_address_id, :author_address_extra_id,
-        :organization_id, :owned_essay_id
+        :organization_id, :owned_essay_id, :published_author_id
       ])
       assert_equal %([{"id":1},{"id":2}]), encoded
     end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -198,6 +198,8 @@ class Author < ActiveRecord::Base
   belongs_to :author_address,       dependent: :destroy
   belongs_to :author_address_extra, dependent: :delete, class_name: "AuthorAddress"
 
+  belongs_to :published_author, class_name: "PublishedAuthor", foreign_key: :published_author_id, optional: true
+
   has_many :category_post_comments, through: :categories, source: :post_comments
 
   has_many :misc_posts, -> { where(posts: { title: ["misc post by bob", "misc post by mary"] }) }, class_name: "Post"
@@ -317,4 +319,9 @@ class AuthorFavoriteWithScope < ActiveRecord::Base
 
   belongs_to :author
   belongs_to :favorite_author, class_name: "Author"
+end
+
+class PublishedAuthor < ActiveRecord::Base
+  self.table_name = "authors"
+  has_many :books, class_name: "PublishedBook", foreign_key: :author_id
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define do
     t.references :author_address_extra
     t.string :organization_id
     t.string :owned_essay_id
+    t.integer :published_author_id
   end
 
   create_table :author_addresses, force: true do |t|


### PR DESCRIPTION
Fixes #56047

/cc @d4be4st

```ruby
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'
  #gem 'rails', path: '~/code/rails'
  gem 'rails'
  gem 'sqlite3'
end

require 'active_record'

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = nil

ActiveRecord::Schema.define do
  create_table :authors, force: true do |t|
    t.string :name
    t.integer :origin_author_id
  end

  create_table :books, force: true do |t|
    t.string :title
    t.integer :author_id
  end
end

class Author < ActiveRecord::Base
  has_many :books
  belongs_to :origin_author, class_name: 'SpecialAuthor', foreign_key: :origin_author_id, optional: true
end

class SpecialAuthor < ActiveRecord::Base
  self.table_name = 'authors'
  has_many :books, class_name: 'SpecialBook', foreign_key: :author_id
end

class Book < ActiveRecord::Base
end

class SpecialBook < ActiveRecord::Base
  self.table_name = 'books'
end

origin = SpecialAuthor.create!(name: 'SpecialAuthor')
SpecialBook.create!(title: 'SpecialBook', author_id: origin.id)

normal = Author.create!(name: 'Author', origin_author_id: origin.id)
Book.create!(title: 'Book', author_id: normal.id)

result = Author.includes(books: [], origin_author: { books: [] }).last
puts result.origin_author.books.map(&:class)
# Should be SpecialBook

result = Author.includes(:books).last
puts result.books.map(&:class)
```