### PR TITLE
Remove unnecessary `defined?` check for RubyVM::YJIT.enable

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -229,7 +229,7 @@ module Rails
       end
 
       initializer :enable_yjit do
-        if config.yjit && defined?(RubyVM::YJIT.enable)
+        if config.yjit
           options = config.yjit.is_a?(Hash) ? config.yjit : {}
           RubyVM::YJIT.enable(**options)
         end


### PR DESCRIPTION
### Motivation / Background

This pull request removes unnecessary `defined?` check for RubyVM::YJIT.enable

### Detail

Since Rails main branch now requires Ruby 3.3.0,
`RubyVM::YJIT.enable` is always available and the `defined?` guard is no longer necessary.

```ruby
$ ruby -ve 'p defined?(RubyVM::YJIT.enable)'
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
"method"
```

### Additional information

Refer to
https://github.com/rails/rails/pull/56511

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
> Add RubyVM::YJIT.enable that can enable YJIT at run-time

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
