### PR TITLE
fix: preserve `ssl_bind` when `PORT` env var overrides port in `config/puma.rb`.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Preserve `ssl_bind` and extra `bind` directives in `config/puma.rb` when
+    `ENV["PORT"]` is set.
+
+    Previously, setting `ENV["PORT"]` caused `rails server` to inject `:Port`
+    into Puma's user-supplied options, which replaced the entire bind list and
+    silently discarded any `ssl_bind` or additional `bind` calls in
+    `config/puma.rb`. The fix skips the injection when `config/puma.rb`
+    already handles `ENV["PORT"]` via its own `port` directive, while
+    preserving the existing behaviour for environments without a
+    `config/puma.rb` (e.g. devcontainers).
+
+    *Ruy Rocha*
+
 *   Avoid adding `Rack::Sendfile` to the middleware stack if `config.action_dispatch.x_sendfile_header` is `nil`.
 
     The middleware behave as a noop in such case so it's pointless to have it in the stack.

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -204,7 +204,7 @@ module Rails
               end
             end
             user_supplied_options << :Host if ENV["HOST"] || ENV["BINDING"]
-            user_supplied_options << :Port if ENV["PORT"]
+            user_supplied_options << :Port if ENV["PORT"] && !puma_config_handles_port?
             user_supplied_options << :pid if ENV["PIDFILE"]
             user_supplied_options.uniq
           end
@@ -250,6 +250,12 @@ module Rails
 
         def prepare_restart
           FileUtils.rm_f(pid) if pid && options[:restart]
+        end
+
+        def puma_config_handles_port?
+          config_file = "config/puma.rb"
+
+          File.exist?(config_file) && File.read(config_file).match(/^\s*port[\s(]/)
         end
 
         def rack_server_suggestion(server)

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -110,6 +110,38 @@ class Rails::Command::ServerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_env_port_does_not_inject_Port_into_user_supplied_options_when_puma_config_handles_it
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir_p("config")
+
+        File.write("config/puma.rb", <<~RUBY)
+          port ENV.fetch("PORT", 3000)
+          bind "tcp://0.0.0.0:9292"
+        RUBY
+
+        switch_env "PORT", "3010" do
+          options = parse_arguments
+          assert_not_includes options[:user_supplied_options], :Port,
+            "ENV[PORT] must not inject :Port into user_supplied_options when " \
+            "config/puma.rb already handles it — doing so wipes ssl_bind entries"
+        end
+      end
+    end
+  end
+
+  def test_env_port_injects_Port_into_user_supplied_options_when_no_puma_config
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        switch_env "PORT", "3010" do
+          options = parse_arguments
+          assert_includes options[:user_supplied_options], :Port,
+            "ENV[PORT] must inject :Port when no config/puma.rb exists (e.g. devcontainers)"
+        end
+      end
+    end
+  end
+
   def test_environment_with_binding
     switch_env "BINDING", "1.2.3.4" do
       options = parse_arguments


### PR DESCRIPTION
Fixes #56912

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `ServerCommand#user_supplied_options` unconditionally injects `:Port` into the user-supplied options list when ENV["PORT"] is present. 

### Detail

When `ENV["PORT"]` is set, `rails server` unconditionally injects `:Port` into `user_supplied_options`. Puma evaluates user-supplied options at a higher priority than file config, and its `DSL#port` implementation assigns to `:binds` rather than appending, wiping any `ssl_bind` or extra `bind` directives declared in `config/puma.rb`.

Since the Rails app template always generates a `config/puma.rb` with `port ENV.fetch("PORT", 3000)`, `ENV["PORT"]` is already consumed at the file-config level. Injecting `:Port` as a user-supplied option on top is both redundant and destructive.

Fix by skipping the `:Port` injection when `config/puma.rb` already handles `ENV["PORT"]` via its own `port` DSL call. Fall back to the existing behaviour when no `config/puma.rb` exists so that `ENV["PORT"]` continues to be honoured in environments like Devcontainers.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
