### PR TITLE
Match parent status codes for exception subclasses

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Match parent status codes for exception subclasses in `rescue_responses`.
+
+    Exception subclasses now inherit the HTTP status code of their nearest
+    registered ancestor instead of defaulting to 500. For example, a custom
+    error inheriting from `ActiveRecord::RecordNotFound` will correctly
+    return 404.
+
+    *Joseph Hale*
+
 *   Rate limiting calls `cache_key` on `by:` if the object responds to it.
 
     ```ruby

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -179,7 +179,8 @@ module ActionDispatch
     end
 
     def self.status_code_for_exception(class_name)
-      ActionDispatch::Response.rack_status_code(@@rescue_responses[class_name])
+      response = rescue_response_for_exception(class_name) || @@rescue_responses.default
+      ActionDispatch::Response.rack_status_code(response)
     end
 
     def show?(request)
@@ -198,7 +199,15 @@ module ActionDispatch
     end
 
     def rescue_response?
-      @@rescue_responses.key?(exception.class.name)
+      self.class.rescue_response_for_exception(exception.class.name).present?
+    end
+
+    def self.rescue_response_for_exception(class_name)
+      if @@rescue_responses.key?(class_name)
+        @@rescue_responses[class_name]
+      elsif (superclass_name = class_name&.safe_constantize&.superclass&.name)
+        @@rescue_responses[class_name] = rescue_response_for_exception(superclass_name)
+      end
     end
 
     def source_extracts

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -50,6 +50,11 @@ module ActionDispatch
       @cleaner = ActiveSupport::BacktraceCleaner.new
       @cleaner.remove_filters!
       @cleaner.add_silencer { |line| !line.start_with?("lib") }
+      @old_rescue_responses = ExceptionWrapper.rescue_responses.dup
+    end
+
+    teardown do
+      ExceptionWrapper.rescue_responses.replace(@old_rescue_responses)
     end
 
     class_eval "def index; raise TestError; end", "lib/file.rb", 42
@@ -208,6 +213,23 @@ module ActionDispatch
       assert_equal 400, wrapper.status_code
     end
 
+    test "#status_code walks ancestors to find registered parent exception" do
+      class UnregisteredRoutingError < ActionController::RoutingError; end
+
+      exception = UnregisteredRoutingError.new("")
+      wrapper = ExceptionWrapper.new(@cleaner, exception)
+      assert_equal 404, wrapper.status_code
+    end
+
+    test "#status_code prefers subclass registration over superclass" do
+      class RegisteredRoutingError < ActionController::RoutingError; end
+      ActionDispatch::ExceptionWrapper.rescue_responses[RegisteredRoutingError.name] = :service_unavailable
+
+      exception = RegisteredRoutingError.new("")
+      wrapper = ExceptionWrapper.new(@cleaner, exception)
+      assert_equal 503, wrapper.status_code
+    end
+
     test "#rescue_response? returns false for an exception that's not in rescue_responses" do
       exception = RuntimeError.new
       wrapper = ExceptionWrapper.new(@cleaner, exception)
@@ -216,6 +238,23 @@ module ActionDispatch
 
     test "#rescue_response? returns true for an exception that is in rescue_responses" do
       exception = ActionController::RoutingError.new("")
+      wrapper = ExceptionWrapper.new(@cleaner, exception)
+      assert_equal true, wrapper.rescue_response?
+    end
+
+    test "#rescue_response? returns true for a subclass of a registered exception" do
+      class UnregisteredRoutingError < ActionController::RoutingError; end
+
+      exception = UnregisteredRoutingError.new("")
+      wrapper = ExceptionWrapper.new(@cleaner, exception)
+      assert_equal true, wrapper.rescue_response?
+    end
+
+    test "#rescue_response? returns true when subclass has its own registration" do
+      class RegisteredRoutingError < ActionController::RoutingError; end
+      ActionDispatch::ExceptionWrapper.rescue_responses[RegisteredRoutingError.name] = :service_unavailable
+
+      exception = RegisteredRoutingError.new("")
       wrapper = ExceptionWrapper.new(@cleaner, exception)
       assert_equal true, wrapper.rescue_response?
     end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Rails maps certain [predefined exceptions](https://guides.rubyonrails.org/configuring.html#config-action-dispatch-rescue-responses) to HTTP status codes. For example, raising `ActiveRecord::RecordNotFound` from a controller results in a 404 Not Found, while unregistered exceptions result in a 500 Server Error.

What feels surprising to me is that subclasses of a predefined exception do not have the same behavior as their parent classes. 

```ruby
class MyCustomNotFound < ActiveRecord::RecordNotFound
end

# inside a controller...
raise ActiveRecord::RecordNotFound # -> 404 Not Found
raise MyCustomNotFound  # -> 500 Server Error 🤔
```

Since subclasses have an "is-a" relationship with their parents, it seems sensible that `MyCustomNotFound` should have the same default status code as `ActiveRecord::RecordNotFound`. Currently, to get the same behavior, each custom subclass has to be explicitly configured.

```ruby
# config/application.rb
config.action_dispatch.rescue_responses["MyCustomNotFound"] = :not_found
```

### Detail

This change results in custom subclasses returning their nearest registered parent class's status code. If no parent is registered, the existing default behavior still applies (map to a 500 Server Error).

The implementation is a simple recursive algorithm that walks up the class hierarchy to see if any parent classes are already registered. The results of each walk are cached so future lookups occur in O(1).

```ruby
class MyCustomNotFound < ActiveRecord::RecordNotFound
end

# inside a controller...
raise ActiveRecord::RecordNotFound # -> 404 Not Found
raise MyCustomNotFound  # -> 404 Not Found 😀
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

There's space to debate whether this is a bugfix or a breaking change.

With this change, existing subclasses of [predefined keys](https://guides.rubyonrails.org/configuring.html#config-action-dispatch-rescue-responses) in `ActionDispatch::ExceptionWrapper.rescue_responses` will start returning their parents' HTTP status codes instead of a 500.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
