### PR TITLE
Treat unmarked BINARY strings as already decoded in Bytea#deserialize

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -31,6 +31,16 @@ module ActiveRecord
                   bytea column received a binary string for unescaping. In Rails 8.3, binary strings
                   will be treated as already unescaped.
                 MSG
+
+                # If the string is already-decoded raw binary (e.g. after a cache
+                # round-trip that stripped the @ar_pg_bytea_decoded ivar),
+                # unescape_bytea raises ArgumentError on null bytes. Return the
+                # value as-is in that case, consistent with the planned 8.3 behavior.
+                begin
+                  return PG::Connection.unescape_bytea(value)
+                rescue ArgumentError
+                  return value
+                end
               end
 
             else

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -55,6 +55,18 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_type_cast_binary_value_with_null_bytes
+    # A BINARY-encoded string without @ar_pg_bytea_decoded containing null bytes
+    # (e.g. after a cache serialization round-trip that stripped the ivar) should
+    # be returned as-is instead of raising ArgumentError from unescape_bytea.
+    decoded = "\x01\x00\x02\x00\x03".b
+    assert_deprecated(ActiveRecord.deprecator) do
+      result = @type.deserialize(decoded)
+      assert_equal decoded, result
+      assert_equal Encoding::BINARY, result.encoding
+    end
+  end
+
   def test_type_cast_marked_true_value
     decoded = "\\x414243".b
     decoded.instance_variable_set(:@ar_pg_bytea_decoded, true)


### PR DESCRIPTION
Fixes #56952

## Summary

Fixes `ArgumentError: string contains null byte` in `Bytea#deserialize` when deserializing unmarked BINARY strings (e.g. after a cache serialization round-trip).

### Problem

When a bytea column value goes through a cache serialization round-trip (e.g. via MessagePack/Paquito for memcached), the `@ar_pg_bytea_decoded` instance variable marker set by `ByteaDecoder` is lost — serialization formats don't preserve Ruby ivars on strings.

On deserialization, `Bytea#deserialize` receives an unmarked BINARY-encoded string. It correctly emits a deprecation warning, but then falls through to `PG::Connection.unescape_bytea`, which raises `ArgumentError` when the already-decoded binary data contains null bytes (`\x00`).

For bytea values that happen to not contain null bytes, `unescape_bytea` doesn't crash — but it silently produces incorrect results by attempting to unescape already-decoded data. So the current behavior is broken for all unmarked BINARY strings, it just only raises for the ones with null bytes.

### Fix

Rescue the `ArgumentError` from `PG::Connection.unescape_bytea` in the unmarked BINARY string path and return the value as-is. This is a minimal, non-breaking fix:

- **Hex-encoded BINARY strings without null bytes** continue to be unescaped as before (no behavior change)
- **Already-decoded BINARY strings with null bytes** are returned as-is instead of crashing (bug fix)
- **Deprecation warning preserved** — the full behavior change (treating all unmarked BINARY strings as already unescaped) is deferred to Rails 8.3 as announced by the deprecation

`PG::Connection.unescape_bytea` only raises `ArgumentError` for the null byte case — it's the only `ArgumentError` the PG C function produces — so the rescue is specific and safe.

### Context

Discovered at Shopify when caching ActiveRecord models with bytea columns via Paquito/ActiveRecordCoder. The `attributes_for_database` → `value_for_database` → `value` → `Bytea#deserialize` path re-triggers deserialization on `value_before_type_cast` after the ivar has been stripped by the cache round-trip.