### PR TITLE
Update comment in default application.css for new Rails apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/assets/stylesheets/application.css.tt
@@ -1,10 +1,8 @@
 /*
- * This is a manifest file that'll be compiled into application.css.
+ * Propshaft serves assets efficiently without transpiling or bundling. By default, each
+ * stylesheet is linked individually hence this file should be used for global
+ * styles only. Consider organizing styles into separate files for maintainability.
  *
- * With Propshaft, assets are served efficiently without preprocessing steps. You can still include
- * application-wide styles in this file, but keep in mind that CSS precedence will follow the standard
- * cascading order, meaning styles declared later in the document or manifest will override earlier ones,
- * depending on specificity.
- *
- * Consider organizing styles into separate files for maintainability.
+ * You may transpile and bundle your CSS using the `cssbundling-rails` gem which
+ * integrates with Propshaft.
  */


### PR DESCRIPTION
### Motivation / Background

This PR follows on from https://github.com/rails/rails/pull/53021. New Rails 8 apps use Propshaft by default which doesn't (as far as I can tell) treat `application.css` as a manifest. It simply fingerprints the file and doesn't do any compilation, hence the existing comment is misleading.

### Detail

The PR updates the comment to state that stylesheets are linked individually, and signposts `cssbundling-rails` if the developer would like to transpile/bundle their CSS.

If my understanding is incorrect, or the comment could be improved, please let me know!

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
