### PR TITLE
Skip ROLLBACK statement following TransactionRollbackError

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
+
+    This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.
+
+    *Sorah Fukumori*
+
 *   Add `implicit_persistence_transaction` hook for customizing transaction behavior.
 
     A new protected method `implicit_persistence_transaction` has been added that wraps


### PR DESCRIPTION
Avoid issuing `ROLLBACK` statements after `TransactionRollbackError` is raised during `COMMIT`.

This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq. This is because the transaction was already rolled back by the database engine.

### Motivation / Background

A `SerializationFailure` (kind of `TransactionRollbackError`) is frequently encountered when using Amazon Aurora DSQL, a PostgreSQL-compatible database where transactions commonly fail when concurrent changes conflict. (ref. [Optimistic Concurrency Control](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-concurrency-control.html))

This is similar to `SERIALIZABLE` level transaction on the vanilla PostgreSQL; And this warning log was suppressed using `client_min_messages` when needed, like during `SERIALIZABLE` transaction tests in rails/rails. However, log suppression is not ideal for production workloads. This patch resolves the root cause of the warning instead.

### Detail

This patch adds rescuing `TransactionRollbackError` during commit to invalidate `RealTransaction` then go through normal rollback process, except issuing `ROLLBACK` to database using invalidated state.

### Additional information

- This patch also removes the warning suppression code from the tests, as it is no longer needed
- Existing invalidation logic couldn't be used as Transaction was popped out from `@state` before issuing `COMMIT` (renders `current_transaction` to NullTransaction) https://github.com/rails/rails/commit/6a8a90ea39527f1c78793698e36e430e6014b3c6 https://github.com/rails/rails/blob/76fcc3a31daf57df1fa8b067a7823880605392e7/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1142
- I don't see any specific reason to prefer log supression (in the existing test cases) per past pull requests and commit logs. Thus I determine that there's no blocker to avoid unnecessary ROLLBACK stmt, but lmk if there's any reason for the present behaviour.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
