### PR TITLE
Optimize `ActiveRecord::Base.new` to conditionally remove STI checks

### DIFF
--- a/activerecord/test/cases/fast_path_allocation_test.rb
+++ b/activerecord/test/cases/fast_path_allocation_test.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class FastPathAllocationTest < ActiveRecord::TestCase
+  test "non-STI class is optimized" do
+    klass = non_sti_class
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+  end
+
+  test "non-STI class with abstract superclass is optimized" do
+    abstract = Class.new(ActiveRecord::Base) { self.abstract_class = true }
+    klass = non_sti_class(abstract)
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+  end
+
+  test "STI class and its subclasses are not optimized" do
+    base = sti_class
+    sub = Class.new(base)
+
+    assert_not new_is_native?(base)
+    assert_not new_is_native?(sub)
+
+    base.load_schema
+    sub.load_schema
+
+    assert_new_is_not_optimized(base)
+    assert_new_is_not_optimized(sub)
+  end
+
+  test "class with redefined .new is not optimized" do
+    klass = non_sti_class
+    klass.singleton_class.define_method(:new) { |attributes = nil, &block| super(attributes, &block) }
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_not_optimized(klass)
+  end
+
+  test "class with .new redefined in superclass is not optimized" do
+    abstract = Class.new(ActiveRecord::Base) { self.abstract_class = true }
+    abstract.singleton_class.define_method(:new) { |attributes = nil, &block| super(attributes, &block) }
+    klass = non_sti_class(abstract)
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_not_optimized(klass)
+  end
+
+  test "class with prepended .new is not optimized" do
+    mod = Module.new do
+      def new(attributes = nil, &block)
+        super
+      end
+    end
+    klass = non_sti_class
+    klass.singleton_class.prepend(mod)
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_not_optimized(klass)
+  end
+
+  test "deoptimization upon redefinition" do
+    klass = non_sti_class
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+
+    block_called = false
+    klass.singleton_class.define_method(:new) { |attributes = nil, &block| block_called = true; super(attributes, &block) }
+    klass.new
+
+    assert block_called
+    assert_new_is_not_optimized(klass)
+  end
+
+  test "deoptimization upon extension" do
+    klass = non_sti_class
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+
+    mod = Module.new do
+      def new(attributes = nil, &block)
+        @block_called = true
+        super
+      end
+    end
+    klass.singleton_class.prepend(mod)
+    klass.new
+
+    assert klass.instance_variable_get(:@block_called)
+    assert_new_is_not_optimized(klass)
+  end
+
+  test "optimized class returns correct instance" do
+    klass = non_sti_class
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+
+    instance = klass.new
+
+    assert_instance_of klass, instance
+  end
+
+  test "optimized class passes block to initialize" do
+    klass = non_sti_class
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+
+    block_called = false
+    klass.new { |record| block_called = true }
+
+    assert block_called
+  end
+
+  test "deoptimization after reset_column_information" do
+    klass = non_sti_class
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+
+    klass.reset_column_information
+
+    assert_not new_is_native?(klass)
+  end
+
+  test "reoptimization after schema reload" do
+    klass = non_sti_class
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+
+    klass.reset_column_information
+
+    assert_not new_is_native?(klass)
+
+    klass.load_schema
+
+    assert_new_is_optimized(klass)
+  end
+
+  test "new_is_native? detects C methods" do
+    assert new_is_native?(Class)
+    assert_not new_is_native?(ActiveRecord::Base)
+  end
+
+  private
+    def non_sti_class(base = ActiveRecord::Base)
+      # "accounts" table (see test/schema/schema.rb) has no "type" column, so no STI
+      Class.new(base) { self.table_name = "accounts" }
+    end
+
+    def sti_class
+      # "companies" table (see test/schema/schema.rb) has a "type" column, enabling STI
+      Class.new(ActiveRecord::Base) { self.table_name = "companies" }
+    end
+
+    def new_is_native?(klass)
+      klass.method(:new).source_location.nil?
+    end
+
+    # this calls `new` as a side effect, so it should only be called as a post-condition (not a
+    # pre-condition)
+    def assert_new_is_not_optimized(klass)
+      assert_not new_is_native?(klass)
+
+      if RubyVM.stat.key?(:opt_new_miss) # ruby compiled with -DUSE_DEBUG_COUNTER=1
+        miss_before = RubyVM.stat[:opt_new_miss]
+        klass.new
+        assert RubyVM.stat[:opt_new_miss] > miss_before, "opt_new_miss should have incremented"
+      end
+
+      ruby_new_calls = 0
+      tp = TracePoint.new(:call) { |t| ruby_new_calls += 1 if t.method_id == :new }
+      tp.enable { klass.new }
+      assert ruby_new_calls > 0, "TracePoint should have observed a Ruby-level :call for .new"
+    end
+
+    # this calls `new` as a side effect, so it should only be called as a post-condition (not a
+    # pre-condition)
+    def assert_new_is_optimized(klass)
+      assert new_is_native?(klass)
+
+      if RubyVM.stat.key?(:opt_new_hit) # ruby compiled with -DUSE_DEBUG_COUNTER=1
+        hit_before, miss_before = RubyVM.stat[:opt_new_hit], RubyVM.stat[:opt_new_miss]
+        klass.new
+        assert RubyVM.stat[:opt_new_hit] > hit_before, "opt_new_hit should have incremented"
+        assert_equal miss_before, RubyVM.stat[:opt_new_miss], "opt_new_miss should not have changed"
+      end
+
+      ruby_new_calls = 0
+      tp = TracePoint.new(:call) { |t| ruby_new_calls += 1 if t.method_id == :new }
+      tp.enable { klass.new }
+      assert_equal 0, ruby_new_calls, "TracePoint should not observe a Ruby-level :call for .new"
+    end
+end


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord::Base` overrides the `.new` class method to handle runtime checks for STI models, checking the "type" column and invoking the appropriate subclass's constructor. However, for non-STI models, this method brings disadvantages:

- The STI check is unnecessary overhead for non-STI classes
- In Ruby 4.0, the overridden method prevents a "fast path allocation" optimization from providing additional speedups

This pull request optimizes `ActiveRecord::Base.new` so that non-STI classes can avoid the additional overhead of this method whenever possible, and also take advantage of the Ruby 4.0 "fast path allocation" optimization.

(Note that older versions of Ruby without the "fast allocation path" optimization still show significant speedups due to the removal of runtime checks from the allocation path.)

### Detail

The control flow for STI models is unchanged, and the benchmarks show no change on object allocation performance for STI models.

For non-STI models that do not override `.new`, the method is overridden to point at `Class.new`:

``` ruby
define_singleton_method :new, Class.instance_method(:new)
```

This essentially resets the constructor method back to Ruby's default, eliminates the STI check on every instantiation, and enables Ruby 4.0's fast path optimization for `Class#new`.

Some noteworthy edge cases are taken care of:

- Do not optimize the constructor if the model has already redefined `.new`.
- Tests assert that "deoptimization" happens correctly if a class dynamically redefines `.new`.

The test coverage will also check `opt_new_hit` and `opt_new_miss` debug counters if run with a debug build of Ruby, which should make it a bit easier to determine whether the fast path allocation optimization is working properly


### Benchmark results

Summary: Active Record models not using STI and not redefining `.new` were 15-17% faster on Ruby 4, and 8-17% faster on Ruby 3.4 and 3.3.

When the model redefines `.new` or uses STI, the benchmarks were generally close to the error bars or "same-ish" (my benchmark machine has some jitter I could not eliminate).

```
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]
                              YJIT disabled             YJIT enabled
                              ------------------------  ------------------------
  non-STI, default .new       1.15x faster (±0.01)      1.17x faster (±0.04)
                              68.7k vs 59.6k i/s        197.2k vs 168.4k i/s
  non-STI, redefined .new     same-ish                  same-ish
                              60.0k vs 59.9k i/s        164.5k vs 161.3k i/s
  STI                         same-ish                  same-ish
                              39.2k vs 39.3k i/s        120.2k vs 119.7k i/s

ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [x86_64-linux]
                              YJIT disabled             YJIT enabled
                              ------------------------  ------------------------
  non-STI, default .new       1.13x faster (±0.01)      1.06x faster (±0.04)
                              77.5k vs 68.8k i/s        218.3k vs 206.7k i/s
  non-STI, redefined .new     same-ish                  same-ish
                              68.4k vs 68.2k i/s        191.1k vs 194.4k i/s
  STI                         same-ish                  same-ish
                              42.6k vs 42.6k i/s        141.8k vs 140.3k i/s

ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
                              YJIT disabled             YJIT enabled
                              ------------------------  ------------------------
  non-STI, default .new       1.10x faster (±0.01)      1.09x faster (±0.04)
                              68.8k vs 62.4k i/s        173.6k vs 159.1k i/s
  non-STI, redefined .new     same-ish                  same-ish
                              61.3k vs 62.1k i/s        145.9k vs 149.6k i/s
  STI                         same-ish                  same-ish
                              39.3k vs 39.3k i/s        108.6k vs 107.6k i/s
```

Full benchmark output here: [benchmark.txt](https://github.com/user-attachments/files/25499368/benchmark.txt)

Full benchmark scripts here: [benchmark.zip](https://github.com/user-attachments/files/25241475/benchmark.zip)


#### Benchmark setup

Benchmarks were run on a benchmark rig:

- frequency scaling turned off
- pinned to a non-hyperthreaded core
- that core was kernel-isolated from the kernel scheduler
- disabled the timer tick, and the chosen CPU did not handle interrupts
- intel turbo boost disabled
- scaling governor set to "performance"

The benchmark script also disables Ruby GC and runs a full mark-and-sweep after warmup before the measured run.


### Context on Ruby 4.0's "Fast path allocation"

More information about Ruby 4.0's "fast allocation path" optimization:

- blog post: [Fast Allocations in Ruby 3.5 | Rails at Scale](https://railsatscale.com/2025-05-21-fast-allocations-in-ruby-3-5/)
- redmine ticket: [Feature #21254: Inlining Class#new - Ruby - Ruby Issue Tracking System](https://bugs.ruby-lang.org/issues/21254)
- pull request: [Inline Class#new. by tenderlove � Pull Request #13080 � ruby/ruby](https://github.com/ruby/ruby/pull/13080)
- Ruby commit: ruby/ruby@8ac8225c

Because the fast path optimization implemented at ruby/ruby@8ac8225c simply checks if the method is the same as `Class.new` (`rb_class_new_instance_pass_kw`), redefining `.new` to point at `Class.new` allows the "fast path allocation" optimization to work.

Here's the technique demonstrated using Ruby 4.0 compiled with `-DUSE_DEBUG_COUNTER=1`.

``` ruby
#!/usr/bin/env ruby

class A
  class << self
    def new
      # imagine code that is unnecessary for B
    end
  end
end

class B < A
end

RubyVM.reset_debug_counters
10.times { B.new }
RubyVM.show_debug_counters

B.define_singleton_method :new, Class.instance_method(:new)

RubyVM.reset_debug_counters
10.times { B.new }
RubyVM.show_debug_counters
```

Running this, the first set of debug counters shows:

```
[RUBY_DEBUG_COUNTER]    opt_new_hit                                  0
[RUBY_DEBUG_COUNTER]    opt_new_miss                                10
```

But after defining `B.new`:

```
[RUBY_DEBUG_COUNTER]    opt_new_hit                                 10
[RUBY_DEBUG_COUNTER]    opt_new_miss                                 0
```

This implementation takes care to check whether `.new` has already been redefined by the class, and if so does not modify the class.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [-] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
