### PR TITLE
Fix key generator hash digest class caching issue

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -176,11 +176,17 @@ module Rails
     # specified +secret_key_base+. The return value is memoized, so additional
     # calls with the same +secret_key_base+ will return the same key generator
     # instance.
+    #
+    # The cache key includes both the +secret_key_base+ and the current
+    # hash_digest_class to ensure that key generators are properly invalidated
+    # when the hash digest class changes.
     def key_generator(secret_key_base = self.secret_key_base)
       # number of iterations selected based on consultation with the google security
       # team. Details at https://github.com/rails/rails/pull/6952#issuecomment-7661220
-      @key_generators[secret_key_base] ||= ActiveSupport::CachingKeyGenerator.new(
-        ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000)
+      hash_digest_class = ActiveSupport::KeyGenerator.hash_digest_class
+      cache_key = [secret_key_base, hash_digest_class]
+      @key_generators[cache_key] ||= ActiveSupport::CachingKeyGenerator.new(
+        ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000, hash_digest_class:)
       )
     end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

[Fix #56736]

When `Rails.app.key_generator` was accessed in an initializer before `config.active_support.key_generator_hash_digest_class` was applied, it would cache a key generator with the wrong hash digest class.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

The cache key for `Rails.app.key_generator` now includes both `secret_key_base` and `hash_digest_class` as `[secret_key_base, hash_digest_class]`. This ensures that different hash digest classes get different cached generators, preventing stale generators from being reused when the hash digest class changes.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
