### PR TITLE
Deprecate Resque Active Job adapter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate built-in `resque` adapter.
+
+    If you're using this adapter, upgrade to `resque` 3.0 or later to use the `resque` gem's adapter.
+
+    *zzak, Wojciech Wnętrzak*
+
 *   Remove deprecated `sidekiq` Active Job adapter.
 
     The adapter is available in the `sidekiq` gem.

--- a/activejob/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/resque_adapter.rb
@@ -28,6 +28,13 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :resque
     class ResqueAdapter < AbstractAdapter
+      def check_adapter
+        ActiveJob.deprecator.warn <<~MSG.squish
+          The built-in `resque` adapter is deprecated and will be removed in Rails 9.0.
+          Please upgrade `resque` gem to version 3.0 or later to use the `resque` gem's adapter.
+        MSG
+      end
+
       def enqueue(job) # :nodoc:
         JobWrapper.instance_variable_set(:@queue, job.queue_name)
         Resque.enqueue_to job.queue_name, JobWrapper, job.serialize

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -60,4 +60,21 @@ class AdapterTest < ActiveSupport::TestCase
       end
     end
   end
+
+  if adapter_is?(:resque)
+    test "resque adapter should be deprecated" do
+      before_adapter = ActiveJob::Base.queue_adapter
+
+      msg = <<~MSG.squish
+        The built-in `resque` adapter is deprecated and will be removed in Rails 9.0.
+        Please upgrade `resque` gem to version 3.0 or later to use the `resque` gem's adapter.
+      MSG
+      assert_deprecated(msg, ActiveJob.deprecator) do
+        ActiveJob::Base.queue_adapter = :resque
+      end
+
+    ensure
+      ActiveJob::Base.queue_adapter = before_adapter
+    end
+  end
 end


### PR DESCRIPTION
It is now available inside resque gem

https://github.com/resque/resque/releases/tag/v3.0.0
