### PR TITLE
Fix ActionMailer::Base.mail dispatch in 8.1+

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -607,6 +607,12 @@ module ActionMailer
         end.to_s
       end
 
+      def action_methods
+        methods = super
+        methods.add("mail") if self == ActionMailer::Base
+        methods
+      end
+
     private
       def set_payload_for_mail(payload, mail)
         payload[:mail]               = mail.encoded

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -607,6 +607,10 @@ module ActionMailer
         end.to_s
       end
 
+      def mail(...)
+        MessageDelivery.new(self, :mail, ...)
+      end
+
       def action_methods
         methods = super
         methods.add("mail") if self == ActionMailer::Base

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -30,6 +30,23 @@ class BaseTest < ActiveSupport::TestCase
     assert_nothing_raised { BaseMailer.welcome }
   end
 
+  test "ActionMailer::Base.mail delivers with explicit headers" do
+    ActionMailer::Base.deliveries.clear
+
+    delivery = ActionMailer::Base.mail(
+      from: "from@example.com",
+      to: "to@example.com",
+      subject: "Subject",
+      body: "Body"
+    )
+
+    assert_kind_of ActionMailer::MessageDelivery, delivery
+    delivery.deliver_now
+
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_equal "Subject", ActionMailer::Base.deliveries.last.subject
+  end
+
   # Basic mail usage without block
   test "mail() should set the headers of the mail message" do
     email = BaseMailer.welcome

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -47,6 +47,18 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal "Subject", ActionMailer::Base.deliveries.last.subject
   end
 
+  test "ActionMailer::Base.mail returns a proper message" do
+    delivery = ActionMailer::Base.mail(
+      from: "from@example.com",
+      to: "to@example.com",
+      subject: "Subject",
+      body: "Body"
+    )
+
+    assert_kind_of ActionMailer::MessageDelivery, delivery
+    assert_equal "Subject", delivery.message.subject
+  end
+
   # Basic mail usage without block
   test "mail() should set the headers of the mail message" do
     email = BaseMailer.welcome
@@ -576,7 +588,7 @@ class BaseTest < ActiveSupport::TestCase
   test "should respond to action methods" do
     assert_respond_to BaseMailer, :welcome
     assert_respond_to BaseMailer, :implicit_multipart
-    assert_not_respond_to BaseMailer, :mail
+    assert_respond_to BaseMailer, :mail
     assert_not_respond_to BaseMailer, :headers
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because ActionMailer::Base.mail stopped being treated as an action in Rails 8.1, raising ActionNotFound when called directly. This restores the 8.0 behavior for class-level deliveries. Fixes #56449.

### Detail

This Pull Request changes ActionMailer::Base to always include "mail" in its action_methods when the base class is used, and adds a regression test to exercise ActionMailer::Base.mail delivery.

### Additional information

Test run: `bundle exec ruby -Iactionmailer/test actionmailer/test/base_test.rb -n "/ActionMailer::Base.mail/"`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
