### PR TITLE
Add `unique_by` option to `insert_all!`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `unique_by` option to `insert_all!`.
+
+    *Chedli Bourguiba*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -782,6 +782,18 @@ module ActiveRecord
     #   You can also pass an SQL string if you need more control on the return values
     #   (for example, <tt>returning: Arel.sql("id, name as new_name")</tt>).
     #
+    # [:unique_by]
+    #   (PostgreSQL and SQLite only) By default rows are considered to be unique
+    #   by every unique index on the table.
+    #
+    #   To check uniqueness according to just one unique index pass <tt>:unique_by</tt>.
+    #
+    #   Unique indexes can be identified by columns or name:
+    #
+    #     unique_by: :isbn
+    #     unique_by: %i[ author_id name ]
+    #     unique_by: :index_books_on_isbn
+    #
     # [:record_timestamps]
     #   By default, automatic setting of timestamp columns is controlled by
     #   the model's <tt>record_timestamps</tt> config, matching typical
@@ -807,8 +819,8 @@ module ActiveRecord
     #     { id: 1, title: "Rework", author: "David" },
     #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
     #   ])
-    def insert_all!(attributes, returning: nil, record_timestamps: nil)
-      InsertAll.execute(self, attributes, on_duplicate: :raise, returning: returning, record_timestamps: record_timestamps)
+    def insert_all!(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
+      InsertAll.execute(self, attributes, on_duplicate: :raise, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
     end
 
     # Updates or inserts (upserts) a single record into the database in a


### PR DESCRIPTION
re-submit of https://github.com/rails/rails/pull/45317/

### Description
This PR adds the missing `unique_by:` option to ActiveRecord::Relation#insert_all! and documents it.

### Motivation

`Relation.insert_all` (non-bang) already accepts `unique_by:` to select a specific unique index for conflict target handling, but `Relation.insert_all!` did not expose the same option even though the underlying `ActiveRecord::InsertAll` implementation supports it. 

This change harmonizes the public interface between `insert_all` and `insert_all!`, so callers can use the same option set regardless of whether they want the bang behavior (raise on duplicates, or skip).


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
