### PR TITLE
CI: Add `libvips` package to generated `ci.yml`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `libvips` to generated `ci.yml`
+
+    Conditionally adds `libvips` to `ci.yml`.
+
+    *Steve Polito*
+
 *   Add `Rails.app.revision` to provide a version identifier for error reporting, monitoring, cache keys, etc.
 
     ```ruby

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -632,6 +632,9 @@ module Rails
           packages << "python-is-python3"
         end
 
+        # ActiveStorage preview support
+        packages << "libvips" unless skip_active_storage?
+
         packages.compact.sort
       end
 


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, the generated `ci.yml` file was missing the `libvips` package.

### Detail

This commit uses prior art to add `libvips` so long as the `--skip-active-storage` flag was not passed during app generation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
