### PR TITLE
Make AM::AttributeSet::YAMLEncoder a Module

### DIFF
--- a/activemodel/lib/active_model/attribute_set/yaml_encoder.rb
+++ b/activemodel/lib/active_model/attribute_set/yaml_encoder.rb
@@ -4,12 +4,10 @@ module ActiveModel
   class AttributeSet
     # Attempts to do more intelligent YAML dumping of an
     # ActiveModel::AttributeSet to reduce the size of the resulting string
-    class YAMLEncoder # :nodoc:
-      def initialize(default_types)
-        @default_types = default_types
-      end
+    module YAMLEncoder # :nodoc:
+      extend self
 
-      def encode(attribute_set, coder)
+      def encode(attribute_set, coder, default_types)
         coder["concise_attributes"] = attribute_set.each_value.map do |attr|
           if attr.type.equal?(default_types[attr.name])
             attr.with_type(nil)
@@ -19,7 +17,7 @@ module ActiveModel
         end
       end
 
-      def decode(coder)
+      def decode(coder, default_types)
         if coder["attributes"]
           coder["attributes"]
         else
@@ -32,9 +30,6 @@ module ActiveModel
           AttributeSet.new(attributes_hash)
         end
       end
-
-      private
-        attr_reader :default_types
     end
   end
 end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -498,7 +498,7 @@ module ActiveRecord
     #   post.title # => 'hello world'
     def init_with(coder, &block)
       coder = LegacyYamlAdapter.convert(coder)
-      attributes = self.class.yaml_encoder.decode(coder)
+      attributes = ActiveModel::AttributeSet::YAMLEncoder.decode(coder, self.class.attribute_types)
       init_with_attributes(attributes, coder["new_record"], &block)
     end
 
@@ -586,7 +586,7 @@ module ActiveRecord
     #   Post.new.encode_with(coder)
     #   coder # => {"attributes" => {"id" => nil, ... }}
     def encode_with(coder)
-      self.class.yaml_encoder.encode(@attributes, coder)
+      ActiveModel::AttributeSet::YAMLEncoder.encode(@attributes, coder, self.class.attribute_types)
       coder["new_record"] = new_record?
       coder["active_record_yaml_version"] = 2
     end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -459,10 +459,6 @@ module ActiveRecord
         end
       end
 
-      def yaml_encoder # :nodoc:
-        @yaml_encoder ||= ActiveModel::AttributeSet::YAMLEncoder.new(attribute_types)
-      end
-
       # Returns the column object for the named attribute.
       # Returns an ActiveRecord::ConnectionAdapters::NullColumn if the
       # named attribute does not exist.
@@ -578,7 +574,6 @@ module ActiveRecord
           @columns_hash = nil
           @schema_loaded = false
           @attribute_names = nil
-          @yaml_encoder = nil
           if recursive
             subclasses.each do |descendant|
               descendant.send(:reload_schema_from_cache)


### PR DESCRIPTION
It's usefulness as a class is storing a model's `default_types`, but those are cached in an instance variable on the model's class anyways. Making it a Module means less objects (zero vs one per table), and we don't have to ensure its cleared if the schema is reloaded.