### PR TITLE
Fix ERBTracker false news/new dependency from render Component.new(...) #56838

### DIFF
--- a/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
@@ -110,7 +110,7 @@ module ActionView
         end
 
         def add_dynamic_dependency(dependencies, dependency)
-          if dependency
+          if dependency && dependency != "new"
             dependencies << "#{dependency.pluralize}/#{dependency.singularize}"
           end
         end

--- a/actionview/lib/action_view/render_parser.rb
+++ b/actionview/lib/action_view/render_parser.rb
@@ -145,7 +145,9 @@ module ActionView
               when :local_variable_read_node
                 node.slice
               when :call_node
-                node.name.to_s
+                name = node.name.to_s
+                return if name == "new"
+                name
               else
                 return
               end

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -220,6 +220,13 @@ module SharedTrackerTests
     ], tracker.dependencies
   end
 
+  def test_finds_no_dependency_for_component_new_calls
+    template = FakeTemplate.new('<%= render MyComponent.new(text: "Hello") %>', :erb)
+    tracker = make_tracker("components/_component", template)
+
+    assert_equal [], tracker.dependencies
+  end
+
   def test_finds_dependencies_with_bare_assoc_hash_on_constant
     template = FakeTemplate.new(%{
       <%= render SomeConstant.message(this: "that") %>


### PR DESCRIPTION
**Issue**
#56838

### **Update**

- [x] Fix add_dynamic_dependency in erb_tracker.rb
- [x] Add test for render Component.new(...) in dependency_tracker_test.rb
- [x] Run tests to verify

_The 53 tests Done._
You can see the modifications :

- [erb_tracker.rb:113](actionview/lib/action_view/dependency_tracker/erb_tracker.rb#L113) — Adding `&& dependency != "new"` to `add_dynamic_dependency` to ignore constructor calls
- [render_parser.rb:149-150](actionview/lib/action_view/render_parser.rb#L149-L150) — same filter in RubyTracker which had the same bug
- [dependency_tracker_test.rb:223-228](actionview/test/template/dependency_tracker_test.rb#L223-L228) — Test added to verify that `render MyComponent.new(...)` no longer produces `news/newUpdate Todos`
