### PR TITLE
Add changelog for 6f9cbce21d8ec2de86c37b5a37073bac6d5f1d83 to Action Cable and Action Text

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Channel generator now detects which JS package manager to use when
+    installing javascript dependencies.
+
+    *David Lowenfels*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Install generator now detects which JS package manager to use when
+    installing javascript dependencies for the editor.
+
+    *David Lowenfels*
+
 *   Deprecate Trix-specific classes, modules, and methods
 
     * `ActionText::Attachable#to_trix_content_attachment_partial_path`. Override


### PR DESCRIPTION
Added in #56636, there was a changelog to Railties but it does not cover changes in the whole framework.