### PR TITLE
Add per-query role resolution and write-triggered role pinning

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add `query_role_resolver` and `pin_role_on_write` for per-query read/write splitting.
+
+    `query_role_resolver` is a callable that receives the query type (`:read` / `:write`),
+    model class, and current role and returns which role pool to check a connection out from.
+    `pin_role_on_write` automatically pins subsequent queries to the writing role after a
+    write, preventing stale replica reads. Pinning is scoped by `ActiveSupport::Executor`
+    and supports time-based expiry or pinning for the full request.
+
+    ```ruby
+    ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) {
+      query_type == :read ? :reading : current_role
+    }
+
+    # Pin to the primary for 2 seconds after each write:
+    ActiveRecord.pin_role_on_write = 2.seconds
+
+    # Or pin for the entire request:
+    ActiveRecord.pin_role_on_write = true
+    ```
+
+    *Thomas Dippel*
+
 *   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
 
     This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -68,6 +68,7 @@ module ActiveRecord
   autoload :QueryCache
   autoload :QueryLogs
   autoload :Querying
+  autoload :RolePinning
   autoload :ReadonlyAttributes
   autoload :RecordInvalid, "active_record/validations"
   autoload :Reflection
@@ -272,6 +273,47 @@ module ActiveRecord
 
   singleton_class.attr_accessor :reading_role
   self.reading_role = :reading
+
+  ##
+  # :singleton-method: query_role_resolver
+  # A callable used to resolve the role for per-query connection checkout.
+  #
+  # The resolver is called with the query type, model class, and current role and
+  # should return the role to use for checkout, or +nil+ to keep the current role.
+  #
+  #   ActiveRecord::Base.query_role_resolver = ->(query_type, model, current_role) do
+  #     case query_type
+  #     when :read then :reading
+  #     when :write then :writing
+  #     else current_role
+  #     end
+  #   end
+  singleton_class.attr_accessor :query_role_resolver
+  self.query_role_resolver = nil
+
+  ##
+  # :singleton-method: pin_role_on_write
+  # Controls whether writes pin subsequent queries to the writing role within
+  # the current executor scope.
+  #
+  # Accepted values:
+  #
+  # * +nil+ / +false+ - disables role pinning.
+  # * +true+ - pins for the remainder of the current request/job scope.
+  # * Numeric-like (e.g. +2+, +2.seconds+) - pins for that many seconds after each write.
+  #
+  # The pin is tracked in +ActiveSupport::IsolatedExecutionState+ and scoped by
+  # +ActiveSupport::Executor+ hooks. Time-based values use +CLOCK_MONOTONIC+ to
+  # avoid wall-clock drift.
+  #
+  # @example Pin reads to primary for 2 seconds after each write
+  #   ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) {
+  #     query_type == :read ? :reading : current_role
+  #   }
+  #
+  #   ActiveRecord.pin_role_on_write = 2.seconds
+  singleton_class.attr_accessor :pin_role_on_write
+  self.pin_role_on_write = nil
 
   ##
   # :singleton-method: async_query_executor

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -314,8 +314,24 @@ module ActiveRecord
     # back in.
     # If #connection is called inside the block, the connection won't be checked back in
     # unless the +prevent_permanent_checkout+ argument is set to +true+.
-    def with_connection(prevent_permanent_checkout: false, &block)
-      connection_pool.with_connection(prevent_permanent_checkout: prevent_permanent_checkout, &block)
+    #
+    # @param prevent_permanent_checkout [Boolean] whether to keep the connection from
+    #   being permanently checked out when +#connection+ is called in the block.
+    # @param query_type [Symbol, nil] the kind of query about to run. +:read+ and +:write+
+    #   are used by Active Record internals to allow role-aware pool selection before
+    #   checkout. +nil+ keeps current behavior.
+    # @yield [connection] a checked out connection from the selected pool.
+    # @return [Object] the block's return value.
+    #
+    # @example Route reads to a replica
+    #   ActiveRecord::Base.query_role_resolver = ->(query_type, _model, current_role) {
+    #     query_type == :read ? :reading : current_role
+    #   }
+    #
+    #   User.with_connection(query_type: :read) { |c| c.select_all("SELECT 1") }
+    def with_connection(prevent_permanent_checkout: false, query_type: nil, &block)
+      pool = resolve_pool_for_query(query_type)
+      pool.with_connection(prevent_permanent_checkout: prevent_permanent_checkout, &block)
     end
 
     attr_writer :connection_specification_name
@@ -390,6 +406,54 @@ module ActiveRecord
     end
 
     private
+      # Resolves the connection pool for a query before checkout.
+      #
+      # When role pinning is active (see +ActiveRecord.pin_role_on_write+),
+      # a +:write+ query sets or extends the pin window via
+      # +ActiveRecord::RolePinning.pin!+. While pinned, all queries are routed
+      # to the writing role pool regardless of the resolver. Once the pin
+      # expires (or the executor scope ends), the resolver regains control.
+      #
+      # @param query_type [Symbol, nil] the query kind for role resolution.
+      # @return [ActiveRecord::ConnectionAdapters::ConnectionPool] selected connection pool.
+      #
+      # @example Keep the current pool when resolver is disabled
+      #   ActiveRecord::Base.query_role_resolver = nil
+      #   resolve_pool_for_query(:read) # => current connection_pool
+      def resolve_pool_for_query(query_type)
+        current_pool = connection_pool
+
+        return current_pool unless query_type
+
+        if query_type == :write
+          ActiveRecord::RolePinning.pin!
+        end
+
+        if ActiveRecord::RolePinning.pinned?
+          return connection_handler.retrieve_connection_pool(
+            connection_specification_name,
+            role: ActiveRecord.writing_role,
+            shard: current_shard,
+            strict: false
+          ) || current_pool
+        end
+
+        resolver = ActiveRecord.query_role_resolver
+        return current_pool unless resolver
+        return current_pool if current_pool.active_connection?
+
+        resolved_role = resolver.call(query_type, self, current_role)
+        return current_pool unless resolved_role
+        return current_pool if resolved_role == current_role
+
+        connection_handler.retrieve_connection_pool(
+          connection_specification_name,
+          role: resolved_role,
+          shard: current_shard,
+          strict: false
+        ) || current_pool
+      end
+
       def resolve_config_for_connection(config_or_env)
         raise "Anonymous class is not allowed." unless name
 

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
     class << self
       def execute(relation, ...)
-        relation.model.with_connection do |c|
+        relation.model.with_connection(query_type: :write) do |c|
           new(relation, c, ...).execute
         end.tap { relation.reset }
       end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -274,7 +274,7 @@ module ActiveRecord
         um.set(values.transform_keys { |name| arel_table[name] })
         um.wheres = constraints
 
-        with_connection do |c|
+        with_connection(query_type: :write) do |c|
           c.update(um, "#{self} Update")
         end
       end
@@ -292,7 +292,7 @@ module ActiveRecord
         dm = Arel::DeleteManager.new(arel_table)
         dm.wheres = constraints
 
-        with_connection do |c|
+        with_connection(query_type: :write) do |c|
           c.delete(dm, "#{self} Destroy")
         end
       end
@@ -953,7 +953,7 @@ module ActiveRecord
       def _create_record(attribute_names = self.attribute_names)
         attribute_names = attributes_for_create(attribute_names)
 
-        self.class.with_connection do |connection|
+        self.class.with_connection(query_type: :write) do |connection|
           returning_columns = self.class._returning_columns_for_insert(connection)
 
           returning_values = self.class._insert_record(

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -49,7 +49,7 @@ module ActiveRecord
     # Note that building your own SQL query string from user input {may expose your application to
     # injection attacks}[https://guides.rubyonrails.org/security.html#sql-injection].
     def find_by_sql(sql, binds = [], preparable: nil, allow_retry: false, &block)
-      result = with_connection do |c|
+      result = with_connection(query_type: :read) do |c|
         _query_by_sql(c, sql, binds, preparable: preparable, allow_retry: allow_retry)
       end
       _load_from_sql(result, &block)
@@ -57,7 +57,7 @@ module ActiveRecord
 
     # Same as #find_by_sql but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_find_by_sql(sql, binds = [], preparable: nil, allow_retry: false, &block)
-      with_connection do |c|
+      with_connection(query_type: :read) do |c|
         _query_by_sql(c, sql, binds, preparable: preparable, allow_retry: allow_retry, async: true)
       end.then do |result|
         _load_from_sql(result, &block)
@@ -107,14 +107,14 @@ module ActiveRecord
     #
     # * +sql+ - An SQL statement which should return a count query from the database, see the example above.
     def count_by_sql(sql)
-      with_connection do |c|
+      with_connection(query_type: :read) do |c|
         c.select_value(sanitize_sql(sql), "#{name} Count").to_i
       end
     end
 
     # Same as #count_by_sql but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_count_by_sql(sql)
-      with_connection do |c|
+      with_connection(query_type: :read) do |c|
         c.select_value(sanitize_sql(sql), "#{name} Count", async: true).then(&:to_i)
       end
     end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -313,6 +313,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
       ActiveRecord::QueryCache.install_executor_hooks
       ActiveRecord::AsynchronousQueriesTracker.install_executor_hooks
       ActiveRecord::ConnectionAdapters::ConnectionPool.install_executor_hooks
+      ActiveRecord::RolePinning.install_executor_hooks
     end
 
     initializer "active_record.add_watchable_files" do |app|

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -271,7 +271,7 @@ module ActiveRecord
     # and failed due to validation errors it won't be persisted, you get what #create returns in
     # such situation.
     def create_or_find_by(attributes, &block)
-      with_connection do |connection|
+      with_connection(query_type: :write) do |connection|
         record = nil
         transaction(requires_new: true) do
           record = create(attributes, &block)
@@ -291,7 +291,7 @@ module ActiveRecord
     # {create!}[rdoc-ref:Persistence::ClassMethods#create!] so an exception
     # is raised if the created record is invalid.
     def create_or_find_by!(attributes, &block)
-      with_connection do |connection|
+      with_connection(query_type: :write) do |connection|
         record = nil
         transaction(requires_new: true) do
           record = create!(attributes, &block)
@@ -490,7 +490,7 @@ module ActiveRecord
       else
         collection = eager_loading? ? apply_join_dependency : self
 
-        with_connection do |c|
+        with_connection(query_type: :read) do |c|
           column = c.visitor.compile(table[timestamp_column])
           select_values = "COUNT(*) AS #{model.adapter_class.quote_column_name("size")}, MAX(%s) AS timestamp"
 
@@ -624,7 +624,7 @@ module ActiveRecord
         values = Arel.sql(model.sanitize_sql_for_assignment(updates, table.name))
       end
 
-      model.with_connection do |c|
+      model.with_connection(query_type: :write) do |c|
         arel = eager_loading? ? apply_join_dependency.arel : arel()
         arel.source.left = table
 
@@ -1053,7 +1053,7 @@ module ActiveRecord
         raise ActiveRecordError.new("delete_all doesn't support #{invalid_methods.join(', ')}")
       end
 
-      model.with_connection do |c|
+      model.with_connection(query_type: :write) do |c|
         arel = eager_loading? ? apply_join_dependency.arel : arel()
         arel.source.left = table
 
@@ -1168,7 +1168,7 @@ module ActiveRecord
     #
     #   ASYNC Post Load (0.0ms) (db time 2ms)  SELECT "posts".* FROM "posts" LIMIT 100
     def load_async
-      with_connection do |c|
+      with_connection(query_type: :read) do |c|
         return load if !c.async_enabled?
 
         unless loaded?
@@ -1246,7 +1246,7 @@ module ActiveRecord
           relation.to_sql
         end
       else
-        model.with_connection do |conn|
+        model.with_connection(query_type: :read) do |conn|
           conn.unprepared_statement { conn.to_sql(arel) }
         end
       end
@@ -1469,7 +1469,7 @@ module ActiveRecord
           if where_clause.contradiction?
             [].freeze
           elsif eager_loading?
-            model.with_connection do |c|
+            model.with_connection(query_type: :read) do |c|
               apply_join_dependency do |relation, join_dependency|
                 if relation.null_relation?
                   [].freeze
@@ -1481,7 +1481,7 @@ module ActiveRecord
               end
             end
           else
-            model.with_connection do |c|
+            model.with_connection(query_type: :read) do |c|
               model._query_by_sql(c, arel, async: async)
             end
           end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -322,7 +322,7 @@ module ActiveRecord
           if where_clause.contradiction? && !possible_aggregation?(column_names)
             ActiveRecord::Result.empty(async: @async)
           else
-            model.with_connection do |c|
+            model.with_connection(query_type: :read) do |c|
               c.select_all(relation.arel, "#{model.name} Pluck", async: @async)
             end
           end
@@ -399,7 +399,7 @@ module ActiveRecord
         ActiveRecord::Result.empty
       else
         skip_query_cache_if_necessary do
-          model.with_connection do |c|
+          model.with_connection(query_type: :read) do |c|
             c.select_all(relation, "#{model.name} Ids", async: @async)
           end
         end
@@ -508,7 +508,7 @@ module ActiveRecord
           end
         else
           skip_query_cache_if_necessary do
-            model.with_connection do |c|
+            model.with_connection(query_type: :read) do |c|
               c.select_all(query_builder, "#{model.name} #{operation.capitalize}", async: @async)
             end
           end
@@ -537,7 +537,7 @@ module ActiveRecord
         relation = except(:group).distinct!(false)
         group_fields = relation.arel_columns(group_fields)
 
-        model.with_connection do |connection|
+        model.with_connection(query_type: :read) do |connection|
           column_alias_tracker = ColumnAliasTracker.new(connection)
 
           group_aliases = group_fields.map { |field|

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -375,7 +375,7 @@ module ActiveRecord
       return false if relation.where_clause.contradiction?
 
       skip_query_cache_if_necessary do
-        with_connection do |c|
+        with_connection(query_type: :read) do |c|
           c.select_rows(relation.arel, "#{model.name} Exists?").size == 1
         end
       end
@@ -472,7 +472,7 @@ module ActiveRecord
             )
           )
           relation = skip_query_cache_if_necessary do
-            model.with_connection do |c|
+            model.with_connection(query_type: :read) do |c|
               c.distinct_relation_for_primary_key(relation)
             end
           end

--- a/activerecord/lib/active_record/role_pinning.rb
+++ b/activerecord/lib/active_record/role_pinning.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  # Implements write-triggered role pinning within an executor scope.
+  #
+  # Pinning is enabled per request/job by executor hooks. Once enabled, every
+  # write can set or extend a pin window so subsequent checkouts use the writing
+  # role and avoid stale replica reads.
+  module RolePinning
+    PINNING_ENABLED_KEY = :active_record_role_pinning_enabled
+    PINNED_UNTIL_KEY = :active_record_role_pinned_until
+
+    module ExecutorHooks
+      # Enables role pinning for the current executor scope.
+      #
+      # @return [Boolean, nil] +true+ when enabled, +nil+ when disabled by config.
+      # @example
+      #   ActiveRecord.pin_role_on_write = 2
+      #   ActiveRecord::RolePinning::ExecutorHooks.run # => true
+      def self.run
+        return unless ActiveRecord.pin_role_on_write
+
+        ActiveSupport::IsolatedExecutionState[RolePinning::PINNING_ENABLED_KEY] = true
+        true
+      end
+
+      # Clears role pinning state for the current executor scope.
+      #
+      # @param was_enabled [Boolean, nil] the value returned by +run+ for this scope.
+      # @return [void]
+      # @example
+      #   ActiveRecord::RolePinning::ExecutorHooks.complete(true)
+      def self.complete(was_enabled)
+        return unless was_enabled
+
+        ActiveSupport::IsolatedExecutionState[RolePinning::PINNING_ENABLED_KEY] = nil
+        ActiveSupport::IsolatedExecutionState[RolePinning::PINNED_UNTIL_KEY] = nil
+      end
+    end
+
+    # Registers role pinning hooks into an executor.
+    #
+    # @param executor [ActiveSupport::Executor] the executor to register hooks on.
+    # @return [void]
+    # @example
+    #   ActiveRecord::RolePinning.install_executor_hooks
+    def self.install_executor_hooks(executor = ActiveSupport::Executor)
+      executor.register_hook(ExecutorHooks)
+    end
+
+    # Returns whether a write pin is currently active.
+    #
+    # A +:permanent+ pin remains active for the whole executor scope. Time-based
+    # pins are compared using +Process::CLOCK_MONOTONIC+ and are cleared once
+    # expired.
+    #
+    # @return [Boolean] +true+ if pinned, otherwise +false+.
+    # @example
+    #   ActiveRecord::RolePinning.pinned? # => false
+    def self.pinned?
+      pinned_until = ActiveSupport::IsolatedExecutionState[PINNED_UNTIL_KEY]
+      return false unless pinned_until
+      return true if pinned_until == :permanent
+
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) < pinned_until
+        true
+      else
+        ActiveSupport::IsolatedExecutionState[PINNED_UNTIL_KEY] = nil
+        false
+      end
+    end
+
+    # Records a write and sets/extends the pin window for this scope.
+    #
+    # When +ActiveRecord.pin_role_on_write+ is +true+, the pin is permanent for
+    # the current executor scope. Otherwise it is treated as a numeric duration
+    # in seconds and added to the monotonic clock.
+    #
+    # @return [void]
+    # @example
+    #   ActiveRecord.pin_role_on_write = 2.seconds
+    #   ActiveRecord::RolePinning.pin!
+    def self.pin!
+      return unless ActiveSupport::IsolatedExecutionState[PINNING_ENABLED_KEY]
+
+      duration = ActiveRecord.pin_role_on_write
+      ActiveSupport::IsolatedExecutionState[PINNED_UNTIL_KEY] =
+        if duration == true
+          :permanent
+        else
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) + duration.to_f
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -228,7 +228,7 @@ module ActiveRecord
     module ClassMethods
       # See the ConnectionAdapters::DatabaseStatements#transaction API docs.
       def transaction(**options, &block)
-        with_connection do |connection|
+        with_connection(query_type: :write) do |connection|
           connection.pool.with_pool_transaction_isolation_level(ActiveRecord.default_transaction_isolation_level, connection.transaction_open?) do
             connection.transaction(**options, &block)
           end
@@ -425,7 +425,7 @@ module ActiveRecord
     # This method is available within the context of an ActiveRecord::Base
     # instance.
     def with_transaction_returning_status # :nodoc:
-      self.class.with_connection do |connection|
+      self.class.with_connection(query_type: :write) do |connection|
         connection.pool.with_pool_transaction_isolation_level(ActiveRecord.default_transaction_isolation_level, connection.transaction_open?) do
           status = nil
           ensure_finalize = !connection.transaction_open?
@@ -533,7 +533,7 @@ module ActiveRecord
       # Add the record to the current transaction so that the #after_rollback and #after_commit
       # callbacks can be called.
       def add_to_transaction(ensure_finalize = true)
-        self.class.with_connection do |connection|
+        self.class.with_connection(query_type: :write) do |connection|
           connection.add_transaction_record(self, ensure_finalize)
         end
       end

--- a/activerecord/test/cases/query_role_resolver_test.rb
+++ b/activerecord/test/cases/query_role_resolver_test.rb
@@ -1,0 +1,357 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "tempfile"
+
+module ActiveRecord
+  class QueryRoleResolverTest < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
+    fixtures :posts
+
+    class ResolverWritingReadingBase < ActiveRecord::Base
+      self.abstract_class = true
+    end
+
+    class ResolverWritingOnlyBase < ActiveRecord::Base
+      self.abstract_class = true
+    end
+
+    def setup
+      @old_query_role_resolver = ActiveRecord.query_role_resolver
+      @old_pin_role_on_write = ActiveRecord.pin_role_on_write
+      @old_writing_role = ActiveRecord.writing_role
+      @old_reading_role = ActiveRecord.reading_role
+      @tempfiles = []
+      clear_role_pinning_state
+    end
+
+    def teardown
+      ActiveRecord.query_role_resolver = @old_query_role_resolver
+      ActiveRecord.pin_role_on_write = @old_pin_role_on_write
+      ActiveRecord.writing_role = @old_writing_role
+      ActiveRecord.reading_role = @old_reading_role
+      clear_role_pinning_state
+
+      ResolverWritingReadingBase.remove_connection if ResolverWritingReadingBase.connected?
+      ResolverWritingOnlyBase.remove_connection if ResolverWritingOnlyBase.connected?
+
+      @tempfiles.each do |file|
+        file.close
+        file.unlink
+      end
+    end
+
+    def test_query_role_resolver_is_called_with_query_type_model_and_current_role
+      configure_writing_and_reading(ResolverWritingReadingBase)
+
+      captured = nil
+      ActiveRecord.query_role_resolver = ->(query_type, model, current_role) do
+        captured = [query_type, model, current_role]
+        nil
+      end
+
+      ResolverWritingReadingBase.release_connection
+      ResolverWritingReadingBase.with_connection(query_type: :read) { }
+
+      assert_equal [:read, ResolverWritingReadingBase, :writing], captured
+    end
+
+    def test_read_queries_can_switch_to_reading_role_before_checkout
+      configure_writing_and_reading(ResolverWritingReadingBase)
+
+      ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) do
+        query_type == :read ? :reading : current_role
+      end
+
+      ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+        assert_equal :reading, connection.pool.role
+      end
+
+      ResolverWritingReadingBase.with_connection(query_type: :write) do |connection|
+        assert_equal :writing, connection.pool.role
+      end
+    end
+
+    def test_existing_lease_prevents_role_switching
+      configure_writing_and_reading(ResolverWritingReadingBase)
+
+      resolver_calls = 0
+      ActiveRecord.query_role_resolver = ->(query_type, _model, _current_role) do
+        resolver_calls += 1
+        query_type == :read ? :reading : :writing
+      end
+
+      ResolverWritingReadingBase.with_connection(query_type: :write) do |connection|
+        connection.transaction do
+          ResolverWritingReadingBase.with_connection(query_type: :read) do |nested_connection|
+            assert_equal :writing, nested_connection.pool.role
+          end
+        end
+      end
+
+      assert_equal 1, resolver_calls
+    end
+
+    def test_missing_resolved_pool_falls_back_to_current_pool
+      configure_writing_only(ResolverWritingOnlyBase)
+
+      ActiveRecord.query_role_resolver = ->(_query_type, _model, _current_role) { :reading }
+
+      ResolverWritingOnlyBase.with_connection(query_type: :read) do |connection|
+        assert_equal :writing, connection.pool.role
+      end
+    end
+
+    def test_nil_resolver_preserves_existing_behavior
+      configure_writing_and_reading(ResolverWritingReadingBase)
+
+      ActiveRecord.query_role_resolver = nil
+
+      ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+        assert_equal :writing, connection.pool.role
+      end
+    end
+
+    def test_connected_to_context_is_visible_to_resolver
+      configure_writing_and_reading(ResolverWritingReadingBase)
+
+      captured_current_role = nil
+      ActiveRecord.query_role_resolver = ->(_query_type, _model, current_role) do
+        captured_current_role = current_role
+        nil
+      end
+
+      ResolverWritingReadingBase.connected_to(role: :reading) do
+        ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+          assert_equal :reading, connection.pool.role
+        end
+      end
+
+      assert_equal :reading, captured_current_role
+    end
+
+    def test_query_operations_pass_query_type_to_with_connection
+      query_types = []
+      ActiveRecord.query_role_resolver = ->(query_type, _model, _current_role) do
+        query_types << query_type
+        nil
+      end
+
+      Post.release_connection
+      Post.first
+
+      Post.release_connection
+      Post.find_by_sql("SELECT * FROM posts LIMIT 1")
+
+      Post.release_connection
+      Post.where(id: 1).pluck(:id)
+
+      Post.release_connection
+      Post.where(id: 1).update_all(title: "captured")
+
+      assert_includes query_types, :read
+      assert_includes query_types, :write
+    end
+
+    def test_role_pinning_pins_to_writing_after_write_with_duration
+      configure_writing_and_reading(ResolverWritingReadingBase)
+      ActiveRecord.pin_role_on_write = 2
+      ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) do
+        query_type == :read ? :reading : current_role
+      end
+
+      monotonic_now = 100.0
+      Process.stub(:clock_gettime, ->(_clock) { monotonic_now }) do
+        with_role_pinning_scope do
+          ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+            assert_equal :reading, connection.pool.role
+          end
+
+          ResolverWritingReadingBase.with_connection(query_type: :write) do |connection|
+            assert_equal :writing, connection.pool.role
+          end
+
+          monotonic_now = 101.0
+          ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+            assert_equal :writing, connection.pool.role
+          end
+
+          monotonic_now = 103.0
+          ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+            assert_equal :reading, connection.pool.role
+          end
+        end
+      end
+    end
+
+    def test_role_pinning_pins_for_entire_scope_when_true
+      configure_writing_and_reading(ResolverWritingReadingBase)
+      ActiveRecord.pin_role_on_write = true
+      ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) do
+        query_type == :read ? :reading : current_role
+      end
+
+      with_role_pinning_scope do
+        ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+          assert_equal :reading, connection.pool.role
+        end
+
+        ResolverWritingReadingBase.with_connection(query_type: :write) do |connection|
+          assert_equal :writing, connection.pool.role
+        end
+
+        ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+          assert_equal :writing, connection.pool.role
+        end
+      end
+    end
+
+    def test_role_pinning_resets_between_executor_scopes
+      configure_writing_and_reading(ResolverWritingReadingBase)
+      ActiveRecord.pin_role_on_write = true
+      ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) do
+        query_type == :read ? :reading : current_role
+      end
+
+      with_role_pinning_scope do
+        ResolverWritingReadingBase.with_connection(query_type: :write) do |connection|
+          assert_equal :writing, connection.pool.role
+        end
+      end
+
+      with_role_pinning_scope do
+        ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+          assert_equal :reading, connection.pool.role
+        end
+      end
+    end
+
+    def test_role_pinning_is_noop_when_disabled
+      configure_writing_and_reading(ResolverWritingReadingBase)
+      ActiveRecord.pin_role_on_write = nil
+      ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) do
+        query_type == :read ? :reading : current_role
+      end
+
+      with_role_pinning_scope do
+        ResolverWritingReadingBase.with_connection(query_type: :write) do |connection|
+          assert_equal :writing, connection.pool.role
+        end
+
+        ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+          assert_equal :reading, connection.pool.role
+        end
+      end
+    end
+
+    def test_role_pinning_extends_on_subsequent_writes
+      configure_writing_and_reading(ResolverWritingReadingBase)
+      ActiveRecord.pin_role_on_write = 2
+      ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) do
+        query_type == :read ? :reading : current_role
+      end
+
+      monotonic_now = 100.0
+      Process.stub(:clock_gettime, ->(_clock) { monotonic_now }) do
+        with_role_pinning_scope do
+          ResolverWritingReadingBase.with_connection(query_type: :write) { }
+          monotonic_now = 101.0
+          ResolverWritingReadingBase.with_connection(query_type: :write) { }
+
+          monotonic_now = 102.5
+          ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+            assert_equal :writing, connection.pool.role
+          end
+
+          monotonic_now = 103.5
+          ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+            assert_equal :reading, connection.pool.role
+          end
+        end
+      end
+    end
+
+    def test_role_pinning_works_without_resolver
+      configure_writing_and_reading(ResolverWritingReadingBase)
+      ActiveRecord.pin_role_on_write = true
+      ActiveRecord.query_role_resolver = nil
+
+      with_role_pinning_scope do
+        ResolverWritingReadingBase.with_connection(query_type: :write) { }
+
+        assert_predicate ActiveRecord::RolePinning, :pinned?
+        ResolverWritingReadingBase.with_connection(query_type: :read) do |connection|
+          assert_equal :writing, connection.pool.role
+        end
+      end
+    end
+
+    private
+      # Executes a block inside role-pinning executor hooks.
+      #
+      # @yield runs inside a simulated executor scope.
+      # @return [Object] block return value.
+      # @example
+      #   with_role_pinning_scope { User.first }
+      def with_role_pinning_scope
+        was_enabled = ActiveRecord::RolePinning::ExecutorHooks.run
+        yield
+      ensure
+        ActiveRecord::RolePinning::ExecutorHooks.complete(was_enabled)
+      end
+
+      # Clears all role-pinning state from isolated execution storage.
+      #
+      # @return [void]
+      # @example
+      #   clear_role_pinning_state
+      def clear_role_pinning_state
+        ActiveSupport::IsolatedExecutionState[ActiveRecord::RolePinning::PINNING_ENABLED_KEY] = nil
+        ActiveSupport::IsolatedExecutionState[ActiveRecord::RolePinning::PINNED_UNTIL_KEY] = nil
+      end
+
+      # Configures a model class with separate writing and reading pools.
+      #
+      # @param klass [Class] an abstract Active Record class to configure.
+      # @return [void]
+      # @example
+      #   configure_writing_and_reading(ResolverWritingReadingBase)
+      def configure_writing_and_reading(klass)
+        writing = create_tempfile
+        reading = create_tempfile
+
+        klass.connects_to database: {
+          writing: { adapter: "sqlite3", database: writing.path },
+          reading: { adapter: "sqlite3", database: reading.path }
+        }
+      end
+
+      # Configures a model class with only a writing pool.
+      #
+      # @param klass [Class] an abstract Active Record class to configure.
+      # @return [void]
+      # @example
+      #   configure_writing_only(ResolverWritingOnlyBase)
+      def configure_writing_only(klass)
+        writing = create_tempfile
+
+        klass.connects_to database: {
+          writing: { adapter: "sqlite3", database: writing.path }
+        }
+      end
+
+      # Creates and tracks a tempfile so teardown can always clean it up.
+      #
+      # @return [Tempfile] an open temporary file.
+      # @example
+      #   db_file = create_tempfile
+      #   db_file.path # => "/tmp/..."
+      def create_tempfile
+        file = Tempfile.open("query_role_resolver")
+        @tempfiles << file
+        file
+      end
+  end
+end

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -9,6 +9,7 @@ After reading this guide you will know:
 
 * How to set up your application for multiple databases.
 * How automatic connection switching works.
+* How to use per-query role resolution and write-triggered role pinning.
 * How to use horizontal sharding for multiple databases.
 * What features are supported and what's still a work in progress.
 
@@ -408,6 +409,102 @@ ActiveRecord::Base.connected_to(role: :reading, prevent_writes: true) do
   # Rails will check each query to ensure it's a read query.
 end
 ```
+
+## Per-Query Role Resolution
+
+The automatic role switching middleware described above operates at the HTTP request level -- it
+chooses a role based on the request verb and a session timestamp. In some cases you may want
+finer-grained control, routing individual queries to the writer or a replica based on whether
+each query reads or writes.
+
+Active Record's `query_role_resolver` lets you provide a callable that is consulted before
+every connection checkout that carries a query type. The resolver receives three arguments:
+
+1. `query_type` -- `:read` or `:write`, reflecting the operation about to be performed.
+2. `model` -- the model class checking out the connection.
+3. `current_role` -- the role that would be used without the resolver.
+
+The resolver should return the role to use, or `nil` to keep the current role.
+
+### Setting Up the Resolver
+
+Add the resolver in an initializer:
+
+```ruby
+# config/initializers/multi_db.rb
+ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) {
+  case query_type
+  when :read  then :reading
+  when :write then :writing
+  else current_role
+  end
+}
+```
+
+With this configuration, every `SELECT` issued by Active Record (e.g. `User.find`,
+`Post.where(...).to_a`) will check out a connection from the `:reading` pool, while
+`INSERT`, `UPDATE`, and `DELETE` operations will use the `:writing` pool -- all without
+wrapping code in `connected_to` blocks.
+
+NOTE: The resolver is only consulted when no connection is already leased. If a connection
+is checked out (for example, inside a transaction), subsequent queries reuse that connection
+regardless of what the resolver would return. This prevents accidentally switching roles
+mid-transaction.
+
+### Write-Triggered Role Pinning
+
+A common problem with read/write splitting is **stale reads**: a request writes data to the
+primary database, then immediately reads it back, but the replica hasn't replicated the change
+yet. The read returns stale data.
+
+`pin_role_on_write` solves this by automatically pinning all subsequent queries to the writing
+role after a write occurs. The resolver is bypassed while the pin is active. Pinning is scoped
+by `ActiveSupport::Executor`, so it is automatically cleared at the end of each request or job.
+
+You can configure pinning in two ways:
+
+**Pin for a fixed duration** -- After each write, pin to the primary for the specified number
+of seconds. If no further writes occur, reads revert to the replica once the window expires.
+Each additional write resets the timer.
+
+```ruby
+# config/initializers/multi_db.rb
+ActiveRecord.pin_role_on_write = 2.seconds
+```
+
+**Pin for the entire request** -- After any write, all remaining queries in the current
+request or job go to the primary.
+
+```ruby
+# config/initializers/multi_db.rb
+ActiveRecord.pin_role_on_write = true
+```
+
+When set to `nil` or `false` (the default), pinning is disabled.
+
+Here is a complete example combining both features:
+
+```ruby
+# config/initializers/multi_db.rb
+ActiveRecord.query_role_resolver = ->(query_type, _model, current_role) {
+  query_type == :read ? :reading : current_role
+}
+
+ActiveRecord.pin_role_on_write = 2.seconds
+```
+
+With this setup, a typical request behaves as follows:
+
+1. `User.find(1)` -- reads from the replica.
+2. `User.create!(name: "Ada")` -- writes to the primary; starts a 2-second pin.
+3. `User.last` -- within the pin window, reads from the primary (avoids stale read).
+4. *(2 seconds elapse with no further writes)*
+5. `User.count` -- pin has expired, reads from the replica again.
+
+At the end of the request the pin is cleared regardless of whether it has expired.
+
+TIP: Time-based pinning uses a monotonic clock (`Process::CLOCK_MONOTONIC`) internally so
+that pin expiry is not affected by system clock adjustments.
 
 ## Horizontal Sharding
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the existing automatic database switching based on request type (`GET`, `POST` etc) is limiting in legacy rails applications where some `GET` requests do perform database writes.
With per-query automatic switching, it becomes trivial to scale such applications by ensuring that the vast majority of read-only queries go to follower databases without having to put explicit code-changes in place.

### Detail

This Pull Request introduces `ActiveRecord.query_role_resolver`, a callable that is consulted before every connection checkout to determine which role pool (e.g. `:reading` or `:writing`) should serve a given query. The resolver receives the query type (`:read` / `:write`), the model class, and the current role, and returns the role to use.

Add `ActiveRecord.pin_role_on_write` to prevent stale replica reads after writes. When enabled, the first write in an executor scope (request or job) pins subsequent queries to the writing role. The pin can be configured as:

  - `true`            -- pin for the remainder of the request/job
  - numeric/duration  -- pin for that many seconds after each write
  - `nil` / `false`   -- disabled (default)

Pinning is managed by `ActiveRecord::RolePinning`, which registers hooks on `ActiveSupport::Executor` following the same pattern as `QueryCache` and `AsynchronousQueriesTracker`. Time-based expiry uses `Process::CLOCK_MONOTONIC` to avoid wall-clock drift. Each write resets the timer so rapid successive writes extend the window.

    # config/initializers/multi_db.rb
    ActiveRecord.query_role_resolver = ->(query_type, _, current_role) {
      query_type == :read ? :reading : current_role
    }
    ActiveRecord.pin_role_on_write = 2.seconds

### Additional information

Consider this Pull Request a suggestion for how this feature could be implemented. Someone with more intimate knowledge of the internals of `ActiveRecord` might be able to suggest a better approach.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
