### PR TITLE
Restore core_ext/benchmark.rb as a silent shim (8-1-stable)

### DIFF
--- a/activesupport/lib/active_support/core_ext.rb
+++ b/activesupport/lib/active_support/core_ext.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-(Dir.glob(File.expand_path("core_ext/*.rb", __dir__)).sort - [File.expand_path("core_ext/benchmark.rb", __dir__)]).each do |path|
+Dir.glob(File.expand_path("core_ext/*.rb", __dir__)).sort.each do |path|
   require path
 end

--- a/activesupport/lib/active_support/core_ext/benchmark.rb
+++ b/activesupport/lib/active_support/core_ext/benchmark.rb
@@ -1,6 +1,1 @@
 # frozen_string_literal: true
-
-# Remove this file from activesupport/lib/active_support/core_ext.rb when deleting the deprecation.
-ActiveSupport.deprecator.warn <<~TEXT
-  active_support/core_ext/benchmark.rb is deprecated and will be removed in Rails 8.2 without replacement.
-TEXT


### PR DESCRIPTION
Backports https://github.com/rails/rails/pull/56831 to 8-1-stable.

`core_ext/benchmark.rb` was deprecated was due to removal of the only remaining extension, Benchmark.ms.

However, this remains the PLACE for benchmark extensions, and it'll endure; it just happens to have no extensions currently.

/cc @rafaelfranca 