### PR TITLE
Add support for scoped preloading with select in associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add support for scoped preloading with `preload`.
+
+    You can now apply scopes (including `select`) to preloaded associations
+    using a lambda or an `ActiveRecord::Relation`:
+
+    ```ruby
+    User.preload(posts: -> { select(:id, :title) })
+    # SELECT "users".* FROM "users"
+    # SELECT "posts"."id", "posts"."title", "posts"."user_id" FROM "posts" WHERE ...
+    ```
+
+    Required columns (primary key, foreign key, type columns for STI/polymorphic)
+    are automatically included even if not specified in `select`.
+
+    For nested associations with scopes, use the `:scope` key:
+
+    ```ruby
+    User.preload(posts: { scope: -> { where(published: true) }, comments: :author })
+    ```
+
+    *Italo Brandao*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -319,7 +319,7 @@ module ActiveRecord
             else
               [preload_scope, false]
             end
-          end 
+          end
 
           def evaluate_preload_scope(preload_scope)
             case preload_scope
@@ -332,23 +332,23 @@ module ActiveRecord
 
           def ensure_required_columns(scope)
             return scope unless scope.select_values.any?
-            
+
             required = [klass.primary_key, association_key_name].flatten.compact.uniq
-            
+
             if reflection.type && !reflection.through_reflection?
               required << reflection.type
             end
-            
+
             if klass.finder_needs_type_condition?
               required << klass.inheritance_column
             end
-            
-            selected_columns = scope.select_values.map { |v| 
-              v.respond_to?(:name) ? v.name.to_s : v.to_s 
+
+            selected_columns = scope.select_values.map { |v|
+              v.respond_to?(:name) ? v.name.to_s : v.to_s
             }
-            
+
             missing = required.reject { |col| selected_columns.include?(col.to_s) }
-            
+
             missing.any? ? scope.select(*missing) : scope
           end
 

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -128,7 +128,7 @@ module ActiveRecord
             Array.wrap(children).flat_map { |association|
               Array(association).flat_map { |parent, child|
                 child_scope, nested_children = extract_scope_and_children(child)
-                
+
                 Branch.new(
                   parent: self,
                   association: parent,
@@ -158,7 +158,7 @@ module ActiveRecord
           def merge_scopes(parent_scope, child_scope)
             return parent_scope if child_scope.nil?
             return child_scope if parent_scope.nil?
-            
+
             if parent_scope.respond_to?(:strict_loading_value) && parent_scope.strict_loading_value
               { scope: child_scope, strict_loading: true }
             else

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -319,6 +319,29 @@ module ActiveRecord
     #   # SELECT "addresses".* FROM "addresses" WHERE "addresses"."id" IN (1,2,3,4,5)
     #   # SELECT "friends".* FROM "friends" WHERE "friends"."user_id" IN (1,2,3,4,5)
     #   # SELECT ...
+    #
+    # == Scoped Preloading
+    #
+    # You can apply scopes (including +select+) to preloaded associations using
+    # a lambda or an ActiveRecord::Relation:
+    #
+    #   User.preload(posts: -> { select(:id, :title) })
+    #   # SELECT "users".* FROM "users"
+    #   # SELECT "posts"."id", "posts"."title", "posts"."user_id" FROM "posts" WHERE "posts"."user_id" IN (...)
+    #
+    # Note: Required columns (primary key, foreign key, type columns for STI/polymorphic)
+    # are automatically included even if not specified in +select+.
+    #
+    # You can combine scopes with nested associations using the +:scope+ key:
+    #
+    #   User.preload(posts: { scope: -> { where(published: true).select(:id, :title) }, comments: :author })
+    #
+    # Or use multiple associations with different scopes:
+    #
+    #   User.preload(
+    #     posts: -> { select(:id, :title) },
+    #     comments: -> { where(visible: true) }
+    #   )
     def preload(*args)
       check_if_method_has_arguments!(__callee__, args)
       spawn.preload!(*args)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1594,16 +1594,16 @@ class PreloaderTest < ActiveRecord::TestCase
 
   def test_preload_with_lambda_select_scope
     author = authors(:david)
-    
+
     assert_queries_count(2) do
       result = Author.where(id: author.id).preload(posts: -> { select(:id, :title, :author_id) }).to_a
       assert_equal 1, result.size
     end
-    
+
     author = Author.where(id: author.id).preload(posts: -> { select(:id, :title, :author_id) }).first
     assert_predicate author.posts, :loaded?
     assert author.posts.any?
-    
+
     # Verify only selected columns are loaded
     post = author.posts.first
     assert post.has_attribute?(:id)
@@ -1613,7 +1613,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
   def test_preload_with_lambda_where_and_select
     author = authors(:david)
-    
+
     Author.where(id: author.id).preload(posts: -> { where(id: 1).select(:id, :title, :author_id) }).first.tap do |a|
       assert_predicate a.posts, :loaded?
       assert_equal [posts(:welcome)], a.posts
@@ -1622,7 +1622,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
   def test_preload_with_relation_scope
     author = authors(:david)
-    
+
     Author.where(id: author.id).preload(posts: Post.select(:id, :title, :author_id)).first.tap do |a|
       assert_predicate a.posts, :loaded?
       assert a.posts.any?
@@ -1631,26 +1631,26 @@ class PreloaderTest < ActiveRecord::TestCase
 
   def test_preload_with_multiple_associations_different_scopes
     author = authors(:david)
-    
+
     assert_queries_count(3) do
       Author.where(id: author.id).preload(
         posts: -> { select(:id, :title, :author_id) },
         comments: -> { select(:id, :body, :post_id) }
       ).to_a
     end
-    
+
     author = Author.where(id: author.id).preload(
       posts: -> { select(:id, :title, :author_id) },
       comments: -> { select(:id, :body, :post_id) }
     ).first
-    
+
     assert_predicate author.posts, :loaded?
     assert_predicate author.comments, :loaded?
   end
 
   def test_preload_auto_includes_foreign_key
     author = authors(:david)
-    
+
     # User only selects id and title, but author_id should be auto-included
     Author.where(id: author.id).preload(posts: -> { select(:id, :title) }).first.tap do |a|
       assert_predicate a.posts, :loaded?
@@ -1661,7 +1661,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
   def test_preload_scope_with_through_association
     author = authors(:david)
-    
+
     # Author has_many :comments, through: :posts
     Author.where(id: author.id).preload(comments: -> { select(:id, :body, :post_id) }).first.tap do |a|
       assert_predicate a.comments, :loaded?
@@ -1671,7 +1671,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
   def test_preload_nested_associations_with_scopes
     author = authors(:david)
-    
+
     # Using scope: key for nested with scope
     Author.where(id: author.id).preload(
       posts: {
@@ -1690,7 +1690,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
     result = Author.strict_loading.where(id: author.id).preload(posts: -> { select(:id, :title, :author_id) }).first
     assert_predicate result.posts, :loaded?
-    
+
     # Should still enforce strict loading on non-preloaded associations
     assert_raises(ActiveRecord::StrictLoadingViolationError) do
       result.posts.first.comments.to_a

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1591,6 +1591,111 @@ class PreloaderTest < ActiveRecord::TestCase
     result = Author.includes(books: [], published_author: { books: [] }).last
     assert_equal [PublishedBook], result.published_author.books.map(&:class)
   end
+
+  def test_preload_with_lambda_select_scope
+    author = authors(:david)
+    
+    assert_queries_count(2) do
+      result = Author.where(id: author.id).preload(posts: -> { select(:id, :title, :author_id) }).to_a
+      assert_equal 1, result.size
+    end
+    
+    author = Author.where(id: author.id).preload(posts: -> { select(:id, :title, :author_id) }).first
+    assert_predicate author.posts, :loaded?
+    assert author.posts.any?
+    
+    # Verify only selected columns are loaded
+    post = author.posts.first
+    assert post.has_attribute?(:id)
+    assert post.has_attribute?(:title)
+    assert post.has_attribute?(:author_id)
+  end
+
+  def test_preload_with_lambda_where_and_select
+    author = authors(:david)
+    
+    Author.where(id: author.id).preload(posts: -> { where(id: 1).select(:id, :title, :author_id) }).first.tap do |a|
+      assert_predicate a.posts, :loaded?
+      assert_equal [posts(:welcome)], a.posts
+    end
+  end
+
+  def test_preload_with_relation_scope
+    author = authors(:david)
+    
+    Author.where(id: author.id).preload(posts: Post.select(:id, :title, :author_id)).first.tap do |a|
+      assert_predicate a.posts, :loaded?
+      assert a.posts.any?
+    end
+  end
+
+  def test_preload_with_multiple_associations_different_scopes
+    author = authors(:david)
+    
+    assert_queries_count(3) do
+      Author.where(id: author.id).preload(
+        posts: -> { select(:id, :title, :author_id) },
+        comments: -> { select(:id, :body, :post_id) }
+      ).to_a
+    end
+    
+    author = Author.where(id: author.id).preload(
+      posts: -> { select(:id, :title, :author_id) },
+      comments: -> { select(:id, :body, :post_id) }
+    ).first
+    
+    assert_predicate author.posts, :loaded?
+    assert_predicate author.comments, :loaded?
+  end
+
+  def test_preload_auto_includes_foreign_key
+    author = authors(:david)
+    
+    # User only selects id and title, but author_id should be auto-included
+    Author.where(id: author.id).preload(posts: -> { select(:id, :title) }).first.tap do |a|
+      assert_predicate a.posts, :loaded?
+      # Should work even though author_id wasn't explicitly selected
+      assert a.posts.all? { |p| p.author_id == author.id }
+    end
+  end
+
+  def test_preload_scope_with_through_association
+    author = authors(:david)
+    
+    # Author has_many :comments, through: :posts
+    Author.where(id: author.id).preload(comments: -> { select(:id, :body, :post_id) }).first.tap do |a|
+      assert_predicate a.comments, :loaded?
+      assert a.comments.any?
+    end
+  end
+
+  def test_preload_nested_associations_with_scopes
+    author = authors(:david)
+    
+    # Using scope: key for nested with scope
+    Author.where(id: author.id).preload(
+      posts: {
+        scope: -> { select(:id, :title, :author_id) },
+        comments: -> { select(:id, :body, :post_id) }
+      }
+    ).first.tap do |a|
+      assert_predicate a.posts, :loaded?
+      post = a.posts.first
+      assert_predicate post.comments, :loaded? if post
+    end
+  end
+
+  def test_preload_with_strict_loading_and_scope
+    author = authors(:david)
+
+    result = Author.strict_loading.where(id: author.id).preload(posts: -> { select(:id, :title, :author_id) }).first
+    assert_predicate result.posts, :loaded?
+    
+    # Should still enforce strict loading on non-preloaded associations
+    assert_raises(ActiveRecord::StrictLoadingViolationError) do
+      result.posts.first.comments.to_a
+    end
+  end
 end
 
 class GeneratedMethodsTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Motivation / Background

At the company I currently work for, we frequently use preload and includes on tables with many columns. This creates performance issues because ActiveRecord loads all columns even when we only need two or three fields in many cases.

Being able to limit the selected columns for preloaded or included associations would significantly improve query performance and memory usage.

Currently, developers can control column selection for the main query using `select`, but there's no way to do the same for preloaded associations:

```ruby
# Can select columns for main query
User.select(:id, :name).where(active: true)

# But cannot control columns for associations - loads ALL columns
User.preload(:books).where(active: true).select(:id, :name)
```

This is particularly problematic for:
- API endpoints returning JSON with limited fields
- Large tables with text/blob columns that are rarely needed
- High-traffic applications where every KB of data transfer matters

### Detail

This Pull Request adds support for scoped preloading with column selection, allowing developers to specify which columns to load for preloaded associations using lambda expressions or `ActiveRecord::Relation` objects.

**New API:**

```ruby
# Lambda with select
User.preload(books: -> { select(:id, :title) })

# Relation with select
User.preload(books: Book.select(:id, :title))

# Lambda with where and select
User.preload(books: -> { where(published: true).select(:id, :title) })

# Multiple associations with different scopes
User.preload(
  books: -> { select(:id, :title) },
  comments: -> { where(visible: true).select(:id, :body) }
)

# Nested associations with scopes
User.preload(
  books: {
    scope: -> { select(:id, :title) },
    chapters: -> { select(:id, :name) }
  }
)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
