### PR TITLE
Use `flat_map` in ContentSecurityPolicy

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -344,7 +344,7 @@ module ActionDispatch # :nodoc:
       end
 
       def validate(directive, sources)
-        sources.flatten.each do |source|
+        sources.each do |source|
           if source.include?(";") || source != source.gsub(/[[:space:]]/, "")
             raise InvalidDirectiveError, <<~MSG.squish
               Invalid Content Security Policy #{directive}: "#{source}".
@@ -356,9 +356,11 @@ module ActionDispatch # :nodoc:
       end
 
       def build_directive(directive, sources, context)
-        resolved_sources = sources.map { |source| resolve_source(source, context) }
+        resolved_sources = sources.flat_map { |source| resolve_source(source, context) }
 
         validate(directive, resolved_sources)
+
+        resolved_sources
       end
 
       def resolve_source(source, context)


### PR DESCRIPTION
The `validate` method flattens the sources that are mapped in the `build_directive` method.

Instead we can call `flat_map` and remove the flatten in `build_directive`.

Also make the return value of the `build_directive` method independent of the return value of the validate method by explicitly returning the resolved_sources.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
