### PR TITLE
Make DatabaseTasks#migration_class public

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -549,7 +549,9 @@ module ActiveRecord
         end
       end
 
-      def migration_class # :nodoc:
+      # Defines what class will be used to connect to the database.
+      # By default, ActiveRecord::Base is choosen for rake tasks.
+      def migration_class
         ActiveRecord::Base
       end
 


### PR DESCRIPTION
This behavior is not likely to change in the near future, so this change makes it explicit which class is being used to connect for rake tasks.

See: #56479