### PR TITLE
Fix eagerly loading ActiveModel::Attributes

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -57,12 +57,6 @@ module ActiveModel
   autoload :Validations
   autoload :Validator
 
-  module Attributes
-    extend ActiveSupport::Autoload
-
-    autoload :Normalization
-  end
-
   eager_autoload do
     autoload :Errors
     autoload :Error

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -28,6 +28,10 @@ module ActiveModel
   #   person.name # => "Volmer"
   #   person.active # => true
   module Attributes
+    extend ActiveSupport::Autoload
+
+    autoload :Normalization
+
     extend ActiveSupport::Concern
     include ActiveModel::AttributeRegistration
     include ActiveModel::AttributeMethods


### PR DESCRIPTION
Ref #56824

An autoload is defined, but then the Normalization autoload referenced the Attributes constant, so it ended up getting loaded immediately.

This commit moves the autoload inside the real Attributes module so that it correctly loads lazily.