### PR TITLE
[8-0-stable] Handle Ruby 4.1 stabby lambda in Proc#source_location start_column

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -320,6 +320,9 @@ module ActiveSupport
             lines[0] = lines[0].byteslice(location[1]...)
             source = lines.join.strip
 
+            # Strip stabby lambda from Ruby 4.1+
+            source = source.sub(/^->\s*/, "")
+
             # We ignore procs defined with do/end as they are likely multi-line anyway.
             if source.start_with?("{")
               source.delete_suffix!("}")


### PR DESCRIPTION
Backports #56624 to `8-0-stable` branch.