### PR TITLE
Raise an ArgumentError on Date and Time #advance with invalid options

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Raise `ArgumentError` if invalid options are passed to `advance`.
+
+    Previously, passing unsupported keys (e.g., `year: 1` instead of `years: 1`) to `advance` would be silently ignored.
+    Now, `Date#advance`, `Time#advance`, `DateTime#advance`, and `ActiveSupport::TimeWithZone#advance` will raise `ArgumentError` for unknown keys.
+
+    ```ruby
+    Time.current.advance(year: 1)
+    # => ArgumentError: Unknown key: :year. Valid keys are: :years, :months, :weeks, :days, :hours, :minutes, :seconds
+    ```
+
+    *Jay Dorsey*
+
 *   Fix inflections to better handle overlapping acronyms.
 
     ```ruby

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -126,7 +126,7 @@ class Date
   #   # => Mon, 01 Nov 2004
   #
   def advance(options)
-    options.assert_valid_keys(:years, :months, :weeks, :days)
+    options.assert_valid_keys(:years, :months, :weeks, :days, :hours, :minutes, :seconds)
     d = self
 
     d = d >> options[:years] * 12 if options[:years]

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -2,6 +2,7 @@
 
 require "date"
 require "active_support/duration"
+require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/object/acts_like"
 require "active_support/core_ext/date/zones"
 require "active_support/core_ext/time/zones"
@@ -125,6 +126,7 @@ class Date
   #   # => Mon, 01 Nov 2004
   #
   def advance(options)
+    options.assert_valid_keys(:years, :months, :weeks, :days)
     d = self
 
     d = d >> options[:years] * 12 if options[:years]

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "date"
+require "active_support/core_ext/hash/keys"
 
 class DateTime
   class << self
@@ -80,6 +81,7 @@ class DateTime
   # largest to smallest. This order can affect the result around the end of a
   # month.
   def advance(options)
+    options.assert_valid_keys(:years, :months, :weeks, :days, :hours, :minutes, :seconds)
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
       options[:days] = options.fetch(:days, 0) + 7 * partial_weeks

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/duration"
+require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/time/conversions"
 require "active_support/time_with_zone"
 require "active_support/core_ext/time/zones"
@@ -192,6 +193,7 @@ class Time
   # largest to smallest. This order can affect the result around the end of a
   # month.
   def advance(options)
+    options.assert_valid_keys(:years, :months, :weeks, :days, :hours, :minutes, :seconds)
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
       options[:days] = options.fetch(:days, 0) + 7 * partial_weeks

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -6,6 +6,7 @@ require "active_support/duration"
 require "active_support/values/time_zone"
 require "active_support/core_ext/object/acts_like"
 require "active_support/core_ext/date_and_time/compatibility"
+require "active_support/core_ext/hash/keys"
 
 module ActiveSupport
   # = Active Support \Time With Zone
@@ -436,6 +437,7 @@ module ActiveSupport
     #   now.advance(months: 1)  # => Tue, 02 Dec 2014 01:26:28.558049687 EST -05:00
     #   now.advance(years: 1)   # => Mon, 02 Nov 2015 01:26:28.558049687 EST -05:00
     def advance(options)
+      options.assert_valid_keys(:years, :months, :weeks, :days, :hours, :minutes, :seconds)
       # If we're advancing a value of variable length (i.e., years, weeks, months, days), advance from #time,
       # otherwise advance from #utc, for accuracy when moving across DST boundaries
       if options.values_at(:years, :weeks, :months, :days).any?

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -134,6 +134,20 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Date.new(2005, 2, 28), Date.new(2004, 2, 29).advance(years: 1) # leap day plus one year
   end
 
+  def test_advance_with_invalid_keys
+    d = Date.new(2005, 2, 28)
+    assert_raise(ArgumentError) { d.advance(year: 1) }
+    assert_raise(ArgumentError) { d.advance(month: 1) }
+    assert_raise(ArgumentError) { d.advance(week: 1) }
+    assert_raise(ArgumentError) { d.advance(day: 1) }
+    assert_raise(ArgumentError) { d.advance(hour: 1) }
+    assert_raise(ArgumentError) { d.advance(minute: 1) }
+    assert_raise(ArgumentError) { d.advance(second: 1) }
+    assert_raise(ArgumentError) { d.advance(hours: 1) }
+    assert_raise(ArgumentError) { d.advance(minutes: 1) }
+    assert_raise(ArgumentError) { d.advance(seconds: 1) }
+  end
+
   def test_advance_does_first_years_and_then_days
     assert_equal Date.new(2012, 2, 29), Date.new(2011, 2, 28).advance(years: 1, days: 1)
     # If day was done first we would jump to 2012-03-01 instead.

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -143,9 +143,6 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_raise(ArgumentError) { d.advance(hour: 1) }
     assert_raise(ArgumentError) { d.advance(minute: 1) }
     assert_raise(ArgumentError) { d.advance(second: 1) }
-    assert_raise(ArgumentError) { d.advance(hours: 1) }
-    assert_raise(ArgumentError) { d.advance(minutes: 1) }
-    assert_raise(ArgumentError) { d.advance(seconds: 1) }
   end
 
   def test_advance_does_first_years_and_then_days

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -197,6 +197,17 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2013, 10, 17, 20, 22, 19), DateTime.civil(2005, 2, 28, 15, 15, 10).advance(years: 7, months: 19, weeks: 2, days: 5, hours: 5, minutes: 7, seconds: 9)
   end
 
+  def test_advance_with_invalid_keys
+    d = DateTime.civil(2005, 2, 28, 15, 15, 10)
+    assert_raise(ArgumentError) { d.advance(year: 1) }
+    assert_raise(ArgumentError) { d.advance(month: 1) }
+    assert_raise(ArgumentError) { d.advance(week: 1) }
+    assert_raise(ArgumentError) { d.advance(day: 1) }
+    assert_raise(ArgumentError) { d.advance(hour: 1) }
+    assert_raise(ArgumentError) { d.advance(minute: 1) }
+    assert_raise(ArgumentError) { d.advance(second: 1) }
+  end
+
   def test_advance_partial_days
     assert_equal DateTime.civil(2012, 9, 29, 13, 15, 10),  DateTime.civil(2012, 9, 28, 1, 15, 10).advance(days: 1.5)
     assert_equal DateTime.civil(2012, 9, 28, 13, 15, 10),  DateTime.civil(2012, 9, 28, 1, 15, 10).advance(days: 0.5)

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -1417,4 +1417,15 @@ class TimeExtMarshalingTest < ActiveSupport::TestCase
   def test_last_quarter_on_31st
     assert_equal Time.local(2004, 2, 29), Time.local(2004, 5, 31).last_quarter
   end
+
+  def test_advance_with_invalid_keys
+    t = Time.local(2005, 2, 28, 15, 15, 10)
+    assert_raise(ArgumentError) { t.advance(year: 1) }
+    assert_raise(ArgumentError) { t.advance(month: 1) }
+    assert_raise(ArgumentError) { t.advance(week: 1) }
+    assert_raise(ArgumentError) { t.advance(day: 1) }
+    assert_raise(ArgumentError) { t.advance(hour: 1) }
+    assert_raise(ArgumentError) { t.advance(minute: 1) }
+    assert_raise(ArgumentError) { t.advance(second: 1) }
+  end
 end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -739,6 +739,16 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal "1999-12-31 19:00:30.000000000 EST -05:00", @twz.advance(seconds: 30).inspect
   end
 
+  def test_advance_with_invalid_keys
+    assert_raise(ArgumentError) { @twz.advance(year: 1) }
+    assert_raise(ArgumentError) { @twz.advance(month: 1) }
+    assert_raise(ArgumentError) { @twz.advance(week: 1) }
+    assert_raise(ArgumentError) { @twz.advance(day: 1) }
+    assert_raise(ArgumentError) { @twz.advance(hour: 1) }
+    assert_raise(ArgumentError) { @twz.advance(minute: 1) }
+    assert_raise(ArgumentError) { @twz.advance(second: 1) }
+  end
+
   def test_beginning_of_year
     assert_equal "1999-12-31 19:00:00.000000000 EST -05:00", @twz.inspect
     assert_equal "1999-01-01 00:00:00.000000000 EST -05:00", @twz.beginning_of_year.inspect


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to improve the behavior of the `advance` method used on `Date`, `DateTime`, `Time`, and `TimeWithZone` per the suggestion I made in the [ruby forum](https://discuss.rubyonrails.org/t/feature-proposal-activesupport-timewithzone-advance-options-validation/90136)

When dealing with time/date classes:

1. The individual segments are often referred to in the singular (year, month, day)
2. Some methods even use the singular, such as `Date.now.change(year: 2025)`
3. The `advance` method accepts plural options, singular options are a no-op

It’s very easy to make the singular/plural mistake and write something like `Time.zone.now.advance(month: 1)` and not realize it is a no-op because we don’t validate the keys. I've seen this in private repos, but have also found examples in public repos for usage of [year](https://github.com/search?q=%22advance%28year%3A%22+language%3ARuby+&type=code), [month](https://github.com/search?q=%22advance%28month%3A%22+language%3ARuby+&type=code), [day](https://github.com/search?q=%22advance%28day%3A%22+language%3ARuby+&type=code) and [hour](https://github.com/search?q=%22advance%28hour%3A%22+language%3ARuby+&type=code)

### Detail

This Pull Request changes

1. Add the appropriate `assert_valid_keys` check to `Time`, `Date`, `DateTime`, and `TimeWithZone`
3. Add relevant specs for each

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

1. We could also make it accept both, and simply pluralize any options that come in
    1. This would seem to expand the interface options, making it more confusing (but backwards compatible)
3. We could optionally warn/deprecate on invalid options being passed in instead of raising an ArgumentError
    1. This behavior is an actual bug imho, so I think the ArgumentError is more helpful. The usage of advance with a singular indicates intent to advance by a unit of time, but no advance occurs
5. I provided some examples of where this happened in real public repos in the description. This PR came about because I discovered the issue in two separate private PRs that I worked on.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.