### PR TITLE
Fix misspellings around load hook guard

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -188,7 +188,7 @@ Below are the default values associated with each target version. In cases of co
 
 The following configuration methods are to be called on a `Rails::Railtie` object, such as a subclass of `Rails::Engine` or `Rails::Application`.
 
-#### `config.action_on_eary_load_hook`
+#### `config.action_on_early_load_hook`
 
 Controls what happens when a load hook is violated before the Rails application is initialized.
 The value is `:log` by default, which will log when when a load hook is invoked early. The value can alternatively be `raise`, which will raise a `LoadError` instead of logging.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -24,7 +24,7 @@ module Rails
                     :content_security_policy_nonce_auto,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
-                    :dom_testing_default_html_version, :yjit, :action_on_eary_load_hook
+                    :dom_testing_default_html_version, :yjit, :action_on_early_load_hook
 
       attr_reader :encoding, :api_only, :loaded_config_version, :log_level
 
@@ -85,7 +85,7 @@ module Rails
         @server_timing                           = false
         @dom_testing_default_html_version        = :html4
         @yjit                                    = false
-        @action_on_eary_load_hook                = :log
+        @action_on_early_load_hook               = :log
       end
 
       # Loads default configuration values for a target version. This includes

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -202,7 +202,7 @@ module Rails
 
       def load_hook_guard_message_for(component) # :nodoc:
         <<~MSG
-          #{component.inspect} was loaded before appliction initialization.
+          #{component.inspect} was loaded before application initialization.
           Prematurely executing load hooks will slow down your boot time
           and could cause conflicts with the load order of your application.
           Please wrap your code with an on_load hook:
@@ -220,7 +220,7 @@ module Rails
         components.each do |component|
           ActiveSupport.on_load(component) do
             if Rails.try(:application) && !Rails.configuration.eager_load && !Rails.application.initialized?
-              case Rails.configuration.action_on_eary_load_hook
+              case Rails.configuration.action_on_early_load_hook
               when :log
                 (Rails.logger || ActiveSupport::Logger.new($stdout)).warn <<~MSG
                   #{Railtie.load_hook_guard_message_for(component)}


### PR DESCRIPTION
### Detail

#56201 introduced load hook guards, and there were some minor typos. This PR fixes:

- `eary` → `early`
- `appliction` → `application`

cc @gmcgibbon

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
