### PR TITLE
Clarify Active Job queue_name_prefix behavior [ci skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -528,6 +528,10 @@ end
 # on your staging environment
 ```
 
+NOTE: `config.active_job.queue_name_prefix` only changes the queue name that
+Active Job enqueues to. Configure your queuing backend to process the resulting
+queue names (including the prefix).
+
 You can also configure the prefix on a per job basis.
 
 ```ruby
@@ -599,8 +603,9 @@ MyJob.set(queue: :another_queue).perform_later(record)
 ```
 
 NOTE: If you choose to use an [alternate queuing
-backend](#alternate-queuing-backends) you may need to specify the queues to
-listen to.
+backend](#alternate-queuing-backends), configure its workers to listen to the
+queue names Active Job enqueues, including any prefix from
+`config.active_job.queue_name_prefix`.
 
 [`config.active_job.queue_name_delimiter`]:
     configuring.html#config-active-job-queue-name-delimiter

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3219,6 +3219,9 @@ config.active_job.default_queue_name = :medium_priority
 
 Allows you to set an optional, non-blank, queue name prefix for all jobs. By default it is blank and not used.
 
+This only changes the queue name that Active Job enqueues to. Configure your
+queue backend separately so its workers listen to the resulting queue names.
+
 The following configuration would queue the given job on the `production_high_priority` queue when run in production:
 
 ```ruby


### PR DESCRIPTION
### Motivation / Background

ActiveJob backends not honoring the `queue_name_prefix` surprised me when using SolidQueue. [Was informed this is the expected behavior of backends](https://github.com/rails/solid_queue/issues/719) and the duplicate configuration is the expected workflow.

To prevent others from being surprised it seems worth while to update the documentation to make this clear it's expected behavior as I queried the [RoR Link Forum](https://www.rubyonrails.link/) before posting [my SolidQueue issue](https://github.com/rails/solid_queue/issues/719) and general consensus was that this must have been an oversight in SolidQueue. Since this is the intended behavior but I'm obviously not the only one to find it unexpected, a doc update seem appropriate.

### Detail

It's just a few doc updates in a few places as I saw fit. Feel free to suggest any changes and I'll be happy to make them.

### Additional information

None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] ~~Tests are added or updated if you fix a bug or add a feature.~~
* [x] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
