### PR TITLE
Handle unsupported formats in HealthController

### DIFF
--- a/railties/lib/rails/health_controller.rb
+++ b/railties/lib/rails/health_controller.rb
@@ -36,6 +36,7 @@ module Rails
   # gracefully.
   class HealthController < ActionController::Base
     rescue_from(Exception) { render_down }
+    rescue_from(ActionController::UnknownFormat) { head :not_acceptable }
 
     def show
       render_up

--- a/railties/test/rails_health_controller_test.rb
+++ b/railties/test/rails_health_controller_test.rb
@@ -55,4 +55,9 @@ class HealthControllerTest < ActionController::TestCase
     assert_includes json_response, "timestamp"
     assert_match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, json_response["timestamp"])
   end
+
+  test "health controller returns not acceptable for unsupported formats" do
+    get :show, format: :php
+    assert_response :not_acceptable
+  end
 end


### PR DESCRIPTION
### Motivation / Background

In production, the /up health check endpoint commonly receives spam requests with unsupported formats like `.php`, .`xml`, or `.env` from automated
 scanners. These requests cause an unhandled `ActionController::UnknownFormat` exception that bubbles up to error tracking services (e.g.
Bugsnag), creating unnecessary noise.

The root cause is that render_up raises `ActionController::UnknownFormat`, which is caught by rescue_from(Exception) and forwarded to
render_down, but render_down also only handles html and json, causing a second ActionController::UnknownFormat that goes unhandled.

### Detail

This Pull Request adds a dedicated `rescue_from(ActionController::UnknownFormat)` to `Rails::HealthController` that returns 406 Not Acceptable.

Since Rails evaluates `rescue_from` handlers in reverse declaration order, this handler takes priority over the general rescue_from(Exception), so real application errors still go through render_down as expected.

# Before
`$ curl -D - http://localhost:3000/up.php # => 500 Internal Server Error (ActionController::UnknownFormat)`

# After
`$ curl -D - http://localhost:3000/up.php # => 406 Not Acceptable`

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
