### PR TITLE
Fix ActiveStorage::Blob content type methods to handle nil

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -195,22 +195,22 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
   # Returns true if the content_type of this blob is in the image range, like image/png.
   def image?
-    content_type.start_with?("image")
+    content_type&.start_with?("image")
   end
 
   # Returns true if the content_type of this blob is in the audio range, like audio/mpeg.
   def audio?
-    content_type.start_with?("audio")
+    content_type&.start_with?("audio")
   end
 
   # Returns true if the content_type of this blob is in the video range, like video/mp4.
   def video?
-    content_type.start_with?("video")
+    content_type&.start_with?("video")
   end
 
   # Returns true if the content_type of this blob is in the text range, like text/plain.
   def text?
-    content_type.start_with?("text")
+    content_type&.start_with?("text")
   end
 
   # Returns the URL of the blob on the service. This returns a permanent URL for public files, and returns a

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -161,6 +161,21 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_not_predicate blob, :audio?
   end
 
+  test "blob type methods return false for nil content type" do
+    blob = create_blob_before_direct_upload(
+      filename: "unknown_file",
+      byte_size: 100,
+      checksum: "test_checksum",
+      content_type: nil
+    )
+
+    assert_nil blob.content_type
+    assert_not_predicate blob, :image?
+    assert_not_predicate blob, :video?
+    assert_not_predicate blob, :audio?
+    assert_not_predicate blob, :text?
+  end
+
   test "download yields chunks" do
     blob   = create_blob data: "a" * 5.0625.megabytes
     chunks = []


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request fixes a `NoMethodError` that occurs when purging unattached Active Storage blobs.

When running `purge_later` to delete unattached records, the process fails if a record has `content_type: nil`. The specific error is:
`undefined method 'start_with?' for nil (NoMethodError)` inside the `image?` method.

This issue was caused by records with `content_type: nil` being inserted into the database. Specifically, this data was created by a vulnerability scanning tool directly sending requests to `/rails/active_storage/direct_uploads` without a content type.

Since it is possible for `content_type` to be nil, the code should handle this gracefully to ensure the cleanup process completes successfully.

### Detail

This Pull Request changes blob type methods to safely handle `nil` values in `content_type`.

It prevents the crash by checking for presence or using safe navigation before calling `start_with?`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
