### PR TITLE
Raise UnknownPrimaryKey for destroy_async without PK

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -34,11 +34,18 @@ module ActiveRecord
 
           unless target.empty?
             association_class = target.first.class
+            primary_key_column = association_class.query_constraints_list || association_class.primary_key
+
+            if primary_key_column.blank?
+              raise UnknownPrimaryKey.new(
+                association_class,
+                "ActiveRecord cannot destroy associated records asynchronously without a primary key. Add a primary key or use dependent: :delete_all."
+              )
+            end
+
             if association_class.query_constraints_list
-              primary_key_column = association_class.query_constraints_list
               ids = target.collect { |assoc| primary_key_column.map { |col| assoc.public_send(col) } }
             else
-              primary_key_column = association_class.primary_key
               ids = target.collect { |assoc| assoc.public_send(primary_key_column) }
             end
 

--- a/activerecord/test/cases/associations/destroy_async_no_primary_key_test.rb
+++ b/activerecord/test/cases/associations/destroy_async_no_primary_key_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_job/base"
+
+class DestroyAsyncNoPrimaryKeyTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  class DummyDestroyJob < ActiveJob::Base
+    queue_as :test
+
+    def perform(*); end
+  end
+
+  setup do
+    @previous_job = ActiveRecord::Base._destroy_association_async_job
+    ActiveRecord::Base._destroy_association_async_job = DummyDestroyJob
+  end
+
+  teardown do
+    ActiveRecord::Base._destroy_association_async_job = @previous_job
+
+    with_lease_connection do |connection|
+      connection.drop_table(:owners_no_pk, if_exists: true)
+      connection.drop_table(:children_no_pk, if_exists: true)
+    end
+  end
+
+  def test_has_many_destroy_async_raises_unknown_primary_key_before_enqueue
+    with_lease_connection do |connection|
+      connection.create_table(:owners_no_pk, force: true) do |t|
+        t.string :name
+      end
+
+      connection.create_table(:children_no_pk, id: false, force: true) do |t|
+        t.integer :owner_id
+        t.string :name
+      end
+    end
+
+    owner_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "owners_no_pk"
+
+      has_many :children_no_pk,
+        class_name: "DestroyAsyncChildNoPk",
+        foreign_key: :owner_id,
+        dependent: :destroy_async
+
+      def self.name
+        "DestroyAsyncOwnerNoPk"
+      end
+    end
+
+    child_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "children_no_pk"
+      self.primary_key = nil
+
+      belongs_to :owner_no_pk,
+        class_name: "DestroyAsyncOwnerNoPk",
+        foreign_key: :owner_id
+
+      def self.name
+        "DestroyAsyncChildNoPk"
+      end
+    end
+
+    Object.const_set(owner_class.name, owner_class)
+    Object.const_set(child_class.name, child_class)
+
+    owner = owner_class.create!(name: "owner")
+    child_class.create!(owner_no_pk: owner, name: "c1")
+
+    error = assert_raises(ActiveRecord::UnknownPrimaryKey) { owner.destroy }
+    assert_includes error.message, "cannot destroy associated records asynchronously without a primary key"
+  ensure
+    Object.send(:remove_const, owner_class.name) if Object.const_defined?(owner_class.name)
+    Object.send(:remove_const, child_class.name) if Object.const_defined?(child_class.name)
+  end
+
+  private
+    def with_lease_connection
+      connection = ActiveRecord::Base.lease_connection
+      yield connection
+    ensure
+      ActiveRecord::Base.connection_pool.release_connection(connection) if connection
+    end
+end


### PR DESCRIPTION
### Motivation / Background

- `dependent: :destroy_async` with an associated model that lacks a primary key fails in Ruby before enqueueing (e.g., `TypeError: nil is not a symbol nor a string` / `to_sym` on nil). We want a clear ActiveRecord error up front instead of a cryptic exception or later adapter error.

<details>
<summary>Minimal executable bug report (current main behavior)</summary>

```ruby
# bug_report_destroy_async_no_pk_main.rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: "."
  gem "sqlite3"
end

require "active_record/railtie"
require "active_job/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
  config.active_job.queue_adapter = :test
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :owners_no_pk_async, force: true do |t|
    t.string :name
  end

  create_table :children_no_pk_async, id: false, force: true do |t|
    t.integer :owner_id
    t.string :name
  end
end

class OwnerNoPkAsync < ActiveRecord::Base
  self.table_name = "owners_no_pk_async"

  has_many :children_no_pk_async,
    class_name: "ChildNoPkAsync",
    foreign_key: :owner_id,
    dependent: :destroy_async
end

class ChildNoPkAsync < ActiveRecord::Base
  self.table_name = "children_no_pk_async"
  self.primary_key = nil

  belongs_to :owner_no_pk_async,
    class_name: "OwnerNoPkAsync",
    foreign_key: :owner_id
end

class BugTest < ActiveSupport::TestCase
  class DummyDestroyJob < ActiveJob::Base
    queue_as :test
    def perform(*); end
  end

  def setup
    @previous_job = ActiveRecord::Base._destroy_association_async_job
    ActiveRecord::Base._destroy_association_async_job = DummyDestroyJob
  end

  def teardown
    ActiveRecord::Base._destroy_association_async_job = @previous_job if @previous_job
  end

  def test_destroy_async_on_no_pk_child_blows_up
    owner = OwnerNoPkAsync.create!(name: "owner")
    ChildNoPkAsync.create!(owner_no_pk_async: owner, name: "c1")
    error = assert_raises(TypeError) { owner.destroy }
    assert_match(/nil is not a symbol nor a string/, error.message)
  end
end
```
</details>

<details>
<summary>Post-fix version (raises UnknownPrimaryKey)</summary>

```ruby
# bug_report_destroy_async_no_pk_branch.rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: "."
  gem "sqlite3"
end

require "active_record/railtie"
require "active_job/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
  config.active_job.queue_adapter = :test
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :owners_no_pk_async, force: true do |t|
    t.string :name
  end

  create_table :children_no_pk_async, id: false, force: true do |t|
    t.integer :owner_id
    t.string :name
  end
end

class OwnerNoPkAsync < ActiveRecord::Base
  self.table_name = "owners_no_pk_async"

  has_many :children_no_pk_async,
    class_name: "ChildNoPkAsync",
    foreign_key: :owner_id,
    dependent: :destroy_async
end

class ChildNoPkAsync < ActiveRecord::Base
  self.table_name = "children_no_pk_async"
  self.primary_key = nil

  belongs_to :owner_no_pk_async,
    class_name: "OwnerNoPkAsync",
    foreign_key: :owner_id
end

class BugTest < ActiveSupport::TestCase
  class DummyDestroyJob < ActiveJob::Base
    queue_as :test
    def perform(*); end
  end

  def setup
    @previous_job = ActiveRecord::Base._destroy_association_async_job
    ActiveRecord::Base._destroy_association_async_job = DummyDestroyJob
  end

  def teardown
    ActiveRecord::Base._destroy_association_async_job = @previous_job if @previous_job
  end

  def test_destroy_async_on_no_pk_child_raises_unknown_primary_key
    owner = OwnerNoPkAsync.create!(name: "owner")
    ChildNoPkAsync.create!(owner_no_pk_async: owner, name: "c1")

    error = assert_raises(ActiveRecord::UnknownPrimaryKey) { owner.destroy }
    assert_includes error.message, "cannot destroy associated records asynchronously without a primary key"
  end
end
```
</details>

### Detail

- Add an early guard in `has_many` and `has_one` `dependent: :destroy_async` to raise `ActiveRecord::UnknownPrimaryKey` when the associated model lacks a primary key, before enqueueing jobs.

### Additional information

- No semantic change for valid setups; only broken no-PK associations now fail earlier with a clear error instead of a cryptic exception.
- Test added: `activerecord/test/cases/associations/destroy_async_no_primary_key_test.rb` (covers `has_many`/`has_one`).

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG not updated (bug fix / DX improvement).
