### PR TITLE
Improve #hash methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -89,16 +89,18 @@ module ActiveRecord
       alias :eql? :==
 
       def hash
-        Column.hash ^
-          name.hash ^
-          name.encoding.hash ^
-          cast_type.hash ^
-          default.hash ^
-          sql_type_metadata.hash ^
-          null.hash ^
-          default_function.hash ^
-          collation.hash ^
-          comment.hash
+        [
+          Column,
+          @name,
+          @name.encoding,
+          @cast_type,
+          @default,
+          @sql_type_metadata,
+          @null,
+          @default_function,
+          @collation,
+          @comment,
+        ].hash
       end
 
       def virtual?

--- a/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type_metadata.rb
@@ -23,9 +23,11 @@ module ActiveRecord
         alias eql? ==
 
         def hash
-          TypeMetadata.hash ^
-            __getobj__.hash ^
-            extra.hash
+          [
+            TypeMetadata,
+            __getobj__,
+            @extra,
+          ].hash
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -75,11 +75,13 @@ module ActiveRecord
         alias :eql? :==
 
         def hash
-          Column.hash ^
-            super.hash ^
-            identity?.hash ^
-            serial?.hash ^
-            virtual?.hash
+          [
+            Column,
+            super,
+            @identity,
+            @serial,
+            @virtual,
+          ].hash
         end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/type_metadata.rb
@@ -26,10 +26,12 @@ module ActiveRecord
         alias eql? ==
 
         def hash
-          TypeMetadata.hash ^
-            __getobj__.hash ^
-            oid.hash ^
-            fmod.hash
+          [
+            TypeMetadata,
+            __getobj__,
+            @oid,
+            @fmod,
+          ].hash
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         end
 
         def to_s
-          parts.join SEPARATOR
+          [@schema, @identifier].compact.join(SEPARATOR)
         end
 
         def quoted
@@ -28,18 +28,19 @@ module ActiveRecord
         end
 
         def ==(o)
-          o.class == self.class && o.parts == parts
+          self.class == o.class &&
+            schema == o.schema &&
+            identifier == o.identifier
         end
         alias_method :eql?, :==
 
         def hash
-          parts.hash
+          [
+            Name,
+            @schema,
+            @identifier,
+          ].hash
         end
-
-        protected
-          def parts
-            @parts ||= [@schema, @identifier].compact
-          end
       end
 
       module Utils # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
@@ -27,12 +27,14 @@ module ActiveRecord
       alias eql? ==
 
       def hash
-        SqlTypeMetadata.hash ^
-          sql_type.hash ^
-          type.hash ^
-          limit.hash ^
-          precision.hash >> 1 ^
-          scale.hash >> 2
+        [
+          SqlTypeMetadata,
+          @sql_type,
+          @type,
+          @limit,
+          @precision,
+          @scale,
+        ].hash
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -52,11 +52,13 @@ module ActiveRecord
         alias :eql? :==
 
         def hash
-          Column.hash ^
-            super.hash ^
-            auto_increment?.hash ^
-            rowid.hash ^
-            virtual?.hash
+          [
+            Column,
+            super,
+            @auto_increment,
+            @rowid,
+            @virtual,
+          ].hash
         end
       end
     end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -653,7 +653,7 @@ module ActiveRecord
       id = self.id
 
       if self.class.composite_primary_key? ? primary_key_values_present? : id
-        self.class.hash ^ id.hash
+        [self.class, id].hash
       else
         super
       end


### PR DESCRIPTION
Starting from version 3.2, Ruby is able to avoid allocating an array for some methods like `Array#hash`, hence it's no longer worth combining hashes manually.

Ref: https://github.com/ruby/ruby/pull/6090
