### PR TITLE
[7-2-stable] Minitest 6 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,14 @@
 source "https://rubygems.org"
 gemspec
 
-gem "minitest"
+# Minitest 6 requires Ruby 3.2 or higher while Rails 7.2 supports Ruby 3.1
+# https://github.com/minitest/minitest/commit/8a50ebfee5d17dc231e5fb87bf936bdf250429a1
+if RUBY_VERSION < "3.2"
+  gem "minitest", "< 6.0"
+else
+  gem "minitest", "~> 6.0"
+  gem "minitest-mock"
+end
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 13"
@@ -138,7 +145,6 @@ local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
-  gem "minitest-bisect", require: false
   gem "minitest-ci", require: false
   gem "minitest-retry"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,17 +360,13 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.25.5)
-    minitest-bisect (1.7.0)
-      minitest-server (~> 1.0)
-      path_expander (~> 1.1)
+    minitest (6.0.0)
+      prism (~> 1.5)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
+    minitest-mock (5.27.0)
     minitest-retry (0.2.5)
       minitest (>= 5.0)
-    minitest-server (1.0.8)
-      drb (~> 2.0)
-      minitest (~> 5.16)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
@@ -410,7 +406,6 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
-    path_expander (1.1.3)
     pg (1.6.2)
     pg (1.6.2-aarch64-linux)
     pg (1.6.2-arm64-darwin)
@@ -690,9 +685,9 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   mdl (!= 0.13.0)
-  minitest
-  minitest-bisect
+  minitest (~> 6.0)
   minitest-ci
+  minitest-mock
   minitest-retry
   msgpack (>= 1.7.0)
   mysql2 (~> 0.5, < 0.5.7)

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -20,13 +20,13 @@ module ActionDispatch
       end
 
       test "not being empty when route is added" do
-        assert_predicate self, :empty?
+        assert_empty @set
 
         draw do
           get "foo", to: SimpleApp.new("foo#index")
         end
 
-        assert_not empty?
+        assert_not_empty @set
       end
 
       test "URL helpers are added when route is added" do

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -45,6 +45,12 @@ module ActiveSupport
         ActiveSupport.test_order ||= :random
       end
 
+      if Minitest.respond_to? :run_order # MT6 API change
+        def run_order # :nodoc:
+          test_order
+        end
+      end
+
       # Parallelizes the test suite.
       #
       # Takes a +workers+ argument that controls how many times the process

--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -2,4 +2,9 @@
 
 require "minitest"
 
+# This respond_to check handles tests running sub-processes in an
+# unbundled environment, which triggers MT5 usage. This conditional may
+# be removable after the version bump, though it currently safeguards
+# against issues in environments with multiple versions installed.
+Minitest.load :rails if Minitest.respond_to? :load
 Minitest.autorun

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -46,8 +46,10 @@ module ActiveSupport
 
           set_process_title("#{klass}##{method}")
 
-          result = klass.with_info_handler reporter do
-            Minitest.run_one_method(klass, method)
+          result = if Minitest.respond_to? :run_one_method then
+            Minitest.run_one_method klass, method
+          else
+            klass.new(method).run
           end
 
           safe_record(reporter, result)

--- a/guides/test/test_helper.rb
+++ b/guides/test/test_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "../../tools/strict_warnings"
+
+$LOAD_PATH.unshift File.expand_path("..", __dir__)
+
+require "rails_guides"
+
+require "minitest/autorun"
+Minitest.load :rails if Minitest.respond_to? :load

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -80,6 +80,13 @@ module Minitest
       options[:fail_fast] = true
     end
 
+    if Minitest::VERSION > "6" then
+      opts.on "-n", "--name PATTERN", "Include /regexp/ or string for run." do |a|
+        warn "Please switch from -n/--name to -i/--include"
+        options[:include] = a
+      end
+    end
+
     opts.on("-c", "--[no-]color", "Enable color in the output") do |value|
       options[:color] = value
     end

--- a/railties/lib/rails/test_unit/line_filtering.rb
+++ b/railties/lib/rails/test_unit/line_filtering.rb
@@ -4,10 +4,31 @@ require "rails/test_unit/runner"
 
 module Rails
   module LineFiltering # :nodoc:
-    def run(reporter, options = {})
-      options = options.merge(filter: Rails::TestUnit::Runner.compose_filter(self, options[:filter]))
+    def self.extended(obj)
+      require "minitest"
 
-      super
+      case Minitest::VERSION
+      when /^5/ then
+        obj.extend MT5
+      when /^6/ then
+        obj.extend MT6
+      end
+    end
+
+    module MT5
+      def run(reporter, options = {})
+        options = options.merge(filter: Rails::TestUnit::Runner.compose_filter(self, options[:filter]))
+
+        super
+      end
+    end
+
+    module MT6
+      def run_suite(reporter, options = {})
+        options = options.merge(include: Rails::TestUnit::Runner.compose_filter(self, options[:include]))
+
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
Backports https://github.com/rails/rails/pull/56207, https://github.com/rails/rails/pull/56385, and https://github.com/rails/rails/pull/56202 (sans https://github.com/rails/rails/commit/c5c678a67a09b1b83f0f7616290512b48bf2d071) to 7-2-stable branch.