### PR TITLE
Raise UnknownPrimaryKey for writes without primary key

### DIFF
--- a/activerecord/test/cases/persistence_without_pk_test.rb
+++ b/activerecord/test/cases/persistence_without_pk_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PersistenceWithoutPkTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  teardown do
+    with_lease_connection do |connection|
+      connection.drop_table(:destroy_without_primary_keys, if_exists: true)
+      connection.drop_table(:update_without_primary_keys, if_exists: true)
+    end
+  end
+
+  def test_destroy_raises_unknown_primary_key_for_models_without_primary_key
+    model_class = build_model_without_primary_key(:destroy_without_primary_keys)
+    record = model_class.create!(name: "example")
+
+    error = assert_raises(ActiveRecord::UnknownPrimaryKey) { record.destroy }
+    assert_includes error.message, "ActiveRecord cannot destroy records without a primary key"
+    assert_includes error.message, "Add a primary key or use dependent: :delete_all"
+  end
+
+  def test_update_raises_unknown_primary_key_for_models_without_primary_key
+    model_class = build_model_without_primary_key(:update_without_primary_keys)
+    record = model_class.create!(name: "example")
+
+    record.name = "changed"
+    error = assert_raises(ActiveRecord::UnknownPrimaryKey) { record.save }
+    assert_includes error.message, "ActiveRecord cannot update records without a primary key"
+    assert_includes error.message, "Add a primary key or use update_all"
+
+    error = assert_raises(ActiveRecord::UnknownPrimaryKey) { record.update(name: "changed again") }
+    assert_includes error.message, "ActiveRecord cannot update records without a primary key"
+    assert_includes error.message, "Add a primary key or use update_all"
+  end
+
+  private
+    def build_model_without_primary_key(table_name)
+      with_lease_connection do |connection|
+        connection.create_table(table_name, id: false, force: true) do |t|
+          t.string :name
+        end
+      end
+
+      Class.new(ActiveRecord::Base) do
+        self.table_name = table_name
+        self.primary_key = nil
+
+        def self.name
+          "PersistenceWithoutPk#{object_id}"
+        end
+      end
+    end
+
+    def with_lease_connection
+      connection = ActiveRecord::Base.lease_connection
+      yield connection
+    ensure
+      ActiveRecord::Base.connection_pool.release_connection(connection) if connection
+    end
+end


### PR DESCRIPTION
### Motivation / Background

- Models without a primary key combined with `destroy` or `dependent: :destroy` currently generate invalid SQL (e.g., `WHERE "table"."\"\" IS NULL`) and fail with cryptic adapter errors (e.g., `PG::SyntaxError: zero-length delimited identifier`).
- The operation already fails; this change makes it fail earlier with a clear ActiveRecord error. Small win: we short-circuit before issuing SQL, avoiding a DB roundtrip when the PK is missing.

<details>
<summary>Minimal executable bug report (SQL invalid on current main)</summary>

```ruby
# bug_report_primary_key_guard_main.rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: "."
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :owners_without_pk, force: true do |t|
    t.string :name
  end

  create_table :joins_without_pk, id: false, force: true do |t|
    t.integer :owner_id
    t.string :name
  end
end

class Owner < ActiveRecord::Base
  self.table_name = "owners_without_pk"

  has_many :joins_without_pk,
    class_name: "Join",
    foreign_key: :owner_id,
    dependent: :destroy
end

class Join < ActiveRecord::Base
  self.table_name = "joins_without_pk"
  self.primary_key = nil

  belongs_to :owner, class_name: "Owner", foreign_key: :owner_id
end

class BugTest < ActiveSupport::TestCase
  def test_destroy_parent_triggers_invalid_sql_on_child_without_primary_key
    owner = Owner.create!(name: "parent")
    owner.joins_without_pk.create!(name: "child", owner_id: owner.id)

    assert_raises(ActiveRecord::StatementInvalid) { owner.destroy }
  end

  def test_update_without_primary_key_generates_invalid_sql_on_child
    owner = Owner.create!(name: "parent")
    record = Join.create!(name: "demo", owner: owner)
    assert_raises(ActiveRecord::StatementInvalid) { record.update(name: "x") }
  end
end
```
</details>

<details>
<summary>Post-fix version (raises UnknownPrimaryKey instead of bad SQL)</summary>

```ruby
# bug_report_primary_key_guard_branch.rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: "."
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :owners_without_pk, force: true do |t|
    t.string :name
  end

  create_table :joins_without_pk, id: false, force: true do |t|
    t.integer :owner_id
    t.string :name
  end
end

class Owner < ActiveRecord::Base
  self.table_name = "owners_without_pk"

  has_many :joins_without_pk,
    class_name: "Join",
    foreign_key: :owner_id,
    dependent: :destroy
end

class Join < ActiveRecord::Base
  self.table_name = "joins_without_pk"
  self.primary_key = nil

  belongs_to :owner, class_name: "Owner", foreign_key: :owner_id
end

class BugTest < ActiveSupport::TestCase
  def test_destroy_parent_raises_unknown_primary_key_on_child_without_pk
    owner = Owner.create!(name: "parent")
    owner.joins_without_pk.create!(name: "child", owner_id: owner.id)

    error = assert_raises(ActiveRecord::UnknownPrimaryKey) { owner.destroy }
    assert_includes error.message, "Unknown primary key for table joins_without_pk in model Join."
  end

  def test_update_without_primary_key_raises_unknown_primary_key_on_child
    owner = Owner.create!(name: "parent")
    record = Join.create!(name: "demo", owner_id: owner.id)
    error = assert_raises(ActiveRecord::UnknownPrimaryKey) { record.update(name: "x") }
    assert_includes error.message, "ActiveRecord cannot update records without a primary key. Add a primary key or use update_all"
  end
end
```
</details>

### Detail

- Add an early PK check in `_update_record` and `_delete_record`. If `primary_key` is blank, raise `ActiveRecord::UnknownPrimaryKey` with actionable guidance:
  - destroy: “ActiveRecord cannot destroy records without a primary key. Add a primary key or use dependent: :delete_all.”
  - update/save: “ActiveRecord cannot update records without a primary key. Add a primary key or use update_all.”
- New private helper `ensure_primary_key_for_write!` powers both paths.
- Added dedicated coverage in `persistence_without_pk_test`: a no-PK model asserts `destroy`, `save`, and `update` raise `UnknownPrimaryKey` with the expected message.

### Additional information

- No semantic change: these operations already failed; now they fail earlier with a clearer error.
- `update_all`/`delete_all` remain untouched and continue to work without a PK.
- Test suites run:
  - `bin/test activerecord/test/cases/persistence_without_pk_test.rb` (per adapter)
  - `bundle exec rake activerecord:sqlite3:test`
  - `bundle exec rake activerecord:postgresql:test`
  - `bundle exec rake activerecord:mysql2:test`

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG not updated (bug fix, no behavior change needed there).
