### PR TITLE
Fix deprecation of sidekiq/testing/inline

### DIFF
--- a/activejob/test/adapters/sidekiq.rb
+++ b/activejob/test/adapters/sidekiq.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
-require "sidekiq/testing/inline"
+require "sidekiq"
+if Sidekiq.respond_to? :testing! # 8.1.1
+  Sidekiq.testing!(:inline)
+else
+  require "sidekiq/testing/inline"
+end
 ActiveJob::Base.queue_adapter = :sidekiq


### PR DESCRIPTION
This worked before 8.1.1 because inline previously required
sidekiq/testing which required sidekiq. That require was removed with
the addition of the deprecation so we now need to do it manually.