### PR TITLE
Add PostgreSQLAdapter.register_type_mapping

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `PostgreSQLAdapter.register_type_mapping` for custom SQL type registration.
+
+    Third-party gems can now register custom type mappings without prepending
+    internal methods:
+
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.register_type_mapping do |type_map|
+          type_map.register_type("geometry") do |oid, fmod, sql_type|
+            MyGeometryType.new(sql_type)
+          end
+        end
+
+    Callbacks execute in registration order.
+
+    *Abdelkader Boudih*
+
 *   Yield the transaction object to the block when using `with_lock`.
 
     *Ngan Pham*

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -775,6 +775,25 @@ module ActiveRecord
             OID::Interval.new(precision: precision)
           end
         end
+
+        # Registers a callback to extend the type map during initialization.
+        # Useful for third-party gems that need to register custom SQL types.
+        #
+        #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.register_type_mapping do |type_map|
+        #     type_map.register_type("geometry") do |oid, fmod, sql_type|
+        #       MyGeometryType.new(sql_type)
+        #     end
+        #   end
+        #
+        def register_type_mapping(&block)
+          raise ArgumentError, "block required" unless block_given?
+          @@type_mapping_callbacks ||= []
+          @@type_mapping_callbacks << block
+        end
+
+        def clear_type_mapping_callbacks! # :nodoc:
+          @@type_mapping_callbacks = [] if defined?(@@type_mapping_callbacks)
+        end
       end
 
       private
@@ -788,6 +807,8 @@ module ActiveRecord
           self.class.register_class_with_precision m, "timestamptz", OID::TimestampWithTimeZone
 
           load_additional_types
+
+          @@type_mapping_callbacks&.each { |block| block.call(m) }
         end
 
         # Extracts the value from a PostgreSQL column default definition.

--- a/activerecord/test/cases/adapters/postgresql/type_map_registration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/type_map_registration_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PostgreSQLTypeMappingRegistrationTest < ActiveRecord::PostgreSQLTestCase
+  def setup
+    @adapter_class = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+    @adapter_class.clear_type_mapping_callbacks!
+  end
+
+  def teardown
+    @adapter_class.clear_type_mapping_callbacks!
+  end
+
+  def test_register_type_mapping_with_block
+    called = false
+    @adapter_class.register_type_mapping do |type_map|
+      called = true
+      assert_kind_of ActiveRecord::Type::HashLookupTypeMap, type_map
+    end
+
+    ActiveRecord::Base.lease_connection.reload_type_map
+    assert called
+  end
+
+  def test_register_requires_block
+    assert_raises(ArgumentError) { @adapter_class.register_type_mapping }
+  end
+
+  def test_custom_type_is_registered
+    @adapter_class.register_type_mapping do |type_map|
+      type_map.register_type("test_custom") { ActiveRecord::Type::String.new }
+    end
+
+    ActiveRecord::Base.lease_connection.reload_type_map
+    type_map = ActiveRecord::Base.lease_connection.send(:type_map)
+    assert type_map.key?("test_custom")
+  end
+end


### PR DESCRIPTION
Gems adding types to postgresql for [postgis](https://github.com/seuros/activerecord-postgis) or  for [vector](https://github.com/ankane/neighbor) monkey patch the adapter to add the types. 

This interface will allow us to add types with a cleaner interface.

cc @ankane 