### PR TITLE
Add `sql_notifications` connection config option to disable SQL notifications

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `sql_notifications` connection configuration option to disable SQL
+    notifications for specific database connections.
+
+    Libraries like Solid Cache and Solid Queue that use separate database
+    connections via `connects_to` can suppress internal SQL notification
+    overhead by setting `sql_notifications: false` in `database.yml`:
+
+    ```yaml
+    cache:
+      adapter: postgresql
+      database: myapp_cache
+      sql_notifications: false
+    ```
+
+    *Rosa Gutierrez*
+
 *   Allow the query log tags format to be configured per connection pool.
 
     A `query_log_tags_format` key in a `database.yml` entry overrides the global

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -188,6 +188,10 @@ module ActiveRecord
           @config.fetch(:advisory_locks, true)
         )
 
+        @sql_notifications = self.class.type_cast_config_to_boolean(
+          @config.fetch(:sql_notifications, true)
+        )
+
         @default_timezone = self.class.validate_default_timezone(@config[:default_timezone])
 
         @raw_connection_dirty = false
@@ -263,6 +267,10 @@ module ActiveRecord
 
       def prepared_statements_disabled_cache # :nodoc:
         ActiveSupport::IsolatedExecutionState[:active_record_prepared_statements_disabled_cache] ||= Set.new
+      end
+
+      def sql_notifications?
+        @sql_notifications
       end
 
       class Version
@@ -1274,7 +1282,11 @@ module ActiveRecord
         end
 
         def instrumenter # :nodoc:
-          ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] ||= ActiveSupport::Notifications.instrumenter
+          if sql_notifications?
+            ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] ||= ActiveSupport::Notifications.instrumenter
+          else
+            ActiveSupport::Notifications.null_instrumenter
+          end
         end
 
         def translate_exception(exception, message:, sql:, binds:)

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -103,8 +103,10 @@ module ActiveRecord
             previous_instrumenter = ActiveSupport::IsolatedExecutionState[:active_record_instrumenter]
             begin
               if pending?
-                @event_buffer = EventBuffer.new(self, ActiveSupport::Notifications.instrumenter)
-                ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] = @event_buffer
+                if connection.sql_notifications?
+                  @event_buffer = EventBuffer.new(self, ActiveSupport::Notifications.instrumenter)
+                  ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] = @event_buffer
+                end
 
                 @adapter = connection
                 @ran_async = true

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -579,6 +579,8 @@ module ActiveRecord
   end
 
   class AdapterConnectionTest < ActiveRecord::TestCase
+    include ConnectionHelper
+
     unless in_memory_db?
       self.use_transactional_tests = false
 
@@ -973,6 +975,26 @@ module ActiveRecord
       ensure
         connection&.disconnect!
       end
+    end
+
+    test "suppresses notifications when sql_notifications=false" do
+      run_without_connection do |orig_connection|
+        ActiveRecord::Base.establish_connection(orig_connection.merge(sql_notifications: false))
+
+        notifications = capture_notifications("sql.active_record") do
+          Post.first
+        end
+
+        assert_empty notifications
+      end
+    end
+
+    test "sql_notifications are enabled by default" do
+      notifications = capture_notifications("sql.active_record") do
+        Post.first
+      end
+
+      assert_not_empty notifications
     end
   end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActiveSupport::Notifications::NullInstrumenter`, a stateless no-op
+    instrumenter that executes blocks without publishing any notifications.
+
+    Available via `ActiveSupport::Notifications.null_instrumenter`, this is
+    useful for suppressing instrumentation on specific components, such as
+    database connections that don't need SQL notification overhead.
+
+    *Rosa Gutierrez*
+
 *   `ActiveSupport::Cache::RedisCacheStore` entirely reimplemented.
 
     Now depends on the much lighter `redis-client >= 0.28.0` instead of `redis >= 4.0.1`.

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -197,6 +197,13 @@ module ActiveSupport
     class << self
       attr_accessor :notifier
 
+      # Returns a singleton no-op instrumenter that executes blocks without
+      # publishing any notifications. Useful for suppressing instrumentation
+      # on specific connections or components.
+      def null_instrumenter
+        @null_instrumenter ||= NullInstrumenter.new
+      end
+
       def publish(name, *args)
         notifier.publish(name, *args)
       end

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -5,6 +5,34 @@ require "securerandom"
 
 module ActiveSupport
   module Notifications
+    # A no-op instrumenter that executes blocks without publishing any
+    # notifications. Useful for disabling instrumentation on specific
+    # connections or components.
+    #
+    # This is stateless and thread-safe, so a single instance can be shared.
+    #
+    #   ActiveSupport::Notifications.null_instrumenter.instrument("sql.active_record") do
+    #     # executes without any notification overhead
+    #   end
+    class NullInstrumenter
+      class NullHandle # :nodoc:
+        def start; end
+        def finish; end
+      end
+      NULL_HANDLE = NullHandle.new.freeze
+
+      def instrument(name, payload = {})
+        yield payload if block_given?
+      end
+
+      def build_handle(name, payload)
+        NULL_HANDLE
+      end
+
+      def start(name, payload); end
+      def finish(name, payload); end
+    end
+
     # Instrumenters are stored in a thread local.
     class Instrumenter
       attr_reader :id


### PR DESCRIPTION
### Motivation / Background

The motivation for this PR came up when discussing suppressing Active Record notifications with @djmb. This is desirable in gems like Solid Cache, where instrumentation might not be needed once a cache deployment is stable. In that case, it might just add overhead and noise. 

Solid Cache has an option to disable instrumentation [that reaches into Active Record internals](https://github.com/rails/solid_cache/blob/4e7219c4210d165e03176439dfca99238ba6fde9/app/models/solid_cache/record.rb#L12-L29), swapping the current per-thread instrumenter with a new instrumenter with an empty fanout as notifier. The problem of this approach, in addition to reaching into internals, is that it requires all the call sites that could trigger AR instrumentation to be wrapped with `disable_instrumentation`. 

We had the idea of improving this and making the possibility available to other gems like Solid Queue, that use separate database connections by default (via `connects_to`). 

### Detail

With this change, you can disable instrumentation per connection, as part of the configuration: 

```yml
    cache:
      adapter: postgresql
      database: myapp_cache
      sql_notifications: false
```

This is similar to the `seeds` option added in https://github.com/rails/rails/pull/53379.

This change introduces a `NullInstrumenter` into `ActiveSupport::Notifications`, which is a no-op, stateless and thread-safe instrumenter that just executes blocks without publishing anything. We don't need to worry about the per-thread registry for this one. This new instrumenter is used in the DB adapter when `sql_notifications` is disabled.

Additionally, this change skips event buffering for async queries when `sql_notifications` is disabled. We don't need the event buffer or to swap the instrumenter stored in the isolated execution state.

### Checklist

Before submitting the PR, make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue, include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behaviour change or additional feature. Minor bug fixes and documentation changes should not be included.