### PR TITLE
fix: remove unnecessary `disconnect!` from `BinaryWithDecoderTest` teardown.

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/binary_with_decoder_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/binary_with_decoder_test.rb
@@ -13,6 +13,5 @@ class BinaryWithDecoderTest < BinaryTest
   def teardown
     super
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea = false
-    ActiveRecord::Base.connection_pool.disconnect!
   end
 end


### PR DESCRIPTION

Fixes #56882

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because of #56882 

### Detail

`BinaryWithDecoderTest#teardown` called `connection_pool.disconnect!` which left the pool in a disconnected state. When `TestUnconnectedAdapter#setup` subsequently called `lease_connection`, the pool auto-reconnected and returned a genuinely active adapter. Since `remove_connection` only removes the pool config without touching the adapter's raw connection, `active?`would issue a live query and return true, failing the assertion "Removed adapter should no longer be active".

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
