### PR TITLE
Raise a more descriptive error when file cannot be decrypted

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -49,6 +49,12 @@ module ActiveSupport
       end
     end
 
+    class DecryptionError < RuntimeError
+      def initialize(content_path)
+        super "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
+      end
+    end
+
     delegate_missing_to :options
 
     def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:)
@@ -108,6 +114,8 @@ module ActiveSupport
     rescue ActiveSupport::EncryptedFile::MissingContentError
       # Allow a config to be started without a file present
       ""
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      raise DecryptionError.new(content_path)
     end
 
     def validate! # :nodoc:

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -53,7 +53,7 @@ module Rails
           disenroll_project_from_credentials_diffing if options[:disenroll]
           enroll_project_in_credentials_diffing if options[:enroll]
         end
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      rescue ActiveSupport::EncryptedConfiguration::DecryptionError
         say credentials.content_path.read
       end
 
@@ -120,10 +120,8 @@ module Rails
             say "File encrypted and saved."
             warn_if_credentials_are_invalid
           end
-        rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+        rescue ActiveSupport::EncryptedFile::MissingKeyError, ActiveSupport::EncryptedConfiguration::DecryptionError => error
           say error.message
-        rescue ActiveSupport::MessageEncryptor::InvalidMessage
-          say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
         end
 
         def warn_if_credentials_are_invalid

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -57,10 +57,8 @@ module Rails
             say "File encrypted and saved."
             warn_if_encrypted_configuration_is_invalid
           end
-        rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+        rescue ActiveSupport::EncryptedFile::MissingKeyError, ActiveSupport::EncryptedConfiguration::DecryptionError => error
           say error.message
-        rescue ActiveSupport::MessageEncryptor::InvalidMessage
-          say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
         end
 
         def warn_if_encrypted_configuration_is_invalid


### PR DESCRIPTION
### Motivation / Background

Today, I helped a Rails user who had `config/credentials/production.yml.enc` they forgot about. They thought they were decrypting `config/credentials.yml.enc` with `config/master.key` but the error message was `ActiveSupport::MessageEncryptor::InvalidMessage` without any additional context about which file failed decryption.

In development, this wasn't noticed since there was no `config/credentials/development.yml.enc`.

### Detail

This introduces a `DecryptionError` that tells the user which file had failed to be decrypted. Issues like the above can be quickly diagnosed and provides a consistent error message anytime encrypted configuration files fail to decrypt.

### Additional information

Original error came from running `rails assets:precompile` during deploy:

```
/home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/messages/codec.rb:57:in 'ActiveSupport::Messages::Codec#catch_and_raise': ActiveSupport::MessageEncryptor::InvalidMessage
	from /home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/message_encryptor.rb:242:in 'ActiveSupport::MessageEncryptor#decrypt_and_verify'
	from /home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/encrypted_file.rb:109:in 'ActiveSupport::EncryptedFile#decrypt'
	from /home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/encrypted_file.rb:72:in 'ActiveSupport::EncryptedFile#read'
	from /home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/encrypted_configuration.rb:63:in 'ActiveSupport::EncryptedConfiguration#read'
	from /home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/encrypted_configuration.rb:86:in 'ActiveSupport::EncryptedConfiguration#config'
	from /home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/encrypted_configuration.rb:113:in 'ActiveSupport::EncryptedConfiguration#options'
	from /home/deploy/myapp/shared/bundle/ruby/3.4.0/gems/activesupport-8.1.2/lib/active_support/delegation.rb:170:in 'ActiveSupport::EncryptedConfiguration#method_missing'
	from /home/deploy/myapp/releases/20260204135542/config/environments/production.rb:65:in 'block in <main>'
```

This would change the exception to be:

```
ActiveSupport::EncryptedConfiguration::DecryptionError: Couldn't decrypt /Users/chris/code/example-rails/config/credentials/test.yml.enc. Perhaps you passed the wrong key? (ActiveSupport::EncryptedConfiguration::DecryptionError)
/Users/chris/code/rails/activesupport/lib/active_support/encrypted_configuration.rb:118:in 'ActiveSupport::EncryptedConfiguration#read'
```

`CredentialsCommand` and `EncryptedCommand` does this already to help with debugging.

https://github.com/rails/rails/blob/cf83ddabb5d850e75625fc38a5c52e573e32d48f/railties/lib/rails/commands/credentials/credentials_command.rb#L125-L126

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
