### PR TITLE
Deprecate delayed_job Active Job adapter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate built-in `delayed_job` adapter.
+
+    If you're using this adapter, upgrade to `delayed_job` 4.2.0 or later to use the `delayed_job` gem's adapter.
+
+    *Dino Maric, David Genord II, Wojciech Wnętrzak*
+
 *   Deprecate built-in `backburner` adapter.
 
     *Dino Maric, Nathan Esquenazi, Earlopain*

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -16,6 +16,13 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :delayed_job
     class DelayedJobAdapter < AbstractAdapter
+      def check_adapter
+        ActiveJob.deprecator.warn <<~MSG.squish
+          The built-in `delayed_job` adapter is deprecated and will be removed in Rails 9.0.
+          Please upgrade `delayed_job` gem to version 4.2.0 or later to use the `delayed_job` gem's adapter.
+        MSG
+      end
+
       def enqueue(job) # :nodoc:
         delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, priority: job.priority)
         job.provider_job_id = delayed_job.id


### PR DESCRIPTION
Follow up to https://github.com/collectiveidea/delayed_job/pull/1236

refs https://github.com/rails/rails/issues/52929
