### PR TITLE
Allow non-boolean values for HTML boolean attributes

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -262,9 +262,12 @@ module ActionView
                 output << prefix_tag_option(key, k, v, escape)
               end
             elsif type == :boolean
-              if value
+              if value == true
                 output << sep
                 output << boolean_tag_option(key)
+              elsif value
+                output << sep
+                output << tag_option(key, value, escape)
               end
             elsif !value.nil?
               output << sep

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -750,7 +750,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_boolean_options
-    assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1" />), checkbox_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
+    assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="yes" type="checkbox" value="1" />), checkbox_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
     assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1" />), checkbox_tag("admin", 1, true, disabled: false, readonly: nil)
     assert_dom_equal %(<input type="checkbox" />), tag(:input, type: "checkbox", checked: false)
     assert_dom_equal %(<select id="people" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: true)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -129,6 +129,22 @@ class TagHelperTest < ActionView::TestCase
       tag.p(disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true, allowpaymentrequest: true, nomodule: true, playsinline: true)
   end
 
+  def test_tag_options_boolean_attribute_with_string_value
+    assert_dom_equal '<p multiple="custom-value" disabled="until-found" />', tag("p", multiple: "custom-value", disabled: "until-found")
+  end
+
+  def test_tag_builder_options_boolean_attribute_with_string_value
+    assert_dom_equal '<p multiple="custom-value" disabled="until-found"></p>', tag.p(multiple: "custom-value", disabled: "until-found")
+  end
+
+  def test_tag_options_boolean_attribute_with_false
+    assert_dom_equal "<p />", tag("p", disabled: false, multiple: false, readonly: false)
+  end
+
+  def test_tag_builder_options_boolean_attribute_with_false
+    assert_dom_equal "<p></p>", tag.p(disabled: false, multiple: false, readonly: false)
+  end
+
   def test_tag_builder_with_options_builds_p_elements
     html = tag.with_options(id: "with-options") { |t| t.p("content") }
 


### PR DESCRIPTION
# Summary

Allow HTML boolean attributes (`multiple`, `disabled`, `readonly`, etc.) to accept non-boolean values and render them as-is, instead of always converting any truthy value to the boolean form (`attr="attr"`).

## Motivation

Per the HTML specification, boolean attributes like `multiple` are only boolean on specific elements (`<select>`, `<input>`). However, ActionView treats them as boolean globally for all elements. This prevents valid use cases like:

- `disabled="until-found"` - a valid HTML attribute value for hidden content
- Custom `data-*` style usage where you want `multiple="custom"` on a `<div>`

## Changes

- Modified `TagBuilder#tag_options` to only use boolean rendering when value is exactly `true`
- Other truthy values (strings, numbers, etc.) are now rendered as regular attributes
- Updated existing test expectation that was testing the old (incorrect) behavior
- Added new tests to explicitly document the new behavior

## Behavior

| Code | Before | After |
|------|--------|-------|
| `tag.div(multiple: true)` | `<div multiple="multiple">` | `<div multiple="multiple">` |
| `tag.div(multiple: "custom")` | `<div multiple="multiple">` | `<div multiple="custom">` |
| `tag.div(disabled: "until-found")` | `<div disabled="disabled">` | `<div disabled="until-found">` |
| `tag.div(multiple: false)` | (omitted) | (omitted) |

## Backwards Compatibility

This change is backwards compatible for all standard uses:
- `attribute: true` still renders `attribute="attribute"`
- `attribute: false` still omits the attribute
- `attribute: nil` still omits the attribute

Only the edge case of passing a non-`true` truthy value changes behavior, which was likely unintentional usage before.