### PR TITLE
Remove minitest-ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,6 @@ local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
-  gem "minitest-ci", require: false
   gem "minitest-retry"
 
   platforms :mri do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,8 +345,6 @@ GEM
     mini_portile2 (2.8.9)
     minitest (6.0.0)
       prism (~> 1.5)
-    minitest-ci (3.4.0)
-      minitest (>= 5.0.6)
     minitest-mock (5.27.0)
     minitest-retry (0.2.3)
       minitest (>= 5.0)
@@ -709,7 +707,6 @@ DEPENDENCIES
   listen (~> 3.3)
   mdl (!= 0.13.0)
   minitest (~> 6.0)
-  minitest-ci
   minitest-mock
   minitest-retry
   msgpack (>= 1.7.0)

--- a/tools/test_common.rb
+++ b/tools/test_common.rb
@@ -7,11 +7,7 @@ ActiveSupport::TestCase.alias_method :force_skip, :skip
 ENV["RAILS_TEST_EXECUTABLE"] = "bin/test"
 
 if ENV["BUILDKITE"]
-  require "minitest-ci"
   ENV.delete("CI") # CI has affect on the applications, and we don't want it applied to the apps.
-
-  Minitest::Ci.report_dir = File.join(__dir__, "../test-reports/#{ENV['BUILDKITE_JOB_ID']}")
-
   module DisableSkipping # :nodoc:
     private
       def skip(message = nil, *)


### PR DESCRIPTION
It was introduced in https://github.com/rails/rails/pull/35698 to allow automatic analysis of failures and such.

Overall it makes sense but it has been broken for ages, so let's just get rid of it. If someone is interested in fixing it, it can be re-introduced.

Until then, it get rid of a CGI warning on Ruby 4.0
