### PR TITLE
Respect `urls_expire_in` in Active Storage proxy controller's cache headers

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Proxy controllers take the `urls_expire_in` setting into account for
+    Cache-Control headers
+
+    Proxy controllers for files and their representations now limit cache
+    max-age to the value set in `urls_expire_in`. Like before this change, the
+    cache validity is still "forever" when `urls_expire_in` is not set (which,
+    by default, it isn't).
+
+    *Alexander Gitter*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -29,7 +29,9 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
     if request.headers["Range"].present?
       send_blob_byte_range_data @blob, request.headers["Range"]
     else
-      http_cache_forever public: true, last_modified: @blob.created_at do
+      expires_in ActiveStorage.urls_expire_in || 100.years, public: true, immutable: true
+
+      if stale?(etag: request.fullpath, last_modified: @blob.created_at, public: true)
         response.headers["Accept-Ranges"] = "bytes"
         response.headers["Content-Length"] = @blob.byte_size.to_s
 

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -25,7 +25,9 @@ class ActiveStorage::Representations::ProxyController < ActiveStorage::Represent
   include ActiveStorage::DisableSession
 
   def show
-    http_cache_forever public: true do
+    expires_in ActiveStorage.urls_expire_in || 100.years, public: true, immutable: true
+
+    if stale?(etag: request.fullpath, last_modified: @blob.created_at, public: true)
       send_blob_stream @representation, disposition: params[:disposition]
     end
   end

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -191,6 +191,7 @@ class ActiveStorage::Blobs::ExpiringProxyControllerTest < ActionDispatch::Integr
   test "signed ID within expiration date" do
     get rails_storage_proxy_url(create_file_blob(filename: "racecar.jpg"))
     assert_response :success
+    assert_equal "max-age=60, public, immutable", response.headers["Cache-Control"]
   end
 
   test "Expired signed ID" do

--- a/activestorage/test/controllers/representations/proxy_controller_test.rb
+++ b/activestorage/test/controllers/representations/proxy_controller_test.rb
@@ -74,6 +74,15 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
     assert request.session_options[:skip],
       "Expected request.session_options[:skip] to be true"
   end
+
+  test "HTTP caching" do
+    get rails_blob_representation_proxy_url(
+      filename: @blob.filename,
+      signed_blob_id: @blob.signed_id,
+      variation_key: ActiveStorage::Variation.encode(@transformations))
+    assert_response :ok
+    assert_equal "max-age=3155695200, public, immutable", response.headers["Cache-Control"]
+  end
 end
 
 class ActiveStorage::Representations::ProxyControllerWithVariantsWithStrictLoadingTest < ActionDispatch::IntegrationTest
@@ -95,7 +104,6 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsWithStrictLoadi
     assert_match(/^inline/, response.headers["Content-Disposition"])
     assert_equal @blob.variant(@transformations).download, response.body
   end
-
 
   test "invalidates cache and returns a 404 if the file is not found on download" do
     # This mock requires a pre-processed variant as processing the variant will call to download
@@ -184,5 +192,27 @@ class ActiveStorage::Representations::ProxyControllerWithPreviewsWithStrictLoadi
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
     assert_equal @blob.preview(@transformations).download, response.body
+  end
+end
+
+class ActiveStorage::Representations::ExpiringProxyControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @blob = create_file_blob filename: "racecar.jpg"
+    @transformations = { resize_to_limit: [100, 100] }
+    @old_urls_expire_in = ActiveStorage.urls_expire_in
+    ActiveStorage.urls_expire_in = 1.minutes
+  end
+
+  teardown do
+    ActiveStorage.urls_expire_in = @old_urls_expire_in
+  end
+
+  test "signed ID within expiration date" do
+    get rails_blob_representation_proxy_url(
+      filename: @blob.filename,
+      signed_blob_id: @blob.signed_id,
+      variation_key: ActiveStorage::Variation.encode(@transformations))
+    assert_response :ok
+    assert_equal "max-age=60, public, immutable", response.headers["Cache-Control"]
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the Active Storage proxy controllers currently don't limit cache expiration times based on `urls_expire_in`.

Fixes #54637

### Detail

The `urls_expire_in` setting determines the expiration of URLs generated by Active Storage. The default is nil, making those URLs never expire. When `urls_expire_in` is set, the routes generated by Rails expire after the given time.

Before this change, Active Storage proxy controllers would always send Cache-Control headers that allowed private and public caches to cache responses "forever". This could be problematic especially with caching reverse proxies / CDNs, where the cache can respond with the stored file, long after the URL on the Rails side already expired.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
