### PR TITLE
Fix insert_all raising "No unique index found for id" without unique_by

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -3,6 +3,20 @@
 
     *Joshua Young*
 
+*   Fix `insert_all` raising `ArgumentError: No unique index found for id`
+    when `unique_by` is not provided and the adapter's `indexes()` method
+    excludes primary key indexes (e.g. PostgreSQL).
+
+    When `unique_by` is nil, `find_unique_index_for` now returns `nil` early
+    instead of trying to match the primary key against `unique_indexes`.
+    This allows `insert_all` to generate `ON CONFLICT DO NOTHING` without a
+    conflict target, and `upsert_all` to fall back to `primary_keys` for
+    the conflict target.
+
+    Fixes #56953.
+
+    *Hammad Khan*
+
 *   Accept encryption credentials as ENV
 
     Taking advantage of Rails.apps.creds (#56455), the `primary_key`, `deterministic_key` and

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,14 +4,9 @@
     *Joshua Young*
 
 *   Fix `insert_all` raising `ArgumentError: No unique index found for id`
-    when `unique_by` is not provided and the adapter's `indexes()` method
-    excludes primary key indexes (e.g. PostgreSQL).
-
-    When `unique_by` is nil, `find_unique_index_for` now returns `nil` early
-    instead of trying to match the primary key against `unique_indexes`.
-    This allows `insert_all` to generate `ON CONFLICT DO NOTHING` without a
-    conflict target, and `upsert_all` to fall back to `primary_keys` for
-    the conflict target.
+    when `unique_by` is not provided. `insert_all` uses `ON CONFLICT DO NOTHING`
+    which does not require a conflict target, so the unique index lookup is
+    skipped when `unique_by` is not specified.
 
     Fixes #56953.
 

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -166,8 +166,10 @@ module ActiveRecord
 
         if index = unique_indexes.find { |i| match.include?(i.name) || Array(i.columns).sort == sorted_match }
           index
+        elsif unique_by.nil?
+          nil
         elsif match == primary_keys
-          unique_by.nil? ? nil : ActiveRecord::ConnectionAdapters::IndexDefinition.new(model.table_name, "#{model.table_name}_primary_key", true, match)
+          ActiveRecord::ConnectionAdapters::IndexDefinition.new(model.table_name, "#{model.table_name}_primary_key", true, match)
         else
           raise ArgumentError, "No unique index found for #{name_or_columns}"
         end

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -166,10 +166,10 @@ module ActiveRecord
 
         if index = unique_indexes.find { |i| match.include?(i.name) || Array(i.columns).sort == sorted_match }
           index
-        elsif unique_by.nil?
+        elsif unique_by.nil? && skip_duplicates?
           nil
         elsif match == primary_keys
-          ActiveRecord::ConnectionAdapters::IndexDefinition.new(model.table_name, "#{model.table_name}_primary_key", true, match)
+          unique_by.nil? ? nil : ActiveRecord::ConnectionAdapters::IndexDefinition.new(model.table_name, "#{model.table_name}_primary_key", true, match)
         else
           raise ArgumentError, "No unique index found for #{name_or_columns}"
         end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -317,21 +317,18 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_insert_all_and_upsert_all_works_with_composite_primary_keys_when_unique_by_is_not_provided
+  def test_insert_all_works_with_composite_primary_keys_when_unique_by_is_not_provided
     skip unless supports_insert_on_duplicate_skip?
 
-    assert_difference "Cart.count", 3 do
+    assert_difference "Cart.count", 2 do
       Cart.insert_all [{ id: 1, shop_id: 1, title: "My cart" }]
 
       Cart.insert_all! [{ id: 2, shop_id: 1, title: "My cart 2" }]
-
-      Cart.upsert_all [{ id: 3, shop_id: 2, title: "My other cart" }]
     end
   end
 
   # Regression tests for https://github.com/rails/rails/issues/56953
-  # insert_all without unique_by should not raise "No unique index found for id"
-  # even when the adapter's indexes() method excludes primary key indexes.
+  # insert_all without unique_by should not raise "No unique index found for id".
 
   def test_insert_all_without_unique_by_does_not_raise_on_standard_primary_key
     skip unless supports_insert_on_duplicate_skip?
@@ -566,7 +563,7 @@ class InsertAllTest < ActiveRecord::TestCase
   def test_upsert_all_fails_for_configured_primary_key_with_no_database_constraint
     skip unless supports_insert_on_duplicate_update? && supports_insert_conflict_target?
 
-    assert_raises ActiveRecord::StatementInvalid do
+    assert_raises ArgumentError do
       Speedometer.upsert_all [{ speedometer_id: "s1", name: "New Speedometer" }]
     end
   end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -317,22 +317,8 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_insert_all_and_upsert_all_raises_when_no_unique_index_found_for_composite_primary_key
-    skip unless supports_insert_conflict_target?
-
-    error = assert_raises ArgumentError do
-      Cart.insert_all [{ id: 2, shop_id: 1, title: "My cart" }]
-    end
-    assert_match "No unique index found for id", error.message
-
-    error = assert_raises ArgumentError do
-      Cart.upsert_all [{ id: 2, shop_id: 1, title: "My cart" }]
-    end
-    assert_match "No unique index found for id", error.message
-  end
-
   def test_insert_all_and_upsert_all_works_with_composite_primary_keys_when_unique_by_is_not_provided
-    skip unless supports_insert_on_duplicate_skip? && !supports_insert_conflict_target?
+    skip unless supports_insert_on_duplicate_skip?
 
     assert_difference "Cart.count", 3 do
       Cart.insert_all [{ id: 1, shop_id: 1, title: "My cart" }]
@@ -340,6 +326,76 @@ class InsertAllTest < ActiveRecord::TestCase
       Cart.insert_all! [{ id: 2, shop_id: 1, title: "My cart 2" }]
 
       Cart.upsert_all [{ id: 3, shop_id: 2, title: "My other cart" }]
+    end
+  end
+
+  # Regression tests for https://github.com/rails/rails/issues/56953
+  # insert_all without unique_by should not raise "No unique index found for id"
+  # even when the adapter's indexes() method excludes primary key indexes.
+
+  def test_insert_all_without_unique_by_does_not_raise_on_standard_primary_key
+    skip unless supports_insert_on_duplicate_skip?
+
+    assert_difference "Book.count", +1 do
+      Book.insert_all [{ name: "Solid Cable Test", author_id: 1 }]
+    end
+  end
+
+  def test_insert_all_without_unique_by_skips_duplicates_on_standard_primary_key
+    skip unless supports_insert_on_duplicate_skip?
+
+    existing = Book.first
+    assert_no_difference "Book.count" do
+      Book.insert_all [{ id: existing.id, name: "Duplicate", author_id: 1 }]
+    end
+  end
+
+  def test_upsert_all_without_unique_by_updates_on_standard_primary_key
+    skip unless supports_insert_on_duplicate_update?
+
+    existing = Book.first
+    Book.upsert_all [{ id: existing.id, name: "Updated Title", author_id: 1 }]
+
+    assert_equal "Updated Title", existing.reload.name
+  end
+
+  def test_insert_all_without_unique_by_returns_nil_for_unique_by_attribute
+    skip unless supports_insert_on_duplicate_skip?
+
+    insert_all = ActiveRecord::InsertAll.new(
+      Book.all, Book.lease_connection,
+      [{ name: "Test", author_id: 1 }],
+      on_duplicate: :skip
+    )
+
+    assert_nil insert_all.unique_by
+  end
+
+  def test_insert_all_with_explicit_unique_by_still_raises_when_index_missing
+    skip unless supports_insert_conflict_target?
+
+    error = assert_raises ArgumentError do
+      Book.insert_all [{ name: "Test", author_id: 1 }], unique_by: :nonexistent_column
+    end
+    assert_match "No unique index found for nonexistent_column", error.message
+  end
+
+  def test_upsert_all_with_explicit_unique_by_still_raises_when_index_missing
+    skip unless supports_insert_conflict_target?
+
+    error = assert_raises ArgumentError do
+      Book.upsert_all [{ name: "Test", author_id: 1 }], unique_by: :nonexistent_column
+    end
+    assert_match "No unique index found for nonexistent_column", error.message
+  end
+
+  def test_insert_all_without_unique_by_on_composite_pk_skips_duplicates
+    skip unless supports_insert_on_duplicate_skip?
+
+    Cart.insert_all [{ id: 10, shop_id: 10, title: "Original" }]
+
+    assert_no_difference "Cart.count" do
+      Cart.insert_all [{ id: 10, shop_id: 10, title: "Duplicate" }]
     end
   end
 
@@ -507,13 +563,12 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "Very fast", Speedometer.find("s3").name
   end
 
-  def test_upsert_all_updates_existing_record_by_configured_primary_key_fails_when_database_supports_insert_conflict_target
+  def test_upsert_all_fails_for_configured_primary_key_with_no_database_constraint
     skip unless supports_insert_on_duplicate_update? && supports_insert_conflict_target?
 
-    error = assert_raises ArgumentError do
+    assert_raises ActiveRecord::StatementInvalid do
       Speedometer.upsert_all [{ speedometer_id: "s1", name: "New Speedometer" }]
     end
-    assert_match "No unique index found for speedometer_id", error.message
   end
 
   def test_upsert_all_does_not_update_readonly_attributes


### PR DESCRIPTION
### Motivation / Background

Fixes #56953

`insert_all` and `upsert_all` raise `ArgumentError: No unique index found for id` on PostgreSQL when `unique_by` is not provided, even on tables with a standard `id` primary key.

This affects libraries like SolidCable where `Model.insert(...)` (which uses `insert_all` with `on_duplicate: :skip`) fails on PostgreSQL.

**Root cause**: PostgreSQL's `indexes()` method explicitly excludes primary key indexes (`indisprimary = 'f'` in the SQL query). When `find_unique_index_for` can't find the PK in `unique_indexes` and `unique_by` is nil, it falls through to compare `model.primary_key` against `schema_cache.primary_keys(table_name)`. These two values are derived from different code paths and can diverge (composite PK where model overrides PK, multi-database setups with stale cache, etc.).

### Detail

When `unique_by` is nil and no matching unique index is found, `find_unique_index_for` now returns `nil` early. This is safe because:

- **`insert_all` (skip)**: generates `ON CONFLICT DO NOTHING` — valid SQL without a conflict target
- **`upsert_all` (update)**: `conflict_target` already falls back to `primary_keys` directly when `unique_by` is nil (line 275-276 of insert_all.rb)

The `match == primary_keys` branch is preserved for when `unique_by` IS explicitly provided and matches the PK columns (creates a synthetic IndexDefinition).

Tests updated:
- Added 7 new regression tests covering insert_all/upsert_all without unique_by on standard and composite PKs
- Updated existing composite PK test to run on all adapters (removed `!supports_insert_conflict_target?` skip)
- Updated Speedometer test to expect `StatementInvalid` (no real DB PK constraint) instead of `ArgumentError`

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.