### PR TITLE
Check for `blank?` instead of `nil?` in CombinedConfiguration

### DIFF
--- a/activesupport/lib/active_support/combined_configuration.rb
+++ b/activesupport/lib/active_support/combined_configuration.rb
@@ -15,7 +15,7 @@ module ActiveSupport
     end
 
     # Find singular or nested keys across all backends.
-    # Raises +KeyError+ if no backend holds the key or if the value is blank.
+    # Raises +KeyError+ if no backend holds the key or if the value is +blank?+ (except +false+).
     #
     # Given ENV:
     #   DATABASE__HOST: "env.example.com"
@@ -30,11 +30,11 @@ module ActiveSupport
     #   require(:database, :host) # => "env.example.com" (ENV overrides credentials)
     #   require(:api_key)         # => "secret" (from credentials)
     #   require(:missing)         # => KeyError
-    #   require(:api_host)        # => KeyError (blank values are treated as missing)
+    #   require(:api_host)        # => KeyError (+blank?+ values (except +false+) are treated as missing)
     def require(*key)
       @configurations.each do |config|
         value = config.option(*key)
-        return value if value.present?
+        return value if value.present? || value == false
       end
 
       raise KeyError, "Missing key: #{key.inspect}"
@@ -42,7 +42,8 @@ module ActiveSupport
 
     # Find singular or nested keys across all backends.
     # Returns +nil+ if no backend holds the key.
-    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key or blank value.
+    # If a +default+ value is defined, it (or its callable value) will be returned on
+    # a missing key or +blank?+ value (except +false+).
     #
     # Given ENV:
     #   DATABASE__HOST: "env.example.com"
@@ -58,11 +59,11 @@ module ActiveSupport
     #   option(:missing)                              # => nil
     #   option(:missing, default: "localhost")        # => "localhost"
     #   option(:missing, default: -> { "localhost" }) # => "localhost"
-    #   option(:api_host, default: "api.example.com") # => "api.example.com" (blank values use default)
+    #   option(:api_host, default: "api.example.com") # => "api.example.com" (+blank?+ values (except +false+) use default)
     def option(*key, default: nil)
       @configurations.each do |config|
         value = config.option(*key)
-        return value if value.present?
+        return value if value.present? || value == false
       end
 
       default.respond_to?(:call) ? default.call : default

--- a/activesupport/lib/active_support/combined_configuration.rb
+++ b/activesupport/lib/active_support/combined_configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/enumerable"
+require "active_support/core_ext/object/blank"
 
 module ActiveSupport
   # Allows for configuration keys to be pulled from multiple backends. Keys are pulled in first-found order from
@@ -14,7 +15,7 @@ module ActiveSupport
     end
 
     # Find singular or nested keys across all backends.
-    # Raises +KeyError+ if no backend holds the key or if the value is nil.
+    # Raises +KeyError+ if no backend holds the key or if the value is blank.
     #
     # Given ENV:
     #   DATABASE__HOST: "env.example.com"
@@ -23,17 +24,17 @@ module ActiveSupport
     #   database:
     #     host: "creds.example.com"
     #   api_key: "secret"
-    #   api_host: null
+    #   api_host: ""
     #
     # Examples:
     #   require(:database, :host) # => "env.example.com" (ENV overrides credentials)
     #   require(:api_key)         # => "secret" (from credentials)
     #   require(:missing)         # => KeyError
-    #   require(:api_host)        # => KeyError (nil values are treated as missing)
+    #   require(:api_host)        # => KeyError (blank values are treated as missing)
     def require(*key)
       @configurations.each do |config|
         value = config.option(*key)
-        return value unless value.nil?
+        return value if value.present?
       end
 
       raise KeyError, "Missing key: #{key.inspect}"
@@ -41,7 +42,7 @@ module ActiveSupport
 
     # Find singular or nested keys across all backends.
     # Returns +nil+ if no backend holds the key.
-    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key or nil value.
+    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key or blank value.
     #
     # Given ENV:
     #   DATABASE__HOST: "env.example.com"
@@ -50,18 +51,18 @@ module ActiveSupport
     #   database:
     #     host: "creds.example.com"
     #   api_key: "secret"
-    #   api_host: null
+    #   api_host: ""
     #
     # Examples:
     #   option(:database, :host)                      # => "env.example.com" (ENV overrides credentials)
     #   option(:missing)                              # => nil
     #   option(:missing, default: "localhost")        # => "localhost"
     #   option(:missing, default: -> { "localhost" }) # => "localhost"
-    #   option(:api_host, default: "api.example.com") # => "api.example.com" (nil values use default)
+    #   option(:api_host, default: "api.example.com") # => "api.example.com" (blank values use default)
     def option(*key, default: nil)
       @configurations.each do |config|
         value = config.option(*key)
-        return value unless value.nil?
+        return value if value.present?
       end
 
       default.respond_to?(:call) ? default.call : default

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -60,7 +60,7 @@ module ActiveSupport
     end
 
     # Find singular or nested keys.
-    # Raises +KeyError+ if not found or blank.
+    # Raises +KeyError+ if not found or +blank?+ (except +false+).
     #
     # Given configuration:
     #   db_port: ""
@@ -70,14 +70,20 @@ module ActiveSupport
     # Examples:
     #   require(:database, :host) # => "db.example.com"
     #   require(:missing)         # => KeyError
-    #   require(:db_port)         # => KeyError (blank values are treated as missing)
+    #   require(:db_port)         # => KeyError (+blank?+ values (except +false+) are treated as missing)
     def require(*key)
-      dig(*key).presence || raise(KeyError, "Missing key: #{key.inspect}")
+      value = dig(*key)
+      if value.present? || value == false
+        value
+      else
+        raise KeyError, "Missing key: #{key.inspect}"
+      end
     end
 
     # Find singular or nested keys.
     # Returns +nil+ if the key isn't found.
-    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key or blank value.
+    # If a +default+ value is defined, it (or its callable value) will be returned on
+    # a missing key or +blank?+ value (except +false+).
     #
     # Given configuration:
     #   db_port: ""
@@ -89,13 +95,16 @@ module ActiveSupport
     #   option(:missing)                              # => nil
     #   option(:missing, default: "localhost")        # => "localhost"
     #   option(:missing, default: -> { "localhost" }) # => "localhost"
-    #   option(:db_port, default: 5432)               # => 5432 (blank values use default)
+    #   option(:db_port, default: 5432)               # => 5432 (+blank?+ values (except +false+) use default)
     def option(*key, default: nil)
-      dig(*key).presence || if default.respond_to?(:call)
-                              default.call
-                            else
-                              default
-                            end
+      value = dig(*key)
+      if value.present? || value == false
+        value
+      elsif default.respond_to?(:call)
+        default.call
+      else
+        default
+      end
     end
 
     # Reload the cached values in case any of them changed or new ones were added during runtime.

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -6,6 +6,7 @@ require "active_support/ordered_options"
 require "active_support/core_ext/object/inclusion"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/object/blank"
 
 module ActiveSupport
   # = Encrypted Configuration
@@ -59,52 +60,42 @@ module ActiveSupport
     end
 
     # Find singular or nested keys.
-    # Raises +KeyError+ if not found or nil.
+    # Raises +KeyError+ if not found or blank.
     #
     # Given configuration:
-    #   db_port: null
+    #   db_port: ""
     #   database:
     #     host: "db.example.com"
     #
     # Examples:
     #   require(:database, :host) # => "db.example.com"
     #   require(:missing)         # => KeyError
-    #   require(:db_port)         # => KeyError (nil values are treated as missing)
+    #   require(:db_port)         # => KeyError (blank values are treated as missing)
     def require(*key)
-      value = dig(*key)
-
-      if !value.nil?
-        value
-      else
-        raise KeyError, "Missing key: #{key.inspect}"
-      end
+      dig(*key).presence || raise(KeyError, "Missing key: #{key.inspect}")
     end
 
     # Find singular or nested keys.
     # Returns +nil+ if the key isn't found.
-    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key or nil value.
+    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key or blank value.
     #
     # Given configuration:
-    #   db_port: null
+    #   db_port: ""
     #   database:
     #     host: "db.example.com"
     #
     # Examples:
-    #   option(:database, :host)               # => "db.example.com"
-    #   option(:missing)                       # => nil
+    #   option(:database, :host)                      # => "db.example.com"
+    #   option(:missing)                              # => nil
     #   option(:missing, default: "localhost")        # => "localhost"
     #   option(:missing, default: -> { "localhost" }) # => "localhost"
-    #   option(:db_port, default: 5432)               # => 5432 (nil values use default)
+    #   option(:db_port, default: 5432)               # => 5432 (blank values use default)
     def option(*key, default: nil)
-      value = dig(*key)
-
-      if !value.nil?
-        value
-      elsif default.respond_to?(:call)
-        default.call
-      else
-        default
-      end
+      dig(*key).presence || if default.respond_to?(:call)
+                              default.call
+                            else
+                              default
+                            end
     end
 
     # Reload the cached values in case any of them changed or new ones were added during runtime.

--- a/activesupport/lib/active_support/env_configuration.rb
+++ b/activesupport/lib/active_support/env_configuration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/object/blank"
 
 module ActiveSupport
   # Provide a better interface for accessing configuration options stored in ENV.
@@ -22,39 +22,43 @@ module ActiveSupport
     end
 
     # Find an upcased and double-underscored-joined string-version of the +key+ in ENV.
-    # Raises +KeyError+ if not found.
+    # Raises +KeyError+ if not found or blank.
     #
     # Given ENV:
     #   DB_HOST: "env.example.com"
     #   DATABASE__HOST: "env.example.com"
+    #   BLANK_VALUE: ""
     #
     # Examples:
     #   require(:db_host)         # => "env.example.com"
     #   require(:database, :host) # => "env.example.com"
     #   require(:missing)         # => KeyError
+    #   require(:blank_value)     # => KeyError (blank values are treated as missing)
     def require(*key)
-      @envs.fetch envify(*key)
+      @envs.fetch(envify(*key)).presence || raise(KeyError, "Missing key: #{key.inspect}")
     end
 
     # Find an upcased and double-underscored-joined string-version of the +key+ in ENV.
     # Returns +nil+ if the key isn't found.
-    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key.
+    # If a +default+ value is defined, it (or its callable value) will be returned on a missing key or blank value.
     #
     # Given ENV:
     #   DB_HOST: "env.example.com"
     #   DATABASE__HOST: "env.example.com"
+    #   BLANK_VALUE: ""
     #
     # Examples:
     #   option(:db_host)                              # => "env.example.com"
     #   option(:missing)                              # => nil
     #   option(:missing, default: "localhost")        # => "localhost"
     #   option(:missing, default: -> { "localhost" }) # => "localhost"
+    #   option(:blank_value, default: "localhost")    # => "localhost" (blank values use default)
     def option(*key, default: nil)
-      if default.respond_to?(:call)
-        @envs.fetch(envify(*key)) { default.call }
-      else
-        @envs.fetch envify(*key), default
-      end
+      @envs[envify(*key)].presence || if default.respond_to?(:call)
+                                        default.call
+                                      else
+                                        default
+                                      end
     end
 
     # Reload the cached ENV values in case any of them changed or new ones were added during runtime.

--- a/activesupport/test/combined_configuration_test.rb
+++ b/activesupport/test/combined_configuration_test.rb
@@ -24,7 +24,7 @@ class CombinedConfigurationTest < ActiveSupport::TestCase
       available_in_all: "cred",
       available_in_dotenv_and_cred: "cred",
       only_in_credentials: "cred",
-      false: false,
+      blank_in_credentials: "",
       nested: {
         available_in_all: "cred",
         available_in_dotenv_and_cred: "cred",
@@ -115,14 +115,6 @@ class CombinedConfigurationTest < ActiveSupport::TestCase
     assert_equal "dotenv", @combined.require(:nested, :available_in_dotenv_and_cred)
   end
 
-  test "require key with a false value" do
-    assert_equal false, @combined.require(:false)
-  end
-
-  test "option key with a false value" do
-    assert_equal false, @combined.option(:false)
-  end
-
   test "require with missing key raises key error" do
     assert_raise(KeyError, match: "Missing key: [:gone]") do
       @combined.require(:gone)
@@ -146,5 +138,19 @@ class CombinedConfigurationTest < ActiveSupport::TestCase
     assert_match(/\A#<ActiveSupport::CombinedConfiguration:0x[0-9a-f]+ keys=\[.*\]>\z/, @combined.inspect)
   ensure
     ENV.delete("SECRET_ENV")
+  end
+
+  test "require with blank value in credentials raises key error" do
+    assert_raise(KeyError, match: "Missing key: [:blank_in_credentials]") do
+      @combined.require(:blank_in_credentials)
+    end
+  end
+
+  test "option with blank value in credentials returns default" do
+    assert_equal "default", @combined.option(:blank_in_credentials, default: "default")
+  end
+
+  test "option with blank value in credentials without default returns nil" do
+    assert_nil @combined.option(:blank_in_credentials)
   end
 end

--- a/activesupport/test/combined_configuration_test.rb
+++ b/activesupport/test/combined_configuration_test.rb
@@ -24,6 +24,7 @@ class CombinedConfigurationTest < ActiveSupport::TestCase
       available_in_all: "cred",
       available_in_dotenv_and_cred: "cred",
       only_in_credentials: "cred",
+      false: false,
       blank_in_credentials: "",
       nested: {
         available_in_all: "cred",
@@ -113,6 +114,20 @@ class CombinedConfigurationTest < ActiveSupport::TestCase
 
   test "read nested key present in dotenv and credentials returns dotenv" do
     assert_equal "dotenv", @combined.require(:nested, :available_in_dotenv_and_cred)
+  end
+
+  test "require key with a false value" do
+    assert_equal false, @combined.require(:false)
+  end
+
+  test "option key with a false value" do
+    assert_equal false, @combined.option(:false)
+  end
+
+  test "option key with a false value does not trigger default" do
+    called = false
+    assert_equal false, @combined.option(:false, default: -> { called = true; "default" })
+    assert_equal false, called
   end
 
   test "require with missing key raises key error" do

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -159,9 +159,11 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     end
   end
 
-  test "require false key does not raise key error" do
-    @credentials.write({ one: false }.to_yaml)
-    assert_equal false, @credentials.require(:one)
+  test "require blank key raises key error" do
+    @credentials.write({ blank: "" }.to_yaml)
+    assert_raise(KeyError, match: "Missing key: [:blank]") do
+      @credentials.require(:blank)
+    end
   end
 
   test "require missing multiword key raises key error" do
@@ -186,11 +188,14 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal "there", @credentials.option(:two_is_not_here, default: -> { "there" })
   end
 
-  test "optional false key with default block can return false without triggering default" do
-    @credentials.write({ bool: false }.to_yaml)
-    called = false
-    assert_equal false, @credentials.option(:bool, default: -> { called = true; "there" })
-    assert_equal false, called
+  test "option blank key returns default" do
+    @credentials.write({ blank: "" }.to_yaml)
+    assert_equal "default", @credentials.option(:blank, default: "default")
+  end
+
+  test "option blank key without default returns nil" do
+    @credentials.write({ blank: "" }.to_yaml)
+    assert_nil @credentials.option(:blank)
   end
 
   test "optional missing key with default block returning false returns false" do

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -166,6 +166,11 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "require false key does not raise key error" do
+    @credentials.write({ one: false }.to_yaml)
+    assert_equal false, @credentials.require(:one)
+  end
+
   test "require missing multiword key raises key error" do
     assert_raise(KeyError, match: "Missing key: [:gone, :missing]") do
       @credentials.require(:gone, :missing)
@@ -196,6 +201,13 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   test "option blank key without default returns nil" do
     @credentials.write({ blank: "" }.to_yaml)
     assert_nil @credentials.option(:blank)
+  end
+
+  test "optional false key with default block can return false without triggering default" do
+    @credentials.write({ bool: false }.to_yaml)
+    called = false
+    assert_equal false, @credentials.option(:bool, default: -> { called = true; "there" })
+    assert_equal false, called
   end
 
   test "optional missing key with default block returning false returns false" do

--- a/activesupport/test/env_configuration_test.rb
+++ b/activesupport/test/env_configuration_test.rb
@@ -85,6 +85,26 @@ class EnvConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "require blank key raises key error" do
+    set_env("BLANK" => "") do
+      assert_raises(KeyError) do
+        @config.require(:blank)
+      end
+    end
+  end
+
+  test "option blank key returns default" do
+    set_env("BLANK" => "") do
+      assert_equal "default", @config.option(:blank, default: "default")
+    end
+  end
+
+  test "option blank key without default returns nil" do
+    set_env("BLANK" => "") do
+      assert_nil @config.option(:blank)
+    end
+  end
+
   private
     def set_env(attributes)
       attributes.each do |key, value|


### PR DESCRIPTION
### Motivation / Background

This Pull Request is extracted from [a discussion in #56430](https://github.com/rails/rails/pull/56430#discussion_r2640480995) with @dhh:

> I don't think nil should be respected, no. We should search through all the configurations for a
> not-nil value. If we can't find one, we raise MissingKey.

> When you do #require, we should blow up **if nil or blank**

### Detail

This Pull Request updates CombinedConfiguration to treat all `blank?` values as missing in configuration lookups, instead of just `nil?` values.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
