### PR TITLE
Add inspect features to `ActiveModel::Attributes`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,40 @@
+*   Add `ActiveModel::Inspection` to provide human-readable `#inspect` output for ActiveModel objects.
+
+    Classes that include `ActiveModel::Attributes` now automatically get formatted inspect output
+    with full feature parity to ActiveRecord, including `filter_attributes`, `attributes_for_inspect`,
+    `full_inspect`, and `pretty_print` support.
+
+    ```ruby
+    class Person
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :name, :string
+      attribute :age, :integer
+      attribute :password, :string
+    end
+
+    person = Person.new(name: "Alice", age: 30, password: "secret")
+    person.inspect
+    # => "#<Person name: \"Alice\", age: 30, password: \"secret\">"
+
+    # Filter sensitive attributes
+    Person.filter_attributes = [:password]
+    person.inspect
+    # => "#<Person name: \"Alice\", age: 30, password: [FILTERED]>"
+
+    # Limit attributes shown in inspect
+    Person.attributes_for_inspect = [:name]
+    person.inspect
+    # => "#<Person name: \"Alice\">"
+
+    # Show all attributes regardless of attributes_for_inspect
+    person.full_inspect
+    # => "#<Person name: \"Alice\", age: 30, password: [FILTERED]>"
+    ```
+
+    *Vinícius Almeida*
+
 *   Add `has_json` and `has_delegated_json` to provide schema-enforced access to JSON attributes.
 
     ```ruby

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -45,6 +45,7 @@ module ActiveModel
   autoload :Dirty
   autoload :EachValidator, "active_model/validator"
   autoload :ForbiddenAttributesProtection
+  autoload :Inspection
   autoload :Lint
   autoload :Model
   autoload :Name, "active_model/naming"

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -31,6 +31,7 @@ module ActiveModel
     extend ActiveSupport::Concern
     include ActiveModel::AttributeRegistration
     include ActiveModel::AttributeMethods
+    include ActiveModel::Inspection
 
     included do
       attribute_method_suffix "=", parameters: "value"

--- a/activemodel/lib/active_model/inspection.rb
+++ b/activemodel/lib/active_model/inspection.rb
@@ -79,7 +79,7 @@ module ActiveModel
 
       # Returns the inspection filter used to mask sensitive attributes.
       def inspection_filter # :nodoc:
-        if defined?(@filter_attributes)
+        if defined?(@filter_attributes) && @filter_attributes
           @inspection_filter ||= begin
             mask = InspectionMask.new(ActiveSupport::ParameterFilter::FILTERED)
             ActiveSupport::ParameterFilter.new(@filter_attributes, mask: mask)

--- a/activemodel/lib/active_model/inspection.rb
+++ b/activemodel/lib/active_model/inspection.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  # = Active \Model \Inspection
+  #
+  # Provides a human-readable representation of your model instances through
+  # the +inspect+ and +pretty_print+ methods.
+  #
+  # This module requires that the including class has an +@attributes+ instance
+  # variable (as provided by ActiveModel::Attributes) and responds to
+  # +attribute_names+.
+  #
+  # == Configuration
+  #
+  # The inspection output can be customized through two class attributes:
+  #
+  # * +filter_attributes+ - An array of attribute names whose values should be
+  #   masked in the output. Useful for sensitive data like passwords.
+  #
+  # * +attributes_for_inspect+ - An array of attribute names to include in
+  #   the output, or +:all+ to show all attributes (default).
+  #
+  # == Example
+  #
+  #   class Person
+  #     include ActiveModel::Model
+  #     include ActiveModel::Attributes
+  #
+  #     attribute :name, :string
+  #     attribute :age, :integer
+  #     attribute :password, :string
+  #   end
+  #
+  #   person = Person.new(name: "Alice", age: 30, password: "secret")
+  #   person.inspect
+  #   # => "#<Person name: \"Alice\", age: 30, password: \"secret\">"
+  #
+  #   Person.filter_attributes = [:password]
+  #   person.inspect
+  #   # => "#<Person name: \"Alice\", age: 30, password: [FILTERED]>"
+  #
+  #   Person.attributes_for_inspect = [:name]
+  #   person.inspect
+  #   # => "#<Person name: \"Alice\">"
+  #
+  module Inspection
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :attributes_for_inspect, instance_accessor: false, default: :all
+    end
+
+    module ClassMethods
+      # Returns an array of attribute names whose values should be masked in
+      # the output of +inspect+.
+      #
+      #   Person.filter_attributes = [:password]
+      #   Person.filter_attributes # => [:password]
+      def filter_attributes
+        if defined?(@filter_attributes)
+          @filter_attributes
+        elsif superclass.respond_to?(:filter_attributes)
+          superclass.filter_attributes
+        else
+          []
+        end
+      end
+
+      # Specifies attributes whose values should be masked in the output of
+      # +inspect+.
+      #
+      #   Person.filter_attributes = [:password]
+      #   Person.new(password: "secret").inspect
+      #   # => "#<Person password: [FILTERED]>"
+      def filter_attributes=(attributes)
+        @inspection_filter = nil
+        @filter_attributes = attributes
+      end
+
+      # Returns the inspection filter used to mask sensitive attributes.
+      def inspection_filter # :nodoc:
+        if defined?(@filter_attributes)
+          @inspection_filter ||= begin
+            mask = InspectionMask.new(ActiveSupport::ParameterFilter::FILTERED)
+            ActiveSupport::ParameterFilter.new(@filter_attributes, mask: mask)
+          end
+        elsif superclass.respond_to?(:inspection_filter)
+          superclass.inspection_filter
+        else
+          @inspection_filter ||= begin
+            mask = InspectionMask.new(ActiveSupport::ParameterFilter::FILTERED)
+            ActiveSupport::ParameterFilter.new([], mask: mask)
+          end
+        end
+      end
+    end
+
+    # Returns the attributes of the model as a nicely formatted string.
+    #
+    #   Person.new(name: "Alice", age: 30).inspect
+    #   # => "#<Person name: \"Alice\", age: 30>"
+    #
+    # The attributes can be limited by setting +.attributes_for_inspect+.
+    #
+    #   Person.attributes_for_inspect = [:name]
+    #   Person.new(name: "Alice", age: 30).inspect
+    #   # => "#<Person name: \"Alice\">"
+    def inspect
+      inspect_with_attributes(attributes_for_inspect)
+    end
+
+    # Returns all attributes of the model as a nicely formatted string,
+    # ignoring +.attributes_for_inspect+.
+    #
+    #   Person.attributes_for_inspect = [:name]
+    #   person = Person.new(name: "Alice", age: 30)
+    #
+    #   person.inspect
+    #   # => "#<Person name: \"Alice\">"
+    #
+    #   person.full_inspect
+    #   # => "#<Person name: \"Alice\", age: 30>"
+    def full_inspect
+      inspect_with_attributes(all_attributes_for_inspect)
+    end
+
+    # Takes a PP and prettily prints this model to it, allowing you to get a
+    # nice result from <tt>pp model</tt> when pp is required.
+    def pretty_print(pp)
+      return super if custom_inspect_method_defined?
+      pp.object_address_group(self) do
+        if @attributes
+          attr_names = attributes_for_inspect.select { |name| @attributes.key?(name.to_s) }
+          pp.seplist(attr_names, proc { pp.text "," }) do |attr_name|
+            attr_name = attr_name.to_s
+            pp.breakable " "
+            pp.group(1) do
+              pp.text attr_name
+              pp.text ":"
+              pp.breakable
+              value = attribute_for_inspect(attr_name)
+              pp.text value
+            end
+          end
+        else
+          pp.breakable " "
+          pp.text "not initialized"
+        end
+      end
+    end
+
+    # Returns a formatted string for the given attribute, suitable for use in
+    # +inspect+ output.
+    #
+    # Long strings are truncated, dates and times are formatted with
+    # +to_fs(:inspect)+, and filtered attributes show +[FILTERED]+.
+    #
+    #   person = Person.new(name: "Alice " * 20, created_at: Time.now)
+    #   person.attribute_for_inspect(:name)
+    #   # => "\"Alice Alice Alice Alice Alice Alice Alice Alice A...\""
+    #   person.attribute_for_inspect(:created_at)
+    #   # => "\"2024-01-15 10:30:00 +0000\""
+    def attribute_for_inspect(attr_name)
+      attr_name = attr_name.to_s
+      value = @attributes.fetch_value(attr_name)
+      format_for_inspect(attr_name, value)
+    end
+
+    private
+      class InspectionMask < DelegateClass(::String)
+        def pretty_print(pp)
+          pp.text __getobj__
+        end
+      end
+      private_constant :InspectionMask
+
+      def inspection_filter
+        self.class.inspection_filter
+      end
+
+      def inspect_with_attributes(attributes_to_list)
+        inspection = if @attributes
+          attributes_to_list.filter_map do |name|
+            name = name.to_s
+            if @attributes.key?(name)
+              "#{name}: #{attribute_for_inspect(name)}"
+            end
+          end.join(", ")
+        else
+          "not initialized"
+        end
+
+        "#<#{self.class} #{inspection}>"
+      end
+
+      def attributes_for_inspect
+        self.class.attributes_for_inspect == :all ? all_attributes_for_inspect : self.class.attributes_for_inspect
+      end
+
+      def all_attributes_for_inspect
+        return [] unless @attributes
+        attribute_names
+      end
+
+      def format_for_inspect(name, value)
+        if value.nil?
+          value.inspect
+        else
+          inspected_value = if value.is_a?(String) && value.length > 50
+            "#{value[0, 50]}...".inspect
+          elsif value.is_a?(Date) || value.is_a?(Time)
+            if value.respond_to?(:to_fs)
+              %("#{value.to_fs(:inspect)}")
+            else
+              %("#{value}")
+            end
+          else
+            value.inspect
+          end
+
+          inspection_filter.filter_param(name, inspected_value)
+        end
+      end
+
+      def custom_inspect_method_defined?
+        self.class.instance_method(:inspect).owner != ActiveModel::Inspection
+      end
+  end
+end

--- a/activemodel/test/cases/inspection_test.rb
+++ b/activemodel/test/cases/inspection_test.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "pp"
+require "stringio"
+
+module ActiveModel
+  class InspectionTest < ActiveModel::TestCase
+    class Person
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :name, :string
+      attribute :age, :integer
+      attribute :email, :string
+      attribute :password, :string
+      attribute :created_at, :datetime
+    end
+
+    class Admin < Person
+    end
+
+    setup do
+      @previous_filter_attributes = Person.filter_attributes
+      @previous_attributes_for_inspect = Person.attributes_for_inspect
+    end
+
+    teardown do
+      Person.filter_attributes = @previous_filter_attributes
+      Person.attributes_for_inspect = @previous_attributes_for_inspect
+    end
+
+    test "inspect shows all attributes by default" do
+      person = Person.new(name: "Alice", age: 30, email: "alice@example.com")
+      assert_equal '#<ActiveModel::InspectionTest::Person name: "Alice", age: 30, email: "alice@example.com", password: nil, created_at: nil>', person.inspect
+    end
+
+    test "inspect shows attribute values" do
+      person = Person.new(name: "Bob", age: 25)
+      assert_includes person.inspect, 'name: "Bob"'
+      assert_includes person.inspect, "age: 25"
+    end
+
+    test "inspect truncates long strings at 50 characters" do
+      long_name = "A" * 60
+      person = Person.new(name: long_name)
+      assert_includes person.inspect, 'name: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA..."'
+    end
+
+    test "inspect formats dates and times" do
+      time = Time.new(2024, 1, 15, 10, 30, 0, "+00:00")
+      person = Person.new(created_at: time)
+      if time.respond_to?(:to_fs)
+        assert_includes person.inspect, "created_at: \"#{time.to_fs(:inspect)}\""
+      else
+        assert_includes person.inspect, "created_at: \"#{time}\""
+      end
+    end
+
+    test "inspect shows nil values" do
+      person = Person.new
+      assert_includes person.inspect, "name: nil"
+      assert_includes person.inspect, "age: nil"
+    end
+
+    test "inspect with filter_attributes masks sensitive data" do
+      Person.filter_attributes = [:password]
+      person = Person.new(name: "Alice", password: "secret123")
+      assert_includes person.inspect, "password: [FILTERED]"
+      assert_not_includes person.inspect, "secret123"
+    end
+
+    test "filter_attributes affects attribute_for_inspect" do
+      Person.filter_attributes = [:password]
+      person = Person.new(password: "secret123")
+      assert_equal "[FILTERED]", person.attribute_for_inspect(:password)
+    end
+
+    test "filter_attributes with regex" do
+      Person.filter_attributes = [/pass/]
+      person = Person.new(password: "secret123")
+      assert_includes person.inspect, "password: [FILTERED]"
+    end
+
+    test "filter_attributes with proc" do
+      Person.filter_attributes = [->(key, value) { value.reverse! if key == "password" }]
+      person = Person.new(password: "secret")
+      assert_includes person.inspect, 'password: "terces"'
+    end
+
+    test "filter_attributes does not filter nil values" do
+      Person.filter_attributes = [:password]
+      person = Person.new(password: nil)
+      assert_includes person.inspect, "password: nil"
+    end
+
+    test "inspect with attributes_for_inspect limits output" do
+      Person.attributes_for_inspect = [:name, :age]
+      person = Person.new(name: "Alice", age: 30, email: "alice@example.com")
+      assert_equal '#<ActiveModel::InspectionTest::Person name: "Alice", age: 30>', person.inspect
+    end
+
+    test "full_inspect shows all attributes regardless of attributes_for_inspect" do
+      Person.attributes_for_inspect = [:name]
+      person = Person.new(name: "Alice", age: 30, email: "alice@example.com")
+
+      assert_equal '#<ActiveModel::InspectionTest::Person name: "Alice">', person.inspect
+      assert_includes person.full_inspect, 'name: "Alice"'
+      assert_includes person.full_inspect, "age: 30"
+      assert_includes person.full_inspect, 'email: "alice@example.com"'
+    end
+
+    test "attributes_for_inspect with :all shows all attributes" do
+      Person.attributes_for_inspect = :all
+      person = Person.new(name: "Alice", age: 30)
+      assert_includes person.inspect, 'name: "Alice"'
+      assert_includes person.inspect, "age: 30"
+    end
+
+    test "pretty_print outputs nicely formatted attributes" do
+      person = Person.new(name: "Alice", age: 30)
+      actual = +""
+      PP.pp(person, StringIO.new(actual))
+
+      assert_includes actual, "name:"
+      assert_includes actual, '"Alice"'
+      assert_includes actual, "age:"
+      assert_includes actual, "30"
+    end
+
+    test "pretty_print respects attributes_for_inspect" do
+      Person.attributes_for_inspect = [:name]
+      person = Person.new(name: "Alice", age: 30)
+      actual = +""
+      PP.pp(person, StringIO.new(actual))
+
+      assert_includes actual, "name:"
+      assert_not_includes actual, "age:"
+    end
+
+    test "pretty_print respects filter_attributes" do
+      Person.filter_attributes = [:password]
+      person = Person.new(name: "Alice", password: "secret")
+      actual = +""
+      PP.pp(person, StringIO.new(actual))
+
+      assert_includes actual, "[FILTERED]"
+      assert_not_includes actual, "secret"
+    end
+
+    test "subclass inherits filter_attributes" do
+      Person.filter_attributes = [:password]
+      admin = Admin.new(password: "admin_secret")
+      assert_includes admin.inspect, "password: [FILTERED]"
+    end
+
+    test "subclass can override filter_attributes" do
+      Person.filter_attributes = [:password]
+      Admin.filter_attributes = []
+
+      person = Person.new(password: "secret")
+      admin = Admin.new(password: "admin_secret")
+
+      assert_includes person.inspect, "password: [FILTERED]"
+      assert_includes admin.inspect, 'password: "admin_secret"'
+    ensure
+      Admin.filter_attributes = nil
+    end
+
+    test "subclass inherits attributes_for_inspect" do
+      Person.attributes_for_inspect = [:name]
+      admin = Admin.new(name: "Admin", age: 40)
+      assert_equal '#<ActiveModel::InspectionTest::Admin name: "Admin">', admin.inspect
+    end
+
+    test "custom inspect method is respected" do
+      person_class = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+
+        attribute :name, :string
+
+        def inspect
+          "Custom: #{name}"
+        end
+      end
+
+      person = person_class.new(name: "Custom Person")
+      assert_equal "Custom: Custom Person", person.inspect
+    end
+
+    test "custom inspect method is respected for pretty_print" do
+      person_class = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+
+        attribute :name, :string
+
+        def inspect
+          "Custom: #{name}"
+        end
+      end
+
+      person = person_class.new(name: "Custom Person")
+      actual = +""
+      PP.pp(person, StringIO.new(actual))
+
+      # When custom inspect is defined, pretty_print falls back to super
+      # which uses Object's default behavior
+      assert_includes actual, "Custom: Custom Person"
+    end
+
+    test "inspect handles uninitialized attributes gracefully" do
+      person = Person.allocate
+      assert_equal "#<ActiveModel::InspectionTest::Person not initialized>", person.inspect
+    end
+
+    test "pretty_print handles uninitialized attributes" do
+      person = Person.allocate
+      actual = +""
+      PP.pp(person, StringIO.new(actual))
+      assert_includes actual, "not initialized"
+    end
+
+    test "attribute_for_inspect with string" do
+      person = Person.new(name: "Alice")
+      assert_equal '"Alice"', person.attribute_for_inspect(:name)
+    end
+
+    test "attribute_for_inspect with long string truncates" do
+      long_name = "A" * 60
+      person = Person.new(name: long_name)
+      assert_equal '"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA..."', person.attribute_for_inspect(:name)
+    end
+
+    test "attribute_for_inspect with integer" do
+      person = Person.new(age: 30)
+      assert_equal "30", person.attribute_for_inspect(:age)
+    end
+
+    test "attribute_for_inspect with nil" do
+      person = Person.new(name: nil)
+      assert_equal "nil", person.attribute_for_inspect(:name)
+    end
+
+    test "attribute_for_inspect with datetime" do
+      time = Time.new(2024, 1, 15, 10, 30, 0, "+00:00")
+      person = Person.new(created_at: time)
+      if time.respond_to?(:to_fs)
+        assert_equal "\"#{time.to_fs(:inspect)}\"", person.attribute_for_inspect(:created_at)
+      else
+        assert_equal "\"#{time}\"", person.attribute_for_inspect(:created_at)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord::Base#inspect` provides a rich, human-readable representation of model instances with features like attribute filtering, string truncation, and date formatting. However, `ActiveModel::Model` classes fall back to Ruby's default `Object#inspect`, which outputs all instance variables in an unhelpful format:

  ```ruby
  # ActiveRecord - nice output
  User.new(name: "Alice").inspect
  #=> "#<User id: nil, name: \"Alice\">"

  # ActiveModel - falls back to Object#inspect
  class Person
    include ActiveModel::Model
    include ActiveModel::Attributes
    attribute :name, :string
  end

  Person.new(name: "Alice").inspect
  #=> "#<Person:0x00007f... @attributes=...>"
  ```
  
  ### Detail

This Pull Request adds `ActiveModel::Inspection` (included automatically via `ActiveModel::Attributes`) with full inspection feature parity to `ActiveRecord`:

  - `#inspect` - Formatted attribute output: `#<Person name: "Alice", age: 30>`
  - `#full_inspect` - Shows all attributes regardless of `attributes_for_inspect`
  - `#pretty_print` - Support for pp with proper formatting
  - `.filter_attributes` - Mask sensitive data with `[FILTERED]`
  - `.attributes_for_inspect` - Limit which attributes appear in output
  - String truncation at 50 characters
  - Date/time formatting with `to_fs(:inspect)`