### PR TITLE
Update documentation for Rails host configuration for local development

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -755,9 +755,18 @@ It is included in the development environment by default with the following conf
 Rails.application.config.hosts = [
   IPAddr.new("0.0.0.0/0"),        # All IPv4 addresses.
   IPAddr.new("::/0"),             # All IPv6 addresses.
-  "localhost",                    # The localhost reserved domain.
+  ".localhost",                   # localhost and *.localhost are natively supported without needing to modify /etc/hosts
+  ".test",                        # to use test or myapp.test domains, add them to /ets/hosts (wildcard not supported)
   ENV["RAILS_DEVELOPMENT_HOSTS"]  # Additional comma-separated hosts for development.
 ]
+```
+
+As noted above, `localhost` and `*.localhost` are natively supported domains for local dev.
+Your computer will also point `*.*.localhost` at your local machine, but this sub sub domain
+isn't supported by the default config above. To support this pattern, do this:
+
+```ruby
+Rails.application.config.hosts << /.*\.*\.localhost/
 ```
 
 In other environments `Rails.application.config.hosts` is empty and no


### PR DESCRIPTION
### Motivation / Background

The documentation here is a bit out of date https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization

```
new-project(dev):002> Rails.version
=> "8.1.2"
new-project(dev):003> Rails.application.config.hosts
=> [".localhost", ".test", #<IPAddr: IPv4:0.0.0.0/0.0.0.0>, #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:0000:0000/0000:0000:0000:0000:0000:0000:0000:0000>]
```

I did the best i could to get the ideas across, but maybe too wordy - any feedback welcome.