### PR TITLE
Materialize transactions before instrumentation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -605,11 +605,19 @@ module ActiveRecord
       # Final wrapper around the subclass-specific +perform_query+. Populates the calling
       # intent's raw_result.
       def execute_intent(intent) # :nodoc:
-        materialize_transactions if intent.materialize_transactions
-        should_dirty = intent.materialize_transactions
+        should_dirty = false
+
+        if intent.materialize_transactions
+          # These can raise locally (e.g., ReadOnlyError). Validate before BEGIN.
+          intent.processed_sql
+          intent.type_casted_binds
+          materialize_transactions
+        end
+
         log(intent) do |notification_payload|
           intent.notification_payload = notification_payload
           with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false) do |conn|
+            should_dirty = intent.materialize_transactions
             result = perform_query(conn, intent)
             intent.raw_result = result
             handle_warnings(result, intent.processed_sql)

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1621,6 +1621,17 @@ class TransactionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_failed_materialization_does_not_dirty_transaction
+    ActiveRecord::Base.transaction do
+      connection = ActiveRecord::Base.lease_connection
+      connection.stub(:begin_db_transaction, -> (*) { raise ActiveRecord::ConnectionFailed, "connection lost" }) do
+        raised = assert_raises(ActiveRecord::ConnectionFailed) { Topic.first }
+        assert_equal "connection lost", raised.message
+      end
+      assert_not connection.current_transaction.dirty?
+    end
+  end
+
   private
     def assert_array_match(expected, actual, message = nil)
       deviations = actual.dup

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1621,6 +1621,17 @@ class TransactionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_locally_rejected_query_does_not_materialize_or_dirty_transaction
+    ActiveRecord::Base.transaction do
+      connection = ActiveRecord::Base.lease_connection
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) { Topic.create!(title: "test") }
+      end
+      assert_not connection.current_transaction.materialized?
+      assert_not connection.current_transaction.dirty?
+    end
+  end
+
   def test_failed_materialization_does_not_dirty_transaction
     ActiveRecord::Base.transaction do
       connection = ActiveRecord::Base.lease_connection


### PR DESCRIPTION
### Motivation / Background

I noticed that when running queries against a database in another datacenter, the timing for the first query in a transaction always looked like it required two round trips. 

Rather than there being two round trips there's a bug where BEGIN/SAVEPOINT queries were double counted when using lazy transaction materialization.

I think this behaviour dates back to https://github.com/rails/rails/commit/542f0951dddac49bf06f7da35d990db4f3829307 (cc @matthewd).

### Detail

When lazy transactions are enabled, the first query inside a transaction triggers BEGIN. This happened inside the log() instrumentation wrapper, so the first query's sql.active_record notification included both the BEGIN round trip and the actual query.

The BEGIN also fires its own notification, so its cost was reported twice.

Move materialization in execute_intent to before log(), so the BEGIN completes with its own notification before the query's instrumentation starts.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
