### PR TITLE
Remove dash for rails new in devcontainers guide [ci skip]

### DIFF
--- a/guides/source/getting_started_with_devcontainer.md
+++ b/guides/source/getting_started_with_devcontainer.md
@@ -5,7 +5,7 @@ Getting Started with Dev Containers
 
 After reading this guide, you will know:
 
-* How to create a new Rails application with the `rails-new` tool.
+* How to create a new Rails application with the `rails new` tool.
 * How to begin working with your application in a development container.
 
 --------------------------------------------------------------------------------
@@ -28,7 +28,7 @@ Setup and Installation
 ----------------------
 
 To get set up, you will need to install the relevant tools; Docker, VS Code and
-`rails-new`. We'll go into details about each one below.
+`rails new`. We'll go into details about each one below.
 
 ### Installing Docker
 


### PR DESCRIPTION
`rails-new` command does not exist, and we can find it only in this guide.
I guess this is a typo