### PR TITLE
Fix `invalid option: --trace` error when running railties tests

### DIFF
--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -164,6 +164,12 @@ namespace :test do
   ensure
     output_file&.close
     output_file&.unlink
+
+    # Clear ARGV to prevent Minitest from trying to parse rake options like --trace
+    # at exit. The abstract_unit.rb requires active_support/testing/autorun which
+    # calls Minitest.autorun, setting up an at_exit hook that would fail on
+    # unrecognized options.
+    ARGV.clear
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

When running `bundle exec rake test --trace` in the railties directory, all tests complete successfully, but the process fails at exit with `invalid option: --trace`.

This happens because:
1. The `test:isolated` task requires `test/isolation/abstract_unit.rb`
2. `abstract_unit.rb` requires `active_support/testing/autorun`
3. `autorun.rb` calls `Minitest.autorun`, which sets up an `at_exit` hook
4. At exit, Minitest tries to parse `ARGV` which still contains `--trace`
5. Minitest doesn't recognize `--trace` (a Rake option) and raises an error

Fixes #56448

### Detail

This Pull Request clears `ARGV` in the `ensure` block of the `test:isolated` task. This prevents Minitest's `at_exit` hook from seeing Rake-specific options like `--trace`.

### Additional information

The error can be reproduced with:
```bash
cd railties
bundle exec rake test --trace
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
