### PR TITLE
Add "Missing key: ..." to `KeyError` message in EncryptedConfiguration

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -71,7 +71,7 @@ module ActiveSupport
       if !value.nil?
         value
       else
-        raise(KeyError)
+        raise KeyError, "Missing key: #{key.inspect}"
       end
     end
 

--- a/activesupport/test/combined_configuration_test.rb
+++ b/activesupport/test/combined_configuration_test.rb
@@ -68,4 +68,16 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   test "option key with a false value" do
     assert_equal false, @combined.option(:false)
   end
+
+  test "require with missing key raises key error" do
+    assert_raise(KeyError, match: "Missing key: [:gone]") do
+      @combined.require(:gone)
+    end
+  end
+
+  test "require with missing nested key raises key error" do
+    assert_raise(KeyError, match: "Missing key: [:gone, :missing]") do
+      @combined.require(:gone, :missing)
+    end
+  end
 end

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -153,7 +153,7 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   end
 
   test "require missing key raises key error" do
-    assert_raises(KeyError) do
+    assert_raise(KeyError, match: "Missing key: [:gone]") do
       @credentials.require(:gone)
     end
   end
@@ -163,8 +163,8 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal false, @credentials.require(:one)
   end
 
-  test "reqiure missing multiword key raises key error" do
-    assert_raises(KeyError) do
+  test "require missing multiword key raises key error" do
+    assert_raise(KeyError, match: "Missing key: [:gone, :missing]") do
       @credentials.require(:gone, :missing)
     end
   end


### PR DESCRIPTION
Minor update for recent `CombinedConfiguration ` PR https://github.com/rails/rails/pull/56404.

This is helpful info for the error message.
And this is what CombinedConfiguration does for `KeyError` already.