### PR TITLE
[ci skip] Correct typo in ActiveRecord changelog

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 *   Speedup `ActiveRecord::Migration.maintain_test_schema!` when using multiple databases.
 
-    Previously, Active Record would inneficiently connect twice to each databases, now it only
+    Previously, Active Record would ineficiently connect twice to each database, now it only
     connects once per database to reverify the schema.
 
     *Iliana Hadzhiatanasova*


### PR DESCRIPTION
Fix typo in CHANGELOG regarding database connections.
