### PR TITLE
Add coverage for stream handler overrides in Action Cable

### DIFF
--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -52,6 +52,45 @@ module ActionCable::StreamTests
     end
   end
 
+  class StreamHandlerOverrideChannel < ActionCable::Channel::Base
+    attr_reader :handled_message, :stream_handler_args, :stream_handler_ran
+
+    def subscribed
+      stream_from "stream_handler_override", coder: DummyEncoder do |message|
+        @handled_message = message
+      end
+    end
+
+    private
+      def stream_handler(broadcasting, user_handler, coder: nil)
+        @stream_handler_args = { broadcasting: broadcasting, user_handler: user_handler, coder: coder }
+        handler = super
+
+        -> message do
+          @stream_handler_ran = true
+          handler.call(message)
+        end
+      end
+  end
+
+  class DefaultStreamHandlerOverrideChannel < ActionCable::Channel::Base
+    attr_reader :handled_message, :default_handler_args
+
+    def subscribed
+      stream_from "default_stream_handler_override", coder: DummyEncoder
+    end
+
+    private
+      def default_stream_handler(broadcasting, coder:)
+        @default_handler_args = { broadcasting: broadcasting, coder: coder }
+        decoder = stream_decoder(coder: coder)
+
+        -> message do
+          @handled_message = decoder.call(message)
+        end
+      end
+  end
+
   class StreamTest < ActionCable::TestCase
     test "streaming start and stop" do
       run_in_eventmachine do
@@ -73,6 +112,26 @@ module ActionCable::StreamTests
       end
     end
 
+    test "stream_handler override receives coder and wraps the user handler" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+
+        channel = StreamHandlerOverrideChannel.new connection, "{id: 1}"
+        channel.subscribe_to_channel
+        wait_for_async
+
+        handler = subscribers_of(connection)["stream_handler_override"].first
+        handler.call("payload")
+        wait_for_executor connection.server.worker_pool.executor
+
+        assert_equal "stream_handler_override", channel.stream_handler_args[:broadcasting]
+        assert_instance_of Proc, channel.stream_handler_args[:user_handler]
+        assert_equal DummyEncoder, channel.stream_handler_args[:coder]
+        assert channel.stream_handler_ran
+        assert_equal({ foo: "decoded" }, channel.handled_message)
+      end
+    end
+
     test "stream from non-string channel" do
       run_in_eventmachine do
         connection = TestConnection.new
@@ -91,6 +150,24 @@ module ActionCable::StreamTests
         end
 
         assert pubsub.verify
+      end
+    end
+
+    test "default_stream_handler override receives coder and handles messages" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+
+        channel = DefaultStreamHandlerOverrideChannel.new connection, "{id: 1}"
+        channel.subscribe_to_channel
+        wait_for_async
+
+        handler = subscribers_of(connection)["default_stream_handler_override"].first
+        handler.call("payload")
+        wait_for_executor connection.server.worker_pool.executor
+
+        assert_equal "default_stream_handler_override", channel.default_handler_args[:broadcasting]
+        assert_equal DummyEncoder, channel.default_handler_args[:coder]
+        assert_equal({ foo: "decoded" }, channel.handled_message)
       end
     end
 

--- a/actioncable/test/stubs/test_connection.rb
+++ b/actioncable/test/stubs/test_connection.rb
@@ -3,7 +3,7 @@
 require "stubs/user"
 
 class TestConnection
-  attr_reader :identifiers, :logger, :current_user, :server, :subscriptions, :transmissions
+  attr_reader :identifiers, :logger, :current_user, :server, :subscriptions, :transmissions, :worker_pool
 
   delegate :pubsub, :config, to: :server
 
@@ -14,6 +14,7 @@ class TestConnection
     @current_user = user
     @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
     @server = TestServer.new(subscription_adapter: subscription_adapter)
+    @worker_pool = @server.worker_pool
     @transmissions = []
   end
 


### PR DESCRIPTION
- Adds tests for `stream_handler` override behavior in stream subscriptions.
- Adds tests for `default_stream_handler` override behavior and coder passthrough.
- Ensures custom coder decoding reaches user handlers and default handlers.
