### PR TITLE
Bump Ruby version to 4.0.1 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 4.0, 3.4, 3.3, 3.2
-ARG VARIANT="4.0.0"
+ARG VARIANT="4.0.1"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
### Motivation / Background

This pull request bumps Ruby version to 4.0.1 in devcontainer.

### Detail

```ruby
vscode ➜ /workspaces/rails (ruby401) $ ruby -v
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [aarch64-linux]
```

### Additional information

Refer to:
Ruby 4.0.1 has been added in https://github.com/rails/devcontainer/pull/111

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
