### PR TITLE
Fix rdoc code formatting

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -143,7 +143,7 @@ module ActionView
       #
       # [+:highlighter+]
       #   The highlighter string. Uses <tt>\1</tt> as the placeholder for a
-      #   phrase, similar to +String#sub+. Defaults to <tt>"<mark>\1</mark>"</tt>.
+      #   phrase, similar to <tt>String#sub</tt>. Defaults to <tt>"<mark>\1</mark>"</tt>.
       #   This option is ignored if a block is specified.
       #
       # [+:sanitize+]


### PR DESCRIPTION
The simple `+` style doesn't work with more complicated snippets, and `tt` is necessary instead.

Before this is merged, you can see the error here: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-highlight

---

<img width="715" height="272" alt="iiokc3ercl 2026-02-10 12-20-02" src="https://github.com/user-attachments/assets/7abd9a16-5dfe-40b1-8e19-647265439c2b" />
