### PR TITLE
[ci skip] Fix typo in railties/CHANGELOG.md, defaults -> default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -4,7 +4,7 @@
     Rails.app.revision # => "3d31d593e6cf0f82fa9bd0338b635af2f30d627b"
     ```
 
-    By defaults it looks for a `REVISION` file at the root of the application, if absent it tries to extract
+    By default it looks for a `REVISION` file at the root of the application, if absent it tries to extract
     the revision from the local git repository.
 
     If none of that is adequate, it can be set in the application config:


### PR DESCRIPTION
Fix typo: By defaults -> By default