### PR TITLE
Action Text `to_markdown` generates markdown links for blob

### DIFF
--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -84,10 +84,14 @@ module ActionText
     #     message = Message.create!(content: "<p>Hello <strong>world</strong></p>")
     #     message.content.to_markdown # => "Hello **world**"
     #
+    # When +attachment_links+ is true, ActiveStorage blob attachments generate Markdown links with
+    # URLs. This requires a rendering context (e.g., controller or mailer action) and will raise if
+    # URL generation fails.
+    #
     # NOTE: that the returned string is not HTML safe and should not be rendered in
     # browsers without additional sanitization.
-    def to_markdown
-      body&.to_markdown.to_s
+    def to_markdown(attachment_links: false)
+      body&.to_markdown(attachment_links: attachment_links).to_s
     end
 
     # Returns the `body` attribute in a format that makes it editable in the Trix

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -21,7 +21,7 @@ module ActionText
         content_instance.fragment.source
       end
 
-      def attachable_markdown_representation(caption)
+      def attachable_markdown_representation(caption, attachment_links: false)
         content_instance.fragment.to_markdown
       end
 

--- a/actiontext/lib/action_text/attachables/missing_attachable.rb
+++ b/actiontext/lib/action_text/attachables/missing_attachable.rb
@@ -25,7 +25,7 @@ module ActionText
         "☒"
       end
 
-      def attachable_markdown_representation(caption = nil)
+      def attachable_markdown_representation(caption = nil, attachment_links: false)
         "☒"
       end
 

--- a/actiontext/lib/action_text/attachables/remote_image.rb
+++ b/actiontext/lib/action_text/attachables/remote_image.rb
@@ -44,7 +44,7 @@ module ActionText
         "[#{caption || "Image"}]"
       end
 
-      def attachable_markdown_representation(caption)
+      def attachable_markdown_representation(caption, attachment_links: false)
         "!#{MarkdownConversion.markdown_link(caption || "Image", url)}"
       end
 

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -140,12 +140,16 @@ module ActionText
     #     content = ActionText::Content.new("<p>Hello <strong>world</strong></p>")
     #     content.to_markdown # => "Hello **world**"
     #
+    # When +attachment_links+ is true, ActiveStorage blob attachments generate Markdown links with
+    # URLs. This requires a rendering context (e.g., controller or mailer action) and will raise if
+    # URL generation fails.
+    #
     # NOTE: that the returned string is not HTML safe and should not be rendered in
     # browsers without additional sanitization.
-    def to_markdown
+    def to_markdown(attachment_links: false)
       render_attachments(with_full_attributes: false) { |attachment|
         ActionText::HtmlConversion.create_element("action-text-markdown").tap do |node|
-          node.content = attachment.to_markdown
+          node.content = attachment.to_markdown(attachment_links: attachment_links)
         end
       }.fragment.to_markdown
     end

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -60,8 +60,22 @@ module ActionText
           "[#{caption || filename}]"
         end
 
-        def attachable_markdown_representation(caption = nil)
-          "[#{MarkdownConversion.escape_markdown_text((caption || filename).to_s)}]"
+        def attachable_markdown_representation(caption = nil, attachment_links: false)
+          title = (caption || filename).to_s
+
+          if attachment_links
+            renderer = ActionText::Content.renderer
+            raise ArgumentError, "attachment_links requires a rendering context" unless renderer
+
+            url = renderer.url_for(self)
+            if image?
+              "!#{MarkdownConversion.markdown_link(title, url)}"
+            else
+              MarkdownConversion.markdown_link(title, url)
+            end
+          else
+            "[#{MarkdownConversion.escape_markdown_text(title)}]"
+          end
         end
 
         def to_trix_content_attachment_partial_path

--- a/actiontext/test/fixtures/files/report.txt
+++ b/actiontext/test/fixtures/files/report.txt
@@ -1,0 +1,1 @@
+This is a test report.

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -569,41 +569,6 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     )
   end
 
-  test "attachment with surrounding text" do
-    assert_converted_to(
-      "Hello world! ![Cat](http://example.com/cat.jpg)",
-      'Hello world! <action-text-attachment url="http://example.com/cat.jpg" content-type="image/jpeg" caption="Cat"></action-text-attachment>'
-    )
-  end
-
-  test "multiple attachments separated by whitespace preserve the whitespace" do
-    assert_converted_to(
-      "![A](https://example.com/a.jpg) ![B](https://example.com/b.jpg)",
-      '<action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment> <action-text-attachment content-type="image/jpeg" url="https://example.com/b.jpg" caption="B"></action-text-attachment>'
-    )
-  end
-
-  test "multiple attachments and text separated by whitespace preserve the whitespace" do
-    assert_converted_to(
-      "![A](https://example.com/a.jpg) and ![B](https://example.com/b.jpg)",
-      '<action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment> and <action-text-attachment content-type="image/jpeg" url="https://example.com/b.jpg" caption="B"></action-text-attachment>'
-    )
-  end
-
-  test "attachment with whitespace before inline element preserves the whitespace" do
-    assert_converted_to(
-      "![A](https://example.com/a.jpg) **bold**",
-      '<action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment> <strong>bold</strong>'
-    )
-  end
-
-  test "inline element with whitespace before attachment preserves the whitespace" do
-    assert_converted_to(
-      "**bold** ![A](https://example.com/a.jpg)",
-      '<strong>bold</strong> <action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment>'
-    )
-  end
-
   test "non-core inline element preserves surrounding whitespace" do
     assert_converted_to(
       "hello world",
@@ -620,42 +585,84 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
 
   # --- Attachment tests ---
 
-  test "image attachment with caption is converted to markdown image" do
+  test "RemoteImage attachment with surrounding text" do
+    assert_converted_to(
+      "Hello world! ![Cat](http://example.com/cat.jpg)",
+      'Hello world! <action-text-attachment url="http://example.com/cat.jpg" content-type="image/jpeg" caption="Cat"></action-text-attachment>'
+    )
+  end
+
+  test "RemoteImage attachments separated by whitespace preserve the whitespace" do
+    assert_converted_to(
+      "![A](https://example.com/a.jpg) ![B](https://example.com/b.jpg)",
+      '<action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment> <action-text-attachment content-type="image/jpeg" url="https://example.com/b.jpg" caption="B"></action-text-attachment>'
+    )
+  end
+
+  test "RemoteImage attachments and text separated by whitespace preserve the whitespace" do
+    assert_converted_to(
+      "![A](https://example.com/a.jpg) and ![B](https://example.com/b.jpg)",
+      '<action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment> and <action-text-attachment content-type="image/jpeg" url="https://example.com/b.jpg" caption="B"></action-text-attachment>'
+    )
+  end
+
+  test "RemoteImage attachment with whitespace before inline element preserves the whitespace" do
+    assert_converted_to(
+      "![A](https://example.com/a.jpg) **bold**",
+      '<action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment> <strong>bold</strong>'
+    )
+  end
+
+  test "RemoteImage attachment with whitespace before attachment preserves the whitespace" do
+    assert_converted_to(
+      "**bold** ![A](https://example.com/a.jpg)",
+      '<strong>bold</strong> <action-text-attachment content-type="image/jpeg" url="https://example.com/a.jpg" caption="A"></action-text-attachment>'
+    )
+  end
+
+  test "RemoteImage attachment with caption is converted to markdown image" do
     assert_converted_to(
       "![A photo](https://example.com/photo.png)",
       '<action-text-attachment content-type="image/png" url="https://example.com/photo.png" caption="A photo"></action-text-attachment>'
     )
   end
 
-  test "image attachment with parentheses in URL is encoded" do
+  test "RemoteImage attachment with parentheses in URL is encoded" do
     assert_converted_to(
       "![Photo](https://example.com/photo_%28large%29.png)",
       '<action-text-attachment content-type="image/png" url="https://example.com/photo_(large).png" caption="Photo"></action-text-attachment>'
     )
   end
 
-  test "image attachment with bracket injection in caption is escaped" do
+  test "RemoteImage attachment with bracket injection in caption is escaped" do
     assert_converted_to(
       '![evil\](https://evil.com)!\[x](https://example.com/photo.png)',
       '<action-text-attachment content-type="image/png" url="https://example.com/photo.png" caption="evil](https://evil.com)![x"></action-text-attachment>'
     )
   end
 
-  test "image attachment with emphasis markers in caption is escaped" do
+  test "RemoteImage attachment with emphasis markers in caption is escaped" do
     assert_converted_to(
       '![photo \*large\*](https://example.com/photo.png)',
       '<action-text-attachment content-type="image/png" url="https://example.com/photo.png" caption="photo *large*"></action-text-attachment>'
     )
   end
 
-  test "image attachment without caption falls back to Image alt text" do
+  test "RemoteImage attachment with angle brackets in caption is escaped" do
+    assert_converted_to(
+      "![photo \\<large\\>](https://example.com/photo.png)",
+      '<action-text-attachment content-type="image/png" url="https://example.com/photo.png" caption="photo &lt;large&gt;"></action-text-attachment>'
+    )
+  end
+
+  test "RemoteImage attachment without caption falls back to Image alt text" do
     assert_converted_to(
       "![Image](https://example.com/photo.jpg)",
       '<action-text-attachment content-type="image/jpeg" url="https://example.com/photo.jpg" filename="photo.jpg"></action-text-attachment>'
     )
   end
 
-  test "content attachment HTML is converted to markdown" do
+  test "Content attachment HTML is converted to markdown" do
     assert_converted_to(
       "**hello**",
       '<action-text-attachment content-type="text/html" content="<strong>hello</strong>"></action-text-attachment>'
@@ -667,42 +674,183 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     )
   end
 
-  test "ActiveStorage blob attachment is converted to markdown with caption" do
+  test "Blob image without :attachment_links uses caption" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
-    assert_equal "[Captioned]", ActionText::Content.new(html).to_markdown
+
+    assert_converted_to("[Captioned]", html)
   end
 
-  test "ActiveStorage blob attachment with metacharacters in caption is escaped" do
+  test "Blob image with attachment_links: true uses caption" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo *large*"></action-text-attachment>)
-    assert_equal '[photo \*large\*]', ActionText::Content.new(html).to_markdown
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_converted_to("![Captioned](#{url})", html, attachment_links: true)
+    end
   end
 
-  test "ActiveStorage blob attachment without caption uses filename" do
+  test "Blob image without :attachment_links uses filename" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
-    assert_equal "[racecar.jpg]", ActionText::Content.new(html).to_markdown
+
+    assert_converted_to("[racecar.jpg]", html)
   end
 
-  test "missing attachable is converted to ☒" do
+  test "Blob image with attachment_links: true uses filename" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_converted_to("![racecar.jpg](#{url})", html, attachment_links: true)
+    end
+  end
+
+  test "Blob without :attachment_links uses caption" do
+    blob = create_file_blob(filename: "report.txt", content_type: "text/plain")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    assert_converted_to("[Captioned]", html)
+  end
+
+  test "Blob with attachment_links: true uses caption" do
+    blob = create_file_blob(filename: "report.txt", content_type: "text/plain")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_converted_to("[Captioned](#{url})", html, attachment_links: true)
+    end
+  end
+
+  test "Blob without :attachment_links uses filename" do
+    blob = create_file_blob(filename: "report.txt", content_type: "text/plain")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
+
+    assert_converted_to("[report.txt]", html)
+  end
+
+  test "Blob with attachment_links: true uses filename" do
+    blob = create_file_blob(filename: "report.txt", content_type: "text/plain")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_converted_to("[report.txt](#{url})", html, attachment_links: true)
+    end
+  end
+
+  test "Blob image without :attachment_links escapes metacharacters in caption" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo *large*"></action-text-attachment>)
+
+    assert_converted_to("[photo \\*large\\*]", html)
+  end
+
+  test "Blob image with attachment_links: true escapes metacharacters in caption" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo *large*"></action-text-attachment>)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_converted_to("![photo \\*large\\*](#{url})", html, attachment_links: true)
+    end
+  end
+
+  test "Blob image without :attachment_links escapes angle brackets in caption" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo <large>"></action-text-attachment>)
+    html2 = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo &lt;large&gt;"></action-text-attachment>)
+
+    assert_converted_to("[photo \\<large\\>]", html)
+    assert_converted_to("[photo \\<large\\>]", html2)
+  end
+
+  test "Blob image with attachment_links: true escapes angle brackets in caption" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo <large>"></action-text-attachment>)
+    html2 = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo &lt;large&gt;"></action-text-attachment>)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_converted_to("![photo \\<large\\>](#{url})", html, attachment_links: true)
+      assert_converted_to("![photo \\<large\\>](#{url})", html2, attachment_links: true)
+    end
+  end
+
+  test "Blob image with mailer renderer and attachment_links: true generates markdown link" do
+    original_default_url_options = ActionMailer::Base.default_url_options
+    ActionMailer::Base.default_url_options = { host: "example.com" }
+
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    mailer = MessagesMailer.new
+    ActionText::Content.with_renderer(mailer) do
+      url = mailer.url_for(blob)
+      assert_converted_to("![Captioned](#{url})", html, attachment_links: true)
+    end
+  ensure
+    ActionMailer::Base.default_url_options = original_default_url_options
+  end
+
+  test "Blob image with attachment_links: true raises when mailer missing host" do
+    original_default_url_options = ActionMailer::Base.default_url_options
+    ActionMailer::Base.default_url_options = {}
+
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    mailer = MessagesMailer.new
+    ActionText::Content.with_renderer(mailer) do
+      assert_raises(ArgumentError) do
+        ActionText::Content.new(html).to_markdown(attachment_links: true)
+      end
+      assert_converted_to("[Captioned]", html)
+    end
+  ensure
+    ActionMailer::Base.default_url_options = original_default_url_options
+  end
+
+  test "Blob image with attachment_links: true raises when no renderer" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    error = assert_raises(ArgumentError) do
+      ActionText::Content.new(html).to_markdown(attachment_links: true)
+    end
+    assert_match(/rendering context/, error.message)
+    assert_converted_to("[Captioned]", html)
+  end
+
+  test "Blob image with renderer uses bracketed title by default" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    with_controller_renderer do
+      assert_converted_to("[Captioned]", html)
+    end
+  end
+
+  test "Blob image with attachment_links: true propagates script_name from request" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Photo"></action-text-attachment>)
+
+    with_controller_renderer(script_name: "/myapp") do |controller|
+      url = controller.url_for(blob)
+      assert_match %r{/myapp/rails/active_storage/blobs/}, url
+      assert_converted_to("![Photo](#{url})", html, attachment_links: true)
+    end
+  end
+
+  test "Blob missing attachable is converted to ☒" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
     blob.destroy!
-    assert_equal "☒", ActionText::Content.new(html).to_markdown
-  end
 
-  test "image attachment with angle brackets in caption is not mangled" do
-    assert_converted_to(
-      '![photo \<large\>](https://example.com/photo.png)',
-      '<action-text-attachment content-type="image/png" url="https://example.com/photo.png" caption="photo &lt;large&gt;"></action-text-attachment>'
-    )
-  end
-
-  test "ActiveStorage blob attachment with angle brackets in caption" do
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-    html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo <large>"></action-text-attachment>)
-    assert_equal '[photo \<large\>]', ActionText::Content.new(html).to_markdown
+    assert_converted_to("☒", html)
   end
 
   # --- Fragment and Rich Text tests ---
@@ -716,6 +864,16 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     assert_equal "**hello**", ActionText::RichText.new(body: "<p><strong>hello</strong></p>").to_markdown
   end
 
+  test "RichText#to_markdown with attachment_links: true" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    body = ActionText::Content.new.append_attachables(blob)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_equal "![racecar.jpg](#{url})", ActionText::RichText.new(body: body).to_markdown(attachment_links: true)
+    end
+  end
+
   test "RichText#to_markdown handles blank body" do
     assert_equal "", ActionText::RichText.new(body: "").to_markdown
   end
@@ -725,7 +883,19 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
   end
 
   private
-    def assert_converted_to(expected_markdown, html)
-      assert_equal expected_markdown, ActionText::Content.new(html).to_markdown
+    def assert_converted_to(expected_markdown, html, **options)
+      assert_equal expected_markdown, ActionText::Content.new(html).to_markdown(**options)
+    end
+
+    def with_controller_renderer(script_name: "")
+      controller = MessagesController.new
+      request = ActionDispatch::TestRequest.create("SCRIPT_NAME" => script_name)
+      request.routes = Rails.application.routes
+      controller.set_request!(request)
+      controller.set_response!(ActionDispatch::TestResponse.new)
+
+      ActionText::Content.with_renderer(controller) do
+        yield controller
+      end
     end
 end


### PR DESCRIPTION
### Motivation / Background

Following up on #56858: `ActiveStorage::Blob#attachable_markdown_representation` rendered a placeholder `[caption]` and not a Markdown link to the attachment, unlike `RemoteImage` which generates `![title](url)`. We should always generate real Markdown links if possible!


### Detail

When a rendering context is available (e.g., controller or mailer action), blob attachments now produce real markdown links:

  - `![title](url)` for image blobs
  - `[title](url)` for non-image blobs

When no renderer is present (e.g., the console):

  - `[title]` placeholder as fallback for all blobs

URL generation uses the thread-local `ActionText::Content.renderer` (set via `around_action` in the engine initializer) and delegates to `url_for(blob)`, which goes through Active Storage's polymorphic route resolution and respects `config.active_storage.resolve_model_to_route` (e.g., `:rails_storage_proxy`).

### Additional information

URLs are derived from the current request context rather than global `default_url_options`. This means `host`, `protocol`, and `script_name` are all picked up from the request automatically — important for multi-tenant apps that vary `script_name` per-request.

No changes to `Attachment#to_markdown`, `Content#to_markdown`, or the `attachable_markdown_representation` signature contract, so custom attachables are unaffected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
