### PR TITLE
fix: breaking support of hyphen in table names 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -773,7 +773,7 @@ module ActiveRecord
         end
 
         def extract_table_ref_from_insert_sql(sql)
-          if sql =~ /into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im
+          if sql =~ /into\s("[-A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im
             $1.delete('"').strip
           end
         end

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -22,6 +22,11 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     assert_not_nil return_the_inserted_id(method: :create)
   end
 
+  def test_extract_table_ref_from_insert_sql_with_hyphen_in_table_name
+    sql = "INSERT INTO \"table-with-hyphen\" (column1, column2) VALUES (value1, value2)"
+    assert_equal "table-with-hyphen", @connection.send(:extract_table_ref_from_insert_sql, sql)
+  end
+
   private
     def return_the_inserted_id(method:)
       @connection.send(method, "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")


### PR DESCRIPTION
### Motivation / Background

Hi, during our upgrade from Rails 7.0 to Rails 8.0 (and even Rails 8.1 and greater, though with different behavior), we noticed a **breaking change** in ActiveRecord.

The following code should reproduce the broken flow:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", "~> 8.0.0"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

# This connection will do for database-independent bug reports.
ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table "table-with-hyphen", force: true do |t|
  end
end

class BugTest < ActiveSupport::TestCase
  def test_insert_exec
    assert_nothing_raised do
      ActiveRecord::Base.connection.exec_insert("INSERT INTO \"table-with-hyphen\" DEFAULT VALUES")
    end
  end
end
```

### Detail

In this Pull Request, we add support for hyphen `-` in table names if quoted properly. 

### Additional information

Adding the following code to the example script makes it green.
Related commit: https://github.com/rails/rails/commit/9bbbf4b8b9bf3d7cb31c0425a6646cec49e4bc6c

Previously, `exec_insert` didn't try to derive private keys from the schema via parsing the table name from the SQL query. 

```ruby
# Rails 8.0 throws an error as primary_key for unknown table_ref raises an error
pk = primary_key(table_ref) if table_ref
```

I see that in main, we try to hit the schema cache instead, and return an empty private key, which is okay, though the returning statement is missing from the final SQL when it is expected to be there with a proper table name.   

```ruby
# in main branch, we access the cache, which is not throwning error when the table name is missing
pk = schema_cache.primary_keys(table_ref) if table_ref
```

```ruby
module ActiveRecord
  module ConnectionAdapters
    module DatabaseStatements
      def extract_table_ref_from_insert_sql(sql)
        if sql =~ /into\s("[-A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im
          $1.delete('"').strip
        end
      end
    end
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
