### PR TITLE
Fix punctuation in ActiveModel::AttributeMethods documentation

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -74,7 +74,7 @@ module ActiveModel
 
     module ClassMethods
       # Declares a method available for all attributes with the given prefix.
-      # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method.
+      # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method:
       #
       #   #{prefix}#{attr}(*args, &block)
       #
@@ -109,7 +109,7 @@ module ActiveModel
       end
 
       # Declares a method available for all attributes with the given suffix.
-      # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method.
+      # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method:
       #
       #   #{attr}#{suffix}(*args, &block)
       #
@@ -144,7 +144,7 @@ module ActiveModel
 
       # Declares a method available for all attributes with the given prefix
       # and suffix. Uses +method_missing+ and <tt>respond_to?</tt> to rewrite
-      # the method.
+      # the method:
       #
       #   #{prefix}#{attr}#{suffix}(*args, &block)
       #


### PR DESCRIPTION
Change periods to colons in `attribute_method_prefix`, `attribute_method_suffix` and `attribute_method_affix` documentation to show the sentences continue after the code examples:

<img width="1000" height="651" alt="Screenshot 2026-01-13 at 19 09 29" src="https://github.com/user-attachments/assets/8f31fddd-7cdf-4d9b-9f49-abd2606476da" />