### PR TITLE
Fix outdated ActiveRecord finder docs. [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -124,7 +124,7 @@ module ActiveRecord
     #
     #   Person.take # returns an object fetched by SELECT * FROM people LIMIT 1
     #   Person.take(5) # returns 5 objects fetched by SELECT * FROM people LIMIT 5
-    #   Person.where(["name LIKE ?", "%#{name}"]).take
+    #   Person.where("name LIKE ?", "%#{name}").take
     def take(limit = nil)
       limit ? find_take_with_limit(limit) : find_take
     end
@@ -165,8 +165,7 @@ module ActiveRecord
     # If no order is defined it will order by primary key.
     #
     #   Person.first # returns the first object fetched by SELECT * FROM people ORDER BY people.id LIMIT 1
-    #   Person.where(["user_name = ?", user_name]).first
-    #   Person.where(["user_name = :u", { u: user_name }]).first
+    #   Person.where(user_name: user_name).first
     #   Person.order("created_on DESC").offset(5).first
     #   Person.first(3) # returns the first three objects fetched by SELECT * FROM people ORDER BY people.id LIMIT 3
     #
@@ -188,7 +187,7 @@ module ActiveRecord
     # If no order is defined it will order by primary key.
     #
     #   Person.last # returns the last object fetched by SELECT * FROM people
-    #   Person.where(["user_name = ?", user_name]).last
+    #   Person.where(user_name: user_name).last
     #   Person.order("created_on DESC").offset(5).last
     #   Person.last(3) # returns the last three objects fetched by SELECT * FROM people.
     #
@@ -219,7 +218,7 @@ module ActiveRecord
     #
     #   Person.second # returns the second object fetched by SELECT * FROM people
     #   Person.offset(3).second # returns the second object from OFFSET 3 (which is OFFSET 4)
-    #   Person.where(["user_name = :u", { u: user_name }]).second
+    #   Person.where(user_name: user_name).second
     def second
       find_nth 1
     end
@@ -235,7 +234,7 @@ module ActiveRecord
     #
     #   Person.third # returns the third object fetched by SELECT * FROM people
     #   Person.offset(3).third # returns the third object from OFFSET 3 (which is OFFSET 5)
-    #   Person.where(["user_name = :u", { u: user_name }]).third
+    #   Person.where(user_name: user_name).third
     def third
       find_nth 2
     end
@@ -251,7 +250,7 @@ module ActiveRecord
     #
     #   Person.fourth # returns the fourth object fetched by SELECT * FROM people
     #   Person.offset(3).fourth # returns the fourth object from OFFSET 3 (which is OFFSET 6)
-    #   Person.where(["user_name = :u", { u: user_name }]).fourth
+    #   Person.where(user_name: user_name).fourth
     def fourth
       find_nth 3
     end
@@ -267,7 +266,7 @@ module ActiveRecord
     #
     #   Person.fifth # returns the fifth object fetched by SELECT * FROM people
     #   Person.offset(3).fifth # returns the fifth object from OFFSET 3 (which is OFFSET 7)
-    #   Person.where(["user_name = :u", { u: user_name }]).fifth
+    #   Person.where(user_name: user_name).fifth
     def fifth
       find_nth 4
     end
@@ -283,7 +282,7 @@ module ActiveRecord
     #
     #   Person.forty_two # returns the forty-second object fetched by SELECT * FROM people
     #   Person.offset(3).forty_two # returns the forty-second object from OFFSET 3 (which is OFFSET 44)
-    #   Person.where(["user_name = :u", { u: user_name }]).forty_two
+    #   Person.where(user_name: user_name).forty_two
     def forty_two
       find_nth 41
     end
@@ -299,7 +298,7 @@ module ActiveRecord
     #
     #   Person.third_to_last # returns the third-to-last object fetched by SELECT * FROM people
     #   Person.offset(3).third_to_last # returns the third-to-last object from OFFSET 3
-    #   Person.where(["user_name = :u", { u: user_name }]).third_to_last
+    #   Person.where(user_name: user_name).third_to_last
     def third_to_last
       find_nth_from_last 3
     end
@@ -315,7 +314,7 @@ module ActiveRecord
     #
     #   Person.second_to_last # returns the second-to-last object fetched by SELECT * FROM people
     #   Person.offset(3).second_to_last # returns the second-to-last object from OFFSET 3
-    #   Person.where(["user_name = :u", { u: user_name }]).second_to_last
+    #   Person.where(user_name: user_name).second_to_last
     def second_to_last
       find_nth_from_last 2
     end
@@ -348,6 +347,7 @@ module ActiveRecord
     #
     #   Person.exists?(5)
     #   Person.exists?('5')
+    #   Person.exists?('name LIKE ?', "%#{query}%")
     #   Person.exists?(['name LIKE ?', "%#{query}%"])
     #   Person.exists?(id: [1, 4, 8])
     #   Person.exists?(name: 'David')


### PR DESCRIPTION
### Motivation / Background

Some of the documentation regarding ActiveRecord::FinderMethods still used the old array notation, instead of using hash notation.

This Pull Request has been created because the documentation is obsolete, which can mislead junior developers just getting into Rails.

### Detail

This Pull Request changes the documentation where the old `where` method arguments using (nested) arrays are used, to the now preferred (implicit) hash notation.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
