### PR TITLE
Select only relevant SQL for payload name on eagerload test

### DIFF
--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -48,7 +48,8 @@ module ActiveRecord
     def test_payload_name_on_eager_load
       ActiveRecord::Base.schema_cache.add(Author.table_name)
       notification = capture_notifications("sql.active_record") { Book.eager_load(:author).to_a }
-      assert_equal "Book Eager Load", notification.first.payload[:name]
+        .find { _1.payload[:sql].match?("SELECT") }
+      assert_equal "Book Eager Load", notification.payload[:name]
     end
 
     def test_payload_name_on_destroy


### PR DESCRIPTION
Fixes: #56456

The SQL we are looking for is for the `books` table.

```sql
SELECT "books"."id" AS t0_r0, "books"."author_id" AS t0_r1, "books"."format" AS t0_r2, "books"."format_record_id" AS t0_r3, "books"."format_record_type" AS t0_r4, "books"."name" AS t0_r5, "books"."status" AS t0_r6, "books"."last_read" AS t0_r7, "books"."nullable_status" AS t0_r8, "books"."language" AS t0_r9, "books"."author_visibility" AS t0_r10, "books"."illustrator_visibility" AS t0_r11, "books"."font_size" AS t0_r12, "books"."difficulty" AS t0_r13, "books"."cover" AS t0_r14, "books"."symbol_status" AS t0_r15, "books"."isbn" AS t0_r16, "books"."external_id" AS t0_r17, "books"."original_name" AS t0_r18, "books"."published_on" AS t0_r19, "books"."boolean_status" AS t0_r20, "books"."tags_count" AS t0_r21, "books"."created_at" AS t0_r22, "books"."updated_at" AS t0_r23, "books"."updated_on" AS t0_r24, "authors"."id" AS t1_r0, "authors"."name" AS t1_r1, "authors"."author_address_id" AS t1_r2, "authors"."author_address_extra_id" AS t1_r3, "authors"."organization_id" AS t1_r4, "authors"."owned_essay_id" AS t1_r5, "authors"."published_author_id" AS t1_r6 FROM "books" LEFT OUTER JOIN "authors" ON "authors"."id" = "books"."author_id"
```

But there are other `sql.active_record` notifications which come through, like:

```sql
SHOW max_identifier_length
```

So we just need to filter, like the other tests in this file.