### PR TITLE
Active Storage: Add @ to unsupported_image_processing_arguments blocklist #56830

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -140,6 +140,7 @@ module ActiveStorage
           -version
           -write
           -write-mask
+          @
         )
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -275,6 +275,60 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "variations with @ file read syntax in string raise UnsupportedImageProcessingArgument" do
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
+        blob.variant(label: "@/etc/passwd").processed
+      end
+    end
+  end
+
+  test "variations with @ file read syntax in array raise UnsupportedImageProcessingArgument" do
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
+        blob.variant(resize: [100, "@/etc/passwd"]).processed
+      end
+    end
+  end
+
+  test "variations with @ file read syntax in hash value raise UnsupportedImageProcessingArgument" do
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
+        blob.variant(draw: { text: "@/etc/passwd" }).processed
+      end
+    end
+  end
+
+  test "variations with @ file read syntax in nested array raise UnsupportedImageProcessingArgument" do
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
+        blob.variant(resize: [100, ["@/etc/passwd"]]).processed
+      end
+    end
+  end
+
+  test "variations with @ file read syntax using draw operator raise UnsupportedImageProcessingArgument" do
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
+        blob.variant(draw: "image over 0,0 0,0 '@/etc/passwd'").processed
+      end
+    end
+  end
+
+  test "variations with @ file read syntax in nested hash raise UnsupportedImageProcessingArgument" do
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
+        blob.variant(draw: { "something": { text: "@/etc/shadow" } }).processed
+      end
+    end
+  end
+
   test "variations with unsupported methods raise UnsupportedImageProcessingMethod" do
     process_variants_with :mini_magick do
       blob = create_file_blob(filename: "racecar.jpg")


### PR DESCRIPTION
**issue** 
#56830

**Update**
- [x] Add @ to unsupported_image_processing_arguments blocklist
- [x] Add regression test for @ file read syntax
- [x] Run tests to verify

**5 tests, 5 assertions, 0 failures :**
String — label: "@/etc/passwd"
Array — resize: [100, "@/etc/passwd"]
Hash value — draw: { text: "@/etc/passwd" }
Nested array — resize: [100, ["@/etc/passwd"]]
Draw operator — draw: "image over 0,0 0,0 '@/etc/passwd'"

**_This covers @ attack vectors in all argument types (string, array, hash, nested) and the two ImageMagick operators mentioned in the issue (label and draw)._**