### PR TITLE
Fix Rails::Application usage of error reporter middleware

### DIFF
--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -213,7 +213,7 @@ module ActiveSupport
     # It must return a hash - the middleware stack returns the hash after it has
     # run through all middlewares. A middleware can mutate or replace the hash.
     #
-    #   Rails.error.add_middleware(-> (error, context) { context.merge({ foo: :bar }) })
+    #   Rails.error.add_middleware(-> (error, handled:, severity:, context:, source:) { context.merge({ foo: :bar }) })
     #
     def add_middleware(middleware)
       @context_middlewares.use(middleware)

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -70,12 +70,12 @@ module Rails
           Rails.error.logger = Rails.logger
         end
 
-        Rails.error.add_middleware(->(error, context) {
-          context[:rails] ||= {
+        Rails.error.add_middleware(->(error, handled:, severity:, context:, source:) {
+          context.reverse_merge(rails: {
             version: Rails::VERSION::STRING,
             app_revision: app.revision,
             environment: Rails.env.to_s,
-          }
+          })
         })
       end
 


### PR DESCRIPTION
Follow-up to #56490

The error reporter middleware was incorrectly used, which results in most of the context being lost. The middleware receives the same arguments as `report` and needs to return the full hash.

cc @byroot 