### PR TITLE
Change config.cache_store note to correct default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -58,8 +58,8 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :mem_cache_store
+  # Replace the default file system cache store with a durable alternative.
+  # config.cache_store = :file_store
 
   <%- unless options[:skip_active_job] -%>
   # Replace the default in-process and non-durable queuing backend for Active Job.


### PR DESCRIPTION
### Motivation / Background

The environments/production template incorrectly says "Replace the _default in-process memory cache store_ with a durable alternative."  The default is `file_store`: https://github.com/rails/rails/blob/428e3d4f1e7218e4965f35cfe75f08ec0808883a/railties/lib/rails/application/configuration.rb#L58

### Detail

Rewrite the comment and the commented out default cache_store value to reflect `file_store`.

#### Open questions

Should we change https://github.com/rails/rails/blob/bef5e41cbfbba750706b05d21e10955f7c8beb45/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt#L31 to also use `file_store`?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
