### PR TITLE
Pin dalli gem to version 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :doc do
 end
 
 # Active Support
-gem "dalli", ">= 3.0.1"
+gem "dalli", ">= 3.0.1", "< 5"
 gem "listen", "~> 3.3", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
-    dalli (4.0.0)
+    dalli (4.3.2)
       logger
     dante (0.2.0)
     dartsass-rails (0.5.1)
@@ -687,7 +687,7 @@ DEPENDENCIES
   capybara (>= 3.39)
   connection_pool
   cssbundling-rails
-  dalli (>= 3.0.1)
+  dalli (>= 3.0.1, < 5)
   dartsass-rails
   debug (>= 1.1.0)
   google-cloud-storage (~> 1.11)


### PR DESCRIPTION
### Motivation / Background

This commit workarounds the following uninitialized constant Dalli::Protocol::Binary since Dalli 5.0.0 was released that removes the binary protocol.

While the fix is being discussed at https://github.com/rails/rails/pull/56721, temporarily pin the version to 4 to avoid errors.

### Detail

```ruby
$ bundle update dalli --conservative
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Resolving dependencies...
Fetching dalli 5.0.0 (was 4.0.0)
Installing dalli 5.0.0 (was 4.0.0)
Bundle updated!
1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details
$ bin/test
/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:22:in '<class:MemCacheStoreTest>': uninitialized constant Dalli::Protocol::Binary (NameError)

  class UnavailableDalliServer < Dalli::Protocol::Binary
                                                ^^^^^^^^
	from /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:8:in '<top (required)>'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:71:in 'block in Rails::TestUnit::Runner.load_tests'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:69:in 'Array#each'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:69:in 'Rails::TestUnit::Runner.load_tests'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/minitest/rails_plugin.rb:147:in 'block in Minitest.plugin_rails_options'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1818:in 'block in OptionParser#parse_in_order'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:930:in 'OptionParser::List#search'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1949:in 'block in OptionParser#visit'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1948:in 'Array#reverse_each'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1948:in 'OptionParser#visit'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1818:in 'OptionParser#parse_in_order'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1728:in 'OptionParser#order!'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1853:in 'OptionParser#permute!'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1878:in 'OptionParser#parse!'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/minitest-6.0.0/lib/minitest.rb:248:in 'block in Minitest.process_args'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/optparse.rb:1192:in 'OptionParser#initialize'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/minitest-6.0.0/lib/minitest.rb:160:in 'Class#new'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/minitest-6.0.0/lib/minitest.rb:160:in 'Minitest.process_args'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/minitest-6.0.0/lib/minitest.rb:294:in 'Minitest.run'
	from /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/minitest-6.0.0/lib/minitest.rb:84:in 'block in Minitest.autorun'
$
```

### Additional information
Ref:
https://github.com/petergoldstein/dalli/blob/main/CHANGELOG.md#500
> Removed binary protocol - The meta protocol is now the only supported protocol

https://github.com/petergoldstein/dalli/commit/b1f092045d98787763c965c0b49605090678e87c#diff-95f40bab82f3e5f469f064bc02fde33597d531cd74aaaad2015ed7a6ce4c1f79

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
