### PR TITLE
Fix PostgreSQL column equality for generated types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -70,7 +70,7 @@ module ActiveRecord
             super &&
             identity? == other.identity? &&
             serial? == other.serial? &&
-            virtual? == other.virtual?
+            generated == other.generated
         end
         alias :eql? :==
 
@@ -83,6 +83,9 @@ module ActiveRecord
             @generated,
           ].hash
         end
+
+        protected
+          attr_reader :generated
       end
     end
     PostgreSQLColumn = PostgreSQL::Column # :nodoc:

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1008,6 +1008,17 @@ module ActiveRecord
         @connection.execute("DROP EXTENSION IF EXISTS hstore")
       end
 
+      def test_generated_changes_column_equality
+        cast_type = @connection.lookup_cast_type("varchar")
+        type_metadata = SqlTypeMetadata.new(sql_type: "varchar", type: :string)
+
+        stored_column = PostgreSQL::Column.new("name", cast_type, nil, type_metadata, true, nil, generated: "s")
+        virtual_column = PostgreSQL::Column.new("name", cast_type, nil, type_metadata, true, nil, generated: "v")
+
+        assert_not_equal stored_column, virtual_column
+        assert_not_equal stored_column.hash, virtual_column.hash
+      end
+
       private
         def with_postgresql_apdater_decode_dates
           PostgreSQLAdapter.decode_dates = true


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

`PostgreSQL::Column#==` compared `virtual?` (a collapsed boolean) while `#hash` used `@generated` directly (the raw `"s"`/`"v"` string). On PostgreSQL 18+, generated columns can be either stored (`"s"`) or virtual (`"v"`), so two otherwise-identical columns with different generated types would be considered equal but produce different hash values - violating the `eql?`/`hash` contract and silently misbehaving in any hash/set.

This mirrors the same bug fixed for SQLite3 in #56817.

### Detail

Replace `virtual? == other.virtual?` in `#==` with `generated == other.generated` via a new `protected attr_reader :generated`, so equality and hashing operate at the same abstraction level.

### Additional information

The root inconsistency was introduced by bdc7adce when `#hash` was refactored to use raw ivars while `#==` was left unchanged.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
