### PR TITLE
Fix SQLite3 column equality for stored vs virtual generated columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -48,7 +48,7 @@ module ActiveRecord
             super &&
             auto_increment? == other.auto_increment? &&
             rowid == other.rowid &&
-            virtual? == other.virtual?
+            generated_type == other.generated_type
         end
         alias :eql? :==
 
@@ -61,6 +61,9 @@ module ActiveRecord
             @generated_type,
           ].hash
         end
+
+        protected
+          attr_reader :generated_type
       end
     end
   end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -1121,6 +1121,16 @@ module ActiveRecord
         assert_not_equal rowid_column, regular_column
       end
 
+      def test_generated_type_changes_column_equality
+        cast_type = @conn.lookup_cast_type("string")
+        type_metadata = SqlTypeMetadata.new(sql_type: "varchar", type: :string)
+
+        stored_column = SQLite3::Column.new("name", cast_type, nil, type_metadata, true, nil, generated_type: :stored)
+        virtual_column = SQLite3::Column.new("name", cast_type, nil, type_metadata, true, nil, generated_type: :virtual)
+
+        assert_not_equal stored_column, virtual_column
+      end
+
       def test_sqlite_extensions_are_constantized_for_the_client_constructor
         mock_adapter = Class.new(SQLite3Adapter) do
           class << self


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveRecord::ConnectionAdapters::SQLite3::Column#==` only compared `virtual?`, while `#hash` already included `@generated_type`.

That allowed `generated_type: :stored` and `generated_type: :virtual` columns to compare equal while producing different hash values, which breaks the `eql?/hash` contract for hash/set usage.

### Detail

This Pull Request changes SQLite3 generated column equality semantics.

- Adds a regression test: `test_generated_type_changes_column_equality` in `activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb`.
- Updates `ActiveRecord::ConnectionAdapters::SQLite3::Column#==` in `activerecord/lib/active_record/connection_adapters/sqlite3/column.rb` to also compare `virtual_stored?`.
- Keeps existing equality checks for `rowid` and `auto_increment` unchanged.

### Additional information

Validation run:

- `ARCONN=sqlite3 bundle exec ruby -Itest test/cases/adapters/sqlite3/sqlite3_adapter_test.rb -i "/test_(generated_type_changes_column_equality|rowid_changes_column_equality)/"`
- `ARCONN=sqlite3 bundle exec ruby -Itest test/cases/adapters/sqlite3/sqlite3_adapter_test.rb`

Both commands passed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (N/A here: minor bug fix)
