### PR TITLE
Fix example in docs for partial index (add_index)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -856,11 +856,11 @@ module ActiveRecord
       #
       # ====== Creating a partial index
       #
-      #   add_index(:accounts, [:branch_id, :party_id], unique: true, where: "active")
+      #   add_index(:accounts, [:branch_id, :party_id], unique: true, where: "state = 'active'")
       #
       # generates:
       #
-      #   CREATE UNIQUE INDEX index_accounts_on_branch_id_and_party_id ON accounts(branch_id, party_id) WHERE active
+      #   CREATE UNIQUE INDEX index_accounts_on_branch_id_and_party_id ON accounts(branch_id, party_id) WHERE state = 'active'
       #
       # Note: Partial indexes are only supported for PostgreSQL and SQLite.
       #


### PR DESCRIPTION
Update the partial index example to use a complete where clause condition instead of just the value

The relevant documentation was added in https://github.com/rails/rails/pull/4956. 
Included tests (`activerecord/test/cases/adapters/postgresql/active_schema_test.rb`) validate the required change in documentation:

`activerecord/test/cases/adapters/postgresql/active_schema_test.rb:30-31`:
```ruby
    expected = %(CREATE UNIQUE INDEX "index_people_on_last_name" ON "people" ("last_name") WHERE state = 'active')
    assert_equal expected, add_index(:people, :last_name, :unique => true, :where => "state = 'active'")
```