### PR TITLE
Allow migration generator to specify default for primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add ability to set a default value for primary keys when generating database migrations.
+
+        config.generators do |g|
+          g.orm :active_record, primary_key_type: :uuid, primary_key_default: "uuidv7()"
+        end
+
+    *Jonathan Baker*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -19,7 +19,13 @@ module ActiveRecord
       private
         def primary_key_type
           key_type = options[:primary_key_type]
-          ", id: :#{key_type}" if key_type
+          return unless key_type
+
+          result = ", id: :#{key_type}"
+          if options[:primary_key_default]
+            result += ", default: -> { \"#{options[:primary_key_default]}\" }"
+          end
+          result
         end
 
         def foreign_key_type

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -9,6 +9,7 @@ module ActiveRecord
 
       class_option :timestamps, type: :boolean
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :primary_key_default, type: :string, desc: "The default value for the primary key"
       class_option :database, type: :string, aliases: %i(--db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
       def create_migration_file

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -14,6 +14,7 @@ module ActiveRecord
       class_option :parent, type: :string, default: "ApplicationRecord", desc: "The parent class for the generated model"
       class_option :indexes, type: :boolean, default: true, desc: "Add indexes for references and belongs_to columns"
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :primary_key_default, type: :string, desc: "The default value for the primary key"
       class_option :database, type: :string, aliases: %i(--db), desc: "The database for your model's migration. By default, the current environment's primary database is used."
 
       Rails::Generators.templates_path.each do |path|

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -295,6 +295,15 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_primary_key_default_to_create_table_migration
+    run_generator ["create_books", "--primary_key_type=uuid", "--primary_key_default=uuidv7()"]
+    assert_migration "db/migrate/create_books.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :books, id: :uuid, default: -> \{ "uuidv7\(\)" \}/, change)
+      end
+    end
+  end
+
   def test_add_migration_with_references_options_when_primary_key_uuid
     migration = "add_references_to_books"
     run_generator [migration, "author:belongs_to", "--primary_key_type=uuid"]

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -456,6 +456,15 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_primary_key_default_to_create_table_migration
+    run_generator ["account", "--primary_key_type=uuid", "--primary_key_default=uuidv7()"]
+    assert_migration "db/migrate/create_accounts.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :accounts, id: :uuid, default: -> \{ "uuidv7\(\)" \}/, change)
+      end
+    end
+  end
+
   def test_database_puts_migrations_in_configured_folder
     with_database_configuration do
       run_generator ["account", "--database=secondary"]


### PR DESCRIPTION
### Motivation / Background

PostgreSQL 18 introduces native support for UUIDv7 via the `uuidv7()` function. However, migrations for new tables must manually be updated to specify its use. Otherwise, the adapter default of `gen_random_uuid()` will eventually be used.

This PR builds on top of https://github.com/rails/rails/pull/21762 and adds a `primary_key_default` generator option to allow configuring the default value for primary keys in generated migrations.

### Detail

Adds `class_option :primary_key_default` to the migration and model generators.

**Configuration:**

```ruby
config.generators do |g|
  g.orm :active_record, primary_key_type: :uuid, primary_key_default: "uuidv7()"
end
```

**Command line:**

```bash
rails g model User --primary_key_type=uuid --primary_key_default="uuidv7()"
```

**Generated migration:**

```ruby
create_table :users, id: :uuid, default: -> { "uuidv7()" } do |t|
end
```

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This PR is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
