### PR TITLE
Restore previous instrumenter after `execute_or_skip`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Restore previous instrumenter after `execute_or_skip`
+
+    `FutureResult#execute_or_skip` replaces the thread's instrumenter with an
+    `EventBuffer` to collect events published during async query execution.
+    If the global async executor is saturated and the `caller_runs` fallback
+    executes the task on the calling thread, we need to make sure the previous
+    instrumenter is restored or the stale `EventBuffer` would stay in place and
+    permanently swallow all subsequent `sql.active_record` notifications on
+    that thread.
+
+    *Rosa Gutierrez*
+
 *   Fix Ruby 4.0 delegator warning when calling inspect on ActiveRecord::Type::Serialized.
 
     *Hammad Khan*

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -105,6 +105,7 @@ module ActiveRecord
 
         @pool.with_connection do |connection|
           return unless @mutex.try_lock
+          previous_instrumenter = ActiveSupport::IsolatedExecutionState[:active_record_instrumenter]
           begin
             if pending?
               @event_buffer = EventBuffer.new(self, @instrumenter)
@@ -113,6 +114,7 @@ module ActiveRecord
               execute_query(connection, async: true)
             end
           ensure
+            ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] = previous_instrumenter
             @mutex.unlock
           end
         end

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -194,6 +194,39 @@ module ActiveRecord
       end
     end
 
+    def test_execute_or_skip_does_not_contaminate_caller_thread_instrumenter
+      skip unless ActiveRecord::Base.connection.async_enabled?
+
+      begin
+        # Intercept schedule_query to run execute_or_skip on the current thread,
+        # simulating what happens when the async executor's caller_runs fallback
+        # policy triggers due to a saturated thread pool.
+        pool = Post.connection_pool
+        old_schedule_query = pool.method(:schedule_query)
+        pool.singleton_class.undef_method(:schedule_query)
+        pool.singleton_class.define_method(:schedule_query) do |future_result|
+          future_result.execute_or_skip
+        end
+
+        # This async query runs execute_or_skip on the current thread
+        Post.async_count
+
+        # After the async query completes, synchronous queries must still
+        # publish sql.active_record notifications
+        notification_called = false
+        ActiveSupport::Notifications.subscribed(->(*) { notification_called = true }, "sql.active_record") do
+          Post.count
+        end
+
+        assert notification_called,
+          "sql.active_record notification was not published after execute_or_skip ran on the caller thread"
+      ensure
+        pool.singleton_class.undef_method(:schedule_query)
+        pool.singleton_class.define_method(:schedule_query, old_schedule_query)
+        ActiveSupport::IsolatedExecutionState.delete(:active_record_instrumenter)
+      end
+    end
+
     def test_eager_loading_query
       expected_records = Post.where(author_id: 1).eager_load(:comments).to_a
 


### PR DESCRIPTION
### Motivation / Background

`FutureResult#execute_or_skip` sets `ActiveSupport::IsolatedExecutionState[:active_record_instrumenter]` to an `EventBuffer` but never restores the previous value. This is safe when the method runs on a background thread (as designed), but the global async executor uses `fallback_policy: :caller_runs`: when the thread pool is saturated, the task executes on the calling thread.

When that calling thread is the request thread, the stale `EventBuffer` permanently replaces the real instrumenter in the thread's `IsolatedExecutionState`. All subsequent `sql.active_record` notifications on that thread are captured by the `EventBuffer` but never published (flush is only called once by result), silently breaking notification subscribers for  `sql.active_record` events.

The contamination is permanent for the life of the thread because nothing in Rails ever clears `ActiveSupport::IsolatedExecutionState[:active_record_instrumenter]` between requests.

### Detail
Fix by saving and restoring the previous instrumenter value around the `EventBuffer`'s lifetime. On background threads this is a no-op (saves `nil`, restores `nil`). On the caller thread via `caller_runs`, it restores the real instrumenter and prevents contamination.


### Additional information

This is the 8.0 backport of https://github.com/rails/rails/pull/56963

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
