### PR TITLE
Simplify applicable `actionpack` tests with `NotificationAssertions` helpers

### DIFF
--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -675,12 +675,9 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_path_relative_url_starting_with_an_at_with_notify
     with_path_relative_redirect(:notify) do
-      events = []
-      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
+      events = capture_notifications("unsafe_redirect.action_controller") do
+        get :redirect_to_path_relative_url_starting_with_an_at
       end
-
-      get :redirect_to_path_relative_url_starting_with_an_at
 
       assert_response :redirect
       assert_equal "http://test.host@example.com", redirect_to_url
@@ -691,19 +688,14 @@ class RedirectTest < ActionController::TestCase
       assert_equal 'Path relative URL redirect detected: "@example.com"', event.payload[:message]
       assert_kind_of Array, event.payload[:stack_trace]
       assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url_starting_with_an_at") }
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
   def test_redirect_to_path_relative_url_with_notify
     with_path_relative_redirect(:notify) do
-      events = []
-      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
+      events = capture_notifications("unsafe_redirect.action_controller") do
+        get :redirect_to_path_relative_url
       end
-
-      get :redirect_to_path_relative_url
 
       assert_response :redirect
       assert_equal "http://test.hostexample.com", redirect_to_url
@@ -714,8 +706,6 @@ class RedirectTest < ActionController::TestCase
       assert_equal 'Path relative URL redirect detected: "example.com"', event.payload[:message]
       assert_kind_of Array, event.payload[:stack_trace]
       assert event.payload[:stack_trace].any? { |line| line.include?("redirect_to_path_relative_url") }
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
@@ -759,22 +749,17 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_absolute_url_does_not_notify
     with_path_relative_redirect(:notify) do
-      events = []
-      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
+      assert_no_notifications("unsafe_redirect.action_controller") do
+        get :redirect_to_url
+        assert_response :redirect
+        assert_equal "http://www.rubyonrails.org/", redirect_to_url
       end
 
-      get :redirect_to_url
-      assert_response :redirect
-      assert_equal "http://www.rubyonrails.org/", redirect_to_url
-      assert_empty events
-
-      get :relative_url_redirect_with_status
-      assert_response :redirect
-      assert_equal "http://test.host/things/stuff", redirect_to_url
-      assert_empty events
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      assert_no_notifications("unsafe_redirect.action_controller") do
+        get :relative_url_redirect_with_status
+        assert_response :redirect
+        assert_equal "http://test.host/things/stuff", redirect_to_url
+      end
     end
   end
 
@@ -807,18 +792,11 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_query_string_url_does_not_trigger_path_relative_warning_with_notify
     with_path_relative_redirect(:notify) do
-      events = []
-      subscriber = ActiveSupport::Notifications.subscribe("unsafe_redirect.action_controller") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
+      assert_no_notifications("unsafe_redirect.action_controller") do
+        get :redirect_to_query_string_url
+        assert_response :redirect
+        assert_equal "http://test.host?foo=bar", redirect_to_url
       end
-
-      get :redirect_to_query_string_url
-      assert_response :redirect
-      assert_equal "http://test.host?foo=bar", redirect_to_url
-
-      assert_empty events.select { |e| e.payload[:message]&.include?("Path relative URL redirect detected") }
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
@@ -863,12 +841,10 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_external_with_action_on_open_redirect_notify
     with_action_on_open_redirect(:notify) do
-      events = []
-      subscriber = ActiveSupport::Notifications.subscribe("open_redirect.action_controller") do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
+      events = capture_notifications("open_redirect.action_controller") do
+        get :redirect_to_url
       end
 
-      get :redirect_to_url
       assert_response :redirect
       assert_equal "http://www.rubyonrails.org/", redirect_to_url
 
@@ -877,8 +853,6 @@ class RedirectTest < ActionController::TestCase
       assert_equal "http://www.rubyonrails.org/", event.payload[:location]
       assert_kind_of ActionDispatch::Request, event.payload[:request]
       assert_kind_of Array, event.payload[:stack_trace]
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I found some more `ActiveSupport::Notifications` centric tests in `actionpack` that can be simplified using the `ActiveSupport::Testing::NotificationAssertions` test helper module which was added in https://github.com/rails/rails/pull/53065 and https://github.com/rails/rails/pull/54126.

Follow up to
- https://github.com/rails/rails/pull/53819

Related recent PRs
- https://github.com/rails/rails/pull/56974
- https://github.com/rails/rails/pull/56975

### Detail

This Pull Request changes five tests in `actionpack/test/controller/redirect_test.rb` to use `NotificationAssertions` test helpers. For example, when using the provided helpers we no longer need to manually clean up subscribers via `ensure` blocks as the helpers do that for us automatically. Additionally, in cases where it makes sense we can directly make assertions using the helpers and in cases where it doesn't we can fall back to simply capturing notifications and manually asserting.

### Additional information

https://api.rubyonrails.org/classes/ActiveSupport/Testing/NotificationAssertions.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. - not necessary