### PR TITLE
Clarify support for custom subdirectories in app/assets

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -150,12 +150,12 @@ dependencies:
 
 ### Asset Organization
 
-Propshaft organizes assets within the app/assets directory. While it includes
-default subdirectories like images, javascripts, and stylesheets, Propshaft
-will automatically manage any subdirectory you create within app/assets (such
-as app/assets/videos) You can place your JavaScript, CSS, image files, and
-other assets into these directories, and Propshaft will manage them during the
-precompilation process.
+Propshaft organizes assets within the `app/assets` directory. While it includes
+default subdirectories like `images`, `javascripts`, and `stylesheets`,
+Propshaft will automatically manage any subdirectory you create within
+`app/assets` (such as `app/assets/videos`). You can place your JavaScript, CSS,
+image files, and other assets into these directories, and Propshaft will manage
+them during the precompilation process.
 
 You can also specify additional asset paths for Propshaft to search by modifying
 `config.assets.paths` in your `config/initializers/assets.rb` file. For example:

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -150,10 +150,12 @@ dependencies:
 
 ### Asset Organization
 
-Propshaft organizes assets within the `app/assets` directory, which includes
-subdirectories like `images`, `javascripts`, and `stylesheets`. You can place
-your JavaScript, CSS, image files, and other assets into these directories, and
-Propshaft will manage them during the precompilation process.
+Propshaft organizes assets within the app/assets directory. While it includes
+default subdirectories like images, javascripts, and stylesheets, Propshaft
+will automatically manage any subdirectory you create within app/assets (such
+as app/assets/videos) You can place your JavaScript, CSS, image files, and
+other assets into these directories, and Propshaft will manage them during the
+precompilation process.
 
 You can also specify additional asset paths for Propshaft to search by modifying
 `config.assets.paths` in your `config/initializers/assets.rb` file. For example:


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to clarify a core convention of the Propshaft asset pipeline that is currently under-documented.

The existing guide lists images, javascripts, and stylesheets as the subdirectories within app/assets, which can lead users to believe these are the only supported or "blessed" folders. In reality, Propshaft automatically scans and manages any subdirectory created within app/assets. This PR explicitly documents this behavior so developers know they can organize media files (like using a /videos folder) without needing manual configuration.

### Detail

This Pull Request changes the Asset Organization section of the Asset Pipeline guide to:

- Explicitly state that Propshaft manages any subdirectory created within app/assets.

- Provide a modern, practical example by mentioning app/assets/videos.

- Use semantic line breaks to improve the maintainability of the documentation source.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
This change helps align the documentation with the "Convention over Configuration" philosophy of Propshaft, which differentiates it from the more explicit requirements of the older Sprockets pipeline.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
