### PR TITLE
ActiveRecord: Add option to only upsert changed rows

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Adds a new `:update_if_dirty` option for the `on_duplicate` parameter of
+    the `upsert_all` method.
+
+    Specifying this option will skip any duplicate rows that are identical
+    to the values being provided for the update. Skipped rows will not
+    appear in the return value of `upsert_all`. This is handy when you want
+    to know which specific rows were modified by the statement.
+
+    Currently this feature is only supported by the postgresql adapter.
+    Using this option should reduce WAL noise and vacuums when your use case
+    for `upsert_all` often results in unchanged rows.
+
+    *Clayton Passmore*
+
 *   Support PostgreSQL `RESET` on readonly queries.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -595,6 +595,10 @@ module ActiveRecord
         false
       end
 
+      def supports_insert_on_duplicate_update_if_dirty?
+        false
+      end
+
       def supports_insert_conflict_target?
         false
       end
@@ -917,7 +921,7 @@ module ActiveRecord
       # should be overridden by adapters to implement common features with
       # non-standard syntax like handling duplicates or returning values.
       def build_insert_sql(insert) # :nodoc:
-        if insert.skip_duplicates? || insert.update_duplicates?
+        if insert.skip_duplicates? || insert.update_duplicates? || insert.update_duplicates_if_dirty?
           raise NotImplementedError, "#{self.class} should define `build_insert_sql` to implement adapter-specific logic for handling duplicates during INSERT"
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -288,6 +288,7 @@ module ActiveRecord
       end
       alias supports_insert_on_duplicate_skip? supports_insert_on_conflict?
       alias supports_insert_on_duplicate_update? supports_insert_on_conflict?
+      alias supports_insert_on_duplicate_update_if_dirty? supports_insert_on_conflict?
       alias supports_insert_conflict_target? supports_insert_on_conflict?
 
       def supports_virtual_columns?
@@ -691,7 +692,7 @@ module ActiveRecord
 
         if insert.skip_duplicates?
           sql << " ON CONFLICT #{insert.conflict_target} DO NOTHING"
-        elsif insert.update_duplicates?
+        elsif insert.update_duplicates? || insert.update_duplicates_if_dirty?
           sql << " ON CONFLICT #{insert.conflict_target} DO UPDATE SET "
           if insert.raw_update_sql?
             sql << insert.raw_update_sql
@@ -699,6 +700,11 @@ module ActiveRecord
             sql << insert.touch_model_timestamps_unless { |column| "#{insert.model.quoted_table_name}.#{column} IS NOT DISTINCT FROM excluded.#{column}" }
             sql << insert.updatable_columns.map { |column| "#{column}=excluded.#{column}" }.join(",")
           end
+        end
+
+        if insert.update_duplicates_if_dirty?
+          sql << " WHERE "
+          sql << insert.updatable_columns.map { |column| "#{insert.model.quoted_table_name}.#{column} IS DISTINCT FROM excluded.#{column}" }.join(" OR ")
         end
 
         sql << " RETURNING #{insert.returning}" if insert.returning

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -49,7 +49,7 @@ module ActiveRecord
 
       message = +"#{model} "
       message << "Bulk " if inserts.many?
-      message << (on_duplicate == :update ? "Upsert" : "Insert")
+      message << ([:update, :update_if_dirty].include?(on_duplicate) ? "Upsert" : "Insert")
       connection.exec_insert_all self, message
     end
 
@@ -67,6 +67,10 @@ module ActiveRecord
 
     def update_duplicates?
       on_duplicate == :update
+    end
+
+    def update_duplicates_if_dirty?
+      on_duplicate == :update_if_dirty
     end
 
     def map_key_with_value
@@ -144,7 +148,7 @@ module ActiveRecord
         elsif custom_update_sql_provided?
           @update_sql = on_duplicate
           @on_duplicate = :update
-        elsif @on_duplicate == :update && updatable_columns.empty?
+        elsif [:update, :update_if_dirty].include?(@on_duplicate) && updatable_columns.empty?
           @on_duplicate = :skip
         end
       end
@@ -190,6 +194,10 @@ module ActiveRecord
           raise ArgumentError, "#{connection.class} does not support upsert"
         end
 
+        if update_duplicates_if_dirty? && !connection.supports_insert_on_duplicate_update_if_dirty?
+          raise ArgumentError, "#{connection.class} does not support upserting only changed rows"
+        end
+
         if unique_by && !connection.supports_insert_conflict_target?
           raise ArgumentError, "#{connection.class} does not support :unique_by"
         end
@@ -222,7 +230,14 @@ module ActiveRecord
       class Builder # :nodoc:
         attr_reader :model
 
-        delegate :skip_duplicates?, :update_duplicates?, :keys, :keys_including_timestamps, :record_timestamps?, :primary_keys, to: :insert_all
+        delegate :skip_duplicates?,
+          :update_duplicates?,
+          :update_duplicates_if_dirty?,
+          :keys,
+          :keys_including_timestamps,
+          :record_timestamps?,
+          :primary_keys,
+          to: :insert_all
 
         def initialize(insert_all)
           @insert_all, @model, @connection = insert_all, insert_all.model, insert_all.connection
@@ -270,7 +285,7 @@ module ActiveRecord
             sql = +"(#{format_columns(index.columns)})"
             sql << " WHERE #{index.where}" if index.where
             sql
-          elsif update_duplicates?
+          elsif update_duplicates? || update_duplicates_if_dirty?
             "(#{format_columns(insert_all.primary_keys)})"
           end
         end
@@ -280,7 +295,7 @@ module ActiveRecord
         end
 
         def touch_model_timestamps_unless(&block)
-          return "" unless update_duplicates? && record_timestamps?
+          return "" unless (update_duplicates? || update_duplicates_if_dirty?) && record_timestamps?
 
           model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
             if touch_timestamp_attribute?(column_name)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -881,9 +881,17 @@ module ActiveRecord
     # Active Record's schema_cache.
     #
     # [:on_duplicate]
-    #   Configure the behavior that will be used in case of conflict. Use `:skip`
-    #   to ignore any conflicts or provide a safe SQL fragment wrapped with
-    #   `Arel.sql`.
+    #   Configure the behavior that will be used in case of conflict. By default, duplicate
+    #   records will be assigned the attributes provided. Timestamps may also be set (see
+    #   the related +:record_timestamps+ option).
+    #
+    #   Use <tt>:update_if_dirty</tt> to only update duplicate records whose attributes differ
+    #   from the attributes provided. If a duplicate record exists with the exact same attributes
+    #   as those provided, it will be skipped.
+    #
+    #   Use <tt>:skip</tt> to ignore all conflicts.
+    #
+    #   Alternatively, you may provide a safe SQL fragment wrapped with <tt>Arel.sql</tt>.
     #
     #   NOTE: If you use this option you must provide all the columns you want to update
     #   by yourself.

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -570,6 +570,24 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_in_delta updated_at, Book.find(101).updated_at, 1
   end
 
+  def test_upsert_all_returns_row_when_values_do_not_change
+    skip unless supports_insert_on_duplicate_update? && supports_insert_returning?
+
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }]
+    ret = Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }], returning: :id
+
+    assert_equal ret.rows, [[101]]
+  end
+
+  def test_upsert_all_returns_row_when_values_do_not_change_and_timestamps_are_not_recorded
+    skip unless supports_insert_on_duplicate_update? && supports_insert_returning?
+
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }]
+    ret = Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }], returning: :id, record_timestamps: false
+
+    assert_equal ret.rows, [[101]]
+  end
+
   def test_upsert_all_touches_updated_at_and_updated_on_when_values_change
     skip unless supports_insert_on_duplicate_update?
 
@@ -766,6 +784,84 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_nil alice.created_on
     assert_not_nil alice.updated_at
     assert_not_nil alice.updated_on
+  end
+
+  def test_upsert_all_update_if_dirty_applies_changes_and_skips_unchanged_rows
+    skip unless supports_insert_on_duplicate_update_if_dirty?
+
+    updated_at = Time.now.utc - 5.years
+    Book.insert_all [
+      { id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_at: updated_at },
+      { id: 102, name: "Perelandra", published_on: Date.new(1943, 4, 20), updated_at: updated_at }
+    ]
+
+    with_record_timestamps(Book, true) do
+      Book.upsert_all [
+        { id: 101, name: "Out of the Silent Planet", published_on: Date.new(1984, 4, 1) },
+        { id: 102, name: "Perelandra", published_on: Date.new(1943, 4, 20) }
+      ], on_duplicate: :update_if_dirty
+
+      book101 = Book.find(101)
+      assert_equal Date.new(1984, 4, 1), book101.published_on
+      assert_equal Time.now.utc.year, book101.updated_at.year
+
+      book102 = Book.find(102)
+      assert_equal Date.new(1943, 4, 20), book102.published_on
+      assert_in_delta book102.updated_at, updated_at, 1
+    end
+  end
+
+  def test_upsert_all_update_if_dirty_omits_unchanged_rows_from_returned_values
+    skip unless supports_insert_on_duplicate_update_if_dirty? && supports_insert_returning?
+
+    Book.insert_all [
+      { id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) },
+      { id: 102, name: "Perelandra", published_on: Date.new(1943, 4, 20) }
+    ]
+
+    ret = Book.upsert_all [
+      { id: 101, name: "Out of the Silent Planet", published_on: Date.new(1984, 4, 1) },
+      { id: 102, name: "Perelandra", published_on: Date.new(1943, 4, 20) }
+    ], on_duplicate: :update_if_dirty, returning: :id
+
+    assert_equal [[101]], ret.rows
+  end
+
+  def test_upsert_all_update_if_dirty_inserts_new_records
+    skip unless supports_insert_on_duplicate_update_if_dirty?
+
+    assert_difference "Book.count", +1 do
+      Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }], on_duplicate: :update_if_dirty
+    end
+  end
+
+  def test_upsert_all_update_if_dirty_updates_when_specified_columns_are_different
+    skip unless supports_insert_on_duplicate_update_if_dirty?
+
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }]
+    Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1984, 4, 1) }], on_duplicate: :update_if_dirty, update_only: [:published_on]
+
+    book = Book.find(101)
+    assert_equal Date.new(1984, 4, 1), book.published_on
+  end
+
+  def test_upsert_all_update_if_dirty_skips_when_specified_columns_are_the_same
+    skip unless supports_insert_on_duplicate_update_if_dirty?
+
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }]
+    Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1984, 4, 1) }], on_duplicate: :update_if_dirty, update_only: [:name]
+
+    book = Book.find(101)
+    assert_equal Date.new(1938, 4, 1), book.published_on
+  end
+
+  def test_upsert_all_update_if_dirty_raises_when_adapter_does_not_support_it
+    skip if supports_insert_on_duplicate_update_if_dirty?
+
+    error = assert_raises ArgumentError do
+      Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1984, 4, 1) }], on_duplicate: :update_if_dirty
+    end
+    assert_match "#{ActiveRecord::Base.lease_connection.class} does not support upserting only changed rows", error.message
   end
 
   def test_insert_all_raises_on_unknown_attribute

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -576,7 +576,7 @@ class InsertAllTest < ActiveRecord::TestCase
     Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }]
     ret = Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }], returning: :id
 
-    assert_equal ret.rows, [[101]]
+    assert_equal [[101]], ret.rows
   end
 
   def test_upsert_all_returns_row_when_values_do_not_change_and_timestamps_are_not_recorded
@@ -585,7 +585,7 @@ class InsertAllTest < ActiveRecord::TestCase
     Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }]
     ret = Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) }], returning: :id, record_timestamps: false
 
-    assert_equal ret.rows, [[101]]
+    assert_equal [[101]], ret.rows
   end
 
   def test_upsert_all_touches_updated_at_and_updated_on_when_values_change

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -72,6 +72,7 @@ module AdapterHelper
     supports_insert_returning?
     supports_insert_on_duplicate_skip?
     supports_insert_on_duplicate_update?
+    supports_insert_on_duplicate_update_if_dirty?
     supports_insert_conflict_target?
     supports_optimizer_hints?
     supports_datetime_with_precision?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The `upsert_all` method has an `on_duplicate` parameter that defaults to `:update`. While this parameter enables "upsert" functionality, it has some shortcomings:

1. It is difficult to know which rows were inserted or updated versus which rows were left unchanged.
2. For use cases where `upsert_all` often leaves rows unchanged, it can create unnecessary WAL activity and trigger frequent vacuums.

### Detail

This Pull Request introduces a new `on_duplicate: :update_if_dirty` option for `upsert_all` that:

1. Only returns rows that were inserted or updated as a result of the operation
2. Reduces WAL activity and vacuums when rows are frequently left unchanged after an upsert

Specifying this option will skip any duplicate rows that are identical to the values being provided for the update. Skipped rows will not appear in the return value of `upsert_all`. This is a departure from the `:update` option, which returns all rows.

Currently this feature is only supported by the postgresql adapter. It leverages a `WHERE` condition that can be provided in the `ON CONFLICT DO UPDATE` statement. It has been supported since PG 9.5, just like the other `ON CONFLICT` features.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

* [PG documentation for INSERT](https://www.postgresql.org/docs/current/sql-insert.html)
* [RoR discussion post](https://discuss.rubyonrails.org/t/only-return-changed-records-from-upsert-all/85801) about detecting changed rows from `upsert_all`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
