### PR TITLE
[ci skip] Update CHANGELOG with transform_keys! overwrite precedence note

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -95,6 +95,26 @@
 
     *Jason T Johnson*, *Jean Boussier*
 
+    **Note on overwrite precedence:**
+
+    This fix also changed the overwrite precedence when distinct keys are transformed into the same key.
+    The later key now overwrites the earlier one (matching standard Ruby `Hash` behavior).
+    Previously, the earlier key's value was preserved.
+
+    Before:
+
+    ```ruby
+    >> {XY: 1, xy: 2}.with_indifferent_access.transform_keys!(&:downcase)
+    => {"xy"=>1}
+    ```
+
+    After:
+
+    ```ruby
+    >> {XY: 1, xy: 2}.with_indifferent_access.transform_keys!(&:downcase)
+    => {"xy"=>2}
+    ```
+
 *   Fix `ActiveSupport::Cache::MemCacheStore#read_multi` to handle network errors.
 
     This method specifically wasn't handling network errors like other codepaths.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the previous bug fix for `ActiveSupport::HashWithIndifferentAccess#transform_keys!` in Rails 8.0.3 introduced a change in overwrite precedence that was not explicitly documented. 

When distinct keys are transformed into the exact same key, the later key now correctly overwrites the earlier one (matching standard Ruby `Hash` behavior). Previously, the earlier key's value was preserved. Documenting this is important to prevent unexpected data loss or silent bugs for users upgrading existing applications.

Fixes #56960

### Detail

This Pull Request changes the `activesupport/CHANGELOG.md` entry for Rails 8.0.3 to include a brief note explaining this overwrite precedence change. It adds a clear `Before` and `After` code example showing the behavior when a camelCase key and a snake_case key collide.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Opening this PR targeting the `8-0-stable` branch as requested in the issue.
cc @byroot

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
