### PR TITLE
Pin Minitest to version 5 on 7-2-stable

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",          "~> 2.0", ">= 2.0.5"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.3.1"
   s.add_dependency "connection_pool", ">= 2.2.5"
-  s.add_dependency "minitest",        ">= 5.1"
+  s.add_dependency "minitest",        ">= 5.1", "< 6"
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "bigdecimal"


### PR DESCRIPTION
### Motivation / Background

Since Minitest 6 requires Ruby 3.2 while Rails 7.2 supports Ruby 3.1, pin Minitest to version 5 on the 7-2-stable branch.

Rails 7.2.x is under security maintenance only, so this approach is reasonable.

### Detail
None

### Additional information

https://github.com/minitest/minitest/commit/8a50ebfee5d17dc231e5fb87bf936bdf250429a1 https://github.com/rails/rails/blob/a24be8d963d2d43c295c89c997c98508ab6237bf/rails.gemspec#L12 https://rubyonrails.org/maintenance

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
