### PR TITLE
Add STI guide note about non-abstract base classes

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1777,6 +1777,10 @@ Here, the `type` field is crucial for STI as it stores the model name (`Car`,
 `Motorcycle`, or `Bicycle`). STI requires this field to differentiate between
 the different models stored in the same table.
 
+NOTE: The STI base class must not be declared as an abstract class. If
+`abstract_class = true` is set on the parent model, Active Record will not
+apply STI semantics, and the `type` column will not be set automatically.
+
 ### Generating Child Models
 
 Next, we generate the `Car`, `Motorcycle`, and `Bicycle` models that inherit


### PR DESCRIPTION
Clarify in the Single Table Inheritance guide that the parent model must not be declared as an abstract class.

### Motivation / Background

This pull request has been created because STI silently breaks when the parent model is declared as an abstract class. In that case, Active Record does not apply STI semantics and does not automatically populate the `type` column, which can be confusing and difficult to diagnose. The current guide does not document this constraint, making the misconfiguration easy to introduce.

### Detail

This pull request adds a note to the Single Table Inheritance guide clarifying that the STI base class must not be declared as an abstract class.

### Additional information

This change is documentation-only-

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
