### PR TITLE
Fix dbconsole NotImplementedError message

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -139,7 +139,7 @@ module ActiveRecord
 
       # Opens a database console session.
       def self.dbconsole(config, options = {})
-        raise NotImplementedError.new("#{self.class} should define `dbconsole` that accepts a db config and options to implement connecting to the db console")
+        raise NotImplementedError.new("#{self} should define `dbconsole` that accepts a db config and options to implement connecting to the db console")
       end
 
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil) # :nodoc:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because PR #54719 changed AbstractAdapter.dbconsole to interpolate self.class in a class method, which results in the misleading message “Class should define…”. Using self (the adapter class) restores the correct class name in the error.

### Detail
This Pull Request changes the NotImplementedError message in ActiveRecord::ConnectionAdapters::AbstractAdapter.dbconsole to use #{self} instead of #{self.class} (since self is the adapter class in def self.dbconsole).

### Before
```
ActiveRecord::ConnectionAdapters::AbstractAdapter.dbconsole(nil)
NotImplementedError: Class should define `dbconsole` ...
```

### After
```
ActiveRecord::ConnectionAdapters::AbstractAdapter.dbconsole(nil)
NotImplementedError: ActiveRecord::ConnectionAdapters::AbstractAdapter should define `dbconsole` ...
```