### PR TITLE
Fix decryption error when switching from deterministic to non-deterministic encryption

### DIFF
--- a/activerecord/lib/active_record/encryption/envelope_encryption_key_provider.rb
+++ b/activerecord/lib/active_record/encryption/envelope_encryption_key_provider.rb
@@ -39,6 +39,8 @@ module ActiveRecord
 
         def decrypt_data_key(encrypted_message)
           encrypted_data_key = encrypted_message.headers.encrypted_data_key
+          raise Errors::Decryption if encrypted_data_key.nil?
+
           key = primary_key_provider.decryption_keys(encrypted_message)&.collect(&:secret)
           ActiveRecord::Encryption.cipher.decrypt encrypted_data_key, key: key if key
         end

--- a/activerecord/test/cases/encryption/envelope_encryption_key_provider_test.rb
+++ b/activerecord/test/cases/encryption/envelope_encryption_key_provider_test.rb
@@ -42,6 +42,14 @@ class ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest < ActiveRecord
     assert_encryptor_works_with @key_provider
   end
 
+  test "decryption_keys raises Decryption error when message has no encrypted_data_key header" do
+    message_without_data_key = ActiveRecord::Encryption::Message.new(payload: "some encrypted data")
+
+    assert_raises ActiveRecord::Encryption::Errors::Decryption do
+      @key_provider.decryption_keys(message_without_data_key)
+    end
+  end
+
   private
     def assert_multiple_primary_keys
       assert Rails.app.credentials.dig(:active_record_encryption, :primary_key).length > 1


### PR DESCRIPTION
### Summary

When using `EnvelopeEncryptionKeyProvider` as the default key provider and switching from deterministic to non-deterministic encryption, a `NoMethodError` was raised instead of properly falling back to the previous encryption scheme.

### Problem

```ruby
# Config using EnvelopeEncryptionKeyProvider
config.active_record.encryption.key_provider = ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider.new

# Migration from deterministic to non-deterministic
encrypts :email, deterministic: false, previous: { deterministic: true }
```

Reading old deterministically-encrypted records raised:
`NoMethodError: undefined method 'payload' for nil`

 ### Root cause

Deterministically encrypted records don't have an `encrypted_data_key` header. The `decrypt_data_key` method was passing `nil` to the cipher's decrypt method instead of signaling that it couldn't decrypt the message.

### Solution

  Added a `nil` check that raises `Errors::Decryption` when `encrypted_data_key` is missing:

```ruby
def decrypt_data_key(encrypted_message)
  encrypted_data_key = encrypted_message.headers.encrypted_data_key
  raise Errors::Decryption if encrypted_data_key.nil?
  # ...
end
```

This allows the decryption machinery to properly fall back to previous encryption schemes (like deterministic encryption).

Fixes #55208

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.