### PR TITLE
Fix Errors#added? with callback options in query

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -179,11 +179,11 @@ module ActiveModel
     # See if error matches provided +attribute+, +type+, and +options+ exactly.
     #
     # All params must be equal to Error's own attributes to be considered a
-    # strict match.
+    # strict match. Callback and message options are filtered from both sides.
     def strict_match?(attribute, type, **options)
       return false unless match?(attribute, type)
 
-      options == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
+      options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS) == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
     end
 
     def ==(other) # :nodoc:

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -262,11 +262,33 @@ class ErrorsTest < ActiveModel::TestCase
     assert person.errors.added?(:name, :too_long)
   end
 
+  test "added? ignores callback option when provided in check" do
+    person = Person.new
+
+    person.errors.add(:name, :too_long, if: -> { true })
+    assert person.errors.added?(:name, :too_long, if: -> { true })
+  end
+
   test "added? ignores message option" do
     person = Person.new
 
     person.errors.add(:name, :too_long, message: proc { "foo" })
     assert person.errors.added?(:name, :too_long)
+  end
+
+  test "added? ignores message option when provided in check" do
+    person = Person.new
+
+    person.errors.add(:name, :too_long, message: proc { "foo" })
+    assert person.errors.added?(:name, :too_long, message: proc { "foo" })
+  end
+
+  test "added? ignores callback options with other options" do
+    person = Person.new
+
+    person.errors.add(:name, :too_long, count: 25, allow_nil: true)
+    assert person.errors.added?(:name, :too_long, count: 25, allow_nil: true)
+    assert person.errors.added?(:name, :too_long, count: 25)
   end
 
   test "added? detects indifferent if a specific error was added to the object" do


### PR DESCRIPTION
When querying errors with `added?` using the same callback options (like `allow_nil`, `if`, `unless`) that were used when creating the error, the method incorrectly returned `false`.

The issue was in `strict_match?` which filtered callback/message options from the stored error but not from the query options, causing an asymmetric comparison that always failed when callback options were provided.

Before:
```ruby
  errors.add(:name, :too_long, allow_nil: true)
  errors.added?(:name, :too_long, allow_nil: true)  # => false (BUG)
```

After:
```ruby
  errors.add(:name, :too_long, allow_nil: true)
  errors.added?(:name, :too_long, allow_nil: true)  # => true
```

Fixes #54483

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
