### PR TITLE
Prefer connected? for connection validity checks

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1056,7 +1056,7 @@ module ActiveRecord
         #
         def with_raw_connection(allow_retry: false, materialize_transactions: true)
           @lock.synchronize do
-            connect! if @raw_connection.nil? && reconnect_can_restore_state?
+            connect! if !connected? && reconnect_can_restore_state?
 
             self.materialize_transactions if materialize_transactions
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -373,13 +373,13 @@ module ActiveRecord
       end
 
       def connected?
-        !(@raw_connection.nil? || @raw_connection.finished?)
+        !(@raw_connection.nil? || @raw_connection.finished? || @raw_connection.status != PG::CONNECTION_OK)
       end
 
       # Is this connection alive and ready for queries?
       def active?
         @lock.synchronize do
-          return false unless @raw_connection
+          return false unless connected?
           @raw_connection.query ";"
           verified!
         end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -667,6 +667,17 @@ module ActiveRecord
         assert_not_predicate @connection, :active?
       end
 
+      test "active? on a 'clean' recently-used but now-failed connection detects but doesn't fix the problem" do
+        remote_disconnect @connection
+        @connection.clean! # this simulates a fresh checkout from the pool
+
+        # Clean did not verify / fix the connection
+        assert_not_predicate @connection, :active?
+
+        # And nor did the above active? check
+        assert_not_predicate @connection, :active?
+      end
+
       test "verify! restores after remote disconnection" do
         remote_disconnect @connection
         @connection.verify!
@@ -702,9 +713,6 @@ module ActiveRecord
         remote_disconnect @connection
 
         @connection.clean! # this simulates a fresh checkout from the pool
-
-        # Clean did not verify / fix the connection
-        assert_not_predicate @connection, :active?
 
         # Because the query cannot be retried, and we (mistakenly) believe the
         # connection is still good, the query will fail. This is what we want,


### PR DESCRIPTION
This doesn't catch fresh disconnections etc, but we can at least remember that a connection is unusable after we've seen it go bad.

The test split is needed because calling `active?` now marks the connection as bad -> not connected, so the previous test would automatically recover the connection before running our victim query.