### PR TITLE
Active Record: Add support for changing PostgreSQL index comments

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `change_index_comment` and improve PostgreSQL index comment support.
+
+    This change introduces a dedicated API for adding, updating, and removing
+    index comments, making index comments reversible in migrations and consistent
+    with existing table and column comment APIs.
+
+    *Tobias Egli*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -874,6 +874,12 @@ module ActiveRecord
       #
       # Note: only supported by PostgreSQL.
       #
+      # ====== Creating an index with a comment
+      #
+      #   add_index(:accounts, :branch_id, comment: "Used by reports")
+      #
+      # Note: only supported by PostgreSQL.
+      #
       # ====== Creating an index where NULLs are treated equally
       #
       #   add_index(:people, :last_name, nulls_not_distinct: true)
@@ -1569,6 +1575,18 @@ module ActiveRecord
       #   change_column_comment(:posts, :state, from: "old_comment", to: "new_comment")
       def change_column_comment(table_name, column_name, comment_or_changes)
         raise NotImplementedError, "#{self.class} does not support changing column comments"
+      end
+
+      # Changes the comment for an index or removes it if +nil+.
+      #
+      # Passing a hash containing +:from+ and +:to+ will make this change
+      # reversible in migration:
+      #
+      #   change_index_comment("index_name", from: "old_comment", to: "new_comment")
+      #
+      # Note: only supported by PostgreSQL
+      def change_index_comment(index_name, comment_or_changes)
+        raise NotImplementedError, "#{self.class} does not support changing index comments"
       end
 
       # Enables an index to be used by queries.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -550,8 +550,13 @@ module ActiveRecord
         false
       end
 
-      # Does this adapter support metadata comments on database objects (tables, columns, indexes)?
+      # Does this adapter support metadata comments on database objects (tables, columns)?
       def supports_comments?
+        false
+      end
+
+      # Does this adapter support metadata comments on indexes?
+      def supports_index_comments?
         false
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -700,7 +700,12 @@ module ActiveRecord
           result = execute schema_creation.accept(create_index)
 
           index = create_index.index
-          execute "COMMENT ON INDEX #{quote_column_name(index.name)} IS #{quote(index.comment)}" if index.comment
+          if index.comment
+            schema, _table = extract_schema_qualified_name(table_name)
+            index_ref = schema.present? ? PostgreSQL::Name.new(schema, index.name).to_s : index.name
+
+            execute "COMMENT ON INDEX #{quote_table_name(index_ref)} IS #{quote(index.comment)}"
+          end
           result
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -688,6 +688,13 @@ module ActiveRecord
           execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
         end
 
+        # Adds comment for given index or drops it if +comment+ is nil
+        def change_index_comment(index_name, comment_or_changes) # :nodoc:
+          clear_cache!
+          comment = extract_new_comment_value(comment_or_changes)
+          execute "COMMENT ON INDEX #{quote_table_name(index_name)} IS #{quote(comment)}"
+        end
+
         # Renames a column in a table.
         def rename_column(table_name, column_name, new_column_name) # :nodoc:
           clear_cache!
@@ -704,7 +711,7 @@ module ActiveRecord
             schema, _table = extract_schema_qualified_name(table_name)
             index_ref = schema.present? ? PostgreSQL::Name.new(schema, index.name).to_s : index.name
 
-            execute "COMMENT ON INDEX #{quote_table_name(index_ref)} IS #{quote(index.comment)}"
+            change_index_comment(index_ref, index.comment)
           end
           result
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -271,6 +271,10 @@ module ActiveRecord
         true
       end
 
+      def supports_index_comments?
+        true
+      end
+
       def supports_savepoints?
         true
       end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -20,6 +20,7 @@ module ActiveRecord
     # * change_column_null
     # * change_column_comment (must supply a +:from+ and +:to+ option)
     # * change_table_comment (must supply a +:from+ and +:to+ option)
+    # * change_index_comment (must supply a +:from+ and +:to+ option)
     # * create_enum
     # * create_join_table
     # * create_virtual_table
@@ -54,7 +55,7 @@ module ActiveRecord
         :drop_join_table, :drop_table, :execute_block, :enable_extension, :disable_extension,
         :change_column, :execute, :remove_columns, :change_column_null,
         :add_foreign_key, :remove_foreign_key,
-        :change_column_comment, :change_table_comment,
+        :change_column_comment, :change_table_comment, :change_index_comment,
         :add_check_constraint, :remove_check_constraint,
         :add_exclusion_constraint, :remove_exclusion_constraint,
         :add_unique_constraint, :remove_unique_constraint,
@@ -334,6 +335,16 @@ module ActiveRecord
           end
 
           [:change_table_comment, [table, from: options[:to], to: options[:from]]]
+        end
+
+        def invert_change_index_comment(args)
+          index_name, options = args
+
+          unless options.is_a?(Hash) && options.has_key?(:from) && options.has_key?(:to)
+            raise ActiveRecord::IrreversibleMigration, "change_index_comment is only reversible if given a :from and :to option."
+          end
+
+          [:change_index_comment, [index_name, from: options[:to], to: options[:from]]]
         end
 
         def invert_add_check_constraint(args)

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -197,5 +197,18 @@ if ActiveRecord::Base.lease_connection.supports_comments?
       output = dump_table_schema "pk_commenteds"
       assert_match %r[create_table "pk_commenteds", id: { comment: "Primary key comment" }.*, comment: "Table comment"], output
     end
+
+    if ActiveRecord::Base.lease_connection.supports_index_comments?
+      def test_change_index_comment
+        @connection.change_index_comment "index_commenteds_on_name", "Edited index comment"
+        index_comment = @connection.indexes("commenteds").find { _1.name == "index_commenteds_on_name" }.comment
+        assert_equal "Edited index comment", index_comment
+      end
+
+      def test_change_index_comment_to_nil
+        @connection.change_index_comment "index_commenteds_on_name", nil
+        assert_nil @connection.indexes("commenteds").find { _1.name == "index_commenteds_on_name" }.comment
+      end
+    end
   end
 end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -279,6 +279,24 @@ module ActiveRecord
         end
       end
 
+      if ActiveRecord::Base.lease_connection.supports_index_comments?
+        def test_invert_change_index_comment
+          assert_raises(ActiveRecord::IrreversibleMigration) do
+            @recorder.inverse_of :change_index_comment, ["index_name", "comment"]
+          end
+        end
+
+        def test_invert_change_index_comment_with_from_and_to
+          change = @recorder.inverse_of :change_index_comment, ["index_name", from: "old_value", to: "new_value"]
+          assert_equal [:change_index_comment, ["index_name", from: "new_value", to: "old_value"]], change
+        end
+
+        def test_invert_change_index_comment_with_from_and_to_with_nil
+          change = @recorder.inverse_of :change_index_comment, ["index_name", from: nil, to: "new_value"]
+          assert_equal [:change_index_comment, ["index_name", from: "new_value", to: nil]], change
+        end
+      end
+
       def test_invert_change_column_null
         add = @recorder.inverse_of :change_column_null, [:table, :column, true]
         assert_equal [:change_column_null, [:table, :column, false]], add

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -911,6 +911,7 @@ actions automatically. Below are some of the actions that `change` supports:
 * [`change_column_default`][] (must supply `:from` and `:to` options)
 * [`change_column_null`][]
 * [`change_table_comment`][] (must supply `:from` and `:to` options)
+* [`change_index_comment`][] (must supply `:from` and `:to` options)
 * [`create_join_table`][]
 * [`create_table`][]
 * `disable_extension`
@@ -944,6 +945,8 @@ If you need to use any other methods, you should use `reversible` or write the
     https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_column_comment
 [`change_table_comment`]:
     https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table_comment
+[`change_index_comment`]:
+    https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_index_comment
 [`drop_join_table`]:
     https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-drop_join_table
 [`drop_table`]:


### PR DESCRIPTION
### Motivation / Background

Active Record supports comments on tables and columns, but index comments are currently only partially supported and lack a dedicated API for modification after creation.

PostgreSQL supports index comments via `COMMENT ON INDEX`, however Active Record does not currently expose a method to change or remove index comments in migrations.

This Pull Request completes index comment support by introducing a dedicated, reversible API that aligns index comments with existing comment functionality in Active Record.

### Detail

This Pull Request adds a new `change_index_comment` migration API and improves index comment handling for PostgreSQL.

Specifically, it:

* Introduces `change_index_comment`, allowing index comments to be added, changed, or removed in migrations.
* Makes `change_index_comment` reversible when `:from` and `:to` options are provided, consistent with other comment-related APIs.
* Implements `change_index_comment` for PostgreSQL using `COMMENT ON INDEX`, including correct handling of schema-qualified index names.
* Refactors PostgreSQL `add_index` to reuse `change_index_comment` when a comment is specified.
* Adds `supports_index_comments?` to explicitly model adapter capabilities, since index comments are not universally supported across databases.
* Adds test coverage and documentation updates to reflect the new API.


### Additional information

This change builds on a bugfix introduced in https://github.com/rails/rails/pull/56582, and extends it by providing a complete public API for working with index comments.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message clearly explains the change and motivation.
* [x] Tests are added for the new behavior.
* [x] CHANGELOG updated to reflect the new feature.
