### PR TITLE
Add `ActionDispatch::Request#bearer_token` to extract the bearer token

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `ActionDispatch::Request#bearer_token` to extract the bearer token from the Authorization header.
+    Bearer tokens are commonly used for API and MCP requests.
+
+    *DHH*
+
 *   Add block support to `ActionController::Parameters#merge`
 
     `ActionController::Parameters#merge` now accepts a block to resolve conflicts,

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -469,6 +469,11 @@ module ActionDispatch
       get_header("REDIRECT_X_HTTP_AUTHORIZATION")
     end
 
+    # Returns the bearer token embedded in the authorization header or nil if missing.
+    def bearer_token
+      authorization.to_s[/\ABearer (.+)\z/, 1]
+    end
+
     # True if the request came from localhost, 127.0.0.1, or ::1.
     def local?
       LOCALHOST.match?(remote_addr) && LOCALHOST.match?(remote_ip)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1503,6 +1503,38 @@ class RequestSession < BaseRequestTest
   end
 end
 
+class RequestBearerToken < BaseRequestTest
+  test "bearer_token returns token from Authorization header" do
+    request = stub_request("HTTP_AUTHORIZATION" => "Bearer my-secret-token")
+    assert_equal "my-secret-token", request.bearer_token
+  end
+
+  test "bearer_token returns nil when no Authorization header" do
+    request = stub_request
+    assert_nil request.bearer_token
+  end
+
+  test "bearer_token returns nil when Authorization header is not Bearer" do
+    request = stub_request("HTTP_AUTHORIZATION" => "Basic dXNlcjpwYXNzd29yZA==")
+    assert_nil request.bearer_token
+  end
+
+  test "bearer_token handles empty Authorization header" do
+    request = stub_request("HTTP_AUTHORIZATION" => "")
+    assert_nil request.bearer_token
+  end
+
+  test "bearer_token handles Bearer with no token" do
+    request = stub_request("HTTP_AUTHORIZATION" => "Bearer ")
+    assert_nil request.bearer_token
+  end
+
+  test "bearer_token returns token via X-HTTP_AUTHORIZATION header" do
+    request = stub_request("X-HTTP_AUTHORIZATION" => "Bearer my-secret-token")
+    assert_equal "my-secret-token", request.bearer_token
+  end
+end
+
 class RequestCacheControlDirectives < BaseRequestTest
   test "lazily initializes cache_control_directives" do
     request = stub_request


### PR DESCRIPTION
Add `ActionDispatch::Request#bearer_token` to extract the bearer token from the Authorization header. Bearer tokens are commonly used for API and MCP requests.