### PR TITLE
Add read_and_delete method to ActiveSupport::Cache::Store

### DIFF
--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -31,6 +31,9 @@ module ActiveSupport
       def decrement(name, amount = 1, **options)
       end
 
+      def read_and_delete(name, options = nil)
+      end
+
       def delete_matched(matcher, options = nil)
       end
 

--- a/activesupport/test/cache/stores/null_store_test.rb
+++ b/activesupport/test/cache/stores/null_store_test.rb
@@ -88,4 +88,11 @@ class NullStoreTest < ActiveSupport::TestCase
       assert_equal({}, @cache.read_multi("foo", "bar"))
     end
   end
+
+  def test_read_and_delete
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    assert_nil @cache.read_and_delete(key)
+    assert_nil @cache.read(key)
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because currently, ActiveSupport::Cache lacks a built-in atomic "read-and-delete" operation. Developers often need to retrieve a value and immediately invalidate it (e.g., for one-time tokens or flash-like data), but doing this with separate read and delete calls can lead to race conditions and requires multiple network round-trips. This PR introduces read_and_delete to provide a thread-safe, atomic (where supported), and performant way to consume cache entries.

### Detail

This Pull Request changes the ActiveSupport::Cache::Store by implementing a new read_and_delete method.

Key implementation details include:

Redis Optimization: In RedisCacheStore, it utilizes the native GETDEL command (available in Redis 6.2.0+) to ensure the operation is atomic and requires only a single network round-trip.

Universal Support: For other cache adapters (File, Memory, MemCache), it provides a fallback implementation that mimics the same behavior to ensure a consistent API across all stores.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
