### PR TITLE
Support withCredentials (Cookie-based auth) in Active Storage Direct Uploads 

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -88,4 +88,8 @@
 
     *Bart de Water*
 
+*   `ActiveStorage.adapters.XMLHttpRequest` can be used in client side to customize the XMLHttpRequest adapter used by `ActiveStorage::DirectUpload`.
+
+    *Radamés Roriz*
+
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -458,6 +458,10 @@ class FileChecksum {
   }
 }
 
+var adapters = {
+  XMLHttpRequest: typeof XMLHttpRequest !== "undefined" ? XMLHttpRequest : undefined
+};
+
 function getMetaValue(name) {
   const element = findElement(document.head, `meta[name="${name}"]`);
   if (element) {
@@ -516,15 +520,18 @@ class BlobRecord {
       byte_size: file.size,
       checksum: checksum
     };
-    this.xhr = new XMLHttpRequest;
+    this.xhr = new adapters.XMLHttpRequest;
     this.xhr.open("POST", url, true);
     this.xhr.responseType = "json";
     this.xhr.setRequestHeader("Content-Type", "application/json");
     this.xhr.setRequestHeader("Accept", "application/json");
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-    Object.keys(customHeaders).forEach((headerKey => {
-      this.xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
-    }));
+    if (Object.keys(customHeaders).length > 0) {
+      console.log("DEPRECATION: The customHeaders parameter has been replaced by dynamic HTTP requester class. Please use ActiveStorage.adapters.XMLHttpRequest = YourAdapter.");
+      for (const key in customHeaders) {
+        this.xhr.setRequestHeader(key, customHeaders[key]);
+      }
+    }
     const csrfToken = getMetaValue("csrf-token");
     if (csrfToken != undefined) {
       this.xhr.setRequestHeader("X-CSRF-Token", csrfToken);
@@ -578,7 +585,7 @@ class BlobUpload {
     this.blob = blob;
     this.file = blob.file;
     const {url: url, headers: headers} = blob.directUploadData;
-    this.xhr = new XMLHttpRequest;
+    this.xhr = new adapters.XMLHttpRequest;
     this.xhr.open("PUT", url, true);
     this.xhr.responseType = "text";
     for (const key in headers) {
@@ -881,4 +888,4 @@ function autostart() {
 
 setTimeout(autostart, 1);
 
-export { DirectUpload, DirectUploadController, DirectUploadsController, dispatchEvent, start };
+export { DirectUpload, DirectUploadController, DirectUploadsController, adapters, dispatchEvent, start };

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -458,6 +458,9 @@
       }
     }
   }
+  var adapters = {
+    XMLHttpRequest: typeof XMLHttpRequest !== "undefined" ? XMLHttpRequest : undefined
+  };
   function getMetaValue(name) {
     const element = findElement(document.head, `meta[name="${name}"]`);
     if (element) {
@@ -511,15 +514,18 @@
         byte_size: file.size,
         checksum: checksum
       };
-      this.xhr = new XMLHttpRequest;
+      this.xhr = new adapters.XMLHttpRequest;
       this.xhr.open("POST", url, true);
       this.xhr.responseType = "json";
       this.xhr.setRequestHeader("Content-Type", "application/json");
       this.xhr.setRequestHeader("Accept", "application/json");
       this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-      Object.keys(customHeaders).forEach((headerKey => {
-        this.xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
-      }));
+      if (Object.keys(customHeaders).length > 0) {
+        console.log("DEPRECATION: The customHeaders parameter has been replaced by dynamic HTTP requester class. Please use ActiveStorage.adapters.XMLHttpRequest = YourAdapter.");
+        for (const key in customHeaders) {
+          this.xhr.setRequestHeader(key, customHeaders[key]);
+        }
+      }
       const csrfToken = getMetaValue("csrf-token");
       if (csrfToken != undefined) {
         this.xhr.setRequestHeader("X-CSRF-Token", csrfToken);
@@ -572,7 +578,7 @@
       this.blob = blob;
       this.file = blob.file;
       const {url: url, headers: headers} = blob.directUploadData;
-      this.xhr = new XMLHttpRequest;
+      this.xhr = new adapters.XMLHttpRequest;
       this.xhr.open("PUT", url, true);
       this.xhr.responseType = "text";
       for (const key in headers) {
@@ -858,6 +864,7 @@
   exports.DirectUpload = DirectUpload;
   exports.DirectUploadController = DirectUploadController;
   exports.DirectUploadsController = DirectUploadsController;
+  exports.adapters = adapters;
   exports.dispatchEvent = dispatchEvent;
   exports.start = start;
   Object.defineProperty(exports, "__esModule", {

--- a/activestorage/app/javascript/activestorage/adapters.js
+++ b/activestorage/app/javascript/activestorage/adapters.js
@@ -1,0 +1,3 @@
+export default {
+  XMLHttpRequest: typeof XMLHttpRequest !== "undefined" ? XMLHttpRequest : undefined,
+}

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -1,5 +1,5 @@
-import { getMetaValue } from "./helpers"
 import adapters from "./adapters"
+import { getMetaValue } from "./helpers"
 
 export class BlobRecord {
   constructor(file, checksum, url, customHeaders = {}) {
@@ -20,7 +20,7 @@ export class BlobRecord {
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest")
 
     if (Object.keys(customHeaders).length > 0) {
-      console.log("DEPRECATION: The customHeaders parameter has been replaced by dynamic HTTP requester class. Please use ActiveStorage.adapters.XMLHttpRequest = YourAdapter.");
+      console.log("DEPRECATION: The customHeaders parameter has been replaced by dynamic HTTP requester class. Please use ActiveStorage.adapters.XMLHttpRequest = YourAdapter.")
       for (const key in customHeaders) {
         this.xhr.setRequestHeader(key, customHeaders[key])
       }

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -1,4 +1,5 @@
 import { getMetaValue } from "./helpers"
+import adapters from "./adapters"
 
 export class BlobRecord {
   constructor(file, checksum, url, customHeaders = {}) {
@@ -11,15 +12,19 @@ export class BlobRecord {
       checksum: checksum
     }
 
-    this.xhr = new XMLHttpRequest
+    this.xhr = new adapters.XMLHttpRequest()
     this.xhr.open("POST", url, true)
     this.xhr.responseType = "json"
     this.xhr.setRequestHeader("Content-Type", "application/json")
     this.xhr.setRequestHeader("Accept", "application/json")
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest")
-    Object.keys(customHeaders).forEach((headerKey) => {
-      this.xhr.setRequestHeader(headerKey, customHeaders[headerKey])
-    })
+
+    if (Object.keys(customHeaders).length > 0) {
+      console.log("DEPRECATION: The customHeaders parameter has been replaced by dynamic HTTP requester class. Please use ActiveStorage.adapters.XMLHttpRequest = YourAdapter.");
+      for (const key in customHeaders) {
+        this.xhr.setRequestHeader(key, customHeaders[key])
+      }
+    }
 
     const csrfToken = getMetaValue("csrf-token")
     if (csrfToken != undefined) {

--- a/activestorage/app/javascript/activestorage/blob_upload.js
+++ b/activestorage/app/javascript/activestorage/blob_upload.js
@@ -1,3 +1,5 @@
+import adapters from "./adapters"
+
 export class BlobUpload {
   constructor(blob) {
     this.blob = blob
@@ -5,7 +7,7 @@ export class BlobUpload {
 
     const { url, headers } = blob.directUploadData
 
-    this.xhr = new XMLHttpRequest
+    this.xhr = new adapters.XMLHttpRequest()
     this.xhr.open("PUT", url, true)
     this.xhr.responseType = "text"
     for (const key in headers) {

--- a/activestorage/app/javascript/activestorage/index.js
+++ b/activestorage/app/javascript/activestorage/index.js
@@ -3,7 +3,17 @@ import { DirectUpload } from "./direct_upload"
 import { DirectUploadController } from "./direct_upload_controller"
 import { DirectUploadsController } from "./direct_uploads_controller"
 import { dispatchEvent } from "./helpers"
-export { start, DirectUpload, DirectUploadController, DirectUploadsController, dispatchEvent }
+import adapters from "./adapters"
+
+
+export {
+  start,
+  DirectUpload,
+  DirectUploadController,
+  DirectUploadsController,
+  dispatchEvent,
+  adapters
+}
 
 function autostart() {
   if (window.ActiveStorage) {

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1374,41 +1374,21 @@ class Uploader {
 
 ### Integrating with Libraries or Frameworks
 
-Once you receive a file from the library you have selected, you need to create
-a `DirectUpload` instance and use its "create" method to initiate the upload process,
-adding any required additional headers as necessary. The "create" method also requires
-a callback function to be provided that will be triggered once the upload has finished.
+Before use the DirectUpload class, you need to set the XMLHttpRequest custom adapter. this can be made replacing the default adapter with a custom one. But make sure the new adapter is compatible with XMLHttpRequest class.
 
 ```js
-import { DirectUpload } from "@rails/activestorage"
+import * as ActiveStorage from "@rails/activestorage"
 
-class Uploader {
-  constructor(file, url, token) {
-    const headers = { 'Authentication': `Bearer ${token}` }
-    // INFO: Sending headers is an optional parameter. If you choose not to send headers,
-    //       authentication will be performed using cookies or session data.
-    this.upload = new DirectUpload(file, url, this, headers)
-  }
-
-  uploadFile(file) {
-    this.upload.create((error, blob) => {
-      if (error) {
-        // Handle the error
-      } else {
-        // Use the with blob.signed_id as a file reference in next request
-      }
-    })
-  }
-
-  directUploadWillStoreFileWithXHR(request) {
-    request.upload.addEventListener("progress",
-      event => this.directUploadDidProgress(event))
-  }
-
-  directUploadDidProgress(event) {
-    // Use event.loaded and event.total to update the progress bar
+class XMLHttpRequestWithBearer extends XMLHttpRequest {
+  constructor() {
+    super()
+    this.setRequestHeader("Authorization", `Bearer ${token}`)
+    // or enable cookies with:
+    // this.withCredentials = true
   }
 }
+
+ActiveStorage.adapters.XMLHttpRequest = XMLHttpRequestWithBearer;
 ```
 
 To implement customized authentication, a new controller must be created on


### PR DESCRIPTION
### Motivation / Background

Fix https://github.com/rails/rails/issues/56419

This Pull Request has been created because currently, the `DirectUpload` class in Active Storage hardcodes the instantiation of `XMLHttpRequest`.

This rigidity makes it impossible to configure the request for specific authentication scenarios without monkey-patching. Specifically, users cannot enable `withCredentials = true` to send session cookies (essential for apps relying on cookie-based authentication rather than headers), nor can they easily integrate other custom request logic.

While Bearer tokens were previously supported via specific headers, this approach was narrow. This PR introduces a more flexible adapter pattern to solve these issues broadly.

### Detail

This Pull Request changes `@rails/activestorage` to use a configurable adapter pattern for creating HTTP requests, inspired by the implementation in `actioncable`.

**Key changes:**

1. **Introduced `ActiveStorage.adapters**`: This object holds the reference to the request constructor. By default, it points to a standard `XMLHttpRequest` wrapper.
2. **Configurability**: Users can now replace `ActiveStorage.adapters.XMLHttpRequest` with a custom class that conforms to the interface. This allows full control over the request object (e.g., setting `withCredentials`, adding custom logging, or using a different underlying library).
3. **Deprecation**: The previous ad-hoc implementation for Bearer tokens has been preserved for backward compatibility but now logs a deprecation warning. Users are encouraged to switch to the new Adapter pattern for custom authentication headers.

### Additional information

**Example Usage: Enabling `withCredentials**`

Here is how a developer can now configure Active Storage to send cookies with direct uploads:

```javascript
import * as ActiveStorage from "@rails/activestorage"

// Define a custom adapter that enables credentials
class CredentialedXMLHttpRequest extends XMLHttpRequest {
  constructor() {
    super()
    this.withCredentials = true
  }
}

// Override the default adapter
ActiveStorage.adapters.XMLHttpRequest = CredentialedXMLHttpRequest

// Now DirectUpload will use this custom XHR
import { DirectUpload } from "@rails/activestorage"
const upload = new DirectUpload(file, url)

```

**References**

* Inspiration taken from https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/adapters.js

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
