### PR TITLE
Fix typos and minor errors in guides [ci skip]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -202,7 +202,7 @@ interchangeably as keys.
 [Composite key parameters](active_record_composite_primary_keys.html) contain
 multiple values in one parameter separated by a delimiter (e.g., an underscore).
 Therefore, you will need to extract each value so that you can pass them to
-Active Record. You can use the `extract_value`  method to do that.
+Active Record. You can use the `extract_value` method to do that.
 
 For example, given the following controller:
 
@@ -1168,7 +1168,7 @@ class ActionDurationCallback
 end
 ```
 
-In above example, the `ActionDurationCallback`'s method is not run in the scope
+In the above example, the `ActionDurationCallback`'s method is not run in the scope
 of the controller but gets `controller` as an argument.
 
 In general, the class being used for a `*_action` callback must implement a

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -934,7 +934,7 @@ This exception indicates that the record was not saved due to the callback's
 interruption.
 
 ```ruby
-User.create! # => raises an ActiveRecord::RecordNotSaved
+Product.create! # => raises an ActiveRecord::RecordNotSaved
 ```
 
 
@@ -1211,7 +1211,7 @@ the transaction.
 
 ### Aliases for `after_commit`
 
-Using the `after_commit` callback only on create, update, or delete is common.
+Using the `after_commit` callback only on create, update, or destroy is common.
 Sometimes you may also want to use a single callback for both `create` and
 `update`. Here are some common aliases for these operations:
 

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -651,7 +651,7 @@ config.active_record.encryption.encryptor = MyEncryptor.new
 ```
 
 You can use
-[`with_encryption_context`](`https://api.rubyonrails.org/classes/ActiveRecord/Encryption/Contexts.html#method-i-with_encryption_context`)
+[`with_encryption_context`](https://api.rubyonrails.org/classes/ActiveRecord/Encryption/Contexts.html#method-i-with_encryption_context)
 to override any of the properties of the encryption context.
 
 ### Encryption Context with a Block of Code

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -524,7 +524,7 @@ Rails migrations with timestamps store the time a model was created or updated. 
 
 ```ruby
 # db/migrate/20241220144913_create_devices.rb
-create_table :post, id: :uuid do |t|
+create_table :posts, id: :uuid do |t|
   t.datetime :published_at
   # By default, Active Record will set the data type of this column to `timestamp without time zone`.
 end
@@ -840,7 +840,7 @@ ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = ["--no-comments"]
 Explain
 -------
 
-Along with the standard [`explain`][explain-options] options, the PostgreSQL adapter supports [`buffers`][explain-analayze-buffers].
+Along with the standard [`explain`][explain-options] options, the PostgreSQL adapter supports [`buffers`][explain-analyze-buffers].
 
 ```ruby
 Company.where(id: owning_companies_ids).explain(:analyze, :buffers)
@@ -853,4 +853,4 @@ Company.where(id: owning_companies_ids).explain(:analyze, :buffers)
 See their documentation for more details.
 
 [explain-options]: active_record_querying.html#explain-options
-[explain-analayze-buffers]: https://www.postgresql.org/docs/current/sql-explain.html
+[explain-analyze-buffers]: https://www.postgresql.org/docs/current/sql-explain.html

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1179,7 +1179,7 @@ SELECT * FROM authors WHERE id = 10 LIMIT 1
 SELECT * FROM books WHERE author_id = 10 ORDER BY year_published DESC
 ```
 
-You can using the `reorder` clause to specify a different way to order the books:
+You can use the `reorder` clause to specify a different way to order the books:
 
 ```ruby
 Author.find(10).books.reorder("year_published ASC")

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -612,7 +612,7 @@ expression or a proc or lambda that returns one.
 
 The default error message is _"is invalid"_.
 
-WARNING. Use `\A` and `\z` to match the start and end of the string, `^` and `$`
+WARNING: Use `\A` and `\z` to match the start and end of the string, `^` and `$`
 match the start/end of a line. Due to frequent misuse of `^` and `$`, you need
 to pass the `multiline: true` option in case you use any of these two anchors in
 the provided regular expression. In most cases, you should be using `\A` and
@@ -1963,5 +1963,5 @@ config.action_view.field_error_proc = Proc.new { |html_tag, instance| content_ta
 
 You can customize this behavior by modifying the field_error_proc setting in
 your application configuration, allowing you to change how errors are presented
-in your forms. For more details,refer to the [Configuration Guide on
+in your forms. For more details, refer to the [Configuration Guide on
 field_error_proc](configuring.html#config-action-view-field-error-proc).


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it fixes typos, wording issues, and minor documentation inaccuracies.

### Detail

N/A

### Additional information

N/A
