### PR TITLE
Avoid nesting Arel Or Nodes

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -31,7 +31,9 @@ module ActiveRecord
           values_predicate
         else
           array_predicates = ranges.map! { |range| predicate_builder.build(attribute, range) }
-          array_predicates.inject(values_predicate, &:or)
+          values_predicate.or(
+            Arel::Nodes::Grouping.new Arel::Nodes::Or.new(array_predicates)
+          )
         end
       end
 

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -239,9 +239,7 @@ module Arel # :nodoc: all
     private
       def grouping_any(method_id, others, *extras)
         nodes = others.map { |expr| send(method_id, expr, *extras) }
-        Nodes::Grouping.new nodes.inject { |memo, node|
-          Nodes::Or.new([memo, node])
-        }
+        Nodes::Grouping.new Nodes::Or.new(nodes)
       end
 
       def grouping_all(method_id, others, *extras)


### PR DESCRIPTION
Fixes #56869

Or was made Nary so that it could have N children instead of just 2, but (at least) these two code paths were not updated to take advantage of this behavior. The largest downside of Or being Binary is the additional nesting. A deeper Arel tree is more likely to exhaust the Ruby stack.

This commit changes a few places to treat Or as Nary, keeping the Arel tree shallower and reducing the liklihood of StackTooDeep errors.