### PR TITLE
Pass sql query to query log tags

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Pass sql query to query log tags.
+
+    ```ruby
+    config.active_record.query_log_tags = [
+      sql_length: ->(context) { context[:sql].length }
+    ]
+    ```
+
+    *fatkodima*
+
 *   Speedup `ActiveRecord::Migration.maintain_test_schema!` when using multiple databases.
 
     Previously, Active Record would inneficiently connect twice to each databases, now it only

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -129,6 +129,14 @@ class QueryLogsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_passes_sql_to_context
+    ActiveRecord::QueryLogs.tags = [ sql_length: ->(context) { context[:sql].length } ]
+
+    assert_queries_match("SELECT 1 /*sql_length:8*/") do
+      ActiveRecord::Base.lease_connection.execute "SELECT 1"
+    end
+  end
+
   def test_resets_cache_on_context_update
     ActiveRecord::QueryLogs.cache_query_log_tags = true
     ActiveSupport::ExecutionContext[:temporary] = "value"


### PR DESCRIPTION
We had a need to debug why the sql query is not hitting the database replica in production. We already attach a single backtrace line for each query as an sql tag, but this is not enough for this case. So depending on the sql string we want to add more backtrace lines.
 
This problem can be also solved via `ActiveSupport::Notifications.subscribe("sql.active_record")` and some custom logic, but it is easier with the proposed solution and I think there can be other cases where passing sql to query log tags can be useful.

Usage example
```ruby
config.active_record.query_log_tags = [
  sql_length: ->(context) { context[:sql].length }
]
```