### PR TITLE
Add inverse grep option (-v) to rails routes

### DIFF
--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -464,6 +464,34 @@ module ActionDispatch
         ], output
       end
 
+      def test_routes_can_be_filtered_with_grep_v
+        output = draw(grep_v: "posts") do
+          resources :articles
+          resources :posts
+        end
+
+        assert_equal ["      Prefix Verb   URI Pattern                  Controller#Action",
+                      "    articles GET    /articles(.:format)          articles#index",
+                      "             POST   /articles(.:format)          articles#create",
+                      " new_article GET    /articles/new(.:format)      articles#new",
+                      "edit_article GET    /articles/:id/edit(.:format) articles#edit",
+                      "     article GET    /articles/:id(.:format)      articles#show",
+                      "             PATCH  /articles/:id(.:format)      articles#update",
+                      "             PUT    /articles/:id(.:format)      articles#update",
+                      "             DELETE /articles/:id(.:format)      articles#destroy"], output
+      end
+
+      def test_no_routes_matched_grep_v_filter
+        output = draw(grep_v: "photos") do
+          get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
+        end
+
+        assert_equal [
+          "No routes were found for this grep pattern.",
+          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html."
+        ], output
+      end
+
       def test_no_routes_were_defined
         output = draw { }
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `--grep-v` (`-v`) option to `rails routes` for inverse grep filtering
+
+    Filter out routes matching a pattern, showing only routes that don't match:
+
+    ```bash
+    $ rails routes -v admin
+    ```
+
+    *Ariel Rzezak*
+
 *   Console `reload!` will reset the console's executor, when present.
 
     *Ben Sheldon*

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -7,6 +7,7 @@ module Rails
     class RoutesCommand < Base # :nodoc:
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
+      class_option :grep_v, aliases: "-v", desc: "Grep routes not matching a specific pattern."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
       class_option :unused, type: :boolean, aliases: "-u", desc: "Print unused routes."
 
@@ -42,7 +43,7 @@ module Rails
         end
 
         def routes_filter
-          options.symbolize_keys.slice(:controller, :grep)
+          options.symbolize_keys.slice(:controller, :grep, :grep_v)
         end
     end
   end

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -118,6 +118,21 @@ rails_blob_representation_proxy GET  /rails/active_storage/representations/proxy
     MESSAGE
   end
 
+  test "rails routes with inverted grep" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get '/cart', to: 'cart#show'
+        post '/cart', to: 'cart#create'
+        get '/basketballs', to: 'basketball#index'
+      end
+    RUBY
+
+    output = run_routes_command([ "-v", "basketballs" ])
+    assert_includes output, "cart#show"
+    assert_includes output, "cart#create"
+    assert_not_includes output, "basketball#index"
+  end
+
   test "rails routes with controller search key" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do


### PR DESCRIPTION
Similar to `grep -v`, this option filters out routes matching the pattern instead of showing only matching routes:

```
$ rails routes -v admin
```

This complements the existing `-g` option which shows only matching routes.