### PR TITLE
Map ActiveStorage::FileNotFoundError to 404 Not Found

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Map `ActiveStorage::FileNotFoundError` to HTTP 404 Not Found.
+
+    When a blob record exists but the backing file is missing from the storage
+    service, Active Storage now returns a 404 response instead of a 500 error.
+    This matches the existing behavior of `ActiveRecord::RecordNotFound`.
+
+    *Yaroslav Shmarov*
+
 *   Restore ADC when signing URLs with IAM for GCS
 
     ADC was previously used for automatic authorization when signing URLs with IAM.

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -30,6 +30,10 @@ module ActiveStorage
     config.active_storage.queues = ActiveSupport::InheritableOptions.new
     config.active_storage.precompile_assets = true
 
+    config.action_dispatch.rescue_responses.merge!(
+      "ActiveStorage::FileNotFoundError" => :not_found
+    )
+
     config.active_storage.variable_content_types = %w(
       image/png
       image/gif

--- a/activestorage/test/controllers/representations/redirect_controller_test.rb
+++ b/activestorage/test/controllers/representations/redirect_controller_test.rb
@@ -40,6 +40,20 @@ class ActiveStorage::Representations::RedirectControllerWithVariantsTest < Actio
 
     assert_response :not_found
   end
+
+  test "returns a 404 if the file is not found" do
+    mock_download = lambda do |_|
+      raise ActiveStorage::FileNotFoundError
+    end
+
+    @blob.service.stub(:download, mock_download) do
+      get rails_blob_representation_url(
+        filename: @blob.filename,
+        signed_blob_id: @blob.signed_id,
+        variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
+    end
+    assert_response :not_found
+  end
 end
 
 class ActiveStorage::Representations::RedirectControllerWithVariantsWithStrictLoadingTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
### Motivation

<img width="543" height="44" alt="Screenshot 2026-03-02 at 10 22 28" src="https://github.com/user-attachments/assets/e6500ed8-4fbf-4ac8-838a-9022e7c67d38" />
<img width="420" height="28" alt="Screenshot 2026-03-02 at 10 22 45" src="https://github.com/user-attachments/assets/b27a04f1-26fb-4917-93bf-7cee2666248c" />

When a blob record exists in the database but the backing file is missing from the storage service (S3, GCS, disk), `ActiveStorage::FileNotFoundError` is raised and surfaces as a **500 Internal Server Error**.

The proxy controllers already handle this gracefully — the `ActiveStorage::Streaming` concern rescues `FileNotFoundError` and returns 404. But any other path that triggers a download (e.g. the representations redirect controller) returns a 500.

This is the same class of problem that `ActiveRecord::RecordNotFound` solves by being mapped to `:not_found` in `rescue_responses` via the ActiveRecord railtie.

### Solution

Register `ActiveStorage::FileNotFoundError` in `config.action_dispatch.rescue_responses` in the ActiveStorage engine, following the exact same pattern ActiveRecord uses:

```ruby
config.action_dispatch.rescue_responses.merge!(
  "ActiveStorage::FileNotFoundError" => :not_found
)
```

This ensures a 404 is returned globally for missing storage files, not just in proxy controllers.

### Related issues

- #33647 — ActiveStorage: Fail more gracefully if file is not found using DiskService
- #51284 — ActiveStorage ProxyController sets Cache-Control headers on errors like FileNotFoundError