### PR TITLE
Render MissingAttachable as "☒" in plain text

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Render `MissingAttachable` as "☒" in plain text.
+
+    Previously, `Content#to_plain_text` would replace a `MissingAttachable` with a blank string.
+    Now it renders the same "☒" character used in the HTML representation.
+
 *   Add `to_markdown` to Action Text, mirroring `to_plain_text`.
 
     Converts rich text content to Markdown, supporting headings, bold, italic,

--- a/actiontext/lib/action_text/attachables/missing_attachable.rb
+++ b/actiontext/lib/action_text/attachables/missing_attachable.rb
@@ -21,6 +21,10 @@ module ActionText
         end
       end
 
+      def attachable_plain_text_representation(caption = nil)
+        "☒"
+      end
+
       def attachable_markdown_representation(caption = nil)
         "☒"
       end

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -88,6 +88,15 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_nil attachable.model
   end
 
+  test "converts missing attachables to plain text" do
+    file = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{file.attachable_sgid}"></action-text-attachment>)
+    file.destroy!
+    content = content_from_html(html)
+
+    assert_equal "☒", content.to_plain_text
+  end
+
   test "converts Trix-formatted attachments" do
     html = %Q(<figure data-trix-attachment='{"sgid":"123","contentType":"text/plain","width":100,"height":100}' data-trix-attributes='{"caption":"Captioned"}'></figure>)
     content = content_from_html(html)


### PR DESCRIPTION
### Motivation / Background

When ActionText content containing a missing or deleted attachment is rendered as HTML, the `MissingAttachable` partial renders "☒" (U+2612, BALLOT BOX WITH X) to indicate the broken attachment.

However, when the same content is rendered with `Content#to_plain_text`, the missing attachment is silently replaced with a blank string because `MissingAttachable` does not implement `attachable_plain_text_representation`.

### Detail

Add `attachable_plain_text_representation` to `MissingAttachable`, returning the same "☒" character used in the HTML partial.

### Additional information

This only applies when the `<action-text-attachment>` node resolves to a `MissingAttachable`. Image attachments whose backing record has been deleted but whose node still contains `url` and `content-type` attributes will resolve as a `RemoteImage` and render as `[Image]` in plain text.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.