### PR TITLE
Batch SQL statements when creating tables.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -302,33 +302,34 @@ module ActiveRecord
           raise ArgumentError, "Options `:force` and `:if_not_exists` cannot be used simultaneously."
         end
 
-        td = build_create_table_definition(table_name, id: id, primary_key: primary_key, force: force, **options, &block)
+        statements = []
 
         if force
-          drop_table(table_name, force: force, if_exists: true)
-        else
-          schema_cache.clear_data_source_cache!(table_name.to_s)
+          statements << drop_table_sql(table_name, if_exists: true)
         end
 
-        result = execute schema_creation.accept(td)
+        schema_cache.clear_data_source_cache!(table_name.to_s)
+
+        td = build_create_table_definition(table_name, id: id, primary_key: primary_key, force: force, **options, &block)
+        statements << schema_creation.accept(td)
 
         unless supports_indexes_in_create?
           td.indexes.each do |column_name, index_options|
-            add_index(table_name, column_name, **index_options, if_not_exists: td.if_not_exists)
+            statements << schema_creation.accept(build_create_index_definition(table_name, column_name, **index_options, if_not_exists: td.if_not_exists))
           end
         end
 
         if supports_comments? && !supports_comments_in_create?
           if table_comment = td.comment.presence
-            change_table_comment(table_name, table_comment)
+            statements << change_table_comment_sql(table_name, table_comment)
           end
 
           td.columns.each do |column|
-            change_column_comment(table_name, column.name, column.comment) if column.comment.present?
+            statements << change_column_comment_sql(table_name, column.name, column.comment) if column.comment.present?
           end
         end
 
-        result
+        execute_batch statements
       end
 
       # Returns a TableDefinition object containing information about the table that would be created
@@ -559,7 +560,7 @@ module ActiveRecord
       def drop_table(*table_names, **options)
         table_names.each do |table_name|
           schema_cache.clear_data_source_cache!(table_name.to_s)
-          execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}"
+          execute drop_table_sql(table_name, options[:if_exists])
         end
       end
 
@@ -1959,6 +1960,18 @@ module ActiveRecord
         end
 
         def quoted_scope(name = nil, type: nil)
+          raise NotImplementedError
+        end
+
+        def drop_table_sql(table_name, if_exists)
+          "DROP TABLE#{' IF EXISTS' if if_exists} #{quote_table_name(table_name)}"
+        end
+
+        def change_table_comment_sql(table_name, comment_or_changes)
+          raise NotImplementedError
+        end
+
+        def change_column_comment_sql(table_name, column_name, comment_or_changes)
           raise NotImplementedError
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -677,15 +677,13 @@ module ActiveRecord
         # Adds comment for given table column or drops it if +comment+ is a +nil+
         def change_column_comment(table_name, column_name, comment_or_changes) # :nodoc:
           clear_cache!
-          comment = extract_new_comment_value(comment_or_changes)
-          execute "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS #{quote(comment)}"
+          execute change_column_comment_sql(table_name, column_name, comment_or_changes)
         end
 
         # Adds comment for given table or drops it if +comment+ is a +nil+
         def change_table_comment(table_name, comment_or_changes) # :nodoc:
           clear_cache!
-          comment = extract_new_comment_value(comment_or_changes)
-          execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
+          execute change_table_comment_sql(table_name, comment_or_changes)
         end
 
         # Renames a column in a table.
@@ -1338,6 +1336,16 @@ module ActiveRecord
 
           def decode_string_array(value)
             PG::TextDecoder::Array.new.decode(value)
+          end
+
+          def change_table_comment_sql(table_name, comment_or_changes)
+            comment = extract_new_comment_value(comment_or_changes)
+            "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
+          end
+
+          def change_column_comment_sql(table_name, column_name, comment_or_changes)
+            comment = extract_new_comment_value(comment_or_changes)
+            execute "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS #{quote(comment)}"
           end
       end
     end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -485,6 +485,27 @@ module ActiveRecord
         assert_nothing_raised { connection.drop_table(:nonexistent, :nonexistent_sobrinho, if_exists: true) }
       end
 
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_create_table_uses_batched_statements
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
+
+          assert_queries_count(1, include_schema: true) do
+            connection.create_table :testings, force: true do |t|
+              t.column :foo, :string
+              t.column :bar, :string
+              t.index :foo
+              t.index :bar
+            end
+          end
+
+          assert connection.table_exists?(:testings)
+          assert connection.index_exists?(:testings, :foo)
+          assert connection.index_exists?(:testings, :bar)
+        end
+      end
+
       private
         def testing_table_with_only_foo_attribute
           connection.create_table :testings, id: false do |t|


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I am working on an app with a very large postgresql database (1000+ tables). It takes ~120s to load the schema on my machine. In this PR I speed that up by batching all the SQL statements during `create_table`. On my machine my schema now loads in ~25s with this change.

### Detail

In `create_table` I store all the generated SQL in an array, and then call it with `execute_batch` at the end.

For `drop_table` and creating comments I had to create new helper methods to just return the sql, since previously those were inlined.

### Additional information

For full disclosure, I found this optimization with the help of the [autoresearch pattern](https://github.com/karpathy/autoresearch) (specifically the [pi implementation](https://github.com/davebcn87/pi-autoresearch)), but the code in this PR is hand written by me. It found some more out-there optimizations which I may try to productionize, but this was by far the biggest win.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
