### PR TITLE
For empty REVISION file, Rails.app.REVISION fallbacks to git fixes #56597

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -406,12 +406,15 @@ module Rails
         @revision = begin
           root.join("REVISION").read.strip.presence
         rescue SystemCallError
+          nil
+        end
+        if @revision.nil?
           r, w = IO.pipe
           success = system("git", "-C", root.to_s, "rev-parse", "HEAD", in: File::NULL, err: File::NULL, out: w)
           w.close
           rev = r.read.strip
           r.close
-          rev if success
+          @revision = rev if success
         end
         @revision_initialized = true
       end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix #56597. 

### Detail

When the REVISION file exists (even if empty), Rails reads from it and doesn't fall back to git. Rails should treat an empty REVISION file as "not present" and fall back to git.

This Pull Request fixes it. Now Git fallback happens both when the file doesn't exist (SystemCallError) and when it exists but is empty/whitespace.

Below test cases passes now.

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "main"
  gem "minitest"
end

require "minitest/autorun"
require "fileutils"
require "tmpdir"

class BugTest < Minitest::Test
  def setup
    @app_path = Dir.mktmpdir("rails_app_test")
    @original_dir = Dir.pwd

    FileUtils.mkdir_p("#{@app_path}/config")

    File.write("#{@app_path}/config/application.rb", <<~RUBY)
      require "rails"
      require "action_controller/railtie"

      module TestApp
        class Application < Rails::Application
          config.load_defaults Rails::VERSION::STRING.to_f
          config.eager_load = false
        end
      end
    RUBY

    File.write("#{@app_path}/config/environment.rb", <<~RUBY)
      require_relative "application"
      Rails.application.initialize!
    RUBY
  end

  def teardown
    Dir.chdir(@original_dir)
    FileUtils.rm_rf(@app_path)
  end

  def test_git_commit_sha_is_used_when_revision_file_is_empty
    Dir.chdir(@app_path) do
      File.write("#{@app_path}/REVISION", "")

      `git init`
      `git config user.email "test@example.com"`
      `git config user.name "Test User"`
      File.write("dummy.txt", "content")
      `git add .`
      `git commit -m "Initial commit"`

      commit_sha = `git rev-parse HEAD`.strip

      require "#{@app_path}/config/environment"
      assert_equal commit_sha, Rails.application.revision
    end
  end
end
```

This PR further adds additional test cases:
1. "revision reads from git commit SHA when REVISION file not present".
2. "REVISION file takes precedence over git commit SHA".
3. "config.revision takes precedence over git commit SHA".

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
