### PR TITLE
Handle Ruby 4.1 stabby lambda in Proc#source_location start_column

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -348,6 +348,9 @@ module ActiveSupport
             lines[0] = lines[0].byteslice(location[1]...)
             source = lines.join.strip
 
+            # Strip stabby lambda from Ruby 4.1+
+            source = source.sub(/^->\s*/, "")
+
             # We ignore procs defined with do/end as they are likely multi-line anyway.
             if source.start_with?("{")
               source.delete_suffix!("}")


### PR DESCRIPTION
This behavior was changed in ruby/ruby@c970d2941d56a862bb9bb3b808cb588c2982f436

If I understand correctly, it's an intended change to include the full syntax definition in the source, so we can work around this by stripping it.

This fixes the following failures on Ruby 4.1.0:

```
Failure:
ExceptionsInsideAssertionsTest#test_warning_is_not_logged_if_assertions_are_nested_correctly [test/test_case_test.rb:512]:
Expected false to be truthy.

bin/test activesupport/test/test_case_test.rb:507

Failure:
AssertionsTest#test_assert_no_changes_message_with_lambda [test/test_case_test.rb:385]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
-"`@object.num` changed.
+"`#<Proc:0xXXXXXX /home/zzak/code/rails/activesupport/test/test_case_test.rb:381 (lambda)>` changed.
 Expected: 0
   Actual: 1"

bin/test activesupport/test/test_case_test.rb:377

Failure:
AssertionsTest#test_assert_difference_message_with_lambda [test/test_case_test.rb:180]:
--- expected
+++ actual
@@ -1,4 +1,4 @@
 "Object Changed.
-`@object.num` didn't change by 1, but by 0.
+`#<Proc:0xXXXXXX /home/zzak/code/rails/activesupport/test/test_case_test.rb:177 (lambda)>` didn't change by 1, but by 0.
 Expected: 1
   Actual: 0"

bin/test activesupport/test/test_case_test.rb:173

Failure:
AssertionsTest#test_assert_changes_message_with_lambda [test/test_case_test.rb:258]:
Expected /`@object\.num`\ didn't\ change\.\ It\ was\ already\ 0\./ to match "`#<Proc:0x00007fa8f34fcd58 /home/zzak/code/rails/activesupport/test/test_case_test.rb:253 (lambda)>` didn't change. It was already 0.".

bin/test activesupport/test/test_case_test.rb:249
```

Since the goal here is to only display the body of the lambda, we can strip the stabby part and things should Just Work.

See: <https://bugs.ruby-lang.org/issues/21816>
/cc @eregon @Earlopain 