### PR TITLE
Add app_port option to kamal proxy configuration in deploy.yml template when thruster is skipped

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -23,6 +23,9 @@ servers:
 # proxy:
 #   ssl: true
 #   host: app.example.com
+<% if skip_thruster? -%>
+#   app_port: 3000
+<% end -%>
 
 # Where you keep your container images.
 registry:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -833,6 +833,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_kamal_deploy_yml_adds_app_port_to_proxy_when_thruster_is_skipped
+    generator [destination_root], ["--skip-thruster"]
+    run_generator_instance
+
+    assert_file "config/deploy.yml" do |content|
+      assert_match(%r{app_port: 3000}, content)
+    end
+  end
+
   def test_usage_read_from_file
     assert_called(File, :read, returns: "USAGE FROM FILE") do
       assert_equal "USAGE FROM FILE", Rails::Generators::AppGenerator.desc


### PR DESCRIPTION
### Motivation / Background


This Pull Request has been created to improve the `deploy.yml` template and document the expected `kamal-proxy` configuration when thruster is skipped (or uninstalled). 

The Dockerfile template explicitly states that the exposed application port is `3000` when thruster is skipped:

https://github.com/rails/rails/blob/4d03ed24b0db6bdb8c7a5274b0bcb4c8a86b4fc0/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt#L123-L131

However in that specific case, the `kamal-proxy` configuration needs to be updated -- when used. Indeed, [`kamal-proxy` defaults to PORT 80](https://kamal-deploy.org/docs/configuration/proxy/#app-port). 

The proposed change hopefully makes it easier to document the `kamal-proxy` configuration when thruster is skipped or removed. 

### Detail

A new comment is added in the `deploy.yml.tt` template to add the correct `app_port` expected by `kamal-proxy` when the container is run without `thruster`. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
