### PR TITLE
Revert: Sort table columns by name when dumping schema

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Revert alphabetical sorting of table columns inside `schema.rb`.
+
+    Alphabetical sorting of table columns inside the schema creates improper production tables when using `db:prepare`.
+
+    *Bert McCutchen*
+
 *   Deprecated `ActiveRecord::ConnectionAdapters::Column#auto_populated?` in favor of
     `auto_populated_on_insert?`
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -192,7 +192,7 @@ module ActiveRecord
           tbl.puts ", force: :cascade do |t|"
 
           # then dump all non-primary key columns
-          columns.sort_by(&:name).each do |column|
+          columns.each do |column|
             raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
             next if column.name == pk
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -167,14 +167,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "ar_internal_metadata"}, output
   end
 
-  def test_table_columns_sorted
-    column_names = column_definition_lines(dump_table_schema("companies")).flatten.filter_map do |line|
-      $1 if line !~ /t\.index/ && line.match(/t\..*"(\w+)"/)
-    end
-
-    assert_equal %w[account_id client_of description firm_id firm_name name rating status type], column_names
-  end
-
   def test_schema_dumps_index_columns_in_right_order
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_index/).first.strip
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created for the Rails core team to review reverting sorted schema columns.

This is based on the findings outlined in discussion on https://github.com/rails/rails/pull/55414#issuecomment-3901961707.

Based on my findings, the original approach of sorting schema columns is not the appropriate solution to the problem the original developer was facing.

### Detail

- Reverted all code changes made in #53281.
- Updated the ActiveRecord CHANGELOG.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
