### PR TITLE
Allow numericality :in to accept proc or symbol returning a Range

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -137,4 +137,9 @@
 
     *Sean Doyle*
 
+
+*   Allow `numericality :in` to accept a proc or symbol.
+
+    *opsys-saito*
+
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -237,6 +237,36 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_valid_values([1, 2, 3])
   end
 
+  def test_validates_numericality_with_in_using_proc
+    Topic.define_method(:approved_range) { 2..4 }
+    Topic.validates_numericality_of :approved, in: Proc.new(&:approved_range)
+
+    assert_invalid_values([1, 5])
+    assert_valid_values([2, 3, 4])
+  ensure
+    Topic.remove_method :approved_range
+  end
+
+  def test_validates_numericality_with_in_using_symbol
+    Topic.define_method(:approved_range) { 2..4 }
+    Topic.validates_numericality_of :approved, in: :approved_range
+
+    assert_invalid_values([1, 5])
+    assert_valid_values([2, 3, 4])
+  ensure
+    Topic.remove_method :approved_range
+  end
+
+  def test_validates_numericality_with_in_using_proc_must_return_range
+    Topic.define_method(:approved_range) { 123 }
+    Topic.validates_numericality_of :approved, in: Proc.new(&:approved_range)
+
+    topic = Topic.new title: "numeric test", content: "whatever", approved: 10
+    assert_raise(ArgumentError) { topic.valid? }
+  ensure
+    Topic.remove_method :approved_range
+  end
+
   def test_validates_numericality_with_other_than_using_string_value
     Topic.validates_numericality_of :approved, other_than: 0
 


### PR DESCRIPTION
## Motivation / Background

The `:in` option of `numericality` currently only accepts a static `Range`,
while other numericality options such as `:greater_than` and
`:less_than_or_equal_to` already support procs and symbols.

In practice, it is common for the valid range of a numeric attribute to depend
on other attributes of the same record. For example, a `Product` model may
define a minimum and maximum allowed price:

```ruby
class Product < ApplicationRecord
  # columns: price, min_price, max_price
end
```

Validating that `price` falls between `min_price` and `max_price` currently
requires a custom `validate` method, even though the intent fits naturally
within `numericality`.

Allowing `:in` to accept a proc or symbol that resolves to a `Range` enables
this use case to be expressed declaratively:

```ruby
validates :price, numericality: { in: ->(p) { p.min_price..p.max_price } }
```

This change brings the `:in` option in line with other numericality options and
with validators such as `inclusion` and `exclusion`, while remaining fully
backward compatible.
