### PR TITLE
Fix `extend_queries` with `support_unencrypted_data` when combined with `normalizes`

### DIFF
--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -28,6 +28,7 @@ module ActiveRecord
         ActiveRecord::Relation.prepend(RelationQueries)
         ActiveRecord::Base.include(CoreQueries)
         ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
+        ActiveModel::Attributes::Normalization.const_get(:NormalizedValueType).prepend(ExtendedNormalizableType)
       end
 
       # When modifying this file run performance tests in
@@ -87,8 +88,9 @@ module ActiveRecord
             end
 
             def additional_values_for(value, type)
+              casted_value = type.cast(value)
               type.previous_types.collect do |additional_type|
-                AdditionalValue.new(value, additional_type)
+                AdditionalValue.new(casted_value, additional_type)
               end
             end
         end
@@ -147,6 +149,28 @@ module ActiveRecord
 
       module ExtendedEncryptableType
         def serialize(data)
+          if data.is_a?(AdditionalValue)
+            data.value
+          else
+            super
+          end
+        end
+      end
+
+      # A separate module for NormalizedValueType to avoid changing
+      # serialize_cast_value_compatible? for EncryptedAttributeType.
+      # Both serialize and serialize_cast_value must be overridden here
+      # to keep serialize_cast_value_compatible? returning true.
+      module ExtendedNormalizableType
+        def serialize(data)
+          if data.is_a?(AdditionalValue)
+            data.value
+          else
+            super
+          end
+        end
+
+        def serialize_cast_value(data)
           if data.is_a?(AdditionalValue)
             data.value
           else

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -95,4 +95,35 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
       assert EncryptedBookWithUnencryptedDataOptedIn.where("id > 0").find_by(name: "Dune") # relation
     end
   end
+
+  test "Finds unencrypted records when normalizes is declared before encrypts" do
+    UnencryptedBook.create!(name: "dune")
+    assert EncryptedBookWithNormalizedName.find_by(name: "DUNE") # core
+    assert EncryptedBookWithNormalizedName.where("id > 0").find_by(name: "DUNE") # relation
+  end
+
+  test "Finds unencrypted records when normalizes is declared after encrypts" do
+    UnencryptedBook.create!(name: "dune")
+    assert EncryptedBookWithNormalizedNameReversed.find_by(name: "DUNE") # core
+    assert EncryptedBookWithNormalizedNameReversed.where("id > 0").find_by(name: "DUNE") # relation
+  end
+
+  test "Finds encrypted records with normalizes and encrypts" do
+    EncryptedBookWithNormalizedName.create!(name: "DUNE")
+    assert EncryptedBookWithNormalizedName.find_by(name: "dune") # core
+    assert EncryptedBookWithNormalizedName.where("id > 0").find_by(name: "dune") # relation
+  end
+
+  test "exists? works with normalizes and encrypts" do
+    EncryptedBookWithNormalizedName.create!(name: "DUNE")
+    assert EncryptedBookWithNormalizedName.exists?(name: "Dune")
+  end
+
+  test "find_or_create_by works with normalizes and encrypts" do
+    EncryptedBookWithNormalizedName.find_or_create_by!(name: "DUNE")
+    assert EncryptedBookWithNormalizedName.find_by(name: "dune")
+
+    EncryptedBookWithNormalizedName.find_or_create_by!(name: "Dune")
+    assert_equal 1, EncryptedBookWithNormalizedName.where(name: "dune").count
+  end
 end

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -89,6 +89,20 @@ class EncryptedBookWithSerializedSecondBinary < ActiveRecord::Base
   serialize :logo, coder: JSON
 end
 
+class EncryptedBookWithNormalizedName < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  normalizes :name, with: ->(value) { value.to_s.strip.downcase }
+  encrypts :name, deterministic: true
+end
+
+class EncryptedBookWithNormalizedNameReversed < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  encrypts :name, deterministic: true
+  normalizes :name, with: ->(value) { value.to_s.strip.downcase }
+end
+
 class EncryptedBookWithCustomCompressor < ActiveRecord::Base
   module CustomCompressor
     def self.deflate(value)


### PR DESCRIPTION
## Summary

Fixes #56684.

When using `encrypts` with `deterministic: true` alongside `normalizes` on the same attribute, extended deterministic queries failed to find plaintext records because the plaintext values added to queries were not normalized.

- Cast query values through the full type chain (`type.cast`) before creating `AdditionalValue` instances, so normalization is applied to the plaintext values included in extended queries
- Prepend `ExtendedNormalizableType` to `NormalizedValueType` so that `AdditionalValue` objects pass through serialization without being re-cast. A separate module is used (rather than reusing `ExtendedEncryptableType`) to avoid changing `serialize_cast_value_compatible?` for `EncryptedAttributeType`

## Test plan

- [x] Added regression tests covering both declaration orders (`normalizes` before `encrypts` and vice versa)
- [x] Tests cover `find_by` (core + relation), `where`, `exists?`, and `find_or_create_by`
- [x] All 222 existing encryption tests pass
- [x] All 6 normalization tests pass (including `test_minimizes_number_of_times_normalization_is_applied`)