### PR TITLE
Only allow known safe ASCII characters in HTML5 tag names in ActionView::Helpers::TagHelper

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -574,7 +574,7 @@ module ActionView
 
       private
         def ensure_valid_html5_tag_name(name)
-          raise ArgumentError, "Invalid HTML5 tag name: #{name.inspect}" unless /\A[a-zA-Z][^\s\/><]*\z/.match?(name)
+          raise ArgumentError, "Invalid HTML5 tag name: #{name.inspect}" unless /\A[a-zA-Z][a-zA-Z0-9:_-]*\z/.match?(name)
         end
         module_function :ensure_valid_html5_tag_name
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -574,7 +574,7 @@ module ActionView
 
       private
         def ensure_valid_html5_tag_name(name)
-          raise ArgumentError, "Invalid HTML5 tag name: #{name.inspect}" unless /\A[a-zA-Z][^\s\/>]*\z/.match?(name)
+          raise ArgumentError, "Invalid HTML5 tag name: #{name.inspect}" unless /\A[a-zA-Z][^\s\/><]*\z/.match?(name)
         end
         module_function :ensure_valid_html5_tag_name
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -151,12 +151,24 @@ class TagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_tag_with_dangerous_name_containing_less_than
+    assert_raise(ArgumentError, 'expected "asdf-<" to be invalid') do
+      tag("asdf-<")
+    end
+  end
+
   def test_tag_builder_with_dangerous_name
     INVALID_TAG_CHARS.each_char do |char|
       tag_name = "asdf-#{char}".to_sym
       assert_raise(ArgumentError, "expected #{tag_name.inspect} to be invalid") do
         tag.public_send(tag_name)
       end
+    end
+  end
+
+  def test_tag_builder_with_dangerous_name_containing_less_than
+    assert_raise(ArgumentError, 'expected :"asdf-<" to be invalid') do
+      tag.public_send(:"asdf-<")
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `TagHelper` currently accepts tag names containing `<` (for example, `tag("asdf-<")`), which produces invalid HTML instead of raising an error.

### Detail

This Pull Request changes tag-name validation in `ActionView::Helpers::TagHelper` to reject `<` in `ensure_valid_html5_tag_name`.

It also adds regression tests to cover both APIs:

- `tag("asdf-<")` now raises `ArgumentError`
- `tag.public_send(:"asdf-<")` now raises `ArgumentError`

### Additional information

Tests run:

- `bin/test test/template/tag_helper_test.rb`
- `bin/test test/template/output_safety_helper_test.rb`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (Not updated here because this is a minor bug fix.)
