### PR TITLE
'rails new' results in failing CI System Tests workflow #56853

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -147,7 +147,89 @@ jobs:
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test
-  <%- unless options[:api] -%>
+  <%- unless options[:api] || options[:skip_system_test] -%>
+  <%- if options[:skip_system_test] == false -%>
+
+  system-test:
+    runs-on: ubuntu-latest
+
+    <%- if options[:database] == "sqlite3" -%>
+    # services:
+    #  redis:
+    #    image: valkey/valkey:9
+    #    ports:
+    #      - 6379:6379
+    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    <%- else -%>
+    services:
+      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "postgresql" -%>
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end -%>
+
+      # redis:
+      #   image: valkey/valkey:9
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    <%- end -%>
+    steps:
+      <%- unless ci_packages.empty? -%>
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
+
+      <%- end -%>
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      <%- if using_bun? -%>
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: <%= dockerfile_bun_version %>
+      <%- end -%>
+
+      - name: Run System Tests
+        env:
+          RAILS_ENV: test
+          <%- if options[:database] == "mysql" -%>
+          DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "trilogy" -%>
+          DATABASE_URL: trilogy://127.0.0.1:3306
+          <%- elsif options[:database] == "postgresql" -%>
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- end -%>
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test:system
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/screenshots
+          if-no-files-found: ignore
+  <%- else -%>
 
   # Optional: Uncomment to enable system tests in CI.
   # Generate system test files first: bin/rails generate system_test
@@ -172,5 +254,6 @@ jobs:
   #         name: screenshots
   #         path: ${{ github.workspace }}/tmp/screenshots
   #         if-no-files-found: ignore
+  <%- end -%>
   <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -147,86 +147,30 @@ jobs:
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test
-  <%- unless options[:api] || options[:skip_system_test] -%>
+  <%- unless options[:api] -%>
 
-  system-test:
-    runs-on: ubuntu-latest
-
-    <%- if options[:database] == "sqlite3" -%>
-    # services:
-    #  redis:
-    #    image: valkey/valkey:9
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-    <%- else -%>
-    services:
-      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
-      mysql:
-        image: mysql
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- elsif options[:database] == "postgresql" -%>
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- end -%>
-
-      # redis:
-      #   image: valkey/valkey:9
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
-    <%- end -%>
-    steps:
-      <%- unless ci_packages.empty? -%>
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
-
-      <%- end -%>
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      <%- if using_bun? -%>
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: <%= dockerfile_bun_version %>
-      <%- end -%>
-
-      - name: Run System Tests
-        env:
-          RAILS_ENV: test
-          <%- if options[:database] == "mysql" -%>
-          DATABASE_URL: mysql2://127.0.0.1:3306
-          <%- elsif options[:database] == "trilogy" -%>
-          DATABASE_URL: trilogy://127.0.0.1:3306
-          <%- elsif options[:database] == "postgresql" -%>
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          <%- end -%>
-          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test:system
-
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v6
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore
+  # Optional: Uncomment to enable system tests in CI.
+  # Generate system test files first: bin/rails generate system_test
+  #
+  # system-test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v6
+  #     - name: Set up Ruby
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         bundler-cache: true
+  #     - name: Run System Tests
+  #       env:
+  #         RAILS_ENV: test
+  #       run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test:system
+  #     - name: Keep screenshots from failed system tests
+  #       uses: actions/upload-artifact@v6
+  #       if: failure()
+  #       with:
+  #         name: screenshots
+  #         path: ${{ github.workspace }}/tmp/screenshots
+  #         if-no-files-found: ignore
   <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -151,6 +151,7 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test
   <%- unless options[:api] || options[:skip_system_test] -%>
+  <%- if options[:skip_system_test] == false -%>
 
   system-test:
     runs-on: ubuntu-latest
@@ -231,5 +232,89 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+  <%- else -%>
+
+  # Optional: Run system tests
+  #
+  # system-test:
+  #   runs-on: ubuntu-latest
+  #
+    <%- if options[:database] == "sqlite3" -%>
+  #   # services:
+  #   #  redis:
+  #   #    image: valkey/valkey:9
+  #   #    ports:
+  #   #      - 6379:6379
+  #   #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    <%- else -%>
+  #   services:
+      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+  #     mysql:
+  #       image: mysql
+  #       env:
+  #         MYSQL_ALLOW_EMPTY_PASSWORD: true
+  #       ports:
+  #         - 3306:3306
+  #       options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "postgresql" -%>
+  #     postgres:
+  #       image: postgres
+  #       env:
+  #         POSTGRES_USER: postgres
+  #         POSTGRES_PASSWORD: postgres
+  #       ports:
+  #         - 5432:5432
+  #       options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end -%>
+  #
+  #     # redis:
+  #     #   image: valkey/valkey:9
+  #     #   ports:
+  #     #     - 6379:6379
+  #     #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+  #
+    <%- end -%>
+  #   steps:
+      <%- unless ci_packages.empty? -%>
+  #     - name: Install packages
+  #       run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
+  #
+      <%- end -%>
+  #     - name: Checkout code
+  #       uses: actions/checkout@v7
+  #
+  #     - name: Set up Ruby
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         bundler-cache: true
+      <%- if using_bun? -%>
+  #
+  #     - uses: oven-sh/setup-bun@v2
+  #       with:
+  #         bun-version: <%= dockerfile_bun_version %>
+      <%- end -%>
+  #
+  #     - name: Run System Tests
+  #       env:
+  #         RAILS_ENV: test
+          <%- if options[:database] == "mysql" -%>
+  #         DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "trilogy" -%>
+  #         DATABASE_URL: trilogy://127.0.0.1:3306
+          <%- elsif options[:database] == "postgresql" -%>
+  #         DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- end -%>
+  #         # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+  #         # REDIS_URL: redis://localhost:6379/0
+  #       run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test:system
+  #
+  #     - name: Keep screenshots from failed system tests
+  #       uses: actions/upload-artifact@v7
+  #       if: failure()
+  #       with:
+  #         name: screenshots
+  #         path: ${{ github.workspace }}/tmp/screenshots
+  #         if-no-files-found: ignore
+  <%- end -%>
   <%- end -%>
 <%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -722,7 +722,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file ".github/workflows/ci.yml" do |content|
       assert_match(/db:test:prepare test/, content)
-      assert_match(/db:test:prepare test:system/, content)
+      assert_match(/#\s+run: bin\/rails db:test:prepare test:system/, content)
+      assert_no_match(/^\s+run: bin\/rails db:test:prepare test:system/, content)
     end
   end
 
@@ -733,7 +734,25 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file ".github/workflows/ci.yml" do |content|
       assert_no_match(/db:test:prepare/, content)
       assert_match(/bin\/rails test/, content)
-      assert_match(/bin\/rails test:system/, content)
+      assert_match(/#\s+run: bin\/rails test:system/, content)
+    end
+  end
+
+  def test_ci_workflow_includes_active_system_test_job_when_no_skip_system_test
+    run_generator [destination_root, "--no-skip-system-test"]
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_match(/^\s+system-test:/, content)
+      assert_match(/^\s+run: bin\/rails db:test:prepare test:system/, content)
+      assert_match(/screenshots/, content)
+    end
+  end
+
+  def test_ci_workflow_comments_out_system_test_job_by_default
+    run_generator
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/^\s+system-test:/, content)
+      assert_match(/#\s+system-test:/, content)
+      assert_match(/Optional: Uncomment to enable system tests/, content)
     end
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -744,7 +744,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file ".github/workflows/ci.yml" do |content|
       assert_match(/db:test:prepare test/, content)
-      assert_match(/db:test:prepare test:system/, content)
+      assert_match(/#\s+run: bin\/rails db:test:prepare test:system/, content)
+      assert_no_match(/^\s+run: bin\/rails db:test:prepare test:system/, content)
     end
   end
 
@@ -755,7 +756,29 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file ".github/workflows/ci.yml" do |content|
       assert_no_match(/db:test:prepare/, content)
       assert_match(/bin\/rails test/, content)
-      assert_match(/bin\/rails test:system/, content)
+      assert_match(/#\s+run: bin\/rails test:system/, content)
+      assert_no_match(/^\s+run: bin\/rails test:system/, content)
+    end
+  end
+
+  def test_ci_workflow_includes_active_system_test_job_when_no_skip_system_test
+    run_generator [destination_root, "--no-skip-system-test"]
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_match(/^\s+system-test:/, content)
+      assert_match(/^\s+run: bin\/rails db:test:prepare test:system/, content)
+      assert_match(/screenshots/, content)
+      assert_no_match(/Optional: Run system tests/, content)
+    end
+  end
+
+  def test_ci_workflow_comments_out_system_test_job_by_default
+    run_generator
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/^\s+system-test:/, content)
+      assert_match(/#\s+system-test:/, content)
+      assert_match(/Optional: Run system tests/, content)
+      assert_match(/actions\/checkout@v7/, content)
+      assert_match(/upload-artifact@v7/, content)
     end
   end
 


### PR DESCRIPTION
issue : #56853


Command | options[:skip_system_test] | CI Result
-- | -- | --
rails new myapp | nil | System-test job commented out (with instructions)
rails new myapp --no-skip-system-test | false | System-test job active (full, with DB services, etc.)
rails new myapp --skip-system-test or --api | true | Nothing



Test | Scenario | Verification
-- | -- | --
test_ci_workflow_comments_out_system_test_job_by_default | New — rails new myapp | The system-test: job is commented out with instructions
test_ci_workflow_includes_active_system_test_job_when_no_skip_system_test | New — rails new myapp --no-skip-system-test | The system-test: job is active and complete
test_generator_if_skip_system_test_is_given | Existing — rails new myapp --skip-system-test | No trace of test:system in the CI
test_ci_workflow_includes_db_test_prepare_by_default | Modified — verifies that test:system is commented out by default |  
test_ci_workflow_does_not_include_db_test_prepare_when_skip_active_record_is_given | Modified — verifies that test:system is commented out |  


