### PR TITLE
Define Delegator#presence to return self

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "concurrent/map"
+require "delegate"
 
 class Object
   # An object is blank if it's false, empty, or a whitespace string.
@@ -195,5 +196,17 @@ class Time # :nodoc:
 
   def present?
     true
+  end
+end
+
+class Delegator # :nodoc:
+  # Returns self.
+  #
+  # This is defined on Delegator to avoid delegating +presence+ to the wrapped
+  # object, which may return a different object and break method chaining.
+  #
+  # @return [self]
+  def presence
+    self
   end
 end

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -40,4 +40,32 @@ class BlankTest < ActiveSupport::TestCase
     BLANK.each { |v| assert_nil v.presence, "#{v.inspect}.presence should return nil" }
     NOT.each   { |v| assert_equal v,   v.presence, "#{v.inspect}.presence should return self" }
   end
+
+  def test_delegator_presence_returns_self_without_touching_wrapped_object
+    require "delegate"
+
+    klass = Class.new(Delegator) do
+      attr_reader :inner_obj
+
+      def initialize
+        __setobj__(Object.new)
+      end
+
+      def __setobj__(obj)
+        @inner_obj = obj
+      end
+
+      def __getobj__
+        @inner_obj
+      end
+
+      def deliver_now
+        :delivered
+      end
+    end
+
+    delegator = klass.new
+    assert_same delegator, delegator.presence
+    assert_equal :delivered, delegator.presence.deliver_now
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `presence` can be delegated from Delegator-based wrappers to the wrapped object via `method_missing`, which may unexpectedly unwrap the delegator and break method chaining on the wrapper.

A concrete example is `ActionMailer::MessageDelivery` (a Delegator) calling presence can return a `Mail::Message`, so subsequent calls like `deliver_now` may fail with `NoMethodError`.

### Detail

This Pull Request changes `Delegator` to define `#presence` and always return `self`. This prevents `presence` from being delegated to the wrapped object, preserves the wrapper, and avoids forcing access to the wrapped object.

A regression test is added to ensure `Delegator#presence`

- returns the same delegator object, and
- does not touch `__getobj__` (i.e., does not force delegation).

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

This is technically a behavior change for code that relied on `delegator.presence` returning the wrapped object, but that behavior is incidental (it depends on delegation through `method_missing`) and can lead to hard-to-debug failures. Returning `self` makes `presence` safe to use with delegator-based wrappers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
