### PR TITLE
Fix ActionView::TestCase to pass setup-defined instance variables to views

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -248,7 +248,7 @@ module ActionView
       included do
         class_attribute :content_class, instance_accessor: false, default: RenderedViewContent
 
-        setup :setup_with_controller
+        setup :capture_setup_ivars, :setup_with_controller
 
         register_parser :html, -> rendered { Rails::Dom::Testing.html_document_fragment.parse(rendered) }
         register_parser :json, -> rendered { JSON.parse(rendered, object_class: ActiveSupport::HashWithIndifferentAccess) }
@@ -266,7 +266,7 @@ module ActionView
         end
       end
 
-      def after_setup
+      def capture_setup_ivars
         @__setup_ivars = instance_variables << :@__setup_ivars
       end
 

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -193,6 +193,23 @@ module ActionView
     end
   end
 
+  class ViewAssignsFromSetupTest < ActionView::TestCase
+    setup do
+      @user = { name: "Alice" }
+    end
+
+    test "view_assigns includes ivars defined in setup block" do
+      assert_includes view_assigns.keys, :user
+      assert_equal({ name: "Alice" }, view_assigns[:user])
+    end
+
+    test "view_assigns includes both setup-defined and test-defined ivars" do
+      @extra = "value"
+      assert_includes view_assigns.keys, :user
+      assert_includes view_assigns.keys, :extra
+    end
+  end
+
   class HelperExposureTest < ActionView::TestCase
     helper(Module.new do
       def render_from_helper


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

The `after_setup` hook introduced in #56476 captured instance variables after all setup callbacks completed,
including user-defined setup blocks. This caused user `ivars` like `@user` to be excluded from `view_assigns`,
breaking view rendering in tests.

Fixes https://github.com/rails/rails/issues/56619

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Solution

Changed `ivar` capture from `after_setup` to a setup callback registered first in the setup chain. This ensures `ivars` are captured after `before_setup` hooks complete but before user setup blocks run (so user-defined ivars are correctly passed to views).

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
