### PR TITLE
Add extension point to customize transaction for persistence methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add `implicit_persistence_transaction` hook for customizing transaction behavior.
+
+    A new protected method `implicit_persistence_transaction` has been added that wraps
+    persistence operations (`save`, `destroy`, `touch`) in a transaction. This method can be
+    overridden in models to customize transaction behavior, such as setting a specific isolation
+    level or skipping transaction creation when one is already open.
+
+    Example skipping transaction creation if one is already open:
+
+    ```ruby
+    class Account < ApplicationRecord
+      private
+        def implicit_persistence_transaction(connection, &block)
+          if connection.transaction_open?
+            yield
+          else
+            super
+          end
+        end
+    end
+    ```
+
+    *Israel P Valverde*
+
 *   Pass sql query to query log tags.
 
     ```ruby


### PR DESCRIPTION
Currently, if you need to use a specific transaction isolation level (e.g., `:read_committed`) for save/destroy operations on a model, you must either:

1. Wrap every call in an explicit transaction block
2. Monkeypatch `with_transaction_returning_status` entirely, which is fragile and breaks when the method changes upstream

Rails already provides `ActiveRecord.with_transaction_isolation_level` for setting isolation levels globally within a block, but there's no per-model way to configure the implicit transactions that persistence methods create.

## Solution

This PR extracts the transaction creation into an overridable private method:

```ruby
class Account < ApplicationRecord
  private
    def implicit_persistence_transaction(connection, &block)
      if connection.transaction_open?
        yield # avoid opening a transaction if one is already open
      else
        super
      end
    end
end
```

The method receives the connection and the block, allowing conditional logic based on whether a transaction is already open. This gives caller full control over the logic.

## Alternative considered

[PR implementation](https://github.com/rails/rails/pull/56673)

Although this would allow tweaking the transaction create, it would not give as much control as the current implementation. For example, it would not allow skipping transaction creation or adding custom handling for `ActiveRecord::Rollback` exceptions or `throw` that might happen as part of the callbacks.

@eileencodes @matthewd @kirs 


## Checklist
Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.