### PR TITLE
Skip unique index lookup for insert_all! since it doesn't need conflict target

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -38,7 +38,7 @@ module ActiveRecord
       @returning = (connection.supports_insert_returning? ? primary_keys : false) if @returning.nil?
       @returning = false if @returning == []
 
-      @unique_by = find_unique_index_for(@unique_by)
+      @unique_by = find_unique_index_for(@unique_by) if @on_duplicate != :raise
 
       configure_on_duplicate_update_logic
       ensure_valid_options_for_connection!

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -287,9 +287,26 @@ class InsertAllTest < ActiveRecord::TestCase
 
       Cart.upsert_all [{ id: 3, shop_id: 2, title: "My other cart" }], unique_by: [:shop_id, :id]
     end
+  end
+
+  def test_insert_all_bang_does_not_require_unique_index
+    skip unless supports_insert_conflict_target?
+
+    assert_difference "Cart.count", +1 do
+      Cart.insert_all! [{ id: 2, shop_id: 1, title: "My cart" }]
+    end
+  end
+
+  def test_insert_all_and_upsert_all_raises_when_no_unique_index_found_for_composite_primary_key
+    skip unless supports_insert_conflict_target?
 
     error = assert_raises ArgumentError do
-      Cart.insert_all! [{ id: 2, shop_id: 1, title: "My cart" }]
+      Cart.insert_all [{ id: 2, shop_id: 1, title: "My cart" }]
+    end
+    assert_match "No unique index found for id", error.message
+
+    error = assert_raises ArgumentError do
+      Cart.upsert_all [{ id: 2, shop_id: 1, title: "My cart" }]
     end
     assert_match "No unique index found for id", error.message
   end


### PR DESCRIPTION
`insert_all!` uses `on_duplicate: :raise` which performs a plain INSERT without any `ON CONFLICT` clause. Previously, `find_unique_index_for` was called unconditionally, requiring a unique index even when one wasn't needed.

This caused unnecessary failures for tables with composite primary keys
where `model.primary_key` differs from the schema's primary key columns, such as when a model sets `self.primary_key = :id` but the table has `primary_key: [:shop_id, :id]`.

`insert_all` (`on_duplicate: :skip`) and `upsert_all` (`on_duplicate: :update`) still require the unique index for generating the conflict target clause.

@eileencodes @matthewd 