### PR TITLE
Warn citext case sensitive

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -19,6 +19,12 @@ module ActiveRecord
 
       def validate_each(record, attribute, value)
         finder_class = find_finder_class_for(record)
+        if options[:case_sensitive] && finder_class.type_for_attribute(attribute.to_s).type == :citext
+          finder_class.logger&.warn(
+            "WARNING: '#{finder_class.name}' validates uniqueness of '#{attribute}' with `case_sensitive: true`, " \
+            "but the column type is 'citext' (case-insensitive). "
+          )
+        end
         value = map_enum_attribute(finder_class, attribute, value)
 
         return if record.persisted? && !validation_needed?(finder_class, record, attribute)


### PR DESCRIPTION
### Motivation / Background

This PR adds a warning when a developer configures `validates :uniqueness, case_sensitive: true` on a PostgreSQL `citext` column.

### Detail

Currently, if a user uses the PostgreSQL `citext` (case-insensitive text) type and attempts to enforce case sensitivity via validation, Rails silently fails to enforce it.

The `UniquenessValidator` generates a standard comparison query (`WHERE column = ?`). Since the underlying database column is `citext`, Postgres treats "Value" and "value" as identical, regardless of the `case_sensitive: true` option in Rails.

This leads to a confusing developer experience where the validation appears to be configured correctly but does not prevent case-insensitive duplicates (unless a unique index exists, in which case a `UniqueViolation` is raised instead of a validation error).

### Additional information

**Example of the issue:**
```ruby
# db/schema.rb
# t.citext "code"

class InviteCode < ApplicationRecord
  # The developer expects this to treat "VIP" and "vip" as different.
  # But Postgres treats them as the same, so "vip" is blocked if "VIP" exists.
  validates :code, uniqueness: { case_sensitive: true }
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
