### PR TITLE
Enable Arel::TreeManagers to use Table's engine

### DIFF
--- a/activerecord/lib/arel/delete_manager.rb
+++ b/activerecord/lib/arel/delete_manager.rb
@@ -5,6 +5,8 @@ module Arel # :nodoc: all
     include TreeManager::StatementMethods
 
     def initialize(table = nil)
+      super
+
       @ast = Nodes::DeleteStatement.new(table)
     end
 

--- a/activerecord/lib/arel/insert_manager.rb
+++ b/activerecord/lib/arel/insert_manager.rb
@@ -3,6 +3,8 @@
 module Arel # :nodoc: all
   class InsertManager < Arel::TreeManager
     def initialize(table = nil)
+      super
+
       @ast = Nodes::InsertStatement.new(table)
     end
 

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -7,6 +7,8 @@ module Arel # :nodoc: all
     STRING_OR_SYMBOL_CLASS = [Symbol, String]
 
     def initialize(table = nil)
+      super
+
       @ast = Nodes::SelectStatement.new(table)
       @ctx = @ast.cores.last
     end

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -9,7 +9,7 @@ module Arel # :nodoc: all
     class << self; attr_accessor :engine; end
 
     attr_accessor :name
-    attr_reader :table_alias
+    attr_reader :table_alias, :klass
 
     def initialize(name, as: nil, klass: nil, type_caster: klass&.type_caster)
       name = name.name if name.is_a?(Symbol)

--- a/activerecord/lib/arel/tree_manager.rb
+++ b/activerecord/lib/arel/tree_manager.rb
@@ -44,13 +44,23 @@ module Arel # :nodoc: all
 
     attr_reader :ast
 
+    def initialize(table = nil)
+      @table = table
+    end
+
     def to_dot
       collector = Arel::Collectors::PlainString.new
       collector = Visitors::Dot.new.accept @ast, collector
       collector.value
     end
 
-    def to_sql(engine = Table.engine)
+    def to_sql(engine = nil)
+      unless engine
+        table = @table.is_a?(Nodes::JoinSource) ? @table.left : @table
+
+        engine = table&.klass || Table.engine
+      end
+
       collector = Arel::Collectors::SQLString.new
       engine.with_connection do |connection|
         connection.visitor.accept(@ast, collector).value

--- a/activerecord/lib/arel/update_manager.rb
+++ b/activerecord/lib/arel/update_manager.rb
@@ -5,6 +5,8 @@ module Arel # :nodoc: all
     include TreeManager::StatementMethods
 
     def initialize(table = nil)
+      super
+
       @ast = Nodes::UpdateStatement.new(table)
     end
 

--- a/activerecord/test/cases/arel/delete_manager_test.rb
+++ b/activerecord/test/cases/arel/delete_manager_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "helper"
+require_relative "support/tree_manager_behavior"
 
 module Arel
   class DeleteManagerTest < Arel::Spec
+    include TreeManagerBehavior
+
     it "handles limit properly" do
       table = Table.new(:users)
       dm = Arel::DeleteManager.new
@@ -43,5 +46,10 @@ module Arel
         _(dm.where(table[:id].eq(10))).must_equal dm
       end
     end
+
+    private
+      def build_manager(table = nil)
+        Arel::DeleteManager.new(table)
+      end
   end
 end

--- a/activerecord/test/cases/arel/insert_manager_test.rb
+++ b/activerecord/test/cases/arel/insert_manager_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "helper"
+require_relative "support/tree_manager_behavior"
 
 module Arel
   class InsertManagerTest < Arel::Spec
+    include TreeManagerBehavior
+
     describe "insert" do
       it "can create a ValuesList node" do
         manager = Arel::InsertManager.new
@@ -231,5 +234,10 @@ module Arel
         }
       end
     end
+
+    private
+      def build_manager(table = nil)
+        Arel::InsertManager.new(table)
+      end
   end
 end

--- a/activerecord/test/cases/arel/support/tree_manager_behavior.rb
+++ b/activerecord/test/cases/arel/support/tree_manager_behavior.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Arel
+  module TreeManagerBehavior
+    extend ActiveSupport::Concern
+
+    class MyEngine
+      class << self
+        def type_caster; end
+
+        def with_connection
+          yield MyConnection.new
+        end
+      end
+
+      class MyConnection
+        def quote_table_name(name)
+          "@#{name}@"
+        end
+
+        def visitor
+          Arel::Visitors::ToSql.new(self)
+        end
+      end
+    end
+
+    included do
+      describe "to_sql" do
+        it "uses given table's engine if available" do
+          table = Table.new(:users, klass: MyEngine)
+          manager = build_manager(table)
+
+          assert_includes manager.to_sql, "@users@"
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/arel/update_manager_test.rb
+++ b/activerecord/test/cases/arel/update_manager_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "helper"
+require_relative "support/tree_manager_behavior"
 
 module Arel
   class UpdateManagerTest < Arel::Spec
+    include TreeManagerBehavior
+
     it "should not quote sql literals" do
       table = Table.new(:users)
       um = Arel::UpdateManager.new
@@ -167,5 +170,10 @@ module Arel
         _(@um.key).must_equal @table[:foo]
       end
     end
+
+    private
+      def build_manager(table = nil)
+        Arel::UpdateManager.new(table)
+      end
   end
 end


### PR DESCRIPTION
Currently, calling `to_sql` on a `TreeManager` subclass will compile the Arel tree using `Table.engine` (always `ActiveRecord::Base`). This can cause issues when multiple database adapters are used, requiring an explicit engine to be passed to `to_sql`:

```
Arel::InsertManager.new(Model.arel_table).to_sql(Model)
```

This commit refactors the `TreeManager` to store the `Arel::Table` passed in the initializer so that it's engine can be used by default before falling back to `ActiveRecord::Base`.

Now,

```
Arel::InsertManager.new(Model.arel_table).to_sql
```

will use `Model` instead of `ActiveRecord::Base`.