### PR TITLE
Escape markdown metacharacters in text nodes and attachment captions

### DIFF
--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -139,7 +139,7 @@ module ActionText
     #       include ActionText::Attachable
     #
     #       def attachable_markdown_representation(caption)
-    #         "[@#{name}](#{Rails.application.routes.url_helpers.person_url(self)})"
+    #         MarkdownConversion.markdown_link("@#{name}", Rails.application.routes.url_helpers.person_url(self))
     #       end
     #     end
     #

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -143,7 +143,11 @@ module ActionText
     # NOTE: that the returned string is not HTML safe and should not be rendered in
     # browsers without additional sanitization.
     def to_markdown
-      render_attachments(with_full_attributes: false, &:to_markdown).fragment.to_markdown
+      render_attachments(with_full_attributes: false) { |attachment|
+        ActionText::HtmlConversion.create_element("action-text-markdown").tap do |node|
+          node.content = attachment.to_markdown
+        end
+      }.fragment.to_markdown
     end
 
     def to_trix_html

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -61,7 +61,7 @@ module ActionText
         end
 
         def attachable_markdown_representation(caption = nil)
-          "[#{caption || filename}]"
+          "[#{MarkdownConversion.escape_markdown_text((caption || filename).to_s)}]"
         end
 
         def to_trix_content_attachment_partial_path


### PR DESCRIPTION
### Motivation / Background

Another leftover task from #56858 was making sure that ordinary content did not render as markdown. So, for example, Rich Text content like this:

```html
<p>## Look at *this*</p>
```

should not become a markdown-formatted heading, and instead should be rendered as ordinary text:

```
\## Look at \*this\*
```

### Detail

Text nodes in HTML that contain CommonMark metacharacters (like `*`, `[`, `]`, `#`, `<`, `>`, etc.) now have those characters backslash-escaped so markdown renderers treat them as literal text rather than formatting.

To preserve markdown generated by attachments' `attachable_markdown_representation` method, `Content#to_markdown` wraps the representation in <action-text-markdown> elements. The tree walker recognizes these and passes their content through without escaping.

Captions and filenames in `ActiveStorage::Blob` and `RemoteImage` attachment representations are also escaped, and `MarkdownConversion#escape_markdown_text` is now public for use by application custom attachables.

This PR is likely escaping Markdown metacharacters where it's not absolutely necessary. We tried to avoid escaping in some obvious cases, but we can continue to refine this in the future by making the regular expression more complex.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~