### PR TITLE
Fix Ruby 4.0 delegator warning for inspect on DelegateClass subclasses

### DIFF
--- a/activemodel/lib/active_model/attributes/normalization.rb
+++ b/activemodel/lib/active_model/attributes/normalization.rb
@@ -183,6 +183,11 @@ module ActiveModel
           define_method(:inspect, Kernel.instance_method(:inspect))
 
           private
+            # Prevent Ruby 4.0 "delegator does not forward private method" warning.
+            # Kernel#inspect calls instance_variables_to_inspect which, without this,
+            # triggers Delegator#respond_to_missing? for a private method.
+            define_method(:instance_variables_to_inspect, Kernel.instance_method(:instance_variables))
+
             def normalize(value)
               normalizer.call(value) unless value.nil? && !normalize_nil?
             end

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -65,6 +65,11 @@ module ActiveRecord
       end
 
       private
+        # Prevent Ruby 4.0 "delegator does not forward private method" warning.
+        # Kernel#inspect calls instance_variables_to_inspect which, without this,
+        # triggers Delegator#respond_to_missing? for a private method.
+        define_method(:instance_variables_to_inspect, Kernel.instance_method(:instance_variables))
+
         def default_value?(value)
           value == coder.load(nil)
         end


### PR DESCRIPTION
## Motivation

Fixes #56756.

Ruby 4.0 introduced a private `Kernel#instance_variables_to_inspect` method that `Kernel#inspect` calls internally via `respond_to?(:instance_variables_to_inspect, true)`.

Two Rails classes override `inspect` on a `DelegateClass` subclass using `define_method(:inspect, Kernel.instance_method(:inspect))`:

- `ActiveModel::Attributes::Normalization::NormalizedValueType`
- `ActiveRecord::Type::Serialized`

When `Kernel#inspect` runs on these delegators, the `respond_to?` call for `instance_variables_to_inspect` with `include_private: true` falls through to `Delegator#respond_to_missing?` ([source](https://github.com/ruby/delegate/blob/f10dbc0f92c73fbc30bffaa93d4274b3e39497d2/lib/delegate.rb#L105)), which detects it is private on the wrapped object and emits:

```
warning: delegator does not forward private method #instance_variables_to_inspect
```

## Solution

Define a private `instance_variables_to_inspect` on both affected classes, bound to `Kernel#instance_variables`. This resolves the method directly on the delegator without entering the delegation chain, preventing the warning.

The method is bound to `Kernel#instance_variables` (rather than forwarding to the wrapped object) because the intent of `define_method(:inspect, Kernel.instance_method(:inspect))` is to inspect the **delegator itself**, not the wrapped object. Returning the delegator's own instance variables is consistent with that intent.

This is safe on Ruby < 4.0 — the method simply won't be called since older `Kernel#inspect` doesn't use it.

### Call chain before fix

1. `Kernel#inspect` (bound to delegator)
2. `respond_to?(:instance_variables_to_inspect, true)`
3. ActiveSupport's `respond_to_missing?` — delegates without `include_private`, returns `false`
4. `super` -> Ruby's `Delegator#respond_to_missing?` — detects private method -> **warning**

### Call chain after fix

1. `Kernel#inspect` (bound to delegator)
2. `respond_to?(:instance_variables_to_inspect, true)` -> **`true`** (defined directly)
3. Calls `instance_variables_to_inspect` -> returns delegator's own ivars
4. No delegation, no warning.

## Affected classes

| Class | File | Line |
|-------|------|------|
| `NormalizedValueType` | `activemodel/lib/active_model/attributes/normalization.rb` | 183 |
| `Type::Serialized` | `activerecord/lib/active_record/type/serialized.rb` | 34 |

## Test plan

- [x] Verified `instance_variables_to_inspect` is defined as private on both classes
- [x] Verified `inspect` returns the delegator's own identity and instance variables
- [x] Verified the method returns the delegator's own ivars (not the wrapped object's)
- [x] ActiveModel normalization tests pass (10 runs, 0 failures)
- [x] ActiveRecord serialized type tests pass (142 runs, 0 failures)
- [x] No-op on Ruby 3.x — method is defined but never called by Kernel#inspect