### PR TITLE
Fix ExecutionContext corruption during reload

### DIFF
--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -23,6 +23,13 @@ module ActiveSupport
         @store = @stack.pop
         self
       end
+
+      def flush
+        @stack = Array.new(@stack.size) { {} }
+        @store = {}
+        @current_attributes_instances = {}
+        self
+      end
     end
 
     @after_change_callbacks = []
@@ -95,6 +102,10 @@ module ActiveSupport
 
       def clear
         IsolatedExecutionState[:active_support_execution_context] = nil
+      end
+
+      def flush
+        record.flush
       end
 
       def current_attributes_instances

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -51,7 +51,7 @@ module ActiveSupport
     initializer "active_support.reset_execution_context" do |app|
       app.reloader.before_class_unload do
         ActiveSupport::CurrentAttributes.clear_all
-        ActiveSupport::ExecutionContext.clear
+        ActiveSupport::ExecutionContext.flush
         ActiveSupport.event_reporter.clear_context
       end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes a bug where `ActiveSupport::Reloader#reload!` can corrupt `ActiveSupport::ExecutionContext` in test environments with `config.enable_reloading = true`, which is [commonly recommended for spring](https://github.com/rails/spring/blob/0242d4d5b5e6cef721f690acf3b13b389eb9276e/README.md#enable-reloading).

`ActiveSupport::ExecutionContext::Record` expects `@store` to always be a `Hash`, but it could become `nil` after reload. That later raises errors such as `NoMethodError` from `ActiveSupport::CurrentAttributes`.

This regression appears to have been introduced by https://github.com/rails/rails/pull/55247.

Reproduction script:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
end

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.enable_reloading = true
  config.active_support.executor_around_test_case = true
end

Rails.application.initialize!

require 'active_support/test_case'

class Current < ActiveSupport::CurrentAttributes
  attribute :trace_id
end

Rails.application.reloader.reload!

# lib/active_support/current_attributes.rb:104:in 'ActiveSupport::CurrentAttributes.instance': undefined method '[]' for nil (NoMethodError)
#         from lib/active_support/current_attributes.rb:121:in 'Current.trace_id'
#         from ./execution_context.rb:26:in '<main>'
Current.trace_id
```

### Detail

This Pull Request changes how execution context is reset during reload.

1. `ActiveSupport::ExecutionContext.flush` now clears context contents while preserving stack
depth.
1. The railtie hook in `before_class_unload` now uses `ExecutionContext.flush` instead of `ExecutionContext.clear`.
1. A regression test was added to cover the `push -> flush -> pop` sequence and verify the context remains valid.

The root cause is [hook](https://github.com/rails/rails/blob/805429182cbaeff8664c5a311dfb53552b53c93b/activesupport/lib/active_support/railtie.rb#L52-L66) ordering during reload:

1. `app.executor.to_run` calls `ActiveSupport::ExecutionContext.push`
2. `app.reloader.before_class_unload` resets context
3. `app.executor.to_complete` calls `ActiveSupport::ExecutionContext.pop`

Using `clear` in step 2 reset stack state itself, so step 3 popped an empty stack and failed to restore a valid store. Preserving stack depth fixes this.

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
