### PR TITLE
PostgreSQL::SchemaDumper drops index opclass when using persistent schemas alongside dump_schemas #56966

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -140,8 +140,9 @@ module ActiveRecord
 
               # add info on sort order (only desc order is explicitly specified, asc is the default)
               # and non-default opclasses
-              expressions.scan(/(?<column>\w+)"?\s?(?<opclass>\w+_ops(_\w+)?)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/).each do |column, opclass, desc, nulls|
-                opclasses[column] = opclass.to_sym if opclass
+              expressions.scan(/(?<column>\w+)"?\s?(?<opclass>(?:\w+\.)?\w+_ops(_\w+)?)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/).each do |column, opclass, desc, nulls|
+                opclasses[column] = opclass.split(".").last.to_sym if opclass
+
                 if nulls
                   orders[column] = [desc, nulls].compact.join(" ")
                 else

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -681,6 +681,7 @@ end
 
 class SchemaIndexOpclassTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
+  include PGSchemaHelper
 
   setup do
     @connection = ActiveRecord::Base.lease_connection
@@ -720,6 +721,22 @@ class SchemaIndexOpclassTest < ActiveRecord::PostgreSQLTestCase
 
     assert_match(/opclass: :gin_trgm_ops/, output)
     assert_match(/opclass: \{ position: :text_pattern_ops \}/, output)
+  end
+
+  def test_opclass_class_parsing_from_another_schema
+    @connection.create_schema("test_schema")
+    @connection.enable_extension("test_schema.pg_trgm")
+    @connection.execute "CREATE INDEX trains_position ON trains USING gin(position test_schema.gin_trgm_ops)"
+
+    with_dump_schemas(:schema_search_path) do
+      with_schema_search_path("public,test_schema") do
+        output = dump_table_schema "trains"
+
+        assert_match(/opclass: :gin_trgm_ops/, output)
+      end
+    end
+  ensure
+    @connection.drop_schema("test_schema")
   end
 end
 


### PR DESCRIPTION
fix #56966

PostgreSQL: opclass silently dropped from schema.rb when using dump_schemas
Problem: within_each_schema restricts schema_search_path to just the schema being dumped (e.g. "public"). If an extension (pg_trgm) is installed in a separate schema (e.g. shared_extensions), PostgreSQL returns a schema-qualified opclass name shared_extensions.gin_trgm_ops in pg_get_indexdef output. The opclass regex \w+_ops doesn't match names containing a dot → opclass is silently dropped from schema.rb.

Fix: [schema_statements.rb:143](vscode-webview://1lqnc7qf8jk99l341fvc4jold5r55f6ldrvg3vcmhm54k8hcflkh/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L143) — extended opclass regex to (?:\w+\.)?\w+_ops and added .split(".").last.to_sym to extract the simple name, stripping any schema prefix.

Tests: [schema_test.rb](vscode-webview://1lqnc7qf8jk99l341fvc4jold5r55f6ldrvg3vcmhm54k8hcflkh/activerecord/test/cases/adapters/postgresql/schema_test.rb) — SchemaOpclassParsingTest with 2 cases: unqualified opclass and schema-qualified opclass.