### PR TITLE
Fix `Column#hash` to use the correct instance variable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -80,7 +80,7 @@ module ActiveRecord
             super,
             @identity,
             @serial,
-            @virtual,
+            @generated,
           ].hash
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -58,7 +58,7 @@ module ActiveRecord
             super,
             @auto_increment,
             @rowid,
-            @virtual,
+            @generated_type,
           ].hash
         end
       end


### PR DESCRIPTION
Follow up to #56801.
