### PR TITLE
Don't filter StructuredEventSubscriber payloads

### DIFF
--- a/actionview/lib/action_view/structured_event_subscriber.rb
+++ b/actionview/lib/action_view/structured_event_subscriber.rb
@@ -75,6 +75,7 @@ module ActionView
 
       def start(name, id, payload)
         ActiveSupport.event_reporter.debug("action_view.render_start",
+          filter_payload: false,
           is_layout: name == "render_layout.action_view",
           identifier: from_rails_root(payload[:identifier]),
           layout: from_rails_root(payload[:layout]),

--- a/actionview/test/template/structured_event_subscriber_test.rb
+++ b/actionview/test/template/structured_event_subscriber_test.rb
@@ -320,6 +320,25 @@ module ActionView
       end
     end
 
+    def test_render_start_does_not_filter_payload
+      old_filter_parameters = ActiveSupport.filter_parameters
+      ActiveSupport.filter_parameters = [:identifier]
+      ActiveSupport.event_reporter.reload_payload_filter
+
+      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+        with_debug_event_reporting do
+          event = assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb" }) do
+            @view.render(template: "test/hello_world")
+          end
+
+          assert_equal "test/hello_world.erb", event[:payload][:identifier]
+        end
+      end
+    ensure
+      ActiveSupport.filter_parameters = old_filter_parameters
+      ActiveSupport.event_reporter.reload_payload_filter
+    end
+
     def test_render_collection_with_cached_set
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
         set_view_cache_dependencies

--- a/activesupport/lib/active_support/structured_event_subscriber.rb
+++ b/activesupport/lib/active_support/structured_event_subscriber.rb
@@ -73,14 +73,14 @@ module ActiveSupport
     # * +caller_depth+ - Stack depth for source location (default: 1)
     # * +kwargs+ - Additional payload data merged with the payload hash
     def emit_event(name, payload = nil, caller_depth: 1, **kwargs)
-      ActiveSupport.event_reporter.notify(name, payload, caller_depth: caller_depth + 1, **kwargs)
+      ActiveSupport.event_reporter.notify(name, payload, caller_depth: caller_depth + 1, filter_payload: false, **kwargs)
     rescue => e
       handle_event_error(name, e)
     end
 
     # Like +emit_event+, but only emits when the event reporter is in debug mode
     def emit_debug_event(name, payload = nil, caller_depth: 1, **kwargs)
-      ActiveSupport.event_reporter.debug(name, payload, caller_depth: caller_depth + 1, **kwargs)
+      ActiveSupport.event_reporter.debug(name, payload, caller_depth: caller_depth + 1, filter_payload: false, **kwargs)
     rescue => e
       handle_event_error(name, e)
     end

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -265,6 +265,41 @@ module ActiveSupport
       end
     end
 
+    test "#notify with filter_payload: false skips payload filtering" do
+      filter = ActiveSupport::ParameterFilter.new([:name], mask: "[FILTERED]")
+      @reporter.stub(:payload_filter, filter) do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { name: "Person Load", sql: "SELECT 1" })
+        ]) do
+          @reporter.notify(:test_event, filter_payload: false, name: "Person Load", sql: "SELECT 1")
+        end
+      end
+    end
+
+    test "#notify with filter_payload: false and hash payload skips filtering" do
+      filter = ActiveSupport::ParameterFilter.new([:name], mask: "[FILTERED]")
+      @reporter.stub(:payload_filter, filter) do
+        assert_called_with(@subscriber, :emit, [
+          event_matcher(name: "test_event", payload: { name: "Person Load" })
+        ]) do
+          @reporter.notify(:test_event, { name: "Person Load" }, filter_payload: false)
+        end
+      end
+    end
+
+    test "#debug with filter_payload: false skips payload filtering" do
+      filter = ActiveSupport::ParameterFilter.new([:name], mask: "[FILTERED]")
+      @reporter.stub(:payload_filter, filter) do
+        @reporter.with_debug do
+          assert_called_with(@subscriber, :emit, [
+            event_matcher(name: "test_event", payload: { name: "Person Load" })
+          ]) do
+            @reporter.debug(:test_event, filter_payload: false, name: "Person Load")
+          end
+        end
+      end
+    end
+
     test "default filter_parameters is used by default" do
       old_filter_parameters = ActiveSupport.filter_parameters
       ActiveSupport.filter_parameters = [:secret]


### PR DESCRIPTION
The EventReporter applies ParameterFilter to hash payloads before emitting them to subscribers. When framework log subscribers were updated to consume events through the EventReporter (54264bde), this caused SQL query names and other internal metadata to be filtered.

For example, `config.filter_parameters += [:name]` turns SQL log lines into:

```
[FILTERED] (0.4ms)  SELECT "people".* FROM "people" WHERE ...
```

instead of:

```
Person Load (0.4ms)  SELECT "people".* FROM "people" WHERE ...
```

Add a `filter:` option to `EventReporter#notify` and `#debug`, defaulting to true for backwards compatibility. `StructuredEventSubscriber` passes `filter: false` from `emit_event` and `emit_debug_event`, so all framework subscribers are covered without per-subscriber changes.
