### PR TITLE
[ci skip] Fix typo in test/guide stategy -> strategy

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -2039,7 +2039,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
       assert strategy.called
     end
 
-    test "migration uses adapter-specific stategy over global strategy" do
+    test "migration uses adapter-specific strategy over global strategy" do
       ActiveRecord.migration_strategy = TestStrategy
       @connection.class.migration_strategy = AlternateStrategy
       migration = TestMigration.new("TestMigration", 1)

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1927,7 +1927,7 @@ end
 Migrations running against `primary` will use `MySQLMigrationStrategy`, and
 migrations running against `animals` will use `PostgreSQLMigrationStrategy`.
 The adapter-specific strategy takes precedence over any globally-configured
-stategy.
+strategy.
 
 [`ActiveRecord::Migration::DefaultStrategy`]:
     https://api.rubyonrails.org/classes/ActiveRecord/Migration/DefaultStrategy.html


### PR DESCRIPTION
Typo: Statetgy -> Strategy