### PR TITLE
Don't reconstruct test schema if maintain_test_schema = false

### DIFF
--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       ActiveRecord::Base.configurations.configs_for(env_name: env_name, include_hidden: true).each do |db_config|
         db_config._database = "#{db_config.database}_#{i}"
 
-        if db_config.database_tasks? && ActiveRecord.maintain_test_schema
+        if db_config.database_tasks? && ActiveRecord.maintain_test_schema != false
           ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, nil)
         end
       end

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       ActiveRecord::Base.configurations.configs_for(env_name: env_name, include_hidden: true).each do |db_config|
         db_config._database = "#{db_config.database}_#{i}"
 
-        if db_config.database_tasks?
+        if db_config.database_tasks? && ActiveRecord.maintain_test_schema
           ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, nil)
         end
       end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

See #56187 for details. When `maintain_test_schema` is false and parallel tests are run, rails nonetheless still tries to modify the schema. In the issue I discussed a few possible approaches to resolving this issue, but didn't receive much feedback so decided to proceed with the simplest approach.

### Detail

This Pull Request prevents the test schema from being reconstructed when `maintain_test_schema` is `false`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
