### PR TITLE
Simplify `activerecord` tests with `NotificationAssertions` helpers

### DIFF
--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -158,14 +158,9 @@ module ActiveRecord
     end
 
     def test_payload_affected_rows
-      affected_row_values = []
-
-      ActiveSupport::Notifications.subscribed(
-        -> (event) { affected_row_values << event.payload[:affected_rows] },
-        "sql.active_record",
-      ) do
-        # The combination of MariaDB + Trilogy returns 0 for affected_rows with
-        # INSERT ... RETURNING
+      # The combination of MariaDB + Trilogy returns 0 for affected_rows with
+      # INSERT ... RETURNING
+      events = capture_notifications("sql.active_record") do
         Book.insert_all!([{ name: "One" }, { name: "Two" }, { name: "Three" }, { name: "Four" }], returning: false)
 
         Book.where(name: ["One", "Two", "Three"]).pluck(:id)
@@ -176,6 +171,7 @@ module ActiveRecord
 
         Book.where(name: ["Three", "Four"]).delete_all
       end
+      affected_row_values = events.map { |e| e.payload[:affected_rows] }
 
       assert_equal 4, affected_row_values.first
       assert_not_equal affected_row_values.first, affected_row_values.second
@@ -185,21 +181,15 @@ module ActiveRecord
     end
 
     def test_payload_affected_rows_cascade
-      affected_row_values = []
-
-      ActiveSupport::Notifications.subscribed(
-        -> (event) do
-          unless event.payload[:name].in? ["SCHEMA", "TRANSACTION"]
-            affected_row_values << event.payload[:affected_rows]
-          end
-        end,
-        "sql.active_record",
-      ) do
+      events = capture_notifications("sql.active_record") do
         l = Lesson.create!(name: "Algebra")
         l.students.create!(name: "Jim")
 
         Student.delete_all
       end
+      affected_row_values = events
+        .reject { |e| e.payload[:name].in?(["SCHEMA", "TRANSACTION"]) }
+        .map { |e| e.payload[:affected_rows] }
 
       assert_equal 4, affected_row_values.length
       assert_equal 1, affected_row_values.fourth

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -55,15 +55,10 @@ module ActiveRecord
         deferred_comments = post.comments.load_async
         assert_predicate deferred_comments, :scheduled?
 
-        events = []
-        callback = -> (event) do
-          events << event unless event.payload[:name] == "SCHEMA"
-        end
-
         wait_for_async_query
-        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        events = capture_notifications("sql.active_record") do
           deferred_comments.to_a
-        end
+        end.reject { |e| e.payload[:name] == "SCHEMA" }
 
         assert_equal [["Comment Load", true]], events.map { |e| [e.payload[:name], e.payload[:async]] }
         assert_not_predicate post.comments, :loaded?
@@ -75,15 +70,10 @@ module ActiveRecord
         deferred_categories = post.scategories.load_async
         assert_predicate deferred_categories, :scheduled?
 
-        events = []
-        callback = -> (event) do
-          events << event unless event.payload[:name] == "SCHEMA"
-        end
-
         wait_for_async_query
-        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        events = capture_notifications("sql.active_record") do
           deferred_categories.to_a
-        end
+        end.reject { |e| e.payload[:name] == "SCHEMA" }
 
         assert_equal [["Category Load", true]], events.map { |e| [e.payload[:name], e.payload[:async]] }
         assert_not_predicate post.scategories, :loaded?
@@ -181,12 +171,9 @@ module ActiveRecord
         Post.async_count
         latch1.wait
 
-        notification_called = false
-        ActiveSupport::Notifications.subscribed(->(*) { notification_called = true }, "sql.active_record") do
+        assert_notification("sql.active_record") do
           Post.count
         end
-
-        assert(notification_called)
       ensure
         latch2.count_down
         ActiveRecord::Base.connection.singleton_class.undef_method(:log)
@@ -213,13 +200,9 @@ module ActiveRecord
 
         # After the async query completes, synchronous queries must still
         # publish sql.active_record notifications
-        notification_called = false
-        ActiveSupport::Notifications.subscribed(->(*) { notification_called = true }, "sql.active_record") do
+        assert_notification("sql.active_record") do
           Post.count
         end
-
-        assert notification_called,
-          "sql.active_record notification was not published after execute_or_skip ran on the caller thread"
       ensure
         pool.singleton_class.undef_method(:schedule_query)
         pool.singleton_class.define_method(:schedule_query, old_schedule_query)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Follow-up to https://github.com/rails/rails/pull/53822, applying `NotificationAssertions` helpers to remaining `activerecord` tests that still used manual `ActiveSupport::Notifications.subscribed` patterns.

### Detail

This Pull Request changes six tests in `activerecord` to use `NotificationAssertions` helpers. In load_async_test.rb, boolean flag plus manual subscriber patterns are replaced with assert_notification. In instrumentation_test.rb, inline accumulation callbacks are replaced with capture_notifications followed by map/reject. In cases where direct assertions make sense we use assert_notification, and where we need to inspect payloads we fall back to capture_notifications.

### Additional information

https://api.rubyonrails.org/classes/ActiveSupport/Testing/NotificationAssertions.html

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
