### PR TITLE
[Fix #56610] Ensure after_commit_jobs is not redefined for subclasses

### DIFF
--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -438,4 +438,16 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     Tag.delete_all
     BookDestroyAsync.delete_all
   end
+
+  test "destroying a record enqueues the job once" do
+    book = BookDestroyAsyncEssaysAndContent.create!
+    book.create_content
+
+    assert_enqueued_jobs 1, only: ActiveRecord::DestroyAssociationAsyncJob do
+      book.destroy
+    end
+  ensure
+    BookDestroyAsyncEssaysAndContent.delete_all
+    Content.delete_all
+  end
 end

--- a/activerecord/test/models/book_destroy_async.rb
+++ b/activerecord/test/models/book_destroy_async.rb
@@ -22,3 +22,14 @@ class BookDestroyAsyncWithScopedTags < ActiveRecord::Base
   has_many :taggings, as: :taggable, class_name: "Tagging"
   has_many :tags, -> { where name: "Der be rum" }, through: :taggings, dependent: :destroy_async
 end
+
+class BookDestroyAsyncOnlyEssays < ActiveRecord::Base
+  self.table_name = "books"
+
+  has_many :essays, dependent: :destroy_async, class_name: "EssayDestroyAsync", foreign_key: "book_id"
+end
+
+
+class BookDestroyAsyncEssaysAndContent < BookDestroyAsyncOnlyEssays
+  has_one :content, dependent: :destroy_async, foreign_key: "book_id"
+end


### PR DESCRIPTION

### Motivation / Background

Fixes #56610 

This Pull Request has been created because there's no reason for the job to be enqueued twice.

### Detail

This Pull Request changes how the the code determine if it needs to define an after_commit callback, checking the in the superclass if `_after_commit_jobs` is defined.

The recursion is stopped when the superclass is `ActiveRecord::Base`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I'm not sure this warrants a changelog entry