### PR TITLE
Fix JSONGemCoderEncoder to call to_s on original hash key

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -151,8 +151,10 @@ module ActiveSupport
           JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
           CODER = ::JSON::Coder.new do |value, is_key|
             json_value = value.as_json
+
             # Keep compatibility by calling to_s on non-String keys
-            next json_value.to_s if is_key
+            next value.to_s if is_key && !(String === json_value)
+
             # Handle objects returning self from as_json
             if json_value.equal?(value)
               next ::JSON::Fragment.new(::JSON.generate(json_value))


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes a bug in `JSONGemCoderEncoder` introduced in Rails 8.1.0 where hash keys with custom objects are incorrectly serialized when their `as_json` method returns a Hash.

Note: [Github Issue submitted here](https://github.com/rails/rails/issues/56784).

When a hash uses custom objects as keys (e.g., `{CustomKey.new(123) => "value"}`), and those objects implement `as_json` to return a Hash (a common Rails pattern for API serialization), the current encoder incorrectly calls `.to_s` on the **Hash returned by `as_json`** instead of on the **original key object**.

**Example of the bug:**
```ruby
class CustomKey
  def initialize(id)
    @id = id
  end

  def to_s
    "custom_#{@id}"
  end

  def as_json(options = nil)
    { id: @id, metadata: { created_at: Time.now.iso8601 } }
  end
end

hash = { CustomKey.new(123) => "value" }

# Rails 7.2.x (correct):
hash.to_json  # => {"custom_123":"value"}

# Rails 8.1.x (buggy):
hash.to_json  # => {"{:id=>123, :metadata=>{...}}":"value"}
```

This affects applications that:
1. Use custom domain objects as hash keys (common in multi-tenant apps, domain-driven design)
2. Store those hashes in JSON/JSONB database columns
3. Have those objects implement `as_json` returning a Hash

**Real-world impact:** Discovered during Rails 7.2 → 8.1 upgrade at my work where `FieldKey` objects used as hash keys in JSONB columns were incorrectly serialized, causing hash lookups to fail after database round-trips.

### Detail

This Pull Request changes one line in `activesupport/lib/active_support/json/encoding.rb`:

**Before (buggy):**
```ruby
CODER = ::JSON::Coder.new do |value, is_key|
  json_value = value.as_json
  next json_value.to_s if is_key  # ← Bug: Calls to_s on as_json result
  ...
end
```

**After (fixed):**
```ruby
CODER = ::JSON::Coder.new do |value, is_key|
  json_value = value.as_json
  next value.to_s if is_key  # ← Fix: Calls to_s on original object
  ...
end
```

**Why this works:**
- The fix ensures that hash keys are converted to strings by calling `to_s` on the **original key object**, not on its `as_json` representation
- This aligns with the code comment's stated intent: "Keep compatibility by calling to_s on non-String keys"
- This restores Rails 8.0 behavior where `JSONGemEncoder` explicitly called `k.to_s` on hash keys before JSON serialization

**Test coverage:**
Added `test_hash_with_object_keys_that_have_complex_as_json` to verify that custom objects with `as_json` returning a Hash are correctly serialized via their `to_s` method when used as hash keys.

### Additional information

**Version introduced:** Rails 8.1.0 (Sept 22, 2025) via [commit 2761020](https://github.com/rails/rails/commit/2761020ddd1e9675d5f4d4573f2bf31b9decdebb)

**Why it worked in Rails 7.2:**
Rails 7.2 uses `JSONGemEncoder` which explicitly converts hash keys to strings first:
```ruby
when Hash
  result = {}
  value.each do |k, v|
    k = k.to_s unless Symbol === k || String === k  # ← Converts keys before as_json!
    result[k] = jsonify(v)
  end
  result
```

Rails 8.1 switched to `JSONGemCoderEncoder` for performance improvements with json gem >= 2.15.2, but the implementation had this ordering bug.

**Backward compatibility:**
- Existing numeric key handling unchanged: `{1 => "one"}` still works
- Symbol/string key handling unchanged
- Objects where `as_json` returns a String/Symbol still work
- No breaking changes - only fixes currently broken behavior

**Standalone reproduction script:**
A complete reproduction script is available on the [reported issue](https://github.com/rails/rails/issues/56784), showing the bug fails in Rails 8.1.x but passes in Rails 7.2.x and Rails 8.0.x:
```bash
# Test with Rails 8.1.2 (shows bug)
ruby verify_bug.rb 8.1.2  # ❌ FAIL

# Test with Rails 7.2.3 (works correctly)
ruby verify_bug.rb 7.2.3  # ✅ PASS

# Test with Rails 8.0.4 (works correctly)
ruby verify_bug.rb 8.0.4  # ✅ PASS
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.