### PR TITLE
Fix using private lookup_cast_type in SQLite tests [8-0-stable]

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -1090,21 +1090,19 @@ module ActiveRecord
       end
 
       def test_rowid_changes_column_equality
-        cast_type = @conn.lookup_cast_type("integer")
         type_metadata = SqlTypeMetadata.new(sql_type: "integer", type: :integer)
 
-        rowid_column = SQLite3::Column.new("id", cast_type, nil, type_metadata, true, nil, rowid: true)
-        regular_column = SQLite3::Column.new("id", cast_type, nil, type_metadata, true, nil, rowid: false)
+        rowid_column = SQLite3::Column.new("id", nil, type_metadata, true, nil, rowid: true)
+        regular_column = SQLite3::Column.new("id", nil, type_metadata, true, nil, rowid: false)
 
         assert_not_equal rowid_column, regular_column
       end
 
       def test_generated_type_changes_column_equality
-        cast_type = @conn.lookup_cast_type("string")
         type_metadata = SqlTypeMetadata.new(sql_type: "varchar", type: :string)
 
-        stored_column = SQLite3::Column.new("name", cast_type, nil, type_metadata, true, nil, generated_type: :stored)
-        virtual_column = SQLite3::Column.new("name", cast_type, nil, type_metadata, true, nil, generated_type: :virtual)
+        stored_column = SQLite3::Column.new("name", nil, type_metadata, true, nil, generated_type: :stored)
+        virtual_column = SQLite3::Column.new("name", nil, type_metadata, true, nil, generated_type: :virtual)
 
         assert_not_equal stored_column, virtual_column
       end


### PR DESCRIPTION
Ref https://github.com/rails/rails/commit/a34dd91b7fc05e4b9910801b6997535d40a94196

cast_type wasn't added to Column's initialize until Rails 8.1, so we can just remove these private methods.