### PR TITLE
Fixes for default handling in CombinedConfiguration

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -90,8 +90,10 @@ module ActiveSupport
 
       if !value.nil?
         value
-      elsif default
-        default.try(:call) || default
+      elsif default.respond_to?(:call)
+        default.call
+      else
+        default
       end
     end
 

--- a/activesupport/lib/active_support/env_configuration.rb
+++ b/activesupport/lib/active_support/env_configuration.rb
@@ -39,14 +39,12 @@ module ActiveSupport
     #   option(:db_host)                                    # => ENV["DB_HOST"]
     #   option(:database, :host)                            # => ENV["DATABASE__HOST"]
     #   option(:database, :host, default: "missing")        # => ENV.fetch("DATABASE__HOST", "missing")
-    #   option(:database, :host, default: -> { "missing" }) # => ENV.fetch("DATABASE__HOST", default.call)
+    #   option(:database, :host, default: -> { "missing" }) # => ENV.fetch("DATABASE__HOST") { default.call }
     def option(*key, default: nil)
       if default.respond_to?(:call)
-        @envs.fetch envify(*key), default.call
-      elsif default
-        @envs.fetch envify(*key), default
+        @envs.fetch(envify(*key)) { default.call }
       else
-        @envs[envify(*key)]
+        @envs.fetch envify(*key), default
       end
     end
 

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -185,13 +185,18 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal "there", @credentials.option(:two_is_not_here, default: -> { "there" })
   end
 
-  test "optional false key with default block returns false" do
+  test "optional false key with default block can return false without triggering default" do
     @credentials.write({ bool: false }.to_yaml)
-    assert_equal false, @credentials.option(:bool, default: -> { "there" })
+    called = false
+    assert_equal false, @credentials.option(:bool, default: -> { called = true; "there" })
+    assert_equal false, called
   end
 
-  test "optional key can return false without triggering default" do
-    @credentials.write({ false: false }.to_yaml)
-    assert_equal false, @credentials.option(:false, default: -> { "true" })
+  test "optional missing key with default block returning false returns false" do
+    assert_equal false, @credentials.option(:missing, default: -> { false })
+  end
+
+  test "optional missing key with default block returning nil returns nil" do
+    assert_nil @credentials.option(:missing, default: -> { nil })
   end
 end

--- a/activesupport/test/env_configuration_test.rb
+++ b/activesupport/test/env_configuration_test.rb
@@ -48,6 +48,22 @@ class EnvConfigurationTest < ActiveSupport::TestCase
     assert_equal "there", @config.option(:two_is_not_here, default: -> { "there" })
   end
 
+  test "optional missing key with default block returning false returns false" do
+    assert_equal false, @config.option(:missing, default: -> { false })
+  end
+
+  test "optional missing key with default block returning nil returns nil" do
+    assert_nil @config.option(:missing, default: -> { nil })
+  end
+
+  test "optional present key with default block returns value without triggering default" do
+    set_env("EXISTS" => "value") do
+      called = false
+      assert_equal "value", @config.option(:exists, default: -> { called = true; "default" })
+      assert_equal false, called
+    end
+  end
+
   test "cached reads can be reloaded" do
     set_env("ONE" => "1") do
       assert_equal "1", @config.require(:one)


### PR DESCRIPTION
### Motivation / Background

A few fixes for the recently-added `CombinedConfiguration` from https://github.com/rails/rails/pull/56404

### Detail

1. Fix `default` in `env_configuration.rb` to be invoked lazily, like `encrypted_configuration.rb` does.
2. Fix `default` in `env_configuration.rb` to return `false` for `default: false`. Previously it would return `nil`.
3. Fix `default` in `encrypted_configuration.rb` when the default callback returns `false`. Previously it would return the callback itself in that case.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
