### PR TITLE
ActionView::TestCase#render resets rendered

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `ActionView::TestCase#render` to reset `rendered`.
+    The behavior was changed when memoization was added in #51093. Now it once again conforms to the documentation.
+
+    *Jeroen Versteeg*
+
 *   Fix `FormBuilder#to_partial_path` returning `nil` for subclasses whose
     name does not end in `Builder`.
 

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -272,7 +272,7 @@ module ActionView
         @request = @controller.request
         @view_flow = ActionView::OutputFlow.new
         @output_buffer = ActionView::OutputBuffer.new
-        @rendered = self.class.content_class.new(+"")
+        _reset_rendered
 
         test_case_instance = self
         controller_class.define_method(:_test_case) { test_case_instance }
@@ -284,8 +284,18 @@ module ActionView
 
       def render(options = {}, local_assigns = {}, &block)
         view.assign(view_assigns)
-        @rendered << output = view.render(options, local_assigns, &block)
-        output
+
+        if @_rendering
+          view.render(options, local_assigns, &block)
+        else
+          _reset_rendered
+          @_rendering = true
+          output = view.render(options, local_assigns, &block)
+          @rendered << output
+          output
+        end
+      ensure
+        @_rendering = false unless @_rendering.nil?
       end
 
       def rendered_views
@@ -383,6 +393,7 @@ module ActionView
         :@method_name,
         :@output_buffer,
         :@_partials,
+        :@_rendering,
         :@passed,
         :@rendered,
         :@request,
@@ -411,6 +422,10 @@ module ActionView
         Hash[_user_defined_ivars.map do |ivar|
           [ivar[1..-1].to_sym, instance_variable_get(ivar)]
         end]
+      end
+
+      def _reset_rendered
+        @rendered = self.class.content_class.new(+"")
       end
 
       def method_missing(selector, ...)

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -341,6 +341,14 @@ module ActionView
       end
     end
 
+    test "nested helper renders do not replace rendered" do
+      render(partial: "test/from_helper")
+
+      assert_equal 1, rendered.html.css("form").size
+      assert_equal 1, rendered.html.css("ul").size
+      assert_equal "/foo", rendered.html.at("form")["action"]
+    end
+
     test "do not memoize the document_root_element in view tests" do
       concat form_tag("/foo")
 
@@ -404,14 +412,14 @@ module ActionView
 
       render "developers/developer", developer: DeveloperStruct.new("second")
 
-      assert_includes rendered, "first"
+      assert_not_includes rendered, "first"
       assert_includes rendered, "second"
       assert_not_includes rendered, "third"
 
       render "developers/developer", developer: DeveloperStruct.new("third")
 
-      assert_includes rendered, "first"
-      assert_includes rendered, "second"
+      assert_not_includes rendered, "first"
+      assert_not_includes rendered, "second"
       assert_includes rendered, "third"
     end
   end


### PR DESCRIPTION
### Motivation / Background

See #56235 for details.

### Detail

`ActionView::TestCase#render` resets `rendered` by calling `@rendered.clear`.

This behavior was broken when memoization was added in #51093.

### Additional information

One alternative is to create a new `@rendered` object.

After all, users may provide their own class by setting the `content_class` class attribute. The only contract / dependency is that the object `responds_to :<<`, so `:clear` might not be implemented.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
