### PR TITLE
ActiveRecord: Allow adapter `#exec_query` methods to take `allow_retry` option

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Adapter `#exec_query` methods now accept an `allow_retry` option. When set to `true`, the SQL statement will be
+    retried, up to the database's configured `connection_retries` value, upon encountering connection-related errors.
+
+    *Adrianna Chang, Francesco Rodriguez*
+
 *   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
 
     This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -169,11 +169,15 @@ module ActiveRecord
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.
       #
+      # Setting +allow_retry+ to true causes the db to reconnect and retry
+      # executing the SQL statement in case of a connection-related exception.
+      # This option should only be enabled for known idempotent queries.
+      #
       # Note: the query is assumed to have side effects and the query cache
       # will be cleared. If the query is read-only, consider using #select_all
       # instead.
-      def exec_query(sql, name = "SQL", binds = [], prepare: false)
-        intent = internal_build_intent(sql, name, binds, prepare: prepare)
+      def exec_query(sql, name = "SQL", binds = [], prepare: false, allow_retry: false)
+        intent = internal_build_intent(sql, name, binds, prepare: prepare, allow_retry: allow_retry)
         intent.execute!
         intent.cast_result
       end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -930,6 +930,16 @@ module ActiveRecord
         assert_not_equal initial_connection_id, connection_id_from_server(@connection)
       end
 
+      test "#exec_query is retryable" do
+        initial_connection_id = connection_id_from_server(@connection)
+
+        kill_connection_from_server(initial_connection_id)
+
+        @connection.exec_query("SELECT 1", allow_retry: true)
+
+        assert_not_equal initial_connection_id, connection_id_from_server(@connection)
+      end
+
       test "disconnect and recover on #configure_connection failure" do
         connection = ActiveRecord::Base.connection_pool.send(:new_connection)
 

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -152,9 +152,9 @@ module AdapterHelper
   def connection_id_from_server(connection)
     case connection.adapter_name
     when "Mysql2", "Trilogy"
-      connection.execute("SELECT CONNECTION_ID()").to_a[0][0]
+      connection.select_value("SELECT CONNECTION_ID()")
     when "PostgreSQL"
-      connection.execute("SELECT pg_backend_pid()").to_a[0]["pg_backend_pid"]
+      connection.select_value("SELECT pg_backend_pid()")
     else
       skip("connection_id_from_server unsupported")
     end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Same as https://github.com/rails/rails/pull/46273, it adds retry support to the #exec_query method. I'd like t override the method to enable retries by default without having to bring the full implementation.

### Additional Information

After upgrading to Rails 8, we started receiving flaky errors on production:

```
begin
  connection.exec_query("SET statement_timeout = '250ms'")
  
  approximate_count # timeouts
rescue ActiveRecord::QueryCanceled
  0
ensure
  connection.exec_query("SET statement_timeout = '7s'")
  # => raises ActiveRecord::QueryCanceled ? Maybe PG socket is not clear 🤔 
 end
```

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
