### PR TITLE
Fix typos and grammar in Maintenance Policy guide

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -5,7 +5,7 @@ Maintenance Policy for Ruby on Rails
 
 Support of the Rails framework is divided into three groups: New features, bug
 fixes, and security issues. They are handled as
-follows, all versions, except for security releases, in `X.Y.Z`, format.
+follows, all versions, except for security releases, in `X.Y.Z` format.
 
 --------------------------------------------------------------------------------
 
@@ -21,7 +21,7 @@ Except as necessary for security fixes.
 
 **Minor `Y`**
 
-New features, may contain API changes (Serve as major versions of Semver).
+New features, may contain API changes (serve as major versions of Semver).
 Breaking changes are paired with deprecation notices in the previous minor
 or major release.
 
@@ -46,7 +46,7 @@ will receive bug fixes until January 1, 2024. After that, it will be considered
 unsupported.
 
 Bug fixes are typically added to the main branch, and backported to the x-y-stable
-branch of the latest release series if there is sufficient need. When enough bugs
+branch of the latest release series if there is sufficient need. When enough bug
 fixes have been added to an x-y-stable branch, a new Patch release is built from it.
 For example, a theoretical 1.2.2 Patch release would be built from the 1-2-stable branch.
 
@@ -85,7 +85,7 @@ End-of-life Release Series
 When a release series reaches its end-of-life, it's your own responsibility to
 deal with bugs and security issues. We may provide backports of the fixes and
 merge them, however there will be no new versions released. We
-recommend to point your application at the stable branch using Git. If you are
+recommend pointing your application at the stable branch using Git. If you are
 not comfortable maintaining your own versions, you should upgrade to a supported
 version.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
I found several small grammatical and punctuation errors in the Maintenance Policy guide that affected readability.

### Detail
This PR fixes the following in `maintenance_policy.md`:
* Corrected "bugs fixes" to "bug fixes".
* Updated "recommend to point" to "recommend pointing" for better grammar.
* Removed an unnecessary comma after `X.Y.Z` in the introduction.
* Lowercased "serve" in a parenthetical fragment to maintain consistency.

### Checklist
* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description...
