### PR TITLE
Remove Ruby < 3.3 compatibility code

### DIFF
--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1714,11 +1714,6 @@ module ActiveRecord
         def terminate
           nil
         end
-
-        unless method_defined?(:kill) # RUBY_VERSION <= "3.3"
-          def kill
-          end
-        end
       end
 
       def setup

--- a/activesupport/lib/active_support/core_ext/range/overlap.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlap.rb
@@ -1,40 +1,5 @@
 # frozen_string_literal: true
 
 class Range
-  unless Range.method_defined?(:overlap?) # Ruby 3.3+
-    # Compare two ranges and see if they overlap each other
-    #  (1..5).overlap?(4..6) # => true
-    #  (1..5).overlap?(7..9) # => false
-    def overlap?(other)
-      raise TypeError unless other.is_a? Range
-
-      self_begin = self.begin
-      other_end = other.end
-      other_excl = other.exclude_end?
-
-      return false if _empty_range?(self_begin, other_end, other_excl)
-
-      other_begin = other.begin
-      self_end = self.end
-      self_excl = self.exclude_end?
-
-      return false if _empty_range?(other_begin, self_end, self_excl)
-      return true if self_begin == other_begin
-
-      return false if _empty_range?(self_begin, self_end, self_excl)
-      return false if _empty_range?(other_begin, other_end, other_excl)
-
-      true
-    end
-
-    private
-    def _empty_range?(b, e, excl)
-      return false if b.nil? || e.nil?
-
-      comp = b <=> e
-      comp.nil? || comp > 0 || (comp == 0 && excl)
-    end
-  end
-
   alias :overlaps? :overlap?
 end

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -17,18 +17,8 @@ module SecureRandom
   #
   #   p SecureRandom.base58 # => "4kUgL2pdQMSCQtjE"
   #   p SecureRandom.base58(24) # => "77TMHrHJFvFDwodq8w7Ev2m7"
-  if SecureRandom.method(:alphanumeric).parameters.size == 2 # Remove check when Ruby 3.3 is the minimum supported version
-    def self.base58(n = 16)
-      alphanumeric(n, chars: BASE58_ALPHABET)
-    end
-  else
-    def self.base58(n = 16)
-      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-        idx = byte % 64
-        idx = SecureRandom.random_number(58) if idx >= 58
-        BASE58_ALPHABET[idx]
-      end.join
-    end
+  def self.base58(n = 16)
+    alphanumeric(n, chars: BASE58_ALPHABET)
   end
 
   # SecureRandom.base36 generates a random base36 string in lowercase.
@@ -42,18 +32,8 @@ module SecureRandom
   #
   #   p SecureRandom.base36 # => "4kugl2pdqmscqtje"
   #   p SecureRandom.base36(24) # => "77tmhrhjfvfdwodq8w7ev2m7"
-  if SecureRandom.method(:alphanumeric).parameters.size == 2 # Remove check when Ruby 3.3 is the minimum supported version
-    def self.base36(n = 16)
-      alphanumeric(n, chars: BASE36_ALPHABET)
-    end
-  else
-    def self.base36(n = 16)
-      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-        idx = byte % 64
-        idx = SecureRandom.random_number(36) if idx >= 36
-        BASE36_ALPHABET[idx]
-      end.join
-    end
+  def self.base36(n = 16)
+    alphanumeric(n, chars: BASE36_ALPHABET)
   end
 
   # SecureRandom.base32 generates a random Crockford base32 string in uppercase.
@@ -67,17 +47,7 @@ module SecureRandom
   #
   #   p SecureRandom.base32 # => "PAK1NG78CM1HJ44A"
   #   p SecureRandom.base32(24) # => "BN9EAB8RG9BNTTC9BX7P5JGJ"
-  if SecureRandom.method(:alphanumeric).parameters.size == 2 # Remove check when Ruby 3.3 is the minimum supported version
-    def self.base32(n = 16)
-      alphanumeric(n, chars: BASE32_ALPHABET)
-    end
-  else
-    def self.base32(n = 16)
-      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-        idx = byte % 64
-        idx = SecureRandom.random_number(32) if idx >= 32
-        BASE32_ALPHABET[idx]
-      end.join
-    end
+  def self.base32(n = 16)
+    alphanumeric(n, chars: BASE32_ALPHABET)
   end
 end


### PR DESCRIPTION
### Motivation / Background

This commit removes Ruby < 3.3 compatibility code since Rails main branch requires Ruby 3.3.

### Detail

- No need to check `SecureRandom.method(:alphanumeric).parameters.size` in Ruby 3.3+ because it is always 2 https://github.com/ruby/securerandom/pull/36

- Ruby 3.3 introduces `Range#overlap?` https://bugs.ruby-lang.org/issues/19839
- Ruby 3.3 introcuces `Fiber#kill` https://bugs.ruby-lang.org/issues/595

### Additional information

Refer to https://github.com/rails/rails/pull/56511

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
