### PR TITLE
Remove deprecated fetch cast type

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -252,11 +252,8 @@ module ActiveRecord
 
       def _default_attributes # :nodoc:
         @default_attributes ||= begin
-          # TODO: Remove the need for a connection after we release 8.1.
-          attributes_hash = with_connection do |connection|
-            columns_hash.transform_values do |column|
-              ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
-            end
+          attributes_hash = columns_hash.transform_values do |column|
+            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(nil, column))
           end
 
           attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
@@ -312,7 +309,6 @@ module ActiveRecord
         end
 
         def type_for_column(connection, column)
-          # TODO: Remove the need for a connection after we release 8.1.
           hook_attribute_type(column.name, super)
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -679,8 +679,7 @@ module ActiveRecord
 
             columns.map do |name, column|
               if fixture.key?(name)
-                # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-                with_yaml_fallback(column.fetch_cast_type(self).serialize(fixture[name]))
+                with_yaml_fallback(column.cast_type.serialize(fixture[name]))
               else
                 default_insert_value(column)
               end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -218,10 +218,9 @@ module ActiveRecord
         end
       end
 
-      private
-        def lookup_cast_type(sql_type)
-          type_map.lookup(sql_type)
-        end
+      def lookup_cast_type(sql_type) # :nodoc:
+        type_map.lookup(sql_type)
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -146,9 +146,7 @@ module ActiveRecord
         if value.is_a?(Proc)
           value.call
         else
-          # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-          cast_type = column.fetch_cast_type(self)
-          value = cast_type.serialize(value)
+          value = column.cast_type.serialize(value)
           quote(value)
         end
       end
@@ -210,11 +208,6 @@ module ActiveRecord
         comment
       end
 
-      def lookup_cast_type(sql_type) # :nodoc:
-        # TODO: Make this method private after we release 8.1.
-        type_map.lookup(sql_type)
-      end
-
       def type_casted_binds(binds) # :nodoc:
         binds&.map do |value|
           if ActiveModel::Attribute === value
@@ -224,6 +217,11 @@ module ActiveRecord
           end
         end
       end
+
+      private
+        def lookup_cast_type(sql_type)
+          type_map.lookup(sql_type)
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -108,10 +108,6 @@ module ActiveRecord
       def aliased_types(name, fallback)
         "timestamp" == name ? :datetime : fallback
       end
-
-      def fetch_cast_type(connection)
-        cast_type
-      end
     end
 
     AddColumnDefinition = Struct.new(:column) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -85,8 +85,7 @@ module ActiveRecord
 
         def schema_default(column)
           return unless column.has_default?
-          # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-          type = column.fetch_cast_type(@connection)
+          type = column.cast_type
           default = type.deserialize(column.default)
           if default.nil?
             schema_expression(column)

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class Column
       include Deduplicable
 
-      attr_reader :name, :default, :sql_type_metadata, :null, :default_function, :collation, :comment
+      attr_reader :name, :default, :sql_type_metadata, :null, :default_function, :collation, :comment, :cast_type
 
       delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
 
@@ -26,11 +26,6 @@ module ActiveRecord
         @default_function = default_function
         @collation = collation
         @comment = comment
-      end
-
-      def fetch_cast_type(connection) # :nodoc:
-        # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-        @cast_type || connection.lookup_cast_type(sql_type)
       end
 
       def has_default?
@@ -109,9 +104,6 @@ module ActiveRecord
       def virtual?
         false
       end
-
-      protected
-        attr_reader :cast_type
 
       private
         def deduplicated

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -160,8 +160,7 @@ module ActiveRecord
           elsif column.type == :uuid && value.is_a?(String) && value.include?("()")
             value # Does not quote function default values for UUID columns
           elsif column.respond_to?(:array?)
-            # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-            quote(column.fetch_cast_type(self).serialize(value))
+            quote(column.cast_type.serialize(value))
           else
             super
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -680,8 +680,7 @@ module ActiveRecord
                 column_options[:stored] = column.virtual_stored?
                 column_options[:type] = column.type
               elsif column.has_default?
-                # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-                default = column.fetch_cast_type(self).deserialize(column.default)
+                default = column.cast_type.deserialize(column.default)
                 default = -> { column.default_function } if default.nil?
 
                 unless column.auto_increment?

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -641,8 +641,7 @@ module ActiveRecord
         end
 
         def type_for_column(connection, column)
-          # TODO: Remove the need for a connection after we release 8.1.
-          type = column.fetch_cast_type(connection)
+          type = column.cast_type
 
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
             type = type.to_immutable_string

--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -18,10 +18,7 @@ module ActiveRecord
 
         if schema_cache.data_source_exists?(table_name)
           column = schema_cache.columns_hash(table_name)[attr_name.to_s]
-          if column
-            # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-            type = column.fetch_cast_type(@klass.lease_connection)
-          end
+          type = column.cast_type if column
         end
 
         type || Type.default_value

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -118,28 +118,6 @@ module ActiveRecord
         end
       end
 
-      def test_yaml_load_8_0_dump_without_cast_type_still_get_the_right_one
-        cache = load_bound_reflection(schema_dump_8_0_path)
-
-        if current_adapter?(:PostgreSQLAdapter)
-          assert_queries_count(include_schema: true) do
-            columns = cache.columns_hash("courses")
-            assert_equal 3, columns.size
-            cast_type = columns["name"].fetch_cast_type(@connection)
-            assert_not_nil cast_type, "expected cast_type to be present"
-            assert_equal :string, cast_type.type
-          end
-        else
-          assert_no_queries do
-            columns = cache.columns_hash("courses")
-            assert_equal 3, columns.size
-            cast_type = columns["name"].fetch_cast_type(@connection)
-            assert_not_nil cast_type, "expected cast_type to be present"
-            assert_equal :string, cast_type.type
-          end
-        end
-      end
-
       def test_primary_key_for_existent_table
         assert_equal "id", @cache.primary_keys("courses")
       end
@@ -358,10 +336,6 @@ module ActiveRecord
         def schema_dump_5_1_path
           "#{ASSETS_ROOT}/schema_dump_5_1.yml"
         end
-
-        def schema_dump_8_0_path
-          "#{ASSETS_ROOT}/schema_dump_8_0.yml"
-        end
     end
 
     module DumpAndLoadTests
@@ -393,7 +367,7 @@ module ActiveRecord
 
           assert_no_queries(include_schema: true) do
             assert_equal 3, cache.columns("courses").size
-            assert_equal 3, cache.columns("courses").map { |column| column.fetch_cast_type(@pool.lease_connection) }.compact.size
+            assert_equal 3, cache.columns("courses").map { |column| column.cast_type }.compact.size
             assert_equal 3, cache.columns_hash("courses").size
             assert cache.data_source_exists?("courses")
             assert_equal "id", cache.primary_keys("courses")
@@ -417,7 +391,7 @@ module ActiveRecord
 
           assert_no_queries(include_schema: true) do
             assert_equal 3, cache.columns(@pool, "courses").size
-            assert_equal 3, cache.columns(@pool, "courses").map { |column| column.fetch_cast_type(@pool.lease_connection) }.compact.size
+            assert_equal 3, cache.columns(@pool, "courses").map { |column| column.cast_type }.compact.size
             assert_equal 3, cache.columns_hash(@pool, "courses").size
             assert cache.data_source_exists?(@pool, "courses")
             assert_equal "id", cache.primary_keys(@pool, "courses")
@@ -429,7 +403,7 @@ module ActiveRecord
 
           assert_no_queries(include_schema: true) do
             assert_equal 3, cache.columns("courses").size
-            assert_equal 3, cache.columns("courses").map { |column| column.fetch_cast_type(@pool.lease_connection) }.compact.size
+            assert_equal 3, cache.columns("courses").map { |column| column.cast_type }.compact.size
             assert_equal 3, cache.columns_hash("courses").size
             assert cache.data_source_exists?("courses")
             assert_equal "id", cache.primary_keys("courses")

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -70,8 +70,8 @@ module ActiveRecord
         five = columns.detect { |c| c.name == "five" } unless mysql
 
         assert_equal "hello", one.default
-        assert_equal true, two.fetch_cast_type(connection).deserialize(two.default)
-        assert_equal false, three.fetch_cast_type(connection).deserialize(three.default)
+        assert_equal true, two.cast_type.deserialize(two.default)
+        assert_equal false, three.cast_type.deserialize(three.default)
         assert_equal 1, four.default
         assert_equal "hello", five.default unless mysql
       end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -195,7 +195,7 @@ module ActiveRecord
 
         old_columns = connection.columns(TestModel.table_name)
         assert old_columns.find { |c|
-          default = c.fetch_cast_type(connection).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
 
@@ -203,11 +203,11 @@ module ActiveRecord
         new_columns = connection.columns(TestModel.table_name)
 
         assert_not new_columns.find { |c|
-          default = c.fetch_cast_type(connection).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
         assert new_columns.find { |c|
-          default = c.fetch_cast_type(connection).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == false
         }
         change_column :test_models, :approved, :boolean, default: true


### PR DESCRIPTION
found these todos from @rafaelfranca .

Now that Rails 8.1 is released, all schema cache dumps include the cast_type attribute, so we no longer need to fall back to fetching it from the connection.