### PR TITLE
Prioritize markdown when accepted

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -220,6 +220,9 @@ module ActionDispatch
         # which case we assume you're a browser and send HTML.
         BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/
 
+        # Match Accept headers where markdown is explicitly preferred before other types
+        MARKDOWN_PREFERRED_ACCEPTS = /\A\s*text\/markdown\s*,/
+
         def params_readable?
           parameters[:format]
         rescue *RESCUABLE_MIME_FORMAT_ERRORS
@@ -228,7 +231,8 @@ module ActionDispatch
 
         def valid_accept_header
           (xhr? && (accept.present? || content_mime_type)) ||
-            (accept.present? && !accept.match?(BROWSER_LIKE_ACCEPTS))
+            (accept.present? && !accept.match?(BROWSER_LIKE_ACCEPTS)) ||
+            (accept.present? && accept.match?(MARKDOWN_PREFERRED_ACCEPTS))
         end
 
         def use_accept_header

--- a/actionpack/test/controller/new_base/content_negotiation_test.rb
+++ b/actionpack/test/controller/new_base/content_negotiation_test.rb
@@ -14,6 +14,15 @@ module ContentNegotiation
     end
   end
 
+  class MarkdownController < ActionController::Base
+    def index
+      respond_to do |format|
+        format.html { render plain: "<h1>HTML content</h1>" }
+        format.md { render plain: "# Markdown content" }
+      end
+    end
+  end
+
   class TestContentNegotiation < Rack::TestCase
     test "A */* Accept header will return HTML" do
       get "/content_negotiation/basic/hello", headers: { "HTTP_ACCEPT" => "*/*" }
@@ -33,6 +42,18 @@ module ContentNegotiation
     test "Unregistered mimes are ignored" do
       get "/content_negotiation/basic/all", headers: { "HTTP_ACCEPT" => "text/plain, mime/another" }
       assert_body "[:text]"
+    end
+
+    test "markdown before html and */* prioritizes markdown" do
+      get "/content_negotiation/markdown/index", headers: { "HTTP_ACCEPT" => "text/markdown, text/html, */*" }
+      assert_body "# Markdown content"
+      assert_equal "text/markdown; charset=utf-8", @response.headers["Content-Type"]
+    end
+
+    test "markdown only with */* prioritizes markdown" do
+      get "/content_negotiation/markdown/index", headers: { "HTTP_ACCEPT" => "text/markdown, */*" }
+      assert_body "# Markdown content"
+      assert_equal "text/markdown; charset=utf-8", @response.headers["Content-Type"]
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Since we have markdown support, I noticed that this was anyway not served to llms. The reason is that, for example Claude Code, send the following header: `Accept: text/markdown, text/html, */*`. 
For historical reasons (?) Rails serves html because the Accept header includes `*/*`.

This Pull Request changes the behavior for markdown, so that markdown is prioritized.

What I am not sure is about having this change **only** for markdown, but I guess it would otherwise be a too big breaking change...

What we did in our app to support this is the followin:

```
def prioritize_markdown_format
  return unless request.accepts.first&.to_s == "text/markdown"
  request.formats = [:md, :html]
end
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


Related to #55511