### PR TITLE
Disable file watcher for console

### DIFF
--- a/activesupport/lib/active_support/disabled_file_update_checker.rb
+++ b/activesupport/lib/active_support/disabled_file_update_checker.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  # = Null File Update Checker
+  #
+  # This class is used by \Rails when file watching is disabled in certain environments
+  # like console.
+  class DisabledFileUpdateChecker
+    def initialize(files, dirs = {}, &block)
+      unless block
+        raise ArgumentError, "A block is required to initialize a DisabledFileUpdateChecker"
+      end
+
+      @block = block
+    end
+
+    def updated?
+      false
+    end
+
+    def execute
+      @block.call
+    end
+
+    def execute_if_updated
+      false
+    end
+  end
+end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -17,7 +17,7 @@ module Rails
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
                     :log_tags, :silence_healthcheck_path, :railties_order, :relative_url_root,
                     :ssl_options, :public_file_server,
-                    :session_options, :time_zone, :reload_classes_only_on_change,
+                    :session_options, :time_zone, :reload_classes_only_on_change, :disable_file_watcher,
                     :beginning_of_week, :filter_redirect, :x,
                     :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
@@ -60,6 +60,7 @@ module Rails
         @relative_url_root                       = ENV["RAILS_RELATIVE_URL_ROOT"]
         @reload_classes_only_on_change           = true
         @file_watcher                            = ActiveSupport::FileUpdateChecker
+        @disable_file_watcher                    = true
         @exceptions_app                          = nil
         @autoflush_log                           = true
         @log_formatter                           = ActiveSupport::Logger::SimpleFormatter.new

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -4,11 +4,18 @@ require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/array/conversions"
 require "active_support/descendants_tracker"
 require "active_support/dependencies"
+require "active_support/disabled_file_update_checker"
 
 module Rails
   class Application
     module Finisher
       include Initializable
+
+      initializer :disable_file_watcher do |app|
+        if app.config.disable_file_watcher
+          app.config.file_watcher = ActiveSupport::DisabledFileUpdateChecker
+        end
+      end
 
       initializer :add_generator_templates do
         ensure_generator_templates_added

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -86,6 +86,9 @@ module Rails
 
       desc "console", "Start the Rails console"
       def perform
+        require_application!
+        Rails.application.config.disable_file_watcher = true
+
         boot_application!
 
         wrap_with_executor = !options[:skip_executor]


### PR DESCRIPTION
### Motivation / Background

I noticed that when I start Rails development console, it would start watching files for updates. Dev console is an environment that supports reloading but doesn't get automatically reloaded upon change. The goal of this change is to provide a way for things that boot the application to disable the file watcher. I asked on the Rails forum and @fxn replied: https://discuss.rubyonrails.org/t/why-does-rails-console-need-to-watch-for-file-changes/90083

Note: I did not update any tests because I wanted to get feedback regarding the approach.

### Detail

This adds a `DisabledFileUpdateChecker` class that is simply a no-op file watcher class. It also adds a configuration on the Application called `disable_file_watcher` (similar to `disable_sandbox`). When set to `true`, an initializer in the `Finisher` will overwrite the `config.file_watcher` and set it to the `DisabledFileUpdateChecker`.

I took this approach because:
1. I didn't want to mess with any near the concept of "reloading." As in, I didn't want to add more logic to `enable_reloading?` since Console does, in fact, support reloading and changing that seems weird and could have other side effects later.
2. I'm trying to separate out the idea of "watch for changed files and automatically reload" vs "reloadability".
3. I found a handful of places in the framework that will always initialize the file watcher class regardless of `enable_reloading?`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
