### PR TITLE
ActiveRecord fails to handle default_scope with string joins when combined with includes #56835

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -36,7 +36,9 @@ module ActiveRecord
             name_escaped ||= Regexp.escape(name)
 
             # Table names + table aliases
-            join.left.scan(
+            join_left = join.left
+            join_left = join_left.left if join_left.is_a?(Arel::Nodes::And)
+            join_left.scan(
               /JOIN(?:\s+\w+)?\s+(?:\S+\s+)?(?:#{quoted_name_escaped}|#{name_escaped})\sON/i
             ).size
           elsif join.is_a?(Arel::Nodes::Join)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1510,7 +1510,9 @@ module ActiveRecord
       def references_eager_loaded_tables?
         joined_tables = build_joins([]).flat_map do |join|
           if join.is_a?(Arel::Nodes::StringJoin)
-            tables_in_string(join.left)
+            join_left = join.left
+            join_left = join_left.left if join_left.is_a?(Arel::Nodes::And)
+            tables_in_string(join_left)
           else
             join.left.name
           end

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -778,6 +778,12 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     end
   end
 
+  def test_includes_and_joins_with_scope_with_string_joins
+    assert_nothing_raised do
+      Post.includes(:author).joins(:very_special_comment_with_string_joins).to_sql
+    end
+  end
+
   private
     # create dynamic Post models to allow different dependency options
     def find_post_with_dependency(post_id, association, association_name, dependency)


### PR DESCRIPTION
**issue** 
#56835

**Update :** 
- [x] Fix references_eager_loaded_tables? in relation.rb
- [x] Fix alias_tracker.rb to handle Arel::Nodes::And in StringJoin#left
- [x] Add test for includes + joins with string join scope
- [x] Run tests to verify