### PR TITLE
Abort rails new when bundle install fails

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -677,7 +677,7 @@ module Rails
       end
 
       def bundle_install?
-        !(options[:skip_bundle] || options[:pretend])
+        !(options[:skip_bundle] || options[:pretend] || ENV["RAILS_SKIP_BUNDLE"])
       end
 
       def depends_on_system_test?

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -711,7 +711,11 @@ module Rails
       end
 
       def run_bundle
-        bundle_command("install --quiet", "BUNDLE_IGNORE_MESSAGES" => "1") if bundle_install?
+        return unless bundle_install?
+
+        unless bundle_command("install --quiet", "BUNDLE_IGNORE_MESSAGES" => "1")
+          abort "Bundle install failed. Please run `bundle install` manually to see the error."
+        end
       end
 
       def run_javascript

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -316,7 +316,8 @@ module ApplicationTests
       app_file "config/initializers/dummy.rb", "puts 'Hello, World!'"
       app_file "template.rb", ""
 
-      output = rails("app:template", "LOCATION=template.rb")
+      # Skip bundle install since the test app's Gemfile references unreleased Rails.
+      output = rails("app:template", "LOCATION=template.rb", "RAILS_SKIP_BUNDLE=1")
       assert_match(/Hello, World!/, output)
     end
   end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -918,6 +918,21 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generation_aborts_on_bundle_install_failure
+    generator([destination_root])
+
+    # Simulate bundle install failure by making bundle_command return false
+    failing_bundle_command = ->(*) { false }
+
+    error = assert_raises(SystemExit) do
+      generator.stub :bundle_command, failing_bundle_command do
+        quietly { generator.invoke_all }
+      end
+    end
+
+    assert_equal 1, error.status
+  end
+
   def test_skip_active_job_option
     run_generator [destination_root, "--skip-active-job"]
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -909,6 +909,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     ensure_environment_is_set = -> *_args do
       assert_equal "user:pass", ENV["BUNDLE_RUBYONRAILS__ORG"]
+      true
     end
 
     Bundler.stub :original_env, mock_original_env do
@@ -1022,7 +1023,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     # fallback to latest when yarn is not installed
     generator.stub :dockerfile_yarn_version, "latest" do
-      quietly { generator.invoke_all }
+      generator.stub :bundle_command, true do
+        quietly { generator.invoke_all }
+      end
     end
 
     assert_gem "jsbundling-rails"
@@ -1063,7 +1066,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     # fallback to constant when bun is not installed
     generator.stub :dockerfile_bun_version, bun_version do
-      quietly { generator.invoke_all }
+      generator.stub :bundle_command, true do
+        quietly { generator.invoke_all }
+      end
     end
 
     assert_gem "jsbundling-rails"
@@ -1354,7 +1359,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
         # assert that we don't run `bundle lock --add-platform`, so the
         # following assertion assumes that the sole call to `bundle_command` is
         # for `bundle install`.
-        assert_called_on_instance_of(generator_class, :bundle_command, times: 1) do
+        assert_called_on_instance_of(generator_class, :bundle_command, times: 1, returns: true) do
           quietly { generator_class.apply_rails_template("lib/template.rb", destination_root) }
         end
       end


### PR DESCRIPTION
 ### Summary

When `bundle install --quiet` fails during rails new (e.g., due to missing dependencies), the error is silently ignored and the generator continues, leading to confusing subsequent errors.
  
Fixes: #56313 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

UPDATE: I haven't noticed that there already is https://github.com/rails/rails/pull/56314, feel free to close this one if that other PR is preferred
