### PR TITLE
Add Rails.app.revision

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -538,6 +538,20 @@ Enables or disables reloading of classes only when tracked files change. By defa
 
 Causes the app to not boot if a master key hasn't been made available through `ENV["RAILS_MASTER_KEY"]` or the `config/master.key` file.
 
+#### `config.revision`
+
+Sets the application revision for deployment tracking and error reporting. Can be a string or a proc.
+When not set, Rails first tries reading from a `REVISION` file in the application root, and if absent
+it attempts to get the current commit from the local git repository (default: `nil`).
+
+```ruby
+config.revision = ENV["GIT_SHA"]
+# or
+config.revision = -> { File.read("BUILD_ID").strip }
+```
+
+Revision can be accessed via `Rails.app.revision`.
+
 #### `config.sandbox_by_default`
 
 When `true`, rails console starts in sandbox mode. To start rails console in non-sandbox mode, `--no-sandbox` must be specified. This is helpful to avoid accidental writing to the production database. Defaults to `false`.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add `Rails.app.revision` to provide a version identifier for error reporting, monitoring, cache keys, etc.
+
+    ```ruby
+    Rails.app.revision # => "3d31d593e6cf0f82fa9bd0338b635af2f30d627b"
+    ```
+
+    By defaults it looks for a `REVISION` file at the root of the application, if absent it tries to extract
+    the revision from the local git repository.
+
+    If none of that is adequate, it can be set in the application config:
+
+    ```ruby
+    # config/application.rb
+    module MyApp
+      class Application < Rails::Application
+        config.revision = ENV["GIT_SHA"]
+      end
+    end
+    ```
+
+    *Abdelkader Boudih*, *Jean Boussier*
+
 *   Add `Rails.app.creds` to provide combined access to credentials stored in either ENV or the encrypted credentials file,
     and in development also .env credentials. Provides a new require/option API for accessing these values. Examples:
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -63,12 +63,20 @@ module Rails
         end
       end
 
-      initializer :initialize_error_reporter, group: :all do
+      initializer :initialize_error_reporter, group: :all do |app|
         if config.consider_all_requests_local
           Rails.error.debug_mode = true
         else
           Rails.error.logger = Rails.logger
         end
+
+        Rails.error.add_middleware(->(error, context) {
+          context[:rails] ||= {
+            version: Rails::VERSION::STRING,
+            app_revision: app.revision,
+            environment: Rails.env.to_s,
+          }
+        })
       end
 
       initializer :initialize_event_reporter, group: :all do

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -566,6 +566,10 @@ module Rails
         end
       end
 
+      def revision=(val)
+        Rails.application.revision = val
+      end
+
       # Specifies what class to use to store the session. Possible values
       # are +:cache_store+, +:cookie_store+, +:mem_cache_store+, a custom
       # store, or +:disabled+. +:disabled+ tells \Rails not to deal with

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -93,6 +93,11 @@ module Rails
       Rails.env
     end
 
+    # The application's revision (deployment identifier)
+    property "Application revision" do
+      Rails.app.revision
+    end
+
     # The name of the database adapter for the current environment.
     property "Database adapter" do
       ActiveRecord::Base.connection_pool.db_config.adapter

--- a/railties/test/application/app_revision_test.rb
+++ b/railties/test/application/app_revision_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class AppVersionTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    test "Rails.app.revision returns nil by default" do
+      Dir.chdir(app_path) do
+        require "#{app_path}/config/environment"
+        assert_nil Rails.app.revision
+      end
+    end
+
+    test "revision reads from REVISION file when present" do
+      File.write("#{app_path}/REVISION", "abc123def456")
+      require "#{app_path}/config/environment"
+      assert_equal "abc123def456", Rails.app.revision
+    end
+
+    test "revision can be set via config.revision string" do
+      add_to_config <<-RUBY
+        config.revision = "deploy-123"
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "deploy-123", Rails.app.revision
+    end
+
+    test "revision can be set via config.revision proc" do
+      add_to_config <<-RUBY
+        config.revision = -> { "proc-456" }
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "proc-456", Rails.app.revision
+    end
+
+    test "config.revision takes precedence over REVISION file" do
+      File.write("#{app_path}/REVISION", "file-revision")
+
+      add_to_config <<-RUBY
+        config.revision = "config-wins"
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "config-wins", Rails.app.revision
+    end
+
+    test "Rails::Info includes revision when present" do
+      File.write("#{app_path}/REVISION", "deadbeef123")
+
+      require "#{app_path}/config/environment"
+
+      assert_equal "deadbeef123", Rails::Info.properties.value_for("Application revision")
+    end
+  end
+end


### PR DESCRIPTION
Useful in many context, deployment tracking, error reporting, monitoring, even sometimes in cache keys.

Fix: https://github.com/rails/rails/pull/56080

Co-Authored-By: @seuros 