### PR TITLE
Raise ArgumentError in TimeZone#parse for invalid strings

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise `ArgumentError` in `ActiveSupport::TimeZone#parse` when an invalid string is provided, aligning with documentation.
+
+    *Koji Toga*
+
 *   Add `ActiveSupport::CombinedConfiguration` to offer interchangeable access to configuration provided by
     either ENV or encrypted credentials. Used by Rails to first look at ENV, then look in encrypted credentials,
     but can be configured separately with any number of API-compatible backends in a first-look order.

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -590,8 +590,7 @@ module ActiveSupport
 
     private
       def parts_to_time(parts, now)
-        raise ArgumentError, "invalid date" if parts.nil?
-        return if parts.empty?
+        raise ArgumentError, "invalid date" if parts.blank?
 
         if parts[:seconds]
           time = Time.at(parts[:seconds])

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -425,8 +425,13 @@ class TimeZoneTest < ActiveSupport::TestCase
 
   def test_parse_returns_nil_when_string_without_date_information_is_passed_in
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
-    assert_nil zone.parse("foobar")
-    assert_nil zone.parse("   ")
+
+    exception = assert_raises(ArgumentError) do
+      zone.parse("foobar")
+      zone.parse("   ")
+    end
+
+    assert_equal "invalid date", exception.message
   end
 
   def test_parse_with_incomplete_date


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the current implementation of `ActiveSupport::TimeZone#parse` does not align with its documentation.

[The documentation](https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html#method-i-parse) states:

> If the string is invalid then an ArgumentError could be raised.

However, in practice, it returns `nil` when an invalid string is provided. This PR ensures the method behaves as documented.

### Detail

This Pull Request changes the internal logic of `ActiveSupport::TimeZone#parse` to raise an `ArgumentError` when the input string cannot be parsed into a valid time, rather than silently returning `nil`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

If returning `nil` is the intended behavior and the documentation is incorrect, please let me know. I would be happy to update the documentation instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
