### PR TITLE
Revert "Sort schema cache columns and indexes per table when dumping"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -267,10 +267,10 @@ module ActiveRecord
       end
 
       def encode_with(coder) # :nodoc:
-        coder["columns"]          = @columns.sort.to_h.transform_values { _1.sort_by(&:name) }
+        coder["columns"]          = @columns.sort.to_h
         coder["primary_keys"]     = @primary_keys.sort.to_h
         coder["data_sources"]     = @data_sources.sort.to_h
-        coder["indexes"]          = @indexes.sort.to_h.transform_values { _1.sort_by(&:name) }
+        coder["indexes"]          = @indexes.sort.to_h
         coder["version"]          = @version
       end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -319,15 +319,11 @@ module ActiveRecord
         values = [["z", nil], ["y", nil], ["x", nil]]
         expected = values.sort.to_h
 
-        named = Struct.new(:name)
-        named_values = [["z", [named.new("c"), named.new("b")]], ["y", [named.new("c"), named.new("b")]], ["x", [named.new("c"), named.new("b")]]]
-        named_expected = named_values.sort.to_h.transform_values { _1.sort_by(&:name) }
-
         coder = {
-          "columns" => named_values,
+          "columns" => values,
           "primary_keys" => values,
           "data_sources" => values,
-          "indexes" => named_values,
+          "indexes" => values,
           "deduplicated" => true
         }
 
@@ -335,10 +331,10 @@ module ActiveRecord
         schema_cache.init_with(coder)
         schema_cache.encode_with(coder)
 
-        assert_equal named_expected, coder["columns"]
+        assert_equal expected, coder["columns"]
         assert_equal expected, coder["primary_keys"]
         assert_equal expected, coder["data_sources"]
-        assert_equal named_expected, coder["indexes"]
+        assert_equal expected, coder["indexes"]
         assert coder.key?("version")
       end
 


### PR DESCRIPTION
Reverts rails/rails#54960

I'm tempted to revert this because while I can get behind sorting `schema.rb` to reduce git conflicts, the schema cache is more of an issue.

By sorting the schema cache we're changing the behavior of some queries such as `pluck("*")` etc, which can lead to bugs (it's not an hypothetical, I just ran into that situation).

For `schema.rb`, there is an escape hatch to preserve the order if you care about it, however for the schema cache, there's none.

cc @flavorjones I wonder if you have a strong opinion here. 