### PR TITLE
Address test_validates_comparison_of_incomparables failure with Ruby 4.1.0dev

### DIFF
--- a/activemodel/test/cases/validations/comparison_validation_test.rb
+++ b/activemodel/test/cases/validations/comparison_validation_test.rb
@@ -291,7 +291,7 @@ class ComparisonValidationTest < ActiveModel::TestCase
   def test_validates_comparison_of_incomparables
     Topic.validates_comparison_of :approved, less_than: "cat"
 
-    assert_invalid_values([12], "comparison of Integer with String failed")
+    assert_invalid_values([12], /\Acomparison of Integer with String failed/)
     assert_invalid_values([nil])
     assert_valid_values([])
   end
@@ -316,7 +316,7 @@ class ComparisonValidationTest < ActiveModel::TestCase
       with_each_topic_approved_value(values) do |topic, value|
         assert_predicate topic, :invalid?, "#{value.inspect} failed comparison"
         assert_predicate topic.errors[:approved], :any?, "FAILED for #{value.inspect}"
-        assert_equal error, topic.errors[:approved].first if error
+        assert_match error, topic.errors[:approved].first if error
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

This commit addresses the following CI failure at Rails Nightly CI: https://buildkite.com/rails/rails-nightly/builds/3843#019cc4f3-df5a-4f84-b26e-a4d5c3b64a11/L1474

### Detail

Without this change:

```ruby
$ ruby -v
ruby 4.1.0dev (2026-03-06T21:27:30Z master fd9448bc87) +PRISM [x86_64-linux]
$ bin/test test/cases/validations/comparison_validation_test.rb:294
Source locally installed gems is ignoring #<Bundler::StubSpecification name=erb version=6.0.1 platform=ruby> because it is missing extensions
Run options: --seed 39842

F

Failure:
ComparisonValidationTest#test_validates_comparison_of_incomparables [test/cases/validations/comparison_validation_test.rb:294]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"comparison of Integer with String failed"
+# encoding: ASCII-8BIT
+#    valid: true
+"comparison of Integer with String failed: coercion was not possible"

bin/test test/cases/validations/comparison_validation_test.rb:291

Finished in 0.008453s, 118.3001 runs/s, 591.5004 assertions/s.
1 runs, 5 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information

Refer to https://github.com/ruby/ruby/pull/16321

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
