### PR TITLE
Fix IsolatedExecutionState.share_with() call in AC::Live

### DIFF
--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -575,6 +575,26 @@ module ActionController
       assert_stream_closed
     end
 
+    def test_isolated_state_with_isolation_level_fiber
+      previous_level = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+
+      @controller.tc = self
+      ActiveSupport::IsolatedExecutionState[:raw_isolated_state] = "buffy"
+
+      get :raw_isolated_state
+      assert_equal "buffy".inspect, response.body
+      assert_stream_closed
+
+      ActiveSupport::IsolatedExecutionState.clear
+
+      get :isolated_state
+      assert_equal nil.inspect, response.body
+      assert_stream_closed
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = previous_level
+    end
+
     def test_connected_to_stack_not_inherited
       original = @controller.class.live_streaming_excluded_keys
       @controller.class.live_streaming_excluded_keys = [:active_record_connected_to_stack]


### PR DESCRIPTION
When `isolation_level = :fiber`, it's wrong to pass the original thread
to `share_with()`.  Instead, save the original `context` and pass that.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
