### PR TITLE
Add documentation for foreign key options to add_reference [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1059,6 +1059,7 @@ module ActiveRecord
       #   Add an appropriate foreign key constraint. Defaults to false, pass true
       #   to add. In case the join table can't be inferred from the association
       #   pass <tt>:to_table</tt> with the appropriate table name.
+      #   For other available options, see #add_foreign_key.
       # [<tt>:polymorphic</tt>]
       #   Whether an additional +_type+ column should be added. Defaults to false.
       # [<tt>:null</tt>]


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the `add_reference` API documentation does not currently mention that foreign key options supported by `add_foreign_key` can also be passed.

`ActiveRecord::ConnectionAdapters::TableDefinition#references` accepts foreign key options via the `foreign_key:` argument, as verified by [the existing test](https://github.com/rails/rails/blob/931401f0603522d21d6ec2e52c1fd1a048bed63b/activerecord/test/cases/migration/references_foreign_key_test.rb#L99) covering `:deferrable`, `:on_delete`, and `:on_update` options.

Since the documentation for [`references`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html#method-i-references) already points readers to `add_reference` for option details, it is beneficial to explicitly link to `add_foreign_key` from `add_reference` to help developers discover these available options.

### Detail

This Pull Request updates the documentation for the `foreign_key` option in `SchemaStatements#add_reference` to include a link to `SchemaStatements#add_foreign_key`, where the supported options are listed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
