### PR TITLE
Rails.cache.read: add support to new option delete: true

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `delete: true` option to `Rails.cache.read` for atomic read-and-delete (only supported by Redis cache store).
+
+    Uses the Redis [GETDEL](https://redis.io/docs/latest/commands/getdel/) command to atomically return a cached value and remove
+    it in a single operation. Useful for single-use values like OTP codes or
+    one-time tokens.
+
+    ```ruby
+    Rails.cache.write("otp", "123456")
+    Rails.cache.read("otp", delete: true)  # => "123456"
+    Rails.cache.read("otp")                # => nil
+    ```
+
+    *Glauco Custodio*
+
 *   Introduce `ActiveSupport::TestCase.around`
 
     Add a callback, which runs between `TestCase#setup` and `TestCase#teardown`.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -35,6 +35,13 @@ module ActiveSupport
     # * +read_multi+ and +write_multi+ support for Redis mget/mset. Use
     #   +Redis::Distributed+ 4.0.1+ for distributed mget support.
     # * +delete_matched+ support for Redis KEYS globs.
+    # * +read+ supports <tt>delete: true</tt> to atomically read and delete
+    #   a cache entry using the Redis +GETDEL+ command.
+    #
+    #     cache.write("greeting", "hello")
+    #     cache.read("greeting", delete: true)  # => "hello"
+    #     cache.read("greeting")                 # => nil
+    #
     class RedisCacheStore < Store
       DEFAULT_REDIS_OPTIONS = {
         connect_timeout:    1,
@@ -345,7 +352,7 @@ module ActiveSupport
 
         def read_serialized_entry(key, raw: false, **options)
           failsafe :read_entry do
-            redis.then { |c| c.get(key) }
+            redis.then { |c| options[:delete] ? c.getdel(key) : c.get(key) }
           end
         end
 

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -158,13 +158,19 @@ module ActiveSupport
         private
           def read_serialized_entry(key, raw: false, **options)
             if cache = local_cache
-              hit = true
-              entry = cache.fetch_entry(key) do
-                hit = false
-                super
+              if options[:delete]
+                entry = super
+                cache.delete_entry(key)
+                entry
+              else
+                hit = true
+                entry = cache.fetch_entry(key) do
+                  hit = false
+                  super
+                end
+                options[:event][:store] = cache.class.name if hit && options[:event]
+                entry
               end
-              options[:event][:store] = cache.class.name if hit && options[:event]
-              entry
             else
               super
             end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -523,4 +523,81 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
   end
+
+  class ReadDeleteTest < StoreTest
+    test "read with delete: true returns the value and removes the key" do
+      @cache.write("foo", "bar")
+      assert_equal "bar", @cache.read("foo", delete: true)
+      assert_nil @cache.read("foo")
+    end
+
+    test "read with delete: true returns nil for missing key" do
+      assert_nil @cache.read("missing", delete: true)
+    end
+
+    test "read with delete: true removes the key from redis" do
+      @cache.write("foo", "bar")
+      @cache.read("foo", delete: true)
+      redis_backend do |r|
+        assert_not r.exists?("#{@namespace}:foo")
+      end
+    end
+
+    test "read with delete: true works with raw values" do
+      @cache.write("foo", "bar", raw: true)
+      assert_equal "bar", @cache.read("foo", raw: true, delete: true)
+      assert_nil @cache.read("foo", raw: true)
+    end
+
+    test "read without delete option still works normally" do
+      @cache.write("foo", "bar")
+      assert_equal "bar", @cache.read("foo")
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    test "read with delete: true on expired entry returns nil" do
+      @cache.write("foo", "bar", expires_in: 1)
+      travel(2.seconds) do
+        assert_nil @cache.read("foo", delete: true)
+      end
+    end
+
+    test "read with delete: true returns value and clears local cache" do
+      @cache.with_local_cache do
+        @cache.write("foo", "bar")
+        assert_equal "bar", @cache.read("foo", delete: true)
+        assert_nil @cache.read("foo")
+      end
+    end
+
+    test "read with delete: true clears remote cache within local cache scope" do
+      @cache.with_local_cache do
+        @cache.write("foo", "bar")
+        assert_equal "bar", @cache.read("foo", delete: true)
+      end
+      # After local cache scope ends, remote should also be gone
+      assert_nil @cache.read("foo")
+    end
+
+    test "read with delete: true bypasses stale local cache" do
+      @cache.with_local_cache do
+        @cache.write("foo", "bar")
+        # Overwrite in remote behind local cache's back
+        @cache.send(:bypass_local_cache) { @cache.write("foo", "baz") }
+        # Without delete, local cache returns stale value
+        assert_equal "bar", @cache.read("foo")
+        # With delete, it should bypass local cache and hit remote
+        assert_equal "baz", @cache.read("foo", delete: true)
+        # Both local and remote should be cleared
+        assert_nil @cache.read("foo")
+      end
+    end
+
+    def redis_backend(cache = @cache)
+      cache.redis.with do |r|
+        yield r if block_given?
+        return r
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Add support for atomically reading and deleting a cache entry in `RedisCacheStore` using the Redis [GETDEL](https://redis.io/docs/latest/commands/getdel/) command. This is useful for one-time-read patterns where you want to guarantee the value can only be consumed once, without a race condition between a separate read and delete.

### Detail

This PR changes `RedisCacheStore#read_serialized_entry` to accept a new `delete: true` option. When passed, the underlying Redis command switches from `GET` to `GETDEL`, which atomically returns the value and removes the key in a single round trip.
Three areas were modified:

- `activesupport/lib/active_support/cache/redis_cache_store.rb`: `read_serialized_entry` now accepts a `delete` keyword argument. When true, it calls `c.getdel(key)` instead of `c.get(key)`. Documentation was added to the class-level RDoc.
- `activesupport/lib/active_support/cache/strategy/local_cache.rb`: When `delete: true`, the local cache layer bypasses its in-memory cache (to ensure the `GETDEL` always reaches Redis) and clears the local cache entry afterward to keep both layers consistent.
- `activesupport/test/cache/stores/redis_cache_store_test.rb`: new tests covering: basic read-and-delete, missing keys, raw values, expired entries, Redis key removal verification, and local cache interaction (clearing, bypassing stale entries).

This is a Redis-specific option. Other cache stores silently ignore it (the option falls through `**options` splat).

### Additional information

- Requires Redis 6.2+ (when `GETDEL` was introduced). Should we care about previous versions of Redis?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
