### PR TITLE
Fix SQLite3 schema dump for non-autoincrement integer primary keys

### DIFF
--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -517,7 +517,6 @@ class PrimaryKeyIntegerNilDefaultTest < ActiveRecord::TestCase
   end
 
   def test_schema_dump_primary_key_integer_with_default_nil
-    skip if current_adapter?(:SQLite3Adapter)
     @connection.create_table(:int_defaults, id: :integer, default: nil, force: true)
     schema = dump_table_schema "int_defaults"
     assert_match %r{create_table "int_defaults", id: :integer, default: nil}, schema


### PR DESCRIPTION
### Summary

When using `create_table :payments, id: :integer, default: nil` in SQLite, the schema dumper was ignoring the `default: nil` option. This caused schema restoration to create tables with autoincrement instead of preserving the original non-autoincrement behavior.

### Problem

```ruby
# Original migration
create_table :payments, id: :integer, default: nil

# Creates: CREATE TABLE "payments" ("id" integer NOT NULL PRIMARY KEY)
# (no AUTOINCREMENT)

# Schema dump output (BEFORE fix):
create_table "payments", force: :cascade do |t|
end

# Restored table: CREATE TABLE "payments" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
# AUTOINCREMENT was incorrectly added!
```

### Solution

Updated the SQLite schema dumper to detect whether the primary key was created with AUTOINCREMENT by querying sqlite_master. This ensures the schema dump correctly includes `id: :integer, default: nil` for non-autoincrement integer primary keys.

```ruby
# Schema dump output (AFTER fix):
create_table "payments", id: :integer, default: nil, force: :cascade do |t|
end
```

Fixes #56485

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
