### PR TITLE
EventReporter: filter events before building the payload

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Changed `ActiveSupport::EventReporter#subscribe` to only provide the event name during filtering.
+
+    Otherwise the event reporter would need to always build the expensive payload even when there is
+    no active subscriber, which is very wasteful.
+
+    *Jean Boussier*
+
 *   Fix inflections to better handle overlapping acronyms.
 
     ```ruby


### PR DESCRIPTION
Following https://github.com/rails/rails/pull/55900, we now always pay the efty price of building the event payload and filtering it before we check subscribers to know if they even need it.

I realize this is technically a breaking change, but the filtering logic seem to have been ported over from AS::Notifications but in AS::Notifications we'd save building the payload, here registering a filter doesn't allow to save any substantial overhead.

So in my opinion the feature doesn't make sense as is.

cc @adrianna-chang-shopify @zzak @gmcgibbon any objections?