### PR TITLE
ActiveStorage routes can still be drawn with config.active_storage.draw_routes = false #56814

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -124,7 +124,7 @@ module ActiveStorage
           end
         end
 
-        ActiveStorage.paths             = app.config.active_storage.paths || {}
+        ActiveStorage.paths = app.config.active_storage.paths || {}
         ActiveStorage.resolve_model_to_route = app.config.active_storage.resolve_model_to_route || :rails_storage_redirect
 
         ActiveStorage.supported_image_processing_methods += app.config.active_storage.supported_image_processing_methods || []

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -86,6 +86,8 @@ module ActiveStorage
     initializer "active_storage.configs" do
       config.before_initialize do |app|
         ActiveStorage.touch_attachment_records = app.config.active_storage.touch_attachment_records != false
+        ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
+        ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
       end
 
       config.after_initialize do |app|
@@ -123,8 +125,6 @@ module ActiveStorage
         end
 
         ActiveStorage.paths             = app.config.active_storage.paths || {}
-        ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
-        ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
         ActiveStorage.resolve_model_to_route = app.config.active_storage.resolve_model_to_route || :rails_storage_redirect
 
         ActiveStorage.supported_image_processing_methods += app.config.active_storage.supported_image_processing_methods || []

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4282,6 +4282,52 @@ module ApplicationTests
       assert_not_includes(output, "rails_direct_uploads")
     end
 
+    test "ActiveStorage.draw_routes = false is respected in config/application.rb" do
+      add_to_config "config.active_storage.draw_routes = false"
+      output = rails("routes")
+      assert_not_includes(output, "rails_service_blob")
+      assert_not_includes(output, "rails_direct_uploads")
+    end
+
+    test "ActiveStorage.draw_routes = false is respected with eager_load enabled" do
+      add_to_config "config.active_storage.draw_routes = false"
+      add_to_config "config.eager_load = true"
+      app "development"
+      assert_equal false, ActiveStorage.draw_routes
+      output = rails("routes")
+      assert_not_includes(output, "rails_service_blob")
+      assert_not_includes(output, "rails_blob_representation")
+      assert_not_includes(output, "rails_disk_service")
+      assert_not_includes(output, "update_rails_disk_service")
+      assert_not_includes(output, "rails_direct_uploads")
+    end
+
+    test "ActiveStorage.draw_routes = false with custom routes and eager_load does not raise" do
+      add_to_config "config.active_storage.draw_routes = false"
+      add_to_config "config.eager_load = true"
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          post "/rails/active_storage/direct_uploads", to: "active_storage/direct_uploads#create", as: :rails_direct_uploads
+          put "/rails/active_storage/disk/:encoded_token", to: "active_storage/disk#update", as: :update_rails_disk_service
+        end
+      RUBY
+      output = rails("routes")
+      assert_includes(output, "rails_direct_uploads")
+      assert_includes(output, "update_rails_disk_service")
+    end
+
+    test "ActiveStorage.draw_routes defaults to true when not configured" do
+      output = rails("routes", "-g", "active_storage")
+      assert_includes(output, "rails_service_blob")
+      assert_includes(output, "rails_direct_uploads")
+    end
+
+    test "ActiveStorage.draw_routes is set before routes are loaded" do
+      add_to_config "config.active_storage.draw_routes = false"
+      app "development"
+      assert_equal false, ActiveStorage.draw_routes
+    end
+
     test "ActiveStorage.video_preview_arguments uses the old arguments without Rails 7 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
 


### PR DESCRIPTION
**issue** 
#56814

ActiveStorage draw_routes = false ignored with eager_load
The Problem
When config.active_storage.draw_routes = false is set in config/application.rb and eager_load = true (test/production environments), ActiveStorage routes are still drawn. If the app defines custom routes with the same names, it crashes with:


ArgumentError: Invalid route name, already in use: 'update_rails_disk_service'
Root Cause
A timing issue in activestorage/lib/active_storage/engine.rb:

ActiveStorage.draw_routes defaults to true (defined in active_storage.rb)
The user's config value (config.active_storage.draw_routes = false) was copied to ActiveStorage.draw_routes in an after_initialize callback — too late
The routes reloader (set_routes_reloader_hook in finisher.rb) loads routes before after_initialize runs
So activestorage/config/routes.rb evaluates end if ActiveStorage.draw_routes while it's still true
The Fix
Moved the assignment of draw_routes and routes_prefix from the after_initialize block to the existing before_initialize block in activestorage/lib/active_storage/engine.rb. This ensures the value is set before any routes are loaded.

Tests Added
6 tests total (1 existing + 5 new) in railties/test/application/configuration_test.rb:

draw_routes = false in config/application.rb — verifies the setting works from application.rb, not just environment config
draw_routes = false with eager_load enabled — reproduces the exact bug: draw_routes = false + eager_load = true, asserts no ActiveStorage routes are drawn
draw_routes = false with custom routes and eager_load — the full bug scenario: custom routes reusing the same names with eager_load enabled, verifies no duplicate route crash
draw_routes defaults to true — verifies default behavior, routes are present
draw_routes is set before routes are loaded — directly asserts ActiveStorage.draw_routes is false after app boot