### PR TITLE
Update Action Cable origin check to respect X-Forwarded-Host

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix Action Cable origin check to respect `X-Forwarded-Host` behind reverse proxies.
+
+    The `allow_same_origin_as_host` check previously compared against the raw
+    `HTTP_HOST` header, which fails when a proxy forwards requests with a
+    different internal host. It now uses `request.host_with_port`, consistent
+    with the rest of Rails.
+
+    *Jordan Brough*
+
 *   Channel generator now detects which JS package manager to use when
     installing javascript dependencies.
 

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -228,8 +228,8 @@ module ActionCable
         def allow_request_origin?
           return true if server.config.disable_request_forgery_protection
 
-          proto = Rack::Request.new(env).ssl? ? "https" : "http"
-          if server.config.allow_same_origin_as_host && env["HTTP_ORIGIN"] == "#{proto}://#{env['HTTP_HOST']}"
+          proto = request.ssl? ? "https" : "http"
+          if server.config.allow_same_origin_as_host && env["HTTP_ORIGIN"] == "#{proto}://#{request.host_with_port}"
             true
           elsif Array(server.config.allowed_request_origins).any? { |allowed_origin|  allowed_origin === env["HTTP_ORIGIN"] }
             true


### PR DESCRIPTION
### Motivation / Background

ActionCable was giving me errors like this:
```
Request origin not allowed: https://...
```
with a reverse proxy where `X-Forwarded-Host` should be used instead of `Host`.

### Detail

The `allow_same_origin_as_host` check in `allow_request_origin?` compared the browser's Origin
header against the raw `HTTP_HOST`, which fails behind a reverse proxy where the internal host
differs from the public host.

This updates to use `request.host_with_port` (which respects `X-Forwarded-Host`) and `request.ssl?`
instead, **consistent with how the rest of Rails resolves the host**.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
