### PR TITLE
fix(guides): bin/jobs start was not copying

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -186,7 +186,7 @@ TIP: You can find the default generated schema for the `queue` database in
 Finally, to start the queue and start processing jobs you can run:
 
 ```bash
-bin/jobs start
+$ bin/jobs start
 ```
 
 #### Production


### PR DESCRIPTION
The `bin/jobs start` command, from [Active Job Basics](https://guides.rubyonrails.org/active_job_basics.html) was not being copied due to the missing $ character.