### PR TITLE
Remove unused "open-uri" require from AppBase

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -3,7 +3,6 @@
 require "fileutils"
 require "digest/md5"
 require "rails/version" unless defined?(Rails::VERSION)
-require "open-uri"
 require "tsort"
 require "uri"
 require "rails/generators"


### PR DESCRIPTION
Ref #56824

This comes from a sixteen year-old [commit][1], which called `Kernel#open` instead of `URI#open` directly. That `open` was also later [removed][2] with the removal of `--builder`.

`open-uri` _is_ required on demand inside Thor where its used, but it seems like the require in Rails is never used.

[1]: https://github.com/rails/rails/commit/785493ffed41abcca0686bf05b0a0157e0844d47
[2]: https://github.com/rails/rails/commit/bce6cbdeabfe2d8fcfae0cee8a03f0521f14c84e
