### PR TITLE
Improve the ScreenshotHelper docs

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -19,7 +19,7 @@ module ActionDispatch
         # different one with `Capybara.save_path`
         #
         # You can use the `html` argument or set the
-        # `RAILS_SYSTEM_TESTING_SCREENSHOT_HTML` environment variable to save the HTML
+        # `RAILS_SYSTEM_TESTING_SCREENSHOT_HTML` environment variable to `1` to save the HTML
         # from the page that is being screenshotted so you can investigate the elements
         # on the page at the time of the screenshot
         #


### PR DESCRIPTION
This adds a small improvement to the `ActionDispatch::SystemTesting::TestHelpers` docs.

Without looking into the source it's not obvious on what to set the ENV variable `RAILS_SYSTEM_TESTING_SCREENSHOT_HTML` to activate HTML screenshots to  (only `1` works).

An alternative would be to use `ENV.key?("RAILS_SYSTEM_TESTING_SCREENSHOT_HTML")` instead, but this could be considered a breaking change.