### PR TITLE
Fix SQLite3 column equality for `rowid` aliases

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -47,6 +47,7 @@ module ActiveRecord
           other.is_a?(Column) &&
             super &&
             auto_increment? == other.auto_increment? &&
+            rowid == other.rowid &&
             virtual? == other.virtual?
         end
         alias :eql? :==

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -1111,6 +1111,16 @@ module ActiveRecord
         end
       end
 
+      def test_rowid_changes_column_equality
+        cast_type = @conn.lookup_cast_type("integer")
+        type_metadata = SqlTypeMetadata.new(sql_type: "integer", type: :integer)
+
+        rowid_column = SQLite3::Column.new("id", cast_type, nil, type_metadata, true, nil, rowid: true)
+        regular_column = SQLite3::Column.new("id", cast_type, nil, type_metadata, true, nil, rowid: false)
+
+        assert_not_equal rowid_column, regular_column
+      end
+
       def test_sqlite_extensions_are_constantized_for_the_client_constructor
         mock_adapter = Class.new(SQLite3Adapter) do
           class << self


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveRecord::ConnectionAdapters::SQLite3::Column#==` did not compare `rowid`, while `#hash` already included it.

That allowed two columns with different `rowid` semantics to compare equal, which is incorrect for deduplication and schema metadata consistency.

### Detail

This Pull Request changes SQLite3 column equality so `rowid` is part of the comparison:

- Updates `ActiveRecord::ConnectionAdapters::SQLite3::Column#==` to compare `rowid`.
- Adds a regression test: `test_rowid_changes_column_equality` in `activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb`.

The new test reproduces the bug by constructing two otherwise-identical SQLite3 columns that differ only by `rowid` and asserting they are not equal.

### Additional information

- Verification run:
  - `ARCONN=sqlite3 bundle exec ruby -Itest test/cases/adapters/sqlite3/sqlite3_adapter_test.rb`
  - Result: `94 runs, 237 assertions, 0 failures, 0 errors, 0 skips`
- No CHANGELOG update was added because this is a minor bug fix.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. (N/A here: minor bug fix)
