### PR TITLE
Fix PostgreSQL disable_referential_integrity with duplicate table names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -9,10 +9,11 @@ module ActiveRecord
             toggle_foreign_key_enforcement(current_schemas_only: true, &block)
           else
             original_exception = nil
+            table_names = schema_qualified_tables
 
             begin
               transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+                execute(table_names.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
               end
             rescue ActiveRecord::ActiveRecordError => e
               original_exception = e
@@ -35,7 +36,7 @@ module ActiveRecord
 
             begin
               transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+                execute(table_names.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
               end
             rescue ActiveRecord::ActiveRecordError
             end
@@ -74,6 +75,17 @@ module ActiveRecord
         end
 
         private
+          # Like #data_source_sql, but returns schema qualified names, so that tables sharing
+          # a name across several schemas on the search path are all covered.
+          def schema_qualified_tables
+            scope = quoted_scope(nil, type: "BASE TABLE")
+            sql = +"SELECT n.nspname || '.' || c.relname FROM pg_class c "
+            sql << "LEFT JOIN pg_namespace n ON n.oid = c.relnamespace"
+            sql << " WHERE n.nspname = #{scope[:schema]}"
+            sql << " AND c.relkind IN (#{scope[:type]})"
+            query_values(sql)
+          end
+
           # conparentid = 0: a partition's child copy can't be ALTERed; the parent's ALTER cascades
           def enforced_foreign_keys(current_schemas_only: false)
             query_all(<<~SQL)

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -426,6 +426,56 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_disable_referential_integrity_with_duplicate_table_names_in_search_path
+    skip if @connection.supports_enforced_foreign_keys?
+
+    first_schema  = "first_referential_integrity_test_schema"
+    second_schema = "second_referential_integrity_test_schema"
+    missing_fk_id = 123_456_789
+
+    begin
+      @connection.execute <<~SQL
+        CREATE SCHEMA #{first_schema};
+        CREATE SCHEMA #{second_schema};
+
+        -- same names in both schemas to create ambiguity in search_path lookups
+        CREATE TABLE #{first_schema}.foo (id bigserial PRIMARY KEY);
+        CREATE TABLE #{second_schema}.foo (id bigserial PRIMARY KEY);
+
+        CREATE TABLE #{first_schema}.bar (id bigserial PRIMARY KEY, foo_id bigint);
+        CREATE TABLE #{second_schema}.bar (
+          id bigserial PRIMARY KEY,
+          foo_id bigint NOT NULL,
+          CONSTRAINT fk_bar_foo FOREIGN KEY (foo_id) REFERENCES #{second_schema}.foo(id)
+        );
+
+        SET search_path TO #{first_schema}, #{second_schema};
+      SQL
+
+      assert_raises(ActiveRecord::InvalidForeignKey) do
+        @connection.transaction(requires_new: true) do
+          @connection.execute("INSERT INTO #{second_schema}.bar (foo_id) VALUES (#{missing_fk_id})")
+        end
+      end
+
+      # Only succeeds if triggers are disabled on BOTH "#{first_schema}.bar" and "#{second_schema}.bar".
+      @connection.disable_referential_integrity do
+        @connection.execute("INSERT INTO #{second_schema}.bar (foo_id) VALUES (#{missing_fk_id})")
+        @connection.execute("DELETE FROM #{second_schema}.bar WHERE foo_id = #{missing_fk_id}")
+      end
+
+      assert_raises(ActiveRecord::InvalidForeignKey) do
+        @connection.transaction(requires_new: true) do
+          @connection.execute("INSERT INTO #{second_schema}.bar (foo_id) VALUES (#{missing_fk_id})")
+        end
+      end
+    ensure
+      @connection.execute("SET search_path TO public")
+      @connection.drop_schema first_schema,  if_exists: true, cascade: true
+      @connection.drop_schema second_schema, if_exists: true, cascade: true
+    end
+  end
+
   private
     def assert_transaction_is_not_broken
       assert_equal 1, @connection.select_value("SELECT 1")


### PR DESCRIPTION
### Motivation / Background

Fixes #56757
Fixes #30846

disable_referential_integrity disables/enables triggers using unqualified table names returned by tables. When multiple schemas in search_path contain tables with the same name, PostgreSQL resolves the unqualified name to the first match, leaving triggers enabled in the other schema(s). This can break fixture loading (and similar workflows) when foreign keys exist in those schemas.

Since #57378 this only affects PostgreSQL below 18.4 - the NOT ENFORCED path builds its table names from pg_catalog and is already qualified. The trigger fallback still covers 10.0 to 18.3.

### Detail

This change schema-qualifies table names when disabling/enabling triggers, so all tables in the current search_path are toggled even when duplicate table names exist across schemas. The list is built once and used for both passes; it was queried twice before. A regression test reproduces the failure with duplicate table names and a foreign key in the later schema.

### Additional information

The change is scoped to disable_referential_integrity to avoid altering the behavior of tables/data_source_sql and other call sites. #57378 does the same thing - enforced_foreign_keys uses its own pg_catalog query.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (not needed, minor bug fix)
