### PR TITLE
 Use instance_variables_to_inspect instead of custom inspect methods …

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -3,6 +3,7 @@
 # :markup: markdown
 
 require "action_dispatch"
+require "active_support/inspect_backport"
 require "active_support/rescuable"
 
 module ActionCable
@@ -165,11 +166,13 @@ module ActionCable
         send_async :handle_close
       end
 
-      def inspect # :nodoc:
-        "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
-      end
+      include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
       private
+        def instance_variables_to_inspect
+          [].freeze
+        end
+
         attr_reader :websocket
         attr_reader :message_buffer
 

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -133,6 +133,13 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
     end
   end
 
+  test "inspect does not show internals" do
+    run_in_eventmachine do
+      connection = open_connection
+      assert_match(/\A#<ActionCable::Connection::BaseTest::Connection:0x[0-9a-f]+>\z/, connection.inspect)
+    end
+  end
+
   private
     def open_connection
       env = Rack::MockRequest.env_for "/test", "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket",

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -4,6 +4,7 @@
 
 require "abstract_controller/error"
 require "active_support/descendants_tracker"
+require "active_support/inspect_backport"
 require "active_support/core_ext/module/anonymous"
 require "active_support/core_ext/module/attr_internal"
 
@@ -196,11 +197,13 @@ module AbstractController
       @_config ||= self.class.config.inheritable_copy
     end
 
-    def inspect # :nodoc:
-      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
     private
+      def instance_variables_to_inspect
+        [].freeze
+      end
+
       # Returns true if the name can be considered an action because it has a method
       # defined in the controller.
       #

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -3,6 +3,7 @@
 # :markup: markdown
 
 require "active_support/core_ext/object/try"
+require "active_support/inspect_backport"
 
 module ActionText
   # # Action Text Attachment
@@ -128,11 +129,13 @@ module ActionText
       to_html
     end
 
-    def inspect
-      "#<#{self.class.name} attachable=#{attachable.inspect}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
     private
+      def instance_variables_to_inspect
+        [:@attachable].freeze
+      end
+
       def node_attributes
         @node_attributes ||= ATTRIBUTES.to_h { |name| [ name.underscore, node[name] ] }.compact
       end

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -95,6 +95,12 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     assert_equal "pages/page", attachable.to_editor_content_attachment_partial_path
   end
 
+  test "inspect shows attachable" do
+    attachment = ActionText::Attachment.from_attachable(attachable)
+
+    assert_match(/\A#<ActionText::Attachment:0x[0-9a-f]+ @attachable=/, attachment.inspect)
+  end
+
   private
     def attachment_from_html(html)
       ActionText::Content.new(html).attachments.first

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/inspect_backport"
 
 module ActiveModel
   # = Active \Model \Error
@@ -195,9 +196,12 @@ module ActiveModel
       attributes_for_hash.hash
     end
 
-    def inspect # :nodoc:
-      "#<#{self.class.name} attribute=#{@attribute}, type=#{@type}, options=#{@options.inspect}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
+
+    private
+      def instance_variables_to_inspect
+        [:@attribute, :@type, :@options].freeze
+      end
 
     protected
       def attributes_for_hash

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/array/conversions"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/deep_dup"
+require "active_support/inspect_backport"
 require "active_model/error"
 require "active_model/nested_error"
 
@@ -485,13 +486,13 @@ module ActiveModel
       Error.generate_message(attribute, type, @base, options)
     end
 
-    def inspect # :nodoc:
-      inspection = @errors.inspect
-
-      "#<#{self.class.name} #{inspection}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
     private
+      def instance_variables_to_inspect
+        [:@errors].freeze
+      end
+
       def normalize_arguments(attribute, type, **options)
         # Evaluate proc first
         if type.respond_to?(:call)

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -252,4 +252,11 @@ class ErrorTest < ActiveModel::TestCase
 
     assert_equal({ error: :invalid, foo: :bar }, error.details)
   end
+
+  test "inspect" do
+    person = Person.new
+    error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+
+    assert_match(/\A#<ActiveModel::Error:0x[0-9a-f]+ @attribute=:name, @type=:too_short, @options=#{Regexp.escape({ count: 5 }.inspect)}>\z/, error.inspect)
+  end
 end

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -748,6 +748,6 @@ class ErrorsTest < ActiveModel::TestCase
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:base)
 
-    assert_equal(%(#<ActiveModel::Errors [#{errors.first.inspect}]>), errors.inspect)
+    assert_match(/\A#<ActiveModel::Errors:0x[0-9a-f]+ @errors=\[#<ActiveModel::Error/, errors.inspect)
   end
 end

--- a/activerecord/lib/active_record/encryption/cipher/aes256_gcm.rb
+++ b/activerecord/lib/active_record/encryption/cipher/aes256_gcm.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/inspect_backport"
 require "openssl"
 
 module ActiveRecord
@@ -79,11 +80,13 @@ module ActiveRecord
           raise ActiveRecord::Encryption::Errors::Decryption
         end
 
-        def inspect # :nodoc:
-          "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
-        end
+        include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
         private
+          def instance_variables_to_inspect
+            [].freeze
+          end
+
           def generate_iv(cipher, clear_text)
             if @deterministic
               generate_deterministic_iv(clear_text)

--- a/activerecord/test/cases/encryption/cipher_test.rb
+++ b/activerecord/test/cases/encryption/cipher_test.rb
@@ -62,4 +62,9 @@ class ActiveRecord::Encryption::CipherTest < ActiveRecord::EncryptionTestCase
     encrypted_text = @cipher.encrypt("Getting around with the ⚡️Go Menu", key: @key)
     assert_equal "Getting around with the ⚡️Go Menu", @cipher.decrypt(encrypted_text, key: @key)
   end
+
+  test "inspect does not show secrets" do
+    aes_cipher = ActiveRecord::Encryption::Cipher::Aes256Gcm.new(@key)
+    assert_match(/\A#<ActiveRecord::Encryption::Cipher::Aes256Gcm:0x[0-9a-f]+>\z/, aes_cipher.inspect)
+  end
 end

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/file/atomic"
+require "active_support/inspect_backport"
 require "active_support/core_ext/string/conversions"
 require "uri/common"
 
@@ -98,11 +99,13 @@ module ActiveSupport
         end
       end
 
-      def inspect # :nodoc:
-        "#<#{self.class.name} cache_path=#{@cache_path}, options=#{@options.inspect}>"
-      end
+      include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
       private
+        def instance_variables_to_inspect
+          [:@cache_path, :@options].freeze
+        end
+
         def read_entry(key, **options)
           if payload = read_serialized_entry(key, **options)
             entry = deserialize_entry(payload)

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/inspect_backport"
+
 module ActiveSupport
   module Cache
     # = Null \Cache \Store
@@ -34,11 +36,13 @@ module ActiveSupport
       def delete_matched(matcher, options = nil)
       end
 
-      def inspect # :nodoc:
-        "#<#{self.class.name} options=#{@options.inspect}>"
-      end
+      include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
       private
+        def instance_variables_to_inspect
+          [:@options].freeze
+        end
+
         def read_entry(key, **s)
           deserialize_entry(read_serialized_entry(key))
         end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -14,6 +14,7 @@ require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/hash/slice"
 require "active_support/core_ext/numeric/time"
 require "active_support/digest"
+require "active_support/inspect_backport"
 
 module ActiveSupport
   module Cache
@@ -170,9 +171,7 @@ module ActiveSupport
         super(universal_options)
       end
 
-      def inspect
-        "#<#{self.class} options=#{options.inspect} redis=#{redis.inspect}>"
-      end
+      include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
       # Cache Store API implementation.
       #
@@ -322,6 +321,10 @@ module ActiveSupport
       end
 
       private
+        def instance_variables_to_inspect
+          [:@options, :@redis].freeze
+        end
+
         def pipeline_entries(entries, &block)
           redis.then { |c|
             if c.is_a?(Redis::Distributed)

--- a/activesupport/lib/active_support/inspect_backport.rb
+++ b/activesupport/lib/active_support/inspect_backport.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  # Provides a Ruby 4.0-compatible +inspect+ method for Ruby < 4.0.
+  #
+  # Ruby 4.0 introduced +instance_variables_to_inspect+, which lets classes
+  # control which instance variables appear in +inspect+ output without
+  # overriding +inspect+ entirely. This module backports that behavior so
+  # classes can define +instance_variables_to_inspect+ on any Ruby version.
+  #
+  #   class MyClass
+  #     include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
+  #
+  #     private
+  #       def instance_variables_to_inspect
+  #         [:@name, :@status].freeze
+  #       end
+  #   end
+  module InspectBackport # :nodoc:
+    def inspect
+      ivars = instance_variables_to_inspect
+      klass = self.class.name || self.class.inspect
+      addr = "0x%x" % object_id
+
+      if ivars.empty?
+        "#<#{klass}:#{addr}>"
+      else
+        pairs = ivars.map { |ivar| "#{ivar}=#{instance_variable_get(ivar).inspect}" }
+        "#<#{klass}:#{addr} #{pairs.join(", ")}>"
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/inspect_backport"
 require "concurrent/map"
 require "openssl"
 
@@ -42,9 +43,12 @@ module ActiveSupport
       OpenSSL::PKCS5.pbkdf2_hmac(@secret, salt, @iterations, key_size, @hash_digest_class.new)
     end
 
-    def inspect # :nodoc:
-      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
+
+    private
+      def instance_variables_to_inspect
+        [].freeze
+      end
   end
 
   # = Caching Key Generator

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -3,6 +3,7 @@
 require "openssl"
 require "base64"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/inspect_backport"
 require "active_support/messages/codec"
 require "active_support/messages/rotator"
 require "active_support/message_verifier"
@@ -261,11 +262,13 @@ module ActiveSupport
       deserialize_with_metadata(decrypt(verify(message)), **options)
     end
 
-    def inspect # :nodoc:
-      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
     private
+      def instance_variables_to_inspect
+        [].freeze
+      end
+
       def sign(data)
         @verifier ? @verifier.create_message(data) : data
       end

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -3,6 +3,7 @@
 require "openssl"
 require "base64"
 require "active_support/core_ext/object/blank"
+require "active_support/inspect_backport"
 require "active_support/security_utils"
 require "active_support/messages/codec"
 require "active_support/messages/rotator"
@@ -315,11 +316,13 @@ module ActiveSupport
       deserialize_with_metadata(decode(extract_encoded(message)), **options)
     end
 
-    def inspect # :nodoc:
-      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
     private
+      def instance_variables_to_inspect
+        [].freeze
+      end
+
       def decode(encoded, url_safe: @url_safe)
         catch :invalid_message_format do
           return super

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -40,6 +40,12 @@ class FileStoreTest < ActiveSupport::TestCase
   include CacheInstrumentationBehavior
   include CacheLoggingBehavior
 
+  def test_inspect_shows_cache_path_and_options
+    assert_match(/\A#<ActiveSupport::Cache::FileStore:0x[0-9a-f]+/, @cache.inspect)
+    assert_match(/@cache_path=/, @cache.inspect)
+    assert_match(/@options=/, @cache.inspect)
+  end
+
   def test_clear
     gitkeep = File.join(cache_dir, ".gitkeep")
     keep = File.join(cache_dir, ".keep")

--- a/activesupport/test/cache/stores/null_store_test.rb
+++ b/activesupport/test/cache/stores/null_store_test.rb
@@ -68,6 +68,13 @@ class NullStoreTest < ActiveSupport::TestCase
     assert_nil @cache.read("name")
   end
 
+  def test_inspect_shows_options
+    expected_options = @cache.options.inspect
+
+    assert_match(/\A#<ActiveSupport::Cache::NullStore:0x[0-9a-f]+/, @cache.inspect)
+    assert_match("@options=#{expected_options}", @cache.inspect)
+  end
+
   def test_local_store_strategy
     @cache.with_local_cache do
       @cache.write("name", "value")

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -128,6 +128,14 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
+    test "inspect shows options and redis" do
+      store = build(url: REDIS_URL)
+
+      assert_match(/@options=/, store.inspect)
+      assert_match(/@redis=/, store.inspect)
+      assert_match(/\A#<ActiveSupport::Cache::RedisCacheStore:0x[0-9a-f]+/, store.inspect)
+    end
+
     private
       def build(**kwargs)
         ActiveSupport::Cache::RedisCacheStore.new(pool: false, **kwargs).tap(&:redis)

--- a/activesupport/test/inspect_backport_test.rb
+++ b/activesupport/test/inspect_backport_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/inspect_backport"
+
+class InspectBackportTest < ActiveSupport::TestCase
+  test "inspect with no instance variables shows only class and address" do
+    klass = Class.new do
+      include ActiveSupport::InspectBackport
+
+      private
+        def instance_variables_to_inspect
+          [].freeze
+        end
+    end
+
+    obj = klass.new
+    assert_match(/\A#<#{Regexp.escape(klass.inspect)}:0x[0-9a-f]+>\z/, obj.inspect)
+  end
+
+  test "inspect with instance variables shows them" do
+    klass = Class.new do
+      include ActiveSupport::InspectBackport
+      def initialize
+        @name = "test"
+        @count = 42
+      end
+
+      private
+        def instance_variables_to_inspect
+          [:@name, :@count].freeze
+        end
+    end
+
+    obj = klass.new
+    assert_match(/@name="test"/, obj.inspect)
+    assert_match(/@count=42/, obj.inspect)
+  end
+
+  test "inspect uses class name when available" do
+    obj = NamedExample.new("hello")
+    assert_match(/\A#<InspectBackportTest::NamedExample:0x[0-9a-f]+ @value="hello">\z/, obj.inspect)
+  end
+
+  test "inspect with unset instance variable shows nil" do
+    klass = Class.new do
+      include ActiveSupport::InspectBackport
+
+      private
+        def instance_variables_to_inspect
+          [:@missing].freeze
+        end
+    end
+
+    obj = klass.new
+    assert_match(/@missing=nil/, obj.inspect)
+  end
+
+  class NamedExample
+    include ActiveSupport::InspectBackport
+
+    def initialize(value)
+      @value = value
+    end
+
+    private
+      def instance_variables_to_inspect
+        [:@value].freeze
+      end
+  end
+end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -2,6 +2,7 @@
 
 require "ipaddr"
 require "active_support/core_ext/array/wrap"
+require "active_support/inspect_backport"
 require "active_support/core_ext/kernel/reporting"
 require "active_support/file_update_checker"
 require "active_support/configuration_file"
@@ -648,9 +649,7 @@ module Rails
         f
       end
 
-      def inspect # :nodoc:
-        "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
-      end
+      include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
       class Custom # :nodoc:
         def initialize
@@ -675,6 +674,10 @@ module Rails
       end
 
       private
+        def instance_variables_to_inspect
+          [].freeze
+        end
+
         def credentials_defaults
           content_path = root.join("config/credentials/#{Rails.env}.yml.enc")
           content_path = root.join("config/credentials.yml.enc") if !content_path.exist?

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -3,6 +3,7 @@
 require "rails/initializable"
 require "active_support/descendants_tracker"
 require "active_support/inflector"
+require "active_support/inspect_backport"
 require "active_support/core_ext/module/introspection"
 require "active_support/logger"
 
@@ -284,9 +285,7 @@ module Rails
       end
     end
 
-    def inspect # :nodoc:
-      "#<#{self.class.name}>"
-    end
+    include ActiveSupport::InspectBackport if RUBY_VERSION < "4"
 
     def configure(&block) # :nodoc:
       instance_eval(&block)
@@ -326,6 +325,10 @@ module Rails
       end
 
     private
+      def instance_variables_to_inspect
+        [].freeze
+      end
+
       # run `&block` in every registered block in `#register_block_for`
       def each_registered_block(type, &block)
         klass = self.class

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1655,7 +1655,10 @@ module ApplicationTests
       app "development"
 
       post "/posts.json", '{ "title": "foo", "name": "bar" }', "CONTENT_TYPE" => "application/json"
-      assert_equal "#<ActionController::Parameters #{{ "title" => "foo" }} permitted: false>", last_response.body
+
+      assert_match(/ActionController::Parameters/, last_response.body)
+      assert_match(/@parameters=.*"title" => "foo"/, last_response.body)
+      assert_match(/@permitted=false/, last_response.body)
     end
 
     test "config.action_controller.permit_all_parameters = true" do

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -246,6 +246,12 @@ module RailtiesTest
       assert_match(/undefined method [`']abc' for.*RailtiesTest::RailtieTest::Foo/, error.original_message)
     end
 
+    test "inspect does not show internals" do
+      class self.class::TestRailtie < Rails::Railtie; end
+
+      assert_match(/\A#<.*TestRailtie:0x[0-9a-f]+>\z/, self.class::TestRailtie.instance.inspect)
+    end
+
     test "rake environment can be called in the ralitie" do
       $ran_block = false
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Ruby 4 added [a new hook `instance_variables_to_inspect`](https://docs.ruby-lang.org/en/4.0/Object.html#method-i-inspect) that lets classes control which instance variables are shown in `inspect` output without overriding `inspect` entirely.

  ### Detail                                                              
   
  There are a total of 56 instances where there is a custom `def inspect` method.                                                   

  **Hide all instance variables (8 changes)**
  These classes override `inspect` to show only `#<ClassName:0xADDRESS>` with no instance variables, likely to avoid leaking secrets or because the object is too large to inspect usefully.

  | Class | File | Reason |
  |-------|------|--------|
  | `ActiveSupport::MessageVerifier` |
  `activesupport/lib/active_support/message_verifier.rb` | Hides secret
  keys |
  | `ActiveSupport::MessageEncryptor` |
  `activesupport/lib/active_support/message_encryptor.rb` | Hides secret
  keys |
  | `ActiveSupport::KeyGenerator` |
  `activesupport/lib/active_support/key_generator.rb` | Hides secret key |
  | `AR::Encryption::Cipher::Aes256Gcm` |
  `activerecord/lib/active_record/encryption/cipher/aes256_gcm.rb` | Hides
   encryption key |
  | `AbstractController::Base` |
  `actionpack/lib/abstract_controller/base.rb` | Too large to inspect |
  | `ActionCable::Connection::Base` |
  `actioncable/lib/action_cable/connection/base.rb` | Too large to inspect|
  | `Rails::Application::Configuration` |`railties/lib/rails/application/configuration.rb` | Too large to inspect|
  | `Rails::Railtie` | `railties/lib/rails/railtie.rb` | Hide all internals |

  **Show specific instance variables (7 changes)**

  | Class | File | Ivars shown |
  |-------|------|-------------|
  | `ActiveModel::Errors` | `activemodel/lib/active_model/errors.rb` |
  `@errors` |
  | `ActiveModel::Error` | `activemodel/lib/active_model/error.rb` |
  `@attribute`, `@type`, `@options` |
  | `ActionController::Parameters` |
  `actionpack/lib/action_controller/metal/strong_parameters.rb` |
  `@parameters`, `@permitted` |
  | `ActionText::Attachment` | `actiontext/lib/action_text/attachment.rb`
  | `@attachable` |
  | `ActiveSupport::Cache::RedisCacheStore` |
  `activesupport/lib/active_support/cache/redis_cache_store.rb` |
  `@options`, `@redis` |
  | `ActiveSupport::Cache::NullStore` |
  `activesupport/lib/active_support/cache/null_store.rb` | `@options` |
  | `ActiveSupport::Cache::FileStore` |
  `activesupport/lib/active_support/cache/file_store.rb` | `@cache_path`,
  `@options` |

  <details>
  <summary><strong>Not migrated (41 instances)</strong></summary>

  These `def inspect` methods cannot be replaced with
  `instance_variables_to_inspect` because they use computed values,
  conditional logic, method calls, non-standard formatting, or delegate to
   other objects.

  | Class | File | Reason |
  |-------|------|--------|
  | `ActionView::Base` | `actionview/lib/action_view/base.rb` | Defined on
   anonymous subclass via `Class.new`; hardcodes class name |
  | `ActiveRecord::Core` (instance) |
  `activerecord/lib/active_record/core.rb` | Complex filtering of AR
  attributes via method calls |
  | `ActiveRecord::Core` (class) |
  `activerecord/lib/active_record/core.rb` | Conditional logic based on
  `schema_loaded?`, `connected?`, `table_exists?` |
  | `ActiveRecord::Relation` |
  `activerecord/lib/active_record/relation.rb` | Shows first 11 records
  with truncation; calls `loaded?`, `annotate` |
  | `ActiveRecord::Relation` (Explain) |
  `activerecord/lib/active_record/relation.rb` | Inner class; calls
  `exec_explain` to execute queries |
  | `ActiveRecord::Promise` | `activerecord/lib/active_record/promise.rb`
  | Calls computed `status` method |
  | `ActiveRecord::Associations::CollectionProxy` |
  `activerecord/lib/active_record/associations/collection_proxy.rb` |
  Calls `load_target` conditionally then delegates to `super` |
  | `AR::ConnectionAdapters::AbstractAdapter` |
  `activerecord/lib/active_record/connection_adapters/abstract_adapter.rb`
   | Method chains, conditional fields based on shard/name |
  | `AR::ConnectionAdapters::ConnectionPool` | `activerecord/lib/active_re
  cord/connection_adapters/abstract/connection_pool.rb` | Calls
  `name_inspect`, `shard_inspect`, `db_config.env_name`, `role` methods |
  | `AR::ConnectionAdapters::QueryIntent` |
  `activerecord/lib/active_record/connection_adapters/query_intent.rb` |
  Shows attr_readers but format uses bare values without `@` prefix |
  | `AR::DatabaseConfigurations::DatabaseConfig` | `activerecord/lib/activ
  e_record/database_configurations/database_config.rb` | `adapter_class`
  is a memoized method — may show `nil` before resolution |
  | `Arel::Nodes::BoundSqlLiteral` |
  `activerecord/lib/arel/nodes/bound_sql_literal.rb` |
  `sql_with_placeholders` is a method; conditionally shows named or
  positional binds |
  | `ActionDispatch::Request` |
  `actionpack/lib/action_dispatch/http/request.rb` | Calls `method`,
  `original_url`, `remote_ip` (lazy-loaded) |
  | `ActionDispatch::Request::Session` |
  `actionpack/lib/action_dispatch/request/session.rb` | Conditional on
  `loaded?` — shows `super` when loaded, custom string when not |
  | `ActionDispatch::MiddlewareStack::Middleware` |
  `actionpack/lib/action_dispatch/middleware/stack.rb` | Conditional on
  `klass.is_a?(Module)`; returns class name string |
  | `ActionDispatch::Routing::Redirect` |
  `actionpack/lib/action_dispatch/routing/redirection.rb` | Non-standard
  format `"redirect(301)"`; no `#<>` wrapping |
  | `ActionDispatch::Routing::PathRedirect` |
  `actionpack/lib/action_dispatch/routing/redirection.rb` | Non-standard
  format `"redirect(301, path)"` |
  | `ActionDispatch::Routing::OptionRedirect` |
  `actionpack/lib/action_dispatch/routing/redirection.rb` | Non-standard
  format with computed options hash |
  | `ActionText::Content` | `actiontext/lib/action_text/content.rb` |
  Calls `to_html` (computed from `fragment`) and `truncate` |
  | `ActionText::AttachmentGallery` |
  `actiontext/lib/action_text/attachment_gallery.rb` | `size` is computed
  from `attachments.size` |
  | `ActionText::Editor::Configurator` |
  `actiontext/lib/action_text/editor/configurator.rb` |
  `configurations.keys` is computed; conditional display |
  | `ActionText::Editor::Registry` |
  `actiontext/lib/action_text/editor/registry.rb` | `configurations.keys`
  is computed; conditional display |
  | `ActionView::Template` | `actionview/lib/action_view/template.rb` |
  Calls `short_identifier` (computed with conditional `Rails.root` logic)|
  | `ActiveSupport::Duration` |
  `activesupport/lib/active_support/duration.rb` | Complex sorting,
  conditional pluralization, `to_sentence` |
  | `ActiveSupport::TimeWithZone` |
  `activesupport/lib/active_support/time_with_zone.rb` | Calls `time`
  (lazy-loads), `zone` (computed), `formatted_offset` |
  | `ActiveSupport::EncryptedConfiguration` |
  `activesupport/lib/active_support/encrypted_configuration.rb` | `keys`
  lazily decrypts YAML |
  | `ActiveSupport::CombinedConfiguration` |
  `activesupport/lib/active_support/combined_configuration.rb` | `keys` is
   a computed method |
  | `ActiveSupport::EnvConfiguration` |
  `activesupport/lib/active_support/env_configuration.rb` | `keys` is a
  computed method |
  | `ActiveSupport::Notifications::Fanout` |
  `activesupport/lib/active_support/notifications/fanout.rb` | Computes a
  summary count from subscriber hashes |
  | `ActiveSupport::Cache::MemoryStore` |
  `activesupport/lib/active_support/cache/memory_store.rb` | Shows
  `@data.size` (method call on ivar) |
  | `ActiveSupport::Cache::MemCacheStore` |
  `activesupport/lib/active_support/cache/mem_cache_store.rb` |
  Conditional — shows `@data` or `@mem_cache_options` |
  | `ActiveSupport::EventedFileUpdateChecker` |
  `activesupport/lib/active_support/evented_file_update_checker.rb` |
  Shows `@core.files.to_a` (method chain on ivar) |
  | `ActiveSupport::OrderedOptions` |
  `activesupport/lib/active_support/ordered_options.rb` | Hash subclass;
  calls `super` (Hash#inspect) |
  | `ActiveSupport::InheritableOptions` |
  `activesupport/lib/active_support/ordered_options.rb` | Hash subclass;
  calls `to_h.inspect` |
  | `ActiveSupport::TestCase` |
  `activesupport/lib/active_support/test_case.rb` | Uses
  `Object.instance_method(:to_s).bind_call(self)` |
  | `ActiveSupport::Deprecation::DeprecationProxy` |
  `activesupport/lib/active_support/deprecation/proxy_wrappers.rb` | Proxy
   object; delegates to `target.inspect` |
  | `ActiveSupport::Deprecation::DeprecatedClassProxy` |
  `activesupport/lib/active_support/deprecation/proxy_wrappers.rb` | Proxy
   object; delegates to `target.inspect` |
  | `ActiveSupport::Testing::EventReporterAssertions::Event` |
  `activesupport/lib/active_support/testing/event_reporter_assertions.rb`
  | Test support inner class; non-standard format |
  | `ActiveStorage::Service` |
  `activestorage/lib/active_storage/service.rb` | Conditional on
  `name.present?` |
  | `ActiveStorage::Service::Configurator` |
  `activestorage/lib/active_storage/service/configurator.rb` |
  `configurations.keys` is computed; conditional display |
  | `ActiveStorage::Service::Registry` |
  `activestorage/lib/active_storage/service/registry.rb` |
  `configurations.keys` is computed; conditional display |

  </details>

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
