### PR TITLE
Fix AM::Serialization#read_attribute_for_serialization doc

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -164,7 +164,9 @@ module ActiveModel
     #       @data[key]
     #     end
     #   end
-    alias :read_attribute_for_serialization :send
+    def read_attribute_for_serialization(key)
+      send(key)
+    end
 
     private
       def attribute_names_for_serialization


### PR DESCRIPTION
Alias methods don't get documented by default.

Define an actual method instead to make sure `read_attribute_for_serialization` shows up in the documentation. This also encodes the method signature to only accept a single key as argument, where `send` accepts any arguments.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
