### PR TITLE
Fix ActiveModel::Type::Boolean casting 0.0 (float) as true

### DIFF
--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -7,14 +7,14 @@ module ActiveModel
     # A class that behaves like a boolean type, including rules for coercion of
     # user input.
     #
-    # - <tt>"false"</tt>, <tt>"f"</tt>, <tt>"0"</tt>, +0+ or any other value in
+    # - <tt>"false"</tt>, <tt>"f"</tt>, <tt>"0"</tt>, +0+, +0.0+ or any other value in
     #   +FALSE_VALUES+ will be coerced to +false+.
     # - Empty strings are coerced to +nil+.
     # - All other values will be coerced to +true+.
     class Boolean < Value
       include Helpers::Immutable
       FALSE_VALUES = [
-        false, 0,
+        false, 0, 0.0,
         "0", :"0",
         "f", :f,
         "F", :F,

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -34,6 +34,7 @@ module ActiveModel
         # explicitly check for false vs nil
         assert_equal false, type.cast(false)
         assert_equal false, type.cast(0)
+        assert_equal false, type.cast(0.0)
         assert_equal false, type.cast("0")
         assert_equal false, type.cast("f")
         assert_equal false, type.cast("F")


### PR DESCRIPTION
## Problem

`ActiveModel::Type::Boolean` correctly casts integer `0` to `false`, but float `0.0` incorrectly casts to `true`:

```ruby
ActiveModel::Type::Boolean.new.cast(0)    # => false  ✓
ActiveModel::Type::Boolean.new.cast(0.0)  # => true   ✗ (should be false)
```

This is because `FALSE_VALUES` includes `0` but not `0.0`. The two are numerically equivalent and should behave consistently.

Fixes #56602.

## Fix

Add `0.0` to `FALSE_VALUES` and update the docs comment to mention it.

## Test

Added `assert_equal false, type.cast(0.0)` alongside the existing `type.cast(0)` assertion in `activemodel/test/cases/type/boolean_test.rb`.