### PR TITLE
Add SchemaDumper.dump API change to Rails 7.2 release notes

### DIFF
--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -480,6 +480,8 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 *   `ActiveRecord::Base.establish_connection` no longer sets `ActiveRecord::Base.connection.active?` to `true`. If you need this behavior, you can use `ActiveRecord::Base.connection.verify!` instead.
 
+*   `ActiveRecord::SchemaDumper.dump` now requires a connection pool as its first argument instead of a connection object. Update calls from `ActiveRecord::Base.connection` to `ActiveRecord::Base.connection_pool`, or omit the first argument to use the default connection pool. [Pull Request #51162](https://github.com/rails/rails/pull/51162)
+
 Active Storage
 --------------
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request documents a breaking change to `ActiveRecord::SchemaDumper.dump` that was introduced in Rails 7.2 but wasn't documented in the release notes. This change requires a connection pool instead of a connection object.

### Detail

This Pull Request adds documentation to the Rails 7.2 release notes about the `ActiveRecord::SchemaDumper.dump` API change. The method signature was changed in PR #51162 to accept a connection pool as its first argument instead of a connection object, aligning with Rails' multi-database support and connection management practices.

### Additional information

- Related PR: #51162
- The change affects anyone using `ActiveRecord::SchemaDumper.dump` directly

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (N/A - documentation only)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (N/A - this IS the changelog/release notes update)