### PR TITLE
Make `rescue_from_handled.action_controller` store the full backtrace

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make `event_backtrace` attribute in `rescue_from_handled.action_controller` notifications the full backtrace, when `config.action_controller.rescue_from_event_backtrace` is `:array`.
+
+    This also affects `action_controller.rescue_from_handled` events.
+
+    *zzak*
+
 *   Avoid loading `ActionController::Live` early in initializer, and introduce
     `action_controller_live` load hook.
 

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -49,6 +49,10 @@ module ActionController
       exception_class = event[:payload][:exception_class]
       exception_message = event[:payload][:exception_message]
       exception_backtrace = event[:payload][:exception_backtrace]
+      if exception_backtrace.is_a?(Array)
+        exception_backtrace = exception_backtrace&.first
+        exception_backtrace = exception_backtrace&.delete_prefix("#{Rails.root}/") if defined?(Rails.root) && Rails.root
+      end
       info { "rescue_from handled #{exception_class} (#{exception_message}) - #{exception_backtrace}" }
     end
     event_log_level :rescue_from_handled, :info

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -89,7 +89,8 @@ module ActionController
           :action_on_unpermitted_parameters,
           :always_permitted_parameters,
           :wrap_parameters_by_default,
-          :live_streaming_excluded_keys
+          :live_streaming_excluded_keys,
+          :rescue_from_event_backtrace
         )
 
         filtered_options.each do |k, v|
@@ -155,6 +156,12 @@ module ActionController
     initializer "action_controller.backtrace_cleaner" do
       ActiveSupport.on_load(:action_controller) do
         ActionController::LogSubscriber.backtrace_cleaner = Rails.backtrace_cleaner
+      end
+    end
+
+    initializer "action_controller.structured_event_subscriber" do |app|
+      ActiveSupport.on_load(:action_controller) do
+        ActionController::StructuredEventSubscriber._rescue_from_event_backtrace = app.config.action_controller.rescue_from_event_backtrace
       end
     end
   end

--- a/actionpack/test/controller/structured_event_subscriber_test.rb
+++ b/actionpack/test/controller/structured_event_subscriber_test.rb
@@ -157,9 +157,22 @@ module ActionController
     def test_rescue_from_callback
       assert_event_reported("action_controller.rescue_from_handled", payload: {
         exception_class: "StandardError",
-        exception_message: "Something went wrong"
+        exception_message: "Something went wrong",
+        exception_backtrace: /structured_event_subscriber_test.rb.*raise_error/
       }) do
         get :raise_error
+      end
+    end
+
+    def test_rescue_from_callback_with_exception_backtrace
+      ActionController::StructuredEventSubscriber.with(_rescue_from_event_backtrace: :array) do
+        assert_event_reported("action_controller.rescue_from_handled", payload: {
+          exception_class: "StandardError",
+          exception_message: "Something went wrong",
+          exception_backtrace: /structured_event_subscriber_test.rb.*raise_error/
+        }) do
+          get :raise_error
+        end
       end
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -62,6 +62,7 @@ Below are the default values associated with each target version. In cases of co
 
 - [`config.action_controller.default_protect_from_forgery_with`](#config-action-controller-default-protect-from-forgery-with): `:exception`
 - [`config.action_controller.forgery_protection_verification_strategy`](#config-action-controller-forgery-protection-verification-strategy): `:header_only`
+- [`config.action_controller.rescue_from_event_backtrace`](#config-action-controller-rescue-from-event-backtrace): `:array`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `true`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
@@ -2214,6 +2215,20 @@ This is mainly for compatibility when upgrading Rails applications, otherwise yo
 | --------------------- | -------------------- |
 | (original)            | `true`               |
 | 8.1                   | `false`              |
+
+#### `config.action_controller.rescue_from_event_backtrace`
+
+Configures the `event_backtrace` attribute in the payload of `rescue_from_handled.action_controller` notifications, and `action_controller.rescue_from_handled` events.
+
+* `:array` - Stores the backtrace as an array of strings.
+* `nil` - Stores the backtrace as the the first string of the backtrace, stripping the `Rails.root` from the controller path.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `nil`                |
+| 8.2                   | `:array`             |
 
 ### Configuring Action Dispatch
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -371,6 +371,7 @@ module Rails
           if respond_to?(:action_controller)
             action_controller.forgery_protection_verification_strategy = :header_only
             action_controller.default_protect_from_forgery_with = :exception
+            action_controller.rescue_from_event_backtrace = :array
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -93,3 +93,11 @@
 #  - :lazily - Skip automatic analysis; analyze on-demand
 #++
 # Rails.application.config.active_storage.analyze = :immediately
+
+# Controls whether the `rescue_from_handled.action_controller` notification payload includes the full backtrace.
+#
+# When set to `:array`, the full backtrace is included as an array of strings.
+#
+# Otherwise, when set to `nil`, only the first string of the backtrace is included, stripping the `Rails.root` from the controller path.
+#++
+# Rails.application.config.action_controller.rescue_from_event_backtrace = :array


### PR DESCRIPTION
When `config.action_controller.rescue_from_event_backtrace` is `:array`, the payload for this notification will include the full backtrace.

This also affects `action_controller.rescue_from_handled` events.

Fixes: #56060

/cc @skipkayhil This is kind of what I had in mind, then we can decide to deprecate and remove that flag (along with the behavior). There is no direct connection to the flag and the payload -- but the combination of changelog, flag, a release, and a deprecation be loud enough to correct any issues that may arise, then again -- it's a brand new event in 8.1, so that might be overkill. Happy to step this back and just change it, but it'd suck to maybe break peoples o11y who might have already started listening for this event.

I did add a test for the `delete_prefix(Rails.root)` part, which is also a nice addition I can pull out from this if we need to think about it more.