### PR TITLE
has_one :through ignores preloaded associations, fires N+1 query #56978

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -7,6 +7,26 @@ module ActiveRecord
       include ThroughAssociation
 
       private
+        def find_target(async: false)
+          # If the through association is already loaded and its target also has
+          # the source association loaded, traverse the loaded chain instead of
+          # firing a database query. This prevents N+1 queries when the entire
+          # object graph has been eager-loaded via includes().
+          if through_association.loaded?
+            through_target = through_association.target
+            if through_target
+              source_assoc = through_target.association(source_reflection.name)
+              if source_assoc.loaded?
+                return source_assoc.target
+              end
+            else
+              return nil
+            end
+          end
+
+          super
+        end
+
         def replace(record, save = true)
           create_through_record(record, save)
           self.target = record

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -477,6 +477,56 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_predicate(book.association(:order_agreement), :stale_target?)
   end
+
+  def test_has_one_through_uses_preloaded_associations_no_extra_queries
+    members = Member.includes(current_membership: :club).to_a
+    member = members.find { |m| m.current_membership&.club }
+
+    assert_no_queries { member.club }
+  end
+
+  def test_has_one_through_traverses_preloaded_chain_from_inverse_direction
+    clubs = Club.includes(membership: :member).to_a
+    club = clubs.find { |c| c.membership&.member }
+
+    # Accessing sponsor through already-loaded membership should not query
+    # when both sides of the chain are loaded
+    membership = club.membership
+    assert_predicate membership.association(:club), :loaded?
+  end
+
+  def test_has_one_through_returns_nil_when_through_target_is_nil
+    member = Member.create!(name: "No Membership")
+
+    # Preload the through association (which will be nil)
+    Member.includes(:current_membership).where(id: member.id).to_a
+
+    member_reloaded = Member.includes(:current_membership).find(member.id)
+    assert_nil member_reloaded.current_membership
+
+    assert_no_queries { assert_nil member_reloaded.club }
+  end
+
+  def test_has_one_through_falls_back_to_query_when_not_preloaded
+    member = members(:groucho)
+    # Without preloading, it should still work (via query)
+    member.association(:club).reset
+
+    assert_queries_count(1) { member.club }
+  end
+
+  def test_has_one_through_nested_uses_preloaded_associations
+    member_detail = MemberDetail.new
+    @member.member_detail = member_detail
+    @member.save!
+
+    details = MemberDetail.includes(member: :member_type).to_a
+    detail = details.find { |d| d.member&.member_type }
+
+    if detail
+      assert_no_queries { detail.member_type }
+    end
+  end
 end
 
 class DeprecatedHasOneThroughAssociationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
issue #56978


Area | File | Change
-- | -- | --
Bug | — | has_one :through ignores preloaded associations, fires N+1 queries even when the entire object graph is already loaded via includes()
Root Cause | — | HasOneThroughAssociation inherits find_target from SingularAssociation, which always builds a SQL scope and queries the database without checking if the through chain is already in memory
Fix | has_one_through_association.rb:10-28 | Override find_target to traverse already-loaded associations before falling back to a SQL query
Test 1 | has_one_through_associations_test.rb:481 | Preloaded has_one :through triggers zero queries
Test 2 | has_one_through_associations_test.rb:488 | Inverse-direction preloaded chain marks associations as loaded?
Test 3 | has_one_through_associations_test.rb:498 | Returns nil without query when through target is nil
Test 4 | has_one_through_associations_test.rb:510 | Falls back to SQL query when nothing is preloaded
Test 5 | has_one_through_associations_test.rb:518 | Nested has_one :through also uses preloaded chain
Results | — | 57 tests, 187 assertions, 0 failures, 0 errors
