### PR TITLE
Bump Valkey Redis Image version to 9

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -41,7 +41,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
 
   redis:
-    image: valkey/valkey:8
+    image: valkey/valkey:9
     restart: unless-stopped
     volumes:
       - redis-data:/data

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -128,7 +128,7 @@ builder:
 #     directories:
 #       - data:/var/lib/mysql
 #   redis:
-#     image: valkey/valkey:8
+#     image: valkey/valkey:9
 #     host: 192.168.0.2
 #     port: 6379
 #     directories:

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -82,7 +82,7 @@ jobs:
     <%- if options[:database] == "sqlite3" -%>
     # services:
     #  redis:
-    #    image: valkey/valkey:8
+    #    image: valkey/valkey:9
     #    ports:
     #      - 6379:6379
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
@@ -108,7 +108,7 @@ jobs:
       <%- end -%>
 
       # redis:
-      #   image: valkey/valkey:8
+      #   image: valkey/valkey:9
       #   ports:
       #     - 6379:6379
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
@@ -155,7 +155,7 @@ jobs:
     <%- if options[:database] == "sqlite3" -%>
     # services:
     #  redis:
-    #    image: valkey/valkey:8
+    #    image: valkey/valkey:9
     #    ports:
     #      - 6379:6379
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
@@ -181,7 +181,7 @@ jobs:
       <%- end -%>
 
       # redis:
-      #   image: valkey/valkey:8
+      #   image: valkey/valkey:9
       #   ports:
       #     - 6379:6379
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -32,7 +32,7 @@ services:
 
 <%- if options[:redis] -%>
   redis:
-    image: valkey/valkey:8
+    image: valkey/valkey:9
     restart: unless-stopped
     volumes:
     - redis-data:/data

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -43,7 +43,7 @@ jobs:
     <%- if options[:database] == "sqlite3" -%>
     # services:
     #  redis:
-    #    image: valkey/valkey:8
+    #    image: valkey/valkey:9
     #    ports:
     #      - 6379:6379
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
@@ -69,7 +69,7 @@ jobs:
       <%- end -%>
 
       # redis:
-      #   image: valkey/valkey:8
+      #   image: valkey/valkey:9
       #   ports:
       #     - 6379:6379
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5

--- a/railties/test/fixtures/.devcontainer/compose.yaml
+++ b/railties/test/fixtures/.devcontainer/compose.yaml
@@ -24,7 +24,7 @@ services:
     restart: unless-stopped
 
   redis:
-    image: valkey/valkey:8
+    image: valkey/valkey:9
     restart: unless-stopped
     volumes:
     - redis-data:/data

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1537,7 +1537,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_includes compose_config["services"]["rails-app"]["depends_on"], "redis"
 
       expected_redis_config = {
-        "image" => "valkey/valkey:8",
+        "image" => "valkey/valkey:9",
         "restart" => "unless-stopped",
         "volumes" => ["redis-data:/data"]
       }

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -270,7 +270,7 @@ module Rails
         assert_compose_file do |compose|
           assert_includes compose["services"]["rails-app"]["depends_on"], "redis"
           expected_redis_config = {
-            "image" => "valkey/valkey:8",
+            "image" => "valkey/valkey:9",
             "restart" => "unless-stopped",
             "volumes" => ["redis-data:/data"]
           }


### PR DESCRIPTION


### Detail

This PR upgrades the [Valkey](https://hub.docker.com/r/valkey/valkey/) redis image version to the latest version 9 in `devcontainer` and other `ci` files.



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
