### PR TITLE
Fix duplicate after_commit callback registration for destroy_async in class inheritance

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix duplicate `after_commit` callback registration for `dependent: :destroy_async` in class inheritance.
+
+    When a parent class and its subclass both declared associations with
+    `dependent: :destroy_async`, the `after_commit` callback that processes
+    async destroy jobs was being registered multiple times, causing
+    `DestroyAssociationAsyncJob` to be enqueued multiple times for the same
+    destruction.
+
+    This fix ensures the callback is only registered once in the parent class
+    and properly inherited by subclasses.
+
+    Fixes #56610.
+
+    *Yuji Teshima*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -157,7 +157,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       if dependent == :destroy_async
         mixin = model.generated_association_methods
 
-        unless mixin.method_defined?(:_after_commit_jobs)
+        unless model.method_defined?(:_after_commit_jobs)
           model.after_commit(-> do
             _after_commit_jobs.each do |job_class, job_arguments|
               job_class.perform_later(**job_arguments)

--- a/activerecord/test/models/book_destroy_async.rb
+++ b/activerecord/test/models/book_destroy_async.rb
@@ -22,3 +22,11 @@ class BookDestroyAsyncWithScopedTags < ActiveRecord::Base
   has_many :taggings, as: :taggable, class_name: "Tagging"
   has_many :tags, -> { where name: "Der be rum" }, through: :taggings, dependent: :destroy_async
 end
+
+# Subclass of BookDestroyAsync with its own destroy_async association
+# Used to test that after_commit callback is not registered multiple times
+# when both parent and child classes have destroy_async associations
+class BookDestroyAsyncWithTags < BookDestroyAsync
+  has_many :taggings, as: :taggable, class_name: "Tagging"
+  has_many :tags, through: :taggings, dependent: :destroy_async
+end


### PR DESCRIPTION
When a parent class and its subclass both declared associations with `dependent: :destroy_async`, the `after_commit` callback was registered multiple times because `mixin.method_defined?` only checked the class's own `GeneratedAssociationMethods` module, not the inherited one.

This caused `DestroyAssociationAsyncJob` to be enqueued multiple times for the same destruction.

The fix changes `mixin.method_defined?(:_after_commit_jobs)` to `model.method_defined?(:_after_commit_jobs)`, which checks the entire inheritance chain.

Fixes #56610.

### Motivation / Background

This Pull Request has been created because when using class inheritance with `dependent: :destroy_async` associations in both parent and child classes, the async destroy job was being enqueued multiple times for a single record destruction.

```ruby
class Post < ApplicationRecord
  has_many :comments, dependent: :destroy_async
end

class VisualPost < Post
  has_many :images, dependent: :destroy_async
end


visual_post = VisualPost.create!
visual_post.destroy  # => DestroyAssociationAsyncJob enqueued multiple times
```

### Detail

This Pull Request changes the method check in add_after_commit_jobs_callback from mixin.method_defined?(:_after_commit_jobs) to model.method_defined?(:_after_commit_jobs). The original code only checked the class's own GeneratedAssociationMethods module. Since each class has its own module, the parent's _after_commit_jobs method was not detected when processing the child class, causing the callback to be registered again. Using model.method_defined? instead checks the entire inheritance chain, including the parent's GeneratedAssociationMethods module.

### Additional information

Related issues:
- #42430 - Another destroy_async bug (different root cause, has existing PR #42452)
- #50048 - Related GeneratedAssociationMethods inheritance issue

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
