### PR TITLE
Allow retry_on wait procs to accept error as a second argument

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Allow `retry_on` `wait` procs to accept the error as a second argument.
+
+    Procs with arity 1 continue to receive only the execution count.
+
+    ```ruby
+    class RemoteServiceJob < ActiveJob::Base
+      retry_on CustomError, wait: ->(executions, error) { error.retry_after || executions * 2 }
+
+      def perform
+        # ...
+      end
+    end
+    ```
+
+    *JP Camara*
+
 *   Deprecate built-in `resque` adapter.
 
     If you're using this adapter, upgrade to `resque` 3.0 or later to use the `resque` gem's adapter.

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -266,6 +266,20 @@ class ExceptionsTest < ActiveSupport::TestCase
       ], JobBuffer.values
     end
 
+    test "custom wait proc can use the error" do
+      travel_to Time.now
+
+      RetryJob.perform_later "RetryWaitIncludedInError", 3, :log_scheduled_at
+
+      assert_equal [
+        "Raised RetryWaitIncludedInError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 11.seconds).to_f}",
+        "Raised RetryWaitIncludedInError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 12.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+
     test "use individual execution timers when calculating retry delay" do
       travel_to Time.now
 

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -12,6 +12,11 @@ class LongWaitError < StandardError; end
 class ShortWaitTenAttemptsError < StandardError; end
 class PolynomialWaitTenAttemptsError < StandardError; end
 class CustomWaitTenAttemptsError < StandardError; end
+class RetryWaitIncludedInError < StandardError
+  def retry_after
+    10
+  end
+end
 class CustomCatchError < StandardError; end
 class DiscardableError < StandardError; end
 class FirstDiscardableErrorOfTwo < StandardError; end
@@ -30,6 +35,7 @@ class RetryJob < ActiveJob::Base
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10
   retry_on PolynomialWaitTenAttemptsError, wait: :polynomially_longer, attempts: 10
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10
+  retry_on RetryWaitIncludedInError, wait: ->(executions, error) { error.retry_after + executions }
   retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
   retry_on(ActiveJob::DeserializationError) { |job, error| JobBuffer.add("Raised #{error.class} for the #{job.executions} time") }
   retry_on UnlimitedRetryError, attempts: :unlimited


### PR DESCRIPTION
### Motivation / Background

Currently, `retry_on` `wait` procs can only accept the execution count as an argument, which limits the ability to customize retry delays based on the error itself. Some exceptions naturally include retry timing information (e.g., rate limit errors with `Retry-After` headers), but there's no way to access this information in the wait proc.

### Detail

This Pull Request adds support for wait procs to optionally receive the error as a second argument:

```ruby
class RemoteServiceJob < ActiveJob::Base
  retry_on CustomError, wait: ->(executions, error) { error.retry_after || executions * 2 }

  def perform
    # ...
  end
end
```

The implementation uses arity checking to maintain backwards compatibility:
- Procs with arity 0 or 1 receive only the execution count (existing behavior)
- Procs with arity 2+ receive both the execution count and error

This allows developers to implement dynamic retry strategies based on error properties while maintaining full backwards compatibility with existing code.

### Additional information

The change is implemented in `ActiveJob::Exceptions#call_retry_delay_algorithm`, which checks the proc's arity and calls it with the appropriate number of arguments. All existing tests pass, and a new test demonstrates the 2-argument form working correctly.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
