### PR TITLE
Support html-safe error messages in Active Model

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Support html-safe error messages in Active Model.
+
+    Validation error message keys ending in `_html` now have their
+    interpolation values HTML-escaped and the resulting message marked as
+    `html_safe`, consistent with the existing convention in Action View
+    and Action Controller translation helpers.
+
+    ```yaml
+    en:
+      errors:
+        messages:
+          taken_html: "has <em>already</em> been taken"
+    ```
+
+    ```ruby
+    model.errors.add(:name, :taken_html)
+    model.errors.messages.first.html_safe? # => true
+    ```
+
+    *Matheus Richard*
+
 *   Add `has_json` and `has_delegated_json` to provide schema-enforced access to JSON attributes.
 
     ```ruby


### PR DESCRIPTION
### Motivation / Background

I needed to write a helper that would create a HTML element for error messages for a specific attribute in Rails. Something like

```rb
def error_messages_for_attribute(model, attribute)
  if model.errors.include?(attribute)
    messages = model.errors.where(attribute).map(&:full_message)

    tag.span(to_sentence(messages), class: "error-message")
  end
end
```

The problem is that currently error messages are never marked as HTML-safe, even when using the `_html`s suffix [like Action View supports][av], so raw HTML is outputted instead.

[av]: https://guides.rubyonrails.org/i18n.html#using-safe-html-translations

### Detail

Validation error message keys ending in `_html` now have their interpolation values HTML-escaped and the resulting message marked as `html_safe`, consistent with the [existing convention][convention] in Action View and Action Controller translation helpers.

```yaml
en:
  errors:
    messages:
      taken_html: "has <em>already</em> been taken"
```

```ruby
model.errors.add(:name, :taken_html)
model.errors.messages.first.html_safe? # => true
```

[convention]: https://guides.rubyonrails.org/i18n.html#using-safe-html-translations


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
