### PR TITLE
Fix strict locals parsing when magic comment has trailing text

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -7,7 +7,7 @@ module ActionView
   class Template
     extend ActiveSupport::Autoload
 
-    STRICT_LOCALS_REGEX = /\#\s+locals:\s+\((.*?)\)(?=\s*-?%>|\s*$)/m
+    STRICT_LOCALS_REGEX = /\#\s+locals:\s+\((.*?)\)(?=\s*[-,]|\s*%>|\s*$)/m
 
     # === Encodings in ActionView::Template
     #


### PR DESCRIPTION
The STRICT_LOCALS_REGEX was too restrictive, requiring the closing parenthesis to be followed by either `%>` (ERB closing tag) or end of line. This caused parsing to fail when template linting tools (like haml-lint) merge multiple comments into a single line.

For example, haml-lint --auto-correct-all merges:

    -# locals: (post:)
    -# haml-lint:disable LineLength

into:

    -# locals: (post:), haml-lint:disable LineLength

The updated regex now also allows a comma or dash to follow the closing parenthesis, enabling proper parsing of such merged comments.

Fixes #56646

### Motivation / Background

This PR fixes a regression introduced in #56270 where `STRICT_LOCALS_REGEX` became too restrictive for non-ERB template engines.

The lookahead `(?=\s*-?%>|\s*$)` was designed for ERB templates, but it fails to match when:
- HAML comments have additional text after the closing parenthesis
- Template linting tools (like haml-lint) merge multiple comment lines

This is a common scenario because `haml-lint --auto-correct-all` automatically merges consecutive comments into a single line.

### Detail

This PR changes the `STRICT_LOCALS_REGEX` lookahead from:

```ruby
(?=\s*-?%>|\s*$)
```

to:

```ruby
(?=\s*[-,]|\s*%>|\s*$)
```

This allows the closing parenthesis to be followed by:
- A comma (`,`) - for merged comments like `locals: (post:), haml-lint:disable`
- A dash (`-`) - for other potential trailing text
- `%>` or `-%>` - for ERB closing tags (existing behavior)
- End of line - for simple comments (existing behavior)

### Additional information

Test case added to verify the regex correctly parses locals with trailing text while maintaining compatibility with all existing test cases.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
