### PR TITLE
Add start_day argument to this_week? for consistency with all_week

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `start_day` argument to `this_week?` for consistency with `all_week`
+
+    `this_week?` now accepts an optional `start_day` argument, matching the
+    existing interface of `all_week`, `beginning_of_week`, and `end_of_week`.
+
+        date.this_week?              # Uses Date.beginning_of_week (default)
+        date.this_week?(:sunday)     # Checks against Sun-Sat week
+
+    *Kenta Ishizaki*
+
 *   Add `delete: true` option to `Rails.cache.read` for atomic read-and-delete (only supported by Redis cache store).
 
     Uses the Redis [GETDEL](https://redis.io/docs/latest/commands/getdel/) command to atomically return a cached value and remove

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -64,8 +64,10 @@ module DateAndTime
     end
 
     # Returns true if the date/time falls within the current week.
-    def this_week?
-      ::Date.current.all_week.include?(to_date)
+    # Week is assumed to start on +start_day+, default is
+    # +Date.beginning_of_week+ or +config.beginning_of_week+ when set.
+    def this_week?(start_day = Date.beginning_of_week)
+      ::Date.current.all_week(start_day).include?(to_date)
     end
 
     # Returns true if the date/time falls within the current month.

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -367,6 +367,19 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_this_week_with_start_day
+    Date.stub(:current, Date.new(2000, 1, 5)) do # Wed, 2000-01-05
+      # Default (Monday start): Mon Jan 3 - Sun Jan 9
+      assert_equal false, Time.utc(2000, 1, 2, 23, 59, 59).this_week?
+      assert_equal true,  Time.utc(2000, 1, 3, 0, 0, 0).this_week?
+
+      # Sunday start: Sun Jan 2 - Sat Jan 8
+      assert_equal true,  Time.utc(2000, 1, 2, 0, 0, 0).this_week?(:sunday)
+      assert_equal true,  Time.utc(2000, 1, 8, 23, 59, 59).this_week?(:sunday)
+      assert_equal false, Time.utc(2000, 1, 9, 0, 0, 0).this_week?(:sunday)
+    end
+  end
+
   def test_this_month
     Date.stub(:current, Date.new(2000, 1, 15)) do
       assert_equal false, Time.utc(1999, 12, 31, 23, 59, 59).this_month?


### PR DESCRIPTION
### Motivation

Discussed on the Rails forum: https://discuss.rubyonrails.org/t/proposal-add-start-day-argument-to-this-week-for-consistency-with-all-week-and-beginning-of-week/90168

The recently introduced `this_week?` always uses the global
`Date.beginning_of_week` setting. However, related methods already
accept an optional `start_day` argument:

- `all_week(start_day = Date.beginning_of_week)`
- `beginning_of_week(start_day = Date.beginning_of_week)`
- `end_of_week(start_day = Date.beginning_of_week)`

### Why a per-call `start_day` matters

The global `Date.beginning_of_week=` setting works well for
single-locale applications. However, it falls short in several
real-world scenarios:

**Multi-tenant / i18n applications**

A SaaS app serving both US (`:sunday`) and European (`:monday`)
customers in the same process cannot safely rely on a global
setting. Changing `Date.beginning_of_week=` per-request (e.g.,
via `around_action`) introduces shared mutable state that is
error-prone in concurrent environments.

**Per-call flexibility without side effects**

`beginning_of_week`, `end_of_week`, and `all_week` already
solve this by accepting `start_day` as an argument — the caller
specifies the convention, no global state is touched. `this_week?`
is the only predicate in this family that lacks this escape hatch.

**Reporting and analytics**

Dashboards that compare “this week (Mon–Sun)” and
“this week (Sun–Sat)” side-by-side need per-call control.
The global setting makes this impossible without temporary
mutation.

### Detail

Added an optional `start_day` parameter to `this_week?` with the
same default value (`Date.beginning_of_week`), keeping the change
fully backward-compatible.

```ruby
date.this_week?           # Uses global default (unchanged)
date.this_week?(:sunday)  # Sun–Sat week
date.this_week?(:monday)  # Mon–Sun week
```

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
