### PR TITLE
fix: skip coder round-trip for Hash/Array values during `insert_all`

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -242,7 +242,9 @@ module ActiveRecord
             elsif pks.include?(key) && value.nil?
               connection.default_insert_value(model.columns_hash[key])
             else
-              ActiveModel::Type::SerializeCastValue.serialize(type = types[key], type.cast(value))
+              type = types[key]
+              value = type.cast(value) unless type.serialized?
+              ActiveModel::Type::SerializeCastValue.serialize(type, value)
             end
           end
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -182,6 +182,25 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal(myobj, topic.content)
   end
 
+  def test_serialized_json_column_direct_attribute_assignment
+    Topic.serialize :content, coder: JSON, type: Hash
+
+    topic = Topic.new(content: { foo: "bar" })
+    topic.save!
+    topic.reload
+
+    assert_equal({ "foo" => "bar" }, topic.content)
+
+    topic.content = { baz: "qux" }
+
+    assert_equal({ "baz" => "qux" }, topic.content)
+
+    topic.save
+    topic.reload
+
+    assert_equal({ "baz" => "qux" }, topic.content)
+  end
+
   def test_serialized_string_attribute
     myobj = "Yes"
     topic = Topic.create("content" => myobj).reload


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Related to #56163.

`insert_all` is ~1.8x slower than raw SQL for tables with serialized columns (YAML/JSON). The bottleneck is in how `Mutable#cast` works for serialized types.

This is a regression introduced by PR #48139. in a fix for handling incorrectly typed values. Ex: `Book.create!(name: ["Array"])` stores `'["Array"]'` vs `Book.insert!({ name: ["Array"] })` stores `'---\n- Array\n'` (if YAML encoded).

Both should produce the same database value, but `insert!` skipped the `cast` step that normalizes the Array to a String. The fix added that cast to normalize values and since `insert!` uses `insert_all!` under the hood `insert_all!` was affected by this change.

The fix was cheap for simple types like String and Integer,  but `Serialized` includes `ActiveModel::Type::Helpers::Mutable`, which defines `cast(value)` as `deserialize(serialize(value))` for dirty tracking. For serialized columns, this means every call to `cast` now does a `YAML.dump` followed by a `YAML.load`, to normalize a value that in the case of `insert_all` is typically already a `Hash` or `Array`. This means that every `insert_all` with serialized columns now includes the overhead of a full extra `deserialize` and `serialize`.

### Other Approaches


I tried a fix that overrides `cast` on `Serialized` to short-circuit when the value is already a Hash or Array — the types that do not need casting. However, this caused an issue where we started skipping casting during other operations like attribute assignment. Ex: with a JSON code `Book.content = { a: :b }` would get stored as `{ a: :b }` until the database save after which it would be `{ "a" => "b" }`.

### Solution

Instead I took the approach of adding a hot path within `insert_all` itself for the case when the incoming value is already `serialized?`. If a value is `serialized?` then it already has a `coder` that can handle converting the value into something the database can handle. Since `insert_all` goes directly to the database we don't need to care the value being formatted correctly in memory (the reason for `deserialize(serialize())`. This approach works because it is localized to `insert_all`, thus, it does not affect direct attribute assignment.

### Additional information

```
=== Benchmark: 10000 rows, 37 columns, 1 YAML-serialized column ===
ruby 4.0.1 (2026-01-13 revision e04267a14b) +YJIT +PRISM [arm64-darwin24]
Calculating -------------------------------------
insert_all! (with cast)
                          1.033 (± 0.0%) i/s  (968.00 ms/i) -      6.000 in   5.813673s
insert_all! (no cast)
                          1.835 (± 0.0%) i/s  (545.08 ms/i) -     10.000 in   5.469083s
insert_all! (array / hash hot path)
                          1.820 (± 0.0%) i/s  (549.54 ms/i) -     10.000 in   5.498318s
             raw_sql      2.070 (± 0.0%) i/s  (483.16 ms/i) -     11.000 in   5.317541s

Comparison:
             raw_sql:        2.1 i/s
insert_all! (no cast):        1.8 i/s - 1.13x  slower
insert_all! (array / hash hot path):        1.8 i/s - 1.14x  slower
insert_all! (with cast):        1.0 i/s - 2.00x  slower
```

<details><summary>Benchmark</summary>
<p>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem 'rails', github: 'rails/rails', branch: 'main'
  # gem "rails", path: "."
  gem "trilogy"
  gem "benchmark-ips"
  gem "vernier"
  gem "stackprof"
  gem "activerecord-typedstore"
end

require "active_record/railtie"
require "benchmark/ips"
require "vernier"
require "stackprof"
require "json"

# This connection will do for database-independent bug reports.
# ENV["DATABASE_URL"] = "sqlite3::memory:"

# podman run -d --name mysql-dev -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:latest
# or podman start mysql-dev
# podman exec mysql-dev mysql -u root -e "CREATE DATABASE IF NOT EXISTS activerecord_test;"

ENV["DATABASE_URL"] = "trilogy://127.0.0.1:3306/activerecord_test?user=root&password="

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

# Create bookstore books table without unique indexes
ActiveRecord::Schema.define do
  create_table :books, force: true do |t|
    # Basic fields
    t.bigint :store_id, null: false
    t.string :title, null: false
    t.string :author
    t.string :isbn
    t.string :publisher
    t.date :publication_date
    t.integer :pages

    # Pricing
    t.decimal :price, precision: 10, scale: 2
    t.decimal :cost, precision: 10, scale: 2
    t.decimal :discount_price, precision: 10, scale: 2

    # Inventory fields
    t.integer :quantity
    t.string :warehouse_location
    t.integer :reorder_level
    t.string :supplier

    # Categorization
    t.string :genre
    t.string :category
    t.string :subcategory
    t.string :language, default: "English"

    # Physical properties
    t.string :cover_type
    t.string :format
    t.integer :edition
    t.decimal :weight_oz, precision: 10, scale: 2

    # Flags
    t.boolean :in_print, default: true
    t.boolean :available, default: true
    t.boolean :featured, default: false
    t.boolean :signed_copy, default: false

    # Metadata
    t.text :description
    t.string :series_name
    t.integer :series_number

    # Serialized column
    t.text :dimensions

    # Timestamps
    t.timestamps
    t.datetime :discontinued_at

    # Other fields
    t.integer :reserved_quantity
    t.boolean :has_incoming_shipment
    t.datetime :next_shipment_date
    t.text :awards
  end
end

class Book < ActiveRecord::Base
  # serialize :dimensions, coder: JSON
  # serialize :dimensions, coder: YAML
  # typed_store :dimensions, coder: JSON do |s|
  typed_store :dimensions, coder: YAML do |s|
    s.float :width
    s.float :height
    s.float :depth
    s.string :unit
  end
end

ActiveRecord::Base.logger = nil

module HotPath
  def values_list
    return super unless ActiveRecord::InsertAll::Builder.hot_path

    types = extract_types_for(keys_including_timestamps)
    pks = primary_keys

    values_list = insert_all.map_key_with_value do |key, value|
      if Arel::Nodes::SqlLiteral === value
        value
      elsif pks.include?(key) && value.nil?
        connection.default_insert_value(model.columns_hash[key])
      else
        if ActiveRecord::InsertAll::Builder.hot_path == :hot_path
          type = types[key]
          value = type.cast(value) unless type.serialized?
          ActiveModel::Type::SerializeCastValue.serialize(type, value)
        elsif ActiveRecord::InsertAll::Builder.hot_path == :skip_cast
          connection.with_yaml_fallback(types[key].serialize(value))
        end
      end
    end

    connection.visitor.compile(Arel::Nodes::ValuesList.new(values_list))
  end
end

ActiveRecord::InsertAll::Builder.prepend(HotPath)

class ActiveRecord::InsertAll::Builder
  class << self
    attr_accessor :hot_path
  end
  self.hot_path = false
end


TIMES = 20
BATCH_SIZE = 10_000
INSERT_COLUMNS = %i[
  store_id title author isbn publisher publication_date pages
  price cost discount_price
  quantity warehouse_location reorder_level supplier
  genre category subcategory language
  cover_type format edition weight_oz
  in_print available featured signed_copy
  description series_name series_number
  dimensions
  created_at updated_at discontinued_at
  reserved_quantity has_incoming_shipment next_shipment_date awards
].freeze

def truncate_table
  Book.connection.execute("TRUNCATE TABLE books")
end

def raw_sql_insert(payload)
  arel_table = Book.arel_table

  all_attr_values = payload.map do |record|
    INSERT_COLUMNS.map { |col| arel_table.type_cast_for_database(col, record[col]) }
  end

  insert_manager = Arel::InsertManager.new(Book.arel_table)
  insert_manager.into(arel_table)
  insert_manager.columns.concat(INSERT_COLUMNS.map { |col| arel_table[col] })
  insert_manager.values = insert_manager.create_values_list(all_attr_values)
  sql = insert_manager.to_sql
  Book.connection.exec_query(sql, "Book Bulk Insert")
end

def build_book_records(count)
  current_time = Time.now.utc
  # current_time = Time.current
  store_id = 1

  authors = ["Jane Austen", "Mark Twain", "Virginia Woolf", "Ernest Hemingway", "Toni Morrison"]
  genres = ["Fiction", "Mystery", "Science Fiction", "Biography", "History"]
  publishers = ["Penguin", "Random House", "HarperCollins", "Simon & Schuster", "Macmillan"]

  Array.new(count) do |i|
    {
      store_id: store_id,
      title: "Book Title #{i}",
      author: authors[i % authors.length],
      isbn: "978-0-#{rand(100..999)}-#{rand(10000..99999)}-#{rand(0..9)}",
      publisher: publishers[i % publishers.length],
      publication_date: Date.today - rand(365..3650),
      pages: rand(100..800),
      price: rand(9.99..49.99).round(2),
      cost: rand(5.00..25.00).round(2),
      discount_price: nil,
      quantity: rand(0..100),
      warehouse_location: "A-#{rand(1..50)}-#{rand(1..10)}",
      reorder_level: 5,
      supplier: "Book Distributor Inc",
      genre: genres[i % genres.length],
      category: "General",
      subcategory: nil,
      language: "English",
      cover_type: ["Hardcover", "Paperback"][i % 2],
      format: "Print",
      edition: 1,
      weight_oz: rand(8.0..32.0).round(2),
      in_print: true,
      available: true,
      featured: false,
      signed_copy: false,
      description: "A captivating story that will keep you turning pages.",
      series_name: nil,
      series_number: nil,
      dimensions: {
        width: 6.0,
        height: 9.0,
        depth: 1.5,
        unit: "inches"
      },
      created_at: current_time,
      updated_at: current_time,
      discontinued_at: nil,
      reserved_quantity: 0,
      has_incoming_shipment: false,
      next_shipment_date: nil,
      awards: nil
    }
  end
end

payload = build_book_records(BATCH_SIZE)

# Warmup all paths
ActiveRecord::InsertAll::Builder.hot_path = false
3.times { Book.insert_all!(payload, record_timestamps: true) }

ActiveRecord::InsertAll::Builder.hot_path = :skip_cast
3.times { Book.insert_all!(payload, record_timestamps: true) }

ActiveRecord::InsertAll::Builder.hot_path = :hot_path
3.times { Book.insert_all!(payload, record_timestamps: true) }

3.times { raw_sql_insert(payload) }
truncate_table

puts "\n=== Benchmark: #{BATCH_SIZE} rows, #{INSERT_COLUMNS.size} columns, 1 YAML-serialized column ==="
Benchmark.ips do |x|
  x.report("insert_all! (with cast)") do
    ActiveRecord::InsertAll::Builder.hot_path = false
    Book.insert_all!(payload, record_timestamps: true)
  end

  x.report("insert_all! (no cast)") do
    ActiveRecord::InsertAll::Builder.hot_path = :skip_cast
    Book.insert_all!(payload, record_timestamps: true)
  end

  x.report("insert_all! (array / hash hot path)") do
    ActiveRecord::InsertAll::Builder.hot_path = :hot_path
    Book.insert_all!(payload, record_timestamps: true)
  end

  x.report("raw_sql") do
    raw_sql_insert(payload)
  end

  x.compare!
end

# Vernier.profile(out: "book_insert_all_vern.json", mode: :wall) do
#   TIMES.times { Book.insert_all!(payload, record_timestamps: true) }
# end
# Vernier.profile(out: "book_raw_sql_vern.json", mode: :wall) do
#   TIMES.times { raw_sql_insert(payload) }
# end

# for speed scope
# profile = StackProf.run(mode: :wall, raw: true) do
#   TIMES.times { Book.insert_all!(payload, record_timestamps: true) }
# end
# File.write("book_insert_all_stack.json", JSON.generate(profile))
# profile = StackProf.run(mode: :wall, raw: true) do
#   TIMES.times { raw_sql_insert(payload) }
# end
# File.write("book_raw_sql_stack.json", JSON.generate(profile))
truncate_table
```

</p>
</details>


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
