### PR TITLE
[ActiveSupport ContinuousIntegration] Add group filtering to CI with -g/--group flags and nesting support

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add group based filtering using `bin/ci -g/--group` to `ActiveSupport::ContinuousIntegration`.
+
+    Example:
+    ```ruby
+    group "lint" do
+      step "Rubocop", "bin/rubocop"
+      step "Biome", "bin/biome"
+    end
+    ```
+
+    *Harsh Deep*
+
 *   Add `ActiveSupport::CombinedConfiguration` to offer interchangeable access to configuration provided by
     either ENV or encrypted credentials. Used by Rails to first look at ENV, then look in encrypted credentials,
     but can be configured separately with any number of API-compatible backends in a first-look order.

--- a/activesupport/lib/active_support/continuous_integration.rb
+++ b/activesupport/lib/active_support/continuous_integration.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "optparse"
+require "active_support/core_ext/object/with"
+
 module ActiveSupport
   # Provides a DSL for declaring a continuous integration workflow that can be run either locally or in the cloud.
   # Each step is timed, reports success/error, and is aggregated into a collective report that reports total runtime,
@@ -31,6 +34,7 @@ module ActiveSupport
     }
 
     attr_reader :results
+    attr_accessor :current_groups # :nodoc:
 
     # Perform a CI run. Execute each step, show their results and runtime, and exit with a non-zero status if there are any failures.
     #
@@ -65,18 +69,68 @@ module ActiveSupport
 
     def initialize
       @results = []
+      @current_groups = []
+      @included_groups = []
+      @fail_fast = false
+      parse_flags
     end
 
     # Declare a step with a title and a command. The command can either be given as a single string or as multiple
     # strings that will be passed to `system` as individual arguments (and therefore correctly escaped for paths etc).
+    #
+    # Steps inside groups will only run when:
+    # - No group filter is specified (runs everything), OR
+    # - The step is inside a group that matches the filter
+    #
+    # Steps outside of any group will only run when no group filter is specified.
     #
     # Examples:
     #
     #   step "Setup", "bin/setup"
     #   step "Single test", "bin/rails", "test", "--name", "test_that_is_one"
     def step(title, *command)
+      return unless should_run?
+
       heading title, command.join(" "), type: :title
       report(title) { results << [ system(*command), title ] }
+    end
+
+    # Declare a group of related steps. Groups can be filtered using the -g/--group flag.
+    # Groups can be nested to create hierarchical organization.
+    #
+    # When filtering by group name, specifying a parent group will run all nested groups within it.
+    # Steps outside of any group will only run when no group filter is specified.
+    #
+    # Examples:
+    #
+    #   step "Single test", "bin/rails", "test", "--name", "test_that_is_one" # Will run when no group is specified
+    #
+    #   group "lint" do
+    #     step "RuboCop", "bin/rubocop"
+    #     step "ESLint", "yarn", "lint"
+    #   end
+    #
+    #   # Nested groups
+    #   group "backend" do
+    #     group "unit" do
+    #       step "Models", "bin/rails test test/models"
+    #     end
+    #
+    #     group "integration" do
+    #       step "API", "bin/rails test test/integration"
+    #     end
+    #   end
+    #
+    # Usage:
+    #   $ bin/ci -g backend # Runs all backend tests (unit and integration)
+    #   $ bin/ci --group unit # Runs only the unit group
+    #   $ bin/ci -g lint,backend # Runs only the lint and backend groups
+    #   $ bin/ci # Runs everything when no group is specified
+    def group(name, subtitle = nil, &block)
+      with(current_groups: current_groups + [name]) do
+        heading "Group: #{name}", subtitle, type: :banner, padding: true if should_run?
+        instance_eval(&block)
+      end
     end
 
     # Returns true if all steps were successful.
@@ -154,10 +208,12 @@ module ActiveSupport
 
     # :nodoc:
     def fail_fast?
-      ARGV.include?("-f") || ARGV.include?("--fail-fast")
+      @fail_fast
     end
 
     private
+      attr_reader :included_groups
+
       def timing
         started_at = Time.now.to_f
         yield
@@ -167,6 +223,26 @@ module ActiveSupport
 
       def colorize(text, type)
         "#{COLORS.fetch(type)}#{text}\033[0m"
+      end
+
+      def parse_flags
+        OptionParser.new do |opts|
+          opts.on("-g GROUPS", "--group GROUPS", Array, "Run only steps in these groups (comma-separated)") do |groups|
+            @included_groups.concat(groups)
+          end
+          opts.on("-f", "--fail-fast", "Exit on first failure") do
+            @fail_fast = true
+          end
+        end.parse!(ARGV.dup)
+      rescue OptionParser::InvalidOption
+        # Ignore unknown options
+      end
+
+      def should_run?
+        return true if included_groups.empty?
+        return false if current_groups.empty?
+
+        current_groups.any? { |g| included_groups.include?(g) }
       end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

Note: see newer attempt at https://github.com/rails/rails/pull/57947

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

At my company, our `bin/ci` takes quite long to run so we internally implemented a group filter to only run parts of the CI relevant to the given change. This has also been helpful for us for distributing the CI workload across multiple cloud workers for our cloud CI. The goal of this PR is to upstream this feature to ActiveSupport since it can be helpful for other rails projects as well.

### Detail

Creates a new `group` block that checks if the CLI argument group name is applicable for the current block and runs the steps accordingly. I was thinking the syntax can look something like:

```rb
# Simple groups
group "lint" do
  step "RuboCop", "bin/rubocop"
  step "ESLint", "yarn", "lint"
end

# Nested groups
group "backend" do
  group "unit" do
    step "Models", "bin/rails test test/models"
  end

  group "integration" do
    step "API", "bin/rails test test/integration"
  end
end
```

I've also moved option parsing to ruby's built in `OptionParser` so that the code for the group flag and pre-existing fail fast option is handled nicely. This can make adding future options nicer as well.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
