### PR TITLE
Improve diagnostics UI to make nested stack traces more discoverable

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -21,8 +21,8 @@
 
   <% @exception_wrapper.wrapped_causes.each.with_index(1) do |wrapper, index| %>
     <div class="details">
-      <a class="summary" href="#" onclick="return toggle(<%= wrapper.exception_id %>)">
-        <%= wrapper.exception_class_name %>: <%= h wrapper.message %>
+      <a class="summary" href="#" onclick="return toggle(<%= wrapper.exception_id %>, this)">
+        <span><%= wrapper.exception_class_name %>: <%= h wrapper.message %></span>
       </a>
     </div>
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -129,6 +129,20 @@
       text-decoration: none;
       background: #C52F24;
       border-bottom: none;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    a.summary::before {
+      content: "▶";
+      font-size: 0.9em;
+      transition: transform 0.2s ease;
+      display: inline-block;
+    }
+
+    a.summary.expanded::before {
+      transform: rotate(90deg);
     }
 
     .details pre {
@@ -298,8 +312,11 @@
   </style>
 
   <script>
-    var toggle = function(id) {
+    var toggle = function(id, element) {
       document.getElementById(id).classList.toggle('hidden');
+      if (element) {
+        element.classList.toggle('expanded');
+      }
       return false;
     }
     var show = function(id) {


### PR DESCRIPTION
### Motivation / Background

Hello! I recently found myself debugging a nested exception locally, and it took me awhile to realize that the stack trace was available but initially hidden on the diagnostics page. I thought it might be useful to add a small visual indicator that the exception can be clicked to reveal the stack trace.

I recognize this is a pretty small cosmetic-only change, but I do think it will help usability of this page when dealing with nested exceptions.


### Detail

Adds a small arrow on the side of the summary bar which rotates when clicked to reveal the stack trace:


<!-- https://github.com/user-attachments/assets/91f674bc-a8fa-430f-85ad-a0a1a28c3d57 -->



https://github.com/user-attachments/assets/e8f68ed8-8e20-4362-a39f-53aec869db99



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
  - I don't think tests are warranted here since this is purely visual
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
  - Similarly, not sure if this is worthy of a CHANGELOG entry or not but happy to be proven wrong!
