### PR TITLE
Add AI prompt to debug exception pages

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -239,3 +239,6 @@
     *Thiago Youssef*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionpack/CHANGELOG.md) for previous changes.
+*   Add an AI agent prompt block to debug exception pages to share structured context for troubleshooting.
+
+    *yottanami*

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -68,8 +68,6 @@ module ActionDispatch
       lines << "- Exception: #{wrapper.exception_class_name}: #{wrapper.message}"
       request_method = begin
         @request.request_method
-      rescue ActionDispatch::Http::Parameters::ParseError, ActionDispatch::Http::Request::InvalidMethod
-        "UNKNOWN"
       rescue StandardError
         "UNKNOWN"
       end

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -53,9 +53,27 @@ module ActionDispatch
       lines = []
       wrapper = @exception_wrapper
 
+      if wrapper.nil?
+        lines << "Issue summary:"
+        lines << "- Exception: (unavailable)"
+        lines << "- Request: (unavailable)"
+        lines << "Task for the AI agent:"
+        lines << "1) Explain the likely root cause in plain language."
+        lines << "2) Suggest a fix with file and line references."
+        lines << "3) Call out tests to add or update."
+        return lines.join("\n")
+      end
+
       lines << "Issue summary:"
       lines << "- Exception: #{wrapper.exception_class_name}: #{wrapper.message}"
-      lines << "- Request: #{@request.request_method} #{@request.fullpath}"
+      request_method = begin
+        @request.request_method
+      rescue ActionDispatch::Http::Parameters::ParseError, ActionDispatch::Http::Request::InvalidMethod
+        "UNKNOWN"
+      rescue StandardError
+        "UNKNOWN"
+      end
+      lines << "- Request: #{request_method} #{@request.fullpath}"
 
       if params_valid? && @request.parameters["controller"]
         action = @request.parameters["action"]

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -45,6 +45,53 @@ module ActionDispatch
       object.to_hash.sort_by { |k, _| k.to_s }.map { |k, v| "#{k}: #{v.inspect rescue $!.message}" }.join("\n")
     end
 
+    def ai_prompt_title
+      "Prompt for AI agents"
+    end
+
+    def ai_prompt_text
+      lines = []
+      wrapper = @exception_wrapper
+
+      lines << "Issue summary:"
+      lines << "- Exception: #{wrapper.exception_class_name}: #{wrapper.message}"
+      lines << "- Request: #{@request.request_method} #{@request.fullpath}"
+
+      if params_valid? && @request.parameters["controller"]
+        action = @request.parameters["action"]
+        controller = @request.parameters["controller"]
+        lines << "- Controller/action: #{controller}##{action}"
+      end
+
+      if params_valid?
+        lines << "Parameters (filtered):"
+        debug_params(@request.filtered_parameters).each_line do |line|
+          lines << "  #{line.rstrip}"
+        end
+      end
+
+      rails_version = defined?(Rails) && Rails.respond_to?(:version) ? Rails.version : "unknown"
+      rails_env = defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : "unknown"
+      lines << "Environment:"
+      lines << "  Rails #{rails_version} on Ruby #{RUBY_VERSION} (#{rails_env})"
+
+      trace = wrapper.exception_trace.map(&:to_s)
+      trace = trace.first(5)
+      lines << "Relevant backtrace:"
+      if trace.empty?
+        lines << "  (no backtrace available)"
+      else
+        trace.each { |entry| lines << "  #{entry}" }
+      end
+
+      lines << "Task for the AI agent:"
+      lines << "1) Explain the likely root cause in plain language."
+      lines << "2) Suggest a fix with file and line references."
+      lines << "3) Call out tests to add or update."
+
+      lines.join("\n")
+    end
+
     def render(*)
       logger = ActionView::Base.logger
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_ai_prompt.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_ai_prompt.html.erb
@@ -1,0 +1,5 @@
+<section class="ai-prompt">
+  <h2><%= ai_prompt_title %></h2>
+  <textarea class="ai-prompt__text" readonly rows="12"><%= h ai_prompt_text %></textarea>
+  <p class="ai-prompt__hint">Select the text above and share it with an AI agent.</p>
+</section>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
@@ -3,6 +3,7 @@
   <h1>Blocked hosts: <%= @hosts.join(", ") %></h1>
 </header>
 <main role="main" id="container">
+  <%= render "rescues/ai_prompt" %>
   <h2>To allow requests to these hosts, make sure they are valid hostnames (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:</h2>
   <pre>
   <% @hosts.each do |host| %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -9,6 +9,7 @@
 </header>
 
 <main role="main" id="container">
+  <%= render "rescues/ai_prompt" %>
   <%= render "rescues/message_and_suggestions", exception: @exception, exception_wrapper: @exception_wrapper %>
   <%= render "rescues/actions", exception: @exception, request: @request, exception_wrapper: @exception_wrapper %>
 

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
@@ -9,6 +9,7 @@
 </header>
 
 <main role="main" id="container">
+  <%= render "rescues/ai_prompt" %>
   <h2>
     <%= h @exception.message %>
     <% if defined?(ActionText) && @exception.message.match?(%r{#{ActionText::RichText.table_name}}) %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -118,6 +118,34 @@
       max-width: 978px;
     }
 
+    .ai-prompt {
+      border: 1px solid #D0D0D0;
+      border-radius: 4px;
+      background: #FFF;
+      margin: 1em 0px;
+      padding: 0.75em;
+      max-width: 978px;
+    }
+
+    .ai-prompt__text {
+      width: 100%;
+      box-sizing: border-box;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size: 12px;
+      line-height: 1.4;
+      border: 1px solid #D0D0D0;
+      border-radius: 4px;
+      padding: 8px;
+      resize: vertical;
+      background: #FFF;
+    }
+
+    .ai-prompt__hint {
+      margin: 0.5em 0 0;
+      font-size: 12px;
+      color: #666;
+    }
+
     .summary {
       padding: 8px 15px;
       border-bottom: 1px solid #D0D0D0;
@@ -268,6 +296,21 @@
 
       .details, .summary {
         border-color: #666;
+      }
+
+      .ai-prompt {
+        border-color: #666;
+        background: #2B2B2B;
+      }
+
+      .ai-prompt__text {
+        border-color: #666;
+        background: #333;
+        color: #ECECEC;
+      }
+
+      .ai-prompt__hint {
+        color: #AAA;
       }
 
       .source {

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
@@ -4,6 +4,7 @@
 </header>
 
 <main id="container">
+  <%= render "rescues/ai_prompt" %>
   <h2><%= h @exception.message %></h2>
 
   <div class="summary">

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
@@ -4,6 +4,7 @@
 </header>
 
 <main role="main" id="container">
+  <%= render "rescues/ai_prompt" %>
   <h2><%= h @exception_wrapper.message %></h2>
 
   <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
@@ -3,6 +3,7 @@
   <h1>Routing Error</h1>
 </header>
 <main role="main" id="container">
+  <%= render "rescues/ai_prompt" %>
   <h2><%= h @exception_wrapper.message %></h2>
   <% unless @exception_wrapper.failures.empty? %>
     <p>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
@@ -7,6 +7,7 @@
 </header>
 
 <main role="main" id="container">
+  <%= render "rescues/ai_prompt" %>
   <p>
     Showing <i><%= @exception_wrapper.file_name %></i> where line <b>#<%= @exception_wrapper.line_number %></b> raised:
   </p>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
@@ -3,5 +3,6 @@
   <h1>Unknown action</h1>
 </header>
 <main role="main" id="container">
+  <%= render "rescues/ai_prompt" %>
   <%= render "rescues/message_and_suggestions", exception: @exception, exception_wrapper: @exception_wrapper %>
 </main>

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -247,6 +247,17 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_match(/ActionDispatch::Http::MimeNegotiation::InvalidType/, body)
   end
 
+  test "includes an ai prompt in the html debug page" do
+    @app = DevelopmentApp
+
+    get "/", headers: { "action_dispatch.show_exceptions" => :all }
+
+    assert_select "section.ai-prompt h2", "Prompt for AI agents"
+    assert_select "textarea.ai-prompt__text", /RuntimeError/
+    assert_select "textarea.ai-prompt__text", /Request: GET \//
+    assert_select "textarea.ai-prompt__text", /Parameters \(filtered\):/
+  end
+
   test "rescue with text error for xhr request" do
     @app = DevelopmentApp
     xhr_request_env = { "action_dispatch.show_exceptions" => :all, "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest" }


### PR DESCRIPTION
 Here’s a PR description aligned with the Rails template and contribution guidance (with placeholders you should fill):

  ### Motivation / Background

 This Pull Request has been created because the debug exception page is often the first place developers gather context to ask AI tools for help, yet that context is currently copied and summarized by hand. This change adds a structured, selectable “Prompt for AI agents” block that reuses existing debug data (exception, request, filtered params, environment, short backtrace excerpt) to make troubleshooting faster and less
  error‑prone while remaining local-only.

  Forum discussion:  https://discuss.rubyonrails.org/t/proposal-add-prompt-for-ai-agents-block-to-debug-exception-pages-pr-open/90157

  ### Detail

  This Pull Request changes the HTML debug exception pages to render a shared AI prompt partial, adds prompt composition to `ActionDispatch::DebugView`, includes styling in the rescue layout, adds a test for the diagnostics page, and updates the Action Pack changelog.

  ### Additional information

  - Only affects the HTML debug pages shown for detailed exceptions (local development); API/XHR responses are unchanged.
  - Uses existing filtered parameters and request metadata—no new data collection.

  ### Checklist

  Before submitting the PR make sure the following are checked:

  * [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
  * [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
  * [x] Tests are added or updated if you fix a bug or add a feature.
  * [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
  
 