### PR TITLE
SQLite3: Preserve triggers on a table when altering it

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   SQLite3: Preserve triggers on a table when altering it.
+
+    Previously, triggers on a SQLite3 table were silently dropped when
+    the table was altered (e.g., adding/removing columns, foreign keys).
+    This happened because SQLite requires table recreation for many ALTER
+    operations, and triggers are automatically dropped when the original
+    table is dropped.
+
+    *Viacheslav Nepomniashchikh*
+
 *   Add `implicit_persistence_transaction` hook for customizing transaction behavior.
 
     A new protected method `implicit_persistence_transaction` has been added that wraps

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -94,6 +94,16 @@ module ActiveRecord
           end
         end
 
+        def triggers(table_name)
+          query_values(<<~SQL, "SCHEMA")
+            SELECT sql FROM sqlite_master
+            WHERE type = 'trigger' AND tbl_name = #{quote(table_name)}
+            UNION ALL
+            SELECT sql FROM sqlite_temp_master
+            WHERE type = 'trigger' AND tbl_name = #{quote(table_name)}
+          SQL
+        end
+
         def add_check_constraint(table_name, expression, **options)
           alter_table(table_name) do |definition|
             definition.check_constraint(expression, **options)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -617,6 +617,7 @@ module ActiveRecord
           table_name,
           foreign_keys = foreign_keys(table_name),
           check_constraints = check_constraints(table_name),
+          triggers = triggers(table_name),
           **options
         )
           altered_table_name = "a#{table_name}"
@@ -642,6 +643,7 @@ module ActiveRecord
             transaction do
               move_table(table_name, altered_table_name, options.merge(temporary: true))
               move_table(altered_table_name, table_name, &caller)
+              triggers.each { |trigger_sql| execute(trigger_sql) if trigger_sql.present? }
             end
           end
         end


### PR DESCRIPTION
Previously, triggers on a SQLite3 table were silently dropped when the table was altered through operations that require table recreation (`remove_column`, `add_foreign_key`, `add_check_constraint`, or `add_column` with `null: false`). This happened because SQLite automatically drops triggers when the referenced table is dropped, and the `alter_table` method did not restore them afterward — unlike foreign keys and check constraints, which are already preserved.

This PR adds a `triggers(table_name)` method that queries `sqlite_master` and `sqlite_temp_master` for existing trigger definitions, and restores them after table recreation in `alter_table`.

Fixes #56810