### PR TITLE
Fix missing comment marker in decrement_counter docs

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -194,7 +194,7 @@ module ActiveRecord
       #   DiscussionBoard.decrement_counter(:posts_count, 5)
       #
       #   # Decrement the posts_count column for the record with an id of 5
-      #   by a specific amount.
+      #   # by a specific amount.
       #   DiscussionBoard.decrement_counter(:posts_count, 5, by: 3)
       #
       #   # Decrement the posts_count column for the record with an id of 5


### PR DESCRIPTION
## Motivation / Background
Fix a missing # in a commented example so the snippet is consistent.

### Detail
Add the missing # before “by a specific amount.” in the decrement_counter example.

<img width="989" height="292" alt="Screenshot 2026-03-04 at 20 58 56" src="https://github.com/user-attachments/assets/094ad54c-1e3f-4edc-b56e-4c54a5db9075" />
