### PR TITLE
Use the random suffix in the atomic temp file name

### DIFF
--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -27,7 +27,7 @@ class File
 
     # Names can't be longer than 255B
     tmp_suffix = ".tmp.#{SecureRandom.hex}"
-    tmp_name = ".#{basename(file_name).byteslice(0, 254 - tmp_suffix.bytesize)}"
+    tmp_name = ".#{basename(file_name).byteslice(0, 254 - tmp_suffix.bytesize)}#{tmp_suffix}"
     tmp_path = File.join(temp_dir, tmp_name)
     open(tmp_path, RDWR | CREAT | EXCL | SHARE_DELETE | BINARY) do |temp_file|
       temp_file.binmode

--- a/activesupport/test/core_ext/file_test.rb
+++ b/activesupport/test/core_ext/file_test.rb
@@ -94,6 +94,20 @@ class AtomicWriteTest < ActiveSupport::TestCase
     end
   end
 
+  def test_atomic_write_uses_unique_temp_file_names
+    temp_file_paths = []
+    2.times do
+      File.atomic_write(file_name, Dir.pwd) do |file|
+        temp_file_paths << file.path
+      end
+    end
+
+    assert_match(/\.atomic-#{Process.pid}\.file\.tmp\.[0-9a-f]{32}\z/, temp_file_paths[0])
+    assert_not_equal temp_file_paths[0], temp_file_paths[1]
+  ensure
+    File.unlink(file_name) rescue nil
+  end
+
   private
     def file_name
       "atomic-#{Process.pid}.file"


### PR DESCRIPTION
In https://github.com/rails/rails/commit/f781cc50e5b27502d01e38039f401bf7cc2fd369, the suffix was not appended to the temp file name, leading to collisions when concurrently writing to the same file.
