### PR TITLE
Avoid AC::Live deadlocks while awaiting commit

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -347,7 +347,9 @@ module ActionController
         end
       end
 
-      @_response.await_commit
+      ActiveSupport::Dependencies.interlock.permit_concurrent_unloads do
+        @_response.await_commit
+      end
 
       raise error if error
     end

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -121,6 +121,10 @@ module ActionController
     class TestController < ActionController::Base
       include ActionController::Live
 
+      class << self
+        attr_accessor :before_live_thread_yield_latch, :release_live_thread_latch
+      end
+
       attr_accessor :latch, :tc, :error_latch
 
       def self.controller_path
@@ -338,6 +342,20 @@ module ActionController
         logger.info "Work complete"
         latch.count_down
       end
+
+      def delayed_commit
+        response.stream.write "hello"
+        response.stream.close
+      end
+
+      private
+        def new_controller_thread(&block)
+          super do
+            self.class.before_live_thread_yield_latch&.count_down
+            self.class.release_live_thread_latch&.wait
+            block.call
+          end
+        end
     end
 
     tests TestController
@@ -453,6 +471,53 @@ module ActionController
       res.each { }
       ActiveSupport::Dependencies.interlock.done_running
       pass
+    end
+
+    def test_waiting_for_live_commit_permits_unloads
+      @controller.class.before_live_thread_yield_latch = Concurrent::CountDownLatch.new
+      @controller.class.release_live_thread_latch = Concurrent::CountDownLatch.new
+
+      request = ActionController::TestRequest.create
+      response = ActionDispatch::TestResponse.create
+
+      request_thread = Thread.new do
+        ActiveSupport::Dependencies.interlock.running do
+          @controller.class.dispatch(:delayed_commit, request, response)
+        end
+      end
+
+      assert @controller.class.before_live_thread_yield_latch.wait(1), "live child thread did not start"
+
+      unload_acquired = Concurrent::CountDownLatch.new
+      release_unload = Concurrent::CountDownLatch.new
+
+      unload_thread = Thread.new do
+        ActiveSupport::Dependencies.interlock.unloading do
+          unload_acquired.count_down
+          release_unload.wait
+        end
+      end
+
+      @controller.class.release_live_thread_latch.count_down
+
+      assert unload_acquired.wait(1), "unload should acquire while the request waits for commit"
+
+      release_unload.count_down
+      assert request_thread.join(1), "request should complete once unload finishes"
+
+      assert_equal "hello", response.body
+    ensure
+      release_unload&.count_down
+      @controller.class.release_live_thread_latch&.count_down
+
+      unload_thread&.kill
+      request_thread&.kill
+
+      unload_thread&.join(1)
+      request_thread&.join(1)
+
+      @controller.class.before_live_thread_yield_latch = nil
+      @controller.class.release_live_thread_latch = nil
     end
 
     def test_async_stream

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -47,6 +47,10 @@ module ActiveSupport # :nodoc:
         yield if block
       end
 
+      def permit_concurrent_unloads(&block)
+        @lock.yield_shares(compatible: [:unload], &block)
+      end
+
       def raw_state(&block) # :nodoc:
         @lock.raw_state(&block)
       end


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because `ActionController::Live` requests can deadlock with the development reloader while the parent request thread is blocked in `await_commit`; Fixes #56888.

### Detail
This Pull Request changes `ActionController::Live` to yield its running share while the parent thread is only waiting for the live child to commit, and adds an unload-specific interlock helper for that handoff.

It also adds a regression test that pauses the live child before it enters the interlock and verifies that unloading can proceed and the request completes afterward. (Not sure if this is super helpful, but my agent gave it to me for free, so ... let me know if you want it tossed instead 😅)

### Additional information
GPT-5.4 was used to validate this approach -- but I would not consider myself to be personally clever enough to actually decide whether this is a reasonable approach or not.

<details><summary>It had a reasonable answer when I asked it if we can unload during the `await_commit`</summary>

> Why I think it is acceptable:
> - While the parent live request thread is in await_commit, it is not executing app code. It is only waiting for the child thread to either commit headers or fail.
> - The thread that actually does the controller work is the child thread inside interlock.running at live.rb.
> - Historically, Rails already relied on this handoff. Commit [3e4a69e52d8](https://github.com/rails/rails/commit/3e4a69e52d8) added exactly this pattern, and because unload used to be compatible with :load, the old permit_concurrent_loads path effectively allowed unloads through too. So this is closer to restoring prior behavior than inventing a new one.
> 
> The real concern is the gap before the child acquires running:
> - If the parent yields and unload wins immediately, the child may start after constants were unloaded.
> - That sounds scary, but it is also the case that the child already has references to the controller instance/class objects it will run on. Ruby objects do not disappear just because their constants were removed.
> - So the main risk is stale-code semantics, not memory corruption. In development, stale-code semantics are usually acceptable if the alternative is deadlock.
</details>

I also updated the [example repo](https://github.com/GetJobber/reproduce-rails-deadlock-behaviour/pull/1) to validate that we no longer have locking with the new approach.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
