### PR TITLE
Preserve SQLite3 triggers across alter_table operations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Preserve triggers on SQLite3 tables during `alter_table` operations.
+
+    Previously, schema migration operations that internally recreate the table (e.g.,
+    `remove_column`, `change_column`, `add_column` with `null: false`) would silently
+    drop all triggers defined on that table. Foreign keys and check constraints were
+    already preserved, but triggers were not.
+
+    Fixes #56810.
+
+    *hammadxcm*
+
 *   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
 
     This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -118,6 +118,20 @@ module ActiveRecord
         end
 
         private
+          # Returns an array of CREATE TRIGGER SQL statements defined on +table_name+.
+          # Used by +alter_table+ to preserve triggers across table recreation.
+          def trigger_definitions(table_name)
+            query_values(<<~SQL)
+              SELECT sql
+              FROM sqlite_master
+              WHERE type = 'trigger' AND tbl_name = #{quote(table_name)}
+              UNION ALL
+              SELECT sql
+              FROM sqlite_temp_master
+              WHERE type = 'trigger' AND tbl_name = #{quote(table_name)}
+            SQL
+          end
+
           def valid_table_definition_options
             super + [:rename]
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -620,6 +620,7 @@ module ActiveRecord
           **options
         )
           altered_table_name = "a#{table_name}"
+          triggers = trigger_definitions(table_name)
 
           caller = lambda do |definition|
             rename = options[:rename] || {}
@@ -642,6 +643,10 @@ module ActiveRecord
             transaction do
               move_table(table_name, altered_table_name, options.merge(temporary: true))
               move_table(altered_table_name, table_name, &caller)
+
+              triggers.each do |trigger_sql|
+                execute(trigger_sql)
+              end
             end
           end
         end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -1323,6 +1323,72 @@ module ActiveRecord
         conn.disconnect! if conn
       end
 
+      def test_alter_table_preserves_triggers
+        conn = SQLite3Adapter.new(database: ":memory:", adapter: "sqlite3", strict: false)
+
+        conn.create_table :posts do |t|
+          t.string :title, null: false
+          t.string :subtitle
+          t.integer :view_count, default: 0
+        end
+
+        conn.execute(<<~SQL)
+          CREATE TRIGGER increment_view_count AFTER INSERT ON posts
+          BEGIN
+            UPDATE posts SET view_count = view_count + 1 WHERE id = NEW.id;
+          END
+        SQL
+
+        assert_equal 1, conn.select_value(
+          "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'posts'"
+        )
+
+        conn.remove_column :posts, :subtitle
+
+        assert_equal 1, conn.select_value(
+          "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'posts'"
+        ), "Trigger should survive ALTER TABLE via remove_column"
+
+        conn.execute("INSERT INTO posts (id, title) VALUES (1, 'Hello')")
+        assert_equal 1, conn.select_value("SELECT view_count FROM posts WHERE id = 1"),
+          "Trigger should still function after ALTER TABLE"
+      ensure
+        conn.disconnect! if conn
+      end
+
+      def test_alter_table_preserves_multiple_triggers
+        conn = SQLite3Adapter.new(database: ":memory:", adapter: "sqlite3", strict: false)
+
+        conn.create_table :posts do |t|
+          t.string :title, null: false
+          t.string :subtitle
+          t.integer :view_count, default: 0
+          t.integer :edit_count, default: 0
+        end
+
+        conn.execute(<<~SQL)
+          CREATE TRIGGER increment_view_count AFTER INSERT ON posts
+          BEGIN
+            UPDATE posts SET view_count = view_count + 1 WHERE id = NEW.id;
+          END
+        SQL
+
+        conn.execute(<<~SQL)
+          CREATE TRIGGER increment_edit_count AFTER UPDATE OF title ON posts
+          BEGIN
+            UPDATE posts SET edit_count = edit_count + 1 WHERE id = NEW.id;
+          END
+        SQL
+
+        conn.remove_column :posts, :subtitle
+
+        assert_equal 2, conn.select_value(
+          "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'posts'"
+        ), "All triggers should survive ALTER TABLE"
+      ensure
+        conn.disconnect! if conn
+      end
+
       def test_rename_table_with_cascade_fk_preserves_referencing_data
         conn = SQLite3Adapter.new(database: ":memory:", adapter: "sqlite3", strict: false)
 


### PR DESCRIPTION
## Summary

- The SQLite3 adapter recreates tables for operations like `remove_column`, `change_column`, and `add_column` with `null: false`. Foreign keys and check constraints were already preserved during this process, but **triggers were silently dropped**.
- Added a private `trigger_definitions` method that reads `CREATE TRIGGER` SQL from `sqlite_master` before table recreation, and re-executes them after the new table is in place — following the same pattern used for foreign keys and check constraints.

Fixes #56810.

## Test plan

- [x] Added `test_alter_table_preserves_triggers` — verifies a single trigger survives `remove_column` and still functions (fires on INSERT)
- [x] Added `test_alter_table_preserves_multiple_triggers` — verifies multiple triggers survive `remove_column`
- [x] Full SQLite3 adapter test suite passes (9372 runs, 0 failures, 0 errors)