### PR TITLE
Detect bun JS package manager when using text-based lockfile

### DIFF
--- a/railties/lib/rails/generators/js_package_manager.rb
+++ b/railties/lib/rails/generators/js_package_manager.rb
@@ -33,7 +33,7 @@ module Rails
       }.freeze
 
       def self.detect(root)
-        if root.join("bun.lockb").exist? || root.join("bun.lock").exist? || root.join("bun.config.js").exist?
+        if root.join("bun.lock").exist? || root.join("bun.lockb").exist? || root.join("bun.config.js").exist?
           :bun
         elsif root.join("pnpm-lock.yaml").exist?
           :pnpm

--- a/railties/lib/rails/generators/js_package_manager.rb
+++ b/railties/lib/rails/generators/js_package_manager.rb
@@ -33,7 +33,7 @@ module Rails
       }.freeze
 
       def self.detect(root)
-        if root.join("bun.lockb").exist? || root.join("bun.config.js").exist?
+        if root.join("bun.lockb").exist? || root.join("bun.lock").exist? || root.join("bun.config.js").exist?
           :bun
         elsif root.join("pnpm-lock.yaml").exist?
           :pnpm

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -67,6 +67,15 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     assert_includes @run_commands, "bun add @rails/actiontext"
   end
 
+  test "installs JavaScript dependencies with bun when bun.lock exists" do
+    FileUtils.touch("#{destination_root}/package.json")
+    FileUtils.touch("#{destination_root}/bun.lock")
+
+    run_generator_instance
+    assert_includes @run_commands, "bun add trix"
+    assert_includes @run_commands, "bun add @rails/actiontext"
+  end
+
   test "throws warning for missing entry point" do
     FileUtils.rm("#{destination_root}/app/javascript/application.js")
     output = run_generator_instance

--- a/railties/test/generators/js_package_manager_test.rb
+++ b/railties/test/generators/js_package_manager_test.rb
@@ -22,6 +22,11 @@ class JsPackageManagerTest < Rails::Generators::TestCase
     assert_equal :bun, Rails::Generators::JsPackageManager.detect(Pathname(destination_root))
   end
 
+  test "detects bun from bun.lock" do
+    FileUtils.touch(File.join(destination_root, "bun.lock"))
+    assert_equal :bun, Rails::Generators::JsPackageManager.detect(Pathname(destination_root))
+  end
+
   test "detects bun from bun.config.js" do
     FileUtils.touch(File.join(destination_root, "bun.config.js"))
     assert_equal :bun, Rails::Generators::JsPackageManager.detect(Pathname(destination_root))


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

https://github.com/rails/rails/pull/56636 streamlined JS package manager detection to be based on presence of lockfiles, however for `bun` it only looks for `bun.lockb`, which is an older binary format bun no longer uses by default. In this PR I add  a check to detect bun based on presence of `bun.lock` too.

### Detail

This Pull Request changes JS lockfile detection to consider a newer lockfile format for bun.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
