### PR TITLE
Revert "Load minitest server plugin to run `minitest` with `--bisect` option"

### DIFF
--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -7,5 +7,4 @@ require "minitest"
 # be removable after the version bump, though it currently safeguards
 # against issues in environments with multiple versions installed.
 Minitest.load :rails if Minitest.respond_to? :load
-Minitest.load :server if Minitest.respond_to? :load
 Minitest.autorun


### PR DESCRIPTION
Reverts rails/rails#56647

minitest 6.0.2 supports `-bisect` option without this workaround needed.

https://github.com/minitest/minitest/blob/master/History.rdoc#602--2026-02-23

Also confirmed `--bisect` option works when I created a minimum repro for #56882.