### PR TITLE
Revert "Remove unnecessary `defined?` check for RubyVM::YJIT.enable"

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -229,7 +229,7 @@ module Rails
       end
 
       initializer :enable_yjit do
-        if config.yjit
+        if config.yjit && defined?(RubyVM::YJIT.enable)
           options = config.yjit.is_a?(Hash) ? config.yjit : {}
           RubyVM::YJIT.enable(**options)
         end


### PR DESCRIPTION
Reverts rails/rails#56526

because of https://github.com/rails/rails/pull/56526#issuecomment-3716645938