### PR TITLE
Bump releaser minitest to 6.x for Ruby 4 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ PATH
   remote: tools/releaser
   specs:
     releaser (1.0.0)
-      minitest
+      minitest (~> 6.0)
       rake (~> 13.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -783,4 +783,4 @@ DEPENDENCIES
   websocket-client-simple
 
 BUNDLED WITH
-   2.7.2
+  4.0.3

--- a/tools/releaser/Gemfile.lock
+++ b/tools/releaser/Gemfile.lock
@@ -2,16 +2,18 @@ PATH
   remote: .
   specs:
     releaser (1.0.0)
-      minitest
+      minitest (~> 6.0)
       rake (~> 13.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     logger (1.7.0)
-    minitest (5.25.1)
+    minitest (6.0.1)
+      prism (~> 1.5)
     net-http (0.6.0)
       uri
+    prism (1.7.0)
     protobug (0.1.0)
     protobug_googleapis_field_behavior_protos (0.1.0)
       protobug (= 0.1.0)
@@ -43,4 +45,4 @@ DEPENDENCIES
   sigstore-cli
 
 BUNDLED WITH
-   2.6.3
+  4.0.2

--- a/tools/releaser/Gemfile.lock
+++ b/tools/releaser/Gemfile.lock
@@ -45,4 +45,4 @@ DEPENDENCIES
   sigstore-cli
 
 BUNDLED WITH
-  4.0.2
+  4.0.3

--- a/tools/releaser/releaser.gemspec
+++ b/tools/releaser/releaser.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency "rake", "~> 13.0"
-  s.add_dependency "minitest"
+  s.add_dependency "minitest", "~> 6.0"
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Ruby 4 CI fails when tools/releaser resolves minitest 5.x, which requires Ruby < 4.0.

### Detail

This Pull Request changes the releaser gemspec to require minitest `~> 6.0` and updates the related lockfiles (`tools/releaser/Gemfile.lock` and the root `Gemfile.lock`) so Ruby 4 can resolve dependencies.

### Additional information

Tests not run locally.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
