### PR TITLE
Fix FrozenError when deriving foreign key from inverse with composite foreign key

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -571,13 +571,12 @@ module ActiveRecord
         else
           derived_fk = derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of)
 
-          if active_record.has_query_constraints?
+          if !derived_fk.is_a?(Array) && active_record.has_query_constraints?
             derived_fk = derive_fk_query_constraints(derived_fk)
           end
 
           if derived_fk.is_a?(Array)
-            derived_fk.map! { |fk| -fk.freeze }
-            derived_fk.freeze
+            derived_fk.map { |fk| -fk.freeze }.freeze
           else
             -derived_fk.freeze
           end

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -700,6 +700,11 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal ["blog_id", "blog_post_id"], blog_post_foreign_key
   end
 
+  def test_has_many_foreign_key_derived_from_inverse_with_composite_foreign_key
+    reflection = Sharded::BlogPost.reflect_on_association(:comments_with_inverse)
+    assert_equal ["blog_id", "blog_post_id"], reflection.foreign_key
+  end
+
   def test_using_query_constraints_warns_about_changing_behavior
     has_many_expected_message = <<~MSG.squish
       Setting `query_constraints:` option on `Firm.has_many :clients` is not allowed.

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -18,5 +18,9 @@ module Sharded
       class_name: "Sharded::Comment",
       primary_key: [:blog_id, :id],
       foreign_key: [:blog_id, :blog_post_id]
+
+    has_many :comments_with_inverse,
+      class_name: "Sharded::Comment",
+      inverse_of: :blog_post_with_inverse
   end
 end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -7,6 +7,11 @@ module Sharded
 
     belongs_to :blog_post
     belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, primary_key: :id
+    belongs_to :blog_post_with_inverse,
+      class_name: "Sharded::BlogPost",
+      foreign_key: [:blog_id, :blog_post_id],
+      primary_key: [:blog_id, :id],
+      inverse_of: :comments_with_inverse
     belongs_to :blog
   end
 end


### PR DESCRIPTION
When a `has_one`/`has_many` association uses `inverse_of` to derive its foreign key from a `belongs_to` that has a composite `foreign_key`, `derive_foreign_key` returns the inverse reflection's memoized frozen array. The existing code then calls map! on this frozen array, raising `FrozenError`.

Replace `map! + freeze with map { ... }.freeze` to avoid mutating the derived array in place.