### PR TITLE
ActiveRecord: Add select_also()

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `select_also` to append columns to the SELECT clause without replacing the default selection.
+
+    `select_also` is useful when a scope or concern needs to include extra computed columns
+    or columns from joined tables alongside the normal set of model columns, without having
+    to explicitly specify `select('*', ...)` or worry about overwriting a caller's `select`.
+
+    ```ruby
+    Post.select_also("LENGTH(title) AS title_length")
+    # SELECT "posts".*, LENGTH(title) AS title_length FROM "posts"
+
+    Post.select(:id, :title).select_also("LENGTH(title) AS title_length")
+    # SELECT "posts"."id", "posts"."title", LENGTH(title) AS title_length FROM "posts"
+    ```
+
+    *Keenan Brock*
+
 *   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
 
     This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       :create_or_find_by, :create_or_find_by!,
       :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
-      :select, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
+      :select, :select_also, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -51,8 +51,8 @@ module ActiveRecord
         end
     end
 
-    MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
-                            :order, :joins, :left_outer_joins, :references,
+    MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :select_also,
+                            :group, :order, :joins, :left_outer_joins, :references,
                             :extending, :unscope, :optimizer_hints, :annotate,
                             :with]
 
@@ -495,8 +495,7 @@ module ActiveRecord
           select_values = "COUNT(*) AS #{model.adapter_class.quote_column_name("size")}, MAX(%s) AS timestamp"
 
           if collection.has_limit_or_offset?
-            query = collection.select("#{column} AS collection_cache_key_timestamp")
-            query._select!(table[Arel.star]) if distinct_value && collection.select_values.empty?
+            query = collection.select_also("#{column} AS collection_cache_key_timestamp")
             subquery_alias = "subquery_for_cache_key"
             subquery_column = "#{subquery_alias}.collection_cache_key_timestamp"
             arel = query.build_subquery(subquery_alias, select_values % subquery_column)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -430,6 +430,49 @@ module ActiveRecord
       self
     end
 
+    # Adds additional columns to the SELECT clause without replacing the
+    # default column selection. This is useful when you want to include
+    # extra computed columns or columns from joined tables alongside the
+    # normal set of columns, without having to explicitly specify
+    # <tt>select('*', ...)</tt> or <tt>select('posts.*', ...)</tt>.
+    #
+    # When no +select+ has been specified, the additional columns are
+    # appended to the default selection (e.g. <tt>SELECT "posts".*, extra_col</tt>).
+    # When a +select+ has already been specified, the additional columns
+    # are appended to that explicit selection.
+    #
+    #   Post.select_also("LENGTH(title) AS title_length")
+    #   # => SELECT "posts".*, LENGTH(title) AS title_length FROM "posts"
+    #
+    #   Post.select_also(posts: { title: :post_title })
+    #   # => SELECT "posts".*, "posts"."title" AS "post_title" FROM "posts"
+    #
+    #   Post.joins(:comments).select_also("COUNT(comments.id) AS comments_count").group("posts.id")
+    #   # => SELECT "posts".*, COUNT(comments.id) AS comments_count FROM "posts" ...
+    #
+    # When combined with +select+, the additional columns are appended:
+    #
+    #   Post.select(:title).select_also("LENGTH(title) AS title_length")
+    #   # => SELECT "posts"."title", LENGTH(title) AS title_length FROM "posts"
+    #
+    def select_also(*fields)
+      check_if_method_has_arguments!(__callee__, fields, "Call `select_also' with at least one field.")
+
+      fields = process_select_args(fields)
+      spawn._select_also!(*fields)
+    end
+
+    def _select_also!(*fields) # :nodoc:
+      self.select_also_values |= fields
+      self
+    end
+
+    # Same as #select_also but operates on relation in-place instead of copying.
+    def select_also!(*fields) # :nodoc:
+      fields = process_select_args(fields)
+      _select_also!(*fields)
+    end
+
     # Add a Common Table Expression (CTE) that you can then reference within another SELECT statement.
     #
     # Note: CTE's are only supported in MySQL for versions 8.0 and above. You will not be able to
@@ -765,7 +808,7 @@ module ActiveRecord
       self
     end
 
-    VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
+    VALID_UNSCOPING_VALUES = Set.new([:where, :select, :select_also, :group, :order, :lock,
                                      :limit, :offset, :joins, :left_outer_joins, :annotate,
                                      :includes, :eager_load, :preload, :from, :readonly,
                                      :having, :optimizer_hints, :with])
@@ -1897,11 +1940,11 @@ module ActiveRecord
 
       def build_select(arel)
         if select_values.any?
-          arel.project(*arel_columns(select_values))
+          arel.project(*arel_columns(select_values | select_also_values))
         elsif model.ignored_columns.any? || model.enumerate_columns_in_select_statements
-          arel.project(*model.column_names.map { |field| table[field] })
+          arel.project(*model.column_names.map { |field| table[field] }, *arel_columns(select_also_values))
         else
-          arel.project(table[Arel.star])
+          arel.project(table[Arel.star], *arel_columns(select_also_values))
         end
       end
 

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -215,5 +215,106 @@ module ActiveRecord
 
       assert_equal "`select' with block doesn't take arguments.", error.message
     end
+
+    # select_also tests
+
+    def test_select_also_appends_to_default_star
+      sql = Post.select_also("LENGTH(title) AS title_length").to_sql
+      assert_match %r{SELECT "posts"\.\*, LENGTH\(title\) AS title_length FROM}i, sql
+    end
+
+    def test_select_also_with_explicit_select
+      q = -> name { Regexp.escape(quote_table_name(name)) }
+      sql = Post.select(:id).select_also(:title).to_sql
+      assert_match %r{SELECT #{q["posts.id"]}, #{q["posts.title"]} FROM}i, sql
+    end
+
+    def test_select_also_deduplicates_with_select
+      q = -> name { Regexp.escape(quote_table_name(name)) }
+      sql = Post.select(:id, :title).select_also(:title).to_sql
+      # title should appear only once
+      assert_match %r{SELECT #{q["posts.id"]}, #{q["posts.title"]} FROM}i, sql
+      assert_equal 1, sql.scan(quote_table_name("posts.title")).count
+    end
+
+    def test_select_also_preserves_caller_columns_with_joined_scope
+      # A scope that joins another table and adds a computed column.
+      # Using select here would lose the caller's columns.
+      post = Post.left_joins(:comments)
+        .group(:id)
+        .select_also("COUNT(comments.id) AS comments_count")
+        .first
+
+      # All original columns are still accessible (via default *)
+      assert_equal "Welcome to the weblog", post.title
+      # The extra computed column is also accessible
+      assert_not_nil post.comments_count
+    end
+
+    def test_select_also_composes_with_caller_select
+      # Caller specifies explicit columns AND a scope adds extra columns
+      post = Post.select(:id, :title, :legacy_comments_count)
+        .left_joins(:comments)
+        .group(:id)
+        .select_also("COUNT(comments.id) AS comments_count")
+        .first
+
+      assert_equal "Welcome to the weblog", post.title
+      assert_not_nil post.comments_count
+    end
+
+    def test_select_also_with_hash_argument
+      post = Post.select_also("UPPER(title)" => :upper_title).first
+      assert_equal "WELCOME TO THE WEBLOG", post.upper_title
+      assert_equal "Welcome to the weblog", post.title
+    end
+
+    def test_select_also_chainable
+      sql = Post.select_also("1 AS one").select_also("2 AS two").to_sql
+      assert_match %r{SELECT "posts"\.\*, 1 AS one, 2 AS two FROM}i, sql
+    end
+
+    def test_select_also_unscope
+      sql = Post.select_also(:title).unscope(:select_also).to_sql
+      assert_match %r{SELECT "posts"\.\* FROM}i, sql
+    end
+
+    def test_select_also_without_arguments
+      error = assert_raises(ArgumentError) { Post.select_also }
+      assert_equal "Call `select_also' with at least one field.", error.message
+    end
+
+    def test_reselect_clears_select_but_keeps_select_also
+      q = -> name { Regexp.escape(quote_table_name(name)) }
+      sql = Post.select(:id).select_also(:title).reselect(:body).to_sql
+      assert_match %r{SELECT #{q["posts.body"]}, #{q["posts.title"]} FROM}i, sql
+    end
+
+    def test_select_also_with_enumerate_columns_in_select_statements
+      original_value = Post.enumerate_columns_in_select_statements
+      Post.enumerate_columns_in_select_statements = true
+      sql = Post.select_also("LENGTH(title) AS title_length").to_sql
+      Post.column_names.each do |column_name|
+        assert_includes sql, column_name
+      end
+      assert_includes sql, "LENGTH(title) AS title_length"
+    ensure
+      Post.enumerate_columns_in_select_statements = original_value
+    end
+
+    def test_select_also_via_merge
+      sql = Post.all.merge(Post.select_also("LENGTH(title) AS title_length")).to_sql
+      assert_match %r{SELECT "posts"\.\*, LENGTH\(title\) AS title_length FROM}i, sql
+    end
+
+    def test_select_also_via_merge_from_different_model
+      posts = Post.select(:id, :title).joins(:comments)
+      comments = Comment.where(body: "Thank you for the welcome")
+
+      post = posts.merge(comments.select_also("comments.body AS comment_body")).first
+      assert_equal 1, post.id
+      assert_equal "Welcome to the weblog", post.title
+      assert_equal "Thank you for the welcome", post.comment_body
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

When we want to add a custom `SELECT` field to our queries, we have to manually add `select("*")` to our queries or risk breaking `JOIN`s in unexpected places. We don't necessarily need these columns, but they are an insurance policy, even though extra columns slow down queries.

My goal is to allow developers to only state the extra columns they want.

```diff
- select(arel_table[Arel.star], "select (1) as extra_column")`
+ select_add("select (1) as extra_column")`
```

### Detail

This Pull Request adds `Model.select_all()` and plumbing.

This may be too small a user case to justify expanding the interface.
A dozen years ago, @matthewd suggested this. Thought of it the other day and put this together.

Thinking that we may want to use this mechanism for any column needed in a join. So even if a user uses select and there is a distinct, joins would still work.

Not sure if we want to be smart about a `select("*")` overriding `select_also()`. I think not, but you all are the stewards.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. 
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
