### PR TITLE
Remove useless connection verification when pinning connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -375,7 +375,6 @@ module ActiveRecord
 
         @pinned_connection.lock_thread = ActiveSupport::IsolatedExecutionState.context if lock_thread
         @pinned_connection.pinned = true
-        @pinned_connection.verify! # eagerly validate the connection
         @pinned_connection.begin_transaction joinable: false, _lazy: false
       end
 
@@ -634,7 +633,7 @@ module ActiveRecord
           synchronize do
             # The pinned connection may have been cleaned up before we synchronized, so check if it is still present
             if @pinned_connection
-              @pinned_connection.verify!
+              @pinned_connection.verify
 
               # Any leased connection must be in @connections otherwise
               # some methods like #connected? won't behave correctly

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -816,6 +816,12 @@ module ActiveRecord
         false
       end
 
+      def verify
+        return if @verified
+        return if (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
+        verify!
+      end
+
       # Checks whether the connection to the database is still active (i.e. not stale).
       # This is done under the hood by calling #active?. If the connection
       # is no longer active, then this method will reconnect to the database.


### PR DESCRIPTION
We know have some decent logic about not revalidating a connection that has been used recently, these explicit verify! calls are just a waste.
