### PR TITLE
Deprecate require_dependency

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Deprecate `require_dependency`.
+
+    `require_dependency` is deprecated without replacement and will be removed in Rails 9.
+
+    - Recommendations for applications:
+
+        - If the call is an old one written in the days of the classic
+          autoloader to ensure a certain constant is loaded for constant lookup
+          to work as expected, you can simply remove it.
+
+        - In order to preload classes when the application boots, which may be
+          necessary for things like STIs or Kafka consumers, please check the
+          autoloading guide for modern approaches.
+
+    - Recommendations for engines that depend on Rails >= 7.0:
+
+      Same recommendations as for applications, since the classic autoloader is
+      no longer available starting with Rails 7.0.
+
+    - Recommendations for engines that support Rails < 7.0:
+
+      Guard the call with a version check just in case the parent application is
+      using the classic autoloader:
+
+      ```ruby
+      require_dependency "some_file" unless Rails::VERSION::MAJOR >= 7
+      ```
+
+    *Xavier Noria*
+
 *   Add `group` method to `ActiveSupport::ContinuousIntegration` for parallel step execution.
 
     Groups collect steps and run them concurrently using a thread pool, reducing CI times

--- a/activesupport/lib/active_support/dependencies/require_dependency.rb
+++ b/activesupport/lib/active_support/dependencies/require_dependency.rb
@@ -1,14 +1,35 @@
 # frozen_string_literal: true
 
 module ActiveSupport::Dependencies::RequireDependency
-  # <b>Warning:</b> This method is obsolete. The semantics of the autoloader
-  # match Ruby's and you do not need to be defensive with load order anymore.
-  # Just refer to classes and modules normally.
-  #
-  # Engines that do not control the mode in which their parent application runs
-  # should call +require_dependency+ where needed in case the runtime mode is
-  # +:classic+.
+  # <b>Warning:</b> This method is deprecated.
   def require_dependency(filename)
+    ActiveSupport.deprecator.warn <<~MSG
+      require_dependency is deprecated without replacement and will be removed
+      in Rails 9.
+
+      - Recommendations for applications:
+
+          - If the call is an old one written in the days of the classic autoloader to ensure a
+            certain constant is loaded for constant lookup to work as expected, you can simply
+            remove it.
+
+          - In order to preload classes when the application boots, which may be necessary for
+            things like STIs or Kafka consumers, please check the autoloading guide for modern
+            approaches.
+
+      - Recommendations for engines that depend on Rails >= 7.0:
+
+        Same recommendations as for applications, since the classic autoloader is no longer
+        available starting with Rails 7.0.
+
+      - Recommendations for engines that support Rails < 7.0:
+
+        Guard the call with a version check just in case the parent application is using
+        the classic autoloader:
+
+            require_dependency "some_file" unless Rails::VERSION::MAJOR >= 7
+    MSG
+
     filename = filename.to_path if filename.respond_to?(:to_path)
 
     unless filename.is_a?(String)

--- a/activesupport/test/dependencies/mutual_one.rb
+++ b/activesupport/test/dependencies/mutual_one.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-$mutual_dependencies_count += 1
-require_dependency "mutual_two"
-require_dependency "mutual_two.rb"
-require_dependency "mutual_two"

--- a/activesupport/test/dependencies/mutual_two.rb
+++ b/activesupport/test/dependencies/mutual_two.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-$mutual_dependencies_count += 1
-require_dependency "mutual_one.rb"
-require_dependency "mutual_one"
-require_dependency "mutual_one.rb"

--- a/activesupport/test/dependencies/requires_nonexistent1.rb
+++ b/activesupport/test/dependencies/requires_nonexistent1.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_dependency "requires_nonexistent0"

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -4,6 +4,10 @@ require_relative "abstract_unit"
 require "active_support/dependencies"
 
 class RequireDependencyTest < ActiveSupport::TestCase
+  def silenced_require_dependency(path)
+    ActiveSupport.deprecator.silence { require_dependency(path) }
+  end
+
   setup do
     @loaded_features_copy = $LOADED_FEATURES.dup
     ActiveSupport::Dependencies.autoload_paths.clear
@@ -22,30 +26,30 @@ class RequireDependencyTest < ActiveSupport::TestCase
   end
 
   test "require_dependency looks autoload paths up" do
-    assert require_dependency("x")
+    assert silenced_require_dependency("x")
     assert_equal :X, X
   end
 
   test "require_dependency looks autoload paths up (idempotent)" do
-    assert require_dependency("x")
-    assert_not require_dependency("x")
+    assert silenced_require_dependency("x")
+    assert_not silenced_require_dependency("x")
   end
 
   test "require_dependency handles absolute paths correctly" do
-    assert require_dependency("#{@root_dir}/x.rb")
+    assert silenced_require_dependency("#{@root_dir}/x.rb")
     assert_equal :X, X
   end
 
   test "require_dependency handles absolute paths correctly (idempotent)" do
-    assert require_dependency("#{@root_dir}/x.rb")
-    assert_not require_dependency("#{@root_dir}/x.rb")
+    assert silenced_require_dependency("#{@root_dir}/x.rb")
+    assert_not silenced_require_dependency("#{@root_dir}/x.rb")
   end
 
   test "require_dependency supports arguments that respond to to_path" do
     x = Object.new
     def x.to_path; "x"; end
 
-    assert require_dependency(x)
+    assert silenced_require_dependency(x)
     assert_equal :X, X
   end
 
@@ -53,8 +57,8 @@ class RequireDependencyTest < ActiveSupport::TestCase
     x = Object.new
     def x.to_path; "x"; end
 
-    assert require_dependency(x)
-    assert_not require_dependency(x)
+    assert silenced_require_dependency(x)
+    assert_not silenced_require_dependency(x)
   end
 
   test "require_dependency fallback to Kernel#require" do
@@ -62,7 +66,7 @@ class RequireDependencyTest < ActiveSupport::TestCase
     $LOAD_PATH << dir
     File.write("#{dir}/y.rb", "Y = :Y")
 
-    assert require_dependency("y")
+    assert silenced_require_dependency("y")
     assert_equal :Y, Y
   ensure
     $LOAD_PATH.pop
@@ -74,18 +78,24 @@ class RequireDependencyTest < ActiveSupport::TestCase
     $LOAD_PATH << dir
     File.write("#{dir}/y.rb", "Y = :Y")
 
-    assert require_dependency("y")
-    assert_not require_dependency("y")
+    assert silenced_require_dependency("y")
+    assert_not silenced_require_dependency("y")
   ensure
     $LOAD_PATH.pop
     Object.send(:remove_const, :Y) if Object.const_defined?(:Y)
   end
 
   test "require_dependency raises ArgumentError if the argument is not a String and does not respond to #to_path" do
-    assert_raises(ArgumentError) { require_dependency(Object.new) }
+    assert_raises(ArgumentError) { silenced_require_dependency(Object.new) }
   end
 
   test "require_dependency raises LoadError if the given argument is not found" do
-    assert_raise(LoadError) { require_dependency("nonexistent_filename") }
+    assert_raise(LoadError) { silenced_require_dependency("nonexistent_filename") }
+  end
+
+  test "require_dependency is deprecated" do
+    assert_deprecated(/require_dependency is deprecated/, ActiveSupport.deprecator) do
+      require_dependency("x")
+    end
   end
 end


### PR DESCRIPTION
`require_dependency` has been kept around to ease the transition from `classic`, and nowadays especially having engines supporting Rails < 7.0 in mind.

It has been a while, I think we can start to prepare its deletion.