### PR TITLE
Deprecate Mail::Address.wrap

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Deprecate `Mail::Address.wrap` because it isn't used.
+
+    *Gannon McGibbon*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionmailbox/CHANGELOG.md) for previous changes.

--- a/actionmailbox/lib/action_mailbox/mail_ext/address_wrapping.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/address_wrapping.rb
@@ -3,6 +3,9 @@
 module Mail
   class Address
     def self.wrap(address)
+      ActionMailbox.deprecator.warn(<<~MSG.squish)
+        Mail::Address.wrap is deprecated and will be removed in Rails 8.2.
+      MSG
       address.is_a?(Mail::Address) ? address : Mail::Address.new(address)
     end
   end

--- a/actionmailbox/test/unit/mail_ext/address_wrapping_test.rb
+++ b/actionmailbox/test/unit/mail_ext/address_wrapping_test.rb
@@ -5,9 +5,11 @@ require_relative "../../test_helper"
 module MailExt
   class AddressWrappingTest < ActiveSupport::TestCase
     test "wrap" do
-      needing_wrapping    = Mail::Address.wrap("david@basecamp.com")
-      wrapping_not_needed = Mail::Address.wrap(Mail::Address.new("david@basecamp.com"))
-      assert_equal needing_wrapping.address, wrapping_not_needed.address
+      assert_deprecated(ActionMailbox.deprecator) do
+        needing_wrapping    = Mail::Address.wrap("david@basecamp.com")
+        wrapping_not_needed = Mail::Address.wrap(Mail::Address.new("david@basecamp.com"))
+        assert_equal needing_wrapping.address, wrapping_not_needed.address
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the patch appears to be unused.

### Detail

This Pull Request deprecates `Mail::Address.wrap` for removal in 8.2.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
