### PR TITLE
feat(activerecord): delegate rfind to records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `rfind` delegation to ActiveRecord::Relation.
+
+    Ruby 4.0 adds `Array.rfind` method, add delegate similar to `reverse`, and `rindex`.
+
+    *markokajzer*
+
 *   Add `implicit_persistence_transaction` hook for customizing transaction behavior.
 
     A new protected method `implicit_persistence_transaction` has been added that wraps

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -102,6 +102,10 @@ module ActiveRecord
              :to_sentence, :to_fs, :to_formatted_s, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("4.0")
+      delegate :rfind, to: :records
+    end
+
     delegate :primary_key, :with_connection, :connection, :table_name, :transaction, :sanitize_sql_like, :unscoped, :name, to: :model
 
     module ClassSpecificRelation # :nodoc:

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -19,6 +19,10 @@ module ActiveRecord
       :intersect?
     ]
 
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("4.0")
+      ARRAY_DELEGATES << :rfind
+    end
+
     ARRAY_DELEGATES.each do |method|
       define_method "test_delegates_#{method}_to_Array" do
         assert_respond_to target, method


### PR DESCRIPTION
### Motivation / Background

[Ruby 4.0](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/) adds `Array#rfind`. `Array#reverse` and `Array#rindex` are already delegated, so I figured we might want to delegate `rfind` as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
