### PR TITLE
Remove non existing autoload for sucker punch

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -121,7 +121,6 @@ module ActiveJob
     autoload :ResqueAdapter
     autoload :SidekiqAdapter
     autoload :SneakersAdapter
-    autoload :SuckerPunchAdapter
     autoload :TestAdapter
 
     ADAPTER = "Adapter"


### PR DESCRIPTION
Looks like a leftover from https://github.com/rails/rails/commit/634f90b883ef0e4af5ba32bba7ca55a7efbe4701
