### PR TITLE
Fix capitalization in Active Record Basics guide

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -541,7 +541,7 @@ book = Book.find_by(title: "The Lord of the Rings")
 book.update(title: "The Lord of the Rings: The Fellowship of the Ring")
 ```
 
-the `update` results in the following SQL:
+The `update` results in the following SQL:
 
 ```sql
 /* Note that `updated_at` is automatically set. */


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
I noticed a grammatical inconsistency in the Active Record Basics guide.

### Detail
In the `### Update` section, the introductory sentence started with a lowercase "t" ("the `update` results..."), whereas parallel sections like `### Read` and `### Delete` correctly use a capitalized "The".

This PR fixes the capitalization to standard English grammar and aligns it with the rest of the document.

### Checklist
Before submitting the PR make sure the following are checked:
* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
