### PR TITLE
Optimize String#squish

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -19,7 +19,9 @@ class String
   #   str.squish!                         # => "foo bar boo"
   #   str                                 # => "foo bar boo"
   def squish!
-    gsub!(/[[:space:]]+/, " ")
+    # Search for two or more `[[:space:]]` OR a single
+    # [[:space:]] that isn't `" "`.
+    gsub!(/([[:space:]]{2,}|[[[:space:]]&&[^ ]])/, " ")
     strip!
     self
   end


### PR DESCRIPTION
Change the regexp to no longer match single `" "` as they're very common in text and we don't need to change them. This makes the regexp noticeably more complex (hence likely slower), but since it match much less often the `gsub` end up faster overall.

~~First call `strip!` first, this saves the `gsub` from matching any leading or trailing spaces.~~

I had to revert that part because we can't `strip` `[[:space:]]` easily. Too bad, but that wasn't the biggest gain.

NB: the actual speedup depends a lot on the test string, so is just indicative, but I can't image a case where it would be slower.

```
ruby 4.0.0 (2025-12-25 revision 553f1675f3) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
            baseline   488.000 i/100ms
                 opt     1.002k i/100ms
Calculating -------------------------------------
            baseline      5.011k (± 1.1%) i/s  (199.55 μs/i) -     25.376k in   5.064492s
                 opt      9.972k (± 1.5%) i/s  (100.28 μs/i) -     50.100k in   5.025050s

Comparison:
            baseline:     5011.2 i/s
                 opt:     9972.4 i/s - 1.99x  faster
```

```

require "benchmark/ips"

def baseline(str)
  str = str.dup
  str.gsub!(/[[:space:]]+/, " ")
  str.strip!
  str
end

def opt(str)
  str = str.dup
  str.strip!
  str.gsub!(/([[:space:]]{2,}|[[[:space:]]&&[^ ]])/, " ")
  str
end

STRING = (" sdsd dfdsf dfdsf\n dfdsf dfdsf" * 400).freeze

Benchmark.ips do |x|
  x.report("baseline") { baseline(STRING) }
  x.report("opt") { opt(STRING) }
  x.compare!(order: :baseline)
end
```
