### PR TITLE
Read from `ENV['REVISION']` if present

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -544,7 +544,7 @@ Causes the app to not boot if a master key hasn't been made available through `E
 #### `config.revision`
 
 Sets the application revision for deployment tracking and error reporting. Must be a string.
-When not set, Rails first tries reading from a `REVISION` file in the application root, and if absent
+When not set, Rails first checks `ENV["REVISION"]`, then tries reading from a `REVISION` file in the application root, and if both are absent
 it attempts to get the current commit from the local git repository (default: `nil`).
 
 ```ruby

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `Rails.app.revision` now checks `ENV["REVISION"]` before falling back to the `REVISION` file or git.
+
+    *Jonathan Baker*
+
 *   Detect JavaScript package manager from lockfiles in generators.
 
     Rails generators now automatically detect bun, pnpm, npm, or yarn by looking

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -399,12 +399,13 @@ module Rails
     # Returns the application's revision (deployment identifier).
     # Useful for error reporting and deployment verification.
     #
-    # Set via config.revision (string) or REVISION file.
+    # Set via config.revision (string), ENV["REVISION"], or REVISION file.
     # Always either a String or +nil+.
     def revision
       unless @revision_initialized
         @revision = begin
-          root.join("REVISION").read.strip.presence
+          ENV["REVISION"].presence ||
+            root.join("REVISION").read.strip.presence
         rescue SystemCallError
           r, w = IO.pipe
           success = system("git", "-C", root.to_s, "rev-parse", "HEAD", in: File::NULL, err: File::NULL, out: w)

--- a/railties/test/application/app_revision_test.rb
+++ b/railties/test/application/app_revision_test.rb
@@ -47,6 +47,37 @@ module ApplicationTests
       assert_equal "config-wins", Rails.app.revision
     end
 
+    test "revision reads from ENV['REVISION'] when present" do
+      ENV["REVISION"] = "env-revision-123"
+      require "#{app_path}/config/environment"
+      assert_equal "env-revision-123", Rails.app.revision
+    ensure
+      ENV.delete("REVISION")
+    end
+
+    test "ENV['REVISION'] takes precedence over REVISION file" do
+      File.write("#{app_path}/REVISION", "file-revision")
+      ENV["REVISION"] = "env-wins"
+
+      require "#{app_path}/config/environment"
+      assert_equal "env-wins", Rails.app.revision
+    ensure
+      ENV.delete("REVISION")
+    end
+
+    test "config.revision takes precedence over ENV['REVISION']" do
+      ENV["REVISION"] = "env-revision"
+
+      add_to_config <<-RUBY
+        config.revision = "config-wins"
+      RUBY
+
+      require "#{app_path}/config/environment"
+      assert_equal "config-wins", Rails.app.revision
+    ensure
+      ENV.delete("REVISION")
+    end
+
     test "Rails::Info includes revision when present" do
       File.write("#{app_path}/REVISION", "deadbeef123")
 


### PR DESCRIPTION
### Motivation / Background

A common pattern on many deployment providers is setting the revision via ENV. This is arguably preferred over writing a REVISION file or bundling the git history. This PR updates the `Rails.app.revision` behavior to check `ENV["REVISION"]` before falling back to the `REVISION` file or `git rev-parse`.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.