### PR TITLE
Add `content_type` parameter to `http_authentication` methods

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `content_type` option to HTTP authentication methods.
+
+    `request_http_basic_authentication`, `request_http_digest_authentication`,
+    and `request_http_token_authentication` now accept a `content_type`
+    parameter to control the Content-Type of the 401 response. The default
+    behavior is unchanged.
+
+    ```ruby
+    http_basic_authenticate_with(
+      name: "admin", password: "secret",
+      message: '{"error":"Access denied"}',
+      content_type: "application/json"
+    )
+    ```
+
+    *Iliana Hadzhiatanasova*
+
 *   Add `RAILS_HOST_APP_PATH` environment variable to support editor links in devcontainer/Docker environments.
 
     When Rails runs inside a container, file paths in error pages are container-internal paths

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -10,6 +10,7 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     before_action :auth_with_special_chars, only: :special_creds
 
     http_basic_authenticate_with name: "David", password: "Goliath", only: :search
+    http_basic_authenticate_with name: "David", password: "Goliath", content_type: "application/json", only: :search_with_content_type
 
     def index
       render plain: "Hello Secret"
@@ -28,6 +29,10 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     end
 
     def search
+      render plain: "All inline"
+    end
+
+    def search_with_content_type
       render plain: "All inline"
     end
 
@@ -190,6 +195,14 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     @request.env["HTTP_AUTHORIZATION"] = header
     get :search
     assert_response :unauthorized
+  end
+
+  test "authentication request with content_type" do
+    @request.env["HTTP_AUTHORIZATION"] = encode_credentials("pretty", "please")
+    get :search_with_content_type
+
+    assert_response :unauthorized
+    assert_equal "application/json", @response.media_type
   end
 
   private

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -31,7 +31,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
         if authenticate_with_http_digest("SuperSecret")  { |username| USERS[username] }
           @logged_in = true
         else
-          request_http_digest_authentication("SuperSecret", "Authentication Failed")
+          request_http_digest_authentication("SuperSecret", "Authentication Failed", "application/json")
         end
       end
   end
@@ -78,6 +78,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
 
     assert_response :unauthorized
     assert_equal "Authentication Failed", @response.body
+    assert_equal "application/json", @response.media_type
     credentials = decode_credentials(@response.headers["WWW-Authenticate"])
     assert_equal "SuperSecret", credentials[:realm]
   end

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -31,7 +31,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
         if authenticate_with_http_token { |token, options| token == '"quote" pretty' && options[:algorithm] == "test" }
           @logged_in = true
         else
-          request_http_token_authentication("SuperSecret", "Authentication Failed\n")
+          request_http_token_authentication("SuperSecret", "Authentication Failed\n", "application/json")
         end
       end
 
@@ -118,6 +118,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
 
     assert_response :unauthorized
     assert_equal "Authentication Failed\n", @response.body
+    assert_equal "application/json", @response.media_type
     assert_equal 'Token realm="SuperSecret"', @response.headers["WWW-Authenticate"]
   end
 
@@ -127,6 +128,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
 
     assert_response :unauthorized
     assert_equal "Authentication Failed\n", @response.body
+    assert_equal "application/json", @response.media_type
     assert_equal 'Token realm="SuperSecret"', @response.headers["WWW-Authenticate"]
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because currently there's no way to customise the `content-type` of an http 401 authentication response. 
The existing `message` parameter is also not exposed at `http_basic_authenticate_with` level.

### Detail

Add an optional `content_type` parameter to `request_http_{basic|digest|token}_authentication`, so that the auth response can use that `content_type` when provided. The PR also exposes the already existing `message` parametr at `http_basic_authenticate_with` level.

If neither of those is provided the behaviour remains unchanged.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
