### PR TITLE
Report `render stream` errors to `Rails.error`

### DIFF
--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -121,15 +121,24 @@ module RenderStreaming
 
     test "rendering with template exception logs the exception" do
       io = StringIO.new
-      _old, ActionView::Base.logger = ActionView::Base.logger, ActiveSupport::Logger.new(io)
+      old_error_reporter, ActiveSupport.error_reporter = ActiveSupport.error_reporter, nil
+      old_logger, ActionView::Base.logger = ActionView::Base.logger, ActiveSupport::Logger.new(io)
 
       begin
         get "/render_streaming/basic/template_exception"
         io.rewind
         assert_match "Ruby was here!", io.read
       ensure
-        ActionView::Base.logger = _old
+        ActiveSupport.error_reporter = old_error_reporter
+        ActionView::Base.logger = old_logger
       end
+    end
+
+    test "rendering with template exception reports error" do
+      error_report = assert_error_reported do
+        get "/render_streaming/basic/template_exception"
+      end
+      assert_match "Ruby was here!", error_report.error.message
     end
 
     def assert_streaming!(status, headers, body)

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 module ActionView
   # == TODO
   #
@@ -18,8 +17,8 @@ module ActionView
       def each(&block)
         begin
           @start.call(block)
-        rescue Exception => exception
-          log_error(exception)
+        rescue => error
+          log_error(error)
           block.call ActionView::Base.streaming_completion_on_exception
         end
         self
@@ -33,15 +32,15 @@ module ActionView
       end
 
       private
-        # This is the same logging logic as in ShowExceptions middleware.
-        def log_error(exception)
-          logger = ActionView::Base.logger
-          return unless logger
-
-          message = +"\n#{exception.class} (#{exception.message}):\n"
-          message << exception.annotated_source_code.to_s if exception.respond_to?(:annotated_source_code)
-          message << "  " << exception.backtrace.join("\n  ")
-          logger.fatal("#{message}\n\n")
+        def log_error(error)
+          if ActiveSupport.error_reporter
+            ActiveSupport.error_reporter.report(error)
+          elsif logger = ActionView::Base.logger
+            message = +"\n#{error.class} (#{error.message}):\n"
+            message << error.annotated_source_code.to_s if error.respond_to?(:annotated_source_code)
+            message << "  " << error.backtrace.join("\n  ")
+            logger.fatal("#{message}\n\n")
+          end
         end
     end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/23856

Previously when an error was raised during streaming, the best Rails could do was log it, but most error reporting integrations wouldn't see it, as they usually hook in ShowExceptions middleware or similar.

Now that Rails has a dedicated API to report errors, we can call it from the streaming code.
