### PR TITLE
[ci skip] Use `/app/models/concerns/` for the `Notifications` concern in Getting Started with Rails

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2455,11 +2455,11 @@ Concern is a Ruby module with some syntactic sugar to make using them easier.
 
 First let’s create the Notifications module.
 
-Create a file at `app/models/product/notifications.rb` with the following:
+Create a file at `app/models/concerns/notifications.rb` with the following:
 
 ```ruby
-# app/models/product/notifications.rb
-module Product::Notifications
+# app/models/concerns/notifications.rb
+module Notifications
   extend ActiveSupport::Concern
 
   included do


### PR DESCRIPTION
### Motivation / Background

**Getting Started with Rails, 16.4 Extracting a Concern** instructs the reader to place the custom `Product::Notifications` concern inside the `/app/models/product/` folder.

I think this is actually a great opportunity to introduce the reader to the dedicated `/app/models/concerns/` directory by creating a `Notifications` concern there instead.

### Detail

This Pull Request changes `guides/source/getting_started.md` section 16.4.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
