### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/more-info-needed.yml
+++ b/.github/workflows/more-info-needed.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       issues: write
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: -1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: lts/*
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 90


### PR DESCRIPTION
---

### Motivation / Background  

This Pull Request has been created because outdated GitHub Action versions may introduce compatibility issues or lack of features. Updating to the latest versions ensures better functionality, security, and alignment with modern workflows.  

---

### Detail  

This Pull Request changes:  
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/release.yml`  
- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/stale.yml`  
- Updated `actions/labeler` from `v5` to `v6` in `.github/workflows/labeler.yml`  
- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/more-info-needed.yml`  

---

### Additional information  

The updates ensure that GitHub Actions are using the latest features and improvements, such as enhanced functionality in `actions/stale` and `actions/labeler`, and better compatibility with newer workflows. These changes are part of a broader effort to maintain robust and up-to-date actions in the Rails ecosystem.  

---

### Checklist  

- [x] This Pull Request is related to one change.  
- [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue, include it in the commit message.  
- [ ] Tests are added or updated if you fix a bug or add a feature.  
- [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.