### PR TITLE
Fix in_batches use_ranges with limit producing negative LIMIT

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -441,8 +441,8 @@ module ActiveRecord
             yielded_relation.load_records(records)
           elsif (empty_scope && use_ranges != false) || use_ranges
             # Efficiently peak at the last value for the next batch using offset and limit.
-            values_size = batch_limit
-            values_last = batch_relation.offset(batch_limit - 1).pick(*cursor)
+            values_size = remaining ? [batch_limit, remaining].min : batch_limit
+            values_last = batch_relation.offset(values_size - 1).pick(*cursor)
 
             # If the last value is not found using offset, there is at most one more batch of size < batch_limit.
             # Retry by getting the whole list of remaining values so that we have the exact size and last value.

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -932,6 +932,18 @@ class EachTest < ActiveRecord::TestCase
       assert_equal limit, total
     end
 
+    test "in_batches should return limit records when limit is greater than batch size with use_ranges and load is #{load}" do
+      limit = 5
+      batch_size = 3
+      total = 0
+
+      Post.limit(limit).in_batches(of: batch_size, load: load, use_ranges: true) do |batch|
+        total += batch.count
+      end
+
+      assert_equal limit, total
+    end
+
     test "in_batches should return limit records when limit is a multiple of the batch size and load is #{load}" do
       limit      = 6
       batch_size = 3


### PR DESCRIPTION
Fixes #56819.

### Motivation / Background

When `in_batches` is called with `use_ranges: true` on a relation that has a `.limit()`, a `PG::InvalidRowCountInLimitClause: ERROR: LIMIT must not be negative` (or equivalent) error is raised when the limit is not a multiple of the batch size.

### Detail

In the `use_ranges` code path, `values_size` is set to `batch_limit` (the original batch size) rather than the actual number of records. When `remaining < batch_limit`, the relation's limit is updated via `relation = relation.limit(remaining)`, but `batch_limit` stays at the original value.

On the next iteration, `remaining -= values_size` subtracts the stale `batch_limit` from `remaining`, causing it to go negative. This results in `relation.limit(-1)` which raises a database error.

### Fix

Update `batch_limit` alongside the relation's limit when `remaining < batch_limit`.

### Reproduction

```ruby
# With 11 Post records in the database:
Post.limit(5).in_batches(of: 3, use_ranges: true) { |batch| batch.count }
# => raises "LIMIT must not be negative"
```

### Checklist

Before submitting the PR make sure the following are checked:

- [x] Added corresponding tests
- [x] All existing tests pass (`116 runs, 836 assertions, 0 failures, 0 errors`)