### PR TITLE
Restore previous instrumenter after `execute_or_skip`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -100,6 +100,7 @@ module ActiveRecord
 
           @pool.with_connection do |connection|
             return unless @mutex.try_lock
+            previous_instrumenter = ActiveSupport::IsolatedExecutionState[:active_record_instrumenter]
             begin
               if pending?
                 @event_buffer = EventBuffer.new(self, ActiveSupport::Notifications.instrumenter)
@@ -112,6 +113,7 @@ module ActiveRecord
             rescue => error
               @error = error
             ensure
+              ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] = previous_instrumenter
               @mutex.unlock
             end
           end

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -194,6 +194,39 @@ module ActiveRecord
       end
     end
 
+    def test_execute_or_skip_does_not_contaminate_caller_thread_instrumenter
+      skip unless ActiveRecord::Base.connection.async_enabled?
+
+      begin
+        # Intercept schedule_query to run execute_or_skip on the current thread,
+        # simulating what happens when the async executor's caller_runs fallback
+        # policy triggers due to a saturated thread pool.
+        pool = Post.connection_pool
+        old_schedule_query = pool.method(:schedule_query)
+        pool.singleton_class.undef_method(:schedule_query)
+        pool.singleton_class.define_method(:schedule_query) do |future_result|
+          future_result.execute_or_skip
+        end
+
+        # This async query runs execute_or_skip on the current thread
+        Post.async_count
+
+        # After the async query completes, synchronous queries must still
+        # publish sql.active_record notifications
+        notification_called = false
+        ActiveSupport::Notifications.subscribed(->(*) { notification_called = true }, "sql.active_record") do
+          Post.count
+        end
+
+        assert notification_called,
+          "sql.active_record notification was not published after execute_or_skip ran on the caller thread"
+      ensure
+        pool.singleton_class.undef_method(:schedule_query)
+        pool.singleton_class.define_method(:schedule_query, old_schedule_query)
+        ActiveSupport::IsolatedExecutionState.delete(:active_record_instrumenter)
+      end
+    end
+
     def test_eager_loading_query
       expected_records = Post.where(author_id: 1).eager_load(:comments).to_a
 


### PR DESCRIPTION
### Motivation / Background

We started using async queries (via `async_load`  and `async_pick`) in one of our apps, with [`async_query_executor`](https://guides.rubyonrails.org/configuring.html#config-active-record-async-query-executor) set to `:global_thread_pool`. We noticed that some requests wouldn't get most of their synchronous queries instrumented and logged. The number of requests with this problem went to zero after a deploy, then increased steadily until we deployed again, when it went back to zero before starting to grow again. 

After some troubleshooting, we realised this was due to the `global_thread_pool` saturating and running some of the async queries in the main thread. This happens because the `fallback_policy` for the global thread pool is `:caller_runs`:
https://github.com/rails/rails/blob/0209a70c57ebef4fb1e271444ec7e62794932db3/activerecord/lib/active_record.rb#L304-L313

The number of tasks that can be running or waiting at most in the global thread pool is 20 (4 threads with the default value for `concurrency` + 16 for the max queue size). We didn't run as many async queries per request with Puma set to a single thread, but Active Record's connection pool reaper also runs its asynchronous maintenance tasks in the global thread pool, so we were seeing the saturation in the end, increasing as the time since the last deploy passed. 

Async queries are executed via  [`QueryIntent#execute_or_skip`](https://github.com/rails/rails/blob/0209a70c57ebef4fb1e271444ec7e62794932db3/activerecord/lib/active_record/connection_adapters/query_intent.rb#L95-L119). This method sets `ActiveSupport::IsolatedExecutionState[:active_record_instrumenter]` to an `EventBuffer` but never restores the previous value. This is safe when the method runs on a background thread (as designed), but when the task executes on the calling thread, because the global thread pool is saturated and because of the `caller_runs` fallback policy, the stale `EventBuffer` permanently replaces the real instrumenter in the thread's `IsolatedExecutionState`. All subsequent `sql.active_record` notifications on that thread are captured by the `EventBuffer` but never published (`flush` is only called once by `ensure_result`, for the async query), silently breaking notification subscribers for `sql.active_record` events. Moreover, I don't think this is ever restored or cleared between requests, so the thread stays contaminated forever, which would also explain the increase in requests with this issue as time passed after the deploy, as more threads would get a broken instrumenter. 

### Detail

This PR implements a fix by saving and restoring the previous instrumenter value around the `EventBuffer'`s lifetime. On background threads, this is a no-op (saves `nil`, restores `nil`). On the caller thread via `caller_runs`, it restores the real instrumenter and prevents contamination.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
