### PR TITLE
Batch SQL statements when creating tables.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Batch SQL statements when creating tables to improve performance.
+
+    *Andrew Novoselac*
+
 *   Support PostgreSQL `RESET` on readonly queries.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -302,33 +302,40 @@ module ActiveRecord
           raise ArgumentError, "Options `:force` and `:if_not_exists` cannot be used simultaneously."
         end
 
-        td = build_create_table_definition(table_name, id: id, primary_key: primary_key, force: force, **options, &block)
+        statements = []
 
         if force
-          drop_table(table_name, force: force, if_exists: true)
-        else
-          schema_cache.clear_data_source_cache!(table_name.to_s)
+          statements << drop_table_sql(table_name, force: force, if_exists: true)
         end
 
-        result = execute schema_creation.accept(td)
+        schema_cache.clear_data_source_cache!(table_name.to_s)
+
+        td = build_create_table_definition(table_name, id: id, primary_key: primary_key, force: force, **options, &block)
+        statements << schema_creation.accept(td)
 
         unless supports_indexes_in_create?
           td.indexes.each do |column_name, index_options|
-            add_index(table_name, column_name, **index_options, if_not_exists: td.if_not_exists)
+            index_definition = build_create_index_definition(table_name, column_name, **index_options, if_not_exists: td.if_not_exists)
+
+            statements << schema_creation.accept(index_definition)
+
+            if supports_comments? && !supports_comments_in_create?
+              statements << change_index_comment_sql(index_definition.index) if index_definition.index.comment.present?
+            end
           end
         end
 
         if supports_comments? && !supports_comments_in_create?
           if table_comment = td.comment.presence
-            change_table_comment(table_name, table_comment)
+            statements << change_table_comment_sql(table_name, table_comment)
           end
 
           td.columns.each do |column|
-            change_column_comment(table_name, column.name, column.comment) if column.comment.present?
+            statements << change_column_comment_sql(table_name, column.name, column.comment) if column.comment.present?
           end
         end
 
-        result
+        execute_batch statements
       end
 
       # Returns a TableDefinition object containing information about the table that would be created
@@ -559,7 +566,7 @@ module ActiveRecord
       def drop_table(*table_names, **options)
         table_names.each do |table_name|
           schema_cache.clear_data_source_cache!(table_name.to_s)
-          execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}"
+          execute drop_table_sql(table_name, **options)
         end
       end
 
@@ -1997,6 +2004,24 @@ module ActiveRecord
         end
 
         def quoted_scope(name = nil, type: nil)
+          raise NotImplementedError
+        end
+
+        def drop_table_sql(table_name, if_exists: nil, force: nil, **)
+          exists = " IF EXISTS" if if_exists
+
+          "DROP TABLE#{exists} #{quote_table_name(table_name)}"
+        end
+
+        def change_table_comment_sql(table_name, comment_or_changes)
+          raise NotImplementedError
+        end
+
+        def change_column_comment_sql(table_name, column_name, comment_or_changes)
+          raise NotImplementedError
+        end
+
+        def change_index_comment_sql(index)
           raise NotImplementedError
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -384,7 +384,7 @@ module ActiveRecord
       # In that case, +options+ and the block will be used by #create_table except if you provide more than one table which is not supported.
       def drop_table(*table_names, **options)
         table_names.each { |table_name| schema_cache.clear_data_source_cache!(table_name.to_s) }
-        execute "DROP#{' TEMPORARY' if options[:temporary]} TABLE#{' IF EXISTS' if options[:if_exists]} #{table_names.map { |table_name| quote_table_name(table_name) }.join(', ')}#{' CASCADE' if options[:force] == :cascade}"
+        execute drop_table_sql(*table_names, **options)
       end
 
       def rename_index(table_name, old_name, new_name)
@@ -1144,6 +1144,15 @@ module ActiveRecord
           else
             raise DatabaseVersionError, "Unable to parse MySQL version from #{full_version_string.inspect}"
           end
+        end
+
+        def drop_table_sql(*table_names, if_exists: nil, force: nil, temporary: nil, **)
+          temporary = " TEMPORARY" if temporary
+          exists = " IF EXISTS" if if_exists
+          quoted_table_names = table_names.map { |table_name| quote_table_name(table_name) }.join(", ")
+          cascade = " CASCADE" if force == :cascade
+
+          "DROP#{temporary} TABLE#{exists} #{quoted_table_names}#{cascade}"
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -68,7 +68,7 @@ module ActiveRecord
 
         def drop_table(*table_names, **options) # :nodoc:
           table_names.each { |table_name| schema_cache.clear_data_source_cache!(table_name.to_s) }
-          execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{table_names.map { |table_name| quote_table_name(table_name) }.join(', ')}#{' CASCADE' if options[:force] == :cascade}"
+          execute drop_table_sql(*table_names, **options)
         end
 
         # Returns true if schema exists.
@@ -677,15 +677,13 @@ module ActiveRecord
         # Adds comment for given table column or drops it if +comment+ is a +nil+
         def change_column_comment(table_name, column_name, comment_or_changes) # :nodoc:
           clear_cache!
-          comment = extract_new_comment_value(comment_or_changes)
-          execute "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS #{quote(comment)}"
+          execute change_column_comment_sql(table_name, column_name, comment_or_changes)
         end
 
         # Adds comment for given table or drops it if +comment+ is a +nil+
         def change_table_comment(table_name, comment_or_changes) # :nodoc:
           clear_cache!
-          comment = extract_new_comment_value(comment_or_changes)
-          execute "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
+          execute change_table_comment_sql(table_name, comment_or_changes)
         end
 
         # Renames a column in a table.
@@ -700,7 +698,7 @@ module ActiveRecord
           result = execute schema_creation.accept(create_index)
 
           index = create_index.index
-          execute "COMMENT ON INDEX #{quote_column_name(index.name)} IS #{quote(index.comment)}" if index.comment
+          execute change_index_comment_sql(index) if index.comment
           result
         end
 
@@ -1338,6 +1336,28 @@ module ActiveRecord
 
           def decode_string_array(value)
             PG::TextDecoder::Array.new.decode(value)
+          end
+
+          def change_table_comment_sql(table_name, comment_or_changes)
+            comment = extract_new_comment_value(comment_or_changes)
+            "COMMENT ON TABLE #{quote_table_name(table_name)} IS #{quote(comment)}"
+          end
+
+          def change_column_comment_sql(table_name, column_name, comment_or_changes)
+            comment = extract_new_comment_value(comment_or_changes)
+            "COMMENT ON COLUMN #{quote_table_name(table_name)}.#{quote_column_name(column_name)} IS #{quote(comment)}"
+          end
+
+          def drop_table_sql(*table_names, if_exists: nil, force: nil, **)
+            exists = " IF EXISTS" if if_exists
+            quoted_table_names = table_names.map { |table_name| quote_table_name(table_name) }.join(", ")
+            cascade = " CASCADE" if force == :cascade
+
+            "DROP TABLE#{exists} #{quoted_table_names}#{cascade}"
+          end
+
+          def change_index_comment_sql(index)
+            "COMMENT ON INDEX #{quote_column_name(index.name)} IS #{quote(index.comment)}"
           end
       end
     end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
@@ -19,6 +19,19 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
           sql
         end
       end
+
+      alias_method :execute_batch_without_stub, :execute_batch
+      def execute_batch(statements, name = nil, **kwargs)
+        statements.each do |sql|
+          ActiveSupport::Notifications.instrumenter.instrument(
+            "sql.active_record",
+            sql: sql,
+            name: name,
+            connection: self) do
+            sql
+          end
+        end.join(";\n")
+      end
     end
   end
 
@@ -264,6 +277,10 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
         alias_method :execute_with_stub, :execute
         remove_method :execute
         alias_method :execute, :execute_without_stub
+
+        alias_method :execute_batch_with_stub, :execute_batch
+        remove_method :execute_batch
+        alias_method :execute_batch, :execute_batch_without_stub
       end
 
       yield
@@ -271,6 +288,9 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
       ActiveRecord::Base.lease_connection.singleton_class.class_eval do
         remove_method :execute
         alias_method :execute, :execute_with_stub
+
+        remove_method :execute_batch
+        alias_method :execute_batch, :execute_batch_with_stub
       end
     end
 

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -485,6 +485,30 @@ module ActiveRecord
         assert_nothing_raised { connection.drop_table(:nonexistent, :nonexistent_sobrinho, if_exists: true) }
       end
 
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_create_table_uses_batched_statements
+          connection.create_table :testings do |t|
+            t.column :foo, :string
+          end
+
+          assert_queries_count(1, include_schema: true) do
+            connection.create_table :testings, comment: "This is a table", force: true do |t|
+              t.column :foo, :string, comment: "This is a column"
+              t.column :bar, :string
+              t.index :foo, comment: "This is an index"
+              t.index :bar
+            end
+          end
+
+          assert connection.table_exists?(:testings)
+          assert connection.index_exists?(:testings, :foo)
+          assert connection.index_exists?(:testings, :bar)
+          assert_equal "This is a table", connection.table_comment(:testings)
+          assert_equal "This is a column", connection.columns(:testings).find { |c| c.name == "foo" }.comment
+          assert_equal "This is an index", connection.indexes(:testings).find { |i| i.columns == ["foo"] }.comment
+        end
+      end
+
       private
         def testing_table_with_only_foo_attribute
           connection.create_table :testings, id: false do |t|


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I am working on an app with a very large postgresql database (1000+ tables). It takes ~120s to load the schema on my machine. In this PR I speed that up by batching all the SQL statements during `create_table`. On my machine my schema now loads in ~25s with this change.

### Detail

In `create_table` I store all the generated SQL in an array, and then call it with `execute_batch` at the end.

For `drop_table` and creating comments I had to create new helper methods to just return the sql, since previously those were inlined.

### Additional information

For full disclosure, I found this optimization with the help of the [autoresearch pattern](https://github.com/karpathy/autoresearch) (specifically the [pi implementation](https://github.com/davebcn87/pi-autoresearch)), but the code in this PR is hand written by me. It found some more out-there optimizations which I may try to productionize, but this was by far the biggest win.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
