### PR TITLE
Fix PostgresqlDbConsoleTest reports Environment leak detected

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
@@ -10,10 +10,14 @@ module ActiveRecord
 
       ENV_VARS = %w(PGUSER PGHOST PGPORT PGPASSWORD PGSSLMODE PGSSLCERT PGSSLKEY PGSSLROOTCERT PGOPTIONS)
 
-      def run(*)
-        preserve_pg_env do
-          super
-        end
+      def setup
+        super
+        @_pg_env_backup = ENV_VARS.index_with { |var| ENV[var] }
+      end
+
+      def teardown
+        ENV_VARS.each { |var| ENV[var] = @_pg_env_backup[var] }
+        super
       end
 
       def test_postgresql
@@ -90,13 +94,6 @@ module ActiveRecord
       end
 
       private
-        def preserve_pg_env
-          old_values = ENV_VARS.map { |var| ENV[var] }
-          yield
-        ensure
-          ENV_VARS.zip(old_values).each { |var, value| ENV[var] = value }
-        end
-
         def make_db_config(config)
           ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", config)
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes: #56812 

The `LeakChecker` module, which is `prepend`ed onto `ActiveSupport::TestCase`, detects environment variable leaks between tests. After its introduction, four tests in `PostgresqlDbConsoleTest` started failing because the ENV cleanup was happening **after** `LeakChecker` had already inspected the environment:

- `test_postgresql_full`
- `test_postgresql_with_ssl`
- `test_postgresql_include_password`
- `test_postgresql_include_variables`

The failures look like:

```
Environment leak detected:
  - Added variables:
    - PGPORT
  - Changed variables:
    - PGUSER from "postgres" to "user"
    - PGHOST from "postgres" to "host"
```

### Detail

This Pull Request changes the ENV variable backup/restore strategy in `PostgresqlDbConsoleTest` from a `#run` override to a `setup`/`teardown` pair.

The previous approach overrode `#run` and wrapped `super` with a `preserve_pg_env` helper that used an `ensure` block to restore ENV vars. The problem is that `LeakChecker#after_teardown` runs **inside** the `super` call, so it checks ENV before the `ensure` block has a chance to restore it:

```
#run -> preserve_pg_env do
  super -> before_setup (LeakChecker snapshots ENV)
        -> test body (sets PGUSER, PGHOST, etc.)
        -> after_teardown (LeakChecker detects leak!) ❌
ensure
  restore ENV (too late)
```

The fix uses `setup`/`teardown`, which are part of the Minitest lifecycle that runs **before** `LeakChecker#after_teardown`:

```
before_setup (LeakChecker snapshots ENV)
setup (backs up PG env vars)
test body (sets PGUSER, PGHOST, etc.)
teardown (restores PG env vars) ✅
after_teardown (LeakChecker finds no diff) ✅
```

The now-unnecessary `preserve_pg_env` private method has been removed.

### Additional information

- Only the test file is modified; no production code changes.
- The `LeakChecker` module is defined in `tools/support/leak_checker.rb` and prepended in `tools/test_common.rb`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
