### PR TITLE
Deprecate queue_classic Active Job adapter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate built-in `queue_classic` Active Job adapter.
+
+    *Harun Sabljaković, Wojciech Wnętrzak*
+
 *   Allow `retry_on` `wait` procs to accept the error as a second argument.
 
     Procs with arity 1 continue to receive only the execution count.

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -19,6 +19,12 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :queue_classic
     class QueueClassicAdapter < AbstractAdapter
+      def check_adapter
+        ActiveJob.deprecator.warn <<~MSG.squish
+          The built-in `queue_classic` adapter is deprecated and will be removed in Rails 9.0.
+        MSG
+      end
+
       def enqueue(job) # :nodoc:
         qc_job = build_queue(job.queue_name).enqueue("#{JobWrapper.name}.perform", job.serialize)
         job.provider_job_id = qc_job["id"] if qc_job.is_a?(Hash)

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -77,4 +77,20 @@ class AdapterTest < ActiveSupport::TestCase
       ActiveJob::Base.queue_adapter = before_adapter
     end
   end
+
+  if adapter_is?(:queue_classic)
+    test "queue classic adapter should be deprecated" do
+      before_adapter = ActiveJob::Base.queue_adapter
+
+      msg = <<~MSG.squish
+        The built-in `queue_classic` adapter is deprecated and will be removed in Rails 9.0.
+      MSG
+      assert_deprecated(msg, ActiveJob.deprecator) do
+        ActiveJob::Base.queue_adapter = :queue_classic
+      end
+
+    ensure
+      ActiveJob::Base.queue_adapter = before_adapter
+    end
+  end
 end


### PR DESCRIPTION
It is proposed to upstream it via https://github.com/QueueClassic/queue_classic/pull/354

There is no response there and the gem did not see activity since 2 years

This is the last AJ adapter to be ejected.

refs https://github.com/rails/rails/issues/52929
