### PR TITLE
Fix stale Rack::Sendfile reference in DebugLocks documentation

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_locks.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_locks.rb
@@ -10,7 +10,7 @@ module ActionDispatch
   # To use it, insert it near the top of the middleware stack, using
   # `config/application.rb`:
   #
-  #     config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
+  #     config.middleware.insert_before ActionDispatch::Executor, ActionDispatch::DebugLocks
   #
   # After restarting the application and re-triggering the deadlock condition, the
   # route `/rails/locks` will show a summary of all threads currently known to the

--- a/guides/source/threading_and_code_execution.md
+++ b/guides/source/threading_and_code_execution.md
@@ -324,7 +324,7 @@ involved, you can temporarily add the ActionDispatch::DebugLocks middleware to
 `config/application.rb`:
 
 ```ruby
-config.middleware.insert_before Rack::Sendfile,
+config.middleware.insert_before ActionDispatch::Executor,
                                   ActionDispatch::DebugLocks
 ```
 


### PR DESCRIPTION
### Motivation / Background                                                                                                                                                                                                              
                                                                       
  Since #56915, `Rack::Sendfile` is no longer added to the middleware stack when `x_sendfile_header` is `nil` (the default in all environments). The `DebugLocks` documentation and the Threading guide both recommend `insert_before      
  Rack::Sendfile`, which now raises `No such middleware to insert before: Rack::Sendfile`.
                                                                                                                                                                                                                                           
  ### Detail                                                           
                                         
  Replace `Rack::Sendfile` with `ActionDispatch::Executor` as the insertion point in:
  - `actionpack/lib/action_dispatch/middleware/debug_locks.rb` (inline docs)
  - `guides/source/threading_and_code_execution.md`

  `ActionDispatch::Executor` is the first unconditional middleware in the stack, keeping DebugLocks near the top as intended.

  ### Checklist

  - [x] This Pull Request is related to one change.
  - [x] Commit message has a detailed description of what changed and why.
  - [ ] Tests are added or updated if you fix a bug or add a feature.
  - [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.