### PR TITLE
[ci skip] [docs] Mark Exception#as_json as nodoc

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -260,7 +260,7 @@ class Process::Status # :nodoc:
   end
 end
 
-class Exception
+class Exception # :nodoc:
   def as_json(options = nil)
     to_s
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

  This Pull Request has been created because `Exception#as_json` in Active Support's core extensions is not intended to be exposed as a public API. This method is an internal implementation detail used by `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` and is not intended for direct use by application developers.

  Similar to other `as_json` implementations like `Object#as_json`, which are already marked as `:nodoc:`, this interface should be hidden from the public API documentation.

### Detail

This Pull Request marks `Exception#as_json` as `:nodoc:` in Active Support's core extensions.

  Since `as_json` is the only interface defined for the `Exception` class in core_ext, and `Exception` extensions in core_ext are not intended to provide public extension points,, the entire `Exception` extension has been marked as `:nodoc:`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

- `Exception#as_json` was introduced in https://github.com/rails/rails/pull/23702 as part of a fix for JSON encoding behavior
- This change is documentation-only and does not affect the runtime behavior of the code

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
