### PR TITLE
Incomplete fix for CVE-2024-54133: Feature-Policy directive injection via ActionDispatch::PermissionsPolicy #56949

### DIFF
--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -29,6 +29,9 @@ module ActionDispatch # :nodoc:
   # use the new name for the middleware but keep the old header name and
   # implementation for now.
   class PermissionsPolicy
+    class InvalidDirectiveError < StandardError
+    end
+
     class Middleware
       def initialize(app)
         @app = app
@@ -156,7 +159,7 @@ module ActionDispatch # :nodoc:
       def build_directives(context)
         @directives.map do |directive, sources|
           if sources.is_a?(Array)
-            "#{directive} #{build_directive(sources, context).join(' ')}"
+            "#{directive} #{build_directive(directive, sources, context).join(' ')}"
           elsif sources
             directive
           else
@@ -165,8 +168,22 @@ module ActionDispatch # :nodoc:
         end
       end
 
-      def build_directive(sources, context)
-        sources.map { |source| resolve_source(source, context) }
+      def build_directive(directive, sources, context)
+        resolved_sources = sources.map { |source| resolve_source(source, context) }
+
+        validate(directive, resolved_sources)
+      end
+
+      def validate(directive, sources)
+        sources.flatten.each do |source|
+          if source.include?(";") || source != source.gsub(/[[:space:]]/, "")
+            raise InvalidDirectiveError, <<~MSG.squish
+              Invalid HTTP permissions policy #{directive}: "#{source}".
+              Directive values must not contain whitespace or semicolons.
+              Please use multiple arguments or other directive methods instead.
+            MSG
+          end
+        end
       end
 
       def resolve_source(source, context)

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -169,13 +169,13 @@ module ActionDispatch # :nodoc:
       end
 
       def build_directive(directive, sources, context)
-        resolved_sources = sources.map { |source| resolve_source(source, context) }
-
+        resolved_sources = sources.flat_map { |source| resolve_source(source, context) }
         validate(directive, resolved_sources)
+        resolved_sources
       end
 
       def validate(directive, sources)
-        sources.flatten.each do |source|
+        sources.each do |source|
           if source.include?(";") || source != source.gsub(/[[:space:]]/, "")
             raise InvalidDirectiveError, <<~MSG.squish
               Invalid HTTP permissions policy #{directive}: "#{source}".

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -7,6 +7,68 @@ class PermissionsPolicyTest < ActiveSupport::TestCase
     @policy = ActionDispatch::PermissionsPolicy.new
   end
 
+  def test_whitespace_validation
+    @policy.camera "https://example.com https://evil.com"
+
+    error = assert_raises(ActionDispatch::PermissionsPolicy::InvalidDirectiveError) do
+      @policy.build
+    end
+    assert_equal(<<~MSG.squish, error.message)
+      Invalid HTTP permissions policy camera: "https://example.com https://evil.com".
+      Directive values must not contain whitespace or semicolons.
+      Please use multiple arguments or other directive methods instead.
+    MSG
+  end
+
+  def test_semicolon_validation
+    @policy.camera "https://evil.com; geolocation *"
+
+    error = assert_raises(ActionDispatch::PermissionsPolicy::InvalidDirectiveError) do
+      @policy.build
+    end
+    assert_equal(<<~MSG.squish, error.message)
+      Invalid HTTP permissions policy camera: "https://evil.com; geolocation *".
+      Directive values must not contain whitespace or semicolons.
+      Please use multiple arguments or other directive methods instead.
+    MSG
+  end
+
+  def test_dynamic_source_semicolon_injection
+    params = { allowed_origin: "https://evil.com; geolocation *" }
+    request = Struct.new(:params).new(params)
+    controller = Struct.new(:request).new(request)
+
+    @policy.camera :self, -> { request.params[:allowed_origin] }
+    @policy.microphone :none
+
+    assert_raises(ActionDispatch::PermissionsPolicy::InvalidDirectiveError) do
+      @policy.build(controller)
+    end
+  end
+
+  def test_dynamic_source_whitespace_injection
+    params = { allowed_origin: "https://evil.com https://other.com" }
+    request = Struct.new(:params).new(params)
+    controller = Struct.new(:request).new(request)
+
+    @policy.camera :self, -> { request.params[:allowed_origin] }
+
+    assert_raises(ActionDispatch::PermissionsPolicy::InvalidDirectiveError) do
+      @policy.build(controller)
+    end
+  end
+
+  def test_dynamic_source_with_valid_input
+    params = { allowed_origin: "https://trusted.com" }
+    request = Struct.new(:params).new(params)
+    controller = Struct.new(:request).new(request)
+
+    @policy.camera :self, -> { request.params[:allowed_origin] }
+    @policy.microphone :none
+
+    assert_equal "camera 'self' https://trusted.com; microphone 'none'", @policy.build(controller)
+  end
+
   def test_mappings
     @policy.midi :self
     assert_equal "midi 'self'", @policy.build


### PR DESCRIPTION
issue #56949


Test | Scenario | Input | Expected | Result
-- | -- | -- | -- | --
test_semicolon_validation | Static source with semicolon injection | "https://evil.com; geolocation *" | Raises InvalidDirectiveError | PASS
test_whitespace_validation | Static source with whitespace injection | "https://example.com https://evil.com" | Raises InvalidDirectiveError | PASS
test_dynamic_source_semicolon_injection | Dynamic Proc source (user input) with semicolon injection | params[:allowed_origin] = "https://evil.com; geolocation *" | Raises InvalidDirectiveError | PASS
test_dynamic_source_whitespace_injection | Dynamic Proc source (user input) with whitespace injection | params[:allowed_origin] = "https://evil.com https://other.com" | Raises InvalidDirectiveError | PASS
test_dynamic_source_with_valid_input | Dynamic Proc source with legitimate input | params[:allowed_origin] = "https://trusted.com" | Builds header normally | PASS

Fix applied: Added InvalidDirectiveError, a validate method, and updated build_directive in [permissions_policy.rb]

