### PR TITLE
Add a development server to view the Rails Guides

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -12,6 +12,12 @@ The editing files for the Guides rebuild reside in `stylesrc` and use SCSS to im
 
 To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process.
 
+A local development server can be used to view the guides:
+
+```
+$ bundle exec rackup
+```
+
 ## FAQ
 
 ### Why are you not using CSS variables?

--- a/guides/config.ru
+++ b/guides/config.ru
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rack/static"
+
+class App
+  def call(env)
+    [404, { "content-type" => "text/plain" }, ["Page not found"]]
+  end
+end
+
+use Rack::Static, urls: [""], root: "output", index: "index.html"
+run App.new


### PR DESCRIPTION
### Motivation / Background

The HTML Rails Guides can only be viewed by opening the HTML file. While this is fine, serving them over HTTP has better ergonomics and better simulates how they will be access in production.

### Detail

This Pull Request adds a basic `config.ru` to serve the Rails Guides using a `Rack::Static` server. This allows the developer to access the guides at `localhost:9292` during development.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
