### PR TITLE
Use schema cache for primary key lookup during insert

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -739,7 +739,7 @@ module ActiveRecord
             if pk.nil?
               # Extract the table from the insert sql. Yuck.
               table_ref = extract_table_ref_from_insert_sql(sql)
-              pk = primary_key(table_ref) if table_ref
+              pk = schema_cache.primary_keys(table_ref) if table_ref
             end
 
             returning_columns = returning || Array(pk)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -53,7 +53,7 @@ module ActiveRecord
             unless sequence_name
               table_ref = extract_table_ref_from_insert_sql(intent.raw_sql)
               if table_ref
-                pk = primary_key(table_ref) if pk.nil?
+                pk = schema_cache.primary_keys(table_ref) if pk.nil?
                 pk = suppress_composite_primary_key(pk)
                 sequence_name = default_sequence_name(table_ref, pk)
               end

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -166,6 +166,16 @@ module ActiveRecord
         assert_equal 0, @cache.size
       end
 
+      def test_insert_uses_schema_cache_for_primary_key
+        # First call might need to populate the schema cache
+        @connection.insert("INSERT INTO courses (name) VALUES ('Prepopulate')")
+
+        # With cache available, insert should not make additional schema queries
+        assert_queries_count(1, include_schema: true) do
+          @connection.insert("INSERT INTO courses (name) VALUES ('INSERT only')")
+        end
+      end
+
       def test_marshal_dump_and_load_with_ignored_tables
         assert_not ActiveRecord.schema_cache_ignored_table?("professors")
 


### PR DESCRIPTION
This isn't a high-traffic code path (model-initiated inserts supply their PK name), but I noticed in passing that we should be trying the schema cache here.