### PR TITLE
Ensure version_manager_ruby_version tests work in rbenv/rvm environments

### DIFF
--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -56,8 +56,10 @@ module Rails
         klass = make_builder_class
         generator = klass.start(["new", "blah"])
 
-        switch_env "rvm_ruby_string", "ruby-3.4.0" do
-          assert_equal "ruby-3.4.0", generator.send(:version_manager_ruby_version)
+        switch_env "RBENV_VERSION", nil do
+          switch_env "rvm_ruby_string", "ruby-3.4.0" do
+            assert_equal "ruby-3.4.0", generator.send(:version_manager_ruby_version)
+          end
         end
       end
 
@@ -65,9 +67,14 @@ module Rails
         klass = make_builder_class
         generator = klass.start(["new", "blah"])
 
-        stub_const(Object, :RUBY_ENGINE, "ruby") do
-          Gem.stub(:ruby_version, Gem::Version.new("3.4.0")) do
-            assert_equal "ruby-3.4.0", generator.send(:version_manager_ruby_version)
+
+        switch_env "RBENV_VERSION", nil do
+          switch_env "rvm_ruby_string", nil do
+            stub_const(Object, :RUBY_ENGINE, "ruby") do
+              Gem.stub(:ruby_version, Gem::Version.new("3.4.0")) do
+                assert_equal "ruby-3.4.0", generator.send(:version_manager_ruby_version)
+              end
+            end
           end
         end
       end
@@ -76,9 +83,13 @@ module Rails
         klass = make_builder_class
         generator = klass.start(["new", "blah"])
 
-        stub_const(Object, :RUBY_ENGINE, "ruby") do
-          Gem.stub(:ruby_version, Gem::Version.new("4.0.0.preview2")) do
-            assert_equal "ruby-4.0.0-preview2", generator.send(:version_manager_ruby_version)
+        switch_env "RBENV_VERSION", nil do
+          switch_env "rvm_ruby_string", nil do
+            stub_const(Object, :RUBY_ENGINE, "ruby") do
+              Gem.stub(:ruby_version, Gem::Version.new("4.0.0.preview2")) do
+                assert_equal "ruby-4.0.0-preview2", generator.send(:version_manager_ruby_version)
+              end
+            end
           end
         end
       end
@@ -87,9 +98,13 @@ module Rails
         klass = make_builder_class
         generator = klass.start(["new", "blah"])
 
-        stub_const(Object, :RUBY_ENGINE, "jruby") do
-          stub_const(Object, :RUBY_ENGINE_VERSION, "10.0.2.0") do
-            assert_equal "jruby-10.0.2.0", generator.send(:version_manager_ruby_version)
+        switch_env "RBENV_VERSION", nil do
+          switch_env "rvm_ruby_string", nil do
+            stub_const(Object, :RUBY_ENGINE, "jruby") do
+              stub_const(Object, :RUBY_ENGINE_VERSION, "10.0.2.0") do
+                assert_equal "jruby-10.0.2.0", generator.send(:version_manager_ruby_version)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Follow up to #56365

These tests would fail when run locally if using rbenv, and presumably rvm.

```
$ bin/test test/generators/generator_test.rb

Failure:
Rails::Generators::GeneratorTest#test_version_manager_ruby_version_with_mri_ruby [test/generators/generator_test.rb:70]:
Expected: "ruby-3.4.0"
  Actual: "4.1.0"

bin/test test/generators/generator_test.rb:64

Failure:
Rails::Generators::GeneratorTest#test_version_manager_ruby_version_with_mri_ruby_prerelease [test/generators/generator_test.rb:81]:
Expected: "ruby-4.0.0-preview2"
  Actual: "4.1.0"

bin/test test/generators/generator_test.rb:75

Failure:
Rails::Generators::GeneratorTest#test_version_manager_ruby_version_with_rvm_env_var [test/generators/generator_test.rb:60]:
Expected: "ruby-3.4.0"
  Actual: "4.1.0"

bin/test test/generators/generator_test.rb:55

Failure:
Rails::Generators::GeneratorTest#test_version_manager_ruby_version_with_non_mri_ruby [test/generators/generator_test.rb:92]:
Expected: "jruby-10.0.2.0"
  Actual: "4.1.0"

bin/test test/generators/generator_test.rb:86

Finished in 0.004560s, 1535.2500 runs/s, 2851.1786 assertions/s.
7 runs, 13 assertions, 4 failures, 0 errors, 0 skips
```