### PR TITLE
Better handle cache deserialization errors

### DIFF
--- a/activesupport/lib/active_support/cache/serializer_with_fallback.rb
+++ b/activesupport/lib/active_support/cache/serializer_with_fallback.rb
@@ -87,7 +87,13 @@ module ActiveSupport
 
           def _load(marked)
             dumped = marked.byteslice(1..-1)
-            dumped = Zlib::Inflate.inflate(dumped) if marked.start_with?(MARK_COMPRESSED)
+            if marked.start_with?(MARK_COMPRESSED)
+              dumped = begin
+                Zlib::Inflate.inflate(dumped)
+              rescue Zlib::Error => error
+                raise Cache::DeserializationError, "#{error.class}: #{error.message}"
+              end
+            end
             Cache::Entry.unpack(marshal_load(dumped))
           end
 

--- a/activesupport/test/cache/serializer_with_fallback_test.rb
+++ b/activesupport/test/cache/serializer_with_fallback_test.rb
@@ -47,6 +47,12 @@ class CacheSerializerWithFallbackTest < ActiveSupport::TestCase
       assert_operator compressed.bytesize, :<, uncompressed.bytesize
       assert_entry @entry, serializer(format).load(compressed)
       assert_entry @entry, serializer(format).load(uncompressed)
+
+      unless format == :passthrough
+        assert_raises ActiveSupport::Cache::DeserializationError do
+          serializer(format).load(compressed.byteslice(0..-4))
+        end
+      end
     end
   end
 

--- a/tools/strict_warnings.rb
+++ b/tools/strict_warnings.rb
@@ -20,7 +20,10 @@ module RailsStrictWarnings # :nodoc:
     # TODO: remove if https://github.com/mikel/mail/pull/1557 or similar fix
     %r{/lib/mail/parsers/.*statement not reached},
     %r{/lib/mail/parsers/.*assigned but unused variable - disp_type_s},
-    %r{/lib/mail/parsers/.*assigned but unused variable - testEof}
+    %r{/lib/mail/parsers/.*assigned but unused variable - testEof},
+
+    # Emitted by zlib
+    /attempt to close unfinished zstream/,
   )
 
   def warn(message, ...)


### PR DESCRIPTION
While rare, it can happen that some cache backend return truncated responses (memcached...).

But generally speaking, the cache should treat any sort of error during deserialization as a cache miss.
