### PR TITLE
Override inspect in Combined, Env & Encrypted Configurations

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -2,10 +2,14 @@
     either ENV or encrypted credentials. Used by Rails to first look at ENV, then look in encrypted credentials,
     but can be configured separately with any number of API-compatible backends in a first-look order.
 
-    *DHH*
+    The object is inspect safe and will only show keys, not values.
+
+    *DHH*, *Emmanuel Hayford*
 
 *   Add `ActiveSupport::EnvConfiguration` to provide access to ENV variables in a way that's compatible with
     `ActiveSupport::EncryptedConfiguration` and therefore can be used by `ActiveSupport::CombinedConfiguration`.
+
+    The object is inspect safe and will only show keys, not values.
 
     Examples:
 
@@ -18,7 +22,7 @@
     conf.option(:cache_host, default: -> { "cache-host-1" }) # ENV["CACHE_HOST"] || "cache-host-1"
     ```
 
-    *DHH*
+    *DHH*, *Emmanuel Hayford*
 
 *   Make flaky parallel tests easier to diagnose by deterministically assigning
     tests to workers.

--- a/activesupport/lib/active_support/combined_configuration.rb
+++ b/activesupport/lib/active_support/combined_configuration.rb
@@ -50,5 +50,23 @@ module ActiveSupport
     def reload
       @configurations.each { |config| config.try(:reload) }
     end
+
+    # Returns a unique array of all symbolized keys available across all backend configurations.
+    #
+    # Examples of Rails-configured access:
+    #
+    #   ENV["DB_HOST"] = "localhost"
+    #   Rails.app.credentials # has keys [:secret_key_base, :aws]
+    #
+    #   Rails.app.creds.keys
+    #   # => [:db_host, :secret_key_base, :aws]
+    #
+    def keys
+      @configurations.flat_map(&:keys).uniq
+    end
+
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)} keys=#{keys.inspect}>"
+    end
   end
 end

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -130,8 +130,20 @@ module ActiveSupport
       @config ||= deep_symbolize_keys(deserialize(read))
     end
 
+    # Returns an array of symbolized keys from the decrypted configuration.
+    #
+    #   my_config = ActiveSupport::EncryptedConfiguration.new(...)
+    #   my_config.read # => "some_secret: 123\nsome_namespace:\n  another_secret: 456"
+    #
+    #   my_config.keys
+    #   # => [:some_secret, :some_namespace]
+    #
+    def keys
+      config.keys
+    end
+
     def inspect # :nodoc:
-      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)} keys=#{keys.inspect}>"
     end
 
     private

--- a/activesupport/lib/active_support/env_configuration.rb
+++ b/activesupport/lib/active_support/env_configuration.rb
@@ -53,6 +53,25 @@ module ActiveSupport
       @envs = ENV.to_h
     end
 
+    # Returns an array of symbolized keys from the environment variables.
+    #
+    # Examples:
+    #
+    #   ENV["DB_HOST"] = "localhost"
+    #   ENV["DATABASE_PORT"] = "5432"
+    #
+    #   env_config = ActiveSupport::EnvConfiguration.new
+    #   env_config.keys
+    #   # => [:db_host, :database_port, ...]
+    #
+    def keys
+      @envs.keys.map { |k| k.downcase.to_sym }
+    end
+
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)} keys=#{keys.inspect}>"
+    end
+
     private
       def lookup(env_key)
         @envs[env_key]

--- a/activesupport/test/combined_configuration_test.rb
+++ b/activesupport/test/combined_configuration_test.rb
@@ -80,4 +80,17 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
       @combined.require(:gone, :missing)
     end
   end
+
+  test "inspect does not show configuration values but shows keys as symbols" do
+    secret_env_value = "secret_env_value"
+    ENV["SECRET_ENV"] = secret_env_value
+    @envs.reload
+
+    assert_no_match(/#{secret_env_value}/, @combined.inspect)
+    assert_match(/keys=/, @combined.inspect)
+    assert_match(/:secret_env/, @combined.inspect)
+    assert_match(/\A#<ActiveSupport::CombinedConfiguration:0x[0-9a-f]+ keys=\[.*\]>\z/, @combined.inspect)
+  ensure
+    ENV.delete("SECRET_ENV")
+  end
 end

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -133,13 +133,14 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_raise(KeyError) { @credentials.something! }
   end
 
-  test "inspect does not show unencrypted attributes" do
+  test "inspect does not show unencrypted attributes but shows keys" do
     secret = "something secret"
     @credentials.write({ secret: secret }.to_yaml)
     @credentials.config
 
     assert_no_match(/#{secret}/, @credentials.inspect)
-    assert_match(/\A#<ActiveSupport::EncryptedConfiguration:0x[0-9a-f]+>\z/, @credentials.inspect)
+    assert_match(/keys=\[:secret\]/, @credentials.inspect)
+    assert_match(/\A#<ActiveSupport::EncryptedConfiguration:0x[0-9a-f]+ keys=\[.*\]>\z/, @credentials.inspect)
   end
 
   test "require key" do

--- a/activesupport/test/env_configuration_test.rb
+++ b/activesupport/test/env_configuration_test.rb
@@ -76,6 +76,15 @@ class EnvConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "inspect does not show ENV variable values but shows keys as symbols" do
+    secret = "something_secret"
+    set_env("SECRET_TOKEN" => secret) do
+      assert_no_match(/#{secret}/, @config.inspect)
+      assert_match(/keys=.*:secret_token/, @config.inspect)
+      assert_match(/\A#<ActiveSupport::EnvConfiguration:0x[0-9a-f]+ keys=\[.*\]>\z/, @config.inspect)
+    end
+  end
+
   private
     def set_env(attributes)
       attributes.each do |key, value|


### PR DESCRIPTION
Previously, inspecting CombinedConfiguration and EnvConfiguration,
would expose all sensitive data including ENV 
variables, credentials and internal object state. This poses a security 
risk when objects are displayed in console, logs, or error messages.

Before:
```ruby
    Rails.app.creds
    #<ActiveSupport::CombinedConfiguration:0x0000000122b45870
     @configurations=[
       #<ActiveSupport::EnvConfiguration:0x0000000122b465b8
        @envs={"SOME_SECRET" => "secret_value", "DATABASE_URL" => "postgresql://user:pass@host/db", ...}>,
       #<ActiveSupport::EncryptedConfiguration:0x00000000007af0>]>
```
All sensitive values were exposed in the output, making it easy to 
accidentally leak secrets in logs or error reports.

After:
```ruby
    Rails.app.creds
    #<ActiveSupport::CombinedConfiguration:0x00000000006490 keys=[:rails_env, :some_secret, ..., :secret_key_base, :stripe_webhook_secret]>

    Rails.app.credentials
    #<ActiveSupport::EncryptedConfiguration:0x00000000008cd0 keys=[:secret_key_base, :stripe_webhook_secret]>

    Rails.app.envs
    #<ActiveSupport::EnvConfiguration:0x0000000000a6a0 keys=[:rails_env, :some_secret, :path, :home, ...]>
```
Now only key names are shown, displayed as symbols (in EncryptedConfiguration too) to match how they're 
accessed in code.

cc: @dhh 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
