### PR TITLE
Simplify applicable `activesupport` tests with `NotificationAssertions` helpers

### DIFF
--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -705,30 +705,30 @@ module CacheStoreBehavior
 
   def test_cache_hit_instrumentation
     key = "test_key"
-    @events = []
-    ActiveSupport::Notifications.subscribe("cache_read.active_support") { |event| @events << event }
+
     assert @cache.write(key, "1", raw: true)
-    assert @cache.fetch(key, raw: true) { }
-    assert_equal 1, @events.length
-    assert_equal "cache_read.active_support", @events[0].name
-    assert_equal :fetch, @events[0].payload[:super_operation]
-    assert @events[0].payload[:hit]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "cache_read.active_support"
+
+    events = capture_notifications("cache_read.active_support") do
+      assert @cache.fetch(key, raw: true) { }
+    end
+
+    assert_equal 1, events.length
+    assert_equal "cache_read.active_support", events[0].name
+    assert_equal :fetch, events[0].payload[:super_operation]
+    assert events[0].payload[:hit]
   end
 
   def test_cache_miss_instrumentation
-    @events = []
-    ActiveSupport::Notifications.subscribe(/^cache_(.*)\.active_support$/) { |event| @events << event }
-    assert_not @cache.fetch(SecureRandom.uuid) { }
-    assert_equal 3, @events.length
-    assert_equal "cache_read.active_support", @events[0].name
-    assert_equal "cache_generate.active_support", @events[1].name
-    assert_equal "cache_write.active_support", @events[2].name
-    assert_equal :fetch, @events[0].payload[:super_operation]
-    assert_not @events[0].payload[:hit]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "cache_read.active_support"
+    events = capture_notifications(/^cache_(.*)\.active_support$/) do
+      assert_not @cache.fetch(SecureRandom.uuid) { }
+    end
+
+    assert_equal 3, events.length
+    assert_equal "cache_read.active_support", events[0].name
+    assert_equal "cache_generate.active_support", events[1].name
+    assert_equal "cache_write.active_support", events[2].name
+    assert_equal :fetch, events[0].payload[:super_operation]
+    assert_not events[0].payload[:hit]
   end
 
   def test_setting_options_in_fetch_block_does_not_change_cache_options


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I found some more `ActiveSupport::Notifications` centric tests in `activesupport` that can be simplified using the `ActiveSupport::Testing::NotificationAssertions` test helper module which was added in https://github.com/rails/rails/pull/53065 and https://github.com/rails/rails/pull/54126.

Follow up to
- https://github.com/rails/rails/pull/53824

Related recent PRs
- https://github.com/rails/rails/pull/56956
- https://github.com/rails/rails/pull/56975

### Detail

This Pull Request changes two helper based tests in `activesupport/test/cache/behaviors/cache_store_behavior.rb` to use `NotificationAssertions` test helpers. These helper based tests are run in the following files via inclusion. The main change is simply using the helper to capture events. Everything else is `@events` to `events` cleanup.
- `activesupport/test/cache/stores/file_store_test.rb`
- `activesupport/test/cache/stores/mem_cache_store_test.rb`
- `activesupport/test/cache/stores/memory_store_test.rb`
- `activesupport/test/cache/stores/redis_cache_store_test.rb`

For example, when using the provided helpers we no longer need to manually clean up subscribers via `ensure` blocks as the helpers do that for us automatically. Additionally, in cases where it makes sense we can directly make assertions using the helpers and in cases where it doesn't we can fall back to simply capturing notifications and manually asserting.

### Additional information

https://api.rubyonrails.org/classes/ActiveSupport/Testing/NotificationAssertions.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. - not necessary