### PR TITLE
Add MySQL lock option and extend algorithm to column DDL operations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add MySQL `lock:` option for `add_index`, `remove_index`, and ALTER TABLE
+    column operations (`add_column`, `remove_column`, `change_column`, `rename_column`).
+
+    Also extend `algorithm:` option support to ALTER TABLE column operations on MySQL.
+
+    MySQL supports `ALGORITHM = {DEFAULT|COPY|INPLACE|INSTANT}` and
+    `LOCK = {DEFAULT|NONE|SHARED|EXCLUSIVE}` to control how DDL operations
+    are performed, enabling online schema changes without blocking reads or writes.
+
+    ```ruby
+    add_index :users, :email, algorithm: :inplace, lock: :none
+    remove_index :users, :email, algorithm: :inplace, lock: :none
+    add_column :users, :name, :string, algorithm: :instant, lock: :none
+    change_column :users, :name, :string, null: false, algorithm: :inplace, lock: :none
+    remove_column :users, :name, algorithm: :inplace, lock: :none
+    rename_column :users, :name, :full_name, algorithm: :inplace, lock: :none
+    ```
+
+    *Dominik Darnel*
+
 *   Avoid issuing a `ROLLBACK` statement following `TransactionRollbackError` during `COMMIT`.
 
     This prevents the unnecessary "WARNING: there is no transaction in progress" log spilled to stderr directly from libpq.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -116,7 +116,7 @@ module ActiveRecord
 
     ChangeColumnDefaultDefinition = Struct.new(:column, :default) # :nodoc:
 
-    CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists) # :nodoc:
+    CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists, :lock) # :nodoc:
 
     PrimaryKeyDefinition = Struct.new(:name) # :nodoc:
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -652,6 +652,13 @@ module ActiveRecord
       #
       #  # Ignores the method call if the column exists
       #  add_column(:shapes, :triangle, 'polygon', if_not_exists: true)
+      #
+      # ====== Creating a column with a specific algorithm and lock mode
+      #
+      #  add_column(:users, :age, :integer, algorithm: :instant, lock: :none)
+      #  # ALTER TABLE `users` ADD `age` int ALGORITHM = INSTANT LOCK = NONE
+      #
+      # Note: only supported by MySQL.
       def add_column(table_name, column_name, type, **options)
         add_column_def = build_add_column_definition(table_name, column_name, type, **options)
         return unless add_column_def
@@ -715,6 +722,12 @@ module ActiveRecord
       # if the column was already removed.
       #
       #   remove_column(:suppliers, :qualification, if_exists: true)
+      #
+      # Removes the column with a specific algorithm and lock mode:
+      #
+      #   remove_column(:suppliers, :qualification, algorithm: :inplace, lock: :none)
+      #
+      # Note: only supported by MySQL.
       def remove_column(table_name, column_name, type = nil, **options)
         return if options[:if_exists] == true && !column_exists?(table_name, column_name)
 
@@ -727,6 +740,11 @@ module ActiveRecord
       #   change_column(:suppliers, :name, :string, limit: 80)
       #   change_column(:accounts, :description, :text)
       #
+      # Changes the column with a specific algorithm and lock mode:
+      #
+      #   change_column(:suppliers, :name, :string, limit: 80, algorithm: :inplace, lock: :none)
+      #
+      # Note: only supported by MySQL.
       def change_column(table_name, column_name, type, **options)
         raise NotImplementedError, "change_column is not implemented"
       end
@@ -782,6 +800,11 @@ module ActiveRecord
       #
       #   rename_column(:suppliers, :description, :name)
       #
+      # Renames the column with a specific algorithm and lock mode:
+      #
+      #   rename_column(:suppliers, :description, :name, algorithm: :inplace, lock: :none)
+      #
+      # Note: only supported by MySQL.
       def rename_column(table_name, column_name, new_column_name)
         raise NotImplementedError, "rename_column is not implemented"
       end
@@ -932,6 +955,16 @@ module ActiveRecord
       #
       # For more information see the {"Transactional Migrations" section}[rdoc-ref:Migration].
       #
+      # ====== Creating an index with a specific lock mode
+      #
+      #  add_index(:developers, :name, lock: :none)
+      #  # CREATE INDEX `index_developers_on_name` ON `developers` (`name`) LOCK = NONE -- MySQL
+      #
+      #  add_index(:developers, :name, algorithm: :inplace, lock: :none)
+      #  # CREATE INDEX `index_developers_on_name` ON `developers` (`name`) ALGORITHM = INPLACE LOCK = NONE -- MySQL
+      #
+      # Note: only supported by MySQL.
+      #
       # ====== Creating an index that is not used by queries
       #
       #   add_index(:developers, :name, enabled: false)
@@ -995,6 +1028,11 @@ module ActiveRecord
       # Concurrently removing an index is not supported in a transaction.
       #
       # For more information see the {"Transactional Migrations" section}[rdoc-ref:Migration].
+      #
+      # Removes the index with a specific algorithm and lock mode on MySQL:
+      #
+      #   remove_index :accounts, :branch_id, algorithm: :inplace, lock: :none
+      #
       def remove_index(table_name, column_name = nil, **options)
         return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
 
@@ -1902,7 +1940,7 @@ module ActiveRecord
         alias :extract_new_comment_value :extract_new_default_value
 
         def can_remove_index_by_name?(column_name, options)
-          column_name.nil? && options.key?(:name) && options.except(:name, :algorithm).empty?
+          column_name.nil? && options.key?(:name) && options.except(:name, :algorithm, :lock).empty?
         end
 
         def reference_name_for_table(table_name)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -209,6 +209,29 @@ module ActiveRecord
         }
       end
 
+      # Returns the available lock options for MySQL DDL operations.
+      #
+      # MySQL supports the following lock modes:
+      # * <tt>:default</tt> - Let MySQL decide the lock level.
+      # * <tt>:none</tt> - Allow concurrent reads and writes (online DDL).
+      # * <tt>:shared</tt> - Allow concurrent reads but block writes.
+      # * <tt>:exclusive</tt> - Block all concurrent reads and writes.
+      def lock_options
+        {
+          default:   "LOCK = DEFAULT",
+          none:      "LOCK = NONE",
+          shared:    "LOCK = SHARED",
+          exclusive: "LOCK = EXCLUSIVE",
+        }
+      end
+
+      def lock_clause(lock) # :nodoc:
+        return unless lock
+        lock_options.fetch(lock) do
+          raise ArgumentError, "Lock must be one of the following: #{lock_options.keys.map(&:inspect).join(', ')}"
+        end
+      end
+
       # Must return the MySQL error number from the exception, if the exception has an
       # error number.
       def error_number(exception) # :nodoc:
@@ -401,8 +424,24 @@ module ActiveRecord
         change_column table_name, column_name, nil, comment: comment
       end
 
+      def add_column(table_name, column_name, type, **options) # :nodoc:
+        algorithm = index_algorithm(options.delete(:algorithm))
+        lock = lock_clause(options.delete(:lock))
+        add_column_def = build_add_column_definition(table_name, column_name, type, **options)
+        return unless add_column_def
+        sql = schema_creation.accept(add_column_def)
+        sql << ", #{algorithm}" if algorithm
+        sql << ", #{lock}" if lock
+        execute(sql)
+      end
+
       def change_column(table_name, column_name, type, **options) # :nodoc:
-        execute("ALTER TABLE #{quote_table_name(table_name)} #{change_column_for_alter(table_name, column_name, type, **options)}")
+        algorithm = index_algorithm(options.delete(:algorithm))
+        lock = lock_clause(options.delete(:lock))
+        sql = +"ALTER TABLE #{quote_table_name(table_name)} #{change_column_for_alter(table_name, column_name, type, **options)}"
+        sql << ", #{algorithm}" if algorithm
+        sql << ", #{lock}" if lock
+        execute(sql)
       end
 
       # Builds a ChangeColumnDefinition object.
@@ -445,8 +484,13 @@ module ActiveRecord
         ChangeColumnDefinition.new(cd, column.name)
       end
 
-      def rename_column(table_name, column_name, new_column_name) # :nodoc:
-        execute("ALTER TABLE #{quote_table_name(table_name)} #{rename_column_for_alter(table_name, column_name, new_column_name)}")
+      def rename_column(table_name, column_name, new_column_name, **options) # :nodoc:
+        algorithm = index_algorithm(options.delete(:algorithm))
+        lock = lock_clause(options.delete(:lock))
+        sql = +"ALTER TABLE #{quote_table_name(table_name)} #{rename_column_for_alter(table_name, column_name, new_column_name)}"
+        sql << ", #{algorithm}" if algorithm
+        sql << ", #{lock}" if lock
+        execute(sql)
         rename_column_indexes(table_name, column_name, new_column_name)
       end
 
@@ -458,11 +502,35 @@ module ActiveRecord
       end
 
       def build_create_index_definition(table_name, column_name, **options) # :nodoc:
+        lock = lock_clause(options.delete(:lock))
         index, algorithm, if_not_exists = add_index_options(table_name, column_name, **options)
 
         return if if_not_exists && index_exists?(table_name, column_name, name: index.name)
 
-        CreateIndexDefinition.new(index, algorithm)
+        CreateIndexDefinition.new(index, algorithm, if_not_exists, lock)
+      end
+
+      def remove_index(table_name, column_name = nil, **options) # :nodoc:
+        algorithm = index_algorithm(options.delete(:algorithm))
+        lock = lock_clause(options.delete(:lock))
+
+        return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
+
+        index_name = index_name_for_remove(table_name, column_name, options)
+
+        if mariadb? && (algorithm || lock)
+          # MariaDB doesn't support ALGORITHM/LOCK on DROP INDEX,
+          # but does support them on ALTER TABLE ... DROP INDEX.
+          sql = +"ALTER TABLE #{quote_table_name(table_name)} DROP INDEX #{quote_column_name(index_name)}"
+          sql << ", #{algorithm}" if algorithm
+          sql << ", #{lock}" if lock
+        else
+          sql = +"DROP INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)}"
+          sql << " #{algorithm}" if algorithm
+          sql << " #{lock}" if lock
+        end
+
+        execute(sql)
       end
 
       def enable_index(table_name, index_name) # :nodoc:
@@ -920,15 +988,22 @@ module ActiveRecord
         end
 
         def add_index_for_alter(table_name, column_name, **options)
+          lock = lock_clause(options.delete(:lock))
           index, algorithm, _ = add_index_options(table_name, column_name, **options)
           algorithm = ", #{algorithm}" if algorithm
+          lock = ", #{lock}" if lock
 
-          "ADD #{schema_creation.accept(index)}#{algorithm}"
+          "ADD #{schema_creation.accept(index)}#{algorithm}#{lock}"
         end
 
         def remove_index_for_alter(table_name, column_name = nil, **options)
+          algorithm = index_algorithm(options.delete(:algorithm))
+          lock = lock_clause(options.delete(:lock))
           index_name = index_name_for_remove(table_name, column_name, options)
-          "DROP INDEX #{quote_column_name(index_name)}"
+          sql = +"DROP INDEX #{quote_column_name(index_name)}"
+          sql << ", #{algorithm}" if algorithm
+          sql << ", #{lock}" if lock
+          sql
         end
 
         def supports_insert_raw_alias_syntax?

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -36,6 +36,7 @@ module ActiveRecord
           def visit_CreateIndexDefinition(o)
             sql = visit_IndexDefinition(o.index, true)
             sql << " #{o.algorithm}" if o.algorithm
+            sql << " #{o.lock}" if o.lock
             sql
           end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -93,7 +93,13 @@ module ActiveRecord
           if foreign_key_exists?(table_name, column: column_name)
             remove_foreign_key(table_name, column: column_name)
           end
-          super
+          algorithm = index_algorithm(options.delete(:algorithm))
+          lock = lock_clause(options.delete(:lock))
+          return if options[:if_exists] == true && !column_exists?(table_name, column_name)
+          sql = +"ALTER TABLE #{quote_table_name(table_name)} #{remove_column_for_alter(table_name, column_name, type, **options)}"
+          sql << ", #{algorithm}" if algorithm
+          sql << ", #{lock}" if lock
+          execute(sql)
         end
 
         def create_table(table_name, options: default_row_format, **)
@@ -252,6 +258,7 @@ module ActiveRecord
           def valid_index_options
             index_options = super
             index_options << :enabled if supports_disabling_indexes?
+            index_options << :lock
             index_options
           end
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -257,8 +257,10 @@ module ActiveRecord
         end
 
         def invert_rename_column(args)
-          table_name, old_name, new_name = args
-          [:rename_column, [table_name, new_name, old_name]]
+          table_name, old_name, new_name, options = args
+          args = [table_name, new_name, old_name]
+          args << options if options
+          [:rename_column, args]
         end
 
         def invert_remove_index(args)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
@@ -76,8 +76,35 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
       add_index(:people, :last_name, algorithm: :coyp)
     end
 
+    assert_raise ArgumentError do
+      add_index(:people, :last_name, lock: :invalid)
+    end
+
     expected = "CREATE INDEX `index_people_on_last_name_and_first_name` USING btree ON `people` (`last_name`(15), `first_name`(15))"
     assert_equal expected, add_index(:people, [:last_name, :first_name], length: 15, using: :btree)
+  end
+
+  def test_add_index_with_lock
+    %i(default none shared exclusive).each do |lock|
+      expected = "CREATE INDEX `index_people_on_last_name` ON `people` (`last_name`) LOCK = #{lock.upcase}"
+      assert_equal expected, add_index(:people, :last_name, lock: lock)
+    end
+  end
+
+  def test_add_index_with_algorithm_and_lock
+    expected = "CREATE INDEX `index_people_on_last_name` ON `people` (`last_name`) ALGORITHM = INPLACE LOCK = NONE"
+    assert_equal expected, add_index(:people, :last_name, algorithm: :inplace, lock: :none)
+  end
+
+  def test_remove_index_with_algorithm_and_lock
+    with_real_execute do
+      ActiveRecord::Base.lease_connection.create_table(:delete_me) { |t| t.string :name }
+      ActiveRecord::Base.lease_connection.add_index(:delete_me, :name)
+      ActiveRecord::Base.lease_connection.remove_index(:delete_me, :name, algorithm: :inplace, lock: :none)
+      assert_not ActiveRecord::Base.lease_connection.index_exists?(:delete_me, :name)
+    ensure
+      ActiveRecord::Base.lease_connection.drop_table(:delete_me) rescue nil
+    end
   end
 
   def test_index_in_create
@@ -96,6 +123,37 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
     assert_match expected, actual
   end
 
+  def test_change_column_with_algorithm_and_lock
+    with_real_execute do
+      ActiveRecord::Base.lease_connection.create_table(:delete_me) { |t| t.string :name, null: true }
+      ActiveRecord::Base.lease_connection.change_column(:delete_me, :name, :string, null: false, algorithm: :inplace, lock: :none)
+      col = ActiveRecord::Base.lease_connection.columns(:delete_me).find { |c| c.name == "name" }
+      assert_not col.null
+    ensure
+      ActiveRecord::Base.lease_connection.drop_table(:delete_me) rescue nil
+    end
+  end
+
+  def test_rename_column_with_algorithm_and_lock
+    with_real_execute do
+      ActiveRecord::Base.lease_connection.create_table(:delete_me) { |t| t.string :name }
+      ActiveRecord::Base.lease_connection.rename_column(:delete_me, :name, :full_name, algorithm: :inplace, lock: :none)
+      assert ActiveRecord::Base.lease_connection.column_exists?(:delete_me, :full_name)
+    ensure
+      ActiveRecord::Base.lease_connection.drop_table(:delete_me) rescue nil
+    end
+  end
+
+  def test_remove_column_with_algorithm_and_lock
+    with_real_execute do
+      ActiveRecord::Base.lease_connection.create_table(:delete_me) { |t| t.string :name; t.string :email }
+      ActiveRecord::Base.lease_connection.remove_column(:delete_me, :name, algorithm: :inplace, lock: :none)
+      assert_not ActiveRecord::Base.lease_connection.column_exists?(:delete_me, :name)
+    ensure
+      ActiveRecord::Base.lease_connection.drop_table(:delete_me) rescue nil
+    end
+  end
+
   def test_index_in_bulk_change
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
       expected = "ALTER TABLE `people` ADD #{type} INDEX `index_people_on_last_name` (`last_name`)"
@@ -110,6 +168,13 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
     assert_queries_match(expected) do
       ActiveRecord::Base.lease_connection.change_table(:people, bulk: true) do |t|
         t.index :last_name, length: 10, using: :btree, algorithm: :copy
+      end
+    end
+
+    expected = "ALTER TABLE `people` ADD INDEX `index_people_on_last_name` USING btree (`last_name`(10)), ALGORITHM = INPLACE, LOCK = NONE"
+    assert_queries_match(expected) do
+      ActiveRecord::Base.lease_connection.change_table(:people, bulk: true) do |t|
+        t.index :last_name, length: 10, using: :btree, algorithm: :inplace, lock: :none
       end
     end
   end
@@ -141,6 +206,11 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
 
   def test_add_column
     assert_equal "ALTER TABLE `people` ADD `last_name` varchar(255)", add_column(:people, :last_name, :string)
+  end
+
+  def test_add_column_with_algorithm_and_lock
+    expected = "ALTER TABLE `people` ADD `last_name` varchar(255), ALGORITHM = INPLACE, LOCK = NONE"
+    assert_equal expected, add_column(:people, :last_name, :string, algorithm: :inplace, lock: :none)
   end
 
   def test_add_column_with_limit

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -300,6 +300,11 @@ module ActiveRecord
         assert_equal [:rename_column, [:table, :new, :old]], rename
       end
 
+      def test_invert_rename_column_with_options
+        rename = @recorder.inverse_of :rename_column, [:table, :old, :new, { algorithm: :inplace, lock: :none }]
+        assert_equal [:rename_column, [:table, :new, :old, { algorithm: :inplace, lock: :none }]], rename
+      end
+
       def test_invert_add_index
         remove = @recorder.inverse_of :add_index, [:table, [:one, :two]]
         assert_equal [:remove_index, [:table, [:one, :two]], nil], remove

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -28,6 +28,10 @@ module ActiveRecord
           default_keys.concat([":enabled"])
         end
 
+        if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+          default_keys.concat([":lock"])
+        end
+
         "Unknown key: :#{key}. Valid keys are: #{default_keys.join(", ")}"
       end
 

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -722,6 +722,24 @@ They need to be added separately using `add_index`.
 Some adapters may support additional options; see the adapter specific API docs
 for further information.
 
+For example, MySQL supports `algorithm` and `lock` options on column operations
+(`add_column`, `remove_column`, `change_column`, `rename_column`) and index
+operations (`add_index`, `remove_index`) to control how DDL statements are
+executed. This enables online schema changes without blocking reads or writes:
+
+```ruby
+add_column :users, :name, :string, algorithm: :instant, lock: :none
+add_index :users, :email, algorithm: :inplace, lock: :none
+```
+
+The MySQL `algorithm` option accepts `:default`, `:copy`, `:inplace`, or `:instant`.
+The `lock` option accepts `:default`, `:none`, `:shared`, or `:exclusive`.
+See the [MySQL documentation on Online DDL](https://dev.mysql.com/doc/refman/en/innodb-online-ddl-operations.html)
+for details on which algorithms and lock modes are supported for each operation.
+
+NOTE: PostgreSQL also supports the `algorithm` option on `add_index` and
+`remove_index` (e.g., `algorithm: :concurrently`), but does not support `lock`.
+
 NOTE: `default` cannot be specified via command line when generating migrations.
 
 ### References


### PR DESCRIPTION
### Motivation / Background

Rails already supports `algorithm:` for MySQL index operations (`:default`, `:copy`, `:inplace`, `:instant`) and for PostgreSQL (`algorithm: :concurrently`). However, MySQL also supports `LOCK = {DEFAULT|NONE|SHARED|EXCLUSIVE}` for controlling table locking during DDL, and neither `algorithm:` nor `lock:` work on column operations (`add_column`, `change_column`, `remove_column`, `rename_column`).

This forces users to drop down to raw SQL for online schema changes on large production tables:

```ruby
# Today — forced to use raw SQL
execute "ALTER TABLE users ADD name VARCHAR(255), ALGORITHM = INSTANT, LOCK = NONE"

# With this change — use the migration DSL
add_column :users, :name, :string, algorithm: :instant, lock: :none
```

Forum discussion: https://discuss.rubyonrails.org/t/add-mysql-lock-option-and-extend-algorithm-to-column-ddl-operations/90249

### Detail

This Pull Request adds:

- `lock:` option for MySQL `add_index`, `remove_index`, and ALTER TABLE column operations (`add_column`, `remove_column`, `change_column`, `rename_column`)
- `algorithm:` option support extended to ALTER TABLE column operations on MySQL
- `CommandRecorder#invert_rename_column` now preserves `algorithm:` and `lock:` options on rollback

```ruby
add_index    :users, :email, algorithm: :inplace, lock: :none
remove_index :users, :email, algorithm: :inplace, lock: :none
add_column    :users, :name, :string, algorithm: :instant, lock: :none
change_column :users, :name, :string, null: false, algorithm: :inplace, lock: :none
remove_column :users, :name, algorithm: :inplace, lock: :none
rename_column :users, :name, :full_name, algorithm: :inplace, lock: :none
```

### Additional information

The implementation follows the same patterns used by the existing `algorithm: :concurrently` support in the PostgreSQL adapter and the existing `algorithm:` support for MySQL index operations.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.