### PR TITLE
Disable console query cache by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -5,6 +5,12 @@
 
     *David Lowenfels*
 
+*   Disable the Active Record query cache in the console by default when using the executor.
+
+    The query cache is now off by default in the console. Pass `--query-cache` to enable it for the session.
+
+    *Cam Allen*
+
 *   Console `reload!` will reset the console's executor, when present.
 
     *Ben Sheldon*

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -191,6 +191,18 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     write_prompt "Rails.application.executor.active?", "false"
   end
 
+  def test_console_query_cache_disabled_by_default
+    spawn_console
+
+    write_prompt "ActiveRecord::Base.connection_pool.query_cache_enabled", "=> false"
+  end
+
+  def test_console_query_cache_option
+    spawn_console "--query-cache"
+
+    write_prompt "ActiveRecord::Base.connection_pool.query_cache_enabled", "=> true"
+  end
+
   def test_app_helper_method
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do


### PR DESCRIPTION
This Pull Request has been created because to fix the rails console using the query cache by default since https://github.com/rails/rails/pull/56297 was merged. 

Resolves #56473

This Pull Request disables the query cache for the session. This behaviour is opt-out and can be disabled by the the `--query-cache` option, e.g. `bin/rails console -q`. Note the -q has no effect when `--skip-executor` options is used.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
