### PR TITLE
[Fix #12940] Prune host helpers for isolated engine controllers

### DIFF
--- a/actionpack/lib/abstract_controller/railties/routes_helpers.rb
+++ b/actionpack/lib/abstract_controller/railties/routes_helpers.rb
@@ -12,12 +12,34 @@ module AbstractController
           define_method(:inherited) do |klass|
             super(klass)
 
-            if namespace = klass.module_parents.detect { |m| m.respond_to?(:railtie_routes_url_helpers) }
-              klass.include(namespace.railtie_routes_url_helpers(include_path_helpers))
-            else
-              klass.include(routes.url_helpers(include_path_helpers))
-            end
+            previous_routes = klass._routes
+            helpers = select_routes_helpers(klass)
+            klass.include(helpers)
+            prune_helper_methods(klass, previous_routes, helpers._routes, include_path_helpers)
           end
+
+          private
+            define_method(:select_routes_helpers) do |klass|
+              if namespace = klass.module_parents.detect { |m| m.respond_to?(:railtie_routes_url_helpers) }
+                namespace.railtie_routes_url_helpers(include_path_helpers)
+              else
+                routes.url_helpers(include_path_helpers)
+              end
+            end
+
+            def prune_helper_methods(klass, previous_routes, desired_routes, include_path_helpers)
+              return unless previous_routes
+              return if previous_routes.equal?(desired_routes)
+
+              # Remove helpers from an inherited route set so they don't become actions when switching namespaces.
+              desired_helpers = desired_routes.named_routes.helper_names
+              desired_helpers = desired_helpers.grep(/_url\z/) unless include_path_helpers
+              removed_helpers = previous_routes.named_routes.helper_names - desired_helpers
+              removed_helpers.each do |helper|
+                helper = helper.to_sym
+                klass.send(:private, helper) if klass.method_defined?(helper)
+              end
+            end
         end
       end
     end


### PR DESCRIPTION
# Motivation / Background

Fixes #12940. Isolated engine controllers inheriting ApplicationController were keeping host route helpers, so engine helpers were missing and host helpers showed up as actions.

# Detail

* In `AbstractController::Railties::RoutesHelpers`, the inherited hook now prunes helper methods from the previously inherited route set when switching to the engine’s route set, avoiding stale host helpers.
* Regression test covers an isolated engine controller inheriting `ApplicationController`, asserting it uses engine routes/helpers and doesn’t expose host helpers as actions.

# Additional information

Bug fix only; no changelog entry required.