### PR TITLE
Improve grammar and punctuation in EncryptedConfiguration docs

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -58,7 +58,7 @@ module ActiveSupport
       @options = nil
     end
 
-    # Find the referenced key
+    # Find the referenced key.
     # Raises +KeyError+ if not found.
     #
     # Examples:
@@ -75,8 +75,8 @@ module ActiveSupport
       end
     end
 
-    # Find a upcased and double-underscored-joined string-version of the +key+ in ENV.
-    # Returns nil if the key isn't found or the value of default when passed If default is
+    # Find an upcased and double-underscored-joined string-version of the +key+ in ENV.
+    # Returns nil if the key isn't found or the value of default when passed. If default is
     # a block, it's called first.
     #
     # Examples:


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because there are a couple of errors in the documentation of `ActiveSupport::EncryptedConfiguration` which #56404 added.

### Detail
This Pull Request changes

1. ~~"Find" to "Finds", "Reload" to "Reloads", given an example in [guidelines](https://guides.rubyonrails.org/api_documentation_guidelines.html#wording)~~
1. "a upcased" to "an upcased"
1. punctuation where missing

Edit: Dropped s/Find/Finds/ and s/Reload/Reloads/ on second thought as it's less relevant than the others, i.e. DotEnvConfiguration and EnvConfiguration contain the same expressions and I thought it's rather good to keep them as they are, than to move on to edit them all. Let me propose that s/a/an/ and punctuation be fixed

Edit 2: Pushed again to rerun CI hoping it might get over seemingly random failure, then it failed again. Sorry but let me leave it as it is.

### Checklist
Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
