### PR TITLE
Make CSRF header-only protection compatible with local installs using HTTP

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Make CSRF header-only protection compatible with local installs using HTTP
+
+    In local installations that don't use HTTPS and where the app is
+    accessed within a local network, requests won't be performed from a
+    secure context. In this case, the browser won't send the
+    `Sec-Fetch-Site` header. This means non-GET requests will be rejected
+    because CSRF protection will fail when using the header-only approach.
+
+    With this change, we allow these requests with missing `Sec-Fetch-Site`
+    headers if:
+
+    - They happen over HTTP
+    - The app is not configured to force SSL
+
+    The `Origin` check always happens in any case.
+
+    *Rosa Gutierrez*
+
 *   Deprecate calling `protect_from_forgery` without specifying a strategy.
 
     When `protect_from_forgery` is called without the `:with` option, it currently defaults to

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -636,7 +636,8 @@ module ActionController # :nodoc:
 
       def verified_via_header_only?
         SAFE_FETCH_SITES.include?(sec_fetch_site_value) ||
-          (sec_fetch_site_value == "cross-site" && origin_trusted?)
+          (sec_fetch_site_value == "cross-site" && origin_trusted?) ||
+          (sec_fetch_site_value.nil? && !request.ssl? && !ActionDispatch::Http::URL.secure_protocol)
       end
 
       def verified_with_legacy_token?

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -83,14 +83,16 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
 
+      header "Sec-Fetch-Site", "cross-site"
+
       get "/foo/write_session"
       get "/foo/read_session"
       assert_equal "1", last_response.body
 
-      post "/foo/read_session"               # Read session using POST request without CSRF token
+      post "/foo/read_session"               # Read session using POST request failing CSRF check
       assert_equal "nil", last_response.body # Stored value shouldn't be accessible
 
-      post "/foo/write_session" # Write session using POST request without CSRF token
+      post "/foo/write_session" # Write session using POST request failing CSRF check
       get "/foo/read_session"   # Session shouldn't be changed
       assert_equal "1", last_response.body
     end
@@ -124,14 +126,16 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
 
+      header "Sec-Fetch-Site", "cross-site"
+
       get "/foo/write_cookie"
       get "/foo/read_cookie"
       assert_equal '"1"', last_response.body
 
-      post "/foo/read_cookie"                # Read cookie using POST request without CSRF token
+      post "/foo/read_cookie"                # Read cookie using POST request failing CSRF check
       assert_equal "nil", last_response.body # Stored value shouldn't be accessible
 
-      post "/foo/write_cookie" # Write cookie using POST request without CSRF token
+      post "/foo/write_cookie" # Write cookie using POST request failing CSRF check
       get "/foo/read_cookie"   # Cookie shouldn't be changed
       assert_equal '"1"', last_response.body
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1014,6 +1014,7 @@ module ApplicationTests
       app_file "config/environments/test.rb", <<-RUBY
         Rails.application.configure do
           config.action_controller.allow_forgery_protection = true
+          config.action_controller.forgery_protection_verification_strategy = :header_or_legacy_token
           config.action_dispatch.show_exceptions = :none
         end
       RUBY


### PR DESCRIPTION
### Motivation / Background

This came up in https://github.com/basecamp/fizzy/discussions/2186 and was addressed in https://github.com/basecamp/fizzy/pull/2291. This PR is the upstreamed version of that. 

In local installations that don't use HTTPS and where the app is accessed within a local network, requests won't be performed from [a secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Secure_Contexts#potentially_trustworthy_origins). In this case, the browser won't send the `Sec-Fetch-Site` header. This means non-GET requests will be rejected because CSRF protection will fail when using the header-only approach.

### Detail

With this change, we allow these requests with missing `Sec-Fetch-Site` headers if:

- They happen over HTTP
- The app is not configured to force SSL

The `Origin` check always happens in any case.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
