### PR TITLE
Add alias for sunday and monday methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -275,6 +275,7 @@ module DateAndTime
     def monday
       beginning_of_week(:monday)
     end
+    alias :previous_or_current_monday :monday
 
     # Returns a new date/time representing the end of this week on the given day.
     # Week is assumed to start on +start_day+, default is
@@ -290,6 +291,7 @@ module DateAndTime
     def sunday
       end_of_week(:monday)
     end
+    alias :next_or_current_sunday :sunday
 
     # Returns a new date/time representing the end of the month.
     # DateTime objects will have a time set to 23:59:59.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to improve the clarity of the `sunday` and `monday` methods in `DateAndTime::Calculations`, which is included by Date class and Time class.

The current method names `sunday` and `monday` do not explicitly convey their behavior - specifically, that `monday` returns previous monday (or current date if today is Monday), and sunday returns next sunday (or current date if today is Sunday). This implicit behavior can be confusing for developers who are unfamiliar with these methods.

### Detail

  This Pull Request adds more descriptive aliases for the existing `sunday` and `monday` methods:

  - `previous_or_current_monday` as an alias for `monday` - makes it clear that the method returns either the previous Monday or the current date if today is Monday
  - `next_or_current_sunday` as an alias for `sunday` - makes it clear that the method returns either the next Sunday or the current date if today is Sunday

  The original method names remain unchanged to maintain backward compatibility. These aliases provide a more explicit and self-documenting alternative for developers who prefer clearer method names.

```.ruby
  # Both return the same result
  date.monday
  date.previous_or_current_monday

  # Both return the same result  
  date.sunday
  date.next_or_current_sunday
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
