### PR TITLE
Fix `extend_queries` with `support_unencrypted_data` when combined with `normalizes`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `extend_queries` with `support_unencrypted_data` when combined with `normalizes`.
+
+    When using `encrypts` with `normalizes` on the same attribute, queries now correctly
+    include the plaintext value, allowing records with unencrypted data to be found.
+
+    *Péter Bence Márföldi*
+
 *   Fix PostgreSQL schema dumping to handle schema-qualified table names in foreign_key references that span different schemas.
 
         # before

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -28,6 +28,7 @@ module ActiveRecord
         ActiveRecord::Relation.prepend(RelationQueries)
         ActiveRecord::Base.include(CoreQueries)
         ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
+        ActiveModel::Attributes::Normalization::NormalizedValueType.prepend(ExtendedEncryptableType)
       end
 
       # When modifying this file run performance tests in
@@ -88,7 +89,7 @@ module ActiveRecord
 
             def additional_values_for(value, type)
               type.previous_types.collect do |additional_type|
-                AdditionalValue.new(value, additional_type)
+                AdditionalValue.new(type.cast(value), additional_type)
               end
             end
         end

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -95,4 +95,28 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
       assert EncryptedBookWithUnencryptedDataOptedIn.where("id > 0").find_by(name: "Dune") # relation
     end
   end
+
+  test "finds unencrypted records when normalizes is used with encrypts" do
+    UnencryptedBook.create!(name: "dune")
+    assert EncryptedBookWithNormalizedName.find_by(name: "DUNE") # core
+    assert EncryptedBookWithNormalizedName.where("id > 0").find_by(name: "DUNE") # relation
+  end
+
+  test "finds encrypted records when normalizes is used with encrypts" do
+    EncryptedBookWithNormalizedName.create!(name: "Dune")
+    assert EncryptedBookWithNormalizedName.find_by(name: "DUNE") # core
+    assert EncryptedBookWithNormalizedName.where("id > 0").find_by(name: "DUNE") # relation
+  end
+
+  test "finds unencrypted records when normalizes is declared before encrypts" do
+    UnencryptedBook.create!(name: "dune")
+    assert EncryptedBookWithNormalizedNameReversed.find_by(name: "DUNE") # core
+    assert EncryptedBookWithNormalizedNameReversed.where("id > 0").find_by(name: "DUNE") # relation
+  end
+
+  test "finds encrypted records when normalizes is declared before encrypts" do
+    EncryptedBookWithNormalizedNameReversed.create!(name: "Dune")
+    assert EncryptedBookWithNormalizedNameReversed.find_by(name: "DUNE") # core
+    assert EncryptedBookWithNormalizedNameReversed.where("id > 0").find_by(name: "DUNE") # relation
+  end
 end

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -89,6 +89,20 @@ class EncryptedBookWithSerializedSecondBinary < ActiveRecord::Base
   serialize :logo, coder: JSON
 end
 
+class EncryptedBookWithNormalizedName < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  encrypts :name, deterministic: true
+  normalizes :name, with: ->(value) { value.to_s.downcase }
+end
+
+class EncryptedBookWithNormalizedNameReversed < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  normalizes :name, with: ->(value) { value.to_s.downcase }
+  encrypts :name, deterministic: true
+end
+
 class EncryptedBookWithCustomCompressor < ActiveRecord::Base
   module CustomCompressor
     def self.deflate(value)


### PR DESCRIPTION
### Motivation / Background

Fixes #56684

When using `encrypts` with `normalizes` on the same attribute, `extend_queries` with `support_unencrypted_data` fails to include plaintext values in queries. This prevents finding records with unencrypted data during encryption migrations.

### Detail

This Pull Request changes `activerecord/lib/active_record/encryption/extended_deterministic_queries.rb`:

1. Prepend `ExtendedEncryptableType` to `NormalizedValueType` to handle `AdditionalValue` in serialize
2. Use `type.cast(value)` in `additional_values_for` to normalize plaintext before creating `AdditionalValue`

**Root cause:** `NormalizedValueType#serialize` was calling `normalize(value)` on `AdditionalValue` objects, producing garbage strings like `"#<ActiveRecord::Encryption::ExtendedDeterministicQueries::AdditionalValue:0x...>"` that got encrypted.

### Additional information

This fix prepends to an ActiveModel class (`NormalizedValueType`) from ActiveRecord, which crosses module boundaries. There may be a cleaner approach that keeps the fix entirely within ActiveRecord or ActiveModel.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.