### PR TITLE
Fix code examples and typos [ci skip]

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -1686,7 +1686,7 @@ test "sign up ignores admin attribute" do
     post sign_up_path, params: { user: { first_name: "Example", last_name: "User", email_address: "example@user.org", password: "password", password_confirmation: "password", admin: true } }
     assert_redirected_to root_path
   end
-  refute User.find_by(email_address: "example@user.org").admin?
+  assert_not User.find_by(email_address: "example@user.org").admin?
 end
 ```
 
@@ -1756,7 +1756,7 @@ two:
   last_name: Two
 ```
 
-This tests submits successful params, confirms the email is saved to the
+This test submits successful params, confirms the email is saved to the
 database, the user was redirected and the confirmation email was queued for
 delivery.
 
@@ -1879,7 +1879,7 @@ class SettingsTest < ActionDispatch::IntegrationTest
     sign_in_as users(:one)
     get settings_profile_path
     assert_dom "h4", "Account Settings"
-    assert_not_dom "a", "Store Settings"
+    assert_not_dom "h4", "Store Settings"
   end
 
   test "admin settings nav" do
@@ -1993,13 +1993,6 @@ your account.
 $ bin/kamal dbc
 UPDATE users SET admin=true WHERE users.email_address='you@example.org';
 .quit
-```
-
-Otherwise, you can use the Rails console to update your account.
-
-```bash
-$ bin/kamal console
-irb> User.find_by(email_address: "you@example.org").update(admin: true)
 ```
 
 You can now access the Store settings in production with your account.


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes typos and code examples in the "Sign Up and Settings" guide.
Since this page is targeted at beginners, ensuring the code examples works correctly and follows the conventions is beneficial.

### Detail

This Pull Request includes the following fixes:

* Use `assert_not` instead of `refute`: adhering to the [Coding Conventions](https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions).
* Fix a typo: "This tests submits" -> "This test submits"
* Fix DOM assertion: Change "a" to "h4". "Store Settings" is rendered as an `h4`, so the assertion for its absence should target the same tag for accuracy.
* Remove the Rails console example that attempted to update the `admin` attribute via ActiveRecord, which raises `ActiveRecord::ReadonlyAttributeError` because of `attr_readonly :admin` set in [7.2. Readonly Attributes](https://guides.rubyonrails.org/sign_up_and_settings.html#readonly-attributes).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
