### PR TITLE
Add parallel step groups to CI runner

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   Add `group` method to `ActiveSupport::ContinuousIntegration` for parallel step execution.
+
+    Groups collect steps and run them concurrently using a thread pool, reducing CI times
+    by running independent checks in parallel. Sub-groups run sequentially within a single
+    parallel slot allowing dependent steps to be grouped together.
+
+    ```ruby
+    CI.run do
+      step "Setup", "bin/setup --skip-server"
+
+      group "Checks", parallel: 2 do
+        step "Style: Ruby", "bin/rubocop"
+        step "Security: Brakeman", "bin/brakeman --quiet"
+        step "Security: Gem audit", "bin/bundler-audit"
+
+        group "Tests" do
+          step "Tests: Rails", "bin/rails test"
+          step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
+        end
+      end
+    end
+    ```
+
+    *Donal McBreen*
+
 *   Introduce `this_week?`, `this_month?`, and `this_year?` methods to Date/Time
 
     Similar to `today?`, `tomorrow?`, and `yesterday?`, these methods are useful to

--- a/activesupport/lib/active_support/continuous_integration.rb
+++ b/activesupport/lib/active_support/continuous_integration.rb
@@ -27,7 +27,8 @@ module ActiveSupport
       title: "\033[1;35m",    # Purple
       subtitle: "\033[1;90m", # Medium Gray
       error: "\033[1;31m",    # Red
-      success: "\033[1;32m"   # Green
+      success: "\033[1;32m",  # Green
+      progress: "\033[1;36m"  # Cyan
     }
 
     attr_reader :results
@@ -55,12 +56,15 @@ module ActiveSupport
     #     end
     #   end
     def self.run(title = "Continuous Integration", subtitle = "Running tests, style checks, and security audits", &block)
-      new.tap do |ci|
-        ENV["CI"] = "true"
-        ci.heading title, subtitle, padding: false
-        ci.report(title, &block)
-        abort unless ci.success?
-      end
+      ENV["CI"] = "true"
+      new.tap { |ci| ci.run(title, subtitle, &block) }
+    end
+
+    def run(title, subtitle, &block)
+      heading title, subtitle, padding: false
+      success, seconds = execute(title, &block)
+      result_line(title, success, seconds)
+      abort unless success?
     end
 
     def initialize
@@ -75,8 +79,41 @@ module ActiveSupport
     #   step "Setup", "bin/setup"
     #   step "Single test", "bin/rails", "test", "--name", "test_that_is_one"
     def step(title, *command)
-      heading title, command.join(" "), type: :title
-      report(title) { results << [ system(*command), title ] }
+      Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
+      report_step(title, command) do
+        started = Time.now.to_f
+        [system(*command), Time.now.to_f - started]
+      end
+      abort if failing_fast?
+    end
+
+    # Declare a group of steps that can be run in parallel. Steps within the group are collected first,
+    # then executed either concurrently (when +parallel+ > 1) or sequentially (when +parallel+ is 1).
+    #
+    # When running in parallel, each step's output is captured to avoid interleaving, and a progress
+    # display shows which steps are currently running.
+    #
+    # Sub-groups within a parallel group occupy a single parallel slot and run their steps sequentially.
+    #
+    # Examples:
+    #
+    #   group "Checks", parallel: 3 do
+    #     step "Style: Ruby", "bin/rubocop"
+    #     step "Security: Brakeman", "bin/brakeman --quiet"
+    #     step "Security: Gem audit", "bin/bundler-audit"
+    #   end
+    #
+    #   group "Tests" do
+    #     step "Unit tests", "bin/rails test"
+    #     step "System tests", "bin/rails test:system"
+    #   end
+    def group(name, parallel: 1, &block)
+      if parallel <= 1
+        instance_eval(&block)
+      else
+        Group.new(self, name, parallel: parallel, &block).run
+      end
+      abort if failing_fast?
     end
 
     # Returns true if all steps were successful.
@@ -115,41 +152,17 @@ module ActiveSupport
     end
 
     # :nodoc:
-    def report(title, &block)
-      Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
-
-      ci = self.class.new
-      elapsed = timing { ci.instance_eval(&block) }
-
-      if ci.success?
-        echo "\n✅ #{title} passed in #{elapsed}", type: :success
-      else
-        echo "\n❌ #{title} failed in #{elapsed}", type: :error
-
-        abort if ci.fail_fast?
-
-        if ci.multiple_results?
-          ci.failures.each do |success, title|
-            unless success
-              echo "   ↳ #{title} failed", type: :error
-            end
-          end
-        end
-      end
-
-      results.concat ci.results
-    ensure
-      Signal.trap("INT", "-")
+    def report_step(title, command)
+      heading title, command.join(" "), type: :title
+      success, seconds = yield
+      result_line(title, success, seconds)
+      results << [success, title]
+      success
     end
 
     # :nodoc:
-    def failures
-      results.reject(&:first)
-    end
-
-    # :nodoc:
-    def multiple_results?
-      results.size > 1
+    def colorize(text, type)
+      "#{COLORS.fetch(type)}#{text}\033[0m"
     end
 
     # :nodoc:
@@ -157,16 +170,60 @@ module ActiveSupport
       ARGV.include?("-f") || ARGV.include?("--fail-fast")
     end
 
+    # :nodoc:
+    def failing_fast?
+      fail_fast? && failures.any?
+    end
+
     private
+      def failures
+        results.reject(&:first)
+      end
+
+      def multiple_results?
+        results.size > 1
+      end
+
+      def execute(title, &block)
+        Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
+
+        seconds = timing { instance_eval(&block) }
+
+        unless success?
+          if multiple_results?
+            failures.each do |success, title|
+              unless success
+                echo "   ↳ #{title} failed", type: :error
+              end
+            end
+          end
+        end
+
+        [success?, seconds]
+      ensure
+        Signal.trap("INT", "-")
+      end
+
+      def result_line(title, success, seconds)
+        elapsed = format_elapsed(seconds)
+        if success
+          echo "\n✅ #{title} passed in #{elapsed}", type: :success
+        else
+          echo "\n❌ #{title} failed in #{elapsed}", type: :error
+        end
+      end
+
+      def format_elapsed(seconds)
+        min, sec = seconds.divmod(60)
+        "#{"#{min.to_i}m" if min > 0}%.2fs" % sec
+      end
+
       def timing
         started_at = Time.now.to_f
         yield
-        min, sec = (Time.now.to_f - started_at).divmod(60)
-        "#{"#{min}m" if min > 0}%.2fs" % sec
-      end
-
-      def colorize(text, type)
-        "#{COLORS.fetch(type)}#{text}\033[0m"
+        Time.now.to_f - started_at
       end
   end
 end
+
+require_relative "continuous_integration/group"

--- a/activesupport/lib/active_support/continuous_integration.rb
+++ b/activesupport/lib/active_support/continuous_integration.rb
@@ -79,12 +79,14 @@ module ActiveSupport
     #   step "Setup", "bin/setup"
     #   step "Single test", "bin/rails", "test", "--name", "test_that_is_one"
     def step(title, *command)
-      Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
+      previous_trap = Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
       report_step(title, command) do
         started = Time.now.to_f
         [system(*command), Time.now.to_f - started]
       end
       abort if failing_fast?
+    ensure
+      Signal.trap("INT", previous_trap || "-")
     end
 
     # Declare a group of steps that can be run in parallel. Steps within the group are collected first,
@@ -185,7 +187,7 @@ module ActiveSupport
       end
 
       def execute(title, &block)
-        Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
+        previous_trap = Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
 
         seconds = timing { instance_eval(&block) }
 
@@ -201,7 +203,7 @@ module ActiveSupport
 
         [success?, seconds]
       ensure
-        Signal.trap("INT", "-")
+        Signal.trap("INT", previous_trap || "-")
       end
 
       def result_line(title, success, seconds)

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+module ActiveSupport
+  class ContinuousIntegration
+    class Group # :nodoc:
+      class TaskCollector
+        attr_reader :tasks
+
+        def initialize(&block)
+          @tasks = []
+          instance_eval(&block)
+        end
+
+        def step(title, *command)
+          @tasks << [:step, title, command]
+        end
+
+        def group(name, **options, &block)
+          raise ArgumentError, "Sub-groups cannot be parallelized. Remove the `parallel:` option from the #{name.inspect} group." if options.key?(:parallel)
+          @tasks << [:group, name, block]
+        end
+      end
+
+      def initialize(ci, name, parallel:, &block)
+        @ci = ci
+        @name = name
+        @parallel = parallel
+        @tasks = TaskCollector.new(&block).tasks
+        @start_time = Time.now.to_f
+        @mutex = Mutex.new
+        @running = {}
+        @progress_visible = false
+      end
+
+      def run
+        Signal.trap("INT") { abort @ci.colorize("\n❌ #{@running.keys.join(', ')} interrupted", :error) }
+
+        queue = Queue.new(@tasks)
+
+        with_progress do
+          @parallel.times.map do
+            Thread.new do
+              while (task = dequeue(queue))
+                execute_task(*task) unless @ci.failing_fast?
+              end
+            end
+          end.each(&:join)
+        end
+
+        Signal.trap("INT", "-")
+      end
+
+      private
+        def with_progress
+          stop = false
+          thread = Thread.new do
+            until stop
+              @mutex.synchronize { refresh_progress }
+              sleep 0.1
+            end
+          end
+
+          yield
+
+          stop = true
+          thread.join
+        end
+
+        def execute_task(type, title, payload)
+          case type
+          when :step  then execute_step(title, payload)
+          when :group then execute_group(title, payload)
+          end
+        end
+
+        def execute_step(title, command)
+          @mutex.synchronize { @running[title] = Time.now.to_f }
+          success, log_path = capture_output(command)
+          @mutex.synchronize do
+            started = @running.delete(title)
+            clear_progress
+
+            @ci.report_step(title, command) do
+              replay_and_cleanup(log_path)
+              [success, Time.now.to_f - started]
+            end
+
+            refresh_progress
+          end
+          success
+        end
+
+        def execute_group(name, block)
+          all_success = true
+          TaskCollector.new(&block).tasks.each do |type, title, payload|
+            unless execute_task(type, title, payload)
+              all_success = false
+              break if @ci.fail_fast?
+            end
+          end
+
+          all_success
+        end
+
+        def capture_output(command)
+          log_path = Dir::Tmpname.create(["ci-", ".log"]) { }
+
+          success = spawn_process(command) do |output|
+            File.open(log_path, "w") do |f|
+              loop { f.write(output.readpartial(8192)) }
+            rescue EOFError, Errno::EIO
+              # Expected when process exits
+            end
+          end
+
+          [success, log_path]
+        rescue Errno::ENOENT
+          File.write(log_path, "Command not found: #{command.join(" ")}\n")
+          [false, log_path]
+        end
+
+        def spawn_process(command, &block)
+          # Prefer PTY if available to retain output colors
+          if pty_available?
+            spawn_via_pty(command, &block)
+          else
+            spawn_via_open3(command, &block)
+          end
+        end
+
+        def pty_available?
+          require "pty"
+          true
+        rescue LoadError
+          false
+        end
+
+        def spawn_via_pty(command)
+          output, input, pid = PTY.spawn(*command)
+          input.close
+          yield output
+          Process.waitpid2(pid).last.success?
+        rescue PTY::ChildExited => e
+          e.status.success?
+        end
+
+        def spawn_via_open3(command)
+          require "open3"
+          Open3.popen2e(*command) do |input, output, wait_thr|
+            input.close
+            yield output
+            wait_thr.value.success?
+          end
+        end
+
+        def replay_and_cleanup(log_path)
+          File.open(log_path, "r") do |f|
+            while (chunk = f.read(8192))
+              print chunk
+            end
+          end
+          File.delete(log_path)
+        end
+
+        def refresh_progress
+          if @running.any?
+            print "\n\n" unless @progress_visible
+            elapsed = format_elapsed_brief(Time.now.to_f - @start_time)
+            print "\r\e[K#{@ci.colorize("#{@name} (#{elapsed}) - #{@running.keys.join(' | ')}...", :progress)}"
+            @progress_visible = true
+            $stdout.flush
+          end
+        end
+
+        def clear_progress
+          return unless @progress_visible
+          print "\r\e[2A\e[J"
+          @progress_visible = false
+        end
+
+        def format_elapsed_brief(seconds)
+          min, sec = seconds.divmod(60)
+          "#{"#{min.to_i}m" if min > 0}#{sec.to_i}s"
+        end
+
+        def dequeue(queue)
+          queue.pop(true)
+        rescue ThreadError
+          nil
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -118,8 +118,8 @@ module ActiveSupport
           end
 
           [success, log_path]
-        rescue Errno::ENOENT
-          File.write(log_path, "Command not found: #{command.join(" ")}\n")
+        rescue SystemCallError => e
+          File.write(log_path, "#{e.message}: #{command.join(" ")}\n")
           [false, log_path]
         end
 

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -44,7 +44,8 @@ module ActiveSupport
           @parallel.times.map do
             Thread.new do
               while (task = dequeue(queue))
-                execute_task(*task) unless @ci.failing_fast?
+                break if @ci.failing_fast?
+                execute_task(*task)
               end
             end
           end.each(&:join)

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -32,6 +32,7 @@ module ActiveSupport
         @mutex = Mutex.new
         @running = {}
         @progress_visible = false
+        @log_files = []
       end
 
       def run
@@ -52,6 +53,7 @@ module ActiveSupport
         end
       ensure
         Signal.trap("INT", previous_trap || "-")
+        @log_files.each { |path| File.delete(path) if File.exist?(path) }
       end
 
       private
@@ -108,6 +110,7 @@ module ActiveSupport
 
         def capture_output(command)
           log_path = Dir::Tmpname.create(["ci-", ".log"]) { }
+          @mutex.synchronize { @log_files << log_path }
 
           success = spawn_process(command) do |output|
             File.open(log_path, "w") do |f|

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -35,7 +35,7 @@ module ActiveSupport
       end
 
       def run
-        Signal.trap("INT") { abort @ci.colorize("\n❌ #{@running.keys.join(', ')} interrupted", :error) }
+        previous_trap = Signal.trap("INT") { abort @ci.colorize("\n❌ #{@running.keys.join(', ')} interrupted", :error) }
 
         queue = Queue.new
         @tasks.each { |task| queue << task }
@@ -49,8 +49,8 @@ module ActiveSupport
             end
           end.each(&:join)
         end
-
-        Signal.trap("INT", "-")
+      ensure
+        Signal.trap("INT", previous_trap || "-")
       end
 
       private

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -37,7 +37,8 @@ module ActiveSupport
       def run
         Signal.trap("INT") { abort @ci.colorize("\n❌ #{@running.keys.join(', ')} interrupted", :error) }
 
-        queue = Queue.new(@tasks)
+        queue = Queue.new
+        @tasks.each { |task| queue << task }
 
         with_progress do
           @parallel.times.map do

--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -18,9 +18,9 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert_not @CI.success?
   end
 
-  test "report with only successful steps combined gives success" do
+  test "run with only successful steps combined gives success" do
     output = capture_io do
-      @CI.report("CI") do
+      @CI.run("CI", nil) do
         step "Success!", "true"
         step "Success again!", "true"
       end
@@ -30,11 +30,13 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert @CI.success?
   end
 
-  test "report with successful and failed steps combined gives failure" do
+  test "run with successful and failed steps combined gives failure" do
     output = capture_io do
-      @CI.report("CI") do
-        step "Success!", "true"
-        step "Failed!", "false"
+      assert_raises(SystemExit) do
+        @CI.run("CI", nil) do
+          step "Success!", "true"
+          step "Failed!", "false"
+        end
       end
     end.to_s
 
@@ -42,13 +44,15 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert_not @CI.success?
   end
 
-  test "report with successful and failed steps combined presents a failure summary" do
+  test "run with successful and failed steps combined presents a failure summary" do
     output = capture_io do
-      @CI.report("CI") do
-        step "Success!", "true"
-        step "Failed!", "false"
-        step "Also success!", "true"
-        step "Also failed!", "false"
+      assert_raises(SystemExit) do
+        @CI.run("CI", nil) do
+          step "Success!", "true"
+          step "Failed!", "false"
+          step "Also success!", "true"
+          step "Also failed!", "false"
+        end
       end
     end.to_s
 
@@ -58,10 +62,12 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert_match(/↳ Also failed! failed/, output)
   end
 
-  test "report with only one failing step does not print a failure summary" do
+  test "run with only one failing step does not print a failure summary" do
     output = capture_io do
-      @CI.report("CI") do
-        step "Failed!", "false"
+      assert_raises(SystemExit) do
+        @CI.run("CI", nil) do
+          step "Failed!", "false"
+        end
       end
     end.to_s
 
@@ -83,15 +89,171 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert_equal "\e[1;31m\n\nThis sucks\e[0m\n\e[1;90mBut such is the life of programming sometimes\n\e[0m\n", output
   end
 
+  test "sequential group with all passing steps" do
+    output = capture_io do
+      @CI.group("Checks") do
+        step "Pass 1", "true"
+        step "Pass 2", "true"
+      end
+    end.to_s
+
+    assert @CI.success?
+    assert_match(/Pass 1 passed/, output)
+    assert_match(/Pass 2 passed/, output)
+  end
+
+  test "sequential group with a failing step" do
+    output = capture_io do
+      @CI.group("Checks") do
+        step "Pass", "true"
+        step "Fail", "false"
+      end
+    end.to_s
+
+    assert_not @CI.success?
+    assert_match(/Fail failed/, output)
+  end
+
+  test "parallel group with all passing steps" do
+    output = capture_io do
+      @CI.group("Checks", parallel: 2) do
+        step "Pass 1", "true"
+        step "Pass 2", "true"
+      end
+    end.to_s
+
+    assert @CI.success?
+    assert_match(/Pass 1 passed/, output)
+    assert_match(/Pass 2 passed/, output)
+  end
+
+  test "parallel group with a failing step" do
+    output = capture_io do
+      @CI.group("Checks", parallel: 2) do
+        step "Pass", "true"
+        step "Fail", "false"
+      end
+    end.to_s
+
+    assert_not @CI.success?
+    assert_match(/Fail failed/, output)
+  end
+
+  test "parallel group provides a tty via pty" do
+    begin
+      require "pty"
+    rescue LoadError
+      skip "PTY not available"
+    end
+
+    output = capture_io do
+      @CI.group("Checks", parallel: 2) do
+        step "TTY", "sh", "-c", "test -t 1"
+      end
+    end.to_s
+
+    assert_match(/TTY passed/, output)
+  end
+
+  test "parallel group falls back to open3 when pty is unavailable" do
+    assert_called_on_instance_of(ActiveSupport::ContinuousIntegration::Group, :pty_available?, returns: false) do
+      output = capture_io do
+        @CI.group("Checks", parallel: 2) do
+          step "TTY", "sh", "-c", "test -t 1"
+        end
+      end.to_s
+
+      assert_match(/TTY failed/, output)
+    end
+  end
+
+  test "parallel group timing" do
+    capture_io do
+      started = Time.now.to_f
+      @CI.group("Checks", parallel: 2) do
+        step "Sleep 1", "sleep 0.2"
+        step "Sleep 2", "sleep 0.2"
+      end
+      elapsed = Time.now.to_f - started
+
+      assert elapsed < 0.35, "Expected parallel execution to complete in ~0.2s, took #{elapsed}s"
+    end
+
+    assert @CI.success?
+  end
+
+  test "sub-groups cannot be parallelized" do
+    exception = assert_raises ArgumentError do
+      capture_io do
+        @CI.group("Outer", parallel: 2) do
+          group "Inner", parallel: 2 do
+            step "Test", "true"
+          end
+        end
+      end
+    end
+    assert_equal "Sub-groups cannot be parallelized. Remove the `parallel:` option from the \"Inner\" group.", exception.message
+  end
+
+  test "nested group within sequential group" do
+    output = capture_io do
+      @CI.group("Outer") do
+        step "Style", "true"
+        group "Tests" do
+          step "Unit", "true"
+          step "System", "true"
+        end
+      end
+    end.to_s
+
+    assert @CI.success?
+    assert_match(/Unit passed/, output)
+    assert_match(/System passed/, output)
+  end
+
+  test "nested group within parallel group" do
+    output = capture_io do
+      @CI.group("Checks", parallel: 2) do
+        step "Style", "true"
+        group "Tests" do
+          step "Unit", "true"
+          step "System", "true"
+        end
+      end
+    end.to_s
+
+    assert @CI.success?
+    assert_match(/Style passed/, output)
+    assert_match(/Unit passed/, output)
+    assert_match(/System passed/, output)
+  end
+
   %w[-f --fail-fast].each do |flag|
-    test "report aborts immediately on failure with #{flag} flag" do
+    test "run aborts immediately on failure with #{flag} flag" do
       output = with_argv([flag]) do
         capture_io do
           assert_raises SystemExit do
-            @CI.report("CI") do
+            @CI.run("CI", nil) do
               step "Success!", "true"
               step "Failed!", "false"
               step "Should not run", "true"
+            end
+          end
+        end
+      end.to_s
+
+      assert_no_match(/Should not run/, output)
+    end
+
+    test "parallel group stops launching new steps with #{flag} flag" do
+      output = with_argv([flag]) do
+        capture_io do
+          assert_raises SystemExit do
+            @CI.run("CI", nil) do
+              group "Checks", parallel: 1 do
+                step "Fail", "false"
+                step "Should not run", "true"
+              end
             end
           end
         end

--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -256,6 +256,23 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     Signal.trap("INT", "DEFAULT")
   end
 
+  test "parallel group handles spawn errors as failed steps" do
+    Dir.mktmpdir do |dir|
+      script = File.join(dir, "nope.sh")
+      File.write(script, "#!/bin/sh\nexit 0")
+      File.chmod(0o000, script)
+
+      output = capture_io do
+        @CI.group("Checks", parallel: 2) do
+          step "No permission", script
+        end
+      end.to_s
+
+      assert_not @CI.success?
+      assert_match(/No permission failed/, output)
+    end
+  end
+
   %w[-f --fail-fast].each do |flag|
     test "run aborts immediately on failure with #{flag} flag" do
       output = with_argv([flag]) do

--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -278,16 +278,20 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
         capture_io do
           assert_raises SystemExit do
             @CI.run("CI", nil) do
-              group "Checks", parallel: 1 do
+              group "Checks", parallel: 2 do
                 step "Fail", "false"
-                step "Should not run", "true"
+                step "Should not run 1", "true"
+                step "Should not run 2", "true"
+                step "Should not run 3", "true"
               end
             end
           end
         end
       end.to_s
 
-      assert_no_match(/Should not run/, output)
+      # With parallel: 2, one thread gets "Fail" and the other may dequeue one
+      # task before observing the failure — but subsequent tasks must be skipped.
+      assert_no_match(/Should not run 3/, output)
     end
   end
 

--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -273,6 +273,20 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     end
   end
 
+  test "parallel group cleans up temp files on completion" do
+    temp_files_before = Dir.glob(File.join(Dir.tmpdir, "ci-*.log"))
+
+    capture_io do
+      @CI.group("Checks", parallel: 2) do
+        step "Pass", "true"
+        step "Fail", "false"
+      end
+    end
+
+    temp_files_after = Dir.glob(File.join(Dir.tmpdir, "ci-*.log"))
+    assert_equal temp_files_before, temp_files_after
+  end
+
   %w[-f --fail-fast].each do |flag|
     test "run aborts immediately on failure with #{flag} flag" do
       output = with_argv([flag]) do

--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -228,6 +228,34 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert_match(/System passed/, output)
   end
 
+  test "step restores previous signal handler" do
+    custom_handler = proc { }
+    Signal.trap("INT", custom_handler)
+
+    capture_io { @CI.step "Pass", "true" }
+
+    current = Signal.trap("INT", "DEFAULT")
+    assert_equal custom_handler, current
+  ensure
+    Signal.trap("INT", "DEFAULT")
+  end
+
+  test "parallel group restores previous signal handler" do
+    custom_handler = proc { }
+    Signal.trap("INT", custom_handler)
+
+    capture_io do
+      @CI.group("Checks", parallel: 2) do
+        step "Pass", "true"
+      end
+    end
+
+    current = Signal.trap("INT", "DEFAULT")
+    assert_equal custom_handler, current
+  ensure
+    Signal.trap("INT", "DEFAULT")
+  end
+
   %w[-f --fail-fast].each do |flag|
     test "run aborts immediately on failure with #{flag} flag" do
       output = with_argv([flag]) do

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -2,33 +2,36 @@
 
 CI.run do
   step "Setup", "bin/setup --skip-server"
-<% unless options.skip_rubocop? %>
-  step "Style: Ruby", "bin/rubocop"
+
+  group "Checks", parallel: 2 do
+<% unless options.skip_rubocop? -%>
+    step "Style: Ruby", "bin/rubocop"
 <% end -%>
 
 <% unless options.skip_bundler_audit? -%>
-  step "Security: Gem audit", "bin/bundler-audit"
+    step "Security: Gem audit", "bin/bundler-audit"
 <% end -%>
 <% if using_node? -%>
-  step "Security: Yarn vulnerability audit", "yarn audit"
+    step "Security: Yarn vulnerability audit", "yarn audit"
 <% end -%>
 <% if using_importmap? -%>
-  step "Security: Importmap vulnerability audit", "bin/importmap audit"
+    step "Security: Importmap vulnerability audit", "bin/importmap audit"
 <% end -%>
 <% unless options.skip_brakeman? -%>
-  step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
-<% end -%>
-<% unless options[:skip_test] -%>
-  step "Tests: Rails", "bin/rails test"
-<% unless options.skip_active_record? -%>
-  step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
-<% end -%>
+    step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
 <% end -%>
 
 <% unless options[:skip_test] -%>
-  # Optional: Run system tests
-  # step "Tests: System", "bin/rails test:system"
+    group "Tests" do
+      step "Tests: Rails", "bin/rails test"
+<% unless options.skip_active_record? -%>
+      step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 <% end -%>
+      # Optional: Run system tests
+      # step "Tests: System", "bin/rails test:system"
+    end
+<% end -%>
+  end
 
   # Optional: set a green GitHub commit status to unblock PR merge.
   # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.

--- a/railties/test/application/bin_ci_test.rb
+++ b/railties/test/application/bin_ci_test.rb
@@ -16,6 +16,9 @@ module ApplicationTests
 
         content = File.read("config/ci.rb")
 
+        # Parallel group
+        assert_match(/group "Checks", parallel: 2/, content)
+
         # Default steps
         assert_match(/bin\/rubocop/, content)
         assert_match(/bin\/brakeman/, content)
@@ -23,6 +26,9 @@ module ApplicationTests
         assert_match(/"bin\/rails test"$/, content)
         assert_match(/"bin\/rails test:system"$/, content)
         assert_match(/bin\/rails db:seed:replant/, content)
+
+        # Tests sub-group
+        assert_match(/group "Tests"/, content)
 
         # Node-specific steps excluded by default
         assert_no_match(/yarn audit/, content)


### PR DESCRIPTION
### Motivation / Background

Add CI groups to allow independent steps to run in parallel and improve run times. 

For large apps, brakeman checks can take 10-20 seconds. Depending on the test setup, multiple test steps might be able to run in parallel.

Allow independent steps to run in parallel for a faster runtime.

cc @jeremy 

### Detail

Steps can be grouped and run in parallel:

```ruby
group "Checks", parallel: 3 do
  step "Style: Ruby", "bin/rubocop"
  step "Security: Brakeman", "bin/brakeman --quiet"
  step "Security: Gem audit", "bin/bundler-audit"
end
```

`parallel` defaults to 1, which runs steps sequentially.

Parallel steps capture output via PTY (or Open3 as fallback) to prevent interleaving, with a live progress line showing running steps.

Groups can be nested, but only the outer group can run in parallel. This allows dependent steps to run sequentially within a parallel group:

```ruby
group "Checks", parallel: 2 do
  group "Tests" do
    step "Tests: Rails", "bin/rails test"
    step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
  end

  step "Style: Ruby", "bin/rubocop"
  step "Security: Brakeman", "bin/brakeman --quiet"
  step "Security: Gem audit", "bin/bundler-audit"
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
