### PR TITLE
Fix deprecation horizon for AJ adapters

### DIFF
--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -17,7 +17,7 @@ module ActiveJob
     class BackburnerAdapter < AbstractAdapter
       def check_adapter
         ActiveJob.deprecator.warn <<~MSG.squish
-          The built-in `backburner` adapter is deprecated and will be removed in Rails 8.2.
+          The built-in `backburner` adapter is deprecated and will be removed in Rails 9.0.
           Please upgrade `backburner` gem to version 1.7 or later to use the `backburner` gem's adapter.
         MSG
       end

--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -20,7 +20,7 @@ module ActiveJob
     class SneakersAdapter < AbstractAdapter
       def check_adapter
         ActiveJob.deprecator.warn <<~MSG.squish
-          The built-in `sneakers` adapter is deprecated and will be removed in Rails 8.2.
+          The built-in `sneakers` adapter is deprecated and will be removed in Rails 9.0.
           Please migrate from `sneakers` gem to `kicks` gem version 3.1.1 or later to use `ActiveJob` adapter from `kicks`.
         MSG
       end

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -28,7 +28,7 @@ class AdapterTest < ActiveSupport::TestCase
       before_adapter = ActiveJob::Base.queue_adapter
 
       msg = <<~MSG.squish
-        The built-in `sneakers` adapter is deprecated and will be removed in Rails 8.2.
+        The built-in `sneakers` adapter is deprecated and will be removed in Rails 9.0.
         Please migrate from `sneakers` gem to `kicks` gem version 3.1.1 or later to use `ActiveJob` adapter from `kicks`.
       MSG
       assert_deprecated(msg, ActiveJob.deprecator) do
@@ -41,7 +41,7 @@ class AdapterTest < ActiveSupport::TestCase
 
     test "sneakers check_adapter should warn" do
       msg = <<~MSG.squish
-        The built-in `sneakers` adapter is deprecated and will be removed in Rails 8.2.
+        The built-in `sneakers` adapter is deprecated and will be removed in Rails 9.0.
         Please migrate from `sneakers` gem to `kicks` gem version 3.1.1 or later to use `ActiveJob` adapter from `kicks`.
       MSG
       assert_deprecated(msg, ActiveJob.deprecator) do
@@ -55,7 +55,7 @@ class AdapterTest < ActiveSupport::TestCase
       before_adapter = ActiveJob::Base.queue_adapter
 
       msg = <<~MSG.squish
-        The built-in `backburner` adapter is deprecated and will be removed in Rails 8.2.
+        The built-in `backburner` adapter is deprecated and will be removed in Rails 9.0.
         Please upgrade `backburner` gem to version 1.7 or later to use the `backburner` gem's adapter.
       MSG
       assert_deprecated(msg, ActiveJob.deprecator) do
@@ -68,7 +68,7 @@ class AdapterTest < ActiveSupport::TestCase
 
     test "backburner check_adapter should warn" do
       msg = <<~MSG.squish
-        The built-in `backburner` adapter is deprecated and will be removed in Rails 8.2.
+        The built-in `backburner` adapter is deprecated and will be removed in Rails 9.0.
         Please upgrade `backburner` gem to version 1.7 or later to use the `backburner` gem's adapter.
       MSG
       assert_deprecated(msg, ActiveJob.deprecator) do


### PR DESCRIPTION
They will be deprecated in 8.2

Follow up to https://github.com/rails/rails/pull/53334 and https://github.com/rails/rails/pull/53335

cc @guilleiguaran @yahonda 
https://github.com/rails/rails/pull/53334#issuecomment-3708536258