### PR TITLE
Add hover state to Copy as Text button on error pages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -51,7 +51,11 @@
       margin: 0.35em 0;
     }
     header button:active {
+      background-color: hsl(0 0% 0% / 0.3);
+    }
+    header button:hover {
       background-color: hsl(0 0% 0% / 0.25);
+      cursor: pointer;
     }
 
     h1 {


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

The `Copy as Text` button was added to the error pages in https://github.com/rails/rails/pull/55431. The button itself doesn't feel like a button. When hovering, the cursor does not change and the button doesn't afford any clickiness.

### Detail

This MR simply adds a subtle hover state to the button in question.

### Additional information

Video recording: 

https://github.com/user-attachments/assets/7626cd44-648f-4023-8efc-e7800f652375

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
