### PR TITLE
Reduce object allocations when building WHERE clauses

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Reduce object allocations when building WHERE clauses.
+
+    Fewer short-lived objects means less GC pressure in high-throughput applications.
+
+    *David Lowenfels*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1041,7 +1041,7 @@ module ActiveRecord
     end
 
     def where!(opts, *rest) # :nodoc:
-      self.where_clause += build_where_clause(opts, rest)
+      self.where_clause = where_clause.add_predicates(build_where_clause_parts(opts, rest))
       self
     end
 
@@ -1612,6 +1612,11 @@ module ActiveRecord
       end
 
       def build_where_clause(opts, rest = []) # :nodoc:
+        Relation::WhereClause.new(build_where_clause_parts(opts, rest))
+      end
+      alias :build_having_clause :build_where_clause
+
+      def build_where_clause_parts(opts, rest = []) # :nodoc:
         opts = sanitize_forbidden_attributes(opts)
 
         if opts.is_a?(Array)
@@ -1650,9 +1655,8 @@ module ActiveRecord
           raise ArgumentError, "Unsupported argument type: #{opts} (#{opts.class})"
         end
 
-        Relation::WhereClause.new(parts)
+        parts
       end
-      alias :build_having_clause :build_where_clause
 
       def async! # :nodoc:
         @async = true

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1041,7 +1041,7 @@ module ActiveRecord
     end
 
     def where!(opts, *rest) # :nodoc:
-      self.where_clause = where_clause.add_predicates(build_where_clause_parts(opts, rest))
+      self.where_clause = where_clause.concat(build_where_clause_parts(opts, rest))
       self
     end
 

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -15,8 +15,13 @@ module ActiveRecord
         WhereClause.new(predicates + other.predicates)
       end
 
-      def add_predicates(other_predicates)
-        WhereClause.new(predicates + other_predicates)
+      def concat(other_predicates)
+        if frozen?
+          WhereClause.new(predicates + other_predicates)
+        else
+          @predicates.concat(other_predicates)
+          self
+        end
       end
 
       def -(other)

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -15,6 +15,10 @@ module ActiveRecord
         WhereClause.new(predicates + other.predicates)
       end
 
+      def add_predicates(other_predicates)
+        WhereClause.new(predicates + other_predicates)
+      end
+
       def -(other)
         WhereClause.new(predicates - other.predicates)
       end


### PR DESCRIPTION
### Motivation / Background                                                                                                                                                             
                                                                                                                                                                                          
  Active Record allocates many short-lived objects when building WHERE clauses. In high-throughput applications, this creates GC pressure that affects tail latencies. Multi-tenant apps  
  that scope every query with `where(tenant_id: id)` are a common example where this compounds.                                                                                           
                                                                                                                                                                                          
  Partially addresses #54943                                                                                                                                                              
                                                                                                                                                                                          
  ### Detail                                                                                                                                                                              
                                                                                                                                                                                          
  Add a fast path for simple column equality queries that skips the full predicate expansion machinery. Also avoid intermediate `WhereClause` allocations by using `concat()` instead of  
  `+()`.                                                                                                                                                                                  
                                                                                                                                                                                          
  - Add `simple_attributes?` check in `PredicateBuilder#build_from_hash`                                                                                                                  
  - Add `WhereClause#concat` to append predicates without intermediate object                                                                                                             
  - Extract `build_where_clause_parts` to return array instead of WhereClause                                                                                                             
                                                                                                                                                                                          
  ### Additional information                                                                                                                                                              
                                                                                                                                                                                          
  ~25% fewer allocations for typical queries:                                                                                                                                             
                                                                                                                                                                                          
  - Simple where: 29 → 21 objects (-28%)                                                                                                                                                  
  - Chained wheres: 54 → 38 objects (-30%)                                                                                                                                                
  - Chain of 4: 71 → 55 objects (-23%)                                                                                                                                                    
  
```                                                                                                                                                                                        
  ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]                                                                                                               
  ActiveRecord: 8.1.0.alpha                                                                                                                                                               
                                                                                                                                                                                          
  ALLOCATIONS PER QUERY                                                                                                                                                                   
                                                                                                                                                                                          
    Simple column queries (fast path):                                                                                                                                                    
      Simple where (1 col)                 21.0 objects                                                                                                                                   
      Simple where (2 cols)                28.0 objects                                                                                                                                   
      Chained simple wheres                38.0 objects                                                                                                                                   
                                                                                                                                                                                          
    Chained queries:                                                                                                                                                                      
      Chain of 4                           55.0 objects                                                                                                                                   
      Chain of 6                           64.0 objects                                                                                                                                   
  ```
                                                                                                                                                                                          
  <details>                                                                                                                                                                               
  <summary>Benchmark script</summary>                                                                                                                                                     
                                                                                                                                                                                          
  ```ruby                                                                                                                                                                                 
  require "bundler/setup"                                                                                                                                                                 
  require "active_record"                                                                                                                                                                 
                                                                                                                                                                                          
  ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")                                                                                                       
  ActiveRecord::Schema.define do                                                                                                                                                          
    create_table :posts, force: true do |t|                                                                                                                                               
      t.string :status                                                                                                                                                                    
      t.integer :author_id                                                                                                                                                                
      t.timestamps                                                                                                                                                                        
    end                                                                                                                                                                                   
  end                                                                                                                                                                                     
                                                                                                                                                                                          
  class Post < ActiveRecord::Base; end                                                                                                                                                    
                                                                                                                                                                                          
  def count_allocations(iterations = 1000)                                                                                                                                                
    GC.start                                                                                                                                                                              
    GC.disable                                                                                                                                                                            
    before = GC.stat[:total_allocated_objects]                                                                                                                                            
    iterations.times { yield }                                                                                                                                                            
    after = GC.stat[:total_allocated_objects]                                                                                                                                             
    GC.enable                                                                                                                                                                             
    (after - before).to_f / iterations                                                                                                                                                    
  end                                                                                                                                                                                     
                                                                                                                                                                                          
  {                                                                                                                                                                                       
    "Simple where (1 col)" => -> { Post.where(status: "published") },                                                                                                                     
    "Simple where (2 cols)" => -> { Post.where(status: "published", author_id: 1) },                                                                                                      
    "Chained simple wheres" => -> { Post.where(status: "published").where(author_id: 1) },                                                                                                
    "Chain of 4" => -> { Post.where(status: "x").where(author_id: 1).order(:created_at).limit(10) },                                                                                      
  }.each do |name, block|                                                                                                                                                                 
    puts "#{name}: #{count_allocations(&block).round(1)} objects"                                                                                                                         
  end
  ```
  
  It's unclear if this merits a CHANGELOG entry, since it is a minor internal thing?                                                             