### PR TITLE
Skip test_via_to_sql_with_complicating_connection for PostgreSQL 19+

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -110,6 +110,8 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_via_to_sql_with_complicating_connection
+    skip "PostgreSQL 19+ no longer allows setting standard_conforming_strings to OFF" if @connection.database_version >= 19_00_00
+
     Thread.new do
       other_conn = ActiveRecord::Base.lease_connection
       other_conn.execute("SET standard_conforming_strings = off")


### PR DESCRIPTION
### Motivation / Background

This pull request skips test_via_to_sql_with_complicating_connection for PostgreSQL 19+

Fix #56789

### Detail
Without this commit, the test_via_to_sql_with_complicating_connection test fails for PostgreSQL 19dev.

```ruby
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/bytea_test.rb -i test_via_to_sql_with_complicating_connection
Using postgresql
Run options: -i test_via_to_sql_with_complicating_connection --seed 5564

# Running:

#<Thread:0x00007f63399444d8 /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapters/postgresql/bytea_test.rb:113 run> terminated with exception (report_on_exception is true):
/home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'PG::Connection#exec': PG::FeatureNotSupported: ERROR:  non-standard string literals are not supported (ActiveRecord::StatementInvalid)
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:611:in 'block (2 levels) in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1095:in 'block in ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'Thread.handle_interrupt'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'block in ActiveSupport::Concurrency::ThreadMonitor#synchronize'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'Thread.handle_interrupt'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'ActiveSupport::Concurrency::ThreadMonitor#synchronize'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1064:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:610:in 'block in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1218:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#log'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:608:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/query_intent.rb:318:in 'ActiveRecord::ConnectionAdapters::QueryIntent#run_query!'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/query_intent.rb:168:in 'ActiveRecord::ConnectionAdapters::QueryIntent#execute!'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:164:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:25:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#execute'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:42:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute'
	from /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapters/postgresql/bytea_test.rb:115:in 'block in PostgresqlByteaTest#test_via_to_sql_with_complicating_connection'
/home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'PG::Connection#exec': ERROR:  non-standard string literals are not supported (PG::FeatureNotSupported)
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:611:in 'block (2 levels) in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1095:in 'block in ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'Thread.handle_interrupt'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'block in ActiveSupport::Concurrency::ThreadMonitor#synchronize'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'Thread.handle_interrupt'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'ActiveSupport::Concurrency::ThreadMonitor#synchronize'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1064:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:610:in 'block in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1218:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#log'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:608:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/query_intent.rb:318:in 'ActiveRecord::ConnectionAdapters::QueryIntent#run_query!'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/query_intent.rb:168:in 'ActiveRecord::ConnectionAdapters::QueryIntent#execute!'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:164:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:25:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#execute'
	from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:42:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute'
	from /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapters/postgresql/bytea_test.rb:115:in 'block in PostgresqlByteaTest#test_via_to_sql_with_complicating_connection'
E

Error:
PostgresqlByteaTest#test_via_to_sql_with_complicating_connection:
ActiveRecord::StatementInvalid: PG::FeatureNotSupported: ERROR:  non-standard string literals are not supported

    lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'PG::Connection#exec'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:611:in 'block (2 levels) in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
    lib/active_record/connection_adapters/abstract_adapter.rb:1095:in 'block in ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'Thread.handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'block in ActiveSupport::Concurrency::ThreadMonitor#synchronize'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'Thread.handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'ActiveSupport::Concurrency::ThreadMonitor#synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:1064:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:610:in 'block in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1218:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:608:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
    lib/active_record/connection_adapters/query_intent.rb:318:in 'ActiveRecord::ConnectionAdapters::QueryIntent#run_query!'
    lib/active_record/connection_adapters/query_intent.rb:168:in 'ActiveRecord::ConnectionAdapters::QueryIntent#execute!'
    lib/active_record/connection_adapters/abstract/database_statements.rb:164:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:25:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#execute'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:42:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute'
    test/cases/adapters/postgresql/bytea_test.rb:115:in 'block in PostgresqlByteaTest#test_via_to_sql_with_complicating_connection'

Error:
PostgresqlByteaTest#test_via_to_sql_with_complicating_connection:
ActiveRecord::StatementInvalid: PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block

    lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'PG::Connection#exec'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:192:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:611:in 'block (2 levels) in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
    lib/active_record/connection_adapters/abstract_adapter.rb:1095:in 'block in ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'Thread.handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:21:in 'block in ActiveSupport::Concurrency::ThreadMonitor#synchronize'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'Thread.handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/thread_monitor.rb:17:in 'ActiveSupport::Concurrency::ThreadMonitor#synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:1064:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:610:in 'block in ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1218:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:608:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_intent'
    lib/active_record/connection_adapters/query_intent.rb:318:in 'ActiveRecord::ConnectionAdapters::QueryIntent#run_query!'
    lib/active_record/connection_adapters/query_intent.rb:168:in 'ActiveRecord::ConnectionAdapters::QueryIntent#execute!'
    lib/active_record/connection_adapters/abstract/database_statements.rb:164:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:25:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#execute'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:42:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute'
    lib/active_record/connection_adapters/postgresql/schema_statements.rb:71:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#drop_table'
    test/cases/adapters/postgresql/bytea_test.rb:26:in 'block in <class:PostgresqlByteaTest>'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:407:in 'BasicObject#instance_exec'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:407:in 'block in ActiveSupport::Callbacks::CallTemplate::InstanceExec0#make_lambda'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:208:in 'ActiveSupport::Callbacks::Filters::After#call'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:564:in 'block in ActiveSupport::Callbacks::CallbackSequence#invoke_after'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:564:in 'Array#each'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:564:in 'ActiveSupport::Callbacks::CallbackSequence#invoke_after'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:111:in 'ActiveSupport::Callbacks#run_callbacks'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:46:in 'ActiveSupport::Testing::SetupAndTeardown#after_teardown'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/tests_without_assertions.rb:10:in 'ActiveSupport::Testing::TestsWithoutAssertions#after_teardown'
    lib/active_record/test_fixtures.rb:15:in 'ActiveRecord::TestFixtures#after_teardown'
    test/cases/test_case.rb:38:in 'ActiveRecord::TestCase#after_teardown'


bin/test test/cases/adapters/postgresql/bytea_test.rb:112



Finished in 0.012951s, 77.2123 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$ 
```

because PostgreSQL 19 no longer allows setting standard_conforming_strings to OFF.

```sql
postgres=# SET standard_conforming_strings = off;
ERROR:  non-standard string literals are not supported
postgres=# select version();
                           version
--------------------------------------------------------------------
 PostgreSQL 19devel on x86_64-linux, compiled by gcc-15.2.1, 64-bit
(1 row)
```

### Additional information
According to #14632, the purpose of the failing test is to ensure that the unescape_bytea method is per-connection, not global. Since PostgreSQL 19dev no longer allows setting standard_conforming_strings to OFF, the value will no longer vary per connection, so  we can skip this test when the PostgreSQL version is 19 or higher.

Refer to https://github.com/postgres/postgres/commit/45762084545ec14dbbe66ace1d69d7e89f8978ac

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
