### PR TITLE
Bump resque-scheduler to 4.10.2 for 7-1-stable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
-    resque-scheduler (4.7.0)
+    resque-scheduler (4.10.2)
       mono_logger (~> 1.0)
       redis (>= 3.3)
       resque (>= 1.27)


### PR DESCRIPTION
## Summary
- Security bump for dependency `resque-scheduler`.
- Scope: version bump only (`Gemfile.lock`).

## Security Advisories Addressed

- [CVE-2022-44303](https://github.com/advisories/GHSA-9hmq-fm33-x4xx) (ghsa)
- [ghsa:GHSA-q7jc-v6f2-q9jr](https://github.com/advisories/GHSA-q7jc-v6f2-q9jr) (ghsa)
