### PR TITLE
Fix PostgreSQL COMMENT ON INDEX for schema-qualified tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -320,7 +320,7 @@ module ActiveRecord
             statements << schema_creation.accept(index_definition)
 
             if supports_comments? && !supports_comments_in_create?
-              statements << change_index_comment_sql(index_definition.index) if index_definition.index.comment.present?
+              statements << change_index_comment_sql(index_definition.index, table_name) if index_definition.index.comment.present?
             end
           end
         end
@@ -2066,7 +2066,7 @@ module ActiveRecord
           raise NotImplementedError
         end
 
-        def change_index_comment_sql(index)
+        def change_index_comment_sql(index, table_name)
           raise NotImplementedError
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -699,7 +699,7 @@ module ActiveRecord
           result = execute schema_creation.accept(create_index)
 
           index = create_index.index
-          execute change_index_comment_sql(index) if index.comment
+          execute change_index_comment_sql(index, table_name) if index.comment
           result
         end
 
@@ -1431,8 +1431,11 @@ module ActiveRecord
             "DROP TABLE#{exists} #{quoted_table_names}#{cascade}"
           end
 
-          def change_index_comment_sql(index)
-            "COMMENT ON INDEX #{quote_column_name(index.name)} IS #{quote(index.comment)}"
+          def change_index_comment_sql(index, table_name)
+            name = Utils.extract_schema_qualified_name(table_name.to_s)
+            index_name = name.schema ? PostgreSQL::Name.new(name.schema, index.name).to_s : index.name
+
+            "COMMENT ON INDEX #{quote_table_name(index_name)} IS #{quote(index.comment)}"
           end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -841,6 +841,17 @@ module ActiveRecord
         end
       end
 
+      def test_index_with_comment_on_table_with_schema
+        @connection.create_schema("second_schema")
+        @connection.create_table("second_schema.posts")
+        @connection.add_index("second_schema.posts", :id, comment: "test comment")
+
+        index = @connection.indexes("second_schema.posts").first
+        assert_equal "test comment", index.comment
+      ensure
+        @connection.drop_schema("second_schema")
+      end
+
       def test_columns_for_distinct_zero_orders
         assert_equal "posts.id",
           @connection.columns_for_distinct("posts.id", [])


### PR DESCRIPTION
Fixes #56581

When `add_index` is called on a schema-qualified table (e.g. `"other_schema.widgets"`) with a `comment:` option, Active Record correctly creates the index in the target schema, but generates an unqualified `COMMENT ON INDEX` statement that fails.

PostgreSQL requires index comments to reference the index using its **schema-qualified name**. As a result, Active Record currently emits:

```sql
COMMENT ON INDEX "index_widgets_on_id" IS '...'
```

instead of:
```sql
COMMENT ON INDEX "other_schema"."index_widgets_on_id" IS '...'
```

This causes `PG::UndefinedTable` errors when commenting on indexes created with a specific schema name.

This change ensures that index comments use a schema-qualified index name when `add_index` is invoked on schema-qualified tables, preventing PostgreSQL errors and aligning comment generation with index creation.
