### PR TITLE
[8-1-stable] Add missing `with_info_handler` removed in 0f8014a0ff

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -46,10 +46,12 @@ module ActiveSupport
 
           set_process_title("#{klass}##{method}")
 
-          result = if Minitest.respond_to? :run_one_method then
-            Minitest.run_one_method klass, method
-          else
-            klass.new(method).run
+          result = klass.with_info_handler reporter do
+            if Minitest.respond_to? :run_one_method
+              Minitest.run_one_method klass, method
+            else
+              klass.new(method).run
+            end
           end
 
           safe_record(reporter, result)


### PR DESCRIPTION
Found by @gstokkink in https://github.com/rails/rails/pull/56434/changes#r2683233800