### PR TITLE
Isolate Update Side Effects

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -439,6 +439,10 @@ module ActiveRecord
         false
       end
 
+      def ignore_savepoint_error?(_error)
+        false
+      end
+
       def supports_restart_db_transaction?
         false
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -28,6 +28,8 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans = false
       class_attribute :emulate_booleans, default: true
 
+      ER_SP_DOES_NOT_EXIST = 1305
+
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigint auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
@@ -115,6 +117,15 @@ module ActiveRecord
 
       def supports_restart_db_transaction?
         true
+      end
+
+      def ignore_savepoint_error?(error)
+        return false unless error
+
+        cause = error.cause
+        return false unless cause
+
+        error_number(cause) == ER_SP_DOES_NOT_EXIST
       end
 
       def supports_explain?

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -424,13 +424,13 @@ module ActiveRecord
     #
     # This method is available within the context of an ActiveRecord::Base
     # instance.
-    def with_transaction_returning_status # :nodoc:
+    def with_transaction_returning_status(requires_new: false) # :nodoc:
       self.class.with_connection do |connection|
         connection.pool.with_pool_transaction_isolation_level(ActiveRecord.default_transaction_isolation_level, connection.transaction_open?) do
           status = nil
           ensure_finalize = !connection.transaction_open?
 
-          connection.transaction do
+          connection.transaction(requires_new: requires_new) do
             add_to_transaction(ensure_finalize || has_transactional_callbacks?)
             remember_transaction_record_state
 


### PR DESCRIPTION
Fixes #14698.

### Motivation / Background

Nested attribute assignment can persist changes to associated records before the parent is validated. When update runs inside a joinable outer transaction, the rollback raised by update is swallowed and those side effects are committed.

### Detail

This Pull Request changes update/update! to request a savepoint when joining an existing transaction (if savepoints are supported), so the internal rollback restores association state without forcing callers to raise.

It also adds a regression test for nested attributes inside an explicit transaction.

### Additional information

The correctness of this fix depends on support for savepoints. If the database does not support savepoints the historical behavior will still be present.

Given that this is a very edge case and given that all the major adapters support savepoints this probably corrects it for 99% of apps and for those that don't they are no worse off than they have for the 11 years this bug has been present.

The alternative would be to delay SQL changes on nested objects until after all validation but that would be a much bigger change for a very small edge case.