### PR TITLE
Remove sentence about deleting output dir from guides readme

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -10,7 +10,7 @@ The editing files for the Guides rebuild reside in `stylesrc` and use SCSS to im
 
 ## Building the Guides in Development
 
-To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process.
+To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. The master SCSS files (style.scss, highlight.scss) will compile as part of this process.
 
 ## FAQ
 


### PR DESCRIPTION
### Motivation / Background

The `output` directory for the Rails Guides needs to be deleted before the HTML guides are generated. This PR implements a Rake task to do this so it's quicker for the developer.

EDIT: The `RailsGuides::Generator` cleans the directory automatically before generating the guides, so this is now a documentation change only.

### Detail

Update the Readme to remove the sentence about deleting the `output` directory before generating the Rails Guides.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.