### PR TITLE
Attempt to fix secret_key_base test failure

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -679,13 +679,18 @@ module Rails
         def generate_local_secret
           key_file = root.join("tmp/local_secret.txt")
 
-          unless File.exist?(key_file)
-            random_key = SecureRandom.hex(64)
-            FileUtils.mkdir_p(key_file.dirname)
-            File.binwrite(key_file, random_key)
+          random_key = begin
+            File.binread(key_file)
+          rescue SystemCallError
+            nil
           end
 
-          File.binread(key_file)
+          return random_key if random_key.present?
+
+          random_key = SecureRandom.hex(64)
+          FileUtils.mkdir_p(key_file.dirname)
+          File.binwrite(key_file, random_key)
+          random_key
         end
     end
   end


### PR DESCRIPTION
We've been experiencing a nasty flaky test, yet it's not very clear what is happening:

```
Error:
InfoControllerTest#test_info_controller_allows_requests_when_all_requests_are_considered_local:
ArgumentError: `secret_key_base` for test environment must be a type of String, got: ""`
    lib/rails/application/configuration.rb:563:in 'Rails::Application::Configuration#secret_key_base='
    lib/rails/application/configuration.rb:547:in 'Rails::Application::Configuration#secret_key_base'
    lib/rails/application.rb:511:in 'Rails::Application#secret_key_base'
    lib/rails/application.rb:328:in 'Rails::Application#env_config'
```