### PR TITLE
Drop workaround for mail gem version < 2.8

### DIFF
--- a/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
@@ -3,11 +3,11 @@
 module Mail
   class Message
     def from_address
-      address_list(header[:from])&.addresses&.first
+      header[:from]&.element&.addresses&.first
     end
 
     def reply_to_address
-      address_list(header[:reply_to])&.addresses&.first
+      header[:reply_to]&.element&.addresses&.first
     end
 
     def recipients_addresses
@@ -15,15 +15,15 @@ module Mail
     end
 
     def to_addresses
-      Array(address_list(header[:to])&.addresses)
+      Array(header[:to]&.element&.addresses)
     end
 
     def cc_addresses
-      Array(address_list(header[:cc])&.addresses)
+      Array(header[:cc]&.element&.addresses)
     end
 
     def bcc_addresses
-      Array(address_list(header[:bcc])&.addresses)
+      Array(header[:bcc]&.element&.addresses)
     end
 
     def x_original_to_addresses
@@ -33,16 +33,5 @@ module Mail
     def x_forwarded_to_addresses
       Array(header[:x_forwarded_to]).collect { |header| Mail::Address.new header.to_s }
     end
-
-    private
-      def address_list(obj)
-        if obj.respond_to?(:element)
-          # Mail 2.8+
-          obj.element
-        else
-          # Mail <= 2.7.x
-          obj&.address_list
-        end
-      end
   end
 end


### PR DESCRIPTION
### Motivation / Background
This pull request drops workaround for mail gem version < 2.8.

### Detail

Action Mailbox now requires mail gem >= 2.8 since #50668, so we can drop this workaround.

### Additional information
Refer to #46643, which added this workaround.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
