### PR TITLE
Clarify that column default values don't apply to existing records [ci skip]

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -705,7 +705,8 @@ Column modifiers can be applied when creating or changing a column:
 * `default`      Allows to set a default value on the column. Note that if you
   are using a dynamic value (such as a date), the default will only be
   calculated the first time (i.e. on the date the migration is applied). Use
-  `nil` for `NULL`.
+  `nil` for `NULL`. The default value will only apply to new records;
+  existing records will retain their current values (including `NULL`).
 * `limit`        Sets the maximum number of characters for a `string` column and
   the maximum number of bytes for `text/binary/integer` columns.
 * `null`         Allows or disallows `NULL` values in the column.

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -705,8 +705,8 @@ Column modifiers can be applied when creating or changing a column:
 * `default`      Allows to set a default value on the column. Note that if you
   are using a dynamic value (such as a date), the default will only be
   calculated the first time (i.e. on the date the migration is applied). Use
-  `nil` for `NULL`. The default value will only apply to new records;
-  existing records will retain their current values (including `NULL`).
+  `nil` for `NULL`. Depending on your database, existing records may not
+  receive the default value.
 * `limit`        Sets the maximum number of characters for a `string` column and
   the maximum number of bytes for `text/binary/integer` columns.
 * `null`         Allows or disallows `NULL` values in the column.


### PR DESCRIPTION
  ### Summary

  Clarify in the migration guide that setting a `default` value on a column only applies to newly created records. Existing records will retain their current values, including `NULL`.

  ### Motivation

  This addresses confusion reported in #56520, where a developer expected `add_column :products, :inventory_count, :integer, default: 0` to update existing records. The current documentation doesn't explicitly mention this behavior, which can lead to unexpected `nil` values and errors like `NoMethodError` when calling methods on the column.

  ### Changes

  Added a clarifying sentence to the `default` column modifier documentation in the Active Record Migrations guide.

  Fixes #56520
