### PR TITLE
 Simplify applicable `activerecord` tests with `NotificationAssertions` helpers

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/empty_all_tables_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/empty_all_tables_test.rb
@@ -14,14 +14,8 @@ class MySQLEmptyTablesTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def test_empty_all_tables_uses_delete_not_truncate
-    queries = []
-    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-      queries << event.payload[:sql] if event.payload[:name] == "Delete Tables"
-    end
-
-    @conn.empty_all_tables
-
-    ActiveSupport::Notifications.unsubscribe(subscriber)
+    queries = capture_notifications("sql.active_record") { @conn.empty_all_tables }
+      .select { |e| e.payload[:name] == "Delete Tables" }.map { |e| e.payload[:sql] }
 
     assert queries.any? { |q| q.include?("DELETE FROM") }, "Expected DELETE statements to be used"
     assert queries.none? { |q| q.include?("TRUNCATE") }, "Expected TRUNCATE statements to NOT be used"

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1903,13 +1903,9 @@ class AsyncBelongsToAssociationsTest < ActiveRecord::TestCase
       client.association(:firm).async_load_target
       wait_for_async_query
 
-      events = []
-      callback = -> (event) do
-        events << event unless event.payload[:name] == "SCHEMA"
-      end
-      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      events = capture_notifications("sql.active_record") do
         client.firm
-      end
+      end.reject { |e| e.payload[:name] == "SCHEMA" }
 
       assert_no_queries do
         assert_equal first_firm, client.firm

--- a/activerecord/test/cases/associations/deprecation_test.rb
+++ b/activerecord/test/cases/associations/deprecation_test.rb
@@ -213,28 +213,22 @@ module AssociationDeprecationTest
     end
 
     def assert_user_facing_reflection(model, association)
-      payloads = []
-      callback = ->(event) { payloads << event.payload }
-
-      ActiveSupport::Notifications.subscribed(callback, "deprecated_association.active_record") do
+      events = capture_notifications("deprecated_association.active_record") do
         model.new.send(association)
       end
 
-      assert_equal 1, payloads.size
-      assert_equal model.reflect_on_association(association), payloads[0][:reflection]
+      assert_equal 1, events.size
+      assert_equal model.reflect_on_association(association), events[0].payload[:reflection]
     end
 
     test "report publishes an Active Support notification in :notify mode" do
-      payloads = []
-      callback = ->(event) { payloads << event.payload }
-
       line = __LINE__ + 2
-      ActiveSupport::Notifications.subscribed(callback, "deprecated_association.active_record") do
+      events = capture_notifications("deprecated_association.active_record") do
         DATS::Car.new.deprecated_tires
       end
 
-      assert_equal 1, payloads.size
-      payload = payloads.first
+      assert_equal 1, events.size
+      payload = events.first.payload
 
       assert_equal DATS::Car.reflect_on_association(:deprecated_tires), payload[:reflection]
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3267,14 +3267,9 @@ class AsyncHasManyAssociationsTest < ActiveRecord::TestCase
       firm.association(:clients).async_load_target
       wait_for_async_query
 
-      events = []
-      callback = -> (event) do
-        events << event unless event.payload[:name] == "SCHEMA"
-      end
-
-      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      events = capture_notifications("sql.active_record") do
         assert_equal 3, firm.clients.size
-      end
+      end.reject { |e| e.payload[:name] == "SCHEMA" }
 
       assert_no_queries do
         assert_not_nil firm.clients[2]

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -985,13 +985,9 @@ class AsyncHasOneAssociationsTest < ActiveRecord::TestCase
       firm.association(:account).async_load_target
       wait_for_async_query
 
-      events = []
-      callback = -> (event) do
-        events << event unless event.payload[:name] == "SCHEMA"
-      end
-      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      events = capture_notifications("sql.active_record") do
         firm.account
-      end
+      end.reject { |e| e.payload[:name] == "SCHEMA" }
 
       assert_no_queries do
         assert_equal first_account, firm.account

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -75,18 +75,14 @@ class TransactionIsolationTest < ActiveRecord::TestCase
     test "pool_transaction_isolation_level" do
       assert_nil Tag.pool_transaction_isolation_level
 
-      events = []
-      ActiveSupport::Notifications.subscribed(
-        -> (event) { events << event.payload[:sql] },
-        "sql.active_record",
-      ) do
+      events = capture_notifications("sql.active_record") do
         Tag.with_pool_transaction_isolation_level(:read_committed) do
           assert_equal :read_committed, Tag.pool_transaction_isolation_level
           Tag.transaction do
             Tag.create!(name: "jon")
           end
         end
-      end
+      end.map { |e| e.payload[:sql] }
       assert_begin_isolation_level_event(events)
     end
 
@@ -101,11 +97,7 @@ class TransactionIsolationTest < ActiveRecord::TestCase
     test "pool_transaction_isolation_level but transaction overrides isolation" do
       assert_nil Tag.pool_transaction_isolation_level
 
-      events = []
-      ActiveSupport::Notifications.subscribed(
-        -> (event) { events << event.payload[:sql] },
-        "sql.active_record",
-      ) do
+      events = capture_notifications("sql.active_record") do
         Tag.with_pool_transaction_isolation_level(:read_committed) do
           assert_equal :read_committed, Tag.pool_transaction_isolation_level
 
@@ -113,7 +105,7 @@ class TransactionIsolationTest < ActiveRecord::TestCase
             Tag.create!(name: "jon")
           end
         end
-      end
+      end.map { |e| e.payload[:sql] }
 
       assert_begin_isolation_level_event(events, isolation: "REPEATABLE READ")
     end
@@ -121,11 +113,7 @@ class TransactionIsolationTest < ActiveRecord::TestCase
     test "with_transaction_isolation_level explicit transaction" do
       assert_nil ActiveRecord.default_transaction_isolation_level
 
-      events = []
-      ActiveSupport::Notifications.subscribed(
-        -> (event) { events << event.payload[:sql] },
-        "sql.active_record",
-      ) do
+      events = capture_notifications("sql.active_record") do
         assert_nil Tag.connection_pool.pool_transaction_isolation_level
         assert_nil Dog.connection_pool.pool_transaction_isolation_level
 
@@ -139,7 +127,7 @@ class TransactionIsolationTest < ActiveRecord::TestCase
             Dog.create!
           end
         end
-      end
+      end.map { |e| e.payload[:sql] }
 
       assert_nil Tag.connection_pool.pool_transaction_isolation_level
       assert_nil Dog.connection_pool.pool_transaction_isolation_level
@@ -149,18 +137,14 @@ class TransactionIsolationTest < ActiveRecord::TestCase
     test "with_transaction_isolation_level implicit transaction" do
       assert_nil ActiveRecord.default_transaction_isolation_level
 
-      events = []
-      ActiveSupport::Notifications.subscribed(
-        -> (event) { events << event.payload[:sql] },
-        "sql.active_record",
-      ) do
+      events = capture_notifications("sql.active_record") do
         ActiveRecord.with_transaction_isolation_level(:read_committed) do
           assert_equal :read_committed, ActiveRecord.default_transaction_isolation_level
 
           Tag.create!(name: "jon")
           Dog.create!
         end
-      end
+      end.map { |e| e.payload[:sql] }
 
       assert_begin_isolation_level_event(events, count: 2)
     end
@@ -194,11 +178,7 @@ class TransactionIsolationTest < ActiveRecord::TestCase
     test "with_transaction_isolation_level but transaction overrides isolation" do
       assert_nil ActiveRecord.default_transaction_isolation_level
 
-      events = []
-      ActiveSupport::Notifications.subscribed(
-        -> (event) { events << event.payload[:sql] },
-        "sql.active_record",
-      ) do
+      events = capture_notifications("sql.active_record") do
         ActiveRecord.with_transaction_isolation_level(:read_committed) do
           assert_equal :read_committed, ActiveRecord.default_transaction_isolation_level
 
@@ -206,7 +186,7 @@ class TransactionIsolationTest < ActiveRecord::TestCase
             Dog.create!
           end
         end
-      end
+      end.map { |e| e.payload[:sql] }
 
       assert_begin_isolation_level_event(events, isolation: "REPEATABLE READ")
     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I found some more `ActiveSupport::Notifications` centric tests in `activerecord` that can be simplified using the `ActiveSupport::Testing::NotificationAssertions` test helper module which was added in https://github.com/rails/rails/pull/53065 and https://github.com/rails/rails/pull/54126.

Follow up to
- https://github.com/rails/rails/pull/53822

Recent related PRs
- https://github.com/rails/rails/pull/56956
- https://github.com/rails/rails/pull/56974

### Detail

This Pull Request changes eleven tests in `activerecord` to use `NotificationAssertions` test helpers. There are still other potentials for cleanup but these were the cleaner and simpler ones for now. Cleanup wise, for example, when using the provided helpers we no longer need to manually clean up subscribers via `ensure` blocks as the helpers do that for us automatically. Additionally, in cases where it makes sense we can directly make assertions using the helpers and in cases where it doesn't we can fall back to simply capturing notifications and manually asserting.

### Additional information

https://api.rubyonrails.org/classes/ActiveSupport/Testing/NotificationAssertions.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. - not necessary