### PR TITLE
ActionText: support block children in editor elements alongside value

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Support block children in editor elements alongside value.
+
+    Blocks were introduced in #55827, but only as an alternative to the value
+    argument: the block was captured and used as the initial editor content,
+    making it either value OR block — not both.
+
+    The block semantics are now changed so that blocks render as DOM children of
+    the editor element instead. Value and block are now independent: value flows
+    into the editor's content binding (the hidden input for Trix, the value
+    attribute for custom editors), while the block renders as inner DOM children
+    — useful for embedding custom elements such as prompt menus or toolbar
+    extensions.
+
+    This enables other editors like Lexxy to use the block form for configuration
+    — injecting child elements into the editor tag — while the rich text value is
+    preserved separately.
+
+    Trix preserves the original block-as-initial-value contract by capturing the
+    block in `TrixEditor::Tag#render_in` when no value is present, keeping its
+    hidden input populated as before.
+
+    *Jorge Manrubia*
+
 *   Render `MissingAttachable` as "☒" in plain text.
 
     Previously, `Content#to_plain_text` would replace a `MissingAttachable` with a blank string.

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -32,7 +32,6 @@ module ActionText
     #     # <input type="hidden" name="content" id="trix_input_post_1" value="&lt;h1&gt;Default content&lt;/h1&gt;">
     #     # <trix-editor id="content" input="trix_input_post_1" class="trix-content" ...></trix-editor>
     def rich_textarea_tag(name, value = nil, options = {}, &block)
-      value = capture(&block) if value.nil? && block_given?
       options = options.symbolize_keys
 
       options[:value] ||= value.try(:to_editor_html) || value
@@ -42,7 +41,7 @@ module ActionText
       options[:data][:direct_upload_url] ||= main_app.rails_direct_uploads_url
       options[:data][:blob_url_template] ||= main_app.rails_service_blob_url(":signed_id", ":filename")
 
-      render RichText.editor.editor_tag(options)
+      render RichText.editor.editor_tag(options, &block)
     end
     alias_method :rich_text_area_tag, :rich_textarea_tag
   end

--- a/actiontext/lib/action_text/editor.rb
+++ b/actiontext/lib/action_text/editor.rb
@@ -47,8 +47,8 @@ module ActionText
       self.class.name.demodulize.delete_suffix("Editor").underscore
     end
 
-    def editor_tag(...)
-      Tag.new(editor_name, ...)
+    def editor_tag(options = {}, &block)
+      Tag.new(editor_name, options, &block)
     end
   end
 
@@ -58,9 +58,10 @@ module ActionText
     attr_reader :editor_name
     attr_reader :options
 
-    def initialize(editor_name, options = {})
+    def initialize(editor_name, options = {}, &block)
       @editor_name = editor_name
       @options = options
+      @block = block
     end
 
     def element_name
@@ -70,7 +71,7 @@ module ActionText
     def render_in(view_context)
       options[:class] ||= "#{editor_name}-content"
 
-      view_context.content_tag(element_name, nil, options)
+      view_context.content_tag(element_name, nil, options, &@block)
     end
   end
 end

--- a/actiontext/lib/action_text/editor/trix_editor.rb
+++ b/actiontext/lib/action_text/editor/trix_editor.rb
@@ -31,13 +31,15 @@ module ActionText
       name = options.delete(:name)
       form = options.delete(:form)
       value = options.delete(:value)
+      value = view_context.capture(&@block) if @block && value.nil?
 
+      options[:class] ||= "#{editor_name}-content"
       options[:input] ||= options[:id] ?
         "#{options[:id]}_#{editor_name}_input_#{name.to_s.gsub(/\[.*\]/, "")}" :
         "#{editor_name}_input_#{self.class.id += 1}"
       input_tag = view_context.hidden_field_tag(name, value, id: options[:input], form: form)
 
-      input_tag + super
+      input_tag + view_context.content_tag(element_name, nil, options)
     end
   end
 end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -238,19 +238,19 @@ class ActionText::FormHelperTest < ActionView::TestCase
     HTML
   end
 
-  test "form with rich text area with value with block" do
-    model = Message.new content: "<h1>ignored</h1>"
+  test "form with rich text area ignores block when value is present" do
+    message = Message.new content: "<h1>existing content</h1>"
 
-    form_with model: model, scope: :message do |form|
-      form.rich_textarea :title do
-        "<h1>hello world</h1>"
+    form_with model: message, scope: :message do |form|
+      form.rich_textarea :content do
+        content_tag("custom-prompt", "hello world")
       end
     end
 
     assert_dom_equal(<<~HTML, output_buffer)
       <form action="/messages" accept-charset="UTF-8" method="post">
-        <input type="hidden" name="message[title]" id="message_title_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;" />
-        <trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
+        <input type="hidden" name="message[content]" id="message_content_trix_input_message" value="&lt;h1&gt;existing content&lt;/h1&gt;"/>
+        <trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
         </trix-editor>
       </form>
     HTML

--- a/actiontext/test/unit/editor_test.rb
+++ b/actiontext/test/unit/editor_test.rb
@@ -99,4 +99,31 @@ class ActionText::Editor::SubclassTest < ActionView::TestCase
     assert_equal "test-content", element["class"]
     assert_equal "<div>hello</div>", element["value"]
   end
+
+  test "#editor_tag with block renders children inside the editor element" do
+    editor = TestEditor.new
+    editor_tag = editor.editor_tag(id: "test_editor_id", name: "message[body]") {
+      content_tag("custom-prompt", "hello world")
+    }
+
+    render(editor_tag)
+
+    element = rendered.html.at("test-editor")
+    assert_not_nil element.at("custom-prompt")
+    assert_equal "hello world", element.at("custom-prompt").text
+  end
+
+  test "#editor_tag supports both value and block children simultaneously" do
+    editor = TestEditor.new
+    editor_tag = editor.editor_tag(id: "test_editor_id", name: "message[body]", value: "<div>hello</div>") {
+      content_tag("custom-prompt", "hello world")
+    }
+
+    render(editor_tag)
+
+    element = rendered.html.at("test-editor")
+    assert_equal "<div>hello</div>", element["value"]
+    assert_not_nil element.at("custom-prompt")
+    assert_equal "hello world", element.at("custom-prompt").text
+  end
 end


### PR DESCRIPTION
Blocks were introduced in #55827, but only as an alternative to the value argument: the block was captured and used as the initial editor content, making it either value OR block — not both.

This changes the block semantics so that blocks render as DOM children of the editor element instead. Value and block are now independent: value flows into the editor's content binding, while the block renders as inner DOM children — useful for embedding custom elements such as prompt menus or toolbar extensions.

This enables other editors like Lexxy to use the block form for configuration — injecting child elements into the editor tag — while the rich text value is preserved separately and passed via standard `value` attribute.

Trix preserves the original block-as-initial-value contract by capturing the block in `TrixEditor::Tag#render_in` when no value is present, keeping its hidden input populated as before.