### PR TITLE
Fix innermost constraint reseting previous constraints

### DIFF
--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3203,6 +3203,19 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "italians#painters", @response.body
   end
 
+  def test_lambda_mount_constraints_do_not_ignore_scoped_constraints
+    draw do
+      constraints ->(req) { false } do
+        mount lambda { |env| [200, {}, [env["REQUEST_METHOD"]]] },
+          at: "/test",
+          constraints: ->(req) { true }
+      end
+    end
+
+    get "/test"
+    assert_equal 404, status
+  end
+
   def test_custom_resource_actions_defined_using_string
     draw do
       resources :customers do


### PR DESCRIPTION

### Motivation / Background

Fixes https://github.com/rails/rails/issues/56528 

This Pull Request has been created because having multiple constraints with nesting causes unexpected behaviour where only the innermost constraint "wins"

### Detail

This Pull Request changes ActionDispatch constraint merging to collect a list of constraint blocks.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Feel free to edit PR description.