### PR TITLE
Add --package-manager option to rails new

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `--package-manager` option to `rails new`.
+
+    Allows selecting yarn (default), npm, or pnpm when generating a new application.
+    Updates `bin/setup`, `Dockerfile`, and `config/ci.rb` to use the selected manager.
+
+    *David Lowenfels*
+
 *   `Rails.app.revision` now checks `ENV["REVISION"]` before falling back to the `REVISION` file or git.
 
     *Jonathan Baker*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -7,6 +7,7 @@ require "tsort"
 require "uri"
 require "rails/generators"
 require "rails/generators/bundle_helper"
+require "rails/generators/js_package_manager"
 require "active_support/core_ext/array/extract_options"
 
 module Rails
@@ -20,6 +21,8 @@ module Rails
 
       JAVASCRIPT_OPTIONS = %w( importmap bun webpack esbuild rollup )
       CSS_OPTIONS = %w( tailwind bootstrap bulma postcss sass )
+      PACKAGE_MANAGER_OPTIONS = %w( yarn npm pnpm )
+      MANAGERS = JsPackageManager::MANAGERS
 
       attr_accessor :rails_template
       add_shebang_option!
@@ -533,6 +536,35 @@ module Rails
 
       def using_bun?
         using_js_runtime? && %w[bun].include?(options[:javascript])
+      end
+
+      def package_manager
+        return :bun if using_bun?
+        (options[:package_manager] || "yarn").to_sym
+      end
+
+      def using_yarn?
+        package_manager == :yarn
+      end
+
+      def using_npm?
+        package_manager == :npm
+      end
+
+      def using_pnpm?
+        package_manager == :pnpm
+      end
+
+      def package_install_command
+        MANAGERS.dig(package_manager, :install)
+      end
+
+      def package_lockfile
+        MANAGERS.dig(package_manager, :lockfile)
+      end
+
+      def package_audit_command
+        MANAGERS.dig(package_manager, :audit)
       end
 
       def using_css_bundling?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -310,6 +310,7 @@ module Rails
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
       class_option :javascript, type: :string, aliases: ["-j", "--js"], default: "importmap", enum: JAVASCRIPT_OPTIONS, desc: "Choose JavaScript approach"
       class_option :css, type: :string, aliases: "-c", enum: CSS_OPTIONS, desc: "Choose CSS processor. Check https://github.com/rails/cssbundling-rails for more options"
+      class_option :package_manager, type: :string, aliases: "-pm", default: "yarn", enum: PACKAGE_MANAGER_OPTIONS, desc: "Choose package manager (yarn, npm, pnpm). Ignored when --javascript=bun"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: nil, desc: "Don't run bundle install"
       class_option :skip_decrypted_diffs, type: :boolean, default: nil, desc: "Don't configure git to show decrypted diffs of encrypted credentials"
 

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -38,17 +38,28 @@ RUN apt-get update -qq && \
 <% if using_node? -%>
 # Install JavaScript dependencies
 ARG NODE_VERSION=<%= node_version %>
+<% if using_yarn? -%>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
+<% end -%>
 ENV PATH=/usr/local/node/bin:$PATH
-<% if yarn_through_corepack? -%>
+<% if using_yarn? && yarn_through_corepack? -%>
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
     rm -rf /tmp/node-build-master
 RUN corepack enable && yarn set version $YARN_VERSION
-<% else -%>
+<% elsif using_yarn? -%>
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
     npm install -g yarn@$YARN_VERSION && \
+    rm -rf /tmp/node-build-master
+<% elsif using_pnpm? -%>
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    npm install -g pnpm && \
+    rm -rf /tmp/node-build-master
+<% else -%>
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
     rm -rf /tmp/node-build-master
 <% end -%>
 
@@ -69,16 +80,10 @@ RUN bundle install && \
     # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495
     bundle exec bootsnap precompile -j 1 --gemfile<% end %>
 
-<% if using_node? -%>
+<% if using_js_runtime? -%>
 # Install node modules
-COPY package.json yarn.lock ./
-RUN yarn install --immutable
-
-<% end -%>
-<% if using_bun? -%>
-# Install node modules
-COPY package.json bun.lock* ./
-RUN bun install --frozen-lockfile
+COPY package.json <%= package_lockfile %><%= using_bun? ? "*" : "" %> ./
+RUN <%= package_install_command %>
 
 <% end -%>
 # Copy application code

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -13,14 +13,10 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
-<% if using_node? -%>
+<% if using_js_runtime? -%>
 
   # Install JavaScript dependencies
-  system("yarn install --check-files")
-<% elsif using_bun? -%>
-
-  # Install JavaScript dependencies
-  system!("bun install")
+  system!("<%= package_manager %> install")
 <% end -%>
 <% unless options.skip_active_record? -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -11,8 +11,8 @@ CI.run do
 <% unless options.skip_bundler_audit? -%>
     step "Security: Gem audit", "bin/bundler-audit"
 <% end -%>
-<% if using_node? -%>
-    step "Security: Yarn vulnerability audit", "yarn audit"
+<% if using_node? && package_audit_command -%>
+    step "Security: Package vulnerability audit", "<%= package_audit_command %>"
 <% end -%>
 <% if using_importmap? -%>
     step "Security: Importmap vulnerability audit", "bin/importmap audit"


### PR DESCRIPTION
### Motivation / Background                                                                                                                                                             
                                                                                                                                                                                        
When creating a new Rails application, there's no way to specify which JavaScript package manager to use. This PR adds a `--package-manager` option to `rails new`.                     
                                                                                                                                                                                        
Depends on #56636 for the Rails::Generators::JsPackageManager module.

### Detail                                                                                                                                                                              
                                                                                                                                                                                        
```bash                                                                                                                                                                                 
rails new myapp --package-manager=npm                                                                                                                                                   
rails new myapp -pm pnpm                                                                                                                                                                
```
                                                                                                                                                                                        
Updates bin/setup, Dockerfile, and config/ci.rb to use the selected manager.                                                                                                            
                                                                                                                                                                                        
When `--javascript=bun` is specified, bun is used automatically (it's both runtime and package manager).                                                                                  
 