### PR TITLE
Fix missing block variable in Wishlists guide example

### DIFF
--- a/guides/source/wishlists.md
+++ b/guides/source/wishlists.md
@@ -617,7 +617,7 @@ Create `show` next at `app/views/wishlists/show.html.erb`:
 <% end %>
 
 <h3><%= pluralize @wishlist.products_count, "Product" %></h3>
-<% @wishlist.wishlist_products.includes(:product).each do %>
+<% @wishlist.wishlist_products.includes(:product).each do |it| %>
   <div>
     <%= link_to it.product.name, it.product %>
     <small>Added <%= l it.created_at, format: :long %></small>


### PR DESCRIPTION
### Motivation / Background

The Wishlists guide contains a small syntax issue in a code example. The loop references `it` but does not define a block variable, which makes the snippet invalid Ruby if copied.

### Detail

Adds the missing block parameter `|it|` to the `each` loop in the example.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are not required because this is a documentation fix.
* [x] CHANGELOG update is not required because this does not change behavior.