### PR TITLE
ActiveSupport::ExecutionContext: Fix nil execution context after pop while nestable

### DIFF
--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -20,7 +20,7 @@ module ActiveSupport
 
       def pop
         @current_attributes_instances = @stack.pop
-        @store = @stack.pop
+        @store = @stack.pop || {}
         self
       end
     end

--- a/activesupport/test/execution_context_test.rb
+++ b/activesupport/test/execution_context_test.rb
@@ -44,4 +44,21 @@ class ExecutionContextTest < ActiveSupport::TestCase
     context[:foo] = 43
     assert_equal 42, ActiveSupport::ExecutionContext.to_h[:foo]
   end
+
+  test "#pop clears the stack" do
+    ActiveSupport::ExecutionContext[:foo] = 42
+    ActiveSupport::ExecutionContext.pop
+
+    assert_equal 0, ActiveSupport::ExecutionContext.to_h.size
+  end
+
+  test "#pop when nestable clears the stack" do
+    ActiveSupport::ExecutionContext.nestable = true
+    ActiveSupport::ExecutionContext[:bar] = 42
+    ActiveSupport::ExecutionContext.pop
+
+    assert_equal 0, ActiveSupport::ExecutionContext.to_h.size
+  ensure
+    ActiveSupport::ExecutionContext.nestable = false # reset
+  end
 end


### PR DESCRIPTION
### Motivation / Background

When `ActiveSupport::ExecutionContext.nestable` is set to true, calling `pop` can result in `ActiveSupport::ExecutionContext.to_h` returning `nil` instead of an empty hash. This is reproducable in a rails application by running:

```ruby
ActiveSupport::ExecutionContext.to_h # => {}
reload!
ActiveSupport::ExecutionContext.to_h # nil
```

### Detail

I believe this is occurring because `ActiveSupport::ExecutionContext.to_h@stack` is empty and so the call to `@stack.pop` returns `nil`, so we can set a default value in that case

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
