### PR TITLE
ActiveSupport::ParameterFilter: optimize redundant patterns out

### DIFF
--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -131,18 +131,21 @@ class ParameterFilterTest < ActiveSupport::TestCase
 
     precompiled = ActiveSupport::ParameterFilter.precompile_filters([*patterns, *deep_patterns, *procs])
 
-    assert_equal 2, precompiled.grep(Regexp).length
-    assert_equal 2 + procs.length, precompiled.length
+    assert_equal 1, precompiled.grep(Regexp).length
+    assert_equal 1 + procs.length, precompiled.length
 
-    regexp = precompiled.find { |filter| filter.to_s.include?(patterns.first.to_s) }
+    regexp = precompiled.grep(Regexp).first
     keys.each { |key| assert_match regexp, key }
     assert_no_match regexp, keys.first.swapcase
 
-    deep_regexp = precompiled.find { |filter| filter.to_s.include?(deep_patterns.first.to_s) }
-    deep_keys.each { |deep_key| assert_match deep_regexp, deep_key }
-    assert_no_match deep_regexp, deep_keys.first.swapcase
+    deep_keys.each { |deep_key| assert_match regexp, deep_key }
+    assert_no_match regexp, deep_keys.first.swapcase
 
-    assert_not_equal regexp, deep_regexp
     assert_equal procs, precompiled & procs
+  end
+
+  test "precompile_filters eliminate dead patterns" do
+    assert_equal [/token/i], ActiveSupport::ParameterFilter.precompile_filters(["user.token", "token"])
+    assert_equal [/password/i], ActiveSupport::ParameterFilter.precompile_filters(["user_password", "password"])
   end
 end


### PR DESCRIPTION
Because Active Record encryption automatically register deep pattern for all encrypted attributes, the list of filtered parameters can quickly grow very large, and severely impact performance.

Given we have a precompilation step, we can perform some dead code elimination.

e.g. in our case the vast majority of encrypted columns have a common suffix (`*_token`) but `token` is already a filtered parameter, making all these extra filters redundant and harmful.
