### PR TITLE
Fix `has_many_inversing` for associations with composite foreign keys

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -409,11 +409,12 @@ module ActiveRecord
         end
 
         def matches_foreign_key?(record)
+          fk = Array(reflection.foreign_key)
           if foreign_key_for?(record)
-            record.read_attribute(reflection.foreign_key) == owner.id ||
-              (foreign_key_for?(owner) && owner.read_attribute(reflection.foreign_key) == record.id)
+            fk.map { |k| record.read_attribute(k) } == Array(owner.id) ||
+              (foreign_key_for?(owner) && fk.map { |k| owner.read_attribute(k) } == Array(record.id))
           else
-            owner.read_attribute(reflection.foreign_key) == record.id
+            fk.map { |k| owner.read_attribute(k) } == Array(record.id)
           end
         end
     end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -28,6 +28,8 @@ require "models/subscriber"
 require "models/book"
 require "models/branch"
 require "models/cpk"
+require "models/sharded/blog_post"
+require "models/sharded/comment"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars, :books
@@ -424,7 +426,7 @@ class InverseHasOneTests < ActiveRecord::TestCase
 end
 
 class InverseHasManyTests < ActiveRecord::TestCase
-  fixtures :humans, :interests, :posts, :authors, :author_addresses, :comments
+  fixtures :humans, :interests, :posts, :authors, :author_addresses, :comments, :sharded_blog_posts, :sharded_comments
 
   def test_parent_instance_should_be_shared_with_every_child_on_find
     human = humans(:gordon)
@@ -633,6 +635,18 @@ class InverseHasManyTests < ActiveRecord::TestCase
     author.save!
 
     assert_predicate book.association(:order), :loaded?
+  end
+
+  def test_has_many_inversing_with_composite_foreign_key
+    with_has_many_inversing do
+      comment = sharded_comments(:great_comment_blog_post_one)
+      blog_post = comment.blog_post_with_composite_fk
+
+      found = blog_post.comments_with_composite_pk.detect { |c| c.id == comment.id }
+
+      assert_same comment, found,
+        "Composite-key: child loaded via belongs_to should be the same Ruby object in parent.has_many"
+    end
   end
 
   def test_raise_record_not_found_error_when_invalid_ids_are_passed

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -17,6 +17,7 @@ module Sharded
     has_many :comments_with_composite_pk,
       class_name: "Sharded::Comment",
       primary_key: [:blog_id, :id],
-      foreign_key: [:blog_id, :blog_post_id]
+      foreign_key: [:blog_id, :blog_post_id],
+      inverse_of: :blog_post_with_composite_fk
   end
 end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -7,6 +7,11 @@ module Sharded
 
     belongs_to :blog_post
     belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, primary_key: :id
+    belongs_to :blog_post_with_composite_fk,
+      class_name: "Sharded::BlogPost",
+      foreign_key: [:blog_id, :blog_post_id],
+      primary_key: [:blog_id, :id],
+      inverse_of: :comments_with_composite_pk
     belongs_to :blog
   end
 end


### PR DESCRIPTION
`Association#matches_foreign_key?` passes `reflection.foreign_key` directly to `read_attribute`. When the foreign key is an array, `read_attribute` returns nil, so `inversable?` returns false and identity preservation is broken for composite foreign keys.

Wrap the foreign key with `Array()` and map over each component, matching the pattern already used by `foreign_key_for?`.

A small repro script:

```ruby
ActiveRecord::Schema.define do
  create_table :blog_posts, force: true do |t|
    t.integer :blog_id, null: false
  end

  create_table :comments, force: true do |t|
    t.integer :blog_id, null: false
    t.integer :blog_post_id, null: false
  end
end

ActiveRecord::Base.has_many_inversing = true

class BlogPost < ActiveRecord::Base
  has_many :comments,
    primary_key: [:blog_id, :id],
    foreign_key: [:blog_id, :blog_post_id],
    inverse_of: :blog_post
end

class Comment < ActiveRecord::Base
  belongs_to :blog_post,
    foreign_key: [:blog_id, :blog_post_id],
    primary_key: [:blog_id, :id],
    inverse_of: :comments
end

blog_post = BlogPost.create!(blog_id: 1)
Comment.create!(blog_id: 1, blog_post_id: blog_post.id)

comment = Comment.first
loaded_post = comment.blog_post
found = loaded_post.comments.detect { |c| c.id == comment.id }

if comment.equal?(found)
  puts "PASS: same Ruby object (inverse_of working)"
else
  puts "FAIL: different Ruby objects (inverse_of broken)"
end
```

@eileencodes @matthewd 