### PR TITLE
Allow skipping default Active Storage direct upload routes

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -39,7 +39,7 @@ module ActionText
       options[:name]  ||= name
 
       options[:data] ||= {}
-      options[:data][:direct_upload_url] ||= main_app.rails_direct_uploads_url
+      options[:data][:direct_upload_url] ||= main_app.rails_direct_uploads_url if main_app.respond_to?(:rails_direct_uploads_url)
       options[:data][:blob_url_template] ||= main_app.rails_service_blob_url(":signed_id", ":filename")
 
       render RichText.editor.editor_tag(options)

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -88,4 +88,8 @@
 
     *Bart de Water*
 
+*   Introduce `ActiveStorage.skip_default_direct_uploads_routes` to skip the default direct upload routes.
+
+    *Radamés Roriz*
+
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
     get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
     put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
-    post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+    post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads unless ActiveStorage.skip_default_direct_uploads_routes
   end
 
   direct :rails_representation do |representation, options|

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -360,6 +360,7 @@ module ActiveStorage
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
   mattr_accessor :draw_routes, default: true
   mattr_accessor :resolve_model_to_route, default: :rails_storage_redirect
+  mattr_accessor :skip_default_direct_uploads_routes, default: false
 
   mattr_accessor :track_variants, default: false
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -124,6 +124,7 @@ module ActiveStorage
         ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
         ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
         ActiveStorage.resolve_model_to_route = app.config.active_storage.resolve_model_to_route || :rails_storage_redirect
+        ActiveStorage.skip_default_direct_uploads_routes = app.config.active_storage.skip_default_direct_uploads_routes != false
 
         ActiveStorage.supported_image_processing_methods += app.config.active_storage.supported_image_processing_methods || []
         ActiveStorage.unsupported_image_processing_arguments = app.config.active_storage.unsupported_image_processing_arguments || %w(

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -124,7 +124,7 @@ module ActiveStorage
         ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
         ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
         ActiveStorage.resolve_model_to_route = app.config.active_storage.resolve_model_to_route || :rails_storage_redirect
-        ActiveStorage.skip_default_direct_uploads_routes = app.config.active_storage.skip_default_direct_uploads_routes != false
+        ActiveStorage.skip_default_direct_uploads_routes = app.config.active_storage.skip_default_direct_uploads_routes == true
 
         ActiveStorage.supported_image_processing_methods += app.config.active_storage.supported_image_processing_methods || []
         ActiveStorage.unsupported_image_processing_arguments = app.config.active_storage.unsupported_image_processing_arguments || %w(

--- a/activestorage/test/urls/rails_storage_direct_upload_test.rb
+++ b/activestorage/test/urls/rails_storage_direct_upload_test.rb
@@ -5,7 +5,7 @@ require "database/setup"
 
 class RailsStorageDirectUploadTest < ActiveSupport::TestCase
   include Rails.application.routes.url_helpers
-  
+
   setup do
     @was_skip_default_direct_uploads_routes = ActiveStorage.skip_default_direct_uploads_routes
   end

--- a/activestorage/test/urls/rails_storage_direct_upload_test.rb
+++ b/activestorage/test/urls/rails_storage_direct_upload_test.rb
@@ -4,9 +4,8 @@ require "test_helper"
 require "database/setup"
 
 class RailsStorageDirectUploadTest < ActiveSupport::TestCase
-  include Rails.application.routes.url_helpers
-
   setup do
+    @routes = Rails.application.routes
     @was_skip_default_direct_uploads_routes = ActiveStorage.skip_default_direct_uploads_routes
   end
 
@@ -17,7 +16,7 @@ class RailsStorageDirectUploadTest < ActiveSupport::TestCase
   test "rails registered direct upload default path" do
     ActiveStorage.skip_default_direct_uploads_routes = false
 
-    assert_includes rails_active_storage_direct_uploads_path(only_path: true), "/rails/active_storage/direct_uploads"
+    assert_equal({ controller: "active_storage/direct_uploads", action: "create" }, @routes.recognize_path("/rails/active_storage/direct_uploads", method: :post))
   end
 
   test "rails skip default direct upload default path" do

--- a/activestorage/test/urls/rails_storage_direct_upload_test.rb
+++ b/activestorage/test/urls/rails_storage_direct_upload_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class RailsStorageDirectUploadTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+  
+  setup do
+    @was_skip_default_direct_uploads_routes = ActiveStorage.skip_default_direct_uploads_routes
+  end
+
+  teardown do
+    ActiveStorage.skip_default_direct_uploads_routes = @was_skip_default_direct_uploads_routes
+  end
+
+  test "rails registered direct upload default path" do
+    ActiveStorage.skip_default_direct_uploads_routes = false
+
+    assert_includes rails_active_storage_direct_uploads_path(only_path: true), "/rails/active_storage/direct_uploads"
+  end
+
+  test "rails skip default direct upload default path" do
+    ActiveStorage.skip_default_direct_uploads_routes = true
+
+    assert_raise(ActionController::RoutingError) { @routes.recognize_path("/rails/active_storage/direct_uploads") }
+  end
+end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1429,6 +1429,14 @@ end
 
 NOTE: Using [Direct Uploads](#direct-uploads) can sometimes result in a file that uploads, but never attaches to a record. Consider [purging unattached uploads](#purging-unattached-uploads).
 
+### Skipping Default Direct Uploads Routes
+
+Direct Uploads can be disabled by setting `ActiveStorage.skip_default_direct_uploads_routes` to `true` in the Rails configuration.
+
+```ruby
+config.active_storage.skip_default_direct_uploads_routes = true
+```
+
 Testing
 -------------------------------------------
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because currently, enabling direct uploads via `config.active_storage.direct_uploads_enabled` automatically registers the default route (`/rails/active_storage/direct_uploads`).

In many modern applications, specifically those using custom API structures, specialized authentication for uploads, or those wishing to avoid exposing default Rails internal routes, developers may want to implement their own direct upload controller while still utilizing the underlying Active Storage direct upload logic. Currently, there is no way to disable the default route without effectively disabling the entire feature or manually blacklisting the route in `routes.rb`, which is counter-intuitive.

### Detail

This Pull Request introduces a new configuration option: `config.active_storage.skip_default_direct_upload_routes`.

* When set to `true`, the `ActiveStorage::Engine` will skip the drawing of the POST route to `active_storage/direct_uploads#create`.
* This allows developers to define their own custom routes and controllers for direct uploads while keeping `direct_uploads_enabled` active for other internal logic or library dependencies.
* The default value is `false` to maintain backward compatibility.

### Additional information

This follows a similar pattern used in other Rails engines and popular gems (like Devise) where route generation is decoupled from feature availability. By providing `skip_default_direct_upload_routes`, we reduce "route pollution" for applications that require a strict or custom URL schema.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries.