### PR TITLE
Remove create tests from passwords_controller_test.rb if ActionMailer::Railtie is not defined

### DIFF
--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
@@ -7,6 +7,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     get new_password_path
     assert_response :success
   end
+  <%- if defined?(ActionMailer::Railtie) -%>
 
   test "create" do
     post passwords_path, params: { email_address: @user.email_address }
@@ -25,6 +26,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_notice "reset instructions sent"
   end
+  <%- end -%>
 
   test "edit" do
     get edit_password_path(@user.password_reset_token)

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -179,6 +179,10 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/def create\n    end/, content)
       assert_no_match(/rate_limit/, content)
     end
+
+    assert_file "test/controllers/passwords_controller_test.rb" do |content|
+      assert_no_match(/assert_enqueued_email/, content)
+    end
   ensure
     ActionMailer.const_set(:Railtie, old_value)
   end


### PR DESCRIPTION
### Motivation / Background

Creating a rails app with `--skip-action-mailer` and using authentication generator will create tests with email stuff and will fail.

### Detail

The authentication generator should not create tests of create action since it does not exist

### Steps to reproduce:

```bash
rails new my-test-app --skip-action-mailer

cd my-test-app
# uncomment root route
sed -i 's/# root/root/g' config/routes.rb
bin/rails g authentication
bin/rails db:migrate
bin/rake test
```

### Current behavior:

```
bin/rake test
Running 12 tests in a single process (parallelization threshold is 50)
Run options: --seed 34224

# Running:

......E

Error:
PasswordsControllerTest#test_create:
NameError: uninitialized constant PasswordsControllerTest::PasswordsMailer
    test/controllers/passwords_controller_test.rb:13:in 'block in <class:PasswordsControllerTest>'


bin/rails test test/controllers/passwords_controller_test.rb:11

...E

Error:
PasswordsControllerTest#test_create_for_an_unknown_user_redirects_but_sends_no_mail:
NoMethodError: undefined method 'assert_enqueued_emails' for an instance of PasswordsControllerTest
    test/controllers/passwords_controller_test.rb:22:in 'block in <class:PasswordsControllerTest>'


bin/rails test test/controllers/passwords_controller_test.rb:20

.

Finished in 1.315053s, 9.1251 runs/s, 27.3753 assertions/s.
12 runs, 36 assertions, 0 failures, 2 errors, 0 skips
```

### Expected behavior:

```
bin/rake test
Running 10 tests in a single process (parallelization threshold is 50)
Run options: --seed 61378

# Running:

..........

Finished in 1.253001s, 7.9808 runs/s, 28.7310 assertions/s.
10 runs, 36 assertions, 0 failures, 0 errors, 0 skips
```
