### PR TITLE
Fix URL options behavior in integration tests

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -139,7 +139,7 @@ module ActionDispatch
 
       def url_options
         @url_options ||= default_url_options.dup.tap do |url_options|
-          url_options.reverse_merge!(controller.url_options) if controller.respond_to?(:url_options)
+          url_options.merge!(controller.url_options) if controller.respond_to?(:url_options)
 
           if @app.respond_to?(:routes)
             url_options.reverse_merge!(@app.routes.default_url_options)

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -972,7 +972,7 @@ class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
     get "/bar"
     assert_response :success
-    assert_equal "http://foobar.com/foo", foos_url
+    assert_equal "http://bar.com/foo", foos_url
   ensure
     ActionDispatch::Integration::Session.default_url_options = self.default_url_options = original_host
   end


### PR DESCRIPTION
### Motivation / Background

URL options should behave the same in tests as they do in actual Rails applications, but they don't.

### Detail

Controller's default_url_options should take precedence over the application's default_url_options, but Integration::Session#url_options didn't work in that way.

The BarController in the test is defined as follows:

https://github.com/rails/rails/blob/92481359a7f74261059a292a7cea61e68144b57e/actionpack/test/controller/integration_test.rb#L918-L921

So when you call `get "/bar"` in the test, the URL helper methods called after that should use `bar.com` as the host, not `foobar.com`. But, the test was expecting `foobar.com`:

https://github.com/rails/rails/blob/92481359a7f74261059a292a7cea61e68144b57e/actionpack/test/controller/integration_test.rb#L967-L975

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
