### PR TITLE
Consistently raise deprecation warnings in CI

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -26,7 +26,7 @@ require "action_view"
 ActionMailer::Base.include(ActionView::Layouts)
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActionMailer.deprecator.debug = true
+ActionMailer.deprecator.behavior = :raise
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -58,8 +58,9 @@ ActionPackTestSuiteUtils.require_helpers("#{__dir__}/fixtures/alternate_helpers"
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActionController.deprecator.debug = true
-ActionDispatch.deprecator.debug = true
+ActionController.deprecator.behavior = :raise
+ActionDispatch.deprecator.behavior = :raise
+ActionView.deprecator.behavior = :raise
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/actionpack/test/controller/render_js_test.rb
+++ b/actionpack/test/controller/render_js_test.rb
@@ -5,7 +5,7 @@ require "controller/fake_models"
 
 class RenderJSTest < ActionController::TestCase
   class TestController < ActionController::Base
-    protect_from_forgery
+    protect_from_forgery with: :null_session
 
     def self.controller_path
       "test"

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -25,7 +25,7 @@ class RenderJsonTest < ActionController::TestCase
   end
 
   class TestController < ActionController::Base
-    protect_from_forgery
+    protect_from_forgery with: :null_session
 
     def self.controller_path
       "test"

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -73,7 +73,7 @@ class InheritedRenderTestController < ImplicitRenderTestController
 end
 
 class TestController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :null_session
 
   before_action :set_variable_for_layout
 

--- a/actionpack/test/controller/render_to_string_test.rb
+++ b/actionpack/test/controller/render_to_string_test.rb
@@ -6,7 +6,7 @@ require "active_support/logger"
 
 class RenderToStringTest < ActionController::TestCase
   class TestController < ActionController::Base
-    protect_from_forgery
+    protect_from_forgery with: :null_session
 
     def self.controller_path
       "test"

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -12,7 +12,7 @@ class RenderXmlTest < ActionController::TestCase
   end
 
   class TestController < ActionController::Base
-    protect_from_forgery
+    protect_from_forgery with: :null_session
 
     def self.controller_path
       "test"

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -39,7 +39,9 @@ ActionViewTestSuiteUtils.require_helpers("#{__dir__}/fixtures/alternate_helpers"
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActionView.deprecator.debug = true
+ActionView.deprecator.behavior = :raise
+ActionController.deprecator.behavior = :raise
+ActiveModel.deprecator.behavior = :raise
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -40,7 +40,7 @@ class ValidatingPost < Post
 end
 
 class TestController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :null_session
 
   before_action :set_variable_for_layout
 

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -4,7 +4,7 @@ require_relative "../../../tools/strict_warnings"
 require "active_model"
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveModel.deprecator.debug = true
+ActiveModel.deprecator.behavior = :raise
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/activerecord/test/support/global_config.rb
+++ b/activerecord/test/support/global_config.rb
@@ -7,7 +7,9 @@ module ARTest
     def self.apply
       Thread.abort_on_exception = true
 
-      ActiveRecord.deprecator.debug = true
+      ActiveRecord.deprecator.behavior = :raise
+      ActiveModel.deprecator.behavior = :raise
+
       ActiveRecord.permanent_connection_checkout = :disallowed
       ActiveRecord::Delegation::DelegateCache.delegate_base_methods = false
       ActiveRecord::Relation.remove_method(:klass)


### PR DESCRIPTION
Previously, Active Support's deprecator was [updated][1] to raise in CI, but other frameworks were not. Raising by default ensures that deprecated behavior is addressed in the PR that introduces it and prevents deprecation logs from going unnoticed in CI output.

This commit updates the remaining frameworks which were configuring their deprecators to log full backtraces to instead raise. It also adds some additional deprecator configuration for framework dependencies which were not previously configured.

[1]: https://github.com/rails/rails/commit/9bf81e4ba99f90566a456326bb9311fa5902d28a