### PR TITLE
Fix SchemaDumper ignoring `default: nil` for non auto-increment PK on Sqlite3 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -23,7 +23,7 @@ module ActiveRecord
           end
 
           def explicit_primary_key_default?(column)
-            column.bigint?
+            column.bigint? || (column.type == :integer && !column.auto_increment?)
           end
 
           def prepare_column_options(column)

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -464,6 +464,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  if current_adapter?(:SQLite3Adapter)
+    def test_schema_dump_includes_default_null_for_non_autoincrement_integer_pk
+      output = dump_table_schema "integer_pk_with_default_null"
+      assert_match %r{create_table "integer_pk_with_default_null".*(, default: nil)}, output
+    end
+  end
+
   def test_schema_dump_keeps_large_precision_integer_columns_as_decimal
     output = standard_dump
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -466,8 +466,23 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   if current_adapter?(:SQLite3Adapter)
     def test_schema_dump_includes_default_null_for_non_autoincrement_integer_pk
+      original, $stdout = $stdout, StringIO.new
+
+      migration = Class.new(ActiveRecord::Migration::Current) do
+        def up
+          create_table :integer_pk_with_default_null, id: :integer, default: nil
+        end
+        def down
+          drop_table(:integer_pk_with_default_null)
+        end
+      end
+      migration.migrate(:up)
+
       output = dump_table_schema "integer_pk_with_default_null"
       assert_match %r{create_table "integer_pk_with_default_null".*(, default: nil)}, output
+    ensure
+      migration.migrate(:down)
+      $stdout = original
     end
   end
 

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -19,6 +19,4 @@ ActiveRecord::Schema.define do
 
 "
     end
-
-  create_table :integer_pk_with_default_null, id: :integer, default: nil
 end

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -19,4 +19,6 @@ ActiveRecord::Schema.define do
 
 "
     end
+
+  create_table :integer_pk_with_default_null, id: :integer, default: nil
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because currently SchemaDumper is ignoring `default: nil` for non auto-increment primary keys on Sqlite3 adapter. 

### Detail

This Pull Request changes `SchemaDumper` for Sqlite3 to ensure `default: nil` is added when the PK is an **integer** and is **not auto-increment**.

### Additional information

Closes #56485

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
