### PR TITLE
Fix collection caching to preserve store default expires_in

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -119,8 +119,11 @@ module ActionView
         end
 
         unless entries_to_write.empty?
-          expires_in = @options[:cached][:expires_in] if @options[:cached].is_a?(Hash)
-          collection_cache.write_multi(entries_to_write, expires_in: expires_in)
+          if @options[:cached].is_a?(Hash) && @options[:cached].key?(:expires_in)
+            collection_cache.write_multi(entries_to_write, expires_in: @options[:cached][:expires_in])
+          else
+            collection_cache.write_multi(entries_to_write)
+          end
         end
 
         keyed_partials


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes #56890, a regression introduced by #51579.

Collection caching in `ActionView::PartialRenderer` now always passes `expires_in` to `write_multi`. When `expires_in` is not provided (for example, when using `cached: true`), it is passed as `expires_in: nil`, which overrides the cache store’s default expiration.

`expires_in` should only be passed to `write_multi` when explicitly provided in the cache options. This preserves the cache store defaults when `expires_in` is omitted, while still honoring explicit usage such as `cached: { expires_in: nil }`.

### Detail

This change ensures that `expires_in` is only included in the arguments to `write_multi` when it is present in the collection cache options.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.