### PR TITLE
Fix explicit nil ignored for nullable columns with default functions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Fix explicit `nil` values being ignored for nullable columns with default functions when `partial_inserts = false`.
+
+    Previously, explicitly setting a nullable column to `nil` would be ignored and the
+    database default function would be used instead.
+
+    ```ruby
+    # Schema: nullable column with default function
+    t.timestamp :perform_at, default: -> { "CURRENT_TIMESTAMP" }
+
+    class Model < ApplicationRecord
+      self.partial_inserts = false
+    end
+
+    # Before
+    Model.create!(perform_at: nil).perform_at # => CURRENT_TIMESTAMP
+    # After
+    Model.create!(perform_at: nil).perform_at # => nil
+    ```
+
+    *Max Romaniv*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -251,11 +251,17 @@ module ActiveRecord
             changed_attribute_names_to_save
           else
             attribute_names.reject do |attr_name|
-              if column_for_attribute(attr_name).auto_populated?
-                !attribute_changed?(attr_name)
-              end
+              next false unless column_for_attribute(attr_name).auto_populated?
+              next false if user_provided_nil?(attr_name)
+
+              !attribute_changed?(attr_name)
             end
           end
+        end
+
+        def user_provided_nil?(attr_name)
+          attribute_came_from_user?(attr_name) &&
+            _read_attribute(attr_name).nil?
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes a bug where explicit `nil` values are ignored for nullable columns with default functions when `partial_inserts = false`.

When creating a record with an explicit `nil` value for a nullable column that has a default function (e.g. `DEFAULT CURRENT_TIMESTAMP`), ActiveRecord incorrectly omits the column from the INSERT statement. This causes the database to use its default function instead of respecting the explicit `nil`.

**The bug manifests differently across database adapters:**
- **PostgreSQL**: Returns the default value immediately (not `nil`) because PostgreSQL uses the `RETURNING` clause to fetch the inserted values, which includes the database-generated default
- **MySQL**: Returns `nil` initially but changes to the default value after `.reload`, making the inconsistency less obvious but still present

This inconsistent behavior makes it difficult to write portable code across different database adapters.

### Detail

This Pull Request changes `attribute_names_for_partial_inserts` in `activerecord/lib/active_record/attribute_methods/dirty.rb` to include explicitly-set `nil` values for nullable auto-populated columns in INSERT statements.

**Changes made:**
- Added logic to detect when a auto-populated column is explicitly set to `nil` by the user
- Added helper method `user_provided_nil?` to check if an attribute is nil and came from the user
- Updated the `else` branch of `attribute_names_for_partial_inserts` to prevent filtering out these explicit `nil` values

**Example:**
```ruby
# Schema: t.timestamp :perform_at, default: -> { "CURRENT_TIMESTAMP" }
class Model < ApplicationRecord
  self.partial_inserts = false
end

# Before: used CURRENT_TIMESTAMP 
Model.create!(perform_at: nil).perform_at # => CURRENT_TIMESTAMP
# After: correctly stores NULL
Model.create!(perform_at: nil).perform_at # => nil

# Omitting the attribute still uses the default (unchanged behavior)
Model.create!.perform_at # => <current timestamp>
```

### Additional information

**Tests added:**
- `test "partial insert off with explicit nil for nullable default function attribute"` - Verifies the bug fix
- `test "partial insert off with unset nullable default function attribute"` - Regression test to ensure omitted attributes still use database defaults

**Test coverage:**
- All tests pass on SQLite (in-memory) and MySQL2
- RuboCop checks pass with no offenses

**CHANGELOG:**
- Updated `activerecord/CHANGELOG.md` with fix description

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.