### PR TITLE
Fix SQLite virtual tables not ignored by `ignore_tables`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
           def virtual_tables(stream)
-            virtual_tables = @connection.virtual_tables
+            virtual_tables = @connection.virtual_tables.reject { |name, _| ignored?(name) }
             if virtual_tables.any?
               stream.puts
               stream.puts "  # Virtual tables defined in this database."

--- a/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
@@ -22,6 +22,12 @@ class SQLite3VirtualTableTest < ActiveRecord::SQLite3TestCase
     assert_includes output, 'create_virtual_table "searchables", "fts5", ["content", "meta UNINDEXED", "tokenize=\'porter ascii\'"]'
   end
 
+  def test_schema_dump_ignores_virtual_tables_in_ignore_tables
+    output = dump_all_table_schema(["searchables"])
+
+    assert_not_includes output, 'create_virtual_table "searchables"'
+  end
+
   def test_schema_load
     original, $stdout = $stdout, StringIO.new
 


### PR DESCRIPTION
### Motivation / Background

Fixes #56976

### Detail

See related issue for relevant details. This enables virtual tables to be ignored using `ActiveRecord::SchemaDumper.ignore_tables`