### PR TITLE
Change default from IPv4 to IPv6

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -117,7 +117,7 @@ module ActionDispatch
     include SystemTesting::TestHelpers::SetupAndTeardown
     include SystemTesting::TestHelpers::ScreenshotHelper
 
-    DEFAULT_HOST = "http://127.0.0.1"
+    DEFAULT_HOST = "http://[::1]"
 
     def initialize(*) # :nodoc:
       super

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -161,7 +161,7 @@ module ActionDispatch
         @url_options = nil
 
         self.host        = DEFAULT_HOST
-        self.remote_addr = "127.0.0.1"
+        self.remote_addr = "::1"
         self.accept      = "text/xml,application/xml,application/xhtml+xml," \
                            "text/html;q=0.9,text/plain;q=0.8,image/png," \
                            "*/*;q=0.5"

--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -9,7 +9,7 @@ module ActionDispatch
   class TestRequest < Request
     DEFAULT_ENV = Rack::MockRequest.env_for("/",
       "HTTP_HOST"                => "test.host".b,
-      "REMOTE_ADDR"              => "0.0.0.0".b,
+      "REMOTE_ADDR"              => "::".b,
       "HTTP_USER_AGENT"          => "Rails Testing".b,
     )
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -733,7 +733,7 @@ class TestCaseTest < ActionController::TestCase
 
   def test_remote_addr
     get :test_remote_addr
-    assert_equal "0.0.0.0", @response.body
+    assert_equal "::", @response.body
 
     @request.remote_addr = "192.0.0.1"
     get :test_remote_addr

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -16,7 +16,7 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal "", env.delete("QUERY_STRING")
 
     assert_equal "test.host", env.delete("HTTP_HOST")
-    assert_equal "0.0.0.0", env.delete("REMOTE_ADDR")
+    assert_equal "::", env.delete("REMOTE_ADDR")
     assert_equal "Rails Testing", env.delete("HTTP_USER_AGENT")
 
     assert_kind_of StringIO, env.delete("rack.errors")
@@ -54,9 +54,9 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal false, req.env.empty?
   end
 
-  test "default remote address is 0.0.0.0" do
+  test "default remote address is ::" do
     req = ActionDispatch::TestRequest.create({})
-    assert_equal "0.0.0.0", req.remote_addr
+    assert_equal "::", req.remote_addr
   end
 
   test "allows remote address to be overridden" do

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Change default server binding from IPv4 to IPv6
+
+    The `bin/rails server` command now binds to `::1` (IPv6 localhost) in development
+    and `::` (all IPv6 interfaces) in other environments, instead of `localhost` and `0.0.0.0`.
+
+    IPv6 sockets on most operating systems accept both IPv4 and IPv6 connections,
+    so existing workflows using `127.0.0.1` will continue to work. This change
+    prepares Rails for the increasing adoption of IPv6 and reduces reliance on
+    increasingly expensive public IPv4 addresses.
+
+    *Richard Schneeman*
+
 *   Add `Rails.app.creds` to provide combined access to credentials stored in either ENV or the encrypted credentials file.
     Provides a new require/option API for accessing these values. Examples:
 

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -105,7 +105,7 @@ module Rails
       class_option :port, aliases: "-p", type: :numeric,
         desc: "Run Rails on the specified port - defaults to 3000.", banner: :port
       class_option :binding, aliases: "-b", type: :string,
-        desc: "Bind Rails to the specified IP - defaults to 'localhost' in development and '0.0.0.0' in other environments'.",
+        desc: "Bind Rails to the specified IP - defaults to '::1' in development and '::' in other environments'.",
         banner: :IP
       class_option :config, aliases: "-c", type: :string, default: "config.ru",
         desc: "Use a custom rackup configuration.", banner: :file
@@ -218,7 +218,7 @@ module Rails
           if options[:binding]
             options[:binding]
           else
-            default_host = environment == "development" ? "localhost" : "0.0.0.0"
+            default_host = environment == "development" ? "::1" : "::"
 
             ENV.fetch("BINDING", default_host)
           end

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/Dockerfile.tt
@@ -2,6 +2,6 @@
 ARG RUBY_VERSION=<%= Gem.ruby_version %>
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
-# Ensure binding is always 0.0.0.0
+# Ensure binding is always ::
 # Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
-ENV BINDING="0.0.0.0"
+ENV BINDING="::"

--- a/railties/test/application/system_test_case_test.rb
+++ b/railties/test/application/system_test_case_test.rb
@@ -26,7 +26,7 @@ class SystemTestCaseTest < ActiveSupport::TestCase
     assert_not_includes(ActionDispatch::SystemTestCase.runnable_methods, :test_foo_url)
   end
 
-  test "system tests use 127.0.0.1 in the url_options be default" do
+  test "system tests use ::1 in the url_options by default" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do
         get 'foo', to: 'foo#index', as: 'test_foo'
@@ -38,7 +38,7 @@ class SystemTestCaseTest < ActiveSupport::TestCase
       driven_by :rack_test
     end
     system_test = rack_test_case.new("my_test")
-    assert_equal("http://127.0.0.1/foo", system_test.test_foo_url)
+    assert_equal("http://[::1]/foo", system_test.test_foo_url)
   end
 
   test "system tests use Capybara.app_host in the url_options if present" do

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -209,12 +209,12 @@ class Rails::Command::ServerTest < ActiveSupport::TestCase
   def test_host
     with_rails_env "development" do
       options = parse_arguments([])
-      assert_equal "localhost", options[:Host]
+      assert_equal "::1", options[:Host]
     end
 
     with_rails_env "production" do
       options = parse_arguments([])
-      assert_equal "0.0.0.0", options[:Host]
+      assert_equal "::", options[:Host]
     end
 
     with_rails_env "development" do

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1475,7 +1475,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
     assert_file(".devcontainer/Dockerfile") do |content|
       assert_match(/ARG RUBY_VERSION=#{RUBY_VERSION}/, content)
-      assert_match(/ENV BINDING="0.0.0.0"/, content)
+      assert_match(/ENV BINDING="::"/, content)
     end
     assert_file("test/application_system_test_case.rb") do |content|
       assert_match(/^    served_by host: "rails-app", port: ENV\["CAPYBARA_SERVER_PORT"\]/, content)

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -366,7 +366,7 @@ module Rails
         def test_common_config_with_folder(folder_name)
           assert_file(".devcontainer/Dockerfile") do |dockerfile|
             assert_match(/ARG RUBY_VERSION=#{RUBY_VERSION}/, dockerfile)
-            assert_match(/ENV BINDING="0.0.0.0"/, dockerfile)
+            assert_match(/ENV BINDING="::"/, dockerfile)
           end
 
           assert_devcontainer_json_file do |devcontainer_json|


### PR DESCRIPTION
IPv4 addresses like 127.0.0.1 and 0.0.0.0 are easy and familiar, but they're increasingly more expensive with provider such as AWS (https://aws.amazon.com/blogs/aws/new-aws-public-ipv4-address-charge-public-ip-insights/). IPv6 addresses are much more plentiful, and therefore cheaper (and represent the future).

This change:

- `0.0.0.0` => `::` (production)
- `127.0.0.1` => `::1` (development)


When Puma binds to these IPv6 addresses, it also works with the old IPv4 equivalents, which means someone can still type in 127.0.0.1:9292 into their browser and have it work, but the opposite is not true.

I have a corresponding issue to update the defaults in Puma to IPv6 as well. https://github.com/puma/puma/issues/3812

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
