### PR TITLE
Remove proc support in config.revision

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -540,14 +540,12 @@ Causes the app to not boot if a master key hasn't been made available through `E
 
 #### `config.revision`
 
-Sets the application revision for deployment tracking and error reporting. Can be a string or a proc.
+Sets the application revision for deployment tracking and error reporting. Must be a string.
 When not set, Rails first tries reading from a `REVISION` file in the application root, and if absent
 it attempts to get the current commit from the local git repository (default: `nil`).
 
 ```ruby
 config.revision = ENV["GIT_SHA"]
-# or
-config.revision = -> { File.read("BUILD_ID").strip }
 ```
 
 Revision can be accessed via `Rails.app.revision`.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -420,9 +420,7 @@ module Rails
     ## Rails internal API
 
     def revision=(rev) # :nodoc:
-      rev = rev.call if rev.respond_to?(:call)
-      rev = rev&.to_s
-      @revision = rev
+      @revision = rev&.to_s
       @revision_initialized = true
     end
 

--- a/railties/test/application/app_revision_test.rb
+++ b/railties/test/application/app_revision_test.rb
@@ -36,15 +36,6 @@ module ApplicationTests
       assert_equal "deploy-123", Rails.app.revision
     end
 
-    test "revision can be set via config.revision proc" do
-      add_to_config <<-RUBY
-        config.revision = -> { "proc-456" }
-      RUBY
-
-      require "#{app_path}/config/environment"
-      assert_equal "proc-456", Rails.app.revision
-    end
-
     test "config.revision takes precedence over REVISION file" do
       File.write("#{app_path}/REVISION", "file-revision")
 


### PR DESCRIPTION
It made sense in an early version of the PR but now that it's immediately invoked it's no longer useful.

cc @ghiculescu 