### PR TITLE
[Backport 8-1-stable] Fix PostgreSQL schema_search_path after reconnect and reset

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix PostgreSQL `schema_search_path` not being reapplied after `reset!` or `reconnect!`.
+
+    The `schema_search_path` configured in `database.yml` is now correctly
+    reapplied instead of falling back to PostgreSQL defaults.
+
+    *Tobias Egli*
+
 *   Restore the ability of enum to be foats.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -395,6 +395,11 @@ module ActiveRecord
         end
       end
 
+      def clear_cache!(new_connection: false)
+        super
+        @schema_search_path = nil if new_connection
+      end
+
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!
@@ -1008,6 +1013,8 @@ module ActiveRecord
 
           add_pg_encoders
           add_pg_decoders
+
+          schema_search_path # populate cache
 
           reload_type_map
         end


### PR DESCRIPTION
### Summary
This PR backports a fix for an Active Record issue related to PostgreSQL adapter behavior to the `8-1-stable` branch.

### Details
- Original PR: #56379
- Fixes #56378
- Includes a CHANGELOG entry for `activerecord` in Rails 8.1.

### Motivation
The bug described in #56378 can affect applications running on Rails 8.1 by causing incorrect behavior when interacting with PostgreSQL, and therefore warrants a fix in the stable branch.
The fix has already been implemented, verified, and merged into `main`.

This backport intentionally includes **only the bug fix**, and excludes the PostgreSQL 18–specific improvements that were part of the original PR, to keep the change minimal and appropriate for a stable release.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
