### PR TITLE
ActionController::UnknownHttpMethod returns 500 instead of 405 in Rails 7.2 #56740

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -65,7 +65,7 @@ module ActionDispatch
             content_type = Mime[:text]
           end
 
-          if request.head?
+          if request.raw_request_method == "HEAD"
             render(wrapper.status_code, "", content_type)
           elsif api_request?(content_type)
             render_for_api_request(content_type, wrapper)

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -226,7 +226,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_match(/<body>/, body)
     assert_match(/ActionController::MethodNotAllowed/, body)
 
-    get "/unknown_http_method", headers: { "action_dispatch.show_exceptions" => :all }
+    process :unknown, "/unknown_http_method", headers: { "action_dispatch.show_exceptions" => :all }
     assert_response 405
     assert_match(/<body>/, body)
     assert_match(/ActionController::UnknownHttpMethod/, body)
@@ -278,7 +278,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "text/plain", response.media_type
     assert_match(/ActionController::MethodNotAllowed/, body)
 
-    get "/unknown_http_method", headers: xhr_request_env
+    process :unknown, "/unknown_http_method", headers: xhr_request_env
     assert_response 405
     assert_no_match(/<body>/, body)
     assert_equal "text/plain", response.media_type
@@ -319,7 +319,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "text/markdown", response.media_type
     assert_match(/ActionController::MethodNotAllowed/, body)
 
-    get "/unknown_http_method", headers: { "Accept" => "text/markdown", "action_dispatch.show_exceptions" => :all }
+    process :unknown, "/unknown_http_method", headers: { "Accept" => "text/markdown", "action_dispatch.show_exceptions" => :all }
     assert_response 405
     assert_no_match(/<body>/, body)
     assert_equal "text/markdown", response.media_type
@@ -360,7 +360,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "application/json", response.media_type
     assert_match(/ActionController::MethodNotAllowed/, body)
 
-    get "/unknown_http_method", headers: { "action_dispatch.show_exceptions" => :all }, as: :json
+    process :unknown, "/unknown_http_method", headers: { "action_dispatch.show_exceptions" => :all }, as: :json
     assert_response 405
     assert_no_match(/<body>/, body)
     assert_equal "application/json", response.media_type


### PR DESCRIPTION
fix for issue #56740

**CONTEXT**
The problem lies in DebugExceptions#render_exception (debug_exceptions.rb:68). When a request with an invalid HTTP method arrives:

The router calls request.request_method → ​​throws UnknownHttpMethod
DebugExceptions catches the exception on line 39
In render_exception, request.head? (line 68) calls request.method again on a new request object → throws UnknownHttpMethod a SECOND time
This second exception escapes the rescue exception handler (because it's already caught)
It's sent to ShowExceptions, which should catch it, but depending on the show_exceptions configuration (:none in some test environments), it can go all the way to the server → 500
The same problem potentially exists in DebugExceptions#render_exception on line 68 (request.head?).

**FIX**
The solution is to protect the call to request.head? in DebugExceptions against UnknownHttpMethod, as is already done for InvalidType on lines 63-66:

**TEST**
The fix works correctly. With your modification in debug_exceptions.rb:68-72, request.head no longer throws an uncaught exception when the HTTP method is invalid. The middleware correctly returns 405 Method Not Allowed instead of 500 Internal Server Error in all configuration modes.

_**4 tests done with success :**_
Test | Scenario | Résult
-- | -- | --
1 | INVALID_METHOD + show_exceptions: :all + dev mode | 405
2 | GET valide | 200
3 | INVALID_METHOD + production mode | 405
4 | INVALID_METHOD + show_exceptions: :rescuable | 405
