### PR TITLE
Expose result set in `instantiation.active_record` hook

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -135,8 +135,11 @@ module ActiveRecord
         message_bus = ActiveSupport::Notifications.instrumenter
 
         payload = {
+          class: join_root.base_klass,
+          class_name: join_root.base_klass.name,
+          results: result_set,
           record_count: result_set.length,
-          class_name: join_root.base_klass.name
+          column_aliases: column_aliases,
         }
 
         message_bus.instrument("instantiation.active_record", payload) do

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -80,8 +80,10 @@ module ActiveRecord
       message_bus = ActiveSupport::Notifications.instrumenter
 
       payload = {
+        class: self,
+        class_name: name,
+        results: result_set,
         record_count: result_set.length,
-        class_name: name
       }
 
       message_bus.instrument("instantiation.active_record", payload) do


### PR DESCRIPTION
This can be used to efficiently enforce some rules on query results. For instance, ensuring that all rows belong to a given tenant.
