### PR TITLE
Remove explicit Rake version constraint from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,6 @@ gemspec
 gem "minitest", "~> 6.0"
 gem "minitest-mock"
 
-# We need a newish Rake since Active Job sets its test tasks' descriptions.
-gem "rake", ">= 13"
-
 gem "releaser", path: "tools/releaser"
 
 gem "sprockets-rails", ">= 2.0.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,7 +714,6 @@ DEPENDENCIES
   rack (~> 3.0)
   rack-cache (~> 1.2)
   rails!
-  rake (>= 13)
   redcarpet (~> 3.6.1)
   redis (>= 4.0.1)
   redis-namespace


### PR DESCRIPTION
### Motivation / Background

This pull request Remove explicit Rake version constraint from Gemfile

### Detail

Ruby 3.3+ bundles Rake 13.1.0, so we no longer need to explicitly require "rake >= 13" in the Gemfile.

### Additional information

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released

> The following bundled gems are updated.
> rake 13.1.0

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
