### PR TITLE
Add LeakChecker to tools and fail on ENV leaks

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -266,6 +266,10 @@ module ActionView
         end
       end
 
+      def after_setup
+        @__setup_ivars = instance_variables << :@__setup_ivars
+      end
+
       def setup_with_controller
         controller_class = Class.new(ActionView::TestCase::TestController)
         @controller = controller_class.new
@@ -399,7 +403,7 @@ module ActionView
       ]
 
       def _user_defined_ivars
-        instance_variables - INTERNAL_IVARS
+        instance_variables - INTERNAL_IVARS - @__setup_ivars
       end
 
       # Returns a Hash of instance variables and their values, as defined by

--- a/railties/test/application/zeitwerk_checker_test.rb
+++ b/railties/test/application/zeitwerk_checker_test.rb
@@ -5,6 +5,7 @@ require "rails/zeitwerk_checker"
 
 class ZeitwerkCheckerTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
+  teardown :teardown_app
 
   def setup
     build_app

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -104,11 +104,11 @@ module TestHelpers
   module Generation
     # Build an application by invoking the generator and going through the whole stack.
     def build_app(options = {})
-      @prev_rails_app_class = Rails.app_class
-      @prev_rails_application = Rails.application
+      @prev_rails_app_class ||= Rails.app_class
+      @prev_rails_application ||= Rails.application
       Rails.app_class = Rails.application = nil
 
-      @prev_rails_env = ENV["RAILS_ENV"]
+      @prev_rails_env ||= ENV["RAILS_ENV"]
       ENV["RAILS_ENV"] = "development"
 
       FileUtils.rm_rf(app_path)

--- a/railties/test/isolation/test_helpers_test.rb
+++ b/railties/test/isolation/test_helpers_test.rb
@@ -5,6 +5,7 @@ require "isolation/abstract_unit"
 module TestHelpersTests
   class GenerationTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
+    teardown :teardown_app
 
     def test_build_app
       build_app

--- a/tools/support/leak_checker.rb
+++ b/tools/support/leak_checker.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module LeakChecker
+  # These keys are out of our control.
+  # Either added by the system or by other libraries.
+  ALLOWED_KEYS = %w[
+    VIPSHOME
+  ]
+
+  def before_setup
+    @__leak_checker_before_env = ENV.to_h
+    super
+  end
+
+  def after_teardown
+    super
+
+    after = ENV.to_h
+    before = @__leak_checker_before_env
+
+    ALLOWED_KEYS.each do |k|
+      after.delete(k)
+      before.delete(k)
+    end
+
+    if after != before
+      message = +"Environment leak detected:\n"
+      added_keys = after.keys - before.keys
+      unless added_keys.empty?
+        message << "  - Added variables:\n"
+        added_keys.each do |k|
+          message << "    - #{k}"
+        end
+      end
+
+      removed_keys = before.keys - after.keys
+      unless removed_keys.empty?
+        message << "  - Removed variables:\n"
+        removed_keys.each do |k|
+          message << "    - #{k}"
+        end
+      end
+
+      changed_keys = (before.keys & after.keys).select { |k| before[k] != after[k] }
+      unless changed_keys.empty?
+        message << "  - Changed variables:\n"
+        changed_keys.each do |k|
+          message << "    - #{k} from #{before[k].inspect} to #{after[k].inspect}"
+        end
+      end
+
+      flunk message
+    end
+  end
+end

--- a/tools/test_common.rb
+++ b/tools/test_common.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "support/leak_checker"
+
 ActiveSupport::TestCase.alias_method :force_skip, :skip
 
 ENV["RAILS_TEST_EXECUTABLE"] = "bin/test"
@@ -20,3 +22,5 @@ if ENV["BUILDKITE"]
   end
   ActiveSupport::TestCase.include(DisableSkipping)
 end
+
+ActiveSupport::TestCase.prepend(LeakChecker)


### PR DESCRIPTION
This adds some support for detecting leaked env vars to our test suite, and fixes any detected cases.

I was debugging this error from a flakey test:
https://buildkite.com/rails/rails/builds/125076#019b624d-1383-4554-97f3-296c60ddeff4/L1729

```
Error:
InfoControllerTest#test_info_controller_returns_fuzzy_matches_for_route_paths:
ArgumentError: `secret_key_base` for test environment must be a type of String`
    lib/rails/application/configuration.rb:559:in `secret_key_base='
    lib/rails/application/configuration.rb:543:in `secret_key_base'
    lib/rails/application.rb:482:in `secret_key_base'
    lib/rails/application.rb:325:in `env_config'
bin/test railties/test/rails_info_controller_test.rb:207
```

First, I thought it might be something leaking `SECRET_KEY_BASE` or `SECRET_KEY_BASE_DUMMY`, but ended up digging this hole instead.

Inspired by Ruby's [leakchecker](https://github.com/ruby/ruby/blob/master/tool/lib/leakchecker.rb) if only in spirit, but at least wanted to put this up to get feedback. :bow: