### PR TITLE
ActionView::Base.precompile_templates compiles templates with strict locals at boot

### DIFF
--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -84,6 +84,9 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
+  # Precompile templates with strict locals at boot.
+  config.action_view.precompile_templates = true
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end

--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -58,6 +58,9 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Precompile templates with strict locals at boot.
+  config.action_view.precompile_templates = ENV["CI"].present?
+
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/actiontext/test/dummy/config/environments/test.rb
+++ b/actiontext/test/dummy/config/environments/test.rb
@@ -58,6 +58,9 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Precompile templates with strict locals at boot.
+  config.action_view.precompile_templates = ENV["CI"].present?
+
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActionView::Base.precompile_templates` compiles templates with strict locals at boot to improve cold render times and allow more memory to be shared via CoW on forking web servers.
+
+    *Joel Hawksley*
+
 *   Fix tag parameter content being overwritten instead of combined with tag block content.
     Before `tag.div("Hello ") { "World" }` would just return `<div>World</div>`, now it returns `<div>Hello World</div>`.
 

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -98,6 +98,7 @@ module ActionView
     super
     ActionView::Helpers.eager_load!
     ActionView::Template.eager_load!
+    ActionView::Template.precompile!
   end
 end
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -179,6 +179,9 @@ module ActionView # :nodoc:
     # Annotate rendered view with file names
     cattr_accessor :annotate_rendered_view_with_filenames, default: false
 
+    # Precompile templates with strict locals at boot.
+    cattr_accessor :precompile_templates, default: false
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -87,9 +87,15 @@ module ActionView
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
           next if k == :render_tracker
+          next if k == :precompile_templates
           send "#{k}=", v
         end
       end
+    end
+
+    initializer "action_view.precompile_templates", before: :eager_load! do |app|
+      precompile = app.config.action_view.delete(:precompile_templates)
+      ActionView::Base.precompile_templates = precompile unless precompile.nil?
     end
 
     initializer "action_view.deprecator", before: :load_environment_config do |app|

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -189,6 +189,38 @@ module ActionView
           const_set(:Types, implementation)
         end
       end
+
+      def precompile!
+        return unless ActionView::Base.precompile_templates
+
+        details = {
+          locale: I18n.available_locales,
+          handlers: ActionView::Template::Handlers.extensions,
+          formats: ActionView::Template::Types.symbols,
+          variants: :any
+        }
+        key = ActionView::LookupContext::DetailsKey.details_cache_key(details)
+
+        ActionController::Base.view_paths.each do |resolver|
+          next unless resolver.is_a?(ActionView::FileSystemResolver)
+
+          resolver.all_template_paths.each do |template_path|
+            templates = resolver.find_all(
+              template_path.name,
+              template_path.prefix,
+              template_path.partial?,
+              details,
+              key,
+              []
+            )
+
+            templates.each do |template|
+              next unless template.strict_locals?
+              template.send(:compile!, ActionController::Base.view_context_class)
+            end
+          end
+        end
+      end
     end
 
     attr_reader :identifier, :handler

--- a/actionview/test/fixtures/test/precompile_strict_locals.html.erb
+++ b/actionview/test/fixtures/test/precompile_strict_locals.html.erb
@@ -1,0 +1,2 @@
+<%# locals: (name: "World") -%>
+Hello, <%= name %>!

--- a/actionview/test/template/precompile_templates_test.rb
+++ b/actionview/test/template/precompile_templates_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class PrecompileTemplatesTest < ActiveSupport::TestCase
+  def setup
+    super
+    @old_precompile = ActionView::Base.precompile_templates
+    ActionController::Base.view_paths.each(&:clear_cache)
+  end
+
+  def teardown
+    ActionView::Base.precompile_templates = @old_precompile
+    ActionController::Base.view_paths.each(&:clear_cache)
+    ActionView::LookupContext::DetailsKey.clear
+    super
+  end
+
+  def test_precompile_templates_compiles_strict_locals_templates
+    ActionView::Base.precompile_templates = true
+
+    # Verify that the fixture template file exists
+    resolver = ActionController::Base.view_paths.paths.first
+    template_path = File.join(resolver.path, "test", "precompile_strict_locals.html.erb")
+    assert File.exist?(template_path), "Fixture template must exist"
+
+    # Precompile templates
+    ActionView::Template.precompile!
+
+    # Look up the template through the resolver with a cache key — since
+    # precompile! populated @unbound_templates, we get the same Template object.
+    details = { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+    key = ActionView::LookupContext::DetailsKey.details_cache_key(details)
+    templates = resolver.find_all("precompile_strict_locals", "test", false, details, key, [])
+    assert_not_empty templates, "Expected to find the strict locals template"
+
+    template = templates.first
+    assert template.strict_locals?, "Expected template to use strict locals"
+    assert template.instance_variable_get(:@compiled),
+      "Expected strict locals template to be compiled after precompile!"
+  end
+
+  def test_precompile_skipped_when_disabled
+    ActionView::Base.precompile_templates = false
+
+    ActionView::Template.precompile!
+
+    resolver = ActionController::Base.view_paths.paths.first
+    details = { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+    key = ActionView::LookupContext::DetailsKey.details_cache_key(details)
+    templates = resolver.find_all("precompile_strict_locals", "test", false, details, key, [])
+    assert_not_empty templates
+
+    template = templates.first
+    assert_not template.instance_variable_get(:@compiled),
+      "Expected strict locals template NOT to be compiled when precompile_templates is false"
+  end
+
+  def test_precompile_only_compiles_strict_locals_templates
+    ActionView::Base.precompile_templates = true
+
+    ActionView::Template.precompile!
+
+    # A template without strict locals should not be compiled
+    resolver = ActionController::Base.view_paths.paths.first
+    details = { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+    key = ActionView::LookupContext::DetailsKey.details_cache_key(details)
+    templates = resolver.find_all("hello_world", "test", false, details, key, [])
+    assert_not_empty templates, "Non-strict-locals fixture must exist"
+
+    template = templates.first
+    assert_not template.instance_variable_get(:@compiled),
+      "Expected non-strict-locals template NOT to be compiled by precompile!"
+  end
+end


### PR DESCRIPTION
### Motivation / Background

_This PR shamelessly builds on extensive work by @jhawthorn and others :heart:_

Currently, Rails templates are loaded from disk and compiled into a Ruby method the first time they are rendered. This process happens on every worker on forking web servers, every time a worker is spawned (such as on a new deploy).

This optimization aims to improve cold render times and to allow more memory to be shared via CoW on forking web servers by precompiling templates that use strict locals at boot time.

Assuming we want to move forward with this optimization, I plan to work to incorporate https://github.com/jhawthorn/actionview_precompiler into core as well.

For now, I’ve put this behind a configuration flag that defaults to false. I’d recommend that we default it to true for production environments starting in the next major release.

### Benchmark

1000 ERB templates (~100 lines each) with strict locals, Puma with 5 workers (clustered mode), Docker (Linux), Ruby 4.0. PSS (Proportional Set Size) accounts for shared memory pages between forked workers:

| | `precompile_templates=false` | `precompile_templates=true` |
|---|---|---|
| Templates compiled before fork | 0 | 1000 |
| Templates compiled after fork (per worker) | 1000 | 0 |
| Total PSS before rendering (5 workers) | 102 MB | 127 MB |
| Total PSS after rendering (5 workers) | 361 MB | 283 MB |
| **PSS increase from rendering** | **259 MB** | **156 MB** |

With `precompile_templates` enabled, compiled template bytecode is shared across all workers via copy-on-write, reducing post-render memory growth by **40%** (259 MB → 156 MB across 5 workers) and total memory after rendering by **22%** (361 MB → 283 MB).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
