### PR TITLE
Ensure UrlGenerationError carries DidYouMean context

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -212,7 +212,7 @@ module ActionDispatch
             def call(t, method_name, args, inner_options, url_strategy)
               if args.size == arg_size && !inner_options && optimize_routes_generation?(t)
                 options = t.url_options.merge @options
-                path = optimized_helper(args)
+                path = optimized_helper(t, method_name, args)
                 path << "/" if options[:trailing_slash] && !path.end_with?("/")
                 options[:path] = path
 
@@ -232,9 +232,9 @@ module ActionDispatch
             end
 
             private
-              def optimized_helper(args)
+              def optimized_helper(t, method_name, args)
                 params = parameterize_args(args) do
-                  raise_generation_error(args)
+                  raise_generation_error(t, method_name, args)
                 end
 
                 @route.format params
@@ -255,7 +255,7 @@ module ActionDispatch
                 params
               end
 
-              def raise_generation_error(args)
+              def raise_generation_error(t, method_name, args)
                 missing_keys = []
                 params = parameterize_args(args) { |missing_key|
                   missing_keys << missing_key
@@ -264,7 +264,7 @@ module ActionDispatch
                 message = +"No route matches #{constraints.inspect}"
                 message << ", missing required keys: #{missing_keys.sort.inspect}"
 
-                raise ActionController::UrlGenerationError, message
+                raise ActionController::UrlGenerationError.new(message, t._routes, @route_name, method_name)
               end
           end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4943,16 +4943,6 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id" => "url-tested") }
     assert_match "Did you mean?", error.detailed_message
   end
-
-  # FIXME: we should fix all locations that raise this exception to provide
-  # the info DidYouMean needs and then delete this test.  Just adding the
-  # test for now because some parameters to the constructor are optional, and
-  # we don't want to break other code.
-  test "correct for empty UrlGenerationError" do
-    err = ActionController::UrlGenerationError.new("oh no!")
-
-    assert_equal [], err.corrections
-  end
 end
 
 class TestDefaultUrlOptions < ActionDispatch::IntegrationTest


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because optimized URL helper errors were raised without route context, so `UrlGenerationError` couldn’t reliably produce DidYouMean suggestions. This aligns optimized helpers with the other raise sites.

### Detail

This Pull Request changes optimized URL helper error raising to pass routes/name/method into `UrlGenerationError` and removes the temporary empty-error test.

### Additional information

Tests not run (not requested).

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
