### PR TITLE
[ci skip][docs] Update I18n guide to recommend actively maintained Accept-Language gem

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -315,7 +315,7 @@ private
 ```
 
 
-In practice, more robust code is necessary to do this reliably. Iain Hecker's [http_accept_language](https://github.com/iain/http_accept_language/tree/master) library or Ryan Tomayko's [locale](https://github.com/rack/rack-contrib/blob/main/lib/rack/contrib/locale.rb) Rack middleware provide solutions to this problem.
+In practice, more robust code is necessary to do this reliably. Cyril Kato's [accept_language](https://github.com/cyril/accept_language.rb) library or the [locale](https://github.com/rack/rack-contrib/blob/main/lib/rack/contrib/locale.rb) Rack middleware from rack-contrib provide solutions to this problem.
 
 ##### Inferring the Locale from IP Geolocation
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the I18n guide currently recommends the `http_accept_language` gem which:
- Has not been updated since June 2017
- Has known RFC 2616 compliance issues with language tag matching for regional variants (e.g., `zh-CN`, `zh-TW`, `en-GB`, `en-AU`)
- Does not have a proper LICENSE file

Fixes #56615

### Detail

This Pull Request changes the gem recommendation in the I18n guide from `http_accept_language` to `accept_language`.
The [`accept_language`](https://github.com/cyril/accept_language.rb) gem is:
- Actively maintained
- Fully RFC 2616 compliant
- Has a proper MIT license
- Has over 1.2 million downloads

The `locale` Rack middleware from rack-contrib is kept as an alternative option.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why. Includes reference to issue #56615.
* [x] No tests or CHANGELOG updates needed (documentation-only change).