### PR TITLE
Explicitly use Marshal serializer for MemCacheStore Dalli client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,8 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
-    dalli (3.2.8)
+    dalli (4.0.0)
+      logger
     dante (0.2.0)
     dartsass-rails (0.5.1)
       railties (>= 6.0.0)

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -90,6 +90,9 @@ module ActiveSupport
         # The value "compress: false" prevents duplicate compression within Dalli.
         @mem_cache_options[:compress] = false
         (OVERRIDDEN_OPTIONS - %i(compress)).each { |name| @mem_cache_options.delete(name) }
+        # Set the default serializer for Dalli to prevent warning about
+        # inheriting the default serializer.
+        @mem_cache_options[:serializer] = Marshal
         @data = self.class.build_mem_cache(*(addresses + [@mem_cache_options]))
       end
 

--- a/activesupport/test/cache/cache_store_setting_test.rb
+++ b/activesupport/test/cache/cache_store_setting_test.rb
@@ -28,7 +28,7 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
   end
 
   def test_mem_cache_fragment_cache_store
-    assert_called_with(Dalli::Client, :new, [%w[localhost], { compress: false }]) do
+    assert_called_with(Dalli::Client, :new, [%w[localhost], { compress: false, serializer: Marshal }]) do
       store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", pool: false
       assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
     end
@@ -44,14 +44,14 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
   end
 
   def test_mem_cache_fragment_cache_store_with_multiple_servers
-    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { compress: false }]) do
+    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { compress: false, serializer: Marshal }]) do
       store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", "192.168.1.1", pool: false
       assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
     end
   end
 
   def test_mem_cache_fragment_cache_store_with_options
-    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { timeout: 10, compress: false }]) do
+    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { timeout: 10, compress: false, serializer: Marshal }]) do
       store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", "192.168.1.1", namespace: "foo", timeout: 10, pool: false
       assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
       assert_equal "foo", store.options[:namespace]

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -34,7 +34,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   else
     begin
       servers = ENV["MEMCACHE_SERVERS"] || "localhost:11211"
-      ss = Dalli::Client.new(servers).stats
+      ss = Dalli::Client.new(servers, serializer: Marshal).stats
       raise Dalli::DalliError unless ss[servers] || ss[servers + ":11211"]
 
       MEMCACHE_UP = true


### PR DESCRIPTION
Fixes #56588

We can assume the default Marshal serializer will be used because the user can never change it, we remove it from the options before init.

Therefore, we can prevent Dalli from warning users about auto-selecting the default Marshal serializer.

Since we previously dropped the serializer option before building the client, users were unable to override the default.

Users are able to pass silence_marshal_warning option to work around this issue as well.

Here is the bug report:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  gem "dalli", "4.0.0"
end

require "active_support"
require "active_support/cache"
require "active_support/cache/mem_cache_store"
require "minitest/autorun"

class MemCacheTest < ActiveSupport::TestCase
  def setup
    @cache = ActiveSupport::Cache::MemCacheStore.new("memcached:11211")
  end

  def test_memcached_write_and_read
    key = "my_test_key"
    value = "Hello, Dalli!"

    write_success = @cache.write(key, value)
    assert write_success, "Failed to write to cache"

    cached_value = @cache.read(key)

    assert_equal value, cached_value
  end
end
```

Dalli 4.0.0 changelog: https://github.com/petergoldstein/dalli/commit/48290a73