### PR TITLE
Fix strict loading fixture association macro

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Fix `strict_loading!(false)` to override the `strict_loading: true` option
+    in association macros.
+
+    Previously, when `strict_loading: true` was set on an association (e.g.,
+    `has_many :comments, strict_loading: true`), calling `strict_loading!(false)`
+    on the owner record had no effect - the association would still raise
+    `StrictLoadingViolationError` when lazily loaded.
+
+    Now, explicitly setting `strict_loading!(false)` on the owner takes precedence
+    over the association macro's `strict_loading: true` setting. This also fixes
+    strict loading violations on fixture records, which have `@strict_loading = false`
+    set explicitly.
+
+    ```ruby
+    class Post < ActiveRecord::Base
+      has_many :comments, strict_loading: true
+    end
+
+    post = Post.first
+    post.comments.to_a # => StrictLoadingViolationError (association macro setting)
+
+    post.strict_loading!(false)
+    post.comments.to_a # => OK (explicit setting takes precedence)
+    ```
+
+    Fixes #56373.
+    Fixes #56014.
+
+    *Yuji Teshima*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -686,7 +686,9 @@ module ActiveRecord
 
     # Returns +true+ if the record is in strict_loading mode.
     def strict_loading?
-      @strict_loading
+      return @strict_loading if defined?(@strict_loading)
+
+      self.class.strict_loading_by_default
     end
 
     # Sets the record to strict_loading mode. This will raise an error
@@ -845,7 +847,6 @@ module ActiveRecord
         klass = self.class
 
         @primary_key         = klass.primary_key
-        @strict_loading      = klass.strict_loading_by_default
         @strict_loading_mode = klass.strict_loading_mode
 
         klass.define_attribute_methods


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `strict_loading!(false)` does not override the `strict_loading: true` option when it is set via association macros.

Fixes #56373
Fixes #56014

When `strict_loading: true` is specified in an association macro (e.g., `has_many :comments, strict_loading: true`), calling `strict_loading!(false)` on the owner record has no effect - the association still raises `StrictLoadingViolationError` when lazily loaded.

This also affects fixture records, which explicitly set `@strict_loading = false` (added in #40792), but still raise `StrictLoadingViolationError` when accessing associations with `strict_loading: true` in the macro.

### Detail

This Pull Request changes `@strict_loading` to use a tri-state approach:

- **undefined**: use the association macro's `strict_loading` setting (backward compatible)
- **true**: explicitly enabled via `strict_loading!`, but association macro's `strict_loading: false` is still respected (for ActiveStorage compatibility)
- **false**: explicitly disabled via `strict_loading!(false)`, takes precedence over macro setting

Changes:
1. `ActiveRecord::Core#strict_loading?` - Returns `@strict_loading` if defined, otherwise falls back to `strict_loading_by_default`
2. `ActiveRecord::Core#init_internals` - Removes the initialization of `@strict_loading` to allow undefined state
3. `ActiveRecord::Associations::Association#violates_strict_loading?` - Uses tri-state logic:
   - If `@strict_loading` is explicitly `false`, returns `false` (no violation)
   - If `@strict_loading` is explicitly `true`, respects association macro's `strict_loading: false` setting (for ActiveStorage)
   - If `@strict_loading` is undefined, uses association macro setting or falls back to `strict_loading_by_default`

### Additional information

**Relationship to #56015:**

This PR implements the same tri-state approach as #56015 (authored by @otrfrn). PR #56015 has been open since October 2025 with CI failures that appear to be environment-related (activestorage tests). After rebasing on the current main branch, all tests pass successfully.

Since #56015 has been inactive and the CI issues were not addressed, I've created this PR with the same approach to move the fix forward. Credit to the original approach goes to @otrfrn.

Related discussion: https://github.com/rails/rails/issues/56373#issuecomment-3753967150

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.