### PR TITLE
Fix deprecation of sidekiq/testing in integration test adapter at 8-1-stable

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -2,8 +2,12 @@
 
 require "sidekiq/api"
 
-require "sidekiq/testing"
-Sidekiq::Testing.disable!
+if Sidekiq.respond_to? :testing! # 8.1.1
+  Sidekiq.testing!(:disabled)
+else
+  require "sidekiq/testing"
+  Sidekiq::Testing.disable!
+end
 
 module SidekiqJobsManager
   def setup


### PR DESCRIPTION
### Motivation / Background

This Pull Request addresses the warning at since Sidekiq 8.1.1.

### Detail

- Steps to reproduce
```
$ git clone https://github.com/rails/rails
$ cd rails
$ git checkout 8-1-stable
$ rm ../Gemfile.lock
$ bundle install
$ bundle exec rake test:integration:sidekiq
```

- Without this commit: `⛔️ `require "sidekiq/testing"` is deprecated and will be removed in Sidekiq 9.0. See https://sidekiq.org/wiki/Testing#new-api` warning appears.
```ruby
$ bundle exec rake test:integration:sidekiq
/home/yahonda/.local/share/mise/installs/ruby/4.0.1/bin/ruby -w -I"lib:test" /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb "test/integration/queuing_test.rb" 
Using sidekiq
/home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/capybara-3.40.0/lib/capybara/rack_test/driver.rb:7: warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
/home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/capybara-3.40.0/lib/capybara/session/config.rb:95: warning: URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly.
⛔️ `require "sidekiq/testing"` is deprecated and will be removed in Sidekiq 9.0. See https://sidekiq.org/wiki/Testing#new-api
INFO  2026-02-24T11:13:56.778Z pid=16519 tid=fbr: Sidekiq 8.1.1 connecting to Redis with options {size: 10, pool_name: "internal", url: nil}
Run options: --seed 38681

# Running:

............

Finished in 27.239365s, 0.4405 runs/s, 0.6975 assertions/s.
12 runs, 19 assertions, 0 failures, 0 errors, 0 skips
$
``` 

- With this commit: No warnings about `require "sidekiq/testing"` is deprecated`.
```ruby
$ bundle exec rake test:integration:sidekiq  
/home/yahonda/.local/share/mise/installs/ruby/4.0.1/bin/ruby -w -I"lib:test" /home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb "test/integration/queuing_test.rb" 
Using sidekiq
/home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/capybara-3.40.0/lib/capybara/rack_test/driver.rb:7: warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
/home/yahonda/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/capybara-3.40.0/lib/capybara/session/config.rb:95: warning: URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly.
INFO  2026-02-24T11:18:40.739Z pid=18296 tid=ep4: Sidekiq 8.1.1 connecting to Redis with options {size: 10, pool_name: "internal", url: nil}
Run options: --seed 57798

# Running:

............

Finished in 27.236024s, 0.4406 runs/s, 0.6976 assertions/s.
12 runs, 19 assertions, 0 failures, 0 errors, 0 skips
$ 
```

### Additional information

Follow up #56862
https://github.com/sidekiq/sidekiq/commit/c4f68077ce714af34f8632fdff17f926b25e6316


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
