### PR TITLE
Validate URI scheme in Action Text markdown link conversion

### DIFF
--- a/actiontext/lib/action_text/attachables/remote_image.rb
+++ b/actiontext/lib/action_text/attachables/remote_image.rb
@@ -45,7 +45,7 @@ module ActionText
       end
 
       def attachable_markdown_representation(caption, attachment_links: false)
-        "!#{MarkdownConversion.markdown_link(caption || "Image", url)}"
+        MarkdownConversion.markdown_link(caption || "Image", url, image: true)
       end
 
       def to_partial_path

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -122,12 +122,12 @@ module ActionText
     #
     #     attachable = ActiveStorage::Blob.find_by filename: "racecar.jpg"
     #     attachment = ActionText::Attachment.from_attachable(attachable)
-    #     attachment.to_markdown # => "[racecar.jpg]"
+    #     attachment.to_markdown # => "\\[racecar.jpg\\]"
     #
     # Use the `caption` when set:
     #
     #     attachment = ActionText::Attachment.from_attachable(attachable, caption: "Vroom vroom")
-    #     attachment.to_markdown # => "[Vroom vroom]"
+    #     attachment.to_markdown # => "\\[Vroom vroom\\]"
     #
     # When +attachment_links+ is true and a rendering context is available (e.g., controller or
     # mailer action), ActiveStorage blob attachments generate Markdown links with URLs.

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -138,10 +138,15 @@ module ActionText
     #     # Non-image blob
     #     attachment.to_markdown(attachment_links: true) # => "[report.pdf](http://example.com/rails/active_storage/blobs/...)"
     #
-    # Remote images always render as Markdown links regardless of +attachment_links+:
+    # Remote images always render as Markdown image links when the URL scheme is allowed:
     #
     #     content = ActionText::Content.new('<action-text-attachment content-type="image/jpeg" url="https://example.com/photo.jpg" caption="A photo"></action-text-attachment>')
     #     content.to_markdown # => "![A photo](https://example.com/photo.jpg)"
+    #
+    # Remote images with a disallowed URL scheme render as escaped bracketed text:
+    #
+    #     content = ActionText::Content.new('<action-text-attachment content-type="image/jpeg" url="data:text/html,PAYLOAD" caption="Click"></action-text-attachment>')
+    #     content.to_markdown # => "\\[Click\\]"
     #
     # The presentation can be overridden by implementing the `attachable_markdown_representation`
     # method:

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -68,13 +68,9 @@ module ActionText
             raise ArgumentError, "attachment_links requires a rendering context" unless renderer
 
             url = renderer.url_for(self)
-            if image?
-              "!#{MarkdownConversion.markdown_link(title, url)}"
-            else
-              MarkdownConversion.markdown_link(title, url)
-            end
+            MarkdownConversion.markdown_link(title, url, image: image?)
           else
-            "[#{MarkdownConversion.escape_markdown_text(title)}]"
+            "\\[#{MarkdownConversion.escape_markdown_text(title)}\\]"
           end
         end
 

--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -28,14 +28,30 @@ module ActionText
       end.strip
     end
 
-    # Returns a Markdown link: +[title](url)+. Escapes brackets and backslashes
-    # in +title+, and percent-encodes characters in +url+ that would break the
-    # link syntax.
+    # Returns a Markdown link: +[title](url)+.
+    #
+    # Escapes metacharacters in +title+, and percent-encodes characters in +url+ that would break
+    # the link syntax.
     #
     #     MarkdownConversion.markdown_link("photo", "https://example.com/photo_(large).png")
     #     # => "[photo](https://example.com/photo_%28large%29.png)"
-    def markdown_link(title, url)
-      "[#{escape_markdown_text(title)}](#{encode_href(url)})"
+    #
+    # Pass <tt>image: true</tt> to produce an image link (+![title](url)+).
+    #
+    #     MarkdownConversion.markdown_link("photo", "https://example.com/photo.png", image: true)
+    #     # => "![photo](https://example.com/photo.png)"
+    #
+    # If the URI scheme is not allowed (per +Rails::HTML::Sanitizer.allowed_uri?+), returns the
+    # escaped title wrapped in escaped brackets (+\[title\]+).
+    #
+    #     MarkdownConversion.markdown_link("click", "javascript:alert(1)")
+    #     # => "\\[click\\]"
+    def markdown_link(title, url, image: false)
+      if Rails::HTML::Sanitizer.allowed_uri?(url)
+        "#{"!" if image}[#{escape_markdown_text(title)}](#{encode_href(url)})"
+      else
+        "\\[#{escape_markdown_text(title)}\\]"
+      end
     end
 
     # Backslash-escapes CommonMark metacharacters in +text+ so they are treated

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -23,6 +23,10 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     assert_equal "\\[Image\\]", ActionText::MarkdownConversion.markdown_link("Image", "data:text/html,PAYLOAD", image: true)
   end
 
+  test "markdown_link with allowed data:image URI produces image link" do
+    assert_equal "![photo](data:image/png;base64,abc)", ActionText::MarkdownConversion.markdown_link("photo", "data:image/png;base64,abc", image: true)
+  end
+
   # --- Text tests ---
 
   test "plain text passes through unchanged" do
@@ -740,6 +744,13 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     assert_converted_to(
       "![photo \\<large\\>](https://example.com/photo.png)",
       '<action-text-attachment content-type="image/png" url="https://example.com/photo.png" caption="photo &lt;large&gt;"></action-text-attachment>'
+    )
+  end
+
+  test "RemoteImage attachment with allowed data:image URI renders as image link" do
+    assert_converted_to(
+      "![Image](data:image/png;base64,abc)",
+      '<action-text-attachment content-type="image/png" url="data:image/png;base64,abc"></action-text-attachment>'
     )
   end
 

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -3,6 +3,26 @@
 require "test_helper"
 
 class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
+  test "escape_markdown_text escapes metacharacters" do
+    assert_equal '\\*\\*bold\\*\\* and \\[link\\](url)', ActionText::MarkdownConversion.escape_markdown_text("**bold** and [link](url)")
+  end
+
+  test "markdown_link escapes title text and encodes URL" do
+    assert_equal '[\\*\\*bold\\*\\*](https://example.com/a%20b)', ActionText::MarkdownConversion.markdown_link("**bold**", "https://example.com/a b")
+  end
+
+  test "markdown_link with disallowed URI scheme returns escaped title" do
+    assert_equal "\\[click here\\]", ActionText::MarkdownConversion.markdown_link("click here", "javascript:alert(1)")
+  end
+
+  test "markdown_link with image: true returns image syntax" do
+    assert_equal "![photo](https://example.com/photo.png)", ActionText::MarkdownConversion.markdown_link("photo", "https://example.com/photo.png", image: true)
+  end
+
+  test "markdown_link with image: true and disallowed URI scheme returns escaped title" do
+    assert_equal "\\[Image\\]", ActionText::MarkdownConversion.markdown_link("Image", "data:text/html,PAYLOAD", image: true)
+  end
+
   # --- Text tests ---
 
   test "plain text passes through unchanged" do
@@ -723,6 +743,13 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "RemoteImage attachment with disallowed URI scheme omits the link" do
+    assert_converted_to(
+      "\\[Image\\]",
+      '<action-text-attachment content-type="image/jpeg" url="data:text/html,DANGEROUS_PAYLOAD"></action-text-attachment>'
+    )
+  end
+
   test "RemoteImage attachment without caption falls back to Image alt text" do
     assert_converted_to(
       "![Image](https://example.com/photo.jpg)",
@@ -746,7 +773,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
 
-    assert_converted_to("[Captioned]", html)
+    assert_converted_to("\\[Captioned\\]", html)
   end
 
   test "Blob image with attachment_links: true uses caption" do
@@ -763,7 +790,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
 
-    assert_converted_to("[racecar.jpg]", html)
+    assert_converted_to("\\[racecar.jpg\\]", html)
   end
 
   test "Blob image with attachment_links: true uses filename" do
@@ -780,7 +807,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "report.txt", content_type: "text/plain")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
 
-    assert_converted_to("[Captioned]", html)
+    assert_converted_to("\\[Captioned\\]", html)
   end
 
   test "Blob with attachment_links: true uses caption" do
@@ -797,7 +824,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "report.txt", content_type: "text/plain")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
 
-    assert_converted_to("[report.txt]", html)
+    assert_converted_to("\\[report.txt\\]", html)
   end
 
   test "Blob with attachment_links: true uses filename" do
@@ -814,7 +841,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo *large*"></action-text-attachment>)
 
-    assert_converted_to("[photo \\*large\\*]", html)
+    assert_converted_to("\\[photo \\*large\\*\\]", html)
   end
 
   test "Blob image with attachment_links: true escapes metacharacters in caption" do
@@ -832,8 +859,8 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo <large>"></action-text-attachment>)
     html2 = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="photo &lt;large&gt;"></action-text-attachment>)
 
-    assert_converted_to("[photo \\<large\\>]", html)
-    assert_converted_to("[photo \\<large\\>]", html2)
+    assert_converted_to("\\[photo \\<large\\>\\]", html)
+    assert_converted_to("\\[photo \\<large\\>\\]", html2)
   end
 
   test "Blob image with attachment_links: true escapes angle brackets in caption" do
@@ -876,7 +903,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
       assert_raises(ArgumentError) do
         ActionText::Content.new(html).to_markdown(attachment_links: true)
       end
-      assert_converted_to("[Captioned]", html)
+      assert_converted_to("\\[Captioned\\]", html)
     end
   ensure
     ActionMailer::Base.default_url_options = original_default_url_options
@@ -890,7 +917,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
       ActionText::Content.new(html).to_markdown(attachment_links: true)
     end
     assert_match(/rendering context/, error.message)
-    assert_converted_to("[Captioned]", html)
+    assert_converted_to("\\[Captioned\\]", html)
   end
 
   test "Blob image with renderer uses bracketed title by default" do
@@ -898,7 +925,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     html = %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
 
     with_controller_renderer do
-      assert_converted_to("[Captioned]", html)
+      assert_converted_to("\\[Captioned\\]", html)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

In the HTML rendering pipeline, `SafeListSanitizer` strips dangerous URI schemes (`javascript:`, `data:text/html`, etc.) from `<img src>` attributes.

But in the Markdown pipeline, `RemoteImage#attachable_markdown_representation` called `MarkdownConversion.markdown_link` with no URI scheme validation, allowing crafted `<action-text-attachment>` elements to pass URLs through unchecked.

Also relevant: `MarkdownConversion` already calls `allowed_uri?` before emitting an anchor link, so there was an inconsistency even within the Markdown path.

### Detail

Add a `Rails::HTML::Sanitizer.allowed_uri?` check to `markdown_link`. When the URI scheme is disallowed, return the escaped title wrapped in escaped brackets (`\[title\]`) instead of emitting a link.

Example: `<action-text-attachment url="data:text/html,PAYLOAD">` previously produced `![Image](data:text/html,PAYLOAD)` in markdown output. Now it produces `\[Image\]`.

Also note that any "downgraded" links, either because the URI is not allowed or because `attached_links: false`, are now wrapped in escaped brackets as well. That is, what was `[caption]` is now `\[caption\]`.

### Additional information

The `ActiveStorage::Blob` path uses `url_for(self)` which generates safe system URLs, but the check in `markdown_link` provides defense-in-depth for all callers.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.