### PR TITLE
Allow Rails.app.creds to access .env values in dev

### DIFF
--- a/activesupport/lib/active_support/dot_env_configuration.rb
+++ b/activesupport/lib/active_support/dot_env_configuration.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "active_support/env_configuration"
+
+module ActiveSupport
+  # Provide an interface for accessing configuration options stored in a .env file.
+  # Keys are accepted as symbols and turned into upcased strings. Nesting is provided by double underscores.
+  #
+  # This interface mirrors what is used for +ActiveSupport::EnvConfiguration+ and +ActiveSupport::EncryptedConfiguration+
+  # and thus allows all three to serve as interchangeable backends for +Rails.app.creds+.
+  #
+  # The .env file format supports:
+  # - Lines with KEY=value pairs
+  # - Comments starting with #
+  # - Empty lines (ignored)
+  # - Quoted values (single or double quotes)
+  #
+  # When used inside Rails, the default path for the .env file will be `Rails.root.join(".env")`.
+  # Otherwise it must be passed in as +path+.
+  #
+  # Examples:
+  #
+  #   require(:db_host)                                   # => value of DB_HOST from .env
+  #   require(:database, :host)                           # => value of DATABASE__HOST from .env
+  #   option(:debug)                                      # => value of DEBUG from .env or nil if missing
+  #   option(:debug, default: "true")                     # => value of DEBUG from .env or "true" if not found
+  #   option(:database, :host, default: -> { "missing" }) # => value of DATABASE__HOST from .env or "missing" if not found
+  class DotEnvConfiguration < EnvConfiguration
+    def initialize(path = nil)
+      @path = path || rails_path
+      reload
+    end
+
+    # Reload the cached .env values in case the file changed during runtime.
+    def reload
+      @envs = parse_env_file
+    end
+
+    private
+      def rails_env_path
+        if defined?(Rails) && Rails.try(:root)
+          Rails.root.join(".env").to_s
+        end
+      end
+
+      def parse_env_file
+        if File.exist?(@path.to_s)
+          envs = {}
+
+          File.foreach(@path) do |line|
+            line = line.strip
+
+            next if line.empty? || line.start_with?("#")
+
+            # Match KEY=value pattern
+            if line =~ /\A([A-Za-z_][A-Za-z0-9_]*)=(.*)\z/
+              key, value = $1, $2
+              envs[key] = unquote(value)
+            end
+          end
+
+          envs
+        else
+          {}
+        end
+      end
+
+      def unquote(value)
+        if value.start_with?('"') && value.end_with?('"')
+          value[1..-2].gsub('\n', "\n").gsub('\"', '"')
+        elsif value.start_with?("'") && value.end_with?("'")
+          value[1..-2]
+        else
+          value
+        end
+      end
+  end
+end

--- a/activesupport/lib/active_support/dot_env_configuration.rb
+++ b/activesupport/lib/active_support/dot_env_configuration.rb
@@ -81,12 +81,12 @@ module ActiveSupport
         end
       end
 
-      def interpolate(value, envs)
-        value.gsub(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/) { envs[$1] || "" }
-      end
-
       def execute_commands(value)
         value.gsub(/\$\((.+?)\)/) { `#{$1}`.chomp }
+      end
+
+      def interpolate(value, envs)
+        value.gsub(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/) { envs[$1] || "" }
       end
   end
 end

--- a/activesupport/lib/active_support/dot_env_configuration.rb
+++ b/activesupport/lib/active_support/dot_env_configuration.rb
@@ -14,6 +14,7 @@ module ActiveSupport
   # - Comments starting with #
   # - Empty lines (ignored)
   # - Quoted values (single or double quotes)
+  # - Variable interpolation with ${VAR} syntax
   #
   # When used inside Rails, the default path for the .env file will be `Rails.root.join(".env")`.
   # Otherwise it must be passed in as +path+.
@@ -37,7 +38,7 @@ module ActiveSupport
     end
 
     private
-      def rails_env_path
+      def rails_path
         if defined?(Rails) && Rails.try(:root)
           Rails.root.join(".env").to_s
         end
@@ -55,7 +56,7 @@ module ActiveSupport
             # Match KEY=value pattern
             if line =~ /\A([A-Za-z_][A-Za-z0-9_]*)=(.*)\z/
               key, value = $1, $2
-              envs[key] = unquote(value)
+              envs[key] = interpolate(unquote(value), envs)
             end
           end
 
@@ -73,6 +74,10 @@ module ActiveSupport
         else
           value
         end
+      end
+
+      def interpolate(value, envs)
+        value.gsub(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/) { envs[$1] || "" }
       end
   end
 end

--- a/activesupport/lib/active_support/dot_env_configuration.rb
+++ b/activesupport/lib/active_support/dot_env_configuration.rb
@@ -53,7 +53,7 @@ module ActiveSupport
             next if line.empty? || line.start_with?("#")
 
             # Match KEY=value pattern
-            if line =~ /\A([A-Za-z_][A-Za-z0-9_]*)=(.*)\z/
+            if line =~ /\A([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\z/
               key, value = $1, $2
               envs[key] = interpolate(execute_commands(unquote(value)), envs)
             end

--- a/activesupport/lib/active_support/dot_env_configuration.rb
+++ b/activesupport/lib/active_support/dot_env_configuration.rb
@@ -32,8 +32,8 @@ module ActiveSupport
   #   option(:debug, default: "true")                     # => value of DEBUG from .env or "true" if not found
   #   option(:database, :host, default: -> { "missing" }) # => value of DATABASE__HOST from .env or "missing" if not found
   class DotEnvConfiguration < EnvConfiguration
-    def initialize(path = nil)
-      @path = path || rails_path
+    def initialize(path)
+      @path = path
       reload
     end
 
@@ -43,12 +43,6 @@ module ActiveSupport
     end
 
     private
-      def rails_path
-        if defined?(Rails) && Rails.try(:root)
-          Rails.root.join(".env").to_s
-        end
-      end
-
       def parse_env_file
         if File.exist?(@path.to_s)
           envs = {}

--- a/activesupport/lib/active_support/env_configuration.rb
+++ b/activesupport/lib/active_support/env_configuration.rb
@@ -11,9 +11,11 @@ module ActiveSupport
   #
   # Examples:
   #
-  #   require(:db_host)           # => ENV.fetch("DB_HOST")
-  #   require(:database, :host)   # => ENV.fetch("DATABASE__HOST")
-  #   optional(:debug) { "true" } # => ENV.fetch("DB_HOST") { "true" }
+  #   require(:db_host)                                   # => ENV.fetch("DB_HOST")
+  #   require(:database, :host)                           # => ENV.fetch("DATABASE__HOST")
+  #   option(:database, :host)                            # => ENV["DATABASE__HOST"]
+  #   option(:debug, default: "true")                     # => ENV.fetch("DB_HOST") { "true" }
+  #   option(:database, :host, default: -> { "missing" }) # => ENV.fetch("DATABASE__HOST") { default.call }
   class EnvConfiguration
     def initialize
       reload

--- a/activesupport/test/combined_configuration_test.rb
+++ b/activesupport/test/combined_configuration_test.rb
@@ -4,11 +4,13 @@ require_relative "abstract_unit"
 require "active_support/combined_configuration"
 require "active_support/encrypted_configuration"
 require "active_support/env_configuration"
+require "active_support/dot_env_configuration"
 
-class EncryptedConfigurationTest < ActiveSupport::TestCase
+class CombinedConfigurationTest < ActiveSupport::TestCase
   setup do
     @tmpdir = Dir.mktmpdir("config-")
     @credentials_config_path = File.join(@tmpdir, "credentials.yml.enc")
+    @env_file_path = File.join(@tmpdir, ".env")
 
     @credentials_key_path = File.join(@tmpdir, "master.key")
     File.write(@credentials_key_path, ActiveSupport::EncryptedConfiguration.generate_key)
@@ -18,47 +20,99 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
       env_key: "RAILS_MASTER_KEY", raise_if_missing_key: true
     )
 
-    @credentials.write({ available_in_both: "cred", only_in_credentials: "cred", false: false, nested: { available_in_both: "cred", only_in_credentials: "cred" } }.to_yaml)
+    @credentials.write({
+      available_in_all: "cred",
+      available_in_dotenv_and_cred: "cred",
+      only_in_credentials: "cred",
+      false: false,
+      nested: {
+        available_in_all: "cred",
+        available_in_dotenv_and_cred: "cred",
+        only_in_credentials: "cred"
+      }
+    }.to_yaml)
 
+    # .env file values (middle priority)
+    File.write(@env_file_path, <<~DOTENV)
+      AVAILABLE_IN_ALL=dotenv
+      AVAILABLE_IN_ENV_AND_DOTENV=dotenv
+      AVAILABLE_IN_DOTENV_AND_CRED=dotenv
+      ONLY_IN_DOTENV=dotenv
+      NESTED__AVAILABLE_IN_ALL=dotenv
+      NESTED__AVAILABLE_IN_ENV_AND_DOTENV=dotenv
+      NESTED__AVAILABLE_IN_DOTENV_AND_CRED=dotenv
+      NESTED__ONLY_IN_DOTENV=dotenv
+    DOTENV
+
+    # ENV values (highest priority)
     ENV["ONLY_IN_ENV"] = "env"
-    ENV["AVAILABLE_IN_BOTH"] = "env"
+    ENV["AVAILABLE_IN_ALL"] = "env"
+    ENV["AVAILABLE_IN_ENV_AND_DOTENV"] = "env"
     ENV["NESTED__ONLY_IN_ENV"] = "env"
-    ENV["NESTED__AVAILABLE_IN_BOTH"] = "env"
+    ENV["NESTED__AVAILABLE_IN_ALL"] = "env"
+    ENV["NESTED__AVAILABLE_IN_ENV_AND_DOTENV"] = "env"
 
     @envs = ActiveSupport::EnvConfiguration.new
-    @combined = ActiveSupport::CombinedConfiguration.new(@envs, @credentials)
+    @dotenvs = ActiveSupport::DotEnvConfiguration.new(@env_file_path)
+    @combined = ActiveSupport::CombinedConfiguration.new(@envs, @dotenvs, @credentials)
   end
 
   teardown do
     FileUtils.rm_rf @tmpdir
     ENV.delete("ONLY_IN_ENV")
-    ENV.delete("AVAILABLE_IN_BOTH")
+    ENV.delete("AVAILABLE_IN_ALL")
+    ENV.delete("AVAILABLE_IN_ENV_AND_DOTENV")
     ENV.delete("NESTED__ONLY_IN_ENV")
-    ENV.delete("NESTED__AVAILABLE_IN_BOTH")
+    ENV.delete("NESTED__AVAILABLE_IN_ALL")
+    ENV.delete("NESTED__AVAILABLE_IN_ENV_AND_DOTENV")
   end
 
-  test "require key present in env not credentials" do
+  test "require key present only in env" do
     assert_equal "env", @combined.require(:only_in_env)
   end
 
-  test "require key present in credentials not env" do
+  test "require key present only in dotenv" do
+    assert_equal "dotenv", @combined.require(:only_in_dotenv)
+  end
+
+  test "require key present only in credentials" do
     assert_equal "cred", @combined.require(:only_in_credentials)
   end
 
-  test "require key present in env and credentials" do
-    assert_equal "env", @combined.require(:available_in_both)
+  test "require key present in all three sources returns env" do
+    assert_equal "env", @combined.require(:available_in_all)
   end
 
-  test "read nested key present in env not credentials" do
+  test "require key present in env and dotenv returns env" do
+    assert_equal "env", @combined.require(:available_in_env_and_dotenv)
+  end
+
+  test "require key present in dotenv and credentials returns dotenv" do
+    assert_equal "dotenv", @combined.require(:available_in_dotenv_and_cred)
+  end
+
+  test "read nested key present only in env" do
     assert_equal "env", @combined.require(:nested, :only_in_env)
   end
 
-  test "read nested key present in credentials not env" do
+  test "read nested key present only in dotenv" do
+    assert_equal "dotenv", @combined.require(:nested, :only_in_dotenv)
+  end
+
+  test "read nested key present only in credentials" do
     assert_equal "cred", @combined.require(:nested, :only_in_credentials)
   end
 
-  test "read nested key present in env and credentials" do
-    assert_equal "env", @combined.require(:nested, :available_in_both)
+  test "read nested key present in all three sources returns env" do
+    assert_equal "env", @combined.require(:nested, :available_in_all)
+  end
+
+  test "read nested key present in env and dotenv returns env" do
+    assert_equal "env", @combined.require(:nested, :available_in_env_and_dotenv)
+  end
+
+  test "read nested key present in dotenv and credentials returns dotenv" do
+    assert_equal "dotenv", @combined.require(:nested, :available_in_dotenv_and_cred)
   end
 
   test "require key with a false value" do

--- a/activesupport/test/dot_env_configuration_test.rb
+++ b/activesupport/test/dot_env_configuration_test.rb
@@ -141,11 +141,6 @@ class DotEnvConfigurationTest < ActiveSupport::TestCase
     assert_nil @config.option(:anything)
   end
 
-  test "returns empty hash when no path given and Rails is not defined" do
-    @config = ActiveSupport::DotEnvConfiguration.new
-    assert_nil @config.option(:anything)
-  end
-
   private
     def write_env_file(attributes)
       write_env_file_raw(attributes.map { |key, value| "#{key}=#{value}" }.join("\n"))

--- a/activesupport/test/dot_env_configuration_test.rb
+++ b/activesupport/test/dot_env_configuration_test.rb
@@ -126,6 +126,16 @@ class DotEnvConfigurationTest < ActiveSupport::TestCase
     assert_equal "https:///path", @config.require(:url)
   end
 
+  test "executes commands" do
+    write_env_file_raw("SECRET=$(echo hello)")
+    assert_equal "hello", @config.require(:secret)
+  end
+
+  test "executes commands and interpolates variables" do
+    write_env_file_raw("PREFIX=hello\nSECRET=$(echo world)\nCOMBINED=\${PREFIX}-\${SECRET}")
+    assert_equal "hello-world", @config.require(:combined)
+  end
+
   test "returns empty hash when file does not exist" do
     @config = ActiveSupport::DotEnvConfiguration.new(File.join(@tmpdir, "nonexistent.env"))
     assert_nil @config.option(:anything)

--- a/activesupport/test/dot_env_configuration_test.rb
+++ b/activesupport/test/dot_env_configuration_test.rb
@@ -116,6 +116,16 @@ class DotEnvConfigurationTest < ActiveSupport::TestCase
     assert_equal "localhost", @config.require(:database, :host)
   end
 
+  test "interpolates variables" do
+    write_env_file_raw("DB_HOST=localhost\nDB_PORT=5432\nDATABASE_URL=postgres://\${DB_HOST}:\${DB_PORT}/app")
+    assert_equal "postgres://localhost:5432/app", @config.require(:database_url)
+  end
+
+  test "interpolates missing variables as empty string" do
+    write_env_file_raw("URL=https://\${MISSING}/path")
+    assert_equal "https:///path", @config.require(:url)
+  end
+
   test "returns empty hash when file does not exist" do
     @config = ActiveSupport::DotEnvConfiguration.new(File.join(@tmpdir, "nonexistent.env"))
     assert_nil @config.option(:anything)

--- a/activesupport/test/dot_env_configuration_test.rb
+++ b/activesupport/test/dot_env_configuration_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/dot_env_configuration"
+
+class DotEnvConfigurationTest < ActiveSupport::TestCase
+  setup do
+    @tmpdir = Dir.mktmpdir("dotenv-")
+    @env_file_path = File.join(@tmpdir, ".env")
+  end
+
+  teardown do
+    FileUtils.rm_rf @tmpdir
+  end
+
+  test "require key" do
+    write_env_file("ONE" => "1")
+    assert_equal "1", @config.require(:one)
+  end
+
+  test "require multiword key" do
+    write_env_file("ONE_MORE" => "1")
+    assert_equal "1", @config.require(:one_more)
+  end
+
+  test "require missing key raises key error" do
+    write_env_file({})
+    assert_raises(KeyError) do
+      @config.require(:gone)
+    end
+  end
+
+  test "require missing multiword key raises key error" do
+    write_env_file({})
+    assert_raises(KeyError) do
+      @config.require(:gone, :missing)
+    end
+  end
+
+  test "optional missing key returns nil" do
+    write_env_file({})
+    assert_nil @config.option(:two_is_not_here)
+  end
+
+  test "optional missing multiword key returns nil" do
+    write_env_file({})
+    assert_nil @config.option(:two_is_not_here, :nor_here)
+  end
+
+  test "optional missing key with default value returns default" do
+    write_env_file({})
+    assert_equal "there", @config.option(:two_is_not_here, default: "there")
+  end
+
+  test "optional missing key with default block returns default" do
+    write_env_file({})
+    assert_equal "there", @config.option(:two_is_not_here, default: -> { "there" })
+  end
+
+  test "optional missing key with default block returning false returns false" do
+    write_env_file({})
+    assert_equal false, @config.option(:missing, default: -> { false })
+  end
+
+  test "optional missing key with default block returning nil returns nil" do
+    write_env_file({})
+    assert_nil @config.option(:missing, default: -> { nil })
+  end
+
+  test "optional present key with default block returns value without triggering default" do
+    write_env_file("EXISTS" => "value")
+    called = false
+    assert_equal "value", @config.option(:exists, default: -> { called = true; "default" })
+    assert_equal false, called
+  end
+
+  test "cached reads can be reloaded" do
+    write_env_file("ONE" => "1")
+    assert_equal "1", @config.require(:one)
+
+    File.write(@env_file_path, "ONE=2")
+    assert_equal "1", @config.require(:one)
+
+    @config.reload
+    assert_equal "2", @config.require(:one)
+  end
+
+  test "parses double quoted values" do
+    write_env_file_raw('MESSAGE="hello world"')
+    assert_equal "hello world", @config.require(:message)
+  end
+
+  test "parses single quoted values" do
+    write_env_file_raw("MESSAGE='hello world'")
+    assert_equal "hello world", @config.require(:message)
+  end
+
+  test "parses escaped newlines in double quoted values" do
+    write_env_file_raw('MESSAGE="hello\nworld"')
+    assert_equal "hello\nworld", @config.require(:message)
+  end
+
+  test "ignores comment lines" do
+    write_env_file_raw("# This is a comment\nONE=1")
+    assert_equal "1", @config.require(:one)
+  end
+
+  test "ignores empty lines" do
+    write_env_file_raw("ONE=1\n\nTWO=2")
+    assert_equal "1", @config.require(:one)
+    assert_equal "2", @config.require(:two)
+  end
+
+  test "handles nested keys with double underscore" do
+    write_env_file_raw("DATABASE__HOST=localhost")
+    assert_equal "localhost", @config.require(:database, :host)
+  end
+
+  test "returns empty hash when file does not exist" do
+    @config = ActiveSupport::DotEnvConfiguration.new(File.join(@tmpdir, "nonexistent.env"))
+    assert_nil @config.option(:anything)
+  end
+
+  test "returns empty hash when no path given and Rails is not defined" do
+    @config = ActiveSupport::DotEnvConfiguration.new
+    assert_nil @config.option(:anything)
+  end
+
+  private
+    def write_env_file(attributes)
+      write_env_file_raw(attributes.map { |key, value| "#{key}=#{value}" }.join("\n"))
+    end
+
+    def write_env_file_raw(content)
+      File.write(@env_file_path, content)
+      @config = ActiveSupport::DotEnvConfiguration.new(@env_file_path)
+    end
+end

--- a/activesupport/test/dot_env_configuration_test.rb
+++ b/activesupport/test/dot_env_configuration_test.rb
@@ -111,6 +111,11 @@ class DotEnvConfigurationTest < ActiveSupport::TestCase
     assert_equal "2", @config.require(:two)
   end
 
+  test "allows spaces around =" do
+    write_env_file_raw("ONE = 1")
+    assert_equal "1", @config.require(:one)
+  end
+
   test "handles nested keys with double underscore" do
     write_env_file_raw("DATABASE__HOST=localhost")
     assert_equal "localhost", @config.require(:database, :host)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,5 @@
-*   Add `Rails.app.creds` to provide combined access to credentials stored in either ENV or the encrypted credentials file.
-    Provides a new require/option API for accessing these values. Examples:
+*   Add `Rails.app.creds` to provide combined access to credentials stored in either ENV or the encrypted credentials file,
+    and in development, also .env credentials. Provides a new require/option API for accessing these values. Examples:
 
     ```ruby
     Rails.app.creds.require(:db_host) # ENV.fetch("DB_HOST") || Rails.app.credentials.require(:db_host)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,5 @@
 *   Add `Rails.app.creds` to provide combined access to credentials stored in either ENV or the encrypted credentials file,
-    and in development, also .env credentials. Provides a new require/option API for accessing these values. Examples:
+    and in development also .env credentials. Provides a new require/option API for accessing these values. Examples:
 
     ```ruby
     Rails.app.creds.require(:db_host) # ENV.fetch("DB_HOST") || Rails.app.credentials.require(:db_host)
@@ -14,6 +14,13 @@
     ```ruby
     Rails.app.creds = ActiveSupport::CombinedConfiguration.new(Rails.app.envs, OnePasswordConfiguration.new)
     ```
+
+    *DHH*
+
+*   Add `Rails.app.dotenvs` to provide access to .env variables through symbol-based lookup with explicit methods
+    for required and optional values. This is the same interface offered by #credentials and can be accessed in a combined manner via #creds.
+
+    It supports both variable interpolation with ${VAR} and command interpolation with $(echo "hello"). Otherwise the same as `Rails.app.envs`.
 
     *DHH*
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -544,8 +544,8 @@ module Rails
     #   Rails.app.dotenvs.option(:cache_host) # CACHE_HOST from .env or nil
     #   Rails.app.dotenvs.option(:cache_host, default: "cache-host-1") # CACHE_HOST from .env or "cache-host-1"
     #   Rails.app.dotenvs.option(:cache_host, default: -> { HostProvider.cache }) # CACHE_HOST from .env or HostProvider.cache
-    def dotenvs
-      @dotenvs ||= ActiveSupport::DotEnvConfiguration.new
+    def dotenvs(path = Rails.root.join(".env"))
+      @dotenvs ||= ActiveSupport::DotEnvConfiguration.new(path)
     end
 
     # Returns an ActiveSupport::EncryptedConfiguration instance for the

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -485,10 +485,10 @@ module Rails
 
     # Returns an ActiveSupport::CombinedConfiguration instance that combines
     # access to the encrypted credentials available via #credentials and keys
-    # used for the same purpose in ENV.
+    # used for the same purpose in ENV and .env.
     #
-    # This allows values in the encrypted credentials to be overwritten via ENV and for values to be
-    # moved between the two ways of providing credentials without rewriting application code.
+    # This allows values in the encrypted credentials to be overwritten via ENV or .env and for values to be
+    # moved between the three ways of providing credentials without rewriting application code.
     #
     # Examples:
     #

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -573,7 +573,7 @@ module Rails
     # <tt>config/credentials/#{environment}.key</tt> for the current
     # environment, or +config/master.key+ if that file does not exist.
     #
-    # Is best used via #creds to ensure that values can be overwritten via ENV.
+    # Is best used via #creds to ensure that values can be overwritten via ENV (or .env in dev).
     def credentials
       @credentials ||= encrypted(config.credentials.content_path, key_path: config.credentials.key_path)
     end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -196,6 +196,10 @@ module Rails
       master_key_generator.add_master_key_file_silently
     end
 
+    def env
+      template "env", ".env"
+    end
+
     def credentials
       return if options[:pretend] || options[:dummy_app]
 
@@ -427,7 +431,8 @@ module Rails
         build(:master_key)
       end
 
-      def create_credentials
+      def create_creds
+        build(:env)
         build(:credentials)
         build(:credentials_diff_enroll)
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -197,6 +197,8 @@ module Rails
     end
 
     def env
+      return if options[:pretend] || options[:dummy_app]
+
       template "env", ".env"
     end
 

--- a/railties/lib/rails/generators/rails/app/templates/env.tt
+++ b/railties/lib/rails/generators/rails/app/templates/env.tt
@@ -1,0 +1,8 @@
+# Add local environment variables that will be accessible via `Rails.app.creds` here.
+#
+# This file will not be checked into git by default for security reasons. But if you
+# maintain it exclusively as a list of remote lookups, you could add it by changing .gitignore to allow it.
+# But then you MUST NOT add any explicit keys here!
+#
+# ONLY_SAFE_OUTSIDE_GIT_KEY=secret123
+# SAFE_FOR_GIT_API_KEY=$(op op read "op://vault/item/api-key")

--- a/railties/test/application/creds_test.rb
+++ b/railties/test/application/creds_test.rb
@@ -43,4 +43,20 @@ class Rails::CredsTest < ActiveSupport::TestCase
   ensure
     ENV.delete("MYSTERY")
   end
+
+  test "dotenvs are available only in development mode" do
+    write_credentials_override(:development)
+    write_credentials_override(:production)
+    File.write("#{app_path}/.env", "MYSTERY=dotenv_revealed")
+
+    app("development")
+
+    Rails.env = "development"
+    Rails.app.creds = nil
+    assert_equal "dotenv_revealed", Rails.app.creds.require(:mystery)
+
+    Rails.env = "production"
+    Rails.app.creds = nil
+    assert_equal "revealed", Rails.app.creds.require(:mystery)
+  end
 end

--- a/railties/test/credentials_helpers.rb
+++ b/railties/test/credentials_helpers.rb
@@ -6,7 +6,7 @@ module CredentialsHelpers
   private
     def write_credentials_override(name, with_key: true)
       Dir.chdir(app_path) do
-        Dir.mkdir  "config/credentials"
+        FileUtils.mkdir_p "config/credentials"
         File.write "config/credentials/#{name}.key", credentials_key if with_key
 
         # secret_key_base: secret

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -167,6 +167,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       %w(.gitignore
         .ruby-version
         .dockerignore
+        .env
         README.md
         Gemfile
         Rakefile

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -6,6 +6,7 @@ require "generators/shared_generator_tests"
 
 DEFAULT_APP_FILES = %w(
   .dockerignore
+  .env
   .git
   .gitattributes
   .github/dependabot.yml
@@ -1389,6 +1390,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file ".dockerignore"
     assert_no_file "Dockerfile"
     assert_no_file "bin/docker-entrypoint"
+  end
+
+  def test_env
+    run_generator
+
+    assert_file ".env" do |content|
+      assert_match(/Add local environment variables/, content)
+    end
   end
 
   unless Gem.win_platform?


### PR DESCRIPTION
In addition to ENV and the encrypted file, let's allow `Rails.app.creds` to also access values from .env files in development mode.

This will now be done in the order of 1) ENV, 2) .env, 3) encrypted credentials.

Values can be both interpolated, like:

```
DB_HOST=localhost
DB_PORT=5432
DATABASE_URL=postgres://${DB_HOST}:${DB_PORT}/app 
```

...and use command execution, so you can use third-party credential providers like 1password:

```
DB_HOST=$(op read op://Vault/item/value --account=MyAccount)
```

This adds `ActiveSupport::DotEnvConfiguration` with the same API as `ActiveSupport::EnvConfiguration`.