### PR TITLE
Fix Concern class_methods to preserve inherited ClassMethods

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -207,9 +207,15 @@ module ActiveSupport
     #   Buzz.foo # => "foo"
     #   Buzz.bar # => private method 'bar' called for Buzz:Class(NoMethodError)
     def class_methods(&class_methods_module_definition)
-      mod = const_defined?(:ClassMethods, false) ?
-        const_get(:ClassMethods) :
-        const_set(:ClassMethods, Module.new)
+      mod = if const_defined?(:ClassMethods, false)
+        const_get(:ClassMethods)
+      else
+        new_mod = Module.new
+        if const_defined?(:ClassMethods)
+          new_mod.include(const_get(:ClassMethods))
+        end
+        const_set(:ClassMethods, new_mod)
+      end
 
       mod.module_eval(&class_methods_module_definition)
     end


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_the_rails_documentation.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `class_methods do` in `ActiveSupport::Concern` currently creates a fresh `ClassMethods` module that drops inherited `ClassMethods` from non-Concern modules, leading to `NoMethodError` when included blocks call those methods. Fixes #56592.

### Detail

This Pull Request changes `ActiveSupport::Concern#class_methods` to include any inherited `ClassMethods` when creating a new module and adds a regression test in `activesupport/test/concern_test.rb` covering the reported scenario.

### Additional information

Tests:
- `bundle exec ruby -Itest activesupport/test/concern_test.rb`
- `bundle exec rake test` (from `activesupport/`)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
