### PR TITLE
Don't eagerly cache JSON Encoder in ActiveRecord::Type::Json

### DIFF
--- a/activerecord/lib/active_record/type/json.rb
+++ b/activerecord/lib/active_record/type/json.rb
@@ -25,10 +25,8 @@ module ActiveRecord
         end
       end
 
-      JSON_ENCODER = ActiveSupport::JSON::Encoding.json_encoder.new(escape: false)
-
       def serialize(value)
-        JSON_ENCODER.encode(value) unless value.nil?
+        ActiveSupport::JSON::Encoding.encode_without_escape(value) unless value.nil?
       end
 
       def changed_in_place?(raw_old_value, new_value)


### PR DESCRIPTION
If we cache the encoder when the class is first referenced, it prevents us from being able to proper override the encoder later. Instead, just make use of ActiveSupport::JSON's cached encoder and prebuilt `without_escaping` option.

[Fix #56766]

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.

Welcoming guidance on how to properly test this in excess of current tests. 🙂 