### PR TITLE
Minimize AWS RDS Proxy connection pinning caused by SET for PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Minimize AWS RDS Proxy connection pinning caused by SET for PostgreSQL.
+
+    When configuring a PostgreSQL connection, the adapter calls `SET` commands
+    to configure timezone, encoding, and other parameters. In AWS RDS Proxy,
+    these `SET` commands cause connection pinning.
+
+    This fix skips `SET` commands when the parameter value is already set to the
+    desired value, minimizing pinning. It's expected that you set these
+    variables in the RDS Proxy initialization query:
+
+    ```SQL
+    SET intervalstyle=iso_8601;SET client_min_messages=warning;
+    ```
+
+    *Ivan Yurchanka*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/connection_adapters/postgresql/configuration_parameters.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/configuration_parameters.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      # Helper methods for working with configuration parameters.
+      module ConfigurationParameters
+        private
+          def ensure_parameter(name, value)
+            return if parameter_set_to?(name, value)
+
+            if block_given?
+              yield value
+            else
+              set_parameter(name, value)
+            end
+          end
+
+          def parameter_set_to?(name, value)
+            validate_parameter!(name)
+
+            normalized_values = Array(value).map do |val|
+              case val
+              when TrueClass
+                "on"
+              when FalseClass
+                "off"
+              else
+                val.to_s
+              end
+            end
+
+            return false if normalized_values.empty?
+
+            current_value = query_value("SHOW #{name}", "SCHEMA")
+            normalized_values.any?(current_value)
+          end
+          alias :parameter_set_to_any? :parameter_set_to?
+
+          def set_parameter(name, value)
+            validate_parameter!(name)
+
+            if value == :default
+              query_command("SET SESSION #{name} TO DEFAULT", "SCHEMA")
+            else
+              query_command("SET SESSION #{name} TO #{quote(value)}", "SCHEMA")
+            end
+          end
+
+          def validate_parameter!(name)
+            raise ArgumentError, "Parameter name '#{name}' is invalid" unless name.match?(/\A[a-zA-Z0-9_.]+\z/)
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -15,7 +15,8 @@ module ActiveRecord
           intent = internal_build_intent(sql, name, allow_retry:, materialize_transactions:)
           intent.execute!
           result = intent.raw_result
-          result.map_types!(@type_map_for_results).values
+          result.map_types!(@type_map_for_results) if @type_map_for_results
+          result.values
         end
 
         READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -200,6 +200,21 @@ module ActiveRecord
       end
     end
 
+    def test_set_invalid_session_variable
+      run_without_connection do |orig_connection|
+        assert_raises(ArgumentError) do
+          ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { 'sql injection': true }))
+        end
+      end
+    end
+
+    def test_set_session_encoding
+      run_without_connection do |orig_connection|
+        ActiveRecord::Base.establish_connection(orig_connection.deep_merge(encoding: "LATIN1"))
+        assert_equal "LATIN1", ActiveRecord::Base.lease_connection.select_value("SHOW client_encoding")
+      end
+    end
+
     def test_get_and_release_advisory_lock
       lock_id = 5295901941911233559
       list_advisory_locks = <<~SQL


### PR DESCRIPTION
### Motivation / Background

Rails applications using **PostgreSQL** cannot effectively use [AWS RDS Proxy](https://aws.amazon.com/rds/proxy/). Active Record’s connection setup issues `SET` commands (timezone, encoding, etc.), and those `SET` commands [cause RDS Proxy connection pinning](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-pinning.html#rds-proxy-pinning.postgres).

Given how widely used AWS and PostgreSQL are, it makes sense to address this.

This issue can also be addressed by using the `EXCLUDE_VARIABLE_SETS` option in [RDS Proxy's SessionPinningFilters](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ConnectionPoolConfigurationInfo.html), but that feature is currently only supported for MySQL.

### Detail

Only issue `SET` command if current value (checked via `SHOW`) differs from expected for:
* `timezone`
* `client_encoding`
* `schema_search_path`
* `client_min_messages`
* `intervalstyle`
* `standard_conforming_strings`
* Custom variables

It is expected that you set these variables in the RDS Proxy **initialization query**. When all the parameters match the expected values, there is no need for `SET` commands, thus pinning is avoided.

**Performance.** For a typical application, this change adds 2-3 `SHOW` commands per connection, resulting in sub-millisecond overhead (verified in both local and cloud environments).

### Additional information

`DatabaseConnectionsCurrentlySessionPinned` before and after the fix:

<img width="1761" height="692" alt="image" src="https://github.com/user-attachments/assets/cb1fc7e6-9009-4e16-acc0-3486b8f3a2a6" />