### PR TITLE
Don't parallelize databases that Rails doesn't manage

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix database renaming for external databases during parallelized tests.
+
+    When using external databases (i.e., those not managed by Rails), parallelized tests
+    would attempt to rename these databases. This change skips the renaming behavior for
+    databases with `database_tasks` set to `false`.
+
+    *Sean Hogge*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because external databases, such as those with `database_tasks` set to `false`, are being renamed in parallelized testing. Obviously, this breaks any connection to that database, and raises errors when classes that use that database are loaded (even if not actually used in tests).

### Detail

This Pull Request changes the behavior of `activerecord/lib/active_record/test_databases.rb` - it skips the renaming and schema reconstruction if `database_tasks` is `false`

### Additional information

Perhaps a more specific setting like `parallelize` should be added to database configs? I'm unaware of a situation in which one would want Rails not to manage a database, but to have it parallelized in tests somehow, but if that situation does exist, then this approach may be naive.

This also may indicate that `database_tasks?` is doing too much - it's really answering "does this database need to be managed, and is it also not a replica."

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.