### PR TITLE
Remove unused connection arg

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -253,7 +253,7 @@ module ActiveRecord
       def _default_attributes # :nodoc:
         @default_attributes ||= begin
           attributes_hash = columns_hash.transform_values do |column|
-            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(nil, column))
+            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
           end
 
           attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
@@ -308,7 +308,7 @@ module ActiveRecord
           Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
         end
 
-        def type_for_column(connection, column)
+        def type_for_column(column)
           hook_attribute_type(column.name, super)
         end
     end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -640,7 +640,7 @@ module ActiveRecord
           end
         end
 
-        def type_for_column(connection, column)
+        def type_for_column(column)
           type = column.cast_type
 
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)


### PR DESCRIPTION
Ref #56484

A [previous commit][1] removed the need for a connection in some of the attribyte type code, but this method was left accepting `nil` for `connection` and never using the argument.

This commit cleans that up.

[1]: https://github.com/rails/rails/commit/c7328608e55c1c18765f840548c13ac646b71988
