### PR TITLE
Fix flaky test: sql.active_record event count in transaction instrumentation tests

### DIFF
--- a/activerecord/test/cases/transaction_instrumentation_test.rb
+++ b/activerecord/test/cases/transaction_instrumentation_test.rb
@@ -7,6 +7,12 @@ class TransactionInstrumentationTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
   fixtures :topics
 
+  setup do
+    # Warm all lazy-loaded caches (columns, data sources, attribute methods) so no SCHEMA queries
+    # fire during the instrumented block in our tests below, which would be a source of flakes.
+    Topic.first
+  end
+
   def test_start_transaction_is_triggered_when_the_transaction_is_materialized
     transactions = []
     subscriber = ActiveSupport::Notifications.subscribe("start_transaction.active_record") do |event|


### PR DESCRIPTION
### Motivation / Background

`TransactionInstrumentationTest#test_sql_events_do_not_overlap_with_savepoints` is flaky in CI (e.g. [Buildkite build #126621](https://buildkite.com/rails/rails/builds/126621)):

```
Failure:
TransactionInstrumentationTest#test_sql_events_do_not_overlap_with_savepoints [test/cases/transaction_instrumentation_test.rb:404]:
Expected: 6
  Actual: 7
```

`test_sql_events_do_not_overlap` is similarly affected.

### Detail

Both tests subscribe globally to `sql.active_record` and assert an exact event count. They fail when a previously-run test leaves `Topic`'s schema cache cleared (via `Topic.reset_column_information` — there are ~200 call sites across the test suite).

When the schema cache is cold, `Topic.first` result instantiation triggers a lazy `data_source_exists?` lookup:

```
instantiate → init_internals → define_attribute_methods →
  attribute_names → table_exists? → schema_cache.data_source_exists?
```

That hits the database (e.g. `SHOW FULL FIELDS` on MySQL2, `PRAGMA table_xinfo` on SQLite3), and the resulting SCHEMA event is captured by the global subscriber, inflating the count.

The fix calls `Topic.first` before subscribing in each test, warming all lazy-loaded caches (columns, data sources, attribute methods) so no SCHEMA queries fire during the instrumented block.

Reproduce (before fix):

```
cd activerecord
bin/test test/cases/persistence_test.rb:804 test/cases/transaction_instrumentation_test.rb:393
```

The persistence test's `ensure` block calls `Topic.reset_column_information`, clearing the schema cache just before our test runs.

### Additional information

N/A

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [ ] Tests are added or updated if you fix a bug or add a feature.
- [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.