### PR TITLE
Avoid duplicate through rows during autosave on create

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -33,6 +33,10 @@ module ActiveRecord
         record
       end
 
+      def persisted_through_record_for?(record)
+        through_records_for(record).any?(&:persisted?)
+      end
+
       private
         def concat_records(records)
           ensure_not_nested

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -428,6 +428,15 @@ module ActiveRecord
           association.reset_scope
 
           if records = associated_records_to_validate_or_save(association, new_record_before_save, autosave)
+            if reflection.through_reflection? && new_record_before_save && !reflection.nested?
+              records = records.select do |record|
+                next true if record.new_record? || record.has_changes_to_save?
+                next true if autosave && record.changed_for_autosave?
+
+                !association.persisted_through_record_for?(record)
+              end
+            end
+
             if autosave
               records_to_destroy = records.select(&:marked_for_destruction?)
               records_to_destroy.each { |record| association.destroy(record) }

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1179,6 +1179,90 @@ class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase
 
     assert_equal 1, post.categories.reload.length
   end
+
+  def test_autosave_new_record_with_after_create_callback_does_not_duplicate_has_many_through_join_rows
+    with_has_many_inversing do
+      audit_class = Class.new(ActiveRecord::Base) do
+        self.table_name = "tags"
+        def self.name; "AutosaveAudit"; end
+      end
+
+      audit_assignment_class = Class.new(ActiveRecord::Base) do
+        self.table_name = "taggings"
+        def self.name; "AutosaveAuditAssignment"; end
+
+        belongs_to :audit, foreign_key: :tag_id, anonymous_class: audit_class
+        belongs_to :item,
+          polymorphic: true,
+          foreign_key: :taggable_id,
+          foreign_type: :taggable_type
+      end
+
+      role_class = Class.new(ActiveRecord::Base) do
+        self.table_name = "readers"
+        def self.name; "AutosaveMembership"; end
+      end
+
+      user_class = Class.new(ActiveRecord::Base) do
+        self.table_name = "people"
+        def self.name; "AutosaveUser"; end
+
+        has_many :roles,
+          foreign_key: :person_id,
+          anonymous_class: role_class,
+          inverse_of: :user
+        has_many :audit_assignments,
+          -> { where(taggable_type: "AutosaveUser") },
+          foreign_key: :taggable_id,
+          anonymous_class: audit_assignment_class,
+          inverse_of: :item
+        has_many :audits,
+          through: :audit_assignments,
+          source: :audit,
+          anonymous_class: audit_class
+      end
+
+      group_class = Class.new(ActiveRecord::Base) do
+        self.table_name = "posts"
+        def self.name; "AutosaveGroup"; end
+
+        has_many :roles,
+          foreign_key: :post_id,
+          anonymous_class: role_class,
+          inverse_of: :group
+      end
+
+      user_class.class_eval do
+        has_many :groups,
+          through: :roles,
+          source: :group,
+          anonymous_class: group_class
+      end
+
+      role_class.class_eval do
+        belongs_to :user,
+          foreign_key: :person_id,
+          anonymous_class: user_class,
+          inverse_of: :roles
+        belongs_to :group,
+          foreign_key: :post_id,
+          anonymous_class: group_class,
+          inverse_of: :roles
+
+        after_create do
+          audit = audit_class.new(name: "User added to group")
+          user.audits << audit
+        end
+      end
+
+      group = group_class.create!(title: "Administrators", body: "Bug reproduction group")
+      user = user_class.new(first_name: "Admin", groups: [group])
+
+      assert_difference -> { audit_assignment_class.count }, 1 do
+        user.save!
+      end
+    end
+  end
 end
 
 class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase


### PR DESCRIPTION
### Motivation / Background

When a new parent record is saved, and an `after_create` callback appends to a `has_many :through` association, Active Record can insert the same join row twice during a single save cycle.

This fixes #17599. 

### Detail

#### Reproduction Script

Based on original issue.

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :audits, force: true do |t|
    t.string :message
  end

  create_table :audit_assignments, force: true do |t|
    t.references :audit, null: false
    t.bigint :item_id, null: false
    t.string :item_type, null: false
  end

  create_table :groups, force: true do |t|
    t.string :name
  end

  create_table :users, force: true do |t|
    t.string :name
  end

  create_table :roles, force: true do |t|
    t.references :user, null: false
    t.references :group, null: false
  end
end

class Audit < ActiveRecord::Base
end

class AuditAssignment < ActiveRecord::Base
  belongs_to :audit
  belongs_to :item, polymorphic: true
end

class Group < ActiveRecord::Base
  has_many :roles
  has_many :users, through: :roles
end

class Role < ActiveRecord::Base
  belongs_to :user
  belongs_to :group

  after_create :audit_creation

  private
    def audit_creation
      audit = Audit.new(message: "User added to group")
      user.audits << audit
    end
end

class User < ActiveRecord::Base
  has_many :roles
  has_many :groups, through: :roles
  has_many :audit_assignments, -> { where(item_type: "User") }, foreign_key: :item_id
  has_many :audits, through: :audit_assignments
end

class Issue17599Test < ActiveSupport::TestCase
  def test_creates_only_one_audit_assignment
    group = Group.create!(name: "Administrators")
    user = User.new(name: "Admin", groups: [group])
    user.save!

    assert_equal 1, AuditAssignment.count
  end
end

```

#### Root Cause

The duplicate is caused by autosave callback ordering and replay in the new-owner path:

1. During save, `around_save_collection_association` marks that the owner was new before save.
2. An `after_create` callback on a related model appends to the owner’s `has_many :through` association. **This creates the first persisted join row.**
3. Later in the same autosave flow, `save_collection_association` processes loaded records for the owner-new path.
4. Because the owner was new before save, the same source record is still treated as insert-eligible.
5. `association.insert_record` runs again, **creating a second join row.**

In short: callback-created through insertion happens first, then autosave replays insertion for the same target without recognizing an already persisted matching through row.

#### What was changed to address it

A targeted guard was added in autosave collection saving for this exact path:

- Scope: only `through` associations when the owner was new before save.
- Behavior:
  - Keep records that are genuinely save-worthy (new/dirty/autosave-changed).
  - For unchanged records, inspect matching through records.
  - Skip reinsertion if a matching through record is already persisted.

This removes the duplicate callback+autosave replay while preserving legitimate insert behavior for pending (not-yet-persisted) through records.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
