### PR TITLE
Fix ThroughReflection#association_primary_key with composite keys

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1102,7 +1102,11 @@ module ActiveRecord
         # Get the "actual" source reflection if the immediate source reflection has a
         # source reflection itself
         if primary_key = actual_source_reflection.options[:primary_key]
-          @association_primary_key ||= -primary_key.to_s
+          @association_primary_key ||= if primary_key.is_a?(Array)
+            primary_key.map { |pk| pk.to_s.freeze }.freeze
+          else
+            -primary_key.to_s
+          end
         else
           primary_key(klass || self.klass)
         end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1705,6 +1705,17 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal(chapter.book, book)
   end
 
+  def test_ids_reader_with_composite_primary_key_on_source
+    blog = Sharded::Blog.create!
+    post = Sharded::BlogPost.create!(blog_id: blog.id)
+    comment = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: post.id)
+
+    ids = blog.comments_via_post_ids
+
+    assert_kind_of Array, ids
+    assert_equal [[comment.blog_id, comment.id]], ids
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -29,7 +29,7 @@ require "models/drink_designer"
 require "models/recipe"
 require "models/user_with_invalid_relation"
 require "models/hardback"
-require "models/sharded/comment"
+require "models/sharded"
 require "models/admin"
 require "models/admin/user"
 require "models/user"
@@ -682,6 +682,14 @@ class ReflectionTest < ActiveRecord::TestCase
   def test_association_primary_key_uses_explicit_primary_key_option_as_first_priority
     actual = Sharded::Comment.reflect_on_association(:blog_post_by_id).association_primary_key
     assert_equal "id", actual
+  end
+
+  def test_through_reflection_association_primary_key_with_composite_key
+    reflection = Sharded::Blog.reflect_on_association(:comments_via_posts)
+    actual = reflection.association_primary_key
+
+    assert_kind_of Array, actual
+    assert_equal ["blog_id", "id"], actual
   end
 
   def test_belongs_to_reflection_with_query_constraints_infers_correct_foreign_key

--- a/activerecord/test/models/sharded/blog.rb
+++ b/activerecord/test/models/sharded/blog.rb
@@ -8,5 +8,11 @@
 module Sharded
   class Blog < ActiveRecord::Base
     self.table_name = :sharded_blogs
+
+    has_many :blog_posts
+
+    has_many :comments_via_posts,
+      through: :blog_posts,
+      source: :comments_with_composite_pk
   end
 end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -13,5 +13,10 @@ module Sharded
 
     has_many :blog_post_tags
     has_many :tags, through: :blog_post_tags
+
+    has_many :comments_with_composite_pk,
+      class_name: "Sharded::Comment",
+      primary_key: [:blog_id, :id],
+      foreign_key: [:blog_id, :blog_post_id]
   end
 end


### PR DESCRIPTION
This Pull Request updates `ThroughReflection#association_primary_key` to check if `primary_key` is an array and map each element to a string, matching the existing behavior in `BelongsToReflection#association_primary_key`.

### Motivation / Background

`ThroughReflection#association_primary_key` doesn't handle composite primary keys correctly. When a source association has `primary_key: [:col1, :col2]`, the method calls `.to_s` on the array, producing the string `"[:col1, :col2]"` instead of an array `["col1", "col2"]`.

This causes the auto-generated `_ids` reader method to fail with:

```
ActiveRecord::UnknownAttributeReference: Dangerous query method called with non-attribute argument(s): "[:col1, :col2]"
```

@nvasilevski 
