### PR TITLE
Improve Active Record Callbacks guide: add section on around_* callbacks and yield

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -506,6 +506,62 @@ User with ID 1 destroyed successfully
 Notification sent to other users about user deletion
 ```
 
+### Understanding Around Callbacks
+
+Around callbacks (such as `around_save` or `around_create`) wrap the execution of a
+life cycle event. They are unique because they require the use of the `yield`
+statement to allow the operation to proceed.
+
+#### The Role of `yield`
+
+When an `around_*` callback is triggered, Rails pauses execution and enters the
+callback method. The actual database operation (and any subsequent callbacks in
+the chain) will only execute when `yield` is called.
+
+* **Before `yield`**: Any code placed here acts like a `before_*` callback.
+* **After `yield`**: Any code placed here acts like an `after_*` callback.
+
+If `yield` is never called, the entire operation is halted and the record will
+not be saved. This is similar to returning `throw :abort` in a `before_*`
+callback.
+
+
+#### Why Use Around Callbacks?
+
+While many tasks can be accomplished by combining `before_*` and `after_*`
+callbacks, `around_*` callbacks offer specific advantages:
+
+1. **Atomic Stack Frame**: Since the entire lifecycle happens within a single
+   method, you can use **local variables** to share state between the "before"
+   and "after" phases. This avoids polluting the object with temporary
+   instance variables.
+2. **Guaranteed Cleanup**: By wrapping `yield` in a `begin...ensure` block, you
+   can guarantee that a specific cleanup task (like releasing a lock) runs
+   even if the database operation fails or raises an exception.
+3. **Exception Handling**: You can wrap `yield` in a `rescue` block to handle
+   specific database errors or external service failures within the
+   transactional context.
+
+#### Common Use Cases
+
+A common use case is performance monitoring or wrapping the save in an external
+service's lifecycle:
+
+```ruby
+class User < ApplicationRecord
+  around_save :benchmark_save
+
+  private
+    def benchmark_save
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      Rails.logger.info "User saved in #{end_time - start_time} seconds"
+    end
+end
+```
+
 ### `after_initialize` and `after_find`
 
 Whenever an Active Record object is instantiated, either by directly using `new`


### PR DESCRIPTION
Currently, the Active Record Callbacks guide lists around_save, around_create, and around_destroy in the lifecycle sections, but it lacks a conceptual explanation of their unique mechanics.

New developers often struggle with:

The mandatory requirement of the yield statement.

Understanding that omitting yield halts the entire operation (persistence).

Knowing when to use an around callback instead of a before + after combination.

What?
This PR adds a new section, "Understanding Around Callbacks", which:

Explains the execution flow: Clarifies how code before and after yield functions relative to the database transaction.

Highlights the "Atomic Context" advantage: Explains the benefit of sharing local variables and using ensure blocks for guaranteed cleanup—functionality that cannot be cleanly replicated by splitting logic across before and after methods.

Provides real-world examples: Includes patterns for performance benchmarking (state sharing) and external resource locking (guaranteed cleanup).

Impact
This addition prevents common implementation bugs (like forgotten yields) and provides senior-level context on architectural choices within the callback lifecycle.