### PR TITLE
Fix Ruby code block syntax highlighting for getting_started.md document [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1896,7 +1896,7 @@ end
 Then we can add a file upload field to our product form before the submit
 button:
 
-```erb#4-7
+```erb#5-8
 <%# app/views/products/_form.html.erb %>
 <%= form_with model: product do |form| %>
   <%# ... %>
@@ -2087,7 +2087,7 @@ $ bin/rails db:migrate
 We'll need to add the inventory count to the product form in
 `app/views/products/_form.html.erb`.
 
-```erb#4-7
+```erb#5-8
 <%# app/views/products/_form.html.erb %>
 <%= form_with model: product do |form| %>
   <%# ... %>
@@ -2174,7 +2174,7 @@ A Product, however, can have many subscribers, so we then add
 second part of this association between the two models. This tells Rails how to
 join queries between the two database tables.
 
-```ruby#2
+```ruby#3
 # app/models/product.rb
 class Product < ApplicationRecord
   has_many :subscribers, dependent: :destroy
@@ -2302,7 +2302,7 @@ method.
 
 Update this method to mail to a subscriber's email address.
 
-```ruby#7-10
+```ruby#8-11
 # app/mailers/product_mailer.rb
 class ProductMailer < ApplicationMailer
   # Subject can be set in your I18n file at config/locales/en.yml
@@ -2517,7 +2517,7 @@ A subscriber may want to unsubscribe at some point, so let's build that next.
 First, we need a route for unsubscribing that will be the URL we include in
 emails.
 
-```ruby#6
+```ruby#7
 # config/routes.rb
 Rails.application.routes.draw do
   # ...


### PR DESCRIPTION
Updated code block syntax highlighting for Ruby in getting_started.md.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The previous version caused incorrect syntax highlighting in the rendered guide. Updating it fixes the highlighting for the example.

### Detail

This is a documentation-only change.

### Checklist

* [x] This Pull Request is related to one change. 
* [x] Commit message has a detailed description of what changed and why.
