### PR TITLE
Fix nil params serialization in ActionController::TestCase

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -105,12 +105,14 @@ module ActionController
 
       if get?
         if query_string.blank?
-          self.query_string = non_path_parameters.to_query
+          self.query_string = normalize_non_path_parameters(non_path_parameters).to_query
         end
       else
-        if ENCODER.should_multipart?(non_path_parameters)
+        normalized_non_path_parameters = normalize_non_path_parameters(non_path_parameters)
+
+        if ENCODER.should_multipart?(normalized_non_path_parameters)
           self.content_type = ENCODER.content_type
-          data = ENCODER.build_multipart non_path_parameters
+          data = ENCODER.build_multipart normalized_non_path_parameters
         else
           fetch_header("CONTENT_TYPE") do |k|
             set_header k, "application/x-www-form-urlencoded"
@@ -124,10 +126,10 @@ module ActionController
           when :xml
             data = non_path_parameters.to_xml
           when :url_encoded_form
-            data = non_path_parameters.to_query
+            data = normalized_non_path_parameters.to_query
           else
             @custom_param_parsers[content_mime_type.symbol] = ->(_) { non_path_parameters }
-            data = non_path_parameters.to_query
+            data = normalized_non_path_parameters.to_query
           end
         end
 
@@ -176,6 +178,19 @@ module ActionController
     end.new
 
     private
+      def normalize_non_path_parameters(value)
+        case value
+        when Hash
+          value.transform_values { |nested_value| normalize_non_path_parameters(nested_value) }
+        when Array
+          value.map { |element| normalize_non_path_parameters(element) }
+        when nil
+          ""
+        else
+          value
+        end
+      end
+
       def params_parsers
         super.merge @custom_param_parsers
       end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -517,6 +517,28 @@ class TestCaseTest < ActionController::TestCase
     )
   end
 
+  def test_nil_values_in_params_are_converted_to_empty_strings
+    params = {
+      foo: nil,
+      page: {
+        title: nil,
+        tags: [nil, "rails"]
+      }
+    }
+
+    get :test_params, params: params
+    parsed_params = JSON.parse(@response.body)
+    assert_equal "", parsed_params["foo"]
+    assert_equal "", parsed_params.dig("page", "title")
+    assert_equal ["", "rails"], parsed_params.dig("page", "tags")
+
+    post :test_params, params: params
+    parsed_params = JSON.parse(@response.body)
+    assert_equal "", parsed_params["foo"]
+    assert_equal "", parsed_params.dig("page", "title")
+    assert_equal ["", "rails"], parsed_params.dig("page", "tags")
+  end
+
   def test_query_param_named_action
     get :test_query_parameters, params: { action: "foobar" }
     parsed_params = JSON.parse(@response.body)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR has been created because `ActionController::TestCase` request helpers no longer convert `nil` param values to empty strings after `NilClass#to_query` changed in 8.1, causing a behavioral regression from 8.0. https://github.com/rails/rails/commit/2952e9a85d0a8a7f5057ef1f8aded9b7c0905327

Fixes #56934.

### Detail

`ActionController::TestCase::TestRequest` now normalizes non-path params by converting `nil` values to `""` before query/form encoding. This restores previous functional test behavior for `get`, `post`, and other helper methods using url-encoded params.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
