### PR TITLE
Mark AutoFilteredParameters as :nodoc:

### DIFF
--- a/activerecord/lib/active_record/encryption/auto_filtered_parameters.rb
+++ b/activerecord/lib/active_record/encryption/auto_filtered_parameters.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Encryption
-    class AutoFilteredParameters
+    class AutoFilteredParameters # :nodoc:
       def initialize(app)
         @app = app
         @attributes_by_class = Concurrent::Map.new


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `AutoFilteredParameters` is an internal implementation detail of Active Record's encryption feature. It should not appear in public API docs. In https://github.com/rails/rails/pull/55939, I'd like to remove it and we need to make it nodoc first.

### Detail

This Pull Request changes the module to be nodoc.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
