### PR TITLE
Mark error page styles as dynamic for Turbo cleanup

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="turbo-visit-control" content="reload">
   <title>Action Controller: Exception caught</title>
-  <style>
+  <style data-turbo-track="dynamic">
     body {
       background-color: #FAFAFA;
       color: #333;


### PR DESCRIPTION
## Summary

When using Turbo Drive, navigating to a development error page and pressing the browser back button causes the error page's inline styles to persist on the application page, resulting in visual corruption (red backgrounds, wrong fonts, etc.).

## Root cause

Turbo's `ErrorRenderer` replaces the entire `<head>` when rendering error pages. When navigating back, `PageRenderer` merges heads but only removes stylesheets marked with `data-turbo-track="dynamic"`. Since the error page's `<style>` tag lacks this attribute, it's never cleaned up.

## Fix

Add `data-turbo-track="dynamic"` to the `<style>` tag in `rescues/layout.erb`. This allows Turbo's existing `removeUnusedDynamicStylesheetElements()` to clean up the error page styles automatically when navigating away.

Fixes #56719