### PR TITLE
Include virtual? in Column#== and Column#hash for SQLite3 and PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -69,7 +69,8 @@ module ActiveRecord
           other.is_a?(Column) &&
             super &&
             identity? == other.identity? &&
-            serial? == other.serial?
+            serial? == other.serial? &&
+            virtual? == other.virtual?
         end
         alias :eql? :==
 
@@ -77,7 +78,8 @@ module ActiveRecord
           Column.hash ^
             super.hash ^
             identity?.hash ^
-            serial?.hash
+            serial?.hash ^
+            virtual?.hash
         end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -46,7 +46,8 @@ module ActiveRecord
         def ==(other)
           other.is_a?(Column) &&
             super &&
-            auto_increment? == other.auto_increment?
+            auto_increment? == other.auto_increment? &&
+            virtual? == other.virtual?
         end
         alias :eql? :==
 
@@ -54,7 +55,8 @@ module ActiveRecord
           Column.hash ^
             super.hash ^
             auto_increment?.hash ^
-            rowid.hash
+            rowid.hash ^
+            virtual?.hash
         end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
@@ -121,5 +121,30 @@ if ActiveRecord::Base.lease_connection.supports_virtual_columns?
       fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :virtual_columns).first
       assert_equal 2, fixtures.size
     end
+
+    def test_virtual_column_does_not_deduplicate_with_regular_column
+      @connection.create_table :regular_columns, force: true do |t|
+        t.string :name
+      end
+
+      regular_model = Class.new(ActiveRecord::Base) { self.table_name = "regular_columns" }
+
+      # Ensure deduplication has seen the virtual column first
+      VirtualColumn.columns_hash
+
+      regular_col = regular_model.columns_hash["name"]
+      virtual_col = VirtualColumn.columns_hash["upper_name"]
+
+      assert_predicate virtual_col, :virtual?
+      assert_not_predicate regular_col, :virtual?
+      assert_not_equal regular_col, virtual_col
+
+      # The regular column must not be excluded from inserts
+      record = regular_model.create!(name: "hello")
+      record.reload
+      assert_equal "hello", record.name
+    ensure
+      @connection.drop_table :regular_columns, if_exists: true
+    end
   end
 end


### PR DESCRIPTION
### Summary

The `Deduplicable` module uses `==` and `hash` to maintain a registry of column instances. When a GENERATED (virtual) column was registered first, a regular column on a different table with the same name and type could be deduplicated to the generated instance. This caused the regular column to be silently excluded from INSERT and UPDATE statements, resulting in NULL values in the database.

This PR includes `virtual?` in both `==` and `hash` for `SQLite3::Column` and `PostgreSQL::Column` so columns with different generated_type values are never treated as identical.

### Changes

- **`SQLite3::Column`**: Add `virtual?` to `==` and `hash`
- **`PostgreSQL::Column`**: Add `virtual?` to `==` and `hash`
- Add tests for both adapters verifying that virtual columns are not deduplicated with regular columns

Fixes #56795