### PR TITLE
Don't guard action_dispatch_request and action_cable load hooks

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -13,7 +13,7 @@ module ActionCable
     config.action_cable.precompile_assets = true
 
     guard_load_hooks(
-      :action_cable, :action_cable_channel, :action_cable_connection,
+      :action_cable_channel, :action_cable_connection,
       :action_cable_test_case, :action_cable_connection_test_case,
     )
 
@@ -88,15 +88,17 @@ module ActionCable
           end
         end
 
+        app.reloader.before_class_unload do
+          ActionCable.server.restart
+        end
+      end
+
+      ActiveSupport.on_load(:action_cable_channel) do
         wrap = lambda do |_, inner|
           app.executor.wrap(source: "application.action_cable", &inner)
         end
         ActionCable::Channel::Base.set_callback :subscribe, :around, prepend: true, &wrap
         ActionCable::Channel::Base.set_callback :unsubscribe, :around, prepend: true, &wrap
-
-        app.reloader.before_class_unload do
-          ActionCable.server.restart
-        end
       end
     end
   end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -51,8 +51,8 @@ module ActionDispatch
     config.eager_load_namespaces << ActionDispatch
 
     guard_load_hooks(
-      :action_dispatch_request, :action_dispatch_response,
-      :action_dispatch_system_test_case, :action_dispatch_integration_test,
+      :action_dispatch_response, :action_dispatch_system_test_case,
+      :action_dispatch_integration_test,
     )
 
     initializer "action_dispatch.deprecator", before: :load_environment_config do |app|


### PR DESCRIPTION
### Motivation / Background

Followup on https://github.com/rails/rails/pull/56201

This Pull Request has been created because action_dispatch_request and action_cable are loaded during app init in production. For now, we can't guarantee requests will load after boot.

### Detail

This Pull Request removes the load hooks guard for action_dispatch_request in action pack and action_cable in action cable. I also fixed a callback that loaded cable channels when loading the main action cable server.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
