### PR TITLE
Fix the Rails Guides task to vendor JavaScript

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -64,7 +64,7 @@ namespace :guides do
     require "importmap/packager"
 
     packager = Importmap::Packager.new(vendor_path: "assets/javascripts")
-    imports = packager.import("@hotwired/turbo", from: "unpkg")
+    imports = packager.import("@hotwired/turbo", from: "unpkg")[:imports]
     imports.each do |package, url|
       umd_url = url.gsub("esm.js", "umd.js")
       puts %(Vendoring "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{umd_url})


### PR DESCRIPTION
### Motivation / Background

The `guides:vendor_javascript` task was failing with the below error:

```
NoMethodError: undefined method 'gsub' for an instance of Hash (NoMethodError)

      umd_url = url.gsub("esm.js", "umd.js")
```

### Detail

This PR fixes the task to correctly instantiate the array of imports.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
