### PR TITLE
Fix has_many :through ignoring join model's custom attribute type in WHERE clause

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -162,7 +162,8 @@ module ActiveRecord
           if scope.table == table
             scope.where!(key => value)
           else
-            scope.where!(table.name => { key => value })
+            bind = Relation::QueryAttribute.new(key, value, table.type_for_attribute(key))
+            scope.where!(table[key].eq(bind))
           end
         end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1716,6 +1716,44 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [[comment.blog_id, comment.id]], ids
   end
 
+  def test_has_many_through_uses_join_model_attribute_type_for_scope
+    # A custom type that multiplies the serialized integer by 1000.
+    # This verifies that Rails uses the join model's declared attribute type
+    # (correct: binds person.id * 1000) rather than falling back to a default
+    # type resolved from the target model (bug: binds raw person.id).
+    custom_type = Class.new(ActiveRecord::Type::Integer) do
+      def serialize(value)
+        serialized = super
+        serialized.nil? ? nil : serialized * 1000
+      end
+    end
+
+    person_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+      def self.name; "Person"; end
+    end
+
+    reader_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "readers"
+      def self.name; "Reader"; end
+      attribute :person_id, custom_type.new
+      belongs_to :person, anonymous_class: person_klass
+      belongs_to :post
+    end
+
+    person_klass.has_many :readers, anonymous_class: reader_klass
+    person_klass.has_many :posts, through: :readers
+
+    person = person_klass.first
+    all_binds = capture_sql_and_binds { person.posts.to_a }.flat_map { |_, binds| binds }
+
+    # The bind value for readers.person_id must be serialized using the join
+    # model's custom attribute type. With the custom type, serialize(person.id)
+    # returns person.id * 1000. Without the fix, the raw person.id is used instead.
+    assert_includes all_binds, person.id * 1000,
+      "has_many :through should use the join model's attribute type to serialize the FK bind value"
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1745,13 +1745,22 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     person_klass.has_many :posts, through: :readers
 
     person = person_klass.first
-    all_binds = capture_sql_and_binds { person.posts.to_a }.flat_map { |_, binds| binds }
+    expected = person.id * 1000
 
-    # The bind value for readers.person_id must be serialized using the join
-    # model's custom attribute type. With the custom type, serialize(person.id)
-    # returns person.id * 1000. Without the fix, the raw person.id is used instead.
-    assert_includes all_binds, person.id * 1000,
-      "has_many :through should use the join model's attribute type to serialize the FK bind value"
+    queries = capture_sql_and_binds { person.posts.to_a }
+    all_binds = queries.flat_map { |_, binds| binds }
+    all_sqls   = queries.map(&:first)
+
+    # The FK bind value for readers.person_id must be serialized using the join
+    # model's custom attribute type: serialize(person.id) == person.id * 1000.
+    # Without the fix the raw person.id is used.
+    # The value appears in bind params (prepared_statements: true) or inlined in
+    # the SQL string (prepared_statements: false, the default for MySQL tests).
+    assert(
+      all_binds.include?(expected) || all_sqls.any? { |sql| sql.include?(expected.to_s) },
+      "Expected join model's custom attribute type to be used (value #{expected}) " \
+      "but found binds=#{all_binds.inspect}"
+    )
   end
 
   private


### PR DESCRIPTION
## Summary

Fixes #56893.

When a join model declares a custom attribute type via `attribute :col, MyType.new`, `has_many :through` queries silently ignore that type when building the WHERE clause for the cross-table FK condition. The value is serialized using the database schema's default type instead of the model's declared type.

### Root cause

`AssociationScope#apply_scope` has two branches:

```ruby
def apply_scope(scope, table, key, value)
  if scope.table == table
    scope.where!(key => value)          # same-table: uses join model's type ✓
  else
    scope.where!(table.name => { key => value })  # cross-table: uses target model's type ✗
  end
end
```

The cross-table branch uses a hash-form condition with the table name as a string key. Rails resolves the column type for this condition via the **outer scope's** (target model's) `PredicateBuilder`. Since the target model (e.g. `Post`) has no knowledge of custom types declared on the join model (e.g. `Reader`), it falls back to the database schema type.

### Fix

Build an explicit `Relation::QueryAttribute` using the join table's own type caster (`table.type_for_attribute(key)`), then use `table[key].eq(bind)`:

```ruby
def apply_scope(scope, table, key, value)
  if scope.table == table
    scope.where!(key => value)
  else
    bind = Relation::QueryAttribute.new(key, value, table.type_for_attribute(key))
    scope.where!(table[key].eq(bind))
  end
end
```

This ensures:
1. The join model's declared attribute type is used to serialize the FK bind value.
2. The fix is fully compatible with Rails' prepared-statement cache: when `value` is a `StatementCache::Substitute`, the `QueryAttribute` wraps it preserving the type, and `BindMap` correctly substitutes the actual value (with proper type-casting) at execution time.

### Test

Added a test using an anonymous join model with `attribute :person_id, custom_type` where the custom type multiplies integers by 1000. The test asserts that the FK bind value in the generated query is `person.id * 1000`, not the raw `person.id`. Without the fix, the test fails with `Expected [1] to include 1000`.

## Real-world impact

This bug affects any application using a custom attribute type on a join model's FK column with `has_many :through`. A prominent example is the `ulid-rails` gem, which registers a `:ulid` type that serializes between ULID strings and 16-byte binary. Without this fix, `has_many :through` queries encode the FK as a 26-byte ASCII string instead of 16-byte binary, causing queries to return empty results.

This was previously reported as #54418 (closed by stalebot) and #52135.
