### PR TITLE
Add `to_markdown` to Action Text, mirroring `to_plain_text`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `to_markdown` to Action Text, mirroring `to_plain_text`.
+
+    Converts rich text content to Markdown, supporting headings, bold, italic,
+    strikethrough, inline code, code blocks, blockquotes, ordered and unordered
+    lists, links, tables, and attachments. Custom attachment representations can be
+    provided by implementing `attachable_markdown_representation` on the
+    attachable model.
+
+        message = Message.create!(content: "<h1>Hello</h1><p>This is <strong>bold</strong></p>")
+        message.content.to_markdown # => "# Hello\n\nThis is **bold**"
+
+    *Mike Dalessio*
+
 *   Make `ActionText::Attachable#read_attribute_for_serialization` public.
 
     *Sally Hall*

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -68,12 +68,26 @@ module ActionText
     #     message.content.to_plain_text # => "Funny times!"
     #
     # NOTE: that the returned string is not HTML safe and should not be rendered in
-    # browsers.
+    # browsers without additional sanitization.
     #
     #     message = Message.create!(content: "&lt;script&gt;alert()&lt;/script&gt;")
     #     message.content.to_plain_text # => "<script>alert()</script>"
     def to_plain_text
       body&.to_plain_text.to_s
+    end
+
+    # Returns a Markdown version of the markup contained by the `body` attribute.
+    #
+    #     message = Message.create!(content: "<h1>Funny times!</h1>")
+    #     message.content.to_markdown # => "# Funny times!"
+    #
+    #     message = Message.create!(content: "<p>Hello <strong>world</strong></p>")
+    #     message.content.to_markdown # => "Hello **world**"
+    #
+    # NOTE: that the returned string is not HTML safe and should not be rendered in
+    # browsers without additional sanitization.
+    def to_markdown
+      body&.to_markdown.to_s
     end
 
     # Returns the `body` attribute in a format that makes it editable in the Trix

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -17,6 +17,7 @@ module ActionText
   autoload :AttachmentGallery
   autoload :Attachment
   autoload :Attribute
+  autoload :BottomUpReducer
   autoload :Configurator
   autoload :Content
   autoload :Editor
@@ -24,6 +25,7 @@ module ActionText
   autoload :Fragment
   autoload :FixtureSet
   autoload :HtmlConversion
+  autoload :MarkdownConversion
   autoload :PlainTextConversion
   autoload :Registry
   autoload :Rendering

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -21,6 +21,10 @@ module ActionText
         content_instance.fragment.source
       end
 
+      def attachable_markdown_representation(caption)
+        content_instance.fragment.to_markdown
+      end
+
       def to_html
         @to_html ||= content_instance.render(content_instance)
       end

--- a/actiontext/lib/action_text/attachables/missing_attachable.rb
+++ b/actiontext/lib/action_text/attachables/missing_attachable.rb
@@ -21,6 +21,10 @@ module ActionText
         end
       end
 
+      def attachable_markdown_representation(caption = nil)
+        "☒"
+      end
+
       def model
         @sgid&.model_name.to_s.safe_constantize
       end

--- a/actiontext/lib/action_text/attachables/remote_image.rb
+++ b/actiontext/lib/action_text/attachables/remote_image.rb
@@ -44,6 +44,10 @@ module ActionText
         "[#{caption || "Image"}]"
       end
 
+      def attachable_markdown_representation(caption)
+        "![#{caption || "Image"}](#{url})"
+      end
+
       def to_partial_path
         "action_text/attachables/remote_image"
       end

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -115,6 +115,44 @@ module ActionText
       end
     end
 
+    # Converts the attachment to Markdown.
+    #
+    #     attachable = ActiveStorage::Blob.find_by filename: "racecar.jpg"
+    #     attachment = ActionText::Attachment.from_attachable(attachable)
+    #     attachment.to_markdown # => "[racecar.jpg]"
+    #
+    # Use the `caption` when set:
+    #
+    #     attachment = ActionText::Attachment.from_attachable(attachable, caption: "Vroom vroom")
+    #     attachment.to_markdown # => "[Vroom vroom]"
+    #
+    # Remote images are rendered as Markdown images:
+    #
+    #     content = ActionText::Content.new('<action-text-attachment content-type="image/jpeg" url="https://example.com/photo.jpg" caption="A photo"></action-text-attachment>')
+    #     content.to_markdown # => "![A photo](https://example.com/photo.jpg)"
+    #
+    # The presentation can be overridden by implementing the
+    # `attachable_markdown_representation` method:
+    #
+    #     class Person < ApplicationRecord
+    #       include ActionText::Attachable
+    #
+    #       def attachable_markdown_representation(caption)
+    #         "[@#{name}](#{Rails.application.routes.url_helpers.person_url(self)})"
+    #       end
+    #     end
+    #
+    #     attachable = Person.create! name: "Javan"
+    #     attachment = ActionText::Attachment.from_attachable(attachable)
+    #     attachment.to_markdown # => "[@Javan](http://example.com/people/1)"
+    def to_markdown
+      if respond_to?(:attachable_markdown_representation)
+        attachable_markdown_representation(caption)
+      else
+        caption.to_s
+      end
+    end
+
     # Converts the attachment to HTML.
     #
     #     attachable = Person.create! name: "Javan"

--- a/actiontext/lib/action_text/bottom_up_reducer.rb
+++ b/actiontext/lib/action_text/bottom_up_reducer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ActionText
+  class BottomUpReducer # :nodoc:
+    def initialize(node)
+      @node = node
+      @values = {}
+    end
+
+    def reduce(&block)
+      traverse_bottom_up(@node) do |n|
+        child_values = @values.values_at(*n.children)
+        @values[n] = block.call(n, child_values)
+      end
+      @values[@node]
+    end
+
+    private
+      def traverse_bottom_up(node, &block)
+        call_stack, processing_stack = [ node ], []
+
+        until call_stack.empty?
+          node = call_stack.pop
+          processing_stack.push(node)
+          call_stack.concat node.children
+        end
+
+        processing_stack.reverse_each(&block)
+      end
+  end
+end

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -132,6 +132,20 @@ module ActionText
       render_attachments(with_full_attributes: false, &:to_plain_text).fragment.to_plain_text
     end
 
+    # Returns a Markdown version of the markup contained by the content.
+    #
+    #     content = ActionText::Content.new("<h1>Funny times!</h1>")
+    #     content.to_markdown # => "# Funny times!"
+    #
+    #     content = ActionText::Content.new("<p>Hello <strong>world</strong></p>")
+    #     content.to_markdown # => "Hello **world**"
+    #
+    # NOTE: that the returned string is not HTML safe and should not be rendered in
+    # browsers without additional sanitization.
+    def to_markdown
+      render_attachments(with_full_attributes: false, &:to_markdown).fragment.to_markdown
+    end
+
     def to_trix_html
       to_editor_html
     end

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -60,6 +60,10 @@ module ActionText
           "[#{caption || filename}]"
         end
 
+        def attachable_markdown_representation(caption = nil)
+          "[#{caption || filename}]"
+        end
+
         def to_trix_content_attachment_partial_path
           to_editor_content_attachment_partial_path
         end

--- a/actiontext/lib/action_text/fragment.rb
+++ b/actiontext/lib/action_text/fragment.rb
@@ -51,6 +51,10 @@ module ActionText
       @plain_text ||= PlainTextConversion.node_to_plain_text(source)
     end
 
+    def to_markdown
+      @markdown ||= MarkdownConversion.node_to_markdown(source)
+    end
+
     def to_html
       @html ||= HtmlConversion.node_to_html(source)
     end

--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActionText
+  module MarkdownConversion
+    extend self
+
+    def node_to_markdown(node)
+      BottomUpReducer.new(node).reduce do |n, child_values|
+        markdown_for_node(n, child_values)
+      end.strip
+    end
+
+    private
+      BOLD_TAGS = %w[b strong].freeze
+      ITALIC_TAGS = %w[i em].freeze
+      LIST_BULLET = /\A(-|\d+\.) /
+      LIST_INDENT = "  "
+      PROTOCOL_REGEXP = /\A([a-zA-Z][a-zA-Z\d+\-.]*):/ # RFC 3986 scheme syntax
+      private_constant :BOLD_TAGS, :ITALIC_TAGS, :LIST_BULLET, :LIST_INDENT, :PROTOCOL_REGEXP
+
+      def markdown_for_node(node, child_values)
+        if node.text?
+          if node.content.blank? && !significant_whitespace?(node)
+            ""
+          else
+            node.content
+          end
+        elsif node.element?
+          method_name = :"visit_#{node.name.tr("-", "_")}"
+          if respond_to?(method_name, true)
+            send(method_name, node, child_values)
+          else
+            join_children(child_values).strip
+          end
+        else
+          join_children(child_values)
+        end
+      end
+
+      def visit_strong(node, child_values)
+        inner = join_children(child_values)
+
+        # lexxy redundantly wraps bold subtrees in `<b>`
+        if ancestor_named?(node, BOLD_TAGS, max_depth: 4)
+          inner
+        else
+          [ :bold, inner ]
+        end
+      end
+      alias_method :visit_b, :visit_strong
+
+      def visit_em(node, child_values)
+        inner = join_children(child_values)
+
+        # lexxy redundantly wraps emphasized subtrees in `<i>`
+        if ancestor_named?(node, ITALIC_TAGS, max_depth: 4)
+          inner
+        else
+          [ :italic, inner ]
+        end
+      end
+      alias_method :visit_i, :visit_em
+
+      def visit_s(_node, child_values)
+        "~~#{join_children(child_values)}~~"
+      end
+
+      def visit_code(node, child_values)
+        inner = join_children(child_values)
+        if node.parent&.name == "pre"
+          inner
+        else
+          "`#{inner}`"
+        end
+      end
+
+      def visit_pre(_node, child_values)
+        "```\n#{join_children(child_values).strip}\n```\n\n"
+      end
+
+      def visit_p(_node, child_values)
+        "#{join_children(child_values)}\n\n"
+      end
+
+      def visit__heading(_node, child_values, level)
+        "#{"#" * level} #{join_children(child_values)}\n\n"
+      end
+      def visit_h1(node, child_values) = visit__heading(node, child_values, 1)
+      def visit_h2(node, child_values) = visit__heading(node, child_values, 2)
+      def visit_h3(node, child_values) = visit__heading(node, child_values, 3)
+      def visit_h4(node, child_values) = visit__heading(node, child_values, 4)
+      def visit_h5(node, child_values) = visit__heading(node, child_values, 5)
+      def visit_h6(node, child_values) = visit__heading(node, child_values, 6)
+
+      def visit_blockquote(_node, child_values)
+        quoted = join_children(child_values).strip.lines.map { |line| "> #{line}" }.join
+        "#{quoted}\n\n"
+      end
+
+      def visit_ul(node, child_values)
+        items = list_item_lines(node, child_values, prefix: "- ")
+        "#{items}\n\n"
+      end
+
+      def visit_ol(node, child_values)
+        items = list_item_lines(node, child_values, prefix: ->(i) { "#{i + 1}. " })
+        "#{items}\n\n"
+      end
+
+      def visit_a(node, child_values)
+        inner = join_children(child_values)
+        if (href = node["href"]) && allowed_href_protocol?(href)
+          "[#{inner}](#{href})"
+        else
+          inner
+        end
+      end
+
+      def visit_tr(node, child_values)
+        # lexxy does not emit `thead`, so we need to infer header rows from `tr` contents
+        if node.element_children.all? { |cell| cell.name == "th" }
+          visit__table_header_row(node, child_values)
+        else
+          cells = child_values_for_elements(node, child_values).map { |v| stringify(v).strip }
+          "| #{cells.join(" | ")} |\n"
+        end
+      end
+
+      def visit_summary(_node, child_values)
+        "**#{join_children(child_values)}**\n\n"
+      end
+
+      def visit_br(_node, _child_values)
+        "\n"
+      end
+
+      def visit_hr(_node, _child_values)
+        "---\n\n"
+      end
+
+      # Avoid including content from elements that aren't meaningful for markdown output
+      def visit__unsupported(_node, _child_values)
+        ""
+      end
+      alias_method :visit_script, :visit__unsupported
+      alias_method :visit_style, :visit__unsupported
+
+      # These elements pass through their content (parent handlers use child_values directly)
+      def visit__passthrough(_node, child_values)
+        join_children(child_values)
+      end
+      alias_method :visit_li, :visit__passthrough
+      alias_method :visit_td, :visit__passthrough
+      alias_method :visit_th, :visit__passthrough
+      alias_method :visit_thead, :visit__passthrough
+      alias_method :visit_tbody, :visit__passthrough
+
+      def visit__table_header_row(node, child_values)
+        cells = child_values_for_elements(node, child_values).map { |v| stringify(v).strip }
+        row = "| #{cells.join(" | ")} |\n"
+        separator = "| #{Array.new(cells.size, "---").join(" | ")} |\n"
+        "#{row}#{separator}"
+      end
+
+      def allowed_href_protocol?(href)
+        if (match = href.match(PROTOCOL_REGEXP))
+          match[1].downcase.in?(Loofah::HTML5::SafeList::ALLOWED_PROTOCOLS)
+        else
+          true # relative URL, no protocol
+        end
+      end
+
+      def list_item_lines(list_node, child_values, prefix:)
+        element_values = child_values_for_elements(list_node, child_values)
+        element_values.each_with_index.filter_map do |value, index|
+          text = stringify(value)
+          lines = text.split("\n").reject(&:blank?)
+          next if lines.empty?
+
+          bullet = prefix.respond_to?(:call) ? prefix.call(index) : prefix
+          format_list_item(lines, bullet)
+        end.join("\n")
+      end
+
+      def format_list_item(lines, bullet)
+        first, *rest = lines
+        leader = first.match?(LIST_BULLET) ? LIST_INDENT : bullet
+        ([ leader + first ] + rest.map { |line| LIST_INDENT + line }).join("\n")
+      end
+
+      def join_children(child_values)
+        merged = []
+
+        child_values.each do |value|
+          # Merge adjacent bold/italic runs which Lexxy emits
+          if value.is_a?(Array) && (value[0] == :bold || value[0] == :italic)
+            if merged.last.is_a?(Array) && merged.last[0] == value[0]
+              merged.last[1] = merged.last[1] + value[1]
+            else
+              merged << [ value[0], value[1] ]
+            end
+          else
+            merged << value
+          end
+        end
+
+        parts = merged.map { |v| stringify(v) }
+        result = +""
+        parts.each do |part|
+          # Nested block elements (e.g., lists and blockquotes) need an initial newline injected
+          if !result.empty? && !result.end_with?("\n") && part.end_with?("\n\n")
+            result << "\n"
+          end
+          result << part
+        end
+        result
+      end
+
+      def child_values_for_elements(node, child_values)
+        node.children.zip(child_values).filter_map do |child, value|
+          value if child.element?
+        end
+      end
+
+      def stringify(value)
+        case value
+        when Array
+          case value[0]
+          when :bold then wrap_emphasis(value[1], "**")
+          when :italic then wrap_emphasis(value[1], "*")
+          else value.join
+          end
+        else
+          value.to_s
+        end
+      end
+
+      # Make sure `<strong> hello </strong>` becomes ` **hello** ` and not `** hello **`
+      # (the latter is not valid markdown).
+      def wrap_emphasis(text, marker)
+        leading = text[/\A\s*/]
+        trailing = text[/\s*\z/]
+        inner = text.strip
+        "#{leading}#{marker}#{inner}#{marker}#{trailing}"
+      end
+
+      def significant_whitespace?(node)
+        node.previous_sibling&.text? && node.next_sibling&.text?
+      end
+
+      def ancestor_named?(node, names, max_depth:)
+        current = node.parent
+        max_depth.times do
+          break unless current&.element?
+          return true if current.name.in?(names)
+          current = current.parent
+        end
+        false
+      end
+  end
+end

--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -122,33 +122,5 @@ module ActionText
           text
         end
       end
-
-      class BottomUpReducer # :nodoc:
-        def initialize(node)
-          @node = node
-          @values = {}
-        end
-
-        def reduce(&block)
-          traverse_bottom_up(@node) do |n|
-            child_values = @values.values_at(*n.children)
-            @values[n] = block.call(n, child_values)
-          end
-          @values[@node]
-        end
-
-        private
-          def traverse_bottom_up(node, &block)
-            call_stack, processing_stack = [ node ], []
-
-            until call_stack.empty?
-              node = call_stack.pop
-              processing_stack.push(node)
-              call_stack.concat node.children
-            end
-
-            processing_stack.reverse_each(&block)
-          end
-      end
   end
 end

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -1,0 +1,409 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
+  test "plain text passes through unchanged" do
+    assert_converted_to(
+      "hello world",
+      "hello world"
+    )
+  end
+
+  test "<strong> tags are converted to bold" do
+    assert_converted_to("**hello**", "<strong>hello</strong>")
+  end
+
+  test "<b> tags are converted to bold" do
+    assert_converted_to("**hello**", "<b>hello</b>")
+  end
+
+  test "<em> tags are converted to italic" do
+    assert_converted_to("*hello*", "<em>hello</em>")
+  end
+
+  test "<i> tags are converted to italic" do
+    assert_converted_to("*hello*", "<i>hello</i>")
+  end
+
+  test "<s> tags are converted to strikethrough" do
+    assert_converted_to("~~hello~~", "<s>hello</s>")
+  end
+
+  test "<code> tags are converted to inline code" do
+    assert_converted_to("`hello`", "<code>hello</code>")
+  end
+
+  test "nested <strong> and <em> tags produce bold italic" do
+    assert_converted_to("***hello***", "<strong><em>hello</em></strong>")
+  end
+
+  test "redundant nested <b> and <strong> tags do not double-bold" do
+    assert_converted_to("**hello**", "<b><strong>hello</strong></b>")
+  end
+
+  test "<strong> with inner whitespace moves spaces outside markers" do
+    assert_converted_to("a **hello** b", "<p>a<strong> hello </strong>b</p>")
+  end
+
+  test "<em> with inner whitespace moves spaces outside markers" do
+    assert_converted_to("a *hello* b", "<p>a<em> hello </em>b</p>")
+  end
+
+  test "<b> wrapping <code> wrapping <strong> collapses to bold code" do
+    assert_converted_to("**`asdf`**", "<b><code><strong>asdf</strong></code></b>")
+  end
+
+  test "adjacent <b> spans are merged" do
+    assert_converted_to(
+      "aaa **`bb` or `cc`** ddd",
+      "<p>aaa <b><code><strong>bb</strong></code></b><b><strong> or </strong></b><b><code><strong>cc</strong></code></b> ddd</p>"
+    )
+  end
+
+  test "adjacent <i> spans are merged" do
+    assert_converted_to(
+      "*`foo` and `bar`*",
+      "<p><i><code><em>foo</em></code></i><i><em> and </em></i><i><code><em>bar</em></code></i></p>"
+    )
+  end
+
+  test "adjacent bold+italic spans are merged" do
+    assert_converted_to(
+      "***`foo`** **and** **`bar`***",
+      "<p><i><b><code><strong>foo</strong></code></b></i><i><b><strong> and </strong></b></i><i><b><code><strong>bar</strong></code></b></i></p>"
+    )
+  end
+
+  test "<p> tags are separated by two new lines" do
+    assert_converted_to(
+      "hello\n\nworld",
+      "<p>hello</p><p>world</p>"
+    )
+  end
+
+  test "<h1> through <h6> tags are converted to heading markers" do
+    assert_converted_to("# hello", "<h1>hello</h1>")
+    assert_converted_to("## hello", "<h2>hello</h2>")
+    assert_converted_to("### hello", "<h3>hello</h3>")
+    assert_converted_to("#### hello", "<h4>hello</h4>")
+    assert_converted_to("##### hello", "<h5>hello</h5>")
+    assert_converted_to("###### hello", "<h6>hello</h6>")
+  end
+
+  test "<blockquote> tags are converted to quoted lines" do
+    assert_converted_to("> hello", "<blockquote>hello</blockquote>")
+  end
+
+  test "<blockquote> with multiple lines prefixes each line" do
+    assert_converted_to(
+      "> line1\n> line2",
+      "<blockquote>line1\nline2</blockquote>"
+    )
+  end
+
+  test "nested <blockquote> tags produce nested quotes" do
+    assert_converted_to(
+      "> this is a quote\n> > of a quote",
+      "<blockquote>this is a quote<blockquote>of a quote</blockquote></blockquote>"
+    )
+  end
+
+  test "<br> tags are converted to newlines" do
+    assert_converted_to("hello\nworld", "hello<br>world")
+  end
+
+  test "<hr> tags are converted to thematic breaks" do
+    assert_converted_to("---", "<hr>")
+  end
+
+  test "<pre> tags are converted to fenced code blocks" do
+    assert_converted_to("```\nhello\n```", "<pre>hello</pre>")
+  end
+
+  test "<pre> with nested <code> tag is converted to fenced code block" do
+    assert_converted_to("```\nhello\n```", "<pre><code>hello</code></pre>")
+  end
+
+  test "<pre> followed by <p> has blank line separator" do
+    assert_converted_to(
+      "```\nhello\n```\n\nworld",
+      "<pre>hello</pre><p>world</p>"
+    )
+  end
+
+  test "<ul> tags are converted to unordered lists" do
+    assert_converted_to(
+      "before\n\n- one\n- two\n- three\n\nafter",
+      "<p>before</p><ul><li>one</li><li>two</li><li>three</li></ul><p>after</p>"
+    )
+  end
+
+  test "<ol> tags are converted to ordered lists" do
+    assert_converted_to(
+      "before\n\n1. one\n2. two\n3. three\n\nafter",
+      "<p>before</p><ol><li>one</li><li>two</li><li>three</li></ol><p>after</p>"
+    )
+  end
+
+  test "empty <li> tags are skipped" do
+    assert_converted_to(
+      "before\n\n- real\n\nafter",
+      "<p>before</p><ul><li></li><li>real</li></ul><p>after</p>"
+    )
+  end
+
+  test "nested <ul> tags are indented" do
+    assert_converted_to(
+      "- one\n  - nested\n- two",
+      "<ul><li>one<ul><li>nested</li></ul></li><li>two</li></ul>"
+    )
+  end
+
+  test "nested <ul> where sublist is in its own <li>" do
+    assert_converted_to(
+      "- top 1\n- top 2\n  - nested 1\n  - nested 2",
+      <<~HTML
+        <ul>
+          <li>top 1</li>
+          <li>top 2</li>
+          <li>
+            <ul>
+              <li>nested 1</li>
+              <li>nested 2</li>
+            </ul>
+          </li>
+        </ul>
+      HTML
+    )
+  end
+
+  test "<ul> followed by <p> has blank line separator" do
+    assert_converted_to(
+      "- Item 1\n  - Subitem\n- Item 2\n\nParagraph",
+      <<~HTML
+        <ul>
+          <li>Item 1</li>
+          <li>
+            <ul>
+              <li>Subitem</li>
+            </ul>
+          </li>
+          <li>Item 2</li>
+        </ul>
+        <p>Paragraph</p>
+      HTML
+    )
+  end
+
+  test "<a> tags are converted to links" do
+    assert_converted_to(
+      "[click here](https://example.com)",
+      '<a href="https://example.com">click here</a>'
+    )
+  end
+
+  test "<a> tags with formatting inside" do
+    assert_converted_to(
+      "[**bold link**](https://example.com)",
+      '<a href="https://example.com"><strong>bold link</strong></a>'
+    )
+  end
+
+  test "<a> tags without href pass through content" do
+    assert_converted_to("**click here**", "<a><strong>click here</strong></a>")
+  end
+
+  test "<a> tags with mailto: href are converted to links" do
+    assert_converted_to("[email](mailto:test@example.com)", '<a href="mailto:test@example.com">email</a>')
+  end
+
+  test "<a> tags with tel: href are converted to links" do
+    assert_converted_to("[call](tel:+1234567890)", '<a href="tel:+1234567890">call</a>')
+  end
+
+  test "<a> tags with relative href are converted to links" do
+    assert_converted_to("[page](/about)", '<a href="/about">page</a>')
+  end
+
+  test "<a> tags with relative href containing colons are converted to links" do
+    assert_converted_to("[notes](/docs/v1:notes)", '<a href="/docs/v1:notes">notes</a>')
+  end
+
+  test "<a> tags with javascript: href pass through content without link" do
+    assert_converted_to("click here", '<a href="javascript:alert(1)">click here</a>')
+  end
+
+  test "<table> with <thead> is converted to markdown table" do
+    assert_converted_to(
+      "| Name | Age |\n| --- | --- |\n| Alice | 30 |",
+      <<~HTML
+        <table>
+          <thead><tr><th>Name</th><th>Age</th></tr></thead>
+          <tbody><tr><td>Alice</td><td>30</td></tr></tbody>
+        </table>
+      HTML
+    )
+  end
+
+  test "<table> cells with formatting" do
+    assert_converted_to(
+      "| **bold** | *italic* |",
+      "<table><tr><td><strong>bold</strong></td><td><em>italic</em></td></tr></table>"
+    )
+  end
+
+  test "<table> without <thead>" do
+    assert_converted_to(
+      "| a | b |\n| c | d |",
+      "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"
+    )
+  end
+
+  test "<table> with <th> headers in <tbody>" do
+    assert_converted_to(
+      "| a | b | c |\n| --- | --- | --- |\n| 1 | asdf | asdf |\n| 2 | asdf | asdf |",
+      "<table><tbody><tr><th><p>a</p></th><th><p>b</p></th><th><p>c</p></th></tr><tr><th><p>1</p></th><td><p>asdf</p></td><td><p>asdf</p></td></tr><tr><th><p>2</p></th><td><p>asdf</p></td><td><p>asdf</p></td></tr></tbody></table>"
+    )
+  end
+
+  test "<details> and <summary> are converted" do
+    assert_converted_to(
+      "**Click to expand**\n\nHidden content",
+      "<details><summary>Click to expand</summary>Hidden content</details>"
+    )
+  end
+
+  test "empty content" do
+    assert_converted_to("", "")
+  end
+
+  test "leading and trailing whitespace is stripped" do
+    assert_converted_to("hello", "<p>  hello  </p>")
+  end
+
+  test "HTML entities are decoded" do
+    assert_converted_to(
+      "asdf < asdf & asdf > asdf",
+      "<p>asdf &lt; asdf &amp; asdf &gt; asdf</p>"
+    )
+  end
+
+  test "unknown elements pass through their content" do
+    assert_converted_to("hello", "<asdf>hello</asdf>")
+  end
+
+  test "<div> passes through content" do
+    assert_converted_to("hello", "<div>  hello  </div>")
+  end
+
+  test "<span> passes through content" do
+    assert_converted_to("hello", "<span>  hello  </span>")
+  end
+
+  test "<script> tags are ignored" do
+    assert_converted_to(
+      "hello",
+      <<~HTML
+        <script type="javascript">
+          console.log("message");
+        </script>
+        <div>hello</div>
+      HTML
+    )
+  end
+
+  test "<style> tags are ignored" do
+    assert_converted_to(
+      "hello",
+      <<~HTML
+        <style type="text/css">
+          body { color: red; }
+        </style>
+        <div>hello</div>
+      HTML
+    )
+  end
+
+  test "image attachment with caption is converted to markdown image" do
+    assert_converted_to(
+      "![A photo](https://example.com/photo.png)",
+      '<action-text-attachment content-type="image/png" url="https://example.com/photo.png" caption="A photo"></action-text-attachment>'
+    )
+  end
+
+  test "image attachment without caption falls back to Image alt text" do
+    assert_converted_to(
+      "![Image](https://example.com/photo.jpg)",
+      '<action-text-attachment content-type="image/jpeg" url="https://example.com/photo.jpg" filename="photo.jpg"></action-text-attachment>'
+    )
+  end
+
+  test "content attachment HTML is converted to markdown" do
+    assert_converted_to(
+      "**hello**",
+      '<action-text-attachment content-type="text/html" content="<strong>hello</strong>"></action-text-attachment>'
+    )
+
+    assert_converted_to(
+      "**hello**",
+      '<action-text-attachment content-type="text/html" content="&lt;strong&gt;hello&lt;/strong&gt;"></action-text-attachment>'
+    )
+  end
+
+  test "attachment with surrounding text" do
+    assert_converted_to(
+      "Hello world! ![Cat](http://example.com/cat.jpg)",
+      'Hello world! <action-text-attachment url="http://example.com/cat.jpg" content-type="image/jpeg" caption="Cat"></action-text-attachment>'
+    )
+  end
+
+  test "ActiveStorage blob attachment is converted to markdown with caption" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+    assert_equal "[Captioned]", ActionText::Content.new(html).to_markdown
+  end
+
+  test "ActiveStorage blob attachment without caption uses filename" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
+    assert_equal "[racecar.jpg]", ActionText::Content.new(html).to_markdown
+  end
+
+  test "missing attachable is converted to ☒" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
+    blob.destroy!
+    assert_equal "☒", ActionText::Content.new(html).to_markdown
+  end
+
+  test "RichText#to_markdown" do
+    assert_equal "**hello**", ActionText::RichText.new(body: "<p><strong>hello</strong></p>").to_markdown
+  end
+
+  test "RichText#to_markdown handles blank body" do
+    assert_equal "", ActionText::RichText.new(body: "").to_markdown
+  end
+
+  test "RichText#to_markdown handles nil body" do
+    assert_equal "", ActionText::RichText.new(body: nil).to_markdown
+  end
+
+  test "multiple attachments separated by whitespace preserve the whitespace" do
+    assert_converted_to(
+      "![A](https://example.com/a.jpg) ![B](https://example.com/b.jpg)",
+      '<action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment> <action-text-attachment content-type="image/jpeg" url="https://example.com/b.jpg" caption="B"></action-text-attachment>'
+    )
+  end
+
+
+  test "Fragment#to_markdown memoizes the result" do
+    fragment = ActionText::Fragment.from_html("<p><strong>hello</strong></p>")
+    assert_same fragment.to_markdown, fragment.to_markdown
+  end
+
+  private
+    def assert_converted_to(expected_markdown, html)
+      assert_equal expected_markdown, ActionText::Content.new(html).to_markdown
+    end
+end


### PR DESCRIPTION
### Motivation / Background

Today, Rails supports two formats for "exporting" rich text content:

- HTML
- Plain text

HTML is very verbose, and not always handled well (or cheaply) by LLM agents. Plain text format is
pretty good for both human and agent consumption, but loses some of the nuance and formatting of the
original (for example: headers, strong, italic, strikethrough).

This pull request was created to allow rich text to be exported as Markdown, keeping as much of the
formatting intact as possible.

### Detail

Introduce markdown conversion across the Action Text stack:

- `Content#to_markdown` renders attachments then converts the fragment
- `Fragment#to_markdown` delegates to the new `MarkdownConversion` module
- `RichText#to_markdown` delegates through `Content`
- `Attachment#to_markdown` delegates to `attachable_markdown_representation`

All attachable types implement `attachable_markdown_representation`:

- `RemoteImage` renders `![caption](url)`
- `ContentAttachment` converts its embedded HTML to markdown
- `ActiveStorage::Blob` renders `[caption || filename]`
- `MissingAttachable` renders `☒` (see related #56854)

`MarkdownConversion` is a bottom-up tree reducer (like `PlainTextConversion`) that converts HTML nodes to Markdown. It handles inline formatting (bold, italic, strikethrough, code), block elements (paragraphs, headings, blockquotes, code blocks, horizontal rules), lists (ordered, unordered, nested), links, tables, and details/summary. This implementation was manually tested against the markup generated by both Trix and Lexxy.

This commit also promotes the `BottomUpReducer` tree-walking class from `ActionText::PlainTextConversion` into its own file as `ActionText::BottomUpReducer` for use by both conversion modules.

### Additional information

Security note: Markdown links are checked against Loofah's allowed URI protocols to prevent unsafe schemes like `javascript:` from appearing in the output.

Performance note: This implementation benchmarks ~35% faster than `to_plain_text` on my development machine for a ~42k HTML document generated by cmark-gfm from a real-world markdown file (but I'll note it's likely that a little effort can bring plain text conversion in line with the markdown performance, should someone choose to work on i).

```
\#!/usr/bin/env ruby

require "bundler/inline"
gemfile do
  source "https://rubygems.org"
  gem "benchmark-ips"
end

require_relative "../config/environment"

html = `cmark-gfm --to html #{File.expand_path("~/code/github.com/basecamp/activerecord-tenanted/GUIDE.md")}`

puts "HTML: #{html.bytesize} bytes, #{html.lines.count} lines"

html_doc = Nokogiri::HTML5.fragment(html)

Benchmark.ips do |x|
  x.report("to_markdown") { ActionText::MarkdownConversion.node_to_markdown(html_doc) }
  x.report("to_plain_text") { ActionText::PlainTextConversion.node_to_plain_text(html_doc) }
  x.compare!
end
```

```
HTML: 42282 bytes, 932 lines
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [x86_64-linux]
Warming up --------------------------------------
         to_markdown     7.000 i/100ms
       to_plain_text     4.000 i/100ms
Calculating -------------------------------------
         to_markdown     70.931 (± 7.0%) i/s   (14.10 ms/i) -    357.000 in   5.066019s
       to_plain_text     51.811 (± 5.8%) i/s   (19.30 ms/i) -    260.000 in   5.033790s

Comparison:
         to_markdown:       70.9 i/s
       to_plain_text:       51.8 i/s - 1.37x  slower

```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
