### PR TITLE
Fix Marshal deserialisation of Integer type from Rails 8.0

### DIFF
--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -102,6 +102,10 @@ module ActiveModel
 
       private
         def out_of_range?(value)
+          if @max.nil?
+            @max = max_value
+            @min = min_value
+          end
           value && (@max <= value || @min > value)
         end
 


### PR DESCRIPTION
Fixes small regression in #53470.

`NoMethodError: undefined method '<=' for nil` when deserialising `ActiveModel::Type::Integer` objects that were Marshal-serialised under Rails 8.0.x and loaded under Rails 8.1.x.

This primarily affects applications using the default marshalling format (6.1). 

While upgrading to format 7.1 mitigates the issue for `AR::Base` objects, the Type class should still be resilient to Marshal round-trips, as Type objects may also appear in other cached contexts (e.g. schema cache, attribute builders).

Discovered after a production outage on a client project immediately after deploying Rails 8.1.

### Info

The performance optimisation in #53470 replaced `@range` with `@max`/`@min` in `Type::Integer#initialize`. 

`Marshal.load` restores instance variables directly without calling `initialize`, so objects serialised under 8.0 (which have `@range` but not `@max`/`@min`) are left with `@max = nil` and `@min = nil`. The `out_of_range?` method then calls `nil <= value`, raising `NoMethodError`.

The fix lazy-initialises `@max` and `@min` from `max_value`/`min_value` (derived from `limit`, which IS correctly restored by Marshal via the parent `Value` class) when they are `nil`. 

No performance impact on the normal code path — the guard only fires once on the degraded path.

### Additional information

The alternative workaround is flushing the entire cache, but this should not be required for a minor version upgrade.
Would appreciate a backport to `8-1-stable` if accepted.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behaviour change or additional feature.
