### PR TITLE
Fix Encoding::CompatibilityError with non-ASCII strict locals defaults

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -370,6 +370,12 @@ module ActionView
 
         return if @strict_locals.nil? # Magic comment not found
 
+        # Tag with the assumed encoding before encode! runs, same as
+        # encode! does for the source itself (see above).
+        if @strict_locals.encoding == Encoding::BINARY
+          @strict_locals.force_encoding(Encoding.default_external)
+        end
+
         @strict_locals = "**nil" if @strict_locals.blank?
       end
 

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -338,6 +338,16 @@ class TestERBTemplate < ActiveSupport::TestCase
     end
   end
 
+  def test_strict_locals_with_non_ascii_default_values
+    # \xC3\xA9 = "é", \xC3\xBC = "ü"
+    source = "<%# locals: (label: \"caf\xC3\xA9\") -%>\n<p><%= label %> \xC3\xBC</p>"
+    assert_equal Encoding::ASCII_8BIT, source.encoding
+
+    @template = new_template(source)
+    assert_equal Encoding::UTF_8, render.encoding
+    assert_equal "<p>caf\u{E9} \u{FC}</p>", render
+  end
+
   def test_error_when_template_isnt_valid_utf8
     e = assert_raises ActionView::Template::Error do
       @template = new_template("hello \xFCmlat", virtual_path: nil)


### PR DESCRIPTION
### Motivation / Background

Fixes #56904

When a template loaded via `File.binread` uses strict locals with non-ASCII default values (e.g. `<%# locals: (label: "café") -%>`), `compiled_source` raises `Encoding::CompatibilityError`.

`strict_locals!` extracts the locals declaration via `$1` before `encode!` runs, so `@strict_locals` inherits the ASCII-8BIT tag from `File.binread`. When the `compiled_source` heredoc interpolates this ASCII-8BIT string (containing bytes > 0x7F) alongside the UTF-8 ERB handler output (also containing bytes > 0x7F), Ruby's encoding negotiation raises `CompatibilityError`.

If the template body happens to contain only bytes ≤ 0x7F, the error is avoided but the compiled source ends up with an incorrect ASCII-8BIT encoding tag instead of UTF-8.

### Detail

This Pull Request adds `force_encoding(Encoding.default_external)` to `@strict_locals` in `strict_locals!`, the same re-tagging that `encode!` already performs on the source body. This is a label change only (`force_encoding`), not a byte conversion (`encode`).

**Note on non-UTF-8 `Encoding.default_external`**: When `default_external` is set to a non-UTF-8 encoding (e.g. ISO-8859-1), the re-tagged `@strict_locals` will conflict with the `compiled_source` heredoc which is always UTF-8 (the encoding of `template.rb` itself). This is a pre-existing structural limitation of `compiled_source` and is outside the scope of this fix.

### Additional information

None.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.