### PR TITLE
Fix credentials being cached with nil key during `load_database_yaml`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix credentials being cached with nil key during `load_database_yaml`.
+
+    When `database.yml` references `Rails.application.credentials`, the credentials
+    were incorrectly cached during early rake task loading before environment files
+    set `config.credentials.key_path`. This caused credential lookups to return nil,
+    breaking database connections for apps using custom credential key paths.
+
+    This has been an issue since Rails 7.1.0 when `DummyConfig` was introduced.
+
+    *Arian Faurtosh*
+
 *   Enable Ruby `frozen_string_literal` by default.
 
     New Rails apps now include a `config/bootsnap.rb` file that enables frozen string

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -468,12 +468,16 @@ module Rails
         if path = paths["config/database"].existent.first
           require "rails/application/dummy_config"
           original_rails_config = Rails.application.config
+          # Use instance_variable_get to avoid triggering lazy initialization which would cache credentials
+          original_credentials = Rails.application.instance_variable_get(:@credentials)
 
           begin
             Rails.application.config = DummyConfig.new(original_rails_config)
+            Rails.application.credentials = DummyConfig.new(nil)
             ActiveSupport::ConfigurationFile.parse(Pathname.new(path))
           ensure
             Rails.application.config = original_rails_config
+            Rails.application.credentials = original_credentials
           end
         else
           {}

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2431,6 +2431,25 @@ module ApplicationTests
       end
     end
 
+    test "load_database_yaml does not cache credentials with nil key" do
+      app_file "config/database.yml", <<-YAML
+        development:
+          adapter: sqlite3
+          database: db/development.sqlite3
+        production:
+          adapter: postgresql
+          url: <%= Rails.application.credentials.dig(:database_url) %>
+      YAML
+
+      app "production"
+
+      Rails.application.with(credentials: nil) do
+        Rails.application.config.load_database_yaml
+        assert_nil Rails.application.instance_variable_get(:@credentials),
+          "Credentials should not be cached during load_database_yaml"
+      end
+    end
+
     test "raises with proper error message if no database configuration found" do
       FileUtils.rm("#{app_path}/config/database.yml")
       err = assert_raises RuntimeError do


### PR DESCRIPTION
### Motivation / Background

Commit 5ba8aa5854 ("Facilitate use of any regular ERB in database.yml") introduced `DummyConfig` to wrap `Rails.application.config` during early `database.yml` parsing. However, it did not wrap `Rails.application.credentials`, causing credentials to be cached with a nil key when accessed in database.yml.

This breaks applications that:
1. Set a custom `key_path` in their environment files (e.g., `config.credentials.key_path = '/path/to/production.key'`)
2. Reference credentials in `database.yml` (e.g., `url: <%= Rails.application.credentials.dig(:database_url) %>`)

When `load_database_yaml` is called during early rake task loading (via `setup_initial_database_yaml` in `databases.rake`), it happens before environment files are loaded, so `config.credentials.key_path` isn't set yet. Credentials get cached with a nil key, causing `credentials.dig(:database_url)` to return nil and database connection failures.

This has been an issue since Rails 7.1.0.

### Detail

This Pull Request wraps `@credentials` with `DummyConfig` during `load_database_yaml`, similar to how `Rails.application.config` is already wrapped. This prevents credentials from being cached during early database.yml parsing.

When the environment loads later and sets `config.credentials.key_path`, credentials will be properly initialized with the correct key.

**Files changed:**
- `railties/lib/rails/application/configuration.rb` - Wrap `@credentials` with `DummyConfig` during `load_database_yaml`
- `railties/test/application/configuration_test.rb` - Add test to verify credentials aren't cached during database.yml parsing

### Additional information

The original commit https://github.com/rails/rails/pull/46134  replaced `DummyERB` (which replaced all `<%= %>` with empty strings) with `DummyConfig` + real ERB evaluation. This enabled full ERB capabilities in database.yml but inadvertently caused credentials to be accessed and cached before the environment was fully loaded.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.