### PR TITLE
Update typemap for timezone during type_casted_binds

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -164,7 +164,6 @@ module ActiveRecord
           end
 
           def perform_query(raw_connection, intent)
-            update_typemap_for_default_timezone
             result = if intent.prepare
               begin
                 stmt_key = prepare_statement(intent.processed_sql, intent.binds, raw_connection)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -191,6 +191,11 @@ module ActiveRecord
           super(query_value("SELECT #{quote(sql_type)}::regtype::oid").to_i)
         end
 
+        def type_casted_binds(binds) # :nodoc:
+          update_typemap_for_default_timezone
+          super
+        end
+
         private
           def encode_array(array_data)
             encoder = array_data.encoder

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1176,6 +1176,20 @@ class BasicsTest < ActiveRecord::TestCase
       end
     end
 
+    def test_switching_default_time_zone_with_find_by_sql
+      with_env_tz do
+        with_timezone_config default: :utc do
+          default = Default.create!
+          assert_equal Time.utc(2004, 1, 1, 0, 0, 0, 0), default.fixed_time
+
+          ActiveRecord.default_timezone = :local
+
+          time = Default.find_by_sql("SELECT * FROM defaults WHERE id = #{default.id}").first.fixed_time
+          assert_equal Time.local(2004, 1, 1, 0, 0, 0, 0), time
+        end
+      end
+    end
+
     def test_mutating_time_objects
       with_env_tz do
         with_timezone_config default: :local do


### PR DESCRIPTION
Typecasting of outgoing binds is the moment we need to have the correct typemap in place, so let's put the call there. 

This doesn't change any existing behaviour; it just sets up a clearer path ahead of other changes I'm planning to make here.