### PR TITLE
Pin connection_pool to version 2 on 7-2-stable

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n",            ">= 1.6", "< 2"
   s.add_dependency "tzinfo",          "~> 2.0", ">= 2.0.5"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.3.1"
-  s.add_dependency "connection_pool", ">= 2.2.5"
+  s.add_dependency "connection_pool", ">= 2.2.5", "< 3"
   s.add_dependency "minitest",        ">= 5.1", "< 6"
   s.add_dependency "base64"
   s.add_dependency "drb"


### PR DESCRIPTION
### Motivation / Background
This pull request pins connection_pool to version 2 on 7-2-stable to address CI failures like https://buildkite.com/rails/rails/builds/125660#019bbf99-1131-47a2-84bb-00881319648a/L1400

This pull request just keeps CI green and will not be released since Rails 7.2 is in Security Release only, so any security releases will be based on the v7.2.3, not based on 7-2-stable.

### Detail

Since connection_pool 3 requires Ruby 3.2 while Rails 7.2 supports Ruby 3.1, pin connection_pool to version 2 on the 7-2-stable branch.

https://github.com/mperham/connection_pool/blob/f0d6dd2ab7241132a5bce4845d011a66786bad2c/connection_pool.gemspec#L19 

### Additional information

https://github.com/rails/rails/issues/56291
https://github.com/rails/rails/pull/56292
https://github.com/rails/rails/pull/56294

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
