### PR TITLE
Distinguish between Pending Migrations and Uninitialized Databases and suggest db:prepare instead

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Raise new `ActiveRecord::UninitializedDatabaseError` with a "Prepare database"
+    action (runs `bin/rails db:prepare`) when migration files exist but the database
+    has never been initialized, instead of `PendingMigrationError`.
+
+    *Ben Sheldon*
+
 *   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
 
     This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -183,6 +183,25 @@ module ActiveRecord
       end
   end
 
+  class UninitializedDatabaseError < MigrationError # :nodoc:
+    include ActiveSupport::ActionableError
+
+    action "Prepare database" do
+      ActiveRecord::Tasks::DatabaseTasks.prepare_all
+    end
+
+    def initialize(message = nil)
+      super(message || default_message)
+    end
+
+    private
+      def default_message
+        message = "Database is uninitialized. To resolve this issue, run:\n\n        bin/rails db:prepare"
+        message += " RAILS_ENV=#{::Rails.env}" if defined?(Rails.env) && !Rails.env.local?
+        message
+      end
+  end
+
   class ConcurrentMigrationError < MigrationError # :nodoc:
     DEFAULT_MESSAGE = "Cannot run migrations because another migration process is currently running."
     RELEASE_LOCK_FAILED_MESSAGE = "Failed to release advisory lock"
@@ -688,12 +707,15 @@ module ActiveRecord
         delegate || superclass.nearest_delegate
       end
 
-      # Raises ActiveRecord::PendingMigrationError error if any migrations are pending
+      # Raises ActiveRecord::UninitializedDatabaseError if any database has not been initialized,
+      # or ActiveRecord::PendingMigrationError if any migrations are pending,
       # for all database configurations in an environment.
       def check_all_pending!
         pending_migrations = []
 
         ActiveRecord::Tasks::DatabaseTasks.with_temporary_pool_for_each(env: env) do |pool|
+          raise_if_uninitialized(pool)
+
           if pending = pool.migration_context.open.pending_migrations
             pending_migrations << pending
           end
@@ -757,6 +779,12 @@ module ActiveRecord
       end
 
       def check_pending_migrations(migrations = nil) # :nodoc:
+        ActiveRecord::Base.configurations.configs_for(env_name: env).each do |db_config|
+          ActiveRecord::PendingMigrationConnection.with_temporary_pool(db_config) do |pool|
+            raise_if_uninitialized(pool)
+          end
+        end
+
         migrations ||= pending_migrations
 
         if migrations.any?
@@ -765,6 +793,15 @@ module ActiveRecord
       end
 
       private
+
+        def raise_if_uninitialized(pool)
+          return if pool.schema_migration.table_exists?
+          migration_paths = Array(pool.db_config.migrations_paths || Migrator.migrations_paths)
+          if migration_paths.any? { |path| Dir["#{path}/**/[0-9]*_*.rb"].any? }
+            raise ActiveRecord::UninitializedDatabaseError
+          end
+        end
+
         def schema_needs_update?(db_config, pool)
           !Tasks::DatabaseTasks.schema_up_to_date?(db_config, pool: pool)
         end

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -39,9 +39,16 @@ module ActiveRecord
           RUBY
         end
 
+        def test_errors_if_uninitialized
+          create_migration "01", "create_foo"
+          assert_uninitialized_database
+        end
+
         def test_errors_if_pending
           create_migration "01", "create_foo"
-          assert_pending_migrations("01_create_foo.rb")
+          quietly { run_migrations }
+          create_migration "02", "create_bar"
+          assert_pending_migrations("02_create_bar.rb")
         end
 
         def test_checks_if_supported
@@ -65,10 +72,17 @@ module ActiveRecord
           assert_pending_migrations("01_create_foo.rb")
         end
 
-        def test_with_multiple_database
+        def test_with_multiple_database_uninitialized
           create_migration "01", "create_bar", database: :primary
           create_migration "02", "create_foo", database: :secondary
-          assert_pending_migrations("01_create_bar.rb", "02_create_foo.rb")
+          assert_uninitialized_database
+        end
+
+        def test_with_multiple_database_pending
+          create_migration "01", "create_bar", database: :primary
+          create_migration "02", "create_foo", database: :secondary
+
+          assert_uninitialized_database
 
           ActiveRecord::Base.establish_connection(:secondary)
           quietly { run_migrations }
@@ -77,6 +91,10 @@ module ActiveRecord
           quietly { run_migrations }
 
           assert_no_pending_migrations
+
+          create_migration "03", "create_baz", database: :primary
+          create_migration "04", "create_qux", database: :primary
+          assert_pending_migrations("03_create_baz.rb", "04_create_qux.rb")
         end
 
         def test_with_stdlib_logger
@@ -87,6 +105,18 @@ module ActiveRecord
         end
 
         private
+          def assert_uninitialized_database
+            2.times do
+              assert_raises ActiveRecord::UninitializedDatabaseError do
+                ActiveRecord::Migration.check_all_pending!
+              end
+
+              assert_raises ActiveRecord::UninitializedDatabaseError do
+                CheckPending.new(proc { flunk }).call({})
+              end
+            end
+          end
+
           def assert_pending_migrations(*expected_migrations)
             2.times do
               assert_raises ActiveRecord::PendingMigrationError do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because when cloning a pre-existing Rails project, the interactive prompts suggestion:

1. Creating a new database (`db:create`)
2. Running all migrations (`db:migrate`)

For a large and longtime Rails project, this may be hundreds or thousands of migrations.

Ideally, instead of running all of the migrations, the schema should be loaded instead. All of the logic for that already lives within `db:prepare` so this PR inserts that suggestion instead.

### Detail

This Pull Request adds new logic to distinguish between a newly created database _that has no migrations table at all_ and a database that has been initialized and has pending migrations. It introduces a new error, `UninitializedDatabaseError`, to identify this situation.

**Alternatively** it would be simpler to have the existing errors, `PendingMigrationError` and `NoDatabaseError` to simply suggest running `db:prepare` rather than the more precise `db:create` and `db:migrate`. That felt like a more momentous change, even if it would be a much simpler implementation and better reflect `db:prepare` being a very smart command. I'd be happy to do that instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
