### PR TITLE
Raise when key_generator is accessed before after_initialize

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -160,6 +160,7 @@ module ActiveSupport
       config.after_initialize do
         if klass = app.config.active_support.key_generator_hash_digest_class
           ActiveSupport::KeyGenerator.hash_digest_class = klass
+          app.send(:key_generator_hash_digest_class_applied!)
         end
       end
     end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -23,6 +23,19 @@
 
     *Lewis Buckley*
 
+*   Raise when `key_generator` is accessed before `key_generator_hash_digest_class` is applied.
+
+    Calling `Rails.application.key_generator` during eager loading silently
+    returned an instance configured with the wrong digest class (SHA1 instead
+    of SHA256), because `key_generator_hash_digest_class` is only applied in
+    an `after_initialize` callback. The memoized instance then poisoned all
+    subsequent key derivations for the process.
+
+    The key generator now raises if accessed before the digest class has been
+    applied and a custom digest class is configured.
+
+    *Daniel López Prat*
+
 *   Avoid adding `Rack::Sendfile` to the middleware stack if `config.action_dispatch.x_sendfile_header` is `nil`.
 
     The middleware behave as a noop in such case so it's pointless to have it in the stack.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3318,6 +3318,56 @@ module ApplicationTests
       assert_equal OpenSSL::Digest::SHA256, ActiveSupport::KeyGenerator.hash_digest_class
     end
 
+    test "key_generator raises when accessed before initialization with key_generator_hash_digest_class configured" do
+      add_to_config <<-RUBY
+        config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+      RUBY
+
+      require "#{app_path}/config/application"
+
+      error = assert_raises(RuntimeError) do
+        Rails.application.key_generator
+      end
+      assert_match(/Cannot call.*key_generator.*before/, error.message)
+    end
+
+    test "key_generator does not raise when accessed before initialization without key_generator_hash_digest_class configured" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      require "#{app_path}/config/application"
+
+      assert_nothing_raised do
+        Rails.application.key_generator
+      end
+    end
+
+    test "key_generator raises when accessed from an initializer with key_generator_hash_digest_class configured" do
+      add_to_config <<-RUBY
+        config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+      RUBY
+
+      app_file "config/initializers/eager_key.rb", <<-RUBY
+        Rails.application.key_generator
+      RUBY
+
+      error = assert_raises(RuntimeError) do
+        app "development"
+      end
+      assert_match(/Cannot call.*key_generator.*before/, error.message)
+    end
+
+    test "key_generator works normally after initialization with key_generator_hash_digest_class configured" do
+      add_to_config <<-RUBY
+        config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+      RUBY
+
+      app "development"
+
+      assert_nothing_raised do
+        Rails.application.key_generator
+      end
+    end
+
     test "ActiveSupport.test_parallelization_threshold can be configured via config.active_support.test_parallelization_threshold" do
       remove_from_config '.*config\.load_defaults.*\n'
 

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -84,25 +84,25 @@ module ApplicationTests
       RUBY
 
       add_to_config <<-RUBY
-        sha1_secret   = Rails.application.key_generator.generate_key("sha1")
-        sha256_secret = Rails.application.key_generator.generate_key("sha256")
-
-        ::TestVerifiers = Class.new do
-          class_attribute :sha1, default: ActiveSupport::MessageVerifier.new(sha1_secret, digest: "SHA1", serializer: Marshal)
-          class_attribute :sha256, default: ActiveSupport::MessageVerifier.new(sha256_secret, digest: "SHA256", serializer: Marshal)
-        end
-
         config.action_dispatch.signed_cookie_digest = "SHA512"
         config.action_dispatch.signed_cookie_salt = "sha512 salt"
         config.action_dispatch.cookies_serializer = :marshal
-
-        config.action_dispatch.cookies_rotations.tap do |cookies|
-          cookies.rotate :signed, sha1_secret,   digest: "SHA1"
-          cookies.rotate :signed, sha256_secret, digest: "SHA256"
-        end
       RUBY
 
       require "#{app_path}/config/environment"
+
+      sha1_secret   = app.key_generator.generate_key("sha1")
+      sha256_secret = app.key_generator.generate_key("sha256")
+
+      ::TestVerifiers = Class.new do
+        class_attribute :sha1, default: ActiveSupport::MessageVerifier.new(sha1_secret, digest: "SHA1", serializer: Marshal)
+        class_attribute :sha256, default: ActiveSupport::MessageVerifier.new(sha256_secret, digest: "SHA256", serializer: Marshal)
+      end
+
+      app.config.action_dispatch.cookies_rotations.tap do |cookies|
+        cookies.rotate :signed, sha1_secret,   digest: "SHA1"
+        cookies.rotate :signed, sha256_secret, digest: "SHA256"
+      end
 
       verifier_sha512 = ActiveSupport::MessageVerifier.new(app.key_generator.generate_key("sha512 salt"), digest: :SHA512, serializer: Marshal)
 
@@ -154,25 +154,25 @@ module ApplicationTests
       RUBY
 
       add_to_config <<-RUBY
-        sha1_secret   = Rails.application.key_generator.generate_key("sha1")
-        sha256_secret = Rails.application.key_generator.generate_key("sha256")
-
-        ::TestVerifiers = Class.new do
-          class_attribute :sha1, default: ActiveSupport::MessageVerifier.new(sha1_secret, digest: "SHA1", serializer: JSON)
-          class_attribute :sha256, default: ActiveSupport::MessageVerifier.new(sha256_secret, digest: "SHA256", serializer: JSON)
-        end
-
         config.action_dispatch.signed_cookie_digest = "SHA512"
         config.action_dispatch.signed_cookie_salt = "sha512 salt"
         config.action_dispatch.cookies_serializer = :json
-
-        config.action_dispatch.cookies_rotations.tap do |cookies|
-          cookies.rotate :signed, sha1_secret,   digest: "SHA1"
-          cookies.rotate :signed, sha256_secret, digest: "SHA256"
-        end
       RUBY
 
       require "#{app_path}/config/environment"
+
+      sha1_secret   = app.key_generator.generate_key("sha1")
+      sha256_secret = app.key_generator.generate_key("sha256")
+
+      ::TestVerifiers = Class.new do
+        class_attribute :sha1, default: ActiveSupport::MessageVerifier.new(sha1_secret, digest: "SHA1", serializer: JSON)
+        class_attribute :sha256, default: ActiveSupport::MessageVerifier.new(sha256_secret, digest: "SHA256", serializer: JSON)
+      end
+
+      app.config.action_dispatch.cookies_rotations.tap do |cookies|
+        cookies.rotate :signed, sha1_secret,   digest: "SHA1"
+        cookies.rotate :signed, sha256_secret, digest: "SHA256"
+      end
 
       verifier_sha512 = ActiveSupport::MessageVerifier.new(app.key_generator.generate_key("sha512 salt"), digest: :SHA512, serializer: JSON)
 
@@ -224,26 +224,26 @@ module ApplicationTests
       RUBY
 
       add_to_config <<-RUBY
-        first_secret  = Rails.application.key_generator.generate_key("first", 32)
-        second_secret = Rails.application.key_generator.generate_key("second", 32)
-
-        ::TestEncryptors = Class.new do
-          class_attribute :first_gcm,  default: ActiveSupport::MessageEncryptor.new(first_secret, cipher: "aes-256-gcm", serializer: Marshal)
-          class_attribute :second_gcm, default: ActiveSupport::MessageEncryptor.new(second_secret, cipher: "aes-256-gcm", serializer: Marshal)
-        end
-
         config.action_dispatch.use_authenticated_cookie_encryption = true
         config.action_dispatch.encrypted_cookie_cipher = "aes-256-gcm"
         config.action_dispatch.authenticated_encrypted_cookie_salt = "salt"
         config.action_dispatch.cookies_serializer = :marshal
-
-        config.action_dispatch.cookies_rotations.tap do |cookies|
-          cookies.rotate :encrypted, first_secret
-          cookies.rotate :encrypted, second_secret
-        end
       RUBY
 
       require "#{app_path}/config/environment"
+
+      first_secret  = app.key_generator.generate_key("first", 32)
+      second_secret = app.key_generator.generate_key("second", 32)
+
+      ::TestEncryptors = Class.new do
+        class_attribute :first_gcm,  default: ActiveSupport::MessageEncryptor.new(first_secret, cipher: "aes-256-gcm", serializer: Marshal)
+        class_attribute :second_gcm, default: ActiveSupport::MessageEncryptor.new(second_secret, cipher: "aes-256-gcm", serializer: Marshal)
+      end
+
+      app.config.action_dispatch.cookies_rotations.tap do |cookies|
+        cookies.rotate :encrypted, first_secret
+        cookies.rotate :encrypted, second_secret
+      end
 
       encryptor = ActiveSupport::MessageEncryptor.new(app.key_generator.generate_key("salt", 32), cipher: "aes-256-gcm", serializer: Marshal)
 
@@ -295,26 +295,26 @@ module ApplicationTests
       RUBY
 
       add_to_config <<-RUBY
-        first_secret  = Rails.application.key_generator.generate_key("first", 32)
-        second_secret = Rails.application.key_generator.generate_key("second", 32)
-
-        ::TestEncryptors = Class.new do
-          class_attribute :first_gcm,  default: ActiveSupport::MessageEncryptor.new(first_secret, cipher: "aes-256-gcm", serializer: ActiveSupport::JSON)
-          class_attribute :second_gcm, default: ActiveSupport::MessageEncryptor.new(second_secret, cipher: "aes-256-gcm", serializer: ActiveSupport::JSON)
-        end
-
         config.action_dispatch.use_authenticated_cookie_encryption = true
         config.action_dispatch.encrypted_cookie_cipher = "aes-256-gcm"
         config.action_dispatch.authenticated_encrypted_cookie_salt = "salt"
         config.action_dispatch.cookies_serializer = :json
-
-        config.action_dispatch.cookies_rotations.tap do |cookies|
-          cookies.rotate :encrypted, first_secret
-          cookies.rotate :encrypted, second_secret
-        end
       RUBY
 
       require "#{app_path}/config/environment"
+
+      first_secret  = app.key_generator.generate_key("first", 32)
+      second_secret = app.key_generator.generate_key("second", 32)
+
+      ::TestEncryptors = Class.new do
+        class_attribute :first_gcm,  default: ActiveSupport::MessageEncryptor.new(first_secret, cipher: "aes-256-gcm", serializer: ActiveSupport::JSON)
+        class_attribute :second_gcm, default: ActiveSupport::MessageEncryptor.new(second_secret, cipher: "aes-256-gcm", serializer: ActiveSupport::JSON)
+      end
+
+      app.config.action_dispatch.cookies_rotations.tap do |cookies|
+        cookies.rotate :encrypted, first_secret
+        cookies.rotate :encrypted, second_secret
+      end
 
       encryptor = ActiveSupport::MessageEncryptor.new(app.key_generator.generate_key("salt", 32), cipher: "aes-256-gcm")
 


### PR DESCRIPTION
Fixes #51750
Fixes #56736

### Motivation

`Rails.application.key_generator` silently returns a misconfigured
instance when accessed during eager loading.

`config.load_defaults 7.0`+ sets `key_generator_hash_digest_class =
SHA256`, but this is only applied in an `after_initialize` callback.
Eager loading runs **before** `after_initialize`, so any class constant
that calls `key_generator` during eager load gets a `KeyGenerator`
locked to SHA1. This instance is then memoized, poisoning all
subsequent key derivations — including unrelated `MessageVerifier`
instances.

The failure mode is entirely silent: no warning, no error, just wrong
HMAC signatures at runtime (`InvalidSignature: mismatched digest`).

Previously reported in #51750 and #56736.

### Example

```ruby
class Message < ApplicationRecord
  # Evaluated during eager loading, before after_initialize
  VERIFIER = ActiveSupport::MessageVerifier.new(
    Rails.application.key_generator.generate_key("replies"),
    url_safe: true,
  )
end
```

This single constant poisons the memoized `key_generator` for the
entire process, breaking every `MessageVerifier` in the application.

### Change

`key_generator` now raises `RuntimeError` if called before the
`key_generator_hash_digest_class` configuration has been applied and a
custom digest class is configured. The error message explains the issue
and suggests using a lazily-initialized method instead of a constant.

The guard uses a dedicated `@key_generator_hash_digest_class_applied`
flag rather than `initialized?` because Rails internals (ActiveStorage,
ActiveRecord) legitimately call `key_generator` during
`after_initialize` callbacks — when `initialized?` is still `false`.
The flag is set by the `set_key_generator_hash_digest_class` callback
immediately after applying the digest class, so subsequent
`after_initialize` callbacks can safely access `key_generator`.

Apps that do not configure `key_generator_hash_digest_class` (pre-7.0
defaults or no explicit config) are unaffected — the guard only
activates when there is a known misconfiguration risk.