### PR TITLE
[ci skip] Update security guide: clean up orphaned sessions

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -266,10 +266,6 @@ module ActionView
         end
       end
 
-      def after_setup
-        @__setup_ivars = instance_variables << :@__setup_ivars
-      end
-
       def setup_with_controller
         controller_class = Class.new(ActionView::TestCase::TestController)
         @controller = controller_class.new
@@ -400,10 +396,11 @@ module ActionView
         :@view_flow,
         :@_subscribers,
         :@html_document,
+        :@__leak_checker_before_env,
       ]
 
       def _user_defined_ivars
-        instance_variables - INTERNAL_IVARS - @__setup_ivars
+        instance_variables - INTERNAL_IVARS
       end
 
       # Returns a Hash of instance variables and their values, as defined by

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -243,29 +243,12 @@ With the authentication generator configured as above, your application is ready
 for a more secure user authentication and password recovery process in just a
 few steps.
 
-NOTE: You may need to think about cleaning up orphaned session records.
-If a user deletes the cookie used for authentication (or the webbrowser is set
-up to remove cookies on exit) the user appears to be logged out but the session
-record still exists in the database.
-Depending on your requirements there are several solutions, like:
-
-- Display all other active sessions in the UI to the logged in user and let the
-  user decide which sessions to remove. You would need to implement the
-  necessary views, routes, and controller actions yourself
-- When a user starts a new session remove old sessions. You could add a line to
-  the end of the `start_new_session_for(user)` method. For instance:
-  `user.sessions.where("created_at < ?", 1.month.ago).delete_all`
-  or even `user.sessions.where.not(id: session.id).delete_all`
-- Regularly remove old session records using a rake task, like so:
-
-  ```
-  namespace :authentication do
-    desc "Purge historical sessions (might drop active sessions requiring users to log in again)"
-    task purge_historical: :environment do
-      Session.where(updated_at: ..1.month.ago).delete_all
-    end
-  end
-  ```
+NOTE: You may need to think about cleaning up stale session records. If a user
+deletes the cookie used for authentication (or the webbrowser is set up to remove
+cookies on exit) the user appears to be logged out but the session record still
+exists in the database. Depending on your requirements there are several
+solutions. A simple solution is to add a line to the 'start_new_session_for(user)'
+method: 'user.sessions.where("created_at < ?", 1.month.ago).delete_all'.
 
 Sessions
 --------

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -244,9 +244,9 @@ for a more secure user authentication and password recovery process in just a
 few steps.
 
 NOTE: You may need to think about cleaning up stale session records. If a user
-deletes the cookie used for authentication (or the webbrowser is set up to remove
-cookies on exit) the user appears to be logged out but the session record still
-exists in the database. Depending on your requirements there are several
+deletes their cookies, or their browser removes them on exit, or the user never
+explicitly logs out on their different devices, stale sessions will accumulate in
+the database. Depending on your requirements there are several
 solutions. A simple solution is to add a line to the 'start_new_session_for(user)'
 method: 'user.sessions.where("created_at < ?", 1.month.ago).delete_all'.
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -243,6 +243,30 @@ With the authentication generator configured as above, your application is ready
 for a more secure user authentication and password recovery process in just a
 few steps.
 
+NOTE: You may need to think about cleaning up orphaned session records.
+If a user deletes the cookie used for authentication (or the webbrowser is set
+up to remove cookies on exit) the user appears to be logged out but the session
+record still exists in the database.
+Depending on your requirements there are several solutions, like:
+
+- Display all other active sessions in the UI to the logged in user and let the
+  user decide which sessions to remove. You would need to implement the
+  necessary views, routes, and controller actions yourself
+- When a user starts a new session remove old sessions. You could add a line to
+  the end of the `start_new_session_for(user)` method. For instance:
+  `user.sessions.where("created_at < ?", 1.month.ago).delete_all`
+  or even `user.sessions.where.not(id: session.id).delete_all`
+- Regularly remove old session records using a rake task, like so:
+
+  ```
+  namespace :authentication do
+    desc "Purge historical sessions (might drop active sessions requiring users to log in again)"
+    task purge_historical: :environment do
+      Session.where(updated_at: ..1.month.ago).delete_all
+    end
+  end
+  ```
+
 Sessions
 --------
 


### PR DESCRIPTION
Added a section to security guide describing why and how orphaned session records (used by authentication generator) may be cleaned up. See: https://github.com/rails/rails/issues/55773