### PR TITLE
refactor(postgresql): make lookup_cast_type private

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -146,7 +146,8 @@ module ActiveRecord
         if value.is_a?(Proc)
           value.call
         else
-          value = column.cast_type.serialize(value)
+          cast_type = column.cast_type || lookup_cast_type(column.sql_type)
+          value = cast_type.serialize(value)
           quote(value)
         end
       end
@@ -218,9 +219,10 @@ module ActiveRecord
         end
       end
 
-      def lookup_cast_type(sql_type) # :nodoc:
-        type_map.lookup(sql_type)
-      end
+      private
+        def lookup_cast_type(sql_type)
+          type_map.lookup(sql_type)
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         :options_include_default?, :supports_indexes_in_create?, :use_foreign_keys?,
         :quoted_columns_for_index, :supports_partial_index?, :supports_check_constraints?,
         :supports_index_include?, :supports_exclusion_constraints?, :supports_unique_constraints?,
-        :supports_nulls_not_distinct?, :lookup_cast_type,
+        :supports_nulls_not_distinct?,
         to: :@conn, private: true
 
       private
@@ -148,7 +148,7 @@ module ActiveRecord
         end
 
         def add_column_options!(sql, options)
-          sql << " DEFAULT #{quote_default_expression_for_column_definition(options[:default], options[:column])}" if options_include_default?(options)
+          sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
           # must explicitly check for :null to allow change_column to work on migrations
           if options[:null] == false
             sql << " NOT NULL"
@@ -160,11 +160,6 @@ module ActiveRecord
             sql << " PRIMARY KEY"
           end
           sql
-        end
-
-        def quote_default_expression_for_column_definition(default, column_definition)
-          column_definition.cast_type = lookup_cast_type(column_definition.sql_type)
-          quote_default_expression(default, column_definition)
         end
 
         def to_sql(sql)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -186,12 +186,11 @@ module ActiveRecord
           end
         end
 
-        # TODO: Make this method private after we release 8.1.
-        def lookup_cast_type(sql_type) # :nodoc:
-          super(query_value("SELECT #{quote(sql_type)}::regtype::oid").to_i)
-        end
-
         private
+          def lookup_cast_type(sql_type)
+            super(query_value("SELECT #{quote(sql_type)}::regtype::oid").to_i)
+          end
+
           def encode_array(array_data)
             encoder = array_data.encoder
             values = type_cast_array(array_data.values)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -100,7 +100,7 @@ module ActiveRecord
               if options[:default].nil?
                 change_column_sql << ", ALTER COLUMN #{quoted_column_name} DROP DEFAULT"
               else
-                quoted_default = quote_default_expression_for_column_definition(options[:default], column)
+                quoted_default = quote_default_expression(options[:default], column)
                 change_column_sql << ", ALTER COLUMN #{quoted_column_name} SET DEFAULT #{quoted_default}"
               end
             end


### PR DESCRIPTION
@rafaelfranca, lookup_cast_type is private now, but we still using internally in the schema_creation.