### PR TITLE
Add `transaction_changes` methods for tracking transaction-level attribute changes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add transaction-level dirty tracking with `transaction_changes`,
+    `transaction_changes?`, `transaction_change_to_attribute?`,
+    `transaction_change_to_attribute`, and `attribute_before_transaction`,
+    including their generated per-attribute methods.
+
+    These methods report cumulative changes across all saves in a transaction
+    and remain available in `after_commit` callbacks.
+
+    *Lucas Campanari*
+
 *   Remove unused `rest` parameter from merge and merge!
 
     *Aaron Patterson*

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -53,6 +53,9 @@ module ActiveRecord
 
       include ActiveModel::Dirty
 
+      EMPTY_HASH = {}.with_indifferent_access.freeze
+      private_constant :EMPTY_HASH
+
       included do
         if self < ::ActiveRecord::Timestamp
           raise "You cannot include Dirty after Timestamp"
@@ -210,7 +213,7 @@ module ActiveRecord
       # values are arrays containing the original value at the start of the
       # transaction and the final committed value.
       def committed_changes
-        @_committed_changes || {}.with_indifferent_access
+        @_committed_changes || EMPTY_HASH
       end
 
       # Will this attribute change the next time we save?

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -163,9 +163,18 @@ module ActiveRecord
       def committed_change_to_attribute?(attr_name, **options)
         attr_name = attr_name.to_s
         return false unless @_committed_changes&.key?(attr_name)
+
         change = @_committed_changes[attr_name]
-        (options.key?(:from) ? change[0] == _type_cast_for_committed(attr_name, options[:from]) : true) &&
-          (options.key?(:to) ? change[1] == _type_cast_for_committed(attr_name, options[:to]) : true)
+
+        if options.key?(:from)
+          return false unless change[0] == _type_cast_for_committed(attr_name, options[:from])
+        end
+
+        if options.key?(:to)
+          return false unless change[1] == _type_cast_for_committed(attr_name, options[:to])
+        end
+
+        true
       end
 
       # Returns the change to an attribute during the last committed

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -300,7 +300,7 @@ module ActiveRecord
         end
 
         def _type_cast_for_committed(attr_name, value)
-          @attributes[attr_name].type_cast(value)
+          @attributes[attr_name].type.cast(value)
         end
 
         def _touch_row(attribute_names, time)

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -87,6 +87,7 @@ module ActiveRecord
           @mutations_before_last_save = nil
           @mutations_from_database = nil
           @_committed_changes = nil
+          @_committed_transaction_state = nil
         end
       end
 
@@ -213,10 +214,11 @@ module ActiveRecord
         attr_name = attr_name.to_s
 
         if @_start_transaction_state
-          @_start_transaction_state[:attributes][attr_name]&.original_value
-        elsif @_committed_changes
-          if @_committed_changes.key?(attr_name)
-            @_committed_changes[attr_name].first
+          original_attributes = _transaction_original_written_attributes
+          (original_attributes&.fetch(attr_name, nil) || @_start_transaction_state[:attributes][attr_name])&.original_value
+        elsif committed_changes = _committed_transaction_changes
+          if committed_changes.key?(attr_name)
+            committed_changes[attr_name].first
           else
             _read_attribute(attr_name)
           end
@@ -241,7 +243,7 @@ module ActiveRecord
       # committed changes. Returns an empty hash when called outside any
       # transaction context.
       def transaction_changes
-        _compute_transaction_changes || @_committed_changes || EMPTY_HASH
+        _compute_transaction_changes || _committed_transaction_changes || EMPTY_HASH
       end
 
       # Will this attribute change the next time we save?
@@ -323,6 +325,7 @@ module ActiveRecord
           @mutations_before_last_save = nil
           @mutations_from_database = nil
           @_committed_changes = nil
+          @_committed_transaction_state = nil
           @_touch_attr_names = nil
           @_skip_dirty_tracking = nil
         end
@@ -337,6 +340,7 @@ module ActiveRecord
           affected_rows = super
 
           if @_skip_dirty_tracking ||= false
+            refresh_transaction_record_state_without_dirty_tracking
             clear_attribute_changes(@_touch_attr_names)
             return affected_rows
           end
@@ -358,18 +362,24 @@ module ActiveRecord
           affected_rows
         ensure
           @_touch_attr_names, @_skip_dirty_tracking = nil, nil
+          @_deferred_touch_original_attributes = nil
+          clear_transaction_written_attributes
         end
 
         def _update_record(attribute_names = attribute_names_for_partial_updates)
           affected_rows = super
           changes_applied
           affected_rows
+        ensure
+          clear_transaction_written_attributes
         end
 
         def _create_record(attribute_names = attribute_names_for_partial_inserts)
           id = super
           changes_applied
           id
+        ensure
+          clear_transaction_written_attributes
         end
 
         def attribute_names_for_partial_updates

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -41,11 +41,13 @@ module ActiveRecord
     #   person.name_before_transaction       # => "Allison"
     #   person.transaction_changes           # => {"name"=>["Allison", "Alice"]}
     #
-    # The +transaction_change_to_*+ methods track cumulative changes across
-    # all saves within the current transaction, making them available in any
-    # callback phase (+before_save+, +after_save+, +after_commit+) and for
-    # cross-model access. The +saved_change_to_*+ methods, by contrast,
-    # only reflect the most recent save.
+    # The +transaction_change_to_*+ methods track cumulative successful writes
+    # across all saves within the current transaction, making them available in
+    # any callback phase (+before_save+, +after_save+, +after_commit+) and for
+    # cross-model access. While the target record is inside a create or update
+    # attempt that has not reached persistence, its pending values are included
+    # too. The +saved_change_to_*+ methods, by contrast, only reflect the most
+    # recent save.
     #
     # Similar to ActiveModel::Dirty, methods can be invoked as
     # +saved_change_to_name?+ or by passing an argument to the generic method
@@ -148,12 +150,13 @@ module ActiveRecord
       # This method tracks cumulative changes across all saves within the
       # current database transaction. It works in any callback phase:
       # +before_save+, +after_save+, +before_update+, +after_update+, and
-      # +after_commit+. During +before_save+ / +before_update+, pending
-      # unsaved changes are included.
+      # +after_commit+. Pending values are included while the target record has
+      # an active create or update attempt that has not reached persistence.
       #
-      # It can also be used cross-model: one model's callback can read
-      # another model's +transaction_change_to_attribute?+ within the same
-      # transaction.
+      # The target record's phase controls this behavior, not the callback from
+      # which the method is called. One model's callback can read another model's
+      # transaction changes, and a touch or destroy nested before the target's
+      # persistence still sees its pending values.
       #
       # It can be invoked as +transaction_change_to_name?+ instead of
       # <tt>transaction_change_to_attribute?("name")</tt>.
@@ -188,7 +191,9 @@ module ActiveRecord
       # Returns the change to an attribute during the current transaction.
       # If the attribute was changed, the result will be an array containing
       # the original value at the start of the transaction and the current
-      # effective value (including pending unsaved changes).
+      # effective value. The effective value includes a pending value only while
+      # the target record is in the pre-persistence part of a create or update
+      # attempt.
       #
       # This method is useful in any callback phase during a transaction. It
       # can be invoked as +transaction_change_to_name+ instead of
@@ -236,12 +241,25 @@ module ActiveRecord
       # values are arrays containing the original value at the start of the
       # transaction and the current effective value.
       #
-      # This includes changes from all saves within the transaction. During
-      # +before_save+ / +before_update+, pending unsaved changes are also
-      # included. During +after_commit+ callbacks (where the transaction
-      # snapshot has already been cleared), falls back to the cached
-      # committed changes. Returns an empty hash when called outside any
-      # transaction context.
+      # This includes successful writes from all saves within the transaction.
+      # Pending values are also included while the target record has an active
+      # create or update attempt that has not reached persistence. This remains
+      # true in nested touch or destroy callbacks and for cross-model readers.
+      # A nested save has its own phase; after it finishes, the enclosing save's
+      # phase resumes. Deferred touches flush after the save attempt and report
+      # their successful writes without reviving its pending values.
+      #
+      # If an attempt halts or raises before persistence, entered around callback
+      # code may see pending values while it unwinds, but they are excluded once
+      # the attempt exits. If persistence has completed, unwind and after
+      # callbacks report only successful writes. Custom create or update
+      # persistence overrides must call +changes_applied+ after a successful
+      # write to establish this boundary; arbitrary pre-save calls to
+      # +changes_applied+ are not supported.
+      #
+      # During +after_commit+ callbacks (where the transaction snapshot has
+      # already been cleared), this falls back to the cached committed changes.
+      # Returns an empty hash when called outside any transaction context.
       def transaction_changes
         _compute_transaction_changes || _committed_transaction_changes || EMPTY_HASH
       end
@@ -335,6 +353,8 @@ module ActiveRecord
         end
 
         def _touch_row(attribute_names, time)
+          # A nested touch snapshots its write without finalizing the enclosing save.
+          @_transaction_changes_touch_finalization_depth = (@_transaction_changes_touch_finalization_depth || 0) + 1
           @_touch_attr_names = Set.new(attribute_names)
 
           affected_rows = super
@@ -361,9 +381,14 @@ module ActiveRecord
 
           affected_rows
         ensure
-          @_touch_attr_names, @_skip_dirty_tracking = nil, nil
-          @_deferred_touch_original_attributes = nil
-          clear_transaction_written_attributes
+          begin
+            @_touch_attr_names, @_skip_dirty_tracking = nil, nil
+            @_deferred_touch_original_attributes = nil
+            clear_transaction_written_attributes
+          ensure
+            @_transaction_changes_touch_finalization_depth -= 1
+            @_transaction_changes_touch_finalization_depth = nil if @_transaction_changes_touch_finalization_depth.zero?
+          end
         end
 
         def _update_record(attribute_names = attribute_names_for_partial_updates)

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -437,7 +437,14 @@ module ActiveRecord
 
   private
     def create_or_update(**)
+      save_attempt = { persistence_finalized: false }
+      (@_transaction_changes_save_attempts ||= []) << save_attempt
       _run_save_callbacks { super }
+    ensure
+      if save_attempt
+        @_transaction_changes_save_attempts.pop
+        @_transaction_changes_save_attempts = nil if @_transaction_changes_save_attempts.empty?
+      end
     end
 
     def _create_record

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -9,12 +9,23 @@ module ActiveRecord
       def initialize(state = nil)
         @state = state
         @children = nil
+        @parent = nil
       end
 
       def add_child(state)
+        state.parent = self
         @children ||= []
         @children << state
       end
+
+      def root
+        @parent ? @parent.root : self
+      end
+
+      protected
+        attr_writer :parent
+
+      public
 
       def finalized?
         @state

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -9,23 +9,12 @@ module ActiveRecord
       def initialize(state = nil)
         @state = state
         @children = nil
-        @parent = nil
       end
 
       def add_child(state)
-        state.parent = self
         @children ||= []
         @children << state
       end
-
-      def root
-        @parent ? @parent.root : self
-      end
-
-      protected
-        attr_writer :parent
-
-      public
 
       def finalized?
         @state

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -150,6 +150,7 @@ module ActiveRecord
               raise ActiveRecord::StaleObjectError.new(self, attempted_action)
             end
 
+            record_transaction_written_attributes(attribute_names)
             affected_rows
 
           # If something went wrong, revert the locking_column value.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -972,18 +972,23 @@ module ActiveRecord
 
           returning_values = result.rows.first
 
+          returned_attribute_names = []
           returning_columns.zip(returning_values).each do |column, value|
             _write_attribute(column, value)
+            returned_attribute_names << column
           end if returning_values.present?
 
-          result.affected_rows
+          affected_rows = result.affected_rows
+          record_transaction_written_attributes(attribute_names | returned_attribute_names) if affected_rows == 1
+          affected_rows
         else
-          result = self.class._update_record(
+          affected_rows = self.class._update_record(
             attributes_with_values(attribute_names),
             _query_constraints_hash,
           )
 
-          result
+          record_transaction_written_attributes(attribute_names) if affected_rows == 1
+          affected_rows
         end
       end
 
@@ -1019,6 +1024,7 @@ module ActiveRecord
       def _create_record(attribute_names = self.attribute_names)
         attribute_names = attributes_for_create(attribute_names)
 
+        returned_attribute_names = []
         self.class.with_connection do |connection|
           returning_columns = self.class._returning_columns_for_insert(connection)
 
@@ -1029,9 +1035,13 @@ module ActiveRecord
           )
 
           returning_columns.zip(returning_values).each do |column, value|
-            _write_attribute(column, type_for_attribute(column).deserialize(value)) if !_read_attribute(column)
+            if !_read_attribute(column)
+              _write_attribute(column, type_for_attribute(column).deserialize(value))
+              returned_attribute_names << column
+            end
           end if returning_values
         end
+        record_transaction_written_attributes(attribute_names | returned_attribute_names)
 
         @new_record = false
         @previously_new_record = true

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -38,10 +38,33 @@ module ActiveRecord
     def touch(*names, time: nil) # :nodoc:
       if has_defer_touch_attrs?
         names |= @_defer_touch_attrs
-        super(*names, time: time)
+        result = super(*names, time: time)
+        # A normal return means the deferred touch was either persisted by
+        # +_touch_row+ or cancelled by a halted touch callback, so the deferred
+        # names are consumed either way. The transaction-change baseline
+        # captured by +surreptitiously_touch+ and any transient written-name
+        # capture must not outlive the deferred names: an orphaned baseline
+        # would be copied into a later transaction's state and report values
+        # from before this touch. When a touch callback raises instead, the
+        # deferred names stay pending and retain ownership of the baseline so
+        # the touch can still be retried or flushed by +before_committed!+.
         @_defer_touch_attrs, @_touch_time = nil, nil
+        @_deferred_touch_original_attributes = nil
+        clear_transaction_written_attributes
+        result
       else
         super
+      end
+    end
+
+    def reload(*) # :nodoc:
+      super.tap do
+        # Reload replaces +@attributes+ with fresh database state, so a
+        # baseline captured before the reload no longer predates the current
+        # attributes. Pending deferred names survive so an in-flight
+        # +touch_later+ can still be flushed; that flush captures its
+        # originals from the reloaded attributes.
+        @_deferred_touch_original_attributes = nil
       end
     end
 
@@ -49,18 +72,40 @@ module ActiveRecord
       def init_internals
         super
         @_defer_touch_attrs = nil
+        @_deferred_touch_original_attributes = nil
       end
 
+      # Captures the database originals of the deferred touch so transaction
+      # change tracking can report them if the touch survives. Invariant:
+      # +@_deferred_touch_original_attributes+ may remain non-nil only while
+      # +@_defer_touch_attrs+ is still pending or while an active transaction
+      # state owns an independent copy (made by
+      # +remember_transaction_record_state+). Consuming or cancelling the
+      # deferred names — +_touch_row+, +touch_deferred_attributes+, a halted
+      # immediate touch, or +reload+ — must clear the baseline with them.
       def surreptitiously_touch(attr_names)
+        @_deferred_touch_original_attributes ||= {}
         attr_names.each do |attr_name|
+          attr = @attributes[attr_name]
+          @_deferred_touch_original_attributes[attr_name] ||= attr.with_value_from_database(attr.original_value_for_database)
           _write_attribute(attr_name, @_touch_time)
           clear_attribute_change(attr_name)
+        end
+
+        if locking_enabled?
+          locking_column = self.class.locking_column
+          lock_attr = @attributes[locking_column]
+          @_deferred_touch_original_attributes[locking_column] ||= lock_attr.with_value_from_database(lock_attr.original_value_for_database)
         end
       end
 
       def touch_deferred_attributes
         @_skip_dirty_tracking = true
         touch(time: @_touch_time)
+      ensure
+        @_skip_dirty_tracking = nil
+        @_deferred_touch_original_attributes = nil
+        clear_transaction_written_attributes
       end
 
       def has_defer_touch_attrs?

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -85,9 +85,16 @@ module ActiveRecord
       # immediate touch, or +reload+ — must clear the baseline with them.
       def surreptitiously_touch(attr_names)
         @_deferred_touch_original_attributes ||= {}
+        transaction_original_attributes =
+          if @_start_transaction_state && @_start_transaction_state[:attributes].equal?(@attributes)
+            @_start_transaction_state[:transaction_change_original_attributes] ||= {}
+          end
+
         attr_names.each do |attr_name|
           attr = @attributes[attr_name]
-          @_deferred_touch_original_attributes[attr_name] ||= attr.with_value_from_database(attr.original_value_for_database)
+          original_attr = attr.with_value_from_database(attr.original_value_for_database)
+          @_deferred_touch_original_attributes[attr_name] ||= original_attr
+          transaction_original_attributes[attr_name] ||= original_attr if transaction_original_attributes
           _write_attribute(attr_name, @_touch_time)
           clear_attribute_change(attr_name)
         end
@@ -95,7 +102,9 @@ module ActiveRecord
         if locking_enabled?
           locking_column = self.class.locking_column
           lock_attr = @attributes[locking_column]
-          @_deferred_touch_original_attributes[locking_column] ||= lock_attr.with_value_from_database(lock_attr.original_value_for_database)
+          original_lock_attr = lock_attr.with_value_from_database(lock_attr.original_value_for_database)
+          @_deferred_touch_original_attributes[locking_column] ||= original_lock_attr
+          transaction_original_attributes[locking_column] ||= original_lock_attr if transaction_original_attributes
         end
       end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   module Transactions
     extend ActiveSupport::Concern
     ACTIONS = [:create, :destroy, :update].freeze # :nodoc:
-    TransactionChangeFrame = Struct.new(:owner_state, :root_state, :attributes, :persisted) # :nodoc:
+    TransactionChangeFrame = Struct.new(:owner_state, :written_attributes) # :nodoc:
 
     included do
       define_callbacks :commit, :rollback,
@@ -392,6 +392,11 @@ module ActiveRecord
       with_transaction_returning_status { super }
     end
 
+    def changes_applied # :nodoc:
+      super
+      refresh_transaction_record_state
+    end
+
     def before_committed! # :nodoc:
       _run_before_commit_callbacks
     end
@@ -420,8 +425,8 @@ module ActiveRecord
       end
     ensure
       @_full_rollback = false
-      transaction_state_count = restore_transaction_record_state(force_restore_state)
-      clear_transaction_record_state(transaction_state_count)
+      restore_transaction_record_state(force_restore_state)
+      clear_transaction_record_state
       @_trigger_update_callback = @_trigger_destroy_callback = false if force_restore_state
     end
 
@@ -442,7 +447,6 @@ module ActiveRecord
             remember_transaction_record_state(connection.current_transaction.state)
 
             status = yield
-            refresh_transaction_record_state if status
             raise ActiveRecord::Rollback unless status
           end
           @_last_transaction_return_status = status
@@ -471,8 +475,6 @@ module ActiveRecord
       def remember_transaction_record_state(owner_state = nil)
         # Zero-argument compatibility remains until bulk persistence callers migrate to the staged session API.
         owner_state ||= self.class.with_connection { |connection| connection.current_transaction.state }
-        # The next rollout stage uses root identity to prevent one bulk session from mixing transactions.
-        root_state = owner_state&.root
 
         @_start_transaction_state ||= {
           id: id,
@@ -485,12 +487,7 @@ module ActiveRecord
           level: 0
         }
         @_start_transaction_state[:level] += 1
-        @_start_transaction_state[:transaction_frames] << TransactionChangeFrame.new(
-          owner_state,
-          root_state,
-          @attributes.deep_dup,
-          false,
-        )
+        @_start_transaction_state[:transaction_frames] << TransactionChangeFrame.new(owner_state)
 
         if _committed_already_called
           @_new_record_before_last_commit = false
@@ -499,14 +496,16 @@ module ActiveRecord
         end
       end
 
-      # After a successful save, update the top transaction frame to capture the actual persisted state.
+      # After a successful save, record only the attributes written by that save.
       def refresh_transaction_record_state
         return unless @_start_transaction_state
         frame = @_start_transaction_state[:transaction_frames]&.last
         return unless frame
 
-        frame.attributes = @attributes.deep_dup
-        frame.persisted = true
+        frame.written_attributes ||= {}
+        mutations_before_last_save.changed_attribute_names.each do |attr_name|
+          frame.written_attributes[attr_name] = @attributes[attr_name].dup
+        end
       end
 
       # Compute cumulative changes by comparing the initial transaction
@@ -540,30 +539,32 @@ module ActiveRecord
         changes
       end
 
+      def _transaction_written_attributes
+        @_start_transaction_state[:transaction_frames].each_with_object({}) do |frame, attributes|
+          next unless transaction_frame_survived?(frame)
+
+          attributes.update(frame.written_attributes) if frame.written_attributes
+        end
+      end
+
       # Cache the transaction diff for +transaction_changes+ / +after_commit+.
-      #
-      # Uses the last persisted transaction frame rather than live +@attributes+ so rolled-back changes are excluded.
       def _compute_committed_changes
         return if @_full_rollback
         return unless @_start_transaction_state
 
-        committed_frame = @_start_transaction_state[:transaction_frames]&.reverse_each&.find(&:persisted)
-        committed = committed_frame&.attributes || @attributes
-        @_committed_changes = _changes_between(@_start_transaction_state[:attributes], committed)
+        snapshot_attributes = @_start_transaction_state[:attributes]
+        @_committed_changes = _changes_between(snapshot_attributes, _transaction_written_attributes)
       end
 
       # Like +_compute_committed_changes+ but computed on-the-fly for
-      # +transaction_changes+ during save callbacks.
-      #
-      # Compares against live +@attributes+ (which is refreshed by
-      # +forget_attribute_assignments+ after each save) and overlays
-      # pending unsaved changes for +before_save+ / +before_update+.
+      # +transaction_changes+ during save callbacks. Pending unsaved changes
+      # are overlaid for +before_save+ / +before_update+.
       def _compute_transaction_changes
         return if @_full_rollback
         return unless @_start_transaction_state
 
         snapshot_attributes = @_start_transaction_state[:attributes]
-        changes = _changes_between(snapshot_attributes, @attributes)
+        changes = _changes_between(snapshot_attributes, _transaction_written_attributes)
 
         changes_to_save.each do |attr_name, (_, pending_new_value)|
           snapshot_attr = snapshot_attributes[attr_name]
@@ -582,18 +583,17 @@ module ActiveRecord
       end
 
       # Clear the new record state and id of a record.
-      def clear_transaction_record_state(transaction_state_count = 1)
+      def clear_transaction_record_state
         return unless @_start_transaction_state
-        @_start_transaction_state[:level] -= transaction_state_count
+        @_start_transaction_state[:level] -= 1
         @_start_transaction_state = nil if @_start_transaction_state[:level] < 1
       end
 
       # Restore the new record state and id of a record that was previously saved by a call to save_record_state.
       def restore_transaction_record_state(force_restore_state = false)
-        return 0 unless restore_state = @_start_transaction_state
+        return unless restore_state = @_start_transaction_state
 
-        frames = restore_state[:transaction_frames]
-        restore_entire_state = force_restore_state || frames.none? { |frame| transaction_frame_survived?(frame) }
+        restore_entire_state = force_restore_state || restore_state[:level] <= 1
 
         if restore_entire_state
           @new_record = restore_state[:new_record]
@@ -629,9 +629,8 @@ module ActiveRecord
             end
           end
           freeze if restore_state[:frozen?]
-          0
         else
-          removed_frames = restore_savepoint_attributes(restore_state)
+          restore_savepoint_attributes(restore_state)
           if self.class.locking_enabled?
             # Nested savepoint rollback. The full restore above only runs at the
             # outermost level, but the same `_update_row` mutation that bumps the
@@ -646,15 +645,11 @@ module ActiveRecord
               @attributes.write_from_database(locking_column, attr.original_value)
             end
           end
-          removed_frames
         end
       end
 
       def restore_savepoint_attributes(restore_state)
-        frames = restore_state[:transaction_frames]
-        original_size = frames.size
-        frames.reject! { |frame| !transaction_frame_survived?(frame) }
-        original_size - frames.size
+        restore_state[:transaction_frames].reject! { |frame| !transaction_frame_survived?(frame) }
       end
 
       def transaction_frame_survived?(frame)

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -395,6 +395,8 @@ module ActiveRecord
     def changes_applied # :nodoc:
       super
       refresh_transaction_record_state
+    ensure
+      clear_transaction_written_attributes
     end
 
     def before_committed! # :nodoc:
@@ -482,6 +484,7 @@ module ActiveRecord
           previously_new_record: @previously_new_record,
           destroyed: @destroyed,
           attributes: @attributes,
+          transaction_change_original_attributes: @_deferred_touch_original_attributes&.dup,
           transaction_frames: [],
           frozen?: frozen?,
           level: 0
@@ -498,14 +501,39 @@ module ActiveRecord
 
       # After a successful save, record only the attributes written by that save.
       def refresh_transaction_record_state
-        return unless @_start_transaction_state
+        snapshot_transaction_written_attributes do |attr_name|
+          @attributes[attr_name].dup
+        end
+      end
+
+      # TouchLater deliberately skips +changes_applied+ so its deferred touch does
+      # not alter the saved-change state. Preserve that behavior while snapshotting
+      # the exact serialized values successfully written by the touch.
+      def refresh_transaction_record_state_without_dirty_tracking
+        snapshot_transaction_written_attributes do |attr_name|
+          @attributes[attr_name].forgetting_assignment
+        end
+      end
+
+      def snapshot_transaction_written_attributes
+        written_attribute_names = @_transaction_written_attribute_names
+        return unless written_attribute_names && @_start_transaction_state
         frame = @_start_transaction_state[:transaction_frames]&.last
         return unless frame
 
         frame.written_attributes ||= {}
-        mutations_before_last_save.changed_attribute_names.each do |attr_name|
-          frame.written_attributes[attr_name] = @attributes[attr_name].dup
+        written_attribute_names.each do |attr_name|
+          frame.written_attributes[attr_name] = yield attr_name
         end
+      end
+
+      def record_transaction_written_attributes(attribute_names)
+        @_transaction_written_attribute_names ||= []
+        @_transaction_written_attribute_names |= attribute_names
+      end
+
+      def clear_transaction_written_attributes
+        @_transaction_written_attribute_names = nil
       end
 
       # Compute cumulative changes by comparing the initial transaction
@@ -518,11 +546,11 @@ module ActiveRecord
       # calls +forget_attribute_assignments+, +@attributes+ is replaced
       # with fresh +FromDatabase+ attributes whose
       # +original_value_for_database+ reflects the newly committed state.
-      def _changes_between(snapshot_attributes, current_attributes)
+      def _changes_between(snapshot_attributes, current_attributes, original_written_attributes = nil)
         changes = {}.with_indifferent_access
 
         current_attributes.keys.each do |attr_name|
-          snapshot_attr = snapshot_attributes[attr_name]
+          snapshot_attr = original_written_attributes&.fetch(attr_name, nil) || snapshot_attributes[attr_name]
           current_attr = current_attributes[attr_name]
 
           old_raw = snapshot_attr.original_value_for_database
@@ -532,7 +560,7 @@ module ActiveRecord
             type = current_attr.type
             old_value = old_raw.nil? ? nil : type.deserialize(old_raw)
             new_value = new_raw.nil? ? nil : type.deserialize(new_raw)
-            changes[attr_name] = [old_value, new_value]
+            changes[attr_name] = [old_value, new_value] unless old_value == new_value
           end
         end
 
@@ -547,13 +575,31 @@ module ActiveRecord
         end
       end
 
-      # Cache the transaction diff for +transaction_changes+ / +after_commit+.
+      def _transaction_original_written_attributes(written_attributes = _transaction_written_attributes)
+        original_attributes = @_start_transaction_state[:transaction_change_original_attributes]
+        original_attributes&.slice(*written_attributes.keys)
+      end
+
+      # Cache raw transaction state for +transaction_changes+ / +after_commit+.
+      # Presentation values are materialized only if a public reader asks.
       def _compute_committed_changes
         return if @_full_rollback
         return unless @_start_transaction_state
 
-        snapshot_attributes = @_start_transaction_state[:attributes]
-        @_committed_changes = _changes_between(snapshot_attributes, _transaction_written_attributes)
+        written_attributes = _transaction_written_attributes
+        @_committed_changes = nil
+        @_committed_transaction_state = [
+          @_start_transaction_state[:attributes],
+          written_attributes,
+          _transaction_original_written_attributes(written_attributes),
+        ]
+      end
+
+      def _committed_transaction_changes
+        return @_committed_changes if @_committed_changes
+        return unless @_committed_transaction_state
+
+        @_committed_changes = _changes_between(*@_committed_transaction_state)
       end
 
       # Like +_compute_committed_changes+ but computed on-the-fly for
@@ -564,10 +610,12 @@ module ActiveRecord
         return unless @_start_transaction_state
 
         snapshot_attributes = @_start_transaction_state[:attributes]
-        changes = _changes_between(snapshot_attributes, _transaction_written_attributes)
+        written_attributes = _transaction_written_attributes
+        original_written_attributes = _transaction_original_written_attributes(written_attributes)
+        changes = _changes_between(snapshot_attributes, written_attributes, original_written_attributes)
 
         changes_to_save.each do |attr_name, (_, pending_new_value)|
-          snapshot_attr = snapshot_attributes[attr_name]
+          snapshot_attr = original_written_attributes&.fetch(attr_name, nil) || snapshot_attributes[attr_name]
           old_raw = snapshot_attr.original_value_for_database
           pending_raw = snapshot_attr.type.serialize(pending_new_value)
 
@@ -620,6 +668,7 @@ module ActiveRecord
           @mutations_from_database = nil
           @mutations_before_last_save = nil
           @_committed_changes = nil
+          @_committed_transaction_state = nil
           @_start_transaction_state = nil
           columns = self.class.primary_key_definition.columns
           restored_id = Array(restore_state[:id])

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -505,7 +505,7 @@ module ActiveRecord
           current_attr = @attributes[attr_name]
 
           old_raw = snapshot_attr.original_value_for_database
-          new_raw = current_attr.value_before_type_cast
+          new_raw = current_attr.original_value_for_database
 
           unless old_raw == new_raw
             old_value = snapshot_attr.original_value

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -513,8 +513,9 @@ module ActiveRecord
           new_raw = current_attr.original_value_for_database
 
           unless old_raw == new_raw
-            old_value = snapshot_attr.original_value
-            new_value = current_attr.type.deserialize(new_raw)
+            type = current_attr.type
+            old_value = old_raw.nil? ? nil : type.deserialize(old_raw)
+            new_value = new_raw.nil? ? nil : type.deserialize(new_raw)
             changes[attr_name] = [old_value, new_value]
           end
         end
@@ -543,7 +544,8 @@ module ActiveRecord
           if old_raw == pending_raw
             changes.delete(attr_name)
           else
-            changes[attr_name] = [snapshot_attr.original_value, pending_new_value]
+            old_value = old_raw.nil? ? nil : snapshot_attr.type.deserialize(old_raw)
+            changes[attr_name] = [old_value, pending_new_value]
           end
         end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -5,6 +5,7 @@ module ActiveRecord
   module Transactions
     extend ActiveSupport::Concern
     ACTIONS = [:create, :destroy, :update].freeze # :nodoc:
+    TransactionChangeFrame = Struct.new(:owner_state, :root_state, :attributes, :persisted) # :nodoc:
 
     included do
       define_callbacks :commit, :rollback,
@@ -419,8 +420,8 @@ module ActiveRecord
       end
     ensure
       @_full_rollback = false
-      restore_transaction_record_state(force_restore_state)
-      clear_transaction_record_state
+      transaction_state_count = restore_transaction_record_state(force_restore_state)
+      clear_transaction_record_state(transaction_state_count)
       @_trigger_update_callback = @_trigger_destroy_callback = false if force_restore_state
     end
 
@@ -438,7 +439,7 @@ module ActiveRecord
 
           implicit_persistence_transaction(connection) do
             add_to_transaction(ensure_finalize || has_transactional_callbacks?)
-            remember_transaction_record_state
+            remember_transaction_record_state(connection.current_transaction.state)
 
             status = yield
             refresh_transaction_record_state if status
@@ -467,19 +468,29 @@ module ActiveRecord
       end
 
       # Save the new record state and id of a record so it can be restored later if a transaction fails.
-      def remember_transaction_record_state
+      def remember_transaction_record_state(owner_state = nil)
+        # Zero-argument compatibility remains until bulk persistence callers migrate to the staged session API.
+        owner_state ||= self.class.with_connection { |connection| connection.current_transaction.state }
+        # The next rollout stage uses root identity to prevent one bulk session from mixing transactions.
+        root_state = owner_state&.root
+
         @_start_transaction_state ||= {
           id: id,
           new_record: @new_record,
           previously_new_record: @previously_new_record,
           destroyed: @destroyed,
           attributes: @attributes,
-          attributes_stack: [],
+          transaction_frames: [],
           frozen?: frozen?,
           level: 0
         }
         @_start_transaction_state[:level] += 1
-        @_start_transaction_state[:attributes_stack] << @attributes.deep_dup
+        @_start_transaction_state[:transaction_frames] << TransactionChangeFrame.new(
+          owner_state,
+          root_state,
+          @attributes.deep_dup,
+          false,
+        )
 
         if _committed_already_called
           @_new_record_before_last_commit = false
@@ -488,14 +499,14 @@ module ActiveRecord
         end
       end
 
-      # After a successful save, update the top of the attributes stack to
-      # capture the actual persisted state (including values set by callbacks
-      # like timestamps). This keeps the stack accurate for computing
-      # transaction_changes without modifying @attributes on rollback.
+      # After a successful save, update the top transaction frame to capture the actual persisted state.
       def refresh_transaction_record_state
         return unless @_start_transaction_state
-        stack = @_start_transaction_state[:attributes_stack]
-        stack[-1] = @attributes.deep_dup if stack && stack.any?
+        frame = @_start_transaction_state[:transaction_frames]&.last
+        return unless frame
+
+        frame.attributes = @attributes.deep_dup
+        frame.persisted = true
       end
 
       # Compute cumulative changes by comparing the initial transaction
@@ -531,15 +542,13 @@ module ActiveRecord
 
       # Cache the transaction diff for +transaction_changes+ / +after_commit+.
       #
-      # Uses the attributes stack (last committed snapshot) rather than
-      # live +@attributes+ so that changes from rolled-back savepoints are
-      # correctly excluded. By commit time +refresh_transaction_record_state+
-      # has already updated the stack with post-save attributes.
+      # Uses the last persisted transaction frame rather than live +@attributes+ so rolled-back changes are excluded.
       def _compute_committed_changes
         return if @_full_rollback
         return unless @_start_transaction_state
 
-        committed = @_start_transaction_state[:attributes_stack]&.last || @attributes
+        committed_frame = @_start_transaction_state[:transaction_frames]&.reverse_each&.find(&:persisted)
+        committed = committed_frame&.attributes || @attributes
         @_committed_changes = _changes_between(@_start_transaction_state[:attributes], committed)
       end
 
@@ -573,72 +582,84 @@ module ActiveRecord
       end
 
       # Clear the new record state and id of a record.
-      def clear_transaction_record_state
+      def clear_transaction_record_state(transaction_state_count = 1)
         return unless @_start_transaction_state
-        @_start_transaction_state[:level] -= 1
+        @_start_transaction_state[:level] -= transaction_state_count
         @_start_transaction_state = nil if @_start_transaction_state[:level] < 1
       end
 
       # Restore the new record state and id of a record that was previously saved by a call to save_record_state.
       def restore_transaction_record_state(force_restore_state = false)
-        if restore_state = @_start_transaction_state
-          if force_restore_state || restore_state[:level] <= 1
-            @new_record = restore_state[:new_record]
-            @previously_new_record = restore_state[:previously_new_record]
-            @destroyed = restore_state[:destroyed]
-            locking_column = self.class.locking_column if self.class.locking_enabled?
-            @attributes = restore_state[:attributes].map do |attr|
-              if attr.name == locking_column
-                # The locking column is bumped by `_update_row` itself, not the caller, and
-                # `_update_row` writes the new value into the same `@attributes` object that
-                # the snapshot is holding a reference to (because the snapshot wraps the
-                # `AttributeSet` rather than deep-duping it). After a successful save,
-                # `forget_attribute_assignments` reassigns `@attributes`, so subsequent
-                # operations see a clean attribute, but the snapshot retains the dirty one.
-                # Forcibly rebuild the locking column attribute from its (still-correct)
-                # original value so the next save uses the pristine value in the WHERE
-                # clause and doesn't raise `StaleObjectError` after a rollback.
-                next attr.with_value_from_database(attr.original_value)
-              end
-              value = @attributes.fetch_value(attr.name)
-              attr = attr.with_value_from_user(value) if attr.value != value
-              attr
+        return 0 unless restore_state = @_start_transaction_state
+
+        frames = restore_state[:transaction_frames]
+        restore_entire_state = force_restore_state || frames.none? { |frame| transaction_frame_survived?(frame) }
+
+        if restore_entire_state
+          @new_record = restore_state[:new_record]
+          @previously_new_record = restore_state[:previously_new_record]
+          @destroyed = restore_state[:destroyed]
+          locking_column = self.class.locking_column if self.class.locking_enabled?
+          @attributes = restore_state[:attributes].map do |attr|
+            if attr.name == locking_column
+              # The locking column is bumped by `_update_row` itself, not the caller, and
+              # `_update_row` writes the new value into the same `@attributes` object that
+              # the snapshot is holding a reference to (because the snapshot wraps the
+              # `AttributeSet` rather than deep-duping it). After a successful save,
+              # `forget_attribute_assignments` reassigns `@attributes`, so subsequent
+              # operations see a clean attribute, but the snapshot retains the dirty one.
+              # Forcibly rebuild the locking column attribute from its (still-correct)
+              # original value so the next save uses the pristine value in the WHERE
+              # clause and doesn't raise `StaleObjectError` after a rollback.
+              next attr.with_value_from_database(attr.original_value)
             end
-            @mutations_from_database = nil
-            @mutations_before_last_save = nil
-            @_committed_changes = nil
-            @_start_transaction_state = nil
-            columns = self.class.primary_key_definition.columns
-            restored_id = Array(restore_state[:id])
-            if columns.map { |col| @attributes.fetch_value(col) } != restored_id
-              columns.zip(restored_id).each do |col, val|
-                @attributes.write_from_user(col, val)
-              end
-            end
-            freeze if restore_state[:frozen?]
-          else
-            restore_savepoint_attributes(restore_state)
-            if self.class.locking_enabled?
-              # Nested savepoint rollback. The full restore above only runs at the
-              # outermost level, but the same `_update_row` mutation that bumps the
-              # in-memory locking column happens for saves performed inside the
-              # savepoint too. Leaving the bumped value in memory after the
-              # savepoint reverts those rows raises `StaleObjectError` on the next
-              # save in the surrounding transaction. Reset just the locking column
-              # so subsequent saves can match the row that the savepoint restored.
-              locking_column = self.class.locking_column
-              attr = restore_state[:attributes][locking_column]
-              if attr
-                @attributes.write_from_database(locking_column, attr.original_value)
-              end
+            value = @attributes.fetch_value(attr.name)
+            attr = attr.with_value_from_user(value) if attr.value != value
+            attr
+          end
+          @mutations_from_database = nil
+          @mutations_before_last_save = nil
+          @_committed_changes = nil
+          @_start_transaction_state = nil
+          columns = self.class.primary_key_definition.columns
+          restored_id = Array(restore_state[:id])
+          if columns.map { |col| @attributes.fetch_value(col) } != restored_id
+            columns.zip(restored_id).each do |col, val|
+              @attributes.write_from_user(col, val)
             end
           end
+          freeze if restore_state[:frozen?]
+          0
+        else
+          removed_frames = restore_savepoint_attributes(restore_state)
+          if self.class.locking_enabled?
+            # Nested savepoint rollback. The full restore above only runs at the
+            # outermost level, but the same `_update_row` mutation that bumps the
+            # in-memory locking column happens for saves performed inside the
+            # savepoint too. Leaving the bumped value in memory after the
+            # savepoint reverts those rows raises `StaleObjectError` on the next
+            # save in the surrounding transaction. Reset just the locking column
+            # so subsequent saves can match the row that the savepoint restored.
+            locking_column = self.class.locking_column
+            attr = restore_state[:attributes][locking_column]
+            if attr
+              @attributes.write_from_database(locking_column, attr.original_value)
+            end
+          end
+          removed_frames
         end
       end
 
       def restore_savepoint_attributes(restore_state)
-        stack = restore_state[:attributes_stack]
-        stack.pop if stack && stack.size > 0
+        frames = restore_state[:transaction_frames]
+        original_size = frames.size
+        frames.reject! { |frame| !transaction_frame_survived?(frame) }
+        original_size - frames.size
+      end
+
+      def transaction_frame_survived?(frame)
+        state = frame.owner_state
+        !state || !(state.rolledback? || state.invalidated?)
       end
 
       # Determine if a transaction included an action for :create, :update, or :destroy. Used in filtering callbacks.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -400,6 +400,7 @@ module ActiveRecord
     # Ensure that it is not called if the object was never persisted (failed create),
     # but call it after the commit of a destroyed object.
     def committed!(should_run_callbacks: true) # :nodoc:
+      _compute_committed_changes
       @_start_transaction_state = nil
       if should_run_callbacks
         @_committed_already_called = true
@@ -482,6 +483,40 @@ module ActiveRecord
         end
       end
 
+      # Compute the cumulative changes across the entire transaction by comparing
+      # the attributes snapshot from the start of the transaction against the
+      # current attributes. This is used to populate +committed_changes+ for
+      # +after_commit+ callbacks.
+      #
+      # We intentionally avoid calling +value+ / +fetch_value+ on current
+      # attributes because that triggers +has_been_read?+, which in turn
+      # causes +changed_in_place?+ to return true for types where the raw
+      # database representation differs from the deserialized Ruby object
+      # (e.g. datetime columns). Instead we compare at the serialized
+      # (database) level and deserialize through the type directly.
+      def _compute_committed_changes
+        return unless @_start_transaction_state
+
+        snapshot_attributes = @_start_transaction_state[:attributes]
+        changes = {}.with_indifferent_access
+
+        @attributes.keys.each do |attr_name|
+          snapshot_attr = snapshot_attributes[attr_name]
+          current_attr = @attributes[attr_name]
+
+          old_raw = snapshot_attr.original_value_for_database
+          new_raw = current_attr.value_before_type_cast
+
+          unless old_raw == new_raw
+            old_value = snapshot_attr.original_value
+            new_value = current_attr.type.deserialize(new_raw)
+            changes[attr_name] = [old_value, new_value]
+          end
+        end
+
+        @_committed_changes = changes
+      end
+
       # Clear the new record state and id of a record.
       def clear_transaction_record_state
         return unless @_start_transaction_state
@@ -516,6 +551,7 @@ module ActiveRecord
             end
             @mutations_from_database = nil
             @mutations_before_last_save = nil
+            @_committed_changes = nil
             columns = self.class.primary_key_definition.columns
             restored_id = Array(restore_state[:id])
             if columns.map { |col| @attributes.fetch_value(col) } != restored_id

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -441,6 +441,7 @@ module ActiveRecord
             remember_transaction_record_state
 
             status = yield
+            refresh_transaction_record_state if status
             raise ActiveRecord::Rollback unless status
           end
           @_last_transaction_return_status = status
@@ -478,7 +479,7 @@ module ActiveRecord
           level: 0
         }
         @_start_transaction_state[:level] += 1
-        @_start_transaction_state[:attributes_stack] << @attributes
+        @_start_transaction_state[:attributes_stack] << @attributes.deep_dup
 
         if _committed_already_called
           @_new_record_before_last_commit = false
@@ -487,27 +488,32 @@ module ActiveRecord
         end
       end
 
-      # Compute the cumulative changes across the entire transaction by comparing
-      # the attributes snapshot from the start of the transaction against the
-      # current attributes. This is used to populate +transaction_changes+ for
-      # +after_commit+ callbacks.
-      #
-      # We intentionally avoid calling +value+ / +fetch_value+ on current
-      # attributes because that triggers +has_been_read?+, which in turn
-      # causes +changed_in_place?+ to return true for types where the raw
-      # database representation differs from the deserialized Ruby object
-      # (e.g. datetime columns). Instead we compare at the serialized
-      # (database) level and deserialize through the type directly.
-      def _changes_since_transaction_start
-        return if @_full_rollback
+      # After a successful save, update the top of the attributes stack to
+      # capture the actual persisted state (including values set by callbacks
+      # like timestamps). This keeps the stack accurate for computing
+      # transaction_changes without modifying @attributes on rollback.
+      def refresh_transaction_record_state
         return unless @_start_transaction_state
+        stack = @_start_transaction_state[:attributes_stack]
+        stack[-1] = @attributes.deep_dup if stack && stack.any?
+      end
 
-        snapshot_attributes = @_start_transaction_state[:attributes]
+      # Compute cumulative changes by comparing the initial transaction
+      # snapshot against a set of "current" attributes.
+      #
+      # We intentionally use +original_value_for_database+ on both sides
+      # rather than +value+ / +value_for_database+ because the latter
+      # triggers +has_been_read?+ and a deserialize round-trip that
+      # corrupts nil values for custom types. After +changes_applied+
+      # calls +forget_attribute_assignments+, +@attributes+ is replaced
+      # with fresh +FromDatabase+ attributes whose
+      # +original_value_for_database+ reflects the newly committed state.
+      def _changes_between(snapshot_attributes, current_attributes)
         changes = {}.with_indifferent_access
 
-        @attributes.keys.each do |attr_name|
+        current_attributes.keys.each do |attr_name|
           snapshot_attr = snapshot_attributes[attr_name]
-          current_attr = @attributes[attr_name]
+          current_attr = current_attributes[attr_name]
 
           old_raw = snapshot_attr.original_value_for_database
           new_raw = current_attr.original_value_for_database
@@ -524,17 +530,31 @@ module ActiveRecord
       end
 
       # Cache the transaction diff for +transaction_changes+ / +after_commit+.
+      #
+      # Uses the attributes stack (last committed snapshot) rather than
+      # live +@attributes+ so that changes from rolled-back savepoints are
+      # correctly excluded. By commit time +refresh_transaction_record_state+
+      # has already updated the stack with post-save attributes.
       def _compute_committed_changes
-        @_committed_changes = _changes_since_transaction_start
+        return if @_full_rollback
+        return unless @_start_transaction_state
+
+        committed = @_start_transaction_state[:attributes_stack]&.last || @attributes
+        @_committed_changes = _changes_between(@_start_transaction_state[:attributes], committed)
       end
 
-      # Like +_compute_committed_changes+ but computed on-the-fly and
-      # overlays pending unsaved changes for +before_save+ / +before_update+.
+      # Like +_compute_committed_changes+ but computed on-the-fly for
+      # +transaction_changes+ during save callbacks.
+      #
+      # Compares against live +@attributes+ (which is refreshed by
+      # +forget_attribute_assignments+ after each save) and overlays
+      # pending unsaved changes for +before_save+ / +before_update+.
       def _compute_transaction_changes
-        changes = _changes_since_transaction_start
-        return unless changes
+        return if @_full_rollback
+        return unless @_start_transaction_state
 
         snapshot_attributes = @_start_transaction_state[:attributes]
+        changes = _changes_between(snapshot_attributes, @attributes)
 
         changes_to_save.each do |attr_name, (_, pending_new_value)|
           snapshot_attr = snapshot_attributes[attr_name]
@@ -618,10 +638,7 @@ module ActiveRecord
 
       def restore_savepoint_attributes(restore_state)
         stack = restore_state[:attributes_stack]
-        return unless stack && stack.size > 1
-
-        stack.pop
-        @attributes = stack.last
+        stack.pop if stack && stack.size > 0
       end
 
       # Determine if a transaction included an action for :create, :update, or :destroy. Used in filtering callbacks.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -413,10 +413,12 @@ module ActiveRecord
     # Call the #after_rollback callbacks. The +force_restore_state+ argument indicates if the record
     # state should be rolled back to the beginning or just to the last savepoint.
     def rolledback!(force_restore_state: false, should_run_callbacks: true) # :nodoc:
+      @_full_rollback = force_restore_state
       if should_run_callbacks
         _run_rollback_callbacks
       end
     ensure
+      @_full_rollback = false
       restore_transaction_record_state(force_restore_state)
       clear_transaction_record_state
       @_trigger_update_callback = @_trigger_destroy_callback = false if force_restore_state
@@ -471,10 +473,12 @@ module ActiveRecord
           previously_new_record: @previously_new_record,
           destroyed: @destroyed,
           attributes: @attributes,
+          attributes_stack: [],
           frozen?: frozen?,
           level: 0
         }
         @_start_transaction_state[:level] += 1
+        @_start_transaction_state[:attributes_stack] << @attributes
 
         if _committed_already_called
           @_new_record_before_last_commit = false
@@ -485,7 +489,7 @@ module ActiveRecord
 
       # Compute the cumulative changes across the entire transaction by comparing
       # the attributes snapshot from the start of the transaction against the
-      # current attributes. This is used to populate +committed_changes+ for
+      # current attributes. This is used to populate +transaction_changes+ for
       # +after_commit+ callbacks.
       #
       # We intentionally avoid calling +value+ / +fetch_value+ on current
@@ -494,7 +498,8 @@ module ActiveRecord
       # database representation differs from the deserialized Ruby object
       # (e.g. datetime columns). Instead we compare at the serialized
       # (database) level and deserialize through the type directly.
-      def _compute_committed_changes
+      def _changes_since_transaction_start
+        return if @_full_rollback
         return unless @_start_transaction_state
 
         snapshot_attributes = @_start_transaction_state[:attributes]
@@ -514,7 +519,35 @@ module ActiveRecord
           end
         end
 
-        @_committed_changes = changes
+        changes
+      end
+
+      # Cache the transaction diff for +transaction_changes+ / +after_commit+.
+      def _compute_committed_changes
+        @_committed_changes = _changes_since_transaction_start
+      end
+
+      # Like +_compute_committed_changes+ but computed on-the-fly and
+      # overlays pending unsaved changes for +before_save+ / +before_update+.
+      def _compute_transaction_changes
+        changes = _changes_since_transaction_start
+        return unless changes
+
+        snapshot_attributes = @_start_transaction_state[:attributes]
+
+        changes_to_save.each do |attr_name, (_, pending_new_value)|
+          snapshot_attr = snapshot_attributes[attr_name]
+          old_raw = snapshot_attr.original_value_for_database
+          pending_raw = snapshot_attr.type.serialize(pending_new_value)
+
+          if old_raw == pending_raw
+            changes.delete(attr_name)
+          else
+            changes[attr_name] = [snapshot_attr.original_value, pending_new_value]
+          end
+        end
+
+        changes
       end
 
       # Clear the new record state and id of a record.
@@ -552,6 +585,7 @@ module ActiveRecord
             @mutations_from_database = nil
             @mutations_before_last_save = nil
             @_committed_changes = nil
+            @_start_transaction_state = nil
             columns = self.class.primary_key_definition.columns
             restored_id = Array(restore_state[:id])
             if columns.map { |col| @attributes.fetch_value(col) } != restored_id
@@ -560,21 +594,32 @@ module ActiveRecord
               end
             end
             freeze if restore_state[:frozen?]
-          elsif self.class.locking_enabled?
-            # Nested savepoint rollback. The full restore above only runs at the
-            # outermost level, but the same `_update_row` mutation that bumps the
-            # in-memory locking column happens for saves performed inside the
-            # savepoint too. Leaving the bumped value in memory after the
-            # savepoint reverts those rows raises `StaleObjectError` on the next
-            # save in the surrounding transaction. Reset just the locking column
-            # so subsequent saves can match the row that the savepoint restored.
-            locking_column = self.class.locking_column
-            attr = restore_state[:attributes][locking_column]
-            if attr
-              @attributes.write_from_database(locking_column, attr.original_value)
+          else
+            restore_savepoint_attributes(restore_state)
+            if self.class.locking_enabled?
+              # Nested savepoint rollback. The full restore above only runs at the
+              # outermost level, but the same `_update_row` mutation that bumps the
+              # in-memory locking column happens for saves performed inside the
+              # savepoint too. Leaving the bumped value in memory after the
+              # savepoint reverts those rows raises `StaleObjectError` on the next
+              # save in the surrounding transaction. Reset just the locking column
+              # so subsequent saves can match the row that the savepoint restored.
+              locking_column = self.class.locking_column
+              attr = restore_state[:attributes][locking_column]
+              if attr
+                @attributes.write_from_database(locking_column, attr.original_value)
+              end
             end
           end
         end
+      end
+
+      def restore_savepoint_attributes(restore_state)
+        stack = restore_state[:attributes_stack]
+        return unless stack && stack.size > 1
+
+        stack.pop
+        @attributes = stack.last
       end
 
       # Determine if a transaction included an action for :create, :update, or :destroy. Used in filtering callbacks.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -376,6 +376,12 @@ module ActiveRecord
       self.class.transaction(**options, &block)
     end
 
+    def initialize_dup(other) # :nodoc:
+      @_transaction_changes_save_attempts = nil
+      @_transaction_changes_touch_finalization_depth = nil
+      super
+    end
+
     def destroy # :nodoc:
       with_transaction_returning_status { super }
     end
@@ -395,6 +401,11 @@ module ActiveRecord
     def changes_applied # :nodoc:
       super
       refresh_transaction_record_state
+
+      unless @_transaction_changes_touch_finalization_depth
+        save_attempt = @_transaction_changes_save_attempts&.last
+        save_attempt[:persistence_finalized] = true if save_attempt
+      end
     ensure
       clear_transaction_written_attributes
     end
@@ -471,6 +482,8 @@ module ActiveRecord
         @_last_transaction_return_status = nil
         @_committed_already_called = nil
         @_new_record_before_last_commit = nil
+        @_transaction_changes_save_attempts = nil
+        @_transaction_changes_touch_finalization_depth = nil
       end
 
       # Save the new record state and id of a record so it can be restored later if a transaction fails.
@@ -614,16 +627,19 @@ module ActiveRecord
         original_written_attributes = _transaction_original_written_attributes(written_attributes)
         changes = _changes_between(snapshot_attributes, written_attributes, original_written_attributes)
 
-        changes_to_save.each do |attr_name, (_, pending_new_value)|
-          snapshot_attr = original_written_attributes&.fetch(attr_name, nil) || snapshot_attributes[attr_name]
-          old_raw = snapshot_attr.original_value_for_database
-          pending_raw = snapshot_attr.type.serialize(pending_new_value)
+        save_attempt = @_transaction_changes_save_attempts&.last
+        if save_attempt && !save_attempt[:persistence_finalized]
+          changes_to_save.each do |attr_name, (_, pending_new_value)|
+            snapshot_attr = original_written_attributes&.fetch(attr_name, nil) || snapshot_attributes[attr_name]
+            old_raw = snapshot_attr.original_value_for_database
+            pending_raw = snapshot_attr.type.serialize(pending_new_value)
 
-          if old_raw == pending_raw
-            changes.delete(attr_name)
-          else
-            old_value = old_raw.nil? ? nil : snapshot_attr.type.deserialize(old_raw)
-            changes[attr_name] = [old_value, pending_new_value]
+            if old_raw == pending_raw
+              changes.delete(attr_name)
+            else
+              old_value = old_raw.nil? ? nil : snapshot_attr.type.deserialize(old_raw)
+              changes[attr_name] = [old_value, pending_new_value]
+            end
           end
         end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -999,6 +999,119 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal [1050, 1400], record_with_defaults.previous_changes[:virtual_stored_number]
   end if current_adapter?(:PostgreSQLAdapter) && supports_virtual_columns?
 
+  test "committed_change_to_attribute? returns whether a change occurred in the last transaction" do
+    person = Person.create!(first_name: "Sean")
+
+    assert_predicate person, :committed_change_to_first_name?
+    assert_not_predicate person, :committed_change_to_gender?
+    assert person.committed_change_to_first_name?(from: nil, to: "Sean")
+    assert person.committed_change_to_first_name?(from: nil)
+    assert person.committed_change_to_first_name?(to: "Sean")
+    assert_not person.committed_change_to_first_name?(from: "Jim", to: "Sean")
+    assert_not person.committed_change_to_first_name?(from: "Jim")
+    assert_not person.committed_change_to_first_name?(to: "Jim")
+  end
+
+  test "committed_change_to_attribute returns the change that occurred in the last transaction" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    assert_equal [nil, "Sean"], person.committed_change_to_first_name
+    assert_equal [nil, "M"], person.committed_change_to_gender
+
+    person.update(first_name: "Jim")
+
+    assert_equal ["Sean", "Jim"], person.committed_change_to_first_name
+    assert_nil person.committed_change_to_gender
+  end
+
+  test "attribute_before_last_commit returns the original value before the transaction" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    assert_nil person.first_name_before_last_commit
+    assert_nil person.gender_before_last_commit
+
+    person.update(first_name: "Jim")
+
+    assert_equal "Sean", person.first_name_before_last_commit
+    assert_equal "M", person.gender_before_last_commit
+  end
+
+  test "committed_changes? returns whether the last transaction changed anything" do
+    person = Person.create!(first_name: "Sean")
+
+    assert_predicate person, :committed_changes?
+
+    person.save
+
+    assert_not_predicate person, :committed_changes?
+  end
+
+  test "committed_changes returns a hash of all the changes that occurred in the transaction" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    assert_equal [nil, "Sean"], person.committed_changes[:first_name]
+    assert_equal [nil, "M"], person.committed_changes[:gender]
+    assert_equal %w(id first_name gender created_at updated_at).sort, person.committed_changes.keys.sort
+
+    travel(1.second) do
+      person.update(first_name: "Jim")
+    end
+
+    assert_equal ["Sean", "Jim"], person.committed_changes[:first_name]
+    assert_equal %w(first_name lock_version updated_at).sort, person.committed_changes.keys.sort
+  end
+
+  test "committed_changes tracks cumulative changes across multiple saves in a transaction" do
+    person = Person.create!(first_name: "Sean")
+
+    Person.transaction do
+      person.update!(first_name: "Intermediate")
+      person.update!(first_name: "Jim")
+    end
+
+    # committed_changes spans the full transaction: Sean -> Jim
+    assert_equal ["Sean", "Jim"], person.committed_change_to_first_name
+    assert person.committed_change_to_first_name?(from: "Sean", to: "Jim")
+  end
+
+  test "committed_changes is empty when attribute is changed back to original value" do
+    person = Person.create!(first_name: "Sean")
+
+    Person.transaction do
+      person.update!(first_name: "Jim")
+      person.update!(first_name: "Sean")
+    end
+
+    assert_not person.committed_change_to_first_name?
+    assert_nil person.committed_change_to_first_name
+  end
+
+  test "committed_changes detects change when a later save modifies a different attribute in the same transaction" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    Person.transaction do
+      person.update!(first_name: "Jim")
+      person.update!(gender: "F")
+    end
+
+    # committed_changes sees both attributes changed
+    assert person.committed_change_to_first_name?
+    assert person.committed_change_to_gender?
+    assert_equal ["Sean", "Jim"], person.committed_change_to_first_name
+    assert_equal ["M", "F"], person.committed_change_to_gender
+  end
+
+  test "committed_changes is cleared on reload" do
+    person = Person.create!(first_name: "Sean")
+
+    assert_predicate person, :committed_changes?
+
+    person.reload
+
+    assert_not_predicate person, :committed_changes?
+    assert_empty person.committed_changes
+  end
+
   private
     def with_partial_writes(klass, on = true)
       old_inserts = klass.partial_inserts?

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -1028,7 +1028,29 @@ class TransactionChangesDirtyTest < ActiveRecord::TestCase
   # that assume each save/transaction block is independent.
   self.use_transactional_tests = false
 
+  class ShardedBase < ActiveRecord::Base
+    self.abstract_class = true
+  end
+
+  class ShardedPerson < ShardedBase
+    self.table_name = :transaction_change_people
+
+    attr_accessor :transaction_changes_log
+
+    after_commit do
+      self.transaction_changes_log = transaction_changes.dup
+    end
+  end
+
   setup do
+    # Re-establish shard connections in setup because the shared connection
+    # pool setup performed by other test cases in a full suite run overwrites
+    # connections established at file load time. See shard_keys_test.rb.
+    ShardedBase.connects_to shards: {
+      default: { writing: :arunit },
+      secondary: { writing: :arunit2 },
+    }
+
     Person.delete_all
     Parrot.delete_all
     Topic.delete_all
@@ -1113,6 +1135,533 @@ class TransactionChangesDirtyTest < ActiveRecord::TestCase
 
     assert_equal ["Sean", "Jim"], person.transaction_changes[:first_name]
     assert_equal %w(first_name lock_version updated_at).sort, person.transaction_changes.keys.sort
+  end
+
+  test "partial updates do not change the net transaction diff" do
+    transaction_changes = [true, false].map do |partial_updates|
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        self.partial_updates = partial_updates
+        self.record_timestamps = false
+      end
+
+      topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today).reload
+      topic.update!(title: "Updated")
+      topic.transaction_changes
+    end
+
+    expected = { "title" => ["Original", "Updated"] }.with_indifferent_access
+    assert_equal expected, transaction_changes.first
+    assert_equal transaction_changes.first, transaction_changes.last
+  end
+
+  test "pending readonly and virtual attributes are excluded after a successful save" do
+    transaction_changes_before_save = nil
+    previous_raise_on_readonly = ActiveRecord.raise_on_assign_to_attr_readonly
+    begin
+      ActiveRecord.raise_on_assign_to_attr_readonly = false
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        attribute :virtual_candidate, :string
+        attr_readonly :author_name
+
+        before_save do
+          transaction_changes_before_save = transaction_changes.dup
+        end
+      end
+    ensure
+      ActiveRecord.raise_on_assign_to_attr_readonly = previous_raise_on_readonly
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today).reload
+    transaction_changes_before_save = nil
+    topic.assign_attributes(title: "Updated", author_name: "Bob", virtual_candidate: "pending")
+    topic.save!
+
+    assert_equal ["Alice", "Bob"], transaction_changes_before_save["author_name"]
+    assert_equal [nil, "pending"], transaction_changes_before_save["virtual_candidate"]
+    assert_equal ["Original", "Updated"], topic.transaction_changes["title"]
+    assert_not topic.transaction_changes.key?("author_name")
+    assert_not topic.transaction_changes.key?("virtual_candidate")
+  end
+
+  test "in-place and forced transaction changes require a different final value" do
+    changed_in_place = Person.create!(first_name: "Sean").reload
+    changed_in_place.first_name << " Jr"
+    changed_in_place.save!
+    assert_equal ["Sean", "Sean Jr"], changed_in_place.transaction_changes["first_name"]
+
+    restored_in_place = Person.create!(first_name: "Sean").reload
+    Person.transaction do
+      restored_in_place.first_name.replace("Jim")
+      restored_in_place.save!
+      restored_in_place.first_name.replace("Sean")
+      restored_in_place.save!
+    end
+    assert_not restored_in_place.transaction_changes.key?("first_name")
+
+    forced_same = Person.create!(first_name: "Sean").reload
+    forced_same.first_name_will_change!
+    forced_same.save!
+    assert_not forced_same.transaction_changes.key?("first_name")
+
+    forced_different = Person.create!(first_name: "Sean").reload
+    forced_different.first_name_will_change!
+    forced_different.first_name = "Jim"
+    forced_different.save!
+    assert_equal ["Sean", "Jim"], forced_different.transaction_changes["first_name"]
+  end
+
+  test "transaction_changes includes touch timestamps and optimistic lock writes" do
+    person = Person.create!(first_name: "Sean").reload
+
+    travel 1.second do
+      person.touch
+    end
+
+    assert_equal [0, 1], person.transaction_changes["lock_version"]
+    assert person.transaction_changes.key?("updated_at")
+  end
+
+  test "transaction_changes includes a deferred touch and optimistic lock write" do
+    klass = deferred_touch_person_class
+    person = klass.create!(first_name: "Sean").reload
+    original_updated_at = person.updated_at
+
+    travel 1.second do
+      klass.transaction do
+        person.touch_later
+      end
+    end
+
+    assert_equal [original_updated_at, person.updated_at], person.transaction_changes_log["updated_at"]
+    assert_equal [0, 1], person.transaction_changes_log["lock_version"]
+    assert_empty person.saved_changes
+    assert_nil person.instance_variable_get(:@_transaction_written_attribute_names)
+    assert_nil person.instance_variable_get(:@_deferred_touch_original_attributes)
+    assert_equal person.transaction_changes_log, person.transaction_changes
+    assert_same person.transaction_changes, person.transaction_changes
+  end
+
+  test "transaction_changes keeps the database original when a deferred touch precedes an update" do
+    klass = deferred_touch_person_class
+    person = klass.create!(first_name: "Sean").reload
+    original_updated_at = person.updated_at
+    deferred_time = (original_updated_at + 1.hour).change(usec: 0)
+
+    travel_to(deferred_time) do
+      klass.transaction do
+        person.touch_later
+        person.update!(first_name: "Jim")
+      end
+    end
+
+    assert_equal ["Jim", deferred_time, 2], klass.where(id: person.id).pick(:first_name, :updated_at, :lock_version)
+    assert_equal ["Sean", "Jim"], person.transaction_changes_log["first_name"]
+    assert_equal [original_updated_at, deferred_time], person.transaction_changes_log["updated_at"]
+    assert_equal [0, 2], person.transaction_changes_log["lock_version"]
+  end
+
+  test "transaction_changes keeps the database original when an immediate touch flushes a deferred touch" do
+    klass = deferred_touch_person_class
+    person = klass.create!(first_name: "Sean").reload
+    original_updated_at = person.updated_at
+    deferred_time = (original_updated_at + 1.hour).change(usec: 0)
+    immediate_time = (original_updated_at + 2.hours).change(usec: 0)
+
+    klass.transaction do
+      travel_to(deferred_time) { person.touch_later }
+      person.touch(time: immediate_time)
+    end
+
+    assert_equal [immediate_time, 1], klass.where(id: person.id).pick(:updated_at, :lock_version)
+    assert_equal [original_updated_at, immediate_time], person.transaction_changes_log["updated_at"]
+    assert_equal [0, 1], person.transaction_changes_log["lock_version"]
+  end
+
+  test "transaction_changes folds repeated deferred touches from the earliest database values" do
+    klass = deferred_touch_person_class
+    person = klass.create!(first_name: "Sean").reload
+    original_created_at = person.created_at
+    original_updated_at = person.updated_at
+    first_time = (original_updated_at + 1.hour).change(usec: 0)
+    last_time = (original_updated_at + 2.hours).change(usec: 0)
+    saved_changes_after_update = nil
+
+    klass.transaction do
+      travel_to(first_time) { person.touch_later }
+      travel_to(last_time) do
+        person.touch_later(:created_at)
+        person.update!(first_name: "Jim")
+        saved_changes_after_update = person.saved_changes.deep_dup
+      end
+    end
+
+    assert_equal ["Jim", last_time, last_time, 2], klass.where(id: person.id).pick(:first_name, :created_at, :updated_at, :lock_version)
+    assert_equal ["Sean", "Jim"], person.transaction_changes_log["first_name"]
+    assert_equal [original_created_at, last_time], person.transaction_changes_log["created_at"]
+    assert_equal [original_updated_at, last_time], person.transaction_changes_log["updated_at"]
+    assert_equal [0, 2], person.transaction_changes_log["lock_version"]
+    assert_equal saved_changes_after_update, person.saved_changes
+  end
+
+  test "an aborted immediate touch after touch_later does not leak its baseline into a later transaction" do
+    klass = deferred_touch_person_class
+    person = klass.create!(first_name: "Sean").reload
+    person.transaction_changes_log = nil
+    original_updated_at = person.updated_at
+    deferred_time = (original_updated_at + 1.hour).change(usec: 0)
+    immediate_time = (original_updated_at + 2.hours).change(usec: 0)
+
+    touch_result = nil
+    row_after_abort = nil
+    state_after_abort = nil
+
+    klass.transaction do
+      travel_to(deferred_time) { person.touch_later }
+      person.abort_touch = true
+      touch_result = person.touch(time: immediate_time)
+      person.abort_touch = false
+      row_after_abort = klass.where(id: person.id).pick(:updated_at, :lock_version)
+      state_after_abort = touch_later_internal_state(person)
+    end
+
+    assert_nil person.transaction_changes_log
+    assert_empty person.transaction_changes
+    assert_equal [original_updated_at, 0], klass.where(id: person.id).pick(:updated_at, :lock_version)
+
+    advanced_time = (original_updated_at + 3.hours).change(usec: 0)
+    final_time = (original_updated_at + 4.hours).change(usec: 0)
+    klass.find(person.id).touch(time: advanced_time)
+
+    person.reload
+    person.touch(time: final_time)
+
+    # The successful touch must report the externally advanced database
+    # values as originals, not the pre-abort baseline (original/0).
+    assert_equal [final_time, 2], klass.where(id: person.id).pick(:updated_at, :lock_version)
+    assert_equal [advanced_time, final_time], person.transaction_changes["updated_at"]
+    assert_equal [1, 2], person.transaction_changes["lock_version"]
+    assert_equal person.transaction_changes, person.transaction_changes_log
+
+    # The halted touch consumed the deferred names without reaching
+    # `_touch_row`, so no SQL ran and no baseline may have survived them.
+    assert_equal false, touch_result
+    assert_equal [original_updated_at, 0], row_after_abort
+    assert_equal({ defer_touch_attrs: nil, deferred_touch_original_attributes: nil, transaction_written_attribute_names: nil }, state_after_abort)
+  end
+
+  test "an aborted immediate touch after touch_later cancels the deferred baseline under nested transactions" do
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      klass = deferred_touch_person_class
+      person = klass.create!(first_name: "Sean").reload
+      person.transaction_changes_log = nil
+      original_updated_at = person.updated_at
+      deferred_time = (original_updated_at + 1.hour).change(usec: 0)
+      immediate_time = (original_updated_at + 2.hours).change(usec: 0)
+      nested_transaction_class = nil
+      live_changes_after_child = nil
+      touch_result = nil
+
+      klass.transaction do
+        klass.create!(first_name: "Dirty parent") if parent_state == :dirty_parent
+
+        klass.transaction(requires_new: true) do
+          nested_transaction_class = klass.lease_connection.current_transaction.class
+          travel_to(deferred_time) { person.touch_later }
+          person.abort_touch = true
+          touch_result = person.touch(time: immediate_time)
+          person.abort_touch = false
+        end
+
+        live_changes_after_child = person.transaction_changes.dup
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_empty live_changes_after_child
+      assert_nil person.transaction_changes_log
+      assert_empty person.transaction_changes
+      assert_equal [original_updated_at, 0], klass.where(id: person.id).pick(:updated_at, :lock_version)
+      assert_nil person.instance_variable_get(:@_start_transaction_state)
+
+      advanced_time = (original_updated_at + 3.hours).change(usec: 0)
+      final_time = (original_updated_at + 4.hours).change(usec: 0)
+      klass.find(person.id).touch(time: advanced_time)
+
+      person.reload
+      person.touch(time: final_time)
+
+      assert_equal [final_time, 2], klass.where(id: person.id).pick(:updated_at, :lock_version)
+      assert_equal [advanced_time, final_time], person.transaction_changes["updated_at"]
+      assert_equal [1, 2], person.transaction_changes["lock_version"]
+      assert_equal person.transaction_changes, person.transaction_changes_log
+      assert_same person.transaction_changes, person.transaction_changes
+      assert_equal false, touch_result
+      assert_equal({ defer_touch_attrs: nil, deferred_touch_original_attributes: nil, transaction_written_attribute_names: nil }, touch_later_internal_state(person))
+    end
+  end
+
+  test "a raised touch callback keeps the deferred names pending and reload discards the stale baseline" do
+    klass = deferred_touch_person_class
+    person = klass.create!(first_name: "Sean").reload
+    original_updated_at = person.updated_at
+    deferred_time = (original_updated_at + 1.hour).change(usec: 0)
+    immediate_time = (original_updated_at + 2.hours).change(usec: 0)
+
+    person.raise_touch = true
+    error = assert_raises(RuntimeError) do
+      klass.transaction do
+        travel_to(deferred_time) { person.touch_later }
+        person.touch(time: immediate_time)
+      end
+    end
+    assert_equal "touch callback failure", error.message
+    person.raise_touch = false
+
+    # A raised (rather than halted) touch keeps the deferred names pending so
+    # the touch can be retried; the baseline stays owned by those names.
+    assert_equal [original_updated_at, 0], klass.where(id: person.id).pick(:updated_at, :lock_version)
+    assert_predicate person.instance_variable_get(:@_defer_touch_attrs), :present?
+    assert_includes person.instance_variable_get(:@_deferred_touch_original_attributes), "updated_at"
+    assert_nil person.instance_variable_get(:@_transaction_written_attribute_names)
+
+    advanced_time = (original_updated_at + 3.hours).change(usec: 0)
+    final_time = (original_updated_at + 4.hours).change(usec: 0)
+    klass.find(person.id).touch(time: advanced_time)
+
+    # Reload replaces the attributes with fresh database state, so the stale
+    # pre-raise baseline must not survive into the next transaction.
+    person.reload
+    baseline_after_reload = person.instance_variable_get(:@_deferred_touch_original_attributes)
+
+    # The explicit transaction commits after the merged deferred names are
+    # consumed, so `before_committed!` does not flush a second touch.
+    klass.transaction { person.touch(time: final_time) }
+
+    # The retried touch must report the externally advanced database values
+    # as originals, not the pre-raise baseline (original/0).
+    assert_equal [final_time, 2], klass.where(id: person.id).pick(:updated_at, :lock_version)
+    assert_equal [advanced_time, final_time], person.transaction_changes["updated_at"]
+    assert_equal [1, 2], person.transaction_changes["lock_version"]
+    assert_nil baseline_after_reload
+    assert_equal({ defer_touch_attrs: nil, deferred_touch_original_attributes: nil, transaction_written_attribute_names: nil }, touch_later_internal_state(person))
+  end
+
+  test "an exception before update names are captured leaves no transient state" do
+    raise_before_update = false
+    extension = Module.new do
+      define_method(:_update_row) do |attribute_names, attempted_action = "update"|
+        raise "before captured #{attempted_action}" if raise_before_update
+        super(attribute_names, attempted_action)
+      end
+    end
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :people
+      self.lock_optimistically = false
+      prepend extension
+    end
+    person = klass.create!(first_name: "Sean").reload
+    original_updated_at = person.updated_at
+
+    raise_before_update = true
+    error = assert_raises(RuntimeError) { person.update!(first_name: "Aborted") }
+    assert_equal "before captured update", error.message
+    assert_nil person.instance_variable_get(:@_transaction_written_attribute_names)
+
+    error = assert_raises(RuntimeError) { travel(1.second) { person.touch } }
+    assert_equal "before captured touch", error.message
+    assert_nil person.instance_variable_get(:@_transaction_written_attribute_names)
+    assert_equal ["Sean", original_updated_at], klass.where(id: person.id).pick(:first_name, :updated_at)
+
+    raise_before_update = false
+    person.update!(first_name: "Recovered")
+
+    assert_equal ["Sean", "Recovered"], person.transaction_changes["first_name"]
+    assert_equal "Recovered", klass.where(id: person.id).pick(:first_name)
+  end
+
+  test "compatible persistence prepends that alter or forward name lists preserve finalized transaction writes" do
+    calls = []
+    extension = Module.new do
+      define_method(:_create_record) do
+        calls << :create
+        super()
+      end
+
+      define_method(:_update_record) do
+        calls << :update
+        super()
+      end
+
+      # Alter the explicit touch name list before forwarding, the way
+      # optimistic locking alters `_update_row`'s list below this seam.
+      define_method(:_touch_row) do |attribute_names, time|
+        calls << :touch
+        super(attribute_names | ["created_at"], time)
+      end
+
+      define_method(:_update_row) do |attribute_names, attempted_action = "update"|
+        if attempted_action == "update"
+          _write_attribute("comments", "extension write")
+          attribute_names |= ["comments"]
+        end
+        super(attribute_names, attempted_action)
+      end
+    end
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :people
+      prepend extension
+    end
+
+    person = klass.create!(first_name: "Sean").reload
+    assert_equal [:create], calls
+    calls.clear
+    original_created_at = person.created_at
+    original_updated_at = person.updated_at
+    touch_time = (original_updated_at + 1.hour).change(usec: 0)
+
+    klass.transaction do
+      person.update!(first_name: "Jim")
+      person.touch(time: touch_time)
+    end
+
+    assert_equal [:update, :touch], calls
+    assert_equal ["Jim", "extension write", touch_time, touch_time, 2],
+      klass.where(id: person.id).pick(:first_name, :comments, :created_at, :updated_at, :lock_version)
+    assert_equal ["Sean", "Jim"], person.transaction_changes["first_name"]
+    assert_equal [nil, "extension write"], person.transaction_changes["comments"]
+    assert_equal [original_created_at, touch_time], person.transaction_changes["created_at"]
+    assert_equal [original_updated_at, touch_time], person.transaction_changes["updated_at"]
+    assert_equal [0, 2], person.transaction_changes["lock_version"]
+    assert_nil person.instance_variable_get(:@_transaction_written_attribute_names)
+  end
+
+  test "transaction changes remain isolated across shards" do
+    ShardedBase.connected_to(shard: :default) do
+      ShardedBase.lease_connection.create_table(:transaction_change_people, force: true) do |t|
+        t.string :first_name
+        t.timestamps
+      end
+    end
+    ShardedBase.connected_to(shard: :secondary) do
+      ShardedBase.lease_connection.create_table(:transaction_change_people, force: true) do |t|
+        t.string :first_name
+        t.timestamps
+      end
+    end
+
+    primary_person = ShardedBase.connected_to(shard: :default) do
+      ShardedPerson.create!(first_name: "Primary").reload
+    end
+    secondary_person = ShardedBase.connected_to(shard: :secondary) do
+      ShardedPerson.create!(first_name: "Secondary").reload
+    end
+
+    ShardedBase.connected_to(shard: :default) do
+      ShardedPerson.transaction do
+        primary_person.update!(first_name: "Primary final")
+        ShardedBase.connected_to(shard: :secondary) do
+          ShardedPerson.transaction do
+            secondary_person.update!(first_name: "Secondary final")
+          end
+        end
+      end
+    end
+
+    assert_equal ["Primary", "Primary final"], primary_person.transaction_changes["first_name"]
+    assert_equal ["Secondary", "Secondary final"], secondary_person.transaction_changes["first_name"]
+    assert_equal ["Primary", "Primary final"], primary_person.transaction_changes_log["first_name"]
+    assert_equal ["Secondary", "Secondary final"], secondary_person.transaction_changes_log["first_name"]
+    assert_not_includes primary_person.transaction_changes.values.flatten, "Secondary final"
+    assert_not_includes secondary_person.transaction_changes.values.flatten, "Primary final"
+
+    ShardedBase.connected_to(shard: :default) do
+      assert_equal "Primary final", ShardedPerson.where(id: primary_person.id).pick(:first_name)
+    end
+    ShardedBase.connected_to(shard: :secondary) do
+      assert_equal "Secondary final", ShardedPerson.where(id: secondary_person.id).pick(:first_name)
+    end
+
+    [primary_person, secondary_person].each do |record|
+      assert_nil record.instance_variable_get(:@_transaction_written_attribute_names)
+      assert_nil record.instance_variable_get(:@_start_transaction_state)
+    end
+  ensure
+    [:default, :secondary].each do |shard|
+      ShardedBase.connected_to(shard: shard) do
+        ShardedBase.lease_connection.drop_table(:transaction_change_people, if_exists: true)
+      end
+    end
+  end
+
+  test "a stale update does not leak captured write names into a later save" do
+    current = Person.create!(first_name: "Sean")
+    stale = Person.find(current.id)
+    current.update!(first_name: "Jim")
+
+    assert_raises(ActiveRecord::StaleObjectError) { stale.update!(gender: "F") }
+    assert_nil stale.instance_variable_get(:@_transaction_written_attribute_names)
+
+    stale.reload
+    stale.update!(comments: "saved")
+
+    assert_equal [nil, "saved"], stale.transaction_changes["comments"]
+    assert_not stale.transaction_changes.key?("gender")
+  end
+
+  test "an exception after update names are captured does not leak them" do
+    raise_after_update = false
+    extension = Module.new do
+      define_method(:_update_row) do |attribute_names, attempted_action = "update"|
+        affected_rows = super(attribute_names, attempted_action)
+        raise "after captured update" if raise_after_update
+        affected_rows
+      end
+    end
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :people
+      self.lock_optimistically = false
+      prepend extension
+    end
+    person = klass.create!(first_name: "Sean").reload
+    raise_after_update = true
+
+    error = assert_raises(RuntimeError) { person.update!(first_name: "Aborted") }
+    assert_equal "after captured update", error.message
+    assert_nil person.instance_variable_get(:@_transaction_written_attribute_names)
+    assert_equal "Sean", klass.where(id: person.id).pick(:first_name)
+
+    raise_after_update = false
+    person.assign_attributes(first_name: "Sean", gender: "M")
+    person.save!
+
+    assert_equal [nil, "M"], person.transaction_changes["gender"]
+    assert_not person.transaction_changes.key?("first_name")
+    assert_equal ["Sean", "M"], klass.where(id: person.id).pick(:first_name, :gender)
+  end
+
+  test "an exception after touch names are captured clears transient state" do
+    raise_after_update = false
+    extension = Module.new do
+      define_method(:_update_row) do |attribute_names, attempted_action = "update"|
+        affected_rows = super(attribute_names, attempted_action)
+        raise "after captured touch" if raise_after_update
+        affected_rows
+      end
+    end
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :people
+      self.lock_optimistically = false
+      prepend extension
+    end
+    person = klass.create!(first_name: "Sean").reload
+    original_updated_at = person.updated_at
+    raise_after_update = true
+
+    error = assert_raises(RuntimeError) { travel(1.second) { person.touch } }
+    assert_equal "after captured touch", error.message
+    assert_nil person.instance_variable_get(:@_transaction_written_attribute_names)
+    assert_equal original_updated_at, klass.where(id: person.id).pick(:updated_at)
   end
 
   test "transaction_changes tracks cumulative changes across multiple saves in a transaction" do
@@ -1230,4 +1779,40 @@ class TransactionChangesDirtyTest < ActiveRecord::TestCase
     # transaction_changes spans the full transaction: Sean -> Final
     assert_equal ["Sean", "Final"], person.transaction_changes[:first_name]
   end
+
+  private
+    # Shared anonymous TouchLater/after_commit model used by the deferred-touch
+    # sequence and the abort/raise record-reuse regressions. The touch toggles
+    # stay inert unless a test sets them.
+    def deferred_touch_person_class
+      Class.new(ActiveRecord::Base) do
+        self.table_name = :people
+
+        attr_accessor :abort_touch, :raise_touch, :transaction_changes_log
+
+        set_callback(:touch, :before) do
+          throw :abort if abort_touch
+          raise "touch callback failure" if raise_touch
+        end
+
+        after_commit do
+          self.transaction_changes_log = transaction_changes.dup
+        end
+      end
+    end
+
+    def nested_transaction_classes
+      {
+        clean_parent: ActiveRecord::ConnectionAdapters::RestartParentTransaction,
+        dirty_parent: ActiveRecord::ConnectionAdapters::SavepointTransaction,
+      }
+    end
+
+    def touch_later_internal_state(record)
+      {
+        defer_touch_attrs: record.instance_variable_get(:@_defer_touch_attrs),
+        deferred_touch_original_attributes: record.instance_variable_get(:@_deferred_touch_original_attributes),
+        transaction_written_attribute_names: record.instance_variable_get(:@_transaction_written_attribute_names),
+      }
+    end
 end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -1012,6 +1012,16 @@ class DirtyTest < ActiveRecord::TestCase
     assert_not person.committed_change_to_first_name?(to: "Jim")
   end
 
+  test "committed_change_to_attribute? properly type casts enum values" do
+    parrot = LiveParrot.create!(name: "Scipio", breed: :african)
+
+    parrot.update!(breed: :australian)
+
+    assert parrot.committed_change_to_breed?(from: "african", to: "australian")
+    assert parrot.committed_change_to_breed?(from: :african, to: :australian)
+    assert parrot.committed_change_to_breed?(from: 0, to: 1)
+  end
+
   test "committed_change_to_attribute returns the change that occurred in the last transaction" do
     person = Person.create!(first_name: "Sean", gender: "M")
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -999,79 +999,88 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal [1050, 1400], record_with_defaults.previous_changes[:virtual_stored_number]
   end if current_adapter?(:PostgreSQLAdapter) && supports_virtual_columns?
 
-  test "committed_change_to_attribute? returns whether a change occurred in the last transaction" do
+  test "transaction_change_to_attribute? returns whether a change occurred in the transaction" do
     person = Person.create!(first_name: "Sean")
 
-    assert_predicate person, :committed_change_to_first_name?
-    assert_not_predicate person, :committed_change_to_gender?
-    assert person.committed_change_to_first_name?(from: nil, to: "Sean")
-    assert person.committed_change_to_first_name?(from: nil)
-    assert person.committed_change_to_first_name?(to: "Sean")
-    assert_not person.committed_change_to_first_name?(from: "Jim", to: "Sean")
-    assert_not person.committed_change_to_first_name?(from: "Jim")
-    assert_not person.committed_change_to_first_name?(to: "Jim")
+    assert_predicate person, :transaction_change_to_first_name?
+    assert_not_predicate person, :transaction_change_to_gender?
+    assert person.transaction_change_to_first_name?(from: nil, to: "Sean")
+    assert person.transaction_change_to_first_name?(from: nil)
+    assert person.transaction_change_to_first_name?(to: "Sean")
+    assert_not person.transaction_change_to_first_name?(from: "Jim", to: "Sean")
+    assert_not person.transaction_change_to_first_name?(from: "Jim")
+    assert_not person.transaction_change_to_first_name?(to: "Jim")
   end
 
-  test "committed_change_to_attribute? properly type casts enum values" do
+  test "transaction_change_to_attribute? properly type casts enum values" do
     parrot = LiveParrot.create!(name: "Scipio", breed: :african)
 
     parrot.update!(breed: :australian)
 
-    assert parrot.committed_change_to_breed?(from: "african", to: "australian")
-    assert parrot.committed_change_to_breed?(from: :african, to: :australian)
-    assert parrot.committed_change_to_breed?(from: 0, to: 1)
+    assert parrot.transaction_change_to_breed?(from: "african", to: "australian")
+    assert parrot.transaction_change_to_breed?(from: :african, to: :australian)
+    assert parrot.transaction_change_to_breed?(from: 0, to: 1)
   end
 
-  test "committed_change_to_attribute returns the change that occurred in the last transaction" do
+  test "transaction_change_to_attribute returns the change that occurred in the transaction" do
     person = Person.create!(first_name: "Sean", gender: "M")
 
-    assert_equal [nil, "Sean"], person.committed_change_to_first_name
-    assert_equal [nil, "M"], person.committed_change_to_gender
+    assert_equal [nil, "Sean"], person.transaction_change_to_first_name
+    assert_equal [nil, "M"], person.transaction_change_to_gender
 
     person.update(first_name: "Jim")
 
-    assert_equal ["Sean", "Jim"], person.committed_change_to_first_name
-    assert_nil person.committed_change_to_gender
+    assert_equal ["Sean", "Jim"], person.transaction_change_to_first_name
+    assert_nil person.transaction_change_to_gender
   end
 
-  test "attribute_before_last_commit returns the original value before the transaction" do
+  test "attribute_before_transaction returns the original value before the transaction" do
     person = Person.create!(first_name: "Sean", gender: "M")
 
-    assert_nil person.first_name_before_last_commit
-    assert_nil person.gender_before_last_commit
+    assert_nil person.first_name_before_transaction
+    assert_nil person.gender_before_transaction
 
     person.update(first_name: "Jim")
 
-    assert_equal "Sean", person.first_name_before_last_commit
-    assert_equal "M", person.gender_before_last_commit
+    assert_equal "Sean", person.first_name_before_transaction
+    assert_equal "M", person.gender_before_transaction
   end
 
-  test "committed_changes? returns whether the last transaction changed anything" do
+  test "attribute_before_transaction returns current value for unchanged attribute" do
+    person = Person.create!(first_name: "Sean", gender: "M")
+
+    person.update!(first_name: "Jim")
+
+    # gender wasn't changed, so before_transaction returns the current value
+    assert_equal "M", person.gender_before_transaction
+  end
+
+  test "transaction_changes? returns whether the transaction changed anything" do
     person = Person.create!(first_name: "Sean")
 
-    assert_predicate person, :committed_changes?
+    assert_predicate person, :transaction_changes?
 
     person.save
 
-    assert_not_predicate person, :committed_changes?
+    assert_not_predicate person, :transaction_changes?
   end
 
-  test "committed_changes returns a hash of all the changes that occurred in the transaction" do
+  test "transaction_changes returns a hash of all the changes that occurred in the transaction" do
     person = Person.create!(first_name: "Sean", gender: "M")
 
-    assert_equal [nil, "Sean"], person.committed_changes[:first_name]
-    assert_equal [nil, "M"], person.committed_changes[:gender]
-    assert_equal %w(id first_name gender created_at updated_at).sort, person.committed_changes.keys.sort
+    assert_equal [nil, "Sean"], person.transaction_changes[:first_name]
+    assert_equal [nil, "M"], person.transaction_changes[:gender]
+    assert_equal %w(id first_name gender created_at updated_at).sort, person.transaction_changes.keys.sort
 
     travel(1.second) do
       person.update(first_name: "Jim")
     end
 
-    assert_equal ["Sean", "Jim"], person.committed_changes[:first_name]
-    assert_equal %w(first_name lock_version updated_at).sort, person.committed_changes.keys.sort
+    assert_equal ["Sean", "Jim"], person.transaction_changes[:first_name]
+    assert_equal %w(first_name lock_version updated_at).sort, person.transaction_changes.keys.sort
   end
 
-  test "committed_changes tracks cumulative changes across multiple saves in a transaction" do
+  test "transaction_changes tracks cumulative changes across multiple saves in a transaction" do
     person = Person.create!(first_name: "Sean")
 
     Person.transaction do
@@ -1079,12 +1088,12 @@ class DirtyTest < ActiveRecord::TestCase
       person.update!(first_name: "Jim")
     end
 
-    # committed_changes spans the full transaction: Sean -> Jim
-    assert_equal ["Sean", "Jim"], person.committed_change_to_first_name
-    assert person.committed_change_to_first_name?(from: "Sean", to: "Jim")
+    # transaction_changes spans the full transaction: Sean -> Jim
+    assert_equal ["Sean", "Jim"], person.transaction_change_to_first_name
+    assert person.transaction_change_to_first_name?(from: "Sean", to: "Jim")
   end
 
-  test "committed_changes is empty when attribute is changed back to original value" do
+  test "transaction_changes is empty when attribute is changed back to original value" do
     person = Person.create!(first_name: "Sean")
 
     Person.transaction do
@@ -1092,11 +1101,11 @@ class DirtyTest < ActiveRecord::TestCase
       person.update!(first_name: "Sean")
     end
 
-    assert_not person.committed_change_to_first_name?
-    assert_nil person.committed_change_to_first_name
+    assert_not person.transaction_change_to_first_name?
+    assert_nil person.transaction_change_to_first_name
   end
 
-  test "committed_changes detects change when a later save modifies a different attribute in the same transaction" do
+  test "transaction_changes detects change when a later save modifies a different attribute in the same transaction" do
     person = Person.create!(first_name: "Sean", gender: "M")
 
     Person.transaction do
@@ -1104,37 +1113,87 @@ class DirtyTest < ActiveRecord::TestCase
       person.update!(gender: "F")
     end
 
-    # committed_changes sees both attributes changed
-    assert person.committed_change_to_first_name?
-    assert person.committed_change_to_gender?
-    assert_equal ["Sean", "Jim"], person.committed_change_to_first_name
-    assert_equal ["M", "F"], person.committed_change_to_gender
+    assert person.transaction_change_to_first_name?
+    assert person.transaction_change_to_gender?
+    assert_equal ["Sean", "Jim"], person.transaction_change_to_first_name
+    assert_equal ["M", "F"], person.transaction_change_to_gender
   end
 
-  test "committed_changes is cleared on reload" do
+  test "transaction_changes is cleared on reload" do
     person = Person.create!(first_name: "Sean")
 
-    assert_predicate person, :committed_changes?
+    assert_predicate person, :transaction_changes?
 
     person.reload
 
-    assert_not_predicate person, :committed_changes?
-    assert_empty person.committed_changes
+    assert_not_predicate person, :transaction_changes?
+    assert_empty person.transaction_changes
+    assert_nil person.first_name_before_transaction
   end
 
-  test "destroy with no prior attribute changes returns empty committed_changes" do
+  test "destroy with no prior attribute changes returns empty transaction_changes" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = :topics
     end
 
     record = klass.create!(title: "To Be Destroyed", written_on: Date.today)
-    record.reload # clear committed_changes from the create
+    record.reload # clear transaction_changes from the create
 
     record.destroy
 
-    assert_empty record.committed_changes,
-      "committed_changes should be empty after destroy with no prior attribute changes"
-    assert_not record.committed_changes?
+    assert_empty record.transaction_changes,
+      "transaction_changes should be empty after destroy with no prior attribute changes"
+    assert_not record.transaction_changes?
+  end
+
+  test "attribute_before_transaction is stable across multiple saves in a transaction" do
+    person = Person.create!(first_name: "Sean")
+
+    Person.transaction do
+      person.update!(first_name: "Intermediate")
+
+      assert_equal "Sean", person.first_name_before_transaction
+
+      person.update!(first_name: "Final")
+
+      assert_equal "Sean", person.first_name_before_transaction
+    end
+
+    assert_equal "Sean", person.first_name_before_transaction
+  end
+
+  test "transaction_changes includes prior attribute changes after destroy in same transaction" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+    end
+
+    record = klass.create!(title: "Original", written_on: Date.today)
+
+    klass.transaction do
+      record.update!(title: "Changed")
+      record.destroy
+    end
+
+    assert_equal ["Original", "Changed"], record.transaction_changes["title"]
+  end
+
+  test "transaction_changes unaffected by failed validation within transaction" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+      validates :first_name, presence: true
+    end
+
+    person = klass.create!(first_name: "Sean")
+
+    klass.transaction do
+      person.update!(first_name: "Jim")
+      person.update(first_name: nil)  # validation fails, returns false
+      person.update!(first_name: "Final")
+    end
+
+    # The failed save should not corrupt transaction_changes;
+    # transaction_changes spans the full transaction: Sean -> Final
+    assert_equal ["Sean", "Final"], person.transaction_changes[:first_name]
   end
 
   private

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -1122,6 +1122,21 @@ class DirtyTest < ActiveRecord::TestCase
     assert_empty person.committed_changes
   end
 
+  test "destroy with no prior attribute changes returns empty committed_changes" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+    end
+
+    record = klass.create!(title: "To Be Destroyed", written_on: Date.today)
+    record.reload # clear committed_changes from the create
+
+    record.destroy
+
+    assert_empty record.committed_changes,
+      "committed_changes should be empty after destroy with no prior attribute changes"
+    assert_not record.committed_changes?
+  end
+
   private
     def with_partial_writes(klass, on = true)
       old_inserts = klass.partial_inserts?

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -999,6 +999,41 @@ class DirtyTest < ActiveRecord::TestCase
     assert_equal [1050, 1400], record_with_defaults.previous_changes[:virtual_stored_number]
   end if current_adapter?(:PostgreSQLAdapter) && supports_virtual_columns?
 
+  private
+    def with_partial_writes(klass, on = true)
+      old_inserts = klass.partial_inserts?
+      old_updates = klass.partial_updates?
+      klass.partial_inserts = on
+      klass.partial_updates = on
+      yield
+    ensure
+      klass.partial_inserts = old_inserts
+      klass.partial_updates = old_updates
+    end
+
+    def check_pirate_after_save_failure(pirate)
+      assert_predicate pirate, :changed?
+      assert_predicate pirate, :parrot_id_changed?
+      assert_equal %w(parrot_id), pirate.changed
+      assert_nil pirate.parrot_id_was
+    end
+end
+
+class TransactionChangesDirtyTest < ActiveRecord::TestCase
+  # These tests require real transaction boundaries so that committed! is
+  # called between independent operations.  Transactional test wrapping
+  # encloses the entire test in a single joinable transaction, which means
+  # committed! is never called and transaction_changes accumulates from the
+  # very first save — correct behaviour, but incompatible with assertions
+  # that assume each save/transaction block is independent.
+  self.use_transactional_tests = false
+
+  setup do
+    Person.delete_all
+    Parrot.delete_all
+    Topic.delete_all
+  end
+
   test "transaction_change_to_attribute? returns whether a change occurred in the transaction" do
     person = Person.create!(first_name: "Sean")
 
@@ -1195,23 +1230,4 @@ class DirtyTest < ActiveRecord::TestCase
     # transaction_changes spans the full transaction: Sean -> Final
     assert_equal ["Sean", "Final"], person.transaction_changes[:first_name]
   end
-
-  private
-    def with_partial_writes(klass, on = true)
-      old_inserts = klass.partial_inserts?
-      old_updates = klass.partial_updates?
-      klass.partial_inserts = on
-      klass.partial_updates = on
-      yield
-    ensure
-      klass.partial_inserts = old_inserts
-      klass.partial_updates = old_updates
-    end
-
-    def check_pirate_after_save_failure(pirate)
-      assert_predicate pirate, :changed?
-      assert_predicate pirate, :parrot_id_changed?
-      assert_equal %w(parrot_id), pirate.changed
-      assert_nil pirate.parrot_id_was
-    end
 end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -1262,6 +1262,25 @@ class TransactionChangesDirtyTest < ActiveRecord::TestCase
     assert_equal [0, 2], person.transaction_changes_log["lock_version"]
   end
 
+  test "transaction_changes keeps transaction-start originals when a deferred touch follows an update" do
+    klass = deferred_touch_person_class
+    person = klass.create!(first_name: "Sean").reload
+    original_updated_at = person.updated_at
+    saved_time = (original_updated_at + 1.hour).change(usec: 0)
+    deferred_time = (original_updated_at + 2.hours).change(usec: 0)
+
+    klass.transaction do
+      travel_to(saved_time) { person.update!(first_name: "Jim") }
+      assert_equal [saved_time, 1], [person.updated_at, person.lock_version]
+      travel_to(deferred_time) { person.touch_later }
+    end
+
+    assert_equal ["Jim", deferred_time, 2], klass.where(id: person.id).pick(:first_name, :updated_at, :lock_version)
+    assert_equal ["Sean", "Jim"], person.transaction_changes_log["first_name"]
+    assert_equal [original_updated_at, deferred_time], person.transaction_changes_log["updated_at"]
+    assert_equal [0, 2], person.transaction_changes_log["lock_version"]
+  end
+
   test "transaction_changes keeps the database original when an immediate touch flushes a deferred touch" do
     klass = deferred_touch_person_class
     person = klass.create!(first_name: "Sean").reload

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1543,4 +1543,35 @@ class TransactionChangesTest < ActiveRecord::TestCase
     assert_equal ["Original Product", "Updated Product"], product_txn_changes["title"],
       "cross-model transaction_changes should reflect the other model's saved changes"
   end
+
+  def test_transaction_changes_does_not_deserialize_nil_database_values
+    sentinel_type = Class.new(ActiveModel::Type::String) do
+      def deserialize(value)
+        value.nil? ? "SENTINEL_NIL_DESERIALIZED" : super
+      end
+    end
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attribute :author_name, sentinel_type.new, default: "default_author"
+
+      attr_accessor :transaction_changes_log
+
+      after_commit do
+        self.transaction_changes_log = transaction_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Hello", written_on: Date.today)
+
+    assert_equal [nil, "default_author"], topic.transaction_changes_log["author_name"],
+      "a nil original database value should not be passed through deserialize"
+
+    topic.reload
+
+    topic.update!(author_name: nil)
+
+    assert_equal ["default_author", nil], topic.transaction_changes_log["author_name"],
+      "a nil new database value should not be passed through deserialize"
+  end
 end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1316,4 +1316,79 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert topic.committed_changes_log.key?("updated_at")
     assert_not topic.committed_changes_log.key?("title")
   end
+
+  def test_committed_changes_when_same_record_updated_in_rolled_back_savepoint
+    topic = TopicWithCommittedChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+    TopicWithCommittedChanges.transaction do
+      topic.update!(title: "Updated")
+      TopicWithCommittedChanges.transaction(requires_new: true) do
+        topic.update!(author_name: "Bob")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    # The outer transaction changed title from "Original" to "Updated".
+    # The savepoint changed author_name but was rolled back.
+    # committed_changes should include the title change from the outer transaction.
+    assert_equal ["Original", "Updated"], topic.committed_title_change_log
+    assert_equal ["Original", "Updated"], topic.committed_changes_log["title"]
+  end
+
+  def test_committed_changes_is_empty_inside_after_rollback_callback
+    committed_changes_in_rollback = nil
+    committed_changes_present_in_rollback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_rollback do
+        committed_changes_in_rollback = committed_changes.dup
+        committed_changes_present_in_rollback = committed_changes?
+      end
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+    topic.reload # Clear committed_changes from the create
+
+    klass.transaction do
+      topic.update!(title: "Should be rolled back")
+      raise ActiveRecord::Rollback
+    end
+
+    assert_empty committed_changes_in_rollback,
+      "committed_changes should be empty inside after_rollback since nothing was committed"
+    assert_not committed_changes_present_in_rollback,
+      "committed_changes? should be false inside after_rollback"
+  end
+
+  def test_committed_change_to_attribute_inside_after_update_commit
+    committed_title_change_in_callback = nil
+    committed_title_detected_in_callback = nil
+    committed_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_update_commit do
+        committed_title_change_in_callback = committed_change_to_title
+        committed_title_detected_in_callback = committed_change_to_title?
+        committed_changes_in_callback = committed_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+
+    klass.transaction do
+      topic.update!(title: "Intermediate")
+      topic.update!(title: "Final")
+    end
+
+    assert committed_title_detected_in_callback,
+      "committed_change_to_title? should be true inside after_update_commit"
+    assert_equal ["Original", "Final"], committed_title_change_in_callback,
+      "committed_change_to_title should span the full transaction inside after_update_commit"
+    assert committed_changes_in_callback.key?("title"),
+      "committed_changes should include title inside after_update_commit"
+  end
 end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1102,6 +1102,17 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     end
   end
 
+  class TopicWithDeferredTouchTransactionChanges < ActiveRecord::Base
+    self.table_name = :topics
+    self.record_timestamps = false
+
+    attr_accessor :transaction_changes_log
+
+    after_commit do
+      self.transaction_changes_log = transaction_changes.dup
+    end
+  end
+
   def test_transaction_changes_tracks_full_transaction_with_multiple_saves
     topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
 
@@ -1367,39 +1378,226 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert_nil topic.transaction_changes_log["author_name"]
   end
 
-  def test_transaction_changes_preserves_committed_savepoint_before_rolled_back_sibling
-    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
-
-    TopicWithTransactionChanges.transaction do
-      topic.update!(title: "Outer")
-
-      TopicWithTransactionChanges.transaction(requires_new: true) do
-        topic.update!(author_name: "Committed child")
-      end
-
-      TopicWithTransactionChanges.transaction(requires_new: true) do
-        topic.update!(author_name: "Rolled back once")
-        topic.update!(author_name: "Rolled back twice")
-        raise ActiveRecord::Rollback
-      end
-    end
-
-    assert_equal "Committed child", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
-    assert_equal ["Alice", "Committed child"], topic.transaction_changes_log["author_name"]
-  end
-
-  def test_rolled_back_first_save_is_not_rewritten_by_later_outer_update
-    nested_transaction_classes = {
-      clean_parent: ActiveRecord::ConnectionAdapters::RestartParentTransaction,
-      dirty_parent: ActiveRecord::ConnectionAdapters::SavepointTransaction,
-    }
-
+  def test_transaction_changes_preserves_committed_child_before_rolled_back_sibling
     nested_transaction_classes.each do |parent_state, expected_transaction_class|
       topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
       nested_transaction_class = nil
 
       TopicWithTransactionChanges.transaction do
-        TopicWithTransactionChanges.create!(title: "Dirty parent", written_on: Date.today) if parent_state == :dirty_parent
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithTransactionChanges.lease_connection.current_transaction.class
+          topic.update!(author_name: "Committed child")
+        end
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          topic.update!(author_name: "Rolled back sibling")
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal "Committed child", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
+      assert_equal ["Alice", "Committed child"], topic.transaction_changes_log["author_name"]
+    end
+  end
+
+  def test_transaction_changes_discards_committed_child_when_parent_rolls_back
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today).reload
+      nested_transaction_class = nil
+
+      TopicWithTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithTransactionChanges.lease_connection.current_transaction.class
+          topic.update!(author_name: "Committed child")
+        end
+
+        raise ActiveRecord::Rollback
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal "Alice", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
+      assert_empty topic.transaction_changes
+    end
+  end
+
+  def test_deferred_touch_changes_are_discarded_with_a_rolled_back_child
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      original_time = Time.utc(2020, 1, 1)
+      deferred_time = original_time + 1.hour
+      immediate_time = original_time + 2.hours
+      topic = TopicWithDeferredTouchTransactionChanges.create!(
+        title: "Original", author_name: "Alice", created_at: original_time, updated_at: original_time
+      ).reload
+      topic.transaction_changes_log = nil
+      nested_transaction_class = nil
+      live_changes_in_child = nil
+      live_changes_after_rollback = nil
+
+      TopicWithDeferredTouchTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithDeferredTouchTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithDeferredTouchTransactionChanges.lease_connection.current_transaction.class
+          travel_to(deferred_time) { topic.touch_later }
+          topic.touch(time: immediate_time)
+          live_changes_in_child = topic.transaction_changes.dup
+          raise ActiveRecord::Rollback
+        end
+
+        live_changes_after_rollback = topic.transaction_changes.dup
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal [original_time, immediate_time], live_changes_in_child["updated_at"]
+      assert_not live_changes_after_rollback.key?("updated_at")
+      assert_equal ["Original", "Alice", original_time], TopicWithDeferredTouchTransactionChanges.where(id: topic.id).pick(:title, :author_name, :updated_at)
+      assert_empty topic.transaction_changes
+    end
+  end
+
+  def test_deferred_touch_from_a_committed_child_survives_an_outer_save
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      original_time = Time.utc(2020, 1, 1)
+      deferred_time = original_time + 1.hour
+      topic = TopicWithDeferredTouchTransactionChanges.create!(
+        title: "Original", author_name: "Alice", created_at: original_time, updated_at: original_time
+      ).reload
+      nested_transaction_class = nil
+      live_changes_after_child = nil
+
+      TopicWithDeferredTouchTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithDeferredTouchTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithDeferredTouchTransactionChanges.lease_connection.current_transaction.class
+          travel_to(deferred_time) { topic.touch_later }
+          topic.update!(author_name: "Child")
+        end
+
+        live_changes_after_child = topic.transaction_changes.dup
+        topic.update!(title: "Outer")
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal ["Alice", "Child"], live_changes_after_child["author_name"]
+      assert_not live_changes_after_child.key?("updated_at")
+      assert_equal ["Outer", "Child", deferred_time], TopicWithDeferredTouchTransactionChanges.where(id: topic.id).pick(:title, :author_name, :updated_at)
+      assert_equal ["Original", "Outer"], topic.transaction_changes_log["title"]
+      assert_equal ["Alice", "Child"], topic.transaction_changes_log["author_name"]
+      assert_equal [original_time, deferred_time], topic.transaction_changes_log["updated_at"]
+    end
+  end
+
+  def test_deferred_touch_from_a_committed_child_is_discarded_with_its_parent
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      original_time = Time.utc(2020, 1, 1)
+      immediate_time = original_time + 2.hours
+      topic = TopicWithDeferredTouchTransactionChanges.create!(
+        title: "Original", author_name: "Alice", created_at: original_time, updated_at: original_time
+      ).reload
+      nested_transaction_class = nil
+
+      TopicWithDeferredTouchTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithDeferredTouchTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithDeferredTouchTransactionChanges.lease_connection.current_transaction.class
+          travel_to(original_time + 1.hour) { topic.touch_later }
+          topic.touch(time: immediate_time)
+        end
+
+        raise ActiveRecord::Rollback
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal ["Original", "Alice", original_time], TopicWithDeferredTouchTransactionChanges.where(id: topic.id).pick(:title, :author_name, :updated_at)
+      assert_empty topic.transaction_changes
+    end
+  end
+
+  def test_repeated_deferred_touch_survives_a_rolled_back_sibling
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      original_time = Time.utc(2020, 1, 1)
+      first_time = original_time + 1.hour
+      last_time = original_time + 2.hours
+      topic = TopicWithDeferredTouchTransactionChanges.create!(
+        title: "Original", author_name: "Alice", created_at: original_time, updated_at: original_time
+      ).reload
+      nested_transaction_class = nil
+      live_changes_after_sibling = nil
+
+      TopicWithDeferredTouchTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithDeferredTouchTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithDeferredTouchTransactionChanges.lease_connection.current_transaction.class
+          travel_to(first_time) { topic.touch_later }
+          travel_to(last_time) do
+            topic.touch_later(:created_at)
+            topic.update!(author_name: "Child")
+          end
+        end
+
+        TopicWithDeferredTouchTransactionChanges.transaction(requires_new: true) do
+          topic.update!(title: "Rolled back sibling")
+          raise ActiveRecord::Rollback
+        end
+        live_changes_after_sibling = topic.transaction_changes.dup
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal ["Alice", "Child"], live_changes_after_sibling["author_name"]
+      assert_not live_changes_after_sibling.key?("title")
+      assert_equal ["Original", "Child", last_time, last_time], TopicWithDeferredTouchTransactionChanges.where(id: topic.id).pick(:title, :author_name, :created_at, :updated_at)
+      assert_equal ["Alice", "Child"], topic.transaction_changes_log["author_name"]
+      assert_equal [original_time, last_time], topic.transaction_changes_log["created_at"]
+      assert_equal [original_time, last_time], topic.transaction_changes_log["updated_at"]
+      assert_not topic.transaction_changes_log.key?("title")
+    end
+  end
+
+  def test_transaction_change_frames_filter_an_internally_invalidated_child
+    # This directly exercises the frame-survival invariant. Public transaction
+    # errors roll back their database writes; here the invalidated write remains
+    # committed so the tracking filter can be observed independently.
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      child_state = nil
+      nested_transaction_class = nil
+
+      TopicWithTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          transaction = TopicWithTransactionChanges.lease_connection.current_transaction
+          nested_transaction_class = transaction.class
+          child_state = transaction.state
+          topic.update!(author_name: "Invalidated child")
+        end
+        child_state.invalidate!
+
+        topic.update!(title: "Outer")
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal ["Outer", "Invalidated child"], TopicWithTransactionChanges.where(id: topic.id).pick(:title, :author_name)
+      assert_equal ["Original", "Outer"], topic.transaction_changes_log["title"]
+      assert_not topic.transaction_changes_log.key?("author_name")
+    end
+  end
+
+  def test_rolled_back_first_save_is_not_rewritten_by_later_outer_update
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      nested_transaction_class = nil
+
+      TopicWithTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
 
         TopicWithTransactionChanges.transaction(requires_new: true) do
           nested_transaction_class = TopicWithTransactionChanges.lease_connection.current_transaction.class
@@ -1418,67 +1616,88 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
   end
 
   def test_transaction_changes_uses_original_value_when_rolled_back_attribute_is_rewritten
-    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      nested_transaction_class = nil
 
-    TopicWithTransactionChanges.transaction do
-      TopicWithTransactionChanges.transaction(requires_new: true) do
-        topic.update!(author_name: "Discarded")
-        raise ActiveRecord::Rollback
+      TopicWithTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithTransactionChanges.lease_connection.current_transaction.class
+          topic.update!(author_name: "Discarded")
+          raise ActiveRecord::Rollback
+        end
+
+        topic.update!(author_name: "Final")
       end
 
-      topic.update!(author_name: "Final")
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal "Final", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
+      assert_equal ["Alice", "Final"], topic.transaction_changes_log["author_name"]
     end
-
-    assert_equal "Final", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
-    assert_equal ["Alice", "Final"], topic.transaction_changes_log["author_name"]
   end
 
   def test_live_transaction_changes_excludes_rolled_back_first_save
-    transaction_changes_before_save = nil
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      transaction_changes_before_save = nil
+      transaction_changes_after_rollback = nil
+      nested_transaction_class = nil
 
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = :topics
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
 
-      before_save do
-        transaction_changes_before_save = transaction_changes.dup
-      end
-    end
-
-    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
-    transaction_changes_before_save = nil
-    transaction_changes_after_rollback = nil
-
-    klass.transaction do
-      klass.transaction(requires_new: true) do
-        topic.update!(author_name: "Discarded")
-        raise ActiveRecord::Rollback
+        before_save do
+          transaction_changes_before_save = transaction_changes.dup
+        end
       end
 
-      transaction_changes_after_rollback = topic.transaction_changes.dup
-      topic.update!(title: "Outer")
-    end
+      topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      transaction_changes_before_save = nil
 
-    assert_nil transaction_changes_after_rollback["author_name"]
-    assert_equal ["Original", "Outer"], transaction_changes_before_save["title"]
-    assert_nil transaction_changes_before_save["author_name"]
+      klass.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        klass.transaction(requires_new: true) do
+          nested_transaction_class = klass.lease_connection.current_transaction.class
+          topic.update!(author_name: "Discarded")
+          raise ActiveRecord::Rollback
+        end
+
+        transaction_changes_after_rollback = topic.transaction_changes.dup
+        topic.update!(title: "Outer")
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_nil transaction_changes_after_rollback["author_name"]
+      assert_equal ["Original", "Outer"], transaction_changes_before_save["title"]
+      assert_nil transaction_changes_before_save["author_name"]
+    end
   end
 
   def test_plain_save_rewrites_rolled_back_first_save_and_reports_it
-    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      nested_transaction_class = nil
 
-    TopicWithTransactionChanges.transaction do
-      TopicWithTransactionChanges.transaction(requires_new: true) do
-        topic.author_name = "Discarded"
-        assert topic.save
-        raise ActiveRecord::Rollback
+      TopicWithTransactionChanges.transaction do
+        dirty_transaction_parent if parent_state == :dirty_parent
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithTransactionChanges.lease_connection.current_transaction.class
+          topic.author_name = "Discarded"
+          assert topic.save
+          raise ActiveRecord::Rollback
+        end
+
+        topic.update!(title: "Outer")
       end
 
-      topic.update!(title: "Outer")
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal ["Outer", "Discarded"], TopicWithTransactionChanges.where(id: topic.id).pick(:title, :author_name)
+      assert_equal ["Original", "Outer"], topic.transaction_changes_log["title"]
+      assert_equal ["Alice", "Discarded"], topic.transaction_changes_log["author_name"]
     end
-
-    assert_equal ["Outer", "Discarded"], TopicWithTransactionChanges.where(id: topic.id).pick(:title, :author_name)
-    assert_equal ["Original", "Outer"], topic.transaction_changes_log["title"]
-    assert_equal ["Alice", "Discarded"], topic.transaction_changes_log["author_name"]
   end
 
   def test_savepoint_first_persisted_values_match_existing_save_and_update_behavior
@@ -1487,11 +1706,11 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
       update!: "Alice",
     }
 
-    [:clean_parent, :dirty_parent].product(expected_values.to_a).each do |parent_state, (operation, expected_author_name)|
+    nested_transaction_classes.keys.product(expected_values.to_a).each do |parent_state, (operation, expected_author_name)|
       topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
 
       TopicWithTransactionChanges.transaction do
-        TopicWithTransactionChanges.create!(title: "Dirty parent", written_on: Date.today) if parent_state == :dirty_parent
+        dirty_transaction_parent if parent_state == :dirty_parent
 
         TopicWithTransactionChanges.transaction(requires_new: true) do
           if operation == :save
@@ -1567,6 +1786,18 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert transaction_changes_in_callback.key?("title"),
       "transaction_changes should include title inside after_update_commit"
   end
+
+  private
+    def nested_transaction_classes
+      {
+        clean_parent: ActiveRecord::ConnectionAdapters::RestartParentTransaction,
+        dirty_parent: ActiveRecord::ConnectionAdapters::SavepointTransaction,
+      }
+    end
+
+    def dirty_transaction_parent
+      TopicWithTransactionChanges.create!(title: "Dirty parent", written_on: Date.today)
+    end
 end
 
 class TransactionChangesTest < ActiveRecord::TestCase
@@ -1705,6 +1936,67 @@ class TransactionChangesTest < ActiveRecord::TestCase
       "cross-model transaction_changes should reflect the other model's saved changes"
   end
 
+  def test_tracking_does_not_cast_unwritten_readonly_binary_attribute
+    binary_type = Class.new(ActiveRecord::Type::Binary) do
+      attr_accessor :armed
+
+      def cast(value)
+        raise "readonly nil was cast during save" if armed && value.nil?
+
+        super
+      end
+    end.new
+
+    previous_raise_on_readonly = ActiveRecord.raise_on_assign_to_attr_readonly
+    begin
+      ActiveRecord.raise_on_assign_to_attr_readonly = false
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        self.partial_updates = false
+        attribute :author_name, binary_type
+        attr_readonly :author_name
+      end
+    ensure
+      ActiveRecord.raise_on_assign_to_attr_readonly = previous_raise_on_readonly
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today).reload
+    binary_type.armed = true
+    topic.author_name = "not persisted"
+    topic.title = "Updated"
+
+    assert_nothing_raised { topic.save! }
+    assert_equal "Updated", klass.where(id: topic.id).pick(:title)
+  end
+
+  def test_commit_does_not_deserialize_transaction_changes_without_a_reader
+    type = transaction_deserialize_counting_type
+    klass = transaction_deserialize_counting_model(type)
+    topic = klass.create!(title: "Original", written_on: Date.today).reload
+
+    topic.arm_transaction_type_after_save = true
+    topic.update!(title: "Updated")
+
+    assert_equal 0, type.deserialize_count
+  end
+
+  def test_transaction_changes_deserializes_lazily_when_read
+    type = transaction_deserialize_counting_type
+    klass = transaction_deserialize_counting_model(type)
+    topic = klass.create!(title: "Original", written_on: Date.today).reload
+
+    topic.arm_transaction_type_after_save = true
+    topic.update!(title: "Updated")
+
+    assert_equal 0, type.deserialize_count
+    assert_equal ["Original", "Updated"], topic.transaction_changes["title"]
+    assert_operator type.deserialize_count, :>, 0
+
+    deserialize_count = type.deserialize_count
+    assert_equal ["Original", "Updated"], topic.transaction_changes["title"]
+    assert_equal deserialize_count, type.deserialize_count
+  end
+
   def test_transaction_changes_does_not_deserialize_nil_database_values
     sentinel_type = Class.new(ActiveModel::Type::String) do
       def deserialize(value)
@@ -1735,4 +2027,40 @@ class TransactionChangesTest < ActiveRecord::TestCase
     assert_equal ["default_author", nil], topic.transaction_changes_log["author_name"],
       "a nil new database value should not be passed through deserialize"
   end
+
+  private
+    def transaction_deserialize_counting_type
+      Class.new(ActiveModel::Type::String) do
+        attr_reader :deserialize_count
+
+        def initialize
+          @armed = false
+          @deserialize_count = 0
+          super
+        end
+
+        def arm!
+          @armed = true
+          @deserialize_count = 0
+        end
+
+        def deserialize(value)
+          @deserialize_count += 1 if @armed
+          super
+        end
+      end.new
+    end
+
+    def transaction_deserialize_counting_model(type)
+      Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        attribute :title, type
+        attr_accessor :arm_transaction_type_after_save
+
+        after_save do
+          type.arm! if arm_transaction_type_after_save
+        end
+        after_commit { }
+      end
+    end
 end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1087,3 +1087,233 @@ class SetCallbackTest < ActiveRecord::TestCase
     assert_equal expected_history, TopicWithCallbacksOnUpdate.history
   end
 end
+
+class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  class TopicWithCommittedChanges < ActiveRecord::Base
+    self.table_name = :topics
+
+    attr_accessor :committed_changes_log, :committed_title_change_log
+
+    after_commit do
+      self.committed_changes_log = committed_changes.dup
+      self.committed_title_change_log = committed_change_to_title
+    end
+  end
+
+  def test_committed_changes_tracks_full_transaction_with_multiple_saves
+    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+
+    TopicWithCommittedChanges.transaction do
+      topic.update!(title: "Intermediate")
+      topic.update!(title: "Final")
+    end
+
+    assert_equal ["Original", "Final"], topic.committed_title_change_log
+    assert_equal ["Original", "Final"], topic.committed_changes_log["title"]
+  end
+
+  def test_committed_changes_with_single_save_in_transaction
+    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+
+    topic.update!(title: "Updated")
+
+    assert_equal ["Original", "Updated"], topic.committed_title_change_log
+    assert_equal ["Original", "Updated"], topic.committed_changes_log["title"]
+  end
+
+  def test_committed_changes_omits_attribute_changed_back_to_original
+    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+
+    TopicWithCommittedChanges.transaction do
+      topic.update!(title: "Temporary")
+      topic.update!(title: "Original")
+    end
+
+    assert_nil topic.committed_title_change_log
+    assert_not topic.committed_changes_log.key?("title")
+  end
+
+  def test_committed_changes_for_create_in_transaction
+    topic = TopicWithCommittedChanges.create!(title: "Brand New", written_on: Date.today)
+
+    assert_equal [nil, "Brand New"], topic.committed_title_change_log
+  end
+
+  def test_committed_changes_for_create_and_update_in_same_transaction
+    topic = nil
+
+    TopicWithCommittedChanges.transaction do
+      topic = TopicWithCommittedChanges.create!(title: "Created", written_on: Date.today)
+      topic.update!(title: "Then Updated")
+    end
+
+    assert_equal [nil, "Then Updated"], topic.committed_title_change_log
+  end
+
+  def test_committed_changes_not_affected_by_rollback
+    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+
+    # Clear committed changes from the create
+    topic.reload
+
+    assert_not topic.committed_changes?
+
+    TopicWithCommittedChanges.transaction do
+      topic.update!(title: "Should be rolled back")
+      raise ActiveRecord::Rollback
+    end
+
+    assert_not topic.committed_changes?
+  end
+
+  def test_committed_changes_with_from_and_to_options_in_callback
+    result = {}
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_commit do
+        result[:from_original] = committed_change_to_title?(from: "Start")
+        result[:to_final] = committed_change_to_title?(to: "End")
+        result[:wrong_from] = committed_change_to_title?(from: "Middle")
+        result[:full_match] = committed_change_to_title?(from: "Start", to: "End")
+      end
+    end
+
+    topic = klass.create!(title: "Start", written_on: Date.today)
+
+    klass.transaction do
+      topic.update!(title: "Middle")
+      topic.update!(title: "End")
+    end
+
+    assert result[:from_original], "should match from: 'Start'"
+    assert result[:to_final], "should match to: 'End'"
+    assert_not result[:wrong_from], "should not match from: 'Middle' (intermediate value)"
+    assert result[:full_match], "should match from: 'Start', to: 'End'"
+  end
+
+  def test_committed_change_fires_callback_when_later_save_changes_different_attribute_in_same_transaction
+    callback_called = false
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_commit :on_title_change, on: :update, if: :committed_change_to_title?
+
+      define_method(:on_title_change) do
+        callback_called = true
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    callback_called = false
+
+    klass.transaction do
+      topic.update!(title: "Updated")
+      topic.update!(author_name: "Bob")
+    end
+
+    assert callback_called,
+      "after_commit with if: :committed_change_to_title? should fire " \
+      "even when the last save only changed a different attribute"
+  end
+
+  def test_committed_changes_differ_from_saved_changes_across_multiple_saves
+    saved_changes_log = nil
+    committed_changes_log = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_commit do
+        saved_changes_log = saved_changes.dup
+        committed_changes_log = committed_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+
+    klass.transaction do
+      topic.update!(title: "Intermediate")
+      topic.update!(title: "Final")
+    end
+
+    # saved_changes only reflects the last save: Intermediate -> Final
+    assert_equal ["Intermediate", "Final"], saved_changes_log["title"]
+    # committed_changes reflects the full transaction: Original -> Final
+    assert_equal ["Original", "Final"], committed_changes_log["title"]
+  end
+
+  def test_committed_changes_is_empty_for_destroyed_record_with_no_attribute_changes
+    topic = TopicWithCommittedChanges.create!(title: "To Be Destroyed", written_on: Date.today)
+    topic.reload
+
+    topic.destroy
+
+    assert_not topic.committed_changes_log.key?("title")
+  end
+
+  def test_committed_changes_unaffected_by_savepoint_rollback
+    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+
+    TopicWithCommittedChanges.transaction do
+      topic.update!(title: "Updated")
+      TopicWithCommittedChanges.transaction(requires_new: true) do
+        TopicWithCommittedChanges.create!(title: "Doomed", written_on: Date.today)
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    assert_equal ["Original", "Updated"], topic.committed_title_change_log
+  end
+
+  def test_committed_change_to_detects_earlier_save_even_when_last_save_changed_different_attribute
+    saved_detected = false
+    committed_detected = false
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_commit do
+        saved_detected = saved_change_to_title?
+        committed_detected = committed_change_to_title?
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+    klass.transaction do
+      topic.update!(title: "Updated")
+      topic.update!(author_name: "Bob")
+    end
+
+    assert_not saved_detected,
+      "saved_change_to_title? should be false because the last save only changed author_name"
+    assert committed_detected,
+      "committed_change_to_title? should be true because title changed during the transaction"
+  end
+
+  def test_attribute_before_last_commit_returns_current_value_for_unchanged_attribute
+    topic = TopicWithCommittedChanges.create!(title: "Title", author_name: "Alice", written_on: Date.today)
+
+    topic.update!(title: "New Title")
+
+    # author_name wasn't changed, so before_last_commit returns the current value
+    assert_equal "Alice", topic.author_name_before_last_commit
+  end
+
+  def test_committed_changes_includes_timestamp_after_touch
+    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+    topic.reload # clear committed_changes from the create
+
+    travel(1.second) do
+      topic.touch
+    end
+
+    assert topic.committed_changes_log.key?("updated_at")
+    assert_not topic.committed_changes_log.key?("title")
+  end
+end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1088,97 +1088,97 @@ class SetCallbackTest < ActiveRecord::TestCase
   end
 end
 
-class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
+class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
-  class TopicWithCommittedChanges < ActiveRecord::Base
+  class TopicWithTransactionChanges < ActiveRecord::Base
     self.table_name = :topics
 
-    attr_accessor :committed_changes_log, :committed_title_change_log
+    attr_accessor :transaction_changes_log, :transaction_title_change_log
 
     after_commit do
-      self.committed_changes_log = committed_changes.dup
-      self.committed_title_change_log = committed_change_to_title
+      self.transaction_changes_log = transaction_changes.dup
+      self.transaction_title_change_log = transaction_change_to_title
     end
   end
 
-  def test_committed_changes_tracks_full_transaction_with_multiple_saves
-    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+  def test_transaction_changes_tracks_full_transaction_with_multiple_saves
+    topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
 
-    TopicWithCommittedChanges.transaction do
+    TopicWithTransactionChanges.transaction do
       topic.update!(title: "Intermediate")
       topic.update!(title: "Final")
     end
 
-    assert_equal ["Original", "Final"], topic.committed_title_change_log
-    assert_equal ["Original", "Final"], topic.committed_changes_log["title"]
+    assert_equal ["Original", "Final"], topic.transaction_title_change_log
+    assert_equal ["Original", "Final"], topic.transaction_changes_log["title"]
   end
 
-  def test_committed_changes_with_single_save_in_transaction
-    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+  def test_transaction_changes_with_single_save_in_transaction
+    topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
 
     topic.update!(title: "Updated")
 
-    assert_equal ["Original", "Updated"], topic.committed_title_change_log
-    assert_equal ["Original", "Updated"], topic.committed_changes_log["title"]
+    assert_equal ["Original", "Updated"], topic.transaction_title_change_log
+    assert_equal ["Original", "Updated"], topic.transaction_changes_log["title"]
   end
 
-  def test_committed_changes_omits_attribute_changed_back_to_original
-    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+  def test_transaction_changes_omits_attribute_changed_back_to_original
+    topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
 
-    TopicWithCommittedChanges.transaction do
+    TopicWithTransactionChanges.transaction do
       topic.update!(title: "Temporary")
       topic.update!(title: "Original")
     end
 
-    assert_nil topic.committed_title_change_log
-    assert_not topic.committed_changes_log.key?("title")
+    assert_nil topic.transaction_title_change_log
+    assert_not topic.transaction_changes_log.key?("title")
   end
 
-  def test_committed_changes_for_create_in_transaction
-    topic = TopicWithCommittedChanges.create!(title: "Brand New", written_on: Date.today)
+  def test_transaction_changes_for_create_in_transaction
+    topic = TopicWithTransactionChanges.create!(title: "Brand New", written_on: Date.today)
 
-    assert_equal [nil, "Brand New"], topic.committed_title_change_log
+    assert_equal [nil, "Brand New"], topic.transaction_title_change_log
   end
 
-  def test_committed_changes_for_create_and_update_in_same_transaction
+  def test_transaction_changes_for_create_and_update_in_same_transaction
     topic = nil
 
-    TopicWithCommittedChanges.transaction do
-      topic = TopicWithCommittedChanges.create!(title: "Created", written_on: Date.today)
+    TopicWithTransactionChanges.transaction do
+      topic = TopicWithTransactionChanges.create!(title: "Created", written_on: Date.today)
       topic.update!(title: "Then Updated")
     end
 
-    assert_equal [nil, "Then Updated"], topic.committed_title_change_log
+    assert_equal [nil, "Then Updated"], topic.transaction_title_change_log
   end
 
-  def test_committed_changes_not_affected_by_rollback
-    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+  def test_transaction_changes_not_affected_by_rollback
+    topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
 
-    # Clear committed changes from the create
+    # Clear transaction changes from the create
     topic.reload
 
-    assert_not topic.committed_changes?
+    assert_not topic.transaction_changes?
 
-    TopicWithCommittedChanges.transaction do
+    TopicWithTransactionChanges.transaction do
       topic.update!(title: "Should be rolled back")
       raise ActiveRecord::Rollback
     end
 
-    assert_not topic.committed_changes?
+    assert_not topic.transaction_changes?
   end
 
-  def test_committed_changes_with_from_and_to_options_in_callback
+  def test_transaction_changes_with_from_and_to_options_in_callback
     result = {}
 
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = :topics
 
       after_commit do
-        result[:from_original] = committed_change_to_title?(from: "Start")
-        result[:to_final] = committed_change_to_title?(to: "End")
-        result[:wrong_from] = committed_change_to_title?(from: "Middle")
-        result[:full_match] = committed_change_to_title?(from: "Start", to: "End")
+        result[:from_original] = transaction_change_to_title?(from: "Start")
+        result[:to_final] = transaction_change_to_title?(to: "End")
+        result[:wrong_from] = transaction_change_to_title?(from: "Middle")
+        result[:full_match] = transaction_change_to_title?(from: "Start", to: "End")
       end
     end
 
@@ -1195,13 +1195,13 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert result[:full_match], "should match from: 'Start', to: 'End'"
   end
 
-  def test_committed_change_fires_callback_when_later_save_changes_different_attribute_in_same_transaction
+  def test_transaction_change_fires_callback_when_later_save_changes_different_attribute_in_same_transaction
     callback_called = false
 
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = :topics
 
-      after_commit :on_title_change, on: :update, if: :committed_change_to_title?
+      after_commit :on_title_change, on: :update, if: :transaction_change_to_title?
 
       define_method(:on_title_change) do
         callback_called = true
@@ -1217,20 +1217,20 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     end
 
     assert callback_called,
-      "after_commit with if: :committed_change_to_title? should fire " \
+      "after_commit with if: :transaction_change_to_title? should fire " \
       "even when the last save only changed a different attribute"
   end
 
-  def test_committed_changes_differ_from_saved_changes_across_multiple_saves
+  def test_transaction_changes_differ_from_saved_changes_across_multiple_saves
     saved_changes_log = nil
-    committed_changes_log = nil
+    transaction_changes_log = nil
 
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = :topics
 
       after_commit do
         saved_changes_log = saved_changes.dup
-        committed_changes_log = committed_changes.dup
+        transaction_changes_log = transaction_changes.dup
       end
     end
 
@@ -1243,55 +1243,56 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
 
     # saved_changes only reflects the last save: Intermediate -> Final
     assert_equal ["Intermediate", "Final"], saved_changes_log["title"]
-    # committed_changes reflects the full transaction: Original -> Final
-    assert_equal ["Original", "Final"], committed_changes_log["title"]
+    # transaction_changes reflects the full transaction: Original -> Final
+    assert_equal ["Original", "Final"], transaction_changes_log["title"]
   end
 
-  def test_committed_changes_is_empty_for_destroyed_record_with_no_attribute_changes
-    topic = TopicWithCommittedChanges.create!(title: "To Be Destroyed", written_on: Date.today)
+  def test_transaction_changes_is_empty_for_destroyed_record_with_no_attribute_changes
+    topic = TopicWithTransactionChanges.create!(title: "To Be Destroyed", written_on: Date.today)
     topic.reload
 
     topic.destroy
 
-    assert_not topic.committed_changes_log.key?("title")
+    assert_not topic.transaction_changes_log.key?("title")
   end
 
-  def test_committed_changes_reflects_saved_value_not_unsaved_dirty_value
-    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+  def test_transaction_changes_reflects_saved_value_not_unsaved_dirty_value
+    topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
     topic.reload
 
-    TopicWithCommittedChanges.transaction do
+    TopicWithTransactionChanges.transaction do
       topic.update!(title: "Saved")
       topic.title = "Not Saved" # dirty but never persisted
     end
 
-    assert_equal ["Original", "Saved"], topic.committed_title_change_log
+    assert_equal ["Original", "Saved"], topic.transaction_title_change_log
   end
 
-  def test_committed_changes_unaffected_by_savepoint_rollback
-    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+  def test_transaction_changes_unaffected_by_savepoint_rollback
+    topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
 
-    TopicWithCommittedChanges.transaction do
+    TopicWithTransactionChanges.transaction do
       topic.update!(title: "Updated")
-      TopicWithCommittedChanges.transaction(requires_new: true) do
-        TopicWithCommittedChanges.create!(title: "Doomed", written_on: Date.today)
+
+      TopicWithTransactionChanges.transaction(requires_new: true) do
+        TopicWithTransactionChanges.create!(title: "Doomed", written_on: Date.today)
         raise ActiveRecord::Rollback
       end
     end
 
-    assert_equal ["Original", "Updated"], topic.committed_title_change_log
+    assert_equal ["Original", "Updated"], topic.transaction_title_change_log
   end
 
-  def test_committed_change_to_detects_earlier_save_even_when_last_save_changed_different_attribute
+  def test_transaction_change_to_detects_earlier_save_even_when_last_save_changed_different_attribute
     saved_detected = false
-    committed_detected = false
+    transaction_detected = false
 
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = :topics
 
       after_commit do
         saved_detected = saved_change_to_title?
-        committed_detected = committed_change_to_title?
+        transaction_detected = transaction_change_to_title?
       end
     end
 
@@ -1304,37 +1305,38 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
 
     assert_not saved_detected,
       "saved_change_to_title? should be false because the last save only changed author_name"
-    assert committed_detected,
-      "committed_change_to_title? should be true because title changed during the transaction"
+    assert transaction_detected,
+      "transaction_change_to_title? should be true because title changed during the transaction"
   end
 
-  def test_attribute_before_last_commit_returns_current_value_for_unchanged_attribute
-    topic = TopicWithCommittedChanges.create!(title: "Title", author_name: "Alice", written_on: Date.today)
+  def test_attribute_before_transaction_returns_current_value_for_unchanged_attribute
+    topic = TopicWithTransactionChanges.create!(title: "Title", author_name: "Alice", written_on: Date.today)
 
     topic.update!(title: "New Title")
 
-    # author_name wasn't changed, so before_last_commit returns the current value
-    assert_equal "Alice", topic.author_name_before_last_commit
+    # author_name wasn't changed, so before_transaction returns the current value
+    assert_equal "Alice", topic.author_name_before_transaction
   end
 
-  def test_committed_changes_includes_timestamp_after_touch
-    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
-    topic.reload # clear committed_changes from the create
+  def test_transaction_changes_includes_timestamp_after_touch
+    topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
+    topic.reload # clear transaction_changes from the create
 
     travel(1.second) do
       topic.touch
     end
 
-    assert topic.committed_changes_log.key?("updated_at")
-    assert_not topic.committed_changes_log.key?("title")
+    assert topic.transaction_changes_log.key?("updated_at")
+    assert_not topic.transaction_changes_log.key?("title")
   end
 
-  def test_committed_changes_when_same_record_updated_in_rolled_back_savepoint
-    topic = TopicWithCommittedChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+  def test_transaction_changes_when_same_record_updated_in_rolled_back_savepoint
+    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
 
-    TopicWithCommittedChanges.transaction do
+    TopicWithTransactionChanges.transaction do
       topic.update!(title: "Updated")
-      TopicWithCommittedChanges.transaction(requires_new: true) do
+
+      TopicWithTransactionChanges.transaction(requires_new: true) do
         topic.update!(author_name: "Bob")
         raise ActiveRecord::Rollback
       end
@@ -1342,50 +1344,51 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
 
     # The outer transaction changed title from "Original" to "Updated".
     # The savepoint changed author_name but was rolled back.
-    # committed_changes should include the title change from the outer transaction.
-    assert_equal ["Original", "Updated"], topic.committed_title_change_log
-    assert_equal ["Original", "Updated"], topic.committed_changes_log["title"]
+    # transaction_changes should include the title change from the outer transaction.
+    assert_equal ["Original", "Updated"], topic.transaction_title_change_log
+    assert_equal ["Original", "Updated"], topic.transaction_changes_log["title"]
+    assert_nil topic.transaction_changes_log["author_name"]
   end
 
-  def test_committed_changes_is_empty_inside_after_rollback_callback
-    committed_changes_in_rollback = nil
-    committed_changes_present_in_rollback = nil
+  def test_transaction_changes_is_empty_inside_after_rollback_callback
+    transaction_changes_in_rollback = nil
+    transaction_changes_present_in_rollback = nil
 
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = :topics
 
       after_rollback do
-        committed_changes_in_rollback = committed_changes.dup
-        committed_changes_present_in_rollback = committed_changes?
+        transaction_changes_in_rollback = transaction_changes.dup
+        transaction_changes_present_in_rollback = transaction_changes?
       end
     end
 
     topic = klass.create!(title: "Original", written_on: Date.today)
-    topic.reload # Clear committed_changes from the create
+    topic.reload # Clear transaction_changes from the create
 
     klass.transaction do
       topic.update!(title: "Should be rolled back")
       raise ActiveRecord::Rollback
     end
 
-    assert_empty committed_changes_in_rollback,
-      "committed_changes should be empty inside after_rollback since nothing was committed"
-    assert_not committed_changes_present_in_rollback,
-      "committed_changes? should be false inside after_rollback"
+    assert_empty transaction_changes_in_rollback,
+      "transaction_changes should be empty inside after_rollback since nothing was committed"
+    assert_not transaction_changes_present_in_rollback,
+      "transaction_changes? should be false inside after_rollback"
   end
 
-  def test_committed_change_to_attribute_inside_after_update_commit
-    committed_title_change_in_callback = nil
-    committed_title_detected_in_callback = nil
-    committed_changes_in_callback = nil
+  def test_transaction_change_to_attribute_inside_after_update_commit
+    transaction_title_change_in_callback = nil
+    transaction_title_detected_in_callback = nil
+    transaction_changes_in_callback = nil
 
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = :topics
 
       after_update_commit do
-        committed_title_change_in_callback = committed_change_to_title
-        committed_title_detected_in_callback = committed_change_to_title?
-        committed_changes_in_callback = committed_changes.dup
+        transaction_title_change_in_callback = transaction_change_to_title
+        transaction_title_detected_in_callback = transaction_change_to_title?
+        transaction_changes_in_callback = transaction_changes.dup
       end
     end
 
@@ -1396,11 +1399,148 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
       topic.update!(title: "Final")
     end
 
-    assert committed_title_detected_in_callback,
-      "committed_change_to_title? should be true inside after_update_commit"
-    assert_equal ["Original", "Final"], committed_title_change_in_callback,
-      "committed_change_to_title should span the full transaction inside after_update_commit"
-    assert committed_changes_in_callback.key?("title"),
-      "committed_changes should include title inside after_update_commit"
+    assert transaction_title_detected_in_callback,
+      "transaction_change_to_title? should be true inside after_update_commit"
+    assert_equal ["Original", "Final"], transaction_title_change_in_callback,
+      "transaction_change_to_title should span the full transaction inside after_update_commit"
+    assert transaction_changes_in_callback.key?("title"),
+      "transaction_changes should include title inside after_update_commit"
+  end
+end
+
+class TransactionChangesTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def test_transaction_changes_in_after_save_with_single_save
+    txn_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_save do
+        txn_changes_in_callback = transaction_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+    txn_changes_in_callback = nil # clear from create
+
+    topic.update!(title: "Updated")
+
+    assert_equal ["Original", "Updated"], txn_changes_in_callback["title"]
+  end
+
+  def test_transaction_changes_in_before_save_includes_pending_changes
+    txn_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      before_save do
+        txn_changes_in_callback = transaction_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+    txn_changes_in_callback = nil
+
+    topic.update!(title: "Updated")
+
+    assert_equal ["Original", "Updated"], txn_changes_in_callback["title"]
+  end
+
+  def test_transaction_changes_in_before_update_includes_pending_changes
+    txn_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      before_update do
+        txn_changes_in_callback = transaction_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+    txn_changes_in_callback = nil
+
+    topic.update!(title: "Updated")
+
+    assert_equal ["Original", "Updated"], txn_changes_in_callback["title"]
+  end
+
+  def test_transaction_changes_in_before_save_with_prior_save_in_transaction
+    txn_changes_in_before_save = nil
+    save_count = 0
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      before_save do
+        save_count += 1
+        txn_changes_in_before_save = transaction_changes.dup if save_count == 2
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    save_count = 0
+
+    klass.transaction do
+      topic.update!(title: "Intermediate")
+      topic.update!(title: "Final")
+    end
+
+    assert_equal ["Original", "Final"], txn_changes_in_before_save["title"]
+  end
+
+  def test_transaction_changes_omits_pending_attribute_changed_back_to_original
+    txn_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      before_save do
+        txn_changes_in_callback = transaction_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+    txn_changes_in_callback = nil
+
+    topic.title = "Temporary"
+    topic.title = "Original"
+    topic.save!
+
+    assert_not txn_changes_in_callback.key?("title"),
+      "transaction_changes should not include a pending change back to the original value"
+  end
+
+  def test_transaction_changes_cross_model_access
+    product_txn_changes = nil
+
+    publication_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      attr_accessor :related_record
+
+      after_save do
+        product_txn_changes = related_record.transaction_changes.dup if related_record
+      end
+    end
+
+    product_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+    end
+
+    product = product_klass.create!(title: "Original Product", written_on: Date.today)
+    publication = publication_klass.create!(title: "Publication", written_on: Date.today)
+    publication.related_record = product
+
+    product_klass.transaction do
+      product.update!(title: "Updated Product")
+      publication.update!(title: "Updated Publication")
+    end
+
+    assert_equal ["Original Product", "Updated Product"], product_txn_changes["title"],
+      "cross-model transaction_changes should reflect the other model's saved changes"
   end
 end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1350,6 +1350,7 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert_nil topic.transaction_changes_log["author_name"]
   end
 
+
   def test_transaction_changes_is_empty_inside_after_rollback_callback
     transaction_changes_in_rollback = nil
     transaction_changes_present_in_rollback = nil

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1256,6 +1256,18 @@ class CommittedChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert_not topic.committed_changes_log.key?("title")
   end
 
+  def test_committed_changes_reflects_saved_value_not_unsaved_dirty_value
+    topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
+    topic.reload
+
+    TopicWithCommittedChanges.transaction do
+      topic.update!(title: "Saved")
+      topic.title = "Not Saved" # dirty but never persisted
+    end
+
+    assert_equal ["Original", "Saved"], topic.committed_title_change_log
+  end
+
   def test_committed_changes_unaffected_by_savepoint_rollback
     topic = TopicWithCommittedChanges.create!(title: "Original", written_on: Date.today)
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1350,6 +1350,43 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert_nil topic.transaction_changes_log["author_name"]
   end
 
+  def test_transaction_changes_excludes_multiple_saves_from_rolled_back_savepoint
+    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+    TopicWithTransactionChanges.transaction do
+      topic.update!(title: "Outer")
+
+      TopicWithTransactionChanges.transaction(requires_new: true) do
+        topic.update!(author_name: "Rolled back once")
+        topic.update!(author_name: "Rolled back twice")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    assert_equal "Alice", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
+    assert_nil topic.transaction_changes_log["author_name"]
+  end
+
+  def test_transaction_changes_preserves_committed_savepoint_before_rolled_back_sibling
+    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+    TopicWithTransactionChanges.transaction do
+      topic.update!(title: "Outer")
+
+      TopicWithTransactionChanges.transaction(requires_new: true) do
+        topic.update!(author_name: "Committed child")
+      end
+
+      TopicWithTransactionChanges.transaction(requires_new: true) do
+        topic.update!(author_name: "Rolled back once")
+        topic.update!(author_name: "Rolled back twice")
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    assert_equal "Committed child", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
+    assert_equal ["Alice", "Committed child"], topic.transaction_changes_log["author_name"]
+  end
 
   def test_transaction_changes_is_empty_inside_after_rollback_callback
     transaction_changes_in_rollback = nil

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1388,6 +1388,129 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert_equal ["Alice", "Committed child"], topic.transaction_changes_log["author_name"]
   end
 
+  def test_rolled_back_first_save_is_not_rewritten_by_later_outer_update
+    nested_transaction_classes = {
+      clean_parent: ActiveRecord::ConnectionAdapters::RestartParentTransaction,
+      dirty_parent: ActiveRecord::ConnectionAdapters::SavepointTransaction,
+    }
+
+    nested_transaction_classes.each do |parent_state, expected_transaction_class|
+      topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      nested_transaction_class = nil
+
+      TopicWithTransactionChanges.transaction do
+        TopicWithTransactionChanges.create!(title: "Dirty parent", written_on: Date.today) if parent_state == :dirty_parent
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          nested_transaction_class = TopicWithTransactionChanges.lease_connection.current_transaction.class
+          topic.update!(author_name: "Discarded")
+          raise ActiveRecord::Rollback
+        end
+
+        topic.update!(title: "Outer")
+      end
+
+      assert_equal expected_transaction_class, nested_transaction_class
+      assert_equal ["Outer", "Alice"], TopicWithTransactionChanges.where(id: topic.id).pick(:title, :author_name)
+      assert_equal ["Original", "Outer"], topic.transaction_changes_log["title"]
+      assert_nil topic.transaction_changes_log["author_name"]
+    end
+  end
+
+  def test_transaction_changes_uses_original_value_when_rolled_back_attribute_is_rewritten
+    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+    TopicWithTransactionChanges.transaction do
+      TopicWithTransactionChanges.transaction(requires_new: true) do
+        topic.update!(author_name: "Discarded")
+        raise ActiveRecord::Rollback
+      end
+
+      topic.update!(author_name: "Final")
+    end
+
+    assert_equal "Final", TopicWithTransactionChanges.where(id: topic.id).pick(:author_name)
+    assert_equal ["Alice", "Final"], topic.transaction_changes_log["author_name"]
+  end
+
+  def test_live_transaction_changes_excludes_rolled_back_first_save
+    transaction_changes_before_save = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      before_save do
+        transaction_changes_before_save = transaction_changes.dup
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    transaction_changes_before_save = nil
+    transaction_changes_after_rollback = nil
+
+    klass.transaction do
+      klass.transaction(requires_new: true) do
+        topic.update!(author_name: "Discarded")
+        raise ActiveRecord::Rollback
+      end
+
+      transaction_changes_after_rollback = topic.transaction_changes.dup
+      topic.update!(title: "Outer")
+    end
+
+    assert_nil transaction_changes_after_rollback["author_name"]
+    assert_equal ["Original", "Outer"], transaction_changes_before_save["title"]
+    assert_nil transaction_changes_before_save["author_name"]
+  end
+
+  def test_plain_save_rewrites_rolled_back_first_save_and_reports_it
+    topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+    TopicWithTransactionChanges.transaction do
+      TopicWithTransactionChanges.transaction(requires_new: true) do
+        topic.author_name = "Discarded"
+        assert topic.save
+        raise ActiveRecord::Rollback
+      end
+
+      topic.update!(title: "Outer")
+    end
+
+    assert_equal ["Outer", "Discarded"], TopicWithTransactionChanges.where(id: topic.id).pick(:title, :author_name)
+    assert_equal ["Original", "Outer"], topic.transaction_changes_log["title"]
+    assert_equal ["Alice", "Discarded"], topic.transaction_changes_log["author_name"]
+  end
+
+  def test_savepoint_first_persisted_values_match_existing_save_and_update_behavior
+    expected_values = {
+      save: "Discarded",
+      update!: "Alice",
+    }
+
+    [:clean_parent, :dirty_parent].product(expected_values.to_a).each do |parent_state, (operation, expected_author_name)|
+      topic = TopicWithTransactionChanges.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+      TopicWithTransactionChanges.transaction do
+        TopicWithTransactionChanges.create!(title: "Dirty parent", written_on: Date.today) if parent_state == :dirty_parent
+
+        TopicWithTransactionChanges.transaction(requires_new: true) do
+          if operation == :save
+            topic.author_name = "Discarded"
+            assert topic.save
+          else
+            topic.update!(author_name: "Discarded")
+          end
+          raise ActiveRecord::Rollback
+        end
+
+        topic.update!(title: "Outer")
+      end
+
+      assert_equal expected_author_name, TopicWithTransactionChanges.where(id: topic.id).pick(:author_name),
+        "#{operation} with a #{parent_state.to_s.tr("_", " ")}"
+    end
+  end
+
   def test_transaction_changes_is_empty_inside_after_rollback_callback
     transaction_changes_in_rollback = nil
     transaction_changes_present_in_rollback = nil

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1279,6 +1279,113 @@ class TransactionChangesInAfterCommitCallbacksTest < ActiveRecord::TestCase
     assert_equal ["Original", "Saved"], topic.transaction_title_change_log
   end
 
+  def test_callback_owner_sees_only_its_instance_changes_for_separate_instances_of_the_same_row
+    [false, true].each do |run_on_first|
+      callbacks = []
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        self.run_commit_callbacks_on_first_saved_instances_in_transaction = run_on_first
+
+        after_update_commit do
+          callbacks << [self, transaction_changes.slice("title", "author_name")]
+        end
+      end
+
+      topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      first = nil
+      second = nil
+
+      klass.transaction do
+        first = klass.find(topic.id)
+        first.update!(title: "Updated")
+        second = klass.find(topic.id)
+        second.update!(author_name: "Bob")
+      end
+
+      expected_record = run_on_first ? first : second
+      expected_changes = if run_on_first
+        { "title" => ["Original", "Updated"] }
+      else
+        { "author_name" => ["Alice", "Bob"] }
+      end
+
+      assert_equal 1, callbacks.size, "run callbacks on first: #{run_on_first}"
+      assert_same expected_record, callbacks.first.first, "run callbacks on first: #{run_on_first}"
+      assert_equal expected_changes, callbacks.first.second, "run callbacks on first: #{run_on_first}"
+    end
+  end
+
+  def test_callback_owner_sees_its_instance_change_when_separate_instances_change_the_same_attribute
+    [false, true].each do |run_on_first|
+      callbacks = []
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        self.run_commit_callbacks_on_first_saved_instances_in_transaction = run_on_first
+
+        after_update_commit do
+          callbacks << [self, transaction_change_to_title]
+        end
+      end
+
+      topic = klass.create!(title: "First", written_on: Date.today)
+      first = nil
+      second = nil
+
+      klass.transaction do
+        first = klass.find(topic.id)
+        first.update!(title: "Intermediate")
+        second = klass.find(topic.id)
+        second.update!(title: "Final")
+      end
+
+      expected_record = run_on_first ? first : second
+      expected_change = run_on_first ? ["First", "Intermediate"] : ["Intermediate", "Final"]
+
+      assert_equal 1, callbacks.size, "run callbacks on first: #{run_on_first}"
+      assert_same expected_record, callbacks.first.first, "run callbacks on first: #{run_on_first}"
+      assert_equal expected_change, callbacks.first.second, "run callbacks on first: #{run_on_first}"
+    end
+  end
+
+  def test_later_after_commit_reads_the_last_transaction_when_an_earlier_callback_saves_again
+    title_change = nil
+    title_before_transaction = nil
+    nested_save_complete = false
+    callback_order = ActiveRecord.run_after_transaction_callbacks_in_order_defined
+
+    begin
+      ActiveRecord.run_after_transaction_callbacks_in_order_defined = true
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        attr_accessor :save_in_after_commit
+
+        after_commit do
+          if save_in_after_commit
+            self.save_in_after_commit = false
+            update!(title: "Final")
+            nested_save_complete = true
+          end
+        end
+
+        after_commit do
+          if nested_save_complete
+            title_change = transaction_change_to_attribute("title")
+            title_before_transaction = attribute_before_transaction("title")
+          end
+        end
+      end
+    ensure
+      ActiveRecord.run_after_transaction_callbacks_in_order_defined = callback_order
+    end
+
+    topic = klass.create!(title: "Original", written_on: Date.today)
+    topic.save_in_after_commit = true
+    topic.update!(title: "Outer")
+
+    assert_equal ["Outer", "Final"], title_change
+    assert_equal "Outer", title_before_transaction
+  end
+
   def test_transaction_changes_unaffected_by_savepoint_rollback
     topic = TopicWithTransactionChanges.create!(title: "Original", written_on: Date.today)
 
@@ -1820,6 +1927,642 @@ class TransactionChangesTest < ActiveRecord::TestCase
     topic.update!(title: "Updated")
 
     assert_equal ["Original", "Updated"], txn_changes_in_callback["title"]
+  end
+
+  def test_transaction_changes_in_after_save_excludes_an_unsaved_change_from_an_earlier_callback
+    txn_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :assign_unsaved_change
+
+      after_save do
+        self.author_name = "Not saved" if assign_unsaved_change
+      end
+
+      after_save do
+        txn_changes_in_callback = transaction_changes.slice("title", "author_name") if assign_unsaved_change
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    topic.assign_unsaved_change = true
+    topic.update!(title: "Saved")
+
+    assert_equal "Not saved", topic.author_name
+    assert_equal({ "title" => ["Original", "Saved"] }, txn_changes_in_callback)
+  end
+
+  def test_transaction_changes_in_after_update_excludes_an_unsaved_change_from_an_earlier_callback
+    txn_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :assign_unsaved_change
+
+      after_update do
+        self.author_name = "Not saved" if assign_unsaved_change
+      end
+
+      after_update do
+        txn_changes_in_callback = transaction_changes.slice("title", "author_name") if assign_unsaved_change
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    topic.assign_unsaved_change = true
+    topic.update!(title: "Saved")
+
+    assert_equal "Not saved", topic.author_name
+    assert_equal({ "title" => ["Original", "Saved"] }, txn_changes_in_callback)
+  end
+
+  def test_transaction_changes_around_save_switches_from_pending_to_persisted_at_yield
+    before_yield = nil
+    after_yield = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :inspect_save_phase
+
+      around_save do |record, callback|
+        if inspect_save_phase
+          before_yield = record.transaction_changes.slice("title", "author_name")
+          callback.call
+          record.author_name = "Not saved"
+          after_yield = record.transaction_changes.slice("title", "author_name")
+        else
+          callback.call
+        end
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    topic.inspect_save_phase = true
+    topic.update!(title: "Saved")
+
+    assert_equal({ "title" => ["Original", "Saved"] }, before_yield)
+    assert_equal "Not saved", topic.author_name
+    assert_equal({ "title" => ["Original", "Saved"] }, after_yield)
+  end
+
+  def test_transaction_changes_after_a_no_op_save_excludes_a_later_unsaved_change
+    txn_changes_in_callback = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      self.record_timestamps = false
+      attr_accessor :assign_unsaved_change
+
+      after_save do
+        if assign_unsaved_change
+          self.author_name = "Not saved"
+          txn_changes_in_callback = transaction_changes.slice("author_name")
+        end
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    topic.assign_unsaved_change = true
+    topic.save!
+
+    assert_equal "Not saved", topic.author_name
+    assert_empty txn_changes_in_callback
+  end
+
+  def test_dup_during_save_has_independent_save_attempt_state
+    original_changes_seen_by_duplicate = nil
+    duplicate_changes_after_save = nil
+    target = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :duplicate_during_save, :duplicate_copy
+
+      before_save do
+        if duplicate_during_save
+          self.duplicate_during_save = false
+          duplicate = dup
+          duplicate.duplicate_copy = true
+          duplicate.save!
+          duplicate.author_name = "Not saved"
+          duplicate_changes_after_save = duplicate.transaction_changes.slice("author_name")
+        end
+      end
+
+      after_save do
+        if duplicate_copy
+          original_changes_seen_by_duplicate = target.transaction_changes.slice("title")
+        end
+      end
+    end
+
+    target = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    target.duplicate_during_save = true
+    target.update!(title: "Outer")
+
+    assert_equal({ "title" => ["Original", "Outer"] }, original_changes_seen_by_duplicate)
+    assert_equal({ "author_name" => [nil, "Alice"] }, duplicate_changes_after_save)
+  end
+
+  def test_touch_nested_in_before_callbacks_does_not_finalize_the_outer_save
+    [:save, :update].each do |callback_chain|
+      changes_in_after_touch = nil
+      changes_in_later_before_callback = nil
+      touch_time = nil
+
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        attr_accessor :touch_before_persistence
+
+        after_touch do
+          changes_in_after_touch = transaction_changes.slice("title", "updated_at")
+        end
+      end
+
+      klass.set_callback(callback_chain, :before) do |record|
+        if record.touch_before_persistence
+          record.touch_before_persistence = false
+          record.touch(time: touch_time)
+        end
+      end
+
+      klass.set_callback(callback_chain, :before) do |record|
+        changes_in_later_before_callback = record.transaction_changes.slice("title") if touch_time
+      end
+
+      topic = klass.create!(title: "Original", written_on: Date.today)
+      original_time = topic.updated_at
+      touch_time = original_time + 1.hour
+      topic.touch_before_persistence = true
+      topic.update!(title: "Outer")
+
+      assert_equal ["Original", "Outer"], changes_in_after_touch["title"], callback_chain
+      assert_equal [original_time, touch_time], changes_in_after_touch["updated_at"], callback_chain
+      assert_equal({ "title" => ["Original", "Outer"] }, changes_in_later_before_callback, callback_chain)
+    end
+  end
+
+  def test_save_from_after_touch_owns_an_inner_attempt_and_restores_the_outer_attempt
+    [:save, :halt].each do |inner_outcome|
+      inner_after_save_changes = nil
+      changes_after_inner_attempt = nil
+      changes_in_later_outer_callback = nil
+      inner_save_result = nil
+
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        attr_accessor :touch_before_persistence, :halt_inner_save, :inner_save_active, :inner_outcome
+
+        before_save do
+          if touch_before_persistence
+            self.touch_before_persistence = false
+            touch(time: updated_at + 1.hour)
+          end
+        end
+
+        before_save do
+          throw :abort if halt_inner_save
+        end
+
+        before_save do
+          if inner_outcome && !inner_save_active
+            changes_in_later_outer_callback = transaction_changes.slice("title", "author_name")
+            self.inner_outcome = nil
+          end
+        end
+
+        after_touch do
+          outcome = inner_outcome
+          self.inner_save_active = true
+          self.author_name = "Inner"
+
+          if outcome == :halt
+            self.halt_inner_save = true
+            inner_save_result = save
+            self.halt_inner_save = false
+          else
+            inner_save_result = save!
+          end
+        ensure
+          self.inner_save_active = false
+          self.author_name = "Outer pending"
+          changes_after_inner_attempt = transaction_changes.slice("title", "author_name")
+        end
+
+        after_save do
+          if inner_save_active
+            self.author_name = "Inner unsaved"
+            inner_after_save_changes = transaction_changes.slice("title", "author_name")
+          end
+        end
+      end
+
+      topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+      topic.inner_outcome = inner_outcome
+      topic.touch_before_persistence = true
+      topic.update!(title: "Outer")
+
+      assert_equal(inner_outcome == :save, inner_save_result, inner_outcome)
+      if inner_outcome == :save
+        assert_equal(
+          { "title" => ["Original", "Outer"], "author_name" => ["Alice", "Inner"] },
+          inner_after_save_changes,
+          inner_outcome
+        )
+      else
+        assert_nil inner_after_save_changes, inner_outcome
+      end
+      assert_equal ["Original", "Outer"], changes_after_inner_attempt["title"], inner_outcome
+      assert_equal ["Alice", "Outer pending"], changes_after_inner_attempt["author_name"], inner_outcome
+      assert_equal changes_after_inner_attempt, changes_in_later_outer_callback, inner_outcome
+    end
+  end
+
+  def test_touch_exception_does_not_suppress_enclosing_save_finalization
+    changes_in_after_save = nil
+    touch_exception = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :raise_during_touch, :capture_after_save
+
+      before_save do
+        if raise_during_touch
+          self.raise_during_touch = false
+          begin
+            touch
+          rescue RuntimeError => error
+            touch_exception = error.message
+          end
+        end
+      end
+
+      after_save do
+        if capture_after_save
+          self.author_name = "Not saved"
+          changes_in_after_save = transaction_changes.slice("title", "author_name")
+        end
+      end
+
+      def _update_row(attribute_names, attempted_action = "update")
+        raise "touch persistence" if attempted_action == "touch"
+        super
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    topic.raise_during_touch = true
+    topic.capture_after_save = true
+    topic.update!(title: "Saved")
+
+    assert_equal "touch persistence", touch_exception
+    assert_equal "Not saved", topic.author_name
+    assert_equal({ "title" => ["Original", "Saved"] }, changes_in_after_save)
+  end
+
+  def test_touch_later_does_not_finalize_an_outer_save_and_flush_allows_an_inner_save
+    changes_after_touch_later = nil
+    changes_in_later_before_callback = nil
+    changes_in_after_touch = nil
+    changes_in_nested_after_save = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      self.record_timestamps = false
+      attr_accessor :defer_touch_in_save, :nested_save_in_after_touch, :nested_save_active
+
+      before_save do
+        if defer_touch_in_save
+          self.defer_touch_in_save = false
+          touch_later
+          changes_after_touch_later = transaction_changes.slice("title", "updated_at")
+        end
+      end
+
+      before_save do
+        if changes_after_touch_later && !changes_in_later_before_callback
+          changes_in_later_before_callback = transaction_changes.slice("title", "updated_at")
+        end
+      end
+
+      after_touch do
+        if nested_save_in_after_touch
+          changes_in_after_touch = transaction_changes.slice("title", "updated_at")
+          self.nested_save_in_after_touch = false
+          self.nested_save_active = true
+          self.author_name = "Nested"
+          save!
+          self.nested_save_active = false
+        end
+      end
+
+      after_save do
+        if nested_save_active
+          self.title = "Not saved"
+          changes_in_nested_after_save = transaction_changes.slice("title", "author_name", "updated_at")
+        end
+      end
+    end
+
+    original_time = Time.utc(2020, 1, 1)
+    deferred_time = original_time + 1.hour
+    topic = klass.create!(
+      title: "Original", author_name: "Alice", written_on: Date.today,
+      created_at: original_time, updated_at: original_time
+    ).reload
+    topic.defer_touch_in_save = true
+    topic.nested_save_in_after_touch = true
+
+    travel_to(deferred_time) { topic.update!(title: "Outer") }
+
+    assert_equal({ "title" => ["Original", "Outer"] }, changes_after_touch_later)
+    assert_equal changes_after_touch_later, changes_in_later_before_callback
+    assert_equal ["Original", "Outer"], changes_in_after_touch["title"]
+    assert_equal [original_time, deferred_time], changes_in_after_touch["updated_at"]
+    assert_equal ["Original", "Outer"], changes_in_nested_after_save["title"]
+    assert_equal ["Alice", "Nested"], changes_in_nested_after_save["author_name"]
+    assert_equal [original_time, deferred_time], changes_in_nested_after_save["updated_at"]
+    assert_equal "Not saved", topic.title
+  end
+
+  def test_pre_persistence_halt_and_exception_keep_pending_values_only_during_unwind
+    [:halt, :raise].each do |failure_mode|
+      changes_during_unwind = nil
+
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = :topics
+        attr_accessor :failure_mode
+
+        around_save do |record, callback|
+          if record.failure_mode
+            begin
+              callback.call
+            ensure
+              changes_during_unwind = record.transaction_changes.slice("title")
+            end
+          else
+            callback.call
+          end
+        end
+
+        before_save do
+          throw :abort if self.failure_mode == :halt
+          raise "before persistence" if self.failure_mode == :raise
+        end
+      end
+
+      topic = klass.create!(title: "Original", written_on: Date.today).reload
+      topic.failure_mode = failure_mode
+      topic.title = "Failed"
+
+      if failure_mode == :halt
+        assert_not topic.save
+      else
+        assert_raises(RuntimeError) { topic.save! }
+      end
+
+      assert_equal ["Original", "Failed"], changes_during_unwind["title"], failure_mode
+      assert_equal "Failed", topic.title, failure_mode
+      assert_empty topic.transaction_changes, failure_mode
+    end
+  end
+
+  def test_exception_after_persistence_remains_post_persistence_during_unwind_and_cleans_up
+    changes_during_unwind = nil
+    changes_after_recovery = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :raise_after_persistence, :capture_recovery
+
+      around_save do |record, callback|
+        if raise_after_persistence
+          begin
+            callback.call
+          ensure
+            changes_during_unwind = record.transaction_changes.slice("title", "author_name")
+          end
+        else
+          callback.call
+        end
+      end
+
+      after_save do
+        if raise_after_persistence
+          self.author_name = "Not saved"
+          raise "after persistence"
+        elsif capture_recovery
+          self.author_name = "Not saved"
+          changes_after_recovery = transaction_changes.slice("title", "author_name")
+        end
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today).reload
+    topic.raise_after_persistence = true
+
+    assert_raises(RuntimeError) { topic.update!(title: "Rolled back") }
+    assert_equal({ "title" => ["Original", "Rolled back"] }, changes_during_unwind)
+    assert_empty topic.transaction_changes
+
+    topic.raise_after_persistence = false
+    topic.capture_recovery = true
+    topic.author_name = "Alice"
+    topic.update!(title: "Recovered")
+
+    assert_equal({ "title" => ["Original", "Recovered"] }, changes_after_recovery)
+  end
+
+  def test_custom_update_override_uses_changes_applied_as_its_persistence_boundary
+    changes_in_after_touch = nil
+    changes_in_after_save = nil
+    touch_time = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :custom_touch, :assign_after_custom_save
+
+      after_touch do
+        changes_in_after_touch = transaction_changes.slice("title", "updated_at") if custom_touch
+      end
+
+      after_save do
+        if assign_after_custom_save
+          self.author_name = "Not saved"
+          changes_in_after_save = transaction_changes.slice("title", "author_name", "updated_at")
+        end
+      end
+
+      define_method(:_update_record) do |attribute_names = attribute_names_for_partial_updates|
+        touch(time: touch_time) if custom_touch
+        affected_rows = _update_row(attribute_names)
+        @_trigger_update_callback = affected_rows == 1
+        changes_applied
+        affected_rows
+      ensure
+        clear_transaction_written_attributes
+      end
+
+      private :_update_record
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    original_time = topic.updated_at
+    touch_time = original_time + 1.hour
+    topic.custom_touch = true
+    topic.assign_after_custom_save = true
+    topic.update!(title: "Saved")
+
+    assert_equal ["Original", "Saved"], changes_in_after_touch["title"]
+    assert_equal [original_time, touch_time], changes_in_after_touch["updated_at"]
+    assert_equal ["Original", "Saved"], changes_in_after_save["title"]
+    assert_equal [original_time, touch_time], changes_in_after_save["updated_at"]
+    assert_not changes_in_after_save.key?("author_name")
+    assert_equal "Not saved", topic.author_name
+  end
+
+  def test_custom_update_override_cleans_up_attempt_when_it_returns_false
+    changes_after_recovery = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :return_false
+
+      def _update_record(attribute_names = attribute_names_for_partial_updates)
+        return false if return_false
+
+        affected_rows = _update_row(attribute_names)
+        @_trigger_update_callback = affected_rows == 1
+        changes_applied
+        affected_rows
+      ensure
+        clear_transaction_written_attributes
+      end
+
+      private :_update_record
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today).reload
+
+    klass.transaction do
+      topic.return_false = true
+      topic.title = "Failed"
+      assert_not topic.save
+      assert_empty topic.transaction_changes
+
+      topic.return_false = false
+      topic.update!(title: "Recovered")
+      topic.author_name = "Not saved"
+      changes_after_recovery = topic.transaction_changes.slice("title", "author_name")
+    end
+
+    assert_equal "Not saved", topic.author_name
+    assert_equal({ "title" => ["Original", "Recovered"] }, changes_after_recovery)
+  end
+
+  def test_touch_and_destroy_outside_a_save_attempt_exclude_unrelated_dirty_values
+    changes_in_after_touch = nil
+    changes_in_after_destroy = nil
+
+    touch_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_touch do
+        changes_in_after_touch = transaction_changes.slice("title", "updated_at")
+      end
+    end
+
+    topic = touch_klass.create!(title: "Original", written_on: Date.today)
+    original_time = topic.updated_at
+    touch_time = original_time + 1.hour
+    topic.title = "Not saved"
+    topic.touch(time: touch_time)
+
+    assert_equal "Not saved", topic.title
+    assert_not changes_in_after_touch.key?("title")
+    assert_equal [original_time, touch_time], changes_in_after_touch["updated_at"]
+
+    destroy_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      after_destroy do
+        changes_in_after_destroy = transaction_changes.slice("author_name")
+      end
+    end
+
+    topic = destroy_klass.create!(title: "Destroy", author_name: "Alice", written_on: Date.today)
+    topic.author_name = "Not saved"
+    topic.destroy!
+
+    assert_equal "Not saved", topic.author_name
+    assert_empty changes_in_after_destroy
+  end
+
+  def test_cross_model_read_uses_the_target_records_active_save_phase
+    nested_read = nil
+    read_after_target_save = nil
+
+    reader_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :target
+
+      after_save do
+        nested_read = target.transaction_changes.slice("title", "author_name") if target
+      end
+    end
+
+    target_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :reader
+
+      before_save do
+        if reader
+          current_reader = reader
+          self.reader = nil
+          current_reader.update!(author_name: "Read target")
+        end
+      end
+    end
+
+    target = target_klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+    reader = reader_klass.create!(title: "Reader", author_name: "Alice", written_on: Date.today)
+    reader.target = target
+    target.reader = reader
+
+    target_klass.transaction do
+      target.update!(title: "Saved")
+      target.author_name = "Not saved"
+      read_after_target_save = target.transaction_changes.slice("title", "author_name")
+    end
+
+    assert_equal({ "title" => ["Original", "Saved"] }, nested_read)
+    assert_equal({ "title" => ["Original", "Saved"] }, read_after_target_save)
+  end
+
+  def test_failed_validation_does_not_leave_a_pending_overlay_after_the_attempt
+    changes_after_failure = nil
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+      attr_accessor :fail_validation
+
+      validate do
+        errors.add(:base, "failed") if fail_validation
+      end
+    end
+
+    topic = klass.create!(title: "Original", author_name: "Alice", written_on: Date.today)
+
+    klass.transaction do
+      topic.update!(title: "Saved")
+      topic.fail_validation = true
+      topic.author_name = "Not saved"
+      assert_not topic.save
+      changes_after_failure = topic.transaction_changes.slice("title", "author_name")
+    end
+
+    assert_equal({ "title" => ["Original", "Saved"] }, changes_after_failure)
   end
 
   def test_transaction_changes_in_before_save_includes_pending_changes

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -1209,48 +1209,77 @@ database record. It can influence the flow and predictability of callback
 sequences, leading to potential inconsistencies in application logic following
 the transaction.
 
-### Tracking Changes in `after_commit`
+### Tracking Changes Across a Transaction
 
-Inside `after_commit` callbacks, you can use the `committed_changes` methods to
-inspect what changed during the entire transaction. These methods track the
-cumulative changes across all saves within the transaction, unlike the
-`saved_change_to_*` methods which only reflect the most recent save.
+You can use the `transaction_changes` methods to inspect what changed during
+an entire transaction. These methods track cumulative changes across all saves
+within the transaction, and work in any callback phase (`before_save`,
+`after_save`, `after_commit`), as well as for cross-model access within the
+same transaction. Unlike the `saved_change_to_*` methods which only reflect
+the most recent save, `transaction_change_to_*` methods reflect all saves
+within the transaction.
 
 The available methods are:
 
 | Method | Purpose |
 |---|---|
-| `committed_changes` | Hash of all changes across the transaction |
-| `committed_changes?` | Whether the transaction changed any attributes |
-| `committed_change_to_attribute(attr)` | The `[old, new]` pair for a specific attribute |
-| `committed_change_to_attribute?(attr)` | Whether the attribute changed during the transaction |
-| `attribute_before_last_commit(attr)` | The pre-transaction value of any attribute (even unchanged ones) |
+| `transaction_changes` | Hash of all cumulative changes across the transaction |
+| `transaction_changes?` | Whether the transaction changed any attributes |
+| `transaction_change_to_attribute(attr)` | The `[old, new]` pair for a specific attribute |
+| `transaction_change_to_attribute?(attr)` | Whether the attribute changed during the transaction |
+| `attribute_before_transaction(attr)` | The pre-transaction value of any attribute (even unchanged ones) |
 
-For example:
+Like `saved_change_to_*`, per-attribute convenience methods are also generated
+for every attribute. For example, an `email` attribute generates
+`transaction_change_to_email?`, `transaction_change_to_email`, and
+`email_before_transaction`.
+
+The distinction between `saved_change_to_*` and `transaction_change_to_*` matters
+when a transaction includes multiple saves. Consider a scenario where a user's
+email is updated in one save, and then an unrelated attribute is updated in a
+second save within the same transaction:
 
 ```ruby
 class User < ApplicationRecord
-  after_commit :sync_to_external_service, on: :update
+  after_commit :sync_email, on: :update
 
   private
-    def sync_to_external_service
-      if committed_change_to_attribute?(:email)
-        old_email, new_email = committed_change_to_attribute(:email)
+    def sync_email
+      # saved_change_to_email? would be FALSE here because the last save
+      # only changed the name, not the email. But the email DID change
+      # earlier in the same transaction.
+      if transaction_change_to_email?
+        old_email, new_email = transaction_change_to_email
         ExternalService.update_email(old_email, new_email)
       end
     end
 end
 ```
 
-The distinction between `saved_change_to_*` and `committed_change_to_*` matters
-when a transaction includes multiple saves. For example, if a record's `name`
-changes from `"Alice"` to `"Bob"` in one save, then from `"Bob"` to `"Carol"` in
-a second save within the same transaction:
+```ruby
+User.transaction do
+  user.update!(email: "new@example.com")
+  user.update!(name: "New Name")
+end
+# saved_change_to_email? => false (last save only changed name)
+# transaction_change_to_email? => true (email changed during the transaction)
+```
+
+More generally, if a record's `name` changes from `"Alice"` to `"Bob"` in one
+save, then from `"Bob"` to `"Carol"` in a second save within the same
+transaction:
 
 * `saved_change_to_name` returns `["Bob", "Carol"]` (the most recent save only)
-* `committed_change_to_name` returns `["Alice", "Carol"]` (the full transaction)
+* `transaction_change_to_name` returns `["Alice", "Carol"]` (the full transaction)
 
-NOTE: `attribute_before_last_commit` returns the pre-transaction value for _any_
+NOTE: During `before_save` and `before_update` callbacks, pending unsaved changes
+are included in `transaction_changes`. In `after_save`, `after_commit`, and other
+post-save callbacks, only persisted changes are reflected.
+
+NOTE: If an attribute is changed and then changed back to its original value
+within the same transaction, it will not appear in `transaction_changes`.
+
+NOTE: `attribute_before_transaction` returns the pre-transaction value for _any_
 attribute, not just ones that changed. For unchanged attributes, this is the same
 as the current value.
 

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -1272,9 +1272,24 @@ transaction:
 * `saved_change_to_name` returns `["Bob", "Carol"]` (the most recent save only)
 * `transaction_change_to_name` returns `["Alice", "Carol"]` (the full transaction)
 
-NOTE: During `before_save` and `before_update` callbacks, pending unsaved changes
-are included in `transaction_changes`. In `after_save`, `after_commit`, and other
-post-save callbacks, only persisted changes are reflected.
+NOTE: `transaction_changes` always includes the target record's successful
+writes in the transaction. It also includes that record's pending values while
+the record has an active create or update attempt that has not reached
+persistence. The target record's phase controls the result: a cross-model
+reader, or a touch or destroy nested before persistence, still sees those
+pending values. A nested save has its own phase, and the enclosing phase resumes
+when it returns. Deferred touches flush after the save attempt and add only
+their successful writes.
+
+In `after_save`, `after_update`, `after_commit`, and other post-persistence
+callbacks, only successful writes are reflected. If a save halts or raises
+before persistence, entered `around_save` code can still see pending values as
+it unwinds, but they are excluded after the save attempt exits. An exception
+after persistence remains in the post-persistence phase while it unwinds.
+Custom create or update persistence overrides must call `changes_applied` after
+a successful write to establish this boundary. Calling `changes_applied` from
+arbitrary pre-save code, or bypassing the standard touch implementation, is not
+a supported persistence protocol.
 
 NOTE: If an attribute is changed and then changed back to its original value
 within the same transaction, it will not appear in `transaction_changes`.


### PR DESCRIPTION
### Motivation / Background

The existing `saved_change_to_*` methods only reflect what changed in the most recent call to `save`. In `after_commit` callbacks this is a problem: when a transaction includes multiple saves, `saved_changes` only shows the last save's diff, not the cumulative change the transaction actually made to the database.

#### Scenario 1
If `name` changes from "Alice" to "Bob" in one save, then from "Bob" to "Carol" in a second save within the same transaction:

```
  saved_change_to_name       #=> ["Bob", "Carol"]    (last save only)
  transaction_change_to_name #=> ["Alice", "Carol"]   (full transaction)
```

#### Scenario 2
If `name` changes from "Alice" to "Bob" in one save, then `age` changes in a second save within the same transaction:

```
  saved_change_to_name       #=> nil                  (not part of last save)
  transaction_change_to_name #=> ["Alice", "Bob"]     (full transaction)
```

### Changes

This PR introduces a new family of methods that track cumulative attribute changes across the entire transaction. They work in any callback phase (`before_save`, `after_save`, `after_commit`), as well as for cross-model access within the same transaction:

  - `transaction_changes` — hash of all cumulative changes across the transaction
  - `transaction_changes?` — whether the transaction changed any attributes
  - `transaction_change_to_attribute(attr)` — the [old, new] pair
  - `transaction_change_to_attribute?(attr, from:, to:)` — query with options
  - `attribute_before_transaction(attr)` — pre-transaction value of any attribute, including ones that didn't change

During `before_save` / `before_update`, pending unsaved changes are included. If an attribute is changed back to its original value within the transaction, it is correctly omitted.

### Details

The implementation snapshots `@attributes` at the start of the transaction (in `remember_transaction_record_state`) and compares against the current attributes at commit time (in `_compute_committed_changes`). For `before_save` / `before_update`, `_compute_transaction_changes` overlays pending unsaved changes on top of the committed-so-far diff. If an attribute is changed back to its original value within the transaction, it is correctly omitted from `transaction_changes`.

### Why not integrate into `saved_changes`?

**1. Silent breaking change for every existing `after_commit` callback**

Every app that uses `saved_change_to_*` in `after_commit` today has established behavior — even if that behavior is sometimes wrong for multi-save transactions, it's *predictable*. Changing what `saved_change_to_name` returns depending on callback context would silently alter return values across every Rails app on upgrade.

**2. They answer fundamentally different questions**

Consider: create a record (name goes `nil -> "Alice"`), then update it (name goes `"Alice" -> "Bob"`). The last `saved_change_to_name` is `["Alice", "Bob"]`. The `transaction_change_to_name` is `[nil, "Bob"]`. These aren't two views of the same data — they're different data. Collapsing them into one method hides the fact that there are two distinct questions people need to ask.

**3. `after_save` fires inside transactions too**

Inside a transaction with multiple saves, `after_save` fires after each one. `saved_change_to_*` must return per-save changes there, that's its contract. So you can't globally swap the semantics; you'd need the method to introspect whether it's being called from `after_save` or `after_commit`. That introspection mechanism itself would be fragile (what about code called from both contexts? helper methods shared between callbacks?).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
