### PR TITLE
Fix crashing schema dump for virtual tables with SQLite and Spatialite

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix schema dump crash when SQLite3 virtual tables use empty parentheses.
+
+    Virtual table modules such as SpatiaLite's `VirtualSpatialIndex()` declare no
+    arguments inside the parentheses. This caused the schema dumper to crash when
+    running `db:migrate`. 
+
+    Fixes #56969.
+
+    *Hans Schnedlitz*
+
 *   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
 
     This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -345,7 +345,7 @@ module ActiveRecord
         exec_query "DROP INDEX #{quote_column_name(index_name)}"
       end
 
-      VIRTUAL_TABLE_REGEX = /USING\s+(\w+)\s*\((.+)\)/i
+      VIRTUAL_TABLE_REGEX = /USING\s+(\w+)\s*\((.*)\)/i
 
       # Returns a list of defined virtual tables
       def virtual_tables

--- a/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
@@ -33,4 +33,13 @@ class SQLite3VirtualTableTest < ActiveRecord::SQLite3TestCase
   ensure
     $stdout = original
   end
+
+  def test_virtual_table_regex_parses_empty_parentheses
+    regex = ActiveRecord::ConnectionAdapters::SQLite3Adapter::VIRTUAL_TABLE_REGEX
+
+    _, module_name, arguments = "CREATE VIRTUAL TABLE t USING SomeModule()".match(regex).to_a
+    assert_equal "SomeModule", module_name
+    assert_equal "", arguments
+    assert_equal [], arguments.split(", ")
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #56969

All details (reproduction, etc) are found in the issue. 

### Detail

 Changes `(.+)` to `(.*)` in `VIRTUAL_TABLE_REGEX`. With zero-or-more
 matching, empty parentheses produce empty string instead of nil, and
 `"".split(", ")` returns [] without error. No changes to the schema
 dumper are needed.

### Additional information

Added a unit test that asserts VIRTUAL_TABLE_REGEX correctly parses
 a USING SomeModule() SQL string. This doesn't test the issue *per se*, but a full integration test isn't feasible without installing a third-party SQLite extension.
 
 