### PR TITLE
[Fix #56892] Fix spacing in ERB comment in getting_started guide [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1855,7 +1855,7 @@ We also need to update the show view to display the description in
 `app/views/products/show.html.erb`:
 
 ```erb#4
-<%# app/views/products/show.html.erb%>
+<%# app/views/products/show.html.erb %>
 <% cache @product do %>
   <h1><%= @product.name %></h1>
   <%= @product.description %>


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #56892

The ERB filepath comment in the Action Text section of the Getting Started
guide was missing a space before the closing `%>`, which caused the wrong
line to be highlighted in the rendered guide.

### Detail

Adds a missing space before `%>` in an ERB filepath comment.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
