### PR TITLE
Reimplement RedisCache store using `redis-client`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ end
 
 # Active Support
 gem "dalli"
+gem "redis-client", ">= 0.28.0"
 gem "listen", "~> 3.3", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.4)
+    connection_pool (3.0.2)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -453,7 +453,7 @@ GEM
     redcarpet (3.6.1)
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.25.2)
+    redis-client (0.28.0)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -719,6 +719,7 @@ DEPENDENCIES
   rails!
   redcarpet (~> 3.6.1)
   redis (>= 4.0.1)
+  redis-client (>= 0.28.0)
   redis-namespace
   releaser!
   resque
@@ -799,7 +800,7 @@ CHECKSUMS
   chef-utils (18.6.2) sha256=d4d0a08fc2d0fd1c490dba4f09dcd6b4e6ddc5c594231c05ff87d2e54a13834a
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
-  connection_pool (2.5.4) sha256=e9e1922327416091f3f6542f5f4446c2a20745276b9aa796dd0bb2fd0ea1e70a
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cssbundling-rails (1.4.1) sha256=4b21273d627b21890da9155c88c67efc9274373d8b0add09149c262cf56c7ce1
@@ -934,7 +935,7 @@ CHECKSUMS
   rdoc (6.15.0) sha256=0f0e68864969e77c2acd4063a9585baa5216d362701d827a93feaa9cbae78b05
   redcarpet (3.6.1) sha256=d444910e6aa55480c6bcdc0cdb057626e8a32c054c29e793fa642ba2f155f445
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
-  redis-client (0.25.2) sha256=aa37e34c29da39fdb0b8663e7a649adb0923959cd4a9351befe2cd19e6f8d6f0
+  redis-client (0.28.0) sha256=888892f9cd8787a41c0ece00bdf5f556dfff7770326ce40bb2bc11f1bfec824b
   redis-namespace (1.11.0) sha256=e91a1aa2b2d888b6dea1d4ab8d39e1ae6fac3426161feb9d91dd5cca598a2239
   regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61
   releaser (1.0.0)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `ActiveSupport::Cache::RedisCacheStore` entirely reimplemented.
+
+    Now depends on the much lighter `redis-client >= 0.28.0` instead of `redis >= 4.0.1`.
+
+    The change shouldn't be noticeable unless the cache is configured with the `:redis` argument.
+    In such case it will keep working for now, but will issue a deprecation warning.
+
+    Prefer configuring Redis Cache Store with an `:url` argument instead, but if you need advanced options
+    not supported by Redis Cache Store constructor, you can alternatively pass a custom `RedisClient::Config` instance
+    via the `:client` argument.
+
+    *Jean Boussier*
+
 *   Fix `NumberHelper` raising `FloatDomainError` for `Infinity` / `NaN` with
     `significant: true`.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -21,6 +21,7 @@ module ActiveSupport
     autoload :MemCacheStore,    "active_support/cache/mem_cache_store"
     autoload :NullStore,        "active_support/cache/null_store"
     autoload :RedisCacheStore,  "active_support/cache/redis_cache_store"
+    autoload :DeprecatedRedisCacheStore,  "active_support/cache/deprecated_redis_cache_store"
 
     # These options mean something to all cache implementations. Individual cache
     # implementations may support additional options.

--- a/activesupport/lib/active_support/cache/deprecated_redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/deprecated_redis_cache_store.rb
@@ -1,0 +1,516 @@
+# frozen_string_literal: true
+
+begin
+  gem "redis", ">= 4.0.1"
+  require "redis"
+  require "redis/distributed"
+rescue LoadError
+  warn "The Redis cache store requires the redis gem, version 4.0.1 or later. Please add it to your Gemfile: `gem \"redis\", \">= 4.0.1\"`"
+  raise
+end
+
+require "connection_pool"
+require "active_support/core_ext/array/wrap"
+require "active_support/core_ext/hash/slice"
+require "active_support/core_ext/numeric/time"
+require "active_support/digest"
+require "active_support/inspect_backport"
+
+module ActiveSupport
+  module Cache
+    # = Deprecated \Redis \Cache \Store
+    #
+    # Deployment note: Take care to use a <b>dedicated Redis cache</b> rather
+    # than pointing this at a persistent Redis server (for example, one used as
+    # an Active Job queue). Redis won't cope well with mixed usage patterns and it
+    # won't expire cache entries by default.
+    #
+    # Redis cache server setup guide: https://redis.io/topics/lru-cache
+    #
+    # * Supports vanilla Redis, hiredis, and +Redis::Distributed+.
+    # * Supports Memcached-like sharding across Redises with +Redis::Distributed+.
+    # * Fault tolerant. If the Redis server is unavailable, no exceptions are
+    #   raised. Cache fetches are all misses and writes are dropped.
+    # * Local cache. Hot in-memory primary cache within block/middleware scope.
+    # * +read_multi+ and +write_multi+ support for Redis mget/mset. Use
+    #   +Redis::Distributed+ 4.0.1+ for distributed mget support.
+    # * +delete_matched+ support for Redis KEYS globs.
+    # * +read+ supports <tt>delete: true</tt> to atomically read and delete
+    #   a cache entry using the Redis +GETDEL+ command.
+    #
+    #     cache.write("greeting", "hello")
+    #     cache.read("greeting", delete: true)  # => "hello"
+    #     cache.read("greeting")                 # => nil
+    #
+    class DeprecatedRedisCacheStore < Store
+      DEFAULT_REDIS_OPTIONS = {
+        connect_timeout:    1,
+        read_timeout:       1,
+        write_timeout:      1,
+      }.freeze
+
+      DEFAULT_ERROR_HANDLER = -> (method:, returning:, exception:) do
+        if logger
+          logger.error { "RedisCacheStore: #{method} failed, returned #{returning.inspect}: #{exception.class}: #{exception.message}" }
+        end
+        ActiveSupport.error_reporter&.report(
+          exception,
+          severity: :warning,
+          source: "redis_cache_store.active_support",
+        )
+      end
+
+      # The maximum number of entries to receive per SCAN call.
+      SCAN_BATCH_SIZE = 1000
+      private_constant :SCAN_BATCH_SIZE
+
+      # Advertise cache versioning support.
+      def self.supports_cache_versioning?
+        true
+      end
+
+      prepend Strategy::LocalCache
+
+      class << self
+        # Factory method to create a new Redis instance.
+        #
+        # Handles four options: :redis block, :redis instance, single :url
+        # string, and multiple :url strings.
+        #
+        #   Option  Class       Result
+        #   :redis  Proc    ->  options[:redis].call
+        #   :redis  Object  ->  options[:redis]
+        #   :url    String  ->  Redis.new(url: …)
+        #   :url    Array   ->  Redis::Distributed.new([{ url: … }, { url: … }, …])
+        #
+        def build_redis(redis: nil, url: nil, **redis_options) # :nodoc:
+          urls = Array(url)
+
+          if redis.is_a?(Proc)
+            redis.call
+          elsif redis
+            redis
+          elsif urls.size > 1
+            build_redis_distributed_client(urls: urls, **redis_options)
+          elsif urls.empty?
+            build_redis_client(**redis_options)
+          else
+            build_redis_client(url: urls.first, **redis_options)
+          end
+        end
+
+        private
+          def build_redis_distributed_client(urls:, **redis_options)
+            ::Redis::Distributed.new([], DEFAULT_REDIS_OPTIONS.merge(redis_options)).tap do |dist|
+              urls.each { |u| dist.add_node url: u }
+            end
+          end
+
+          def build_redis_client(**redis_options)
+            ::Redis.new(DEFAULT_REDIS_OPTIONS.merge(redis_options))
+          end
+      end
+
+      attr_reader :redis
+
+      # Creates a new Redis cache store.
+      #
+      # There are a few ways to provide the Redis client used by the cache:
+      #
+      # 1. The +:redis+ param can be:
+      #    - A Redis instance.
+      #    - A +ConnectionPool+ instance wrapping a Redis instance.
+      #    - A block that returns a Redis instance.
+      #
+      # 2. The +:url+ param can be:
+      #    - A string used to create a Redis instance.
+      #    - An array of strings used to create a +Redis::Distributed+ instance.
+      #
+      # If the final Redis instance is not already a +ConnectionPool+, it will
+      # be wrapped in one using +ActiveSupport::Cache::Store::DEFAULT_POOL_OPTIONS+.
+      # These options can be overridden with the +:pool+ param, or the pool can be
+      # disabled with +:pool: false+.
+      #
+      #   Option  Class       Result
+      #   :redis  Object  ->  options[:redis]
+      #   :redis  Proc    ->  options[:redis].call
+      #   :url    String  ->  Redis.new(url: …)
+      #   :url    Array   ->  Redis::Distributed.new([{ url: … }, { url: … }, …])
+      #
+      # No namespace is set by default. Provide one if the Redis cache
+      # server is shared with other apps: <tt>namespace: 'myapp-cache'</tt>.
+      #
+      # Compression is enabled by default with a 1kB threshold, so cached
+      # values larger than 1kB are automatically compressed. Disable by
+      # passing <tt>compress: false</tt> or change the threshold by passing
+      # <tt>compress_threshold: 4.kilobytes</tt>.
+      #
+      # No expiry is set on cache entries by default. Redis is expected to
+      # be configured with an eviction policy that automatically deletes
+      # least-recently or -frequently used keys when it reaches max memory.
+      # See https://redis.io/topics/lru-cache for cache server setup.
+      #
+      # Race condition TTL is not set by default. This can be used to avoid
+      # "thundering herd" cache writes when hot cache entries are expired.
+      # See ActiveSupport::Cache::Store#fetch for more.
+      #
+      # Setting <tt>skip_nil: true</tt> will not cache nil results:
+      #
+      #   cache.fetch('foo') { nil }
+      #   cache.fetch('bar', skip_nil: true) { nil }
+      #   cache.exist?('foo') # => true
+      #   cache.exist?('bar') # => false
+      def initialize(error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
+        universal_options = redis_options.extract!(*UNIVERSAL_OPTIONS)
+        redis = redis_options[:redis]
+
+        already_pool = redis.instance_of?(::ConnectionPool) ||
+                       (redis.respond_to?(:wrapped_pool) && redis.wrapped_pool.instance_of?(::ConnectionPool))
+
+        if !already_pool && pool_options = self.class.send(:retrieve_pool_options, redis_options)
+          @redis = ::ConnectionPool.new(**pool_options) { self.class.build_redis(**redis_options) }
+        else
+          @redis = self.class.build_redis(**redis_options)
+        end
+
+        @error_handler = error_handler
+
+        super(universal_options)
+      end
+
+      ActiveSupport::InspectBackport.apply(self)
+
+      # Cache Store API implementation.
+      #
+      # Read multiple values at once. Returns a hash of requested keys ->
+      # fetched values.
+      def read_multi(*names)
+        return {} if names.empty?
+
+        options = names.extract_options!
+        options = merged_options(options)
+        keys    = names.map { |name| normalize_key(name, options) }
+
+        instrument_multi(:read_multi, keys, options) do |payload|
+          read_multi_entries(names, **options).tap do |results|
+            payload[:hits] = results.keys.map { |name| normalize_key(name, options) }
+          end
+        end
+      end
+
+      # Cache Store API implementation.
+      #
+      # Supports Redis KEYS glob patterns:
+      #
+      #   h?llo matches hello, hallo and hxllo
+      #   h*llo matches hllo and heeeello
+      #   h[ae]llo matches hello and hallo, but not hillo
+      #   h[^e]llo matches hallo, hbllo, ... but not hello
+      #   h[a-b]llo matches hallo and hbllo
+      #
+      # Use \ to escape special characters if you want to match them verbatim.
+      #
+      # See https://redis.io/commands/KEYS for more.
+      #
+      # Failsafe: Raises errors.
+      def delete_matched(matcher, options = nil)
+        unless String === matcher
+          raise ArgumentError, "Only Redis glob strings are supported: #{matcher.inspect}"
+        end
+        pattern = namespace_key(matcher, options)
+
+        instrument :delete_matched, pattern do
+          redis.then do |c|
+            cursor = "0"
+            # Fetch keys in batches using SCAN to avoid blocking the Redis server.
+            nodes = c.respond_to?(:nodes) ? c.nodes : [c]
+
+            nodes.each do |node|
+              begin
+                cursor, keys = node.scan(cursor, match: pattern, count: SCAN_BATCH_SIZE)
+                node.unlink(*keys) unless keys.empty?
+              end until cursor == "0"
+            end
+          end
+        end
+      end
+
+      # Increment a cached integer value using the Redis incrby atomic operator.
+      # Returns the updated value.
+      #
+      # If the key is unset or has expired, it will be set to +amount+:
+      #
+      #   cache.increment("foo") # => 1
+      #   cache.increment("bar", 100) # => 100
+      #
+      # To set a specific value, call #write passing <tt>raw: true</tt>:
+      #
+      #   cache.write("baz", 5, raw: true)
+      #   cache.increment("baz") # => 6
+      #
+      # Incrementing a non-numeric value, or a value written without
+      # <tt>raw: true</tt>, will fail and return +nil+.
+      #
+      # To read the value later, call #read_counter:
+      #
+      #   cache.increment("baz") # => 7
+      #   cache.read_counter("baz") # 7
+      #
+      # Failsafe: Raises errors.
+      def increment(name, amount = 1, options = nil)
+        options = merged_options(options)
+        key = normalize_key(name, options)
+
+        instrument :increment, key, amount: amount do
+          failsafe :increment do
+            change_counter(key, amount, options)
+          end
+        end
+      end
+
+      # Decrement a cached integer value using the Redis decrby atomic operator.
+      # Returns the updated value.
+      #
+      # If the key is unset or has expired, it will be set to +-amount+:
+      #
+      #   cache.decrement("foo") # => -1
+      #
+      # To set a specific value, call #write passing <tt>raw: true</tt>:
+      #
+      #   cache.write("baz", 5, raw: true)
+      #   cache.decrement("baz") # => 4
+      #
+      # Decrementing a non-numeric value, or a value written without
+      # <tt>raw: true</tt>, will fail and return +nil+.
+      #
+      # To read the value later, call #read_counter:
+      #
+      #   cache.decrement("baz") # => 3
+      #   cache.read_counter("baz") # 3
+      #
+      # Failsafe: Raises errors.
+      def decrement(name, amount = 1, options = nil)
+        options = merged_options(options)
+        key = normalize_key(name, options)
+
+        instrument :decrement, key, amount: amount do
+          failsafe :decrement do
+            change_counter(key, -amount, options)
+          end
+        end
+      end
+
+      # Cache Store API implementation.
+      #
+      # Removes expired entries. Handled natively by Redis least-recently-/
+      # least-frequently-used expiry, so manual cleanup is not supported.
+      def cleanup(options = nil)
+        super
+      end
+
+      # Clear the entire cache on all Redis servers. Safe to use on
+      # shared servers if the cache is namespaced.
+      #
+      # Failsafe: Raises errors.
+      def clear(options = nil)
+        failsafe :clear do
+          if namespace = merged_options(options)[:namespace]
+            delete_matched "*", namespace: namespace
+          else
+            redis.then { |c| c.flushdb }
+          end
+        end
+      end
+
+      # Get info from redis servers.
+      def stats
+        redis.then { |c| c.info }
+      end
+
+      private
+        def instance_variables_to_inspect
+          [:@options, :@redis].freeze
+        end
+
+        def pipeline_entries(entries, &block)
+          redis.then { |c|
+            if c.is_a?(Redis::Distributed)
+              entries.group_by { |k, _v| c.node_for(k) }.each do |node, sub_entries|
+                node.pipelined { |pipe| yield(pipe, sub_entries) }
+              end
+            else
+              c.pipelined { |pipe| yield(pipe, entries) }
+            end
+          }
+        end
+
+        # Store provider interface:
+        # Read an entry from the cache.
+        def read_entry(key, **options)
+          deserialize_entry(read_serialized_entry(key, **options), **options)
+        end
+
+        def read_serialized_entry(key, raw: false, **options)
+          failsafe :read_entry do
+            redis.then { |c| options[:delete] ? c.getdel(key) : c.get(key) }
+          end
+        end
+
+        def read_multi_entries(names, **options)
+          options = merged_options(options)
+          return {} if names == []
+          raw = options&.fetch(:raw, false)
+
+          keys = names.map { |name| normalize_key(name, options) }
+
+          values = failsafe(:read_multi_entries, returning: {}) do
+            redis.then { |c| c.mget(*keys) }
+          end
+
+          names.zip(values).each_with_object({}) do |(name, value), results|
+            if value
+              entry = deserialize_entry(value, raw: raw)
+              unless entry.nil? || entry.expired? || entry.mismatched?(normalize_version(name, options))
+                begin
+                  results[name] = entry.value
+                rescue DeserializationError
+                end
+              end
+            end
+          end
+        end
+
+        # Write an entry to the cache.
+        #
+        # Requires Redis 2.6.12+ for extended SET options.
+        def write_entry(key, entry, raw: false, **options)
+          write_serialized_entry(key, serialize_entry(entry, raw: raw, **options), raw: raw, **options)
+        end
+
+        def write_serialized_entry(key, payload, raw: false, unless_exist: false, expires_in: nil, race_condition_ttl: nil, pipeline: nil, **options)
+          # If race condition TTL is in use, ensure that cache entries
+          # stick around a bit longer after they would have expired
+          # so we can purposefully serve stale entries.
+          if race_condition_ttl && expires_in && expires_in > 0 && !raw
+            expires_in += 5.minutes
+          end
+
+          modifiers = {}
+          if unless_exist || expires_in
+            modifiers[:nx] = unless_exist
+            modifiers[:px] = (1000 * expires_in.to_f).ceil if expires_in
+          end
+
+          if pipeline
+            pipeline.set(key, payload, **modifiers)
+          else
+            failsafe :write_entry, returning: nil do
+              redis.then { |c| !!c.set(key, payload, **modifiers) }
+            end
+          end
+        end
+
+        # Delete an entry from the cache.
+        def delete_entry(key, **options)
+          failsafe :delete_entry, returning: false do
+            redis.then { |c| c.unlink(key) == 1 }
+          end
+        end
+
+        # Deletes multiple entries in the cache. Returns the number of entries deleted.
+        def delete_multi_entries(entries, **_options)
+          return 0 if entries.empty?
+
+          failsafe :delete_multi_entries, returning: 0 do
+            redis.then { |c| c.unlink(*entries) }
+          end
+        end
+
+        # Nonstandard store provider API to write multiple values at once.
+        def write_multi_entries(entries, **options)
+          return if entries.empty?
+
+          failsafe :write_multi_entries do
+            pipeline_entries(entries) do |pipeline, sharded_entries|
+              options = options.dup
+              options[:pipeline] = pipeline
+              sharded_entries.each do |key, entry|
+                write_entry key, entry, **options
+              end
+            end
+          end
+        end
+
+        def deserialize_entry(payload, raw: false, **)
+          if raw && !payload.nil?
+            Entry.new(payload)
+          else
+            super(payload)
+          end
+        end
+
+        def serialize_entry(entry, raw: false, **options)
+          if raw
+            entry.value.to_s
+          else
+            super(entry, raw: raw, **options)
+          end
+        end
+
+        def serialize_entries(entries, **options)
+          entries.transform_values do |entry|
+            serialize_entry(entry, **options)
+          end
+        end
+
+        def change_counter(key, amount, options)
+          redis.then do |c|
+            c = c.node_for(key) if c.is_a?(Redis::Distributed)
+
+            expires_in = options[:expires_in]
+
+            if expires_in
+              if supports_expire_nx?
+                count, _ = c.pipelined do |pipeline|
+                  pipeline.incrby(key, amount)
+                  pipeline.call(:expire, key, expires_in.to_i, "NX")
+                end
+              else
+                count, ttl = c.pipelined do |pipeline|
+                  pipeline.incrby(key, amount)
+                  pipeline.ttl(key)
+                end
+                c.expire(key, expires_in.to_i) if ttl < 0
+              end
+            else
+              count = c.incrby(key, amount)
+            end
+
+            count
+          end
+        end
+
+        def supports_expire_nx?
+          return @supports_expire_nx if defined?(@supports_expire_nx)
+
+          redis_versions = redis.then { |c| Array.wrap(c.info("server")).pluck("redis_version") }
+          @supports_expire_nx = redis_versions.all? { |v| Gem::Version.new(v) >= Gem::Version.new("7.0.0") }
+        end
+
+        FAILSAFE_ERRORS = [
+          ::Redis::BaseError,
+          ConnectionPool::Error,
+          ConnectionPool::TimeoutError,
+          (::RedisClient::Error if defined?(::RedisClient::Error)),
+        ].compact.freeze
+        private_constant :FAILSAFE_ERRORS
+
+        def failsafe(method, returning: nil)
+          yield
+        rescue *FAILSAFE_ERRORS => error
+          @error_handler&.call(method: method, exception: error, returning: returning)
+          returning
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
+redis_client_min_version = "0.28.0"
 begin
-  gem "redis", ">= 4.0.1"
-  require "redis"
-  require "redis/distributed"
+  gem "redis-client", ">= #{redis_client_min_version}"
 rescue LoadError
-  warn "The Redis cache store requires the redis gem, version 4.0.1 or later. Please add it to your Gemfile: `gem \"redis\", \">= 4.0.1\"`"
-  raise
+  raise LoadError, <<~MSG
+    The Redis cache store requires the redis-client gem version #{redis_client_min_version} or later.
+    Please add it to your Gemfile:
+      gem "redis-client", ">= #{redis_client_min_version}"
+  MSG
 end
 
-require "connection_pool"
+require "redis-client"
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/hash/slice"
 require "active_support/core_ext/numeric/time"
@@ -60,82 +62,48 @@ module ActiveSupport
         )
       end
 
-      # The maximum number of entries to receive per SCAN call.
-      SCAN_BATCH_SIZE = 1000
-      private_constant :SCAN_BATCH_SIZE
-
       # Advertise cache versioning support.
       def self.supports_cache_versioning?
         true
       end
 
-      prepend Strategy::LocalCache
+      def self.new(**options)
+        if options[:redis]
+          ActiveSupport.deprecator.warn(<<~MSG.squish)
+            Passing a Redis or ConnectionPool instance via the `:redis` configuration to ActiveSupport::Cache::RedisCacheStore
+            is deprecated and will be removed in Rails 8.3.
 
-      class << self
-        # Factory method to create a new Redis instance.
-        #
-        # Handles four options: :redis block, :redis instance, single :url
-        # string, and multiple :url strings.
-        #
-        #   Option  Class       Result
-        #   :redis  Proc    ->  options[:redis].call
-        #   :redis  Object  ->  options[:redis]
-        #   :url    String  ->  Redis.new(url: …)
-        #   :url    Array   ->  Redis::Distributed.new([{ url: … }, { url: … }, …])
-        #
-        def build_redis(redis: nil, url: nil, **redis_options) # :nodoc:
-          urls = Array(url)
+            RedisCacheStore no longer depends on the `redis` gem, but use the simpler `redis-client`.
 
-          if redis.is_a?(Proc)
-            redis.call
-          elsif redis
-            redis
-          elsif urls.size > 1
-            build_redis_distributed_client(urls: urls, **redis_options)
-          elsif urls.empty?
-            build_redis_client(**redis_options)
-          else
-            build_redis_client(url: urls.first, **redis_options)
-          end
+            Prefer passing a raw `:url` option instead, of if you need more advanced configuration, pass a configured `RedisClient`
+            via the `:client` option.
+          MSG
+          return DeprecatedRedisCacheStore.new(**options)
         end
 
-        private
-          def build_redis_distributed_client(urls:, **redis_options)
-            ::Redis::Distributed.new([], DEFAULT_REDIS_OPTIONS.merge(redis_options)).tap do |dist|
-              urls.each { |u| dist.add_node url: u }
-            end
-          end
-
-          def build_redis_client(**redis_options)
-            ::Redis.new(DEFAULT_REDIS_OPTIONS.merge(redis_options))
-          end
+        super
       end
+
+      prepend Strategy::LocalCache
 
       attr_reader :redis
 
       # Creates a new Redis cache store.
       #
-      # There are a few ways to provide the Redis client used by the cache:
-      #
-      # 1. The +:redis+ param can be:
-      #    - A Redis instance.
-      #    - A +ConnectionPool+ instance wrapping a Redis instance.
-      #    - A block that returns a Redis instance.
-      #
-      # 2. The +:url+ param can be:
-      #    - A string used to create a Redis instance.
-      #    - An array of strings used to create a +Redis::Distributed+ instance.
-      #
-      # If the final Redis instance is not already a +ConnectionPool+, it will
-      # be wrapped in one using +ActiveSupport::Cache::Store::DEFAULT_POOL_OPTIONS+.
-      # These options can be overridden with the +:pool+ param, or the pool can be
-      # disabled with +:pool: false+.
+      # The +:url+ param can be:
+      #    - A string used to create a RedisClient::Pooled instance.
+      #    - An array of strings used to create a +RedisClient::HashRing+ instance.
       #
       #   Option  Class       Result
-      #   :redis  Object  ->  options[:redis]
-      #   :redis  Proc    ->  options[:redis].call
-      #   :url    String  ->  Redis.new(url: …)
-      #   :url    Array   ->  Redis::Distributed.new([{ url: … }, { url: … }, …])
+      #   :url    String  ->  RedisClient.config(url: …).new_pool
+      #   :url    Array   ->  RedisClient::HashRing.new([RedisClient.config(url: …).new_pool, ...])
+      #
+      # If you need some advanced configuration for the client, or want to use an alternative implementation
+      # like `redis-cluster-client`, you can pass an already configued client via the +:client+ option:
+      #
+      #   config.cache_store = :redis_cache_store, client: RedisClient.config(...)
+      #   config.cache_store = :redis_cache_store, client: [RedisClient.config(...), RedisClient.config(...)]
+      #   config.cache_store = :redis_cache_store, client: -> { RedisClient.config(...) }
       #
       # No namespace is set by default. Provide one if the Redis cache
       # server is shared with other apps: <tt>namespace: 'myapp-cache'</tt>.
@@ -162,15 +130,31 @@ module ActiveSupport
       #   cache.exist?('bar') # => false
       def initialize(error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
         universal_options = redis_options.extract!(*UNIVERSAL_OPTIONS)
-        redis = redis_options[:redis]
+        pool_options = self.class.send(:retrieve_pool_options, redis_options)
 
-        already_pool = redis.instance_of?(::ConnectionPool) ||
-                       (redis.respond_to?(:wrapped_pool) && redis.wrapped_pool.instance_of?(::ConnectionPool))
-
-        if !already_pool && pool_options = self.class.send(:retrieve_pool_options, redis_options)
-          @redis = ::ConnectionPool.new(**pool_options) { self.class.build_redis(**redis_options) }
+        if redis_options.key?(:client)
+          client = redis_options.delete(:client)
+          clients = Array.wrap(client.respond_to?(:call) ? client.call : client)
         else
-          @redis = self.class.build_redis(**redis_options)
+          urls = Array.wrap(redis_options.delete(:url))
+          urls << nil if urls.empty?
+          clients = urls.map do |url|
+            RedisClient.config(url: url, protocol: 2, **redis_options)
+          end
+        end
+
+        clients.map! do |c|
+          if c.respond_to?(:new_pool)
+            c.new_pool(**(pool_options || {}))
+          else
+            c
+          end
+        end
+
+        @redis = if clients.size > 1
+          RedisClient.ring(clients)
+        else
+          clients.first
         end
 
         @error_handler = error_handler
@@ -198,6 +182,10 @@ module ActiveSupport
         end
       end
 
+      # The maximum number of entries to receive per SCAN call.
+      SCAN_BATCH_SIZE = 1000
+      private_constant :SCAN_BATCH_SIZE
+
       # Cache Store API implementation.
       #
       # Supports Redis KEYS glob patterns:
@@ -220,16 +208,11 @@ module ActiveSupport
         pattern = namespace_key(matcher, options)
 
         instrument :delete_matched, pattern do
-          redis.then do |c|
-            cursor = "0"
-            # Fetch keys in batches using SCAN to avoid blocking the Redis server.
-            nodes = c.respond_to?(:nodes) ? c.nodes : [c]
-
-            nodes.each do |node|
-              begin
-                cursor, keys = node.scan(cursor, match: pattern, count: SCAN_BATCH_SIZE)
-                node.unlink(*keys) unless keys.empty?
-              end until cursor == "0"
+          redis.nodes.each do |node|
+            node.with do |conn|
+              conn.scan(match: pattern, count: SCAN_BATCH_SIZE).each_slice(SCAN_BATCH_SIZE).each do |keys|
+                conn.call("unlink", *keys)
+              end
             end
           end
         end
@@ -332,18 +315,6 @@ module ActiveSupport
           [:@options, :@redis].freeze
         end
 
-        def pipeline_entries(entries, &block)
-          redis.then { |c|
-            if c.is_a?(Redis::Distributed)
-              entries.group_by { |k, _v| c.node_for(k) }.each do |node, sub_entries|
-                node.pipelined { |pipe| yield(pipe, sub_entries) }
-              end
-            else
-              c.pipelined { |pipe| yield(pipe, entries) }
-            end
-          }
-        end
-
         # Store provider interface:
         # Read an entry from the cache.
         def read_entry(key, **options)
@@ -352,7 +323,8 @@ module ActiveSupport
 
         def read_serialized_entry(key, raw: false, **options)
           failsafe :read_entry do
-            redis.then { |c| options[:delete] ? c.getdel(key) : c.get(key) }
+            command = options[:delete] ? "getdel" : "get"
+            redis.node_for(key).call(command, key)
           end
         end
 
@@ -362,22 +334,27 @@ module ActiveSupport
           raw = options&.fetch(:raw, false)
 
           keys = names.map { |name| normalize_key(name, options) }
+          keys_index = keys.each_with_index.to_h
 
-          values = failsafe(:read_multi_entries, returning: {}) do
-            redis.then { |c| c.mget(*keys) }
-          end
+          results = {}
 
-          names.zip(values).each_with_object({}) do |(name, value), results|
-            if value
-              entry = deserialize_entry(value, raw: raw)
-              unless entry.nil? || entry.expired? || entry.mismatched?(normalize_version(name, options))
-                begin
-                  results[name] = entry.value
-                rescue DeserializationError
+          redis.nodes_for(keys).each do |node, key_subset|
+            failsafe(:read_multi_entries) do
+              node.call("mget", *key_subset).each_with_index do |value, index|
+                if value
+                  results[names[keys_index[key_subset[index]]]] = value
                 end
               end
             end
           end
+
+          results.transform_values! { |value| deserialize_entry(value, raw: raw) }
+          results.reject! do |name, entry|
+            entry.nil? || entry.expired? || entry.mismatched?(normalize_version(name, options))
+          end
+          results.compact!
+          results.transform_values! { |entry| entry&.value }
+          results
         end
 
         # Write an entry to the cache.
@@ -395,17 +372,17 @@ module ActiveSupport
             expires_in += 5.minutes
           end
 
-          modifiers = {}
+          modifiers = []
           if unless_exist || expires_in
-            modifiers[:nx] = unless_exist
-            modifiers[:px] = (1000 * expires_in.to_f).ceil if expires_in
+            modifiers << :nx if unless_exist
+            modifiers << :px << (1000 * expires_in.to_f).ceil if expires_in
           end
 
           if pipeline
-            pipeline.set(key, payload, **modifiers)
+            pipeline.call("set", key, payload, *modifiers)
           else
             failsafe :write_entry, returning: nil do
-              redis.then { |c| !!c.set(key, payload, **modifiers) }
+              redis.node_for(key).call("set", key, payload, *modifiers) == "OK"
             end
           end
         end
@@ -413,7 +390,7 @@ module ActiveSupport
         # Delete an entry from the cache.
         def delete_entry(key, **options)
           failsafe :delete_entry, returning: false do
-            redis.then { |c| c.unlink(key) == 1 }
+            redis.node_for(key).call("unlink", key) == 1
           end
         end
 
@@ -421,21 +398,26 @@ module ActiveSupport
         def delete_multi_entries(entries, **_options)
           return 0 if entries.empty?
 
-          failsafe :delete_multi_entries, returning: 0 do
-            redis.then { |c| c.unlink(*entries) }
+          count = 0
+          redis.nodes_for(*entries).each do |node, keys|
+            failsafe :delete_multi_entries do
+              count += node.call("unlink", *keys)
+            end
           end
+
+          count
         end
 
         # Nonstandard store provider API to write multiple values at once.
         def write_multi_entries(entries, **options)
           return if entries.empty?
 
-          failsafe :write_multi_entries do
-            pipeline_entries(entries) do |pipeline, sharded_entries|
-              options = options.dup
-              options[:pipeline] = pipeline
-              sharded_entries.each do |key, entry|
-                write_entry key, entry, **options
+          redis.nodes_for(entries.keys).each do |node, keys|
+            failsafe :write_multi_entries do
+              node.pipelined do |pipeline|
+                entries.slice(*keys).each do |key, entry|
+                  write_entry key, entry, **options, pipeline: pipeline
+                end
               end
             end
           end
@@ -464,26 +446,24 @@ module ActiveSupport
         end
 
         def change_counter(key, amount, options)
-          redis.then do |c|
-            c = c.node_for(key) if c.is_a?(Redis::Distributed)
-
+          redis.node_for(key).with do |c|
             expires_in = options[:expires_in]
 
             if expires_in
               if supports_expire_nx?
                 count, _ = c.pipelined do |pipeline|
-                  pipeline.incrby(key, amount)
-                  pipeline.call(:expire, key, expires_in.to_i, "NX")
+                  pipeline.call("incrby", key, amount)
+                  pipeline.call("expire", key, expires_in.to_i, "NX")
                 end
               else
                 count, ttl = c.pipelined do |pipeline|
-                  pipeline.incrby(key, amount)
-                  pipeline.ttl(key)
+                  pipeline.call("incrby", key, amount)
+                  pipeline.call("ttl", key)
                 end
-                c.expire(key, expires_in.to_i) if ttl < 0
+                c.call("expire", key, expires_in.to_i) if ttl < 0
               end
             else
-              count = c.incrby(key, amount)
+              count = c.call("incrby", key, amount)
             end
 
             count
@@ -493,21 +473,13 @@ module ActiveSupport
         def supports_expire_nx?
           return @supports_expire_nx if defined?(@supports_expire_nx)
 
-          redis_versions = redis.then { |c| Array.wrap(c.info("server")).pluck("redis_version") }
+          redis_versions = redis.nodes.map { |n| n.call("info", "server").scan(/edis_version:([\d.]+)/)[0][0] || "0" }
           @supports_expire_nx = redis_versions.all? { |v| Gem::Version.new(v) >= Gem::Version.new("7.0.0") }
         end
 
-        FAILSAFE_ERRORS = [
-          ::Redis::BaseError,
-          ConnectionPool::Error,
-          ConnectionPool::TimeoutError,
-          (::RedisClient::Error if defined?(::RedisClient::Error)),
-        ].compact.freeze
-        private_constant :FAILSAFE_ERRORS
-
         def failsafe(method, returning: nil)
           yield
-        rescue *FAILSAFE_ERRORS => error
+        rescue ::RedisClient::ConnectionError => error
           @error_handler&.call(method: method, exception: error, returning: returning)
           returning
         end

--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -107,7 +107,7 @@ module CacheInstrumentationBehavior
 
   def test_increment_instrumentation
     key_1 = SecureRandom.uuid
-    @cache.write(key_1, 0)
+    @cache.write(key_1, 0, raw: true)
 
     events = capture_notifications("cache_increment.active_support") { @cache.increment(key_1) }
 
@@ -119,7 +119,7 @@ module CacheInstrumentationBehavior
 
   def test_decrement_instrumentation
     key_1 = SecureRandom.uuid
-    @cache.write(key_1, 0)
+    @cache.write(key_1, 0, raw: true)
 
     events = capture_notifications("cache_decrement.active_support") { @cache.decrement(key_1) }
 

--- a/activesupport/test/cache/behaviors/failure_raising_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_raising_behavior.rb
@@ -5,7 +5,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.fetch(key)
       end
@@ -17,7 +17,7 @@ module FailureRaisingBehavior
     value = SecureRandom.alphanumeric
     @cache.write(key, value)
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.fetch(key) { SecureRandom.alphanumeric }
       end
@@ -30,7 +30,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.read(key)
       end
@@ -45,7 +45,7 @@ module FailureRaisingBehavior
       other_key => SecureRandom.alphanumeric
     )
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.read_multi(key, other_key)
       end
@@ -53,7 +53,7 @@ module FailureRaisingBehavior
   end
 
   def test_write_failure_raises
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.write(SecureRandom.uuid, SecureRandom.alphanumeric)
       end
@@ -61,7 +61,7 @@ module FailureRaisingBehavior
   end
 
   def test_write_multi_failure_raises
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.write_multi(
           SecureRandom.uuid => SecureRandom.alphanumeric,
@@ -79,7 +79,7 @@ module FailureRaisingBehavior
       other_key => SecureRandom.alphanumeric
     )
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.fetch_multi(key, other_key) { |k| "unavailable" }
       end
@@ -90,7 +90,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.delete(key)
       end
@@ -101,7 +101,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.exist?(key)
       end
@@ -112,7 +112,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, 1, raw: true)
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.increment(key)
       end
@@ -123,7 +123,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, 1, raw: true)
 
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.decrement(key)
       end
@@ -131,7 +131,7 @@ module FailureRaisingBehavior
   end
 
   def test_clear_failure_returns_nil
-    assert_raise Redis::BaseError do
+    assert_raise_redis_error do
       emulating_unavailability do |cache|
         cache.clear
       end

--- a/activesupport/test/cache/stores/deprecated_redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/deprecated_redis_cache_store_test.rb
@@ -410,6 +410,10 @@ module ActiveSupport::Cache::DeprecatedRedisCacheStoreTests
     include FailureRaisingBehavior
 
     private
+      def assert_raise_redis_error(...)
+        assert_raise(Redis::BaseError, ...)
+      end
+
       def emulating_unavailability
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, UnavailableRedisClient)
@@ -426,6 +430,10 @@ module ActiveSupport::Cache::DeprecatedRedisCacheStoreTests
     include FailureRaisingBehavior
 
     private
+      def assert_raise_redis_error(...)
+        assert_raise(Redis::BaseError, ...)
+      end
+
       def emulating_unavailability
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, MaxClientsReachedRedisClient)

--- a/activesupport/test/cache/stores/deprecated_redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/deprecated_redis_cache_store_test.rb
@@ -1,0 +1,630 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/cache"
+require "active_support/cache/deprecated_redis_cache_store"
+require_relative "../behaviors"
+
+# Emulates a latency on Redis's back-end for the key latency to facilitate
+# connection pool testing.
+class SlowRedis < Redis
+  def get(key)
+    if /latency/.match?(key)
+      sleep 0.2
+      super
+    else
+      super
+    end
+  end
+end
+
+module ActiveSupport::Cache::DeprecatedRedisCacheStoreTests
+  REDIS_URL = ENV["REDIS_URL"] || "redis://localhost:6379/0"
+  REDIS_URLS = ENV["REDIS_URLS"]&.split(",") || %w[ redis://localhost:6379/0 redis://localhost:6379/1 ]
+
+  if ENV["BUILDKITE"]
+    REDIS_UP = true
+  else
+    begin
+      redis = Redis.new(url: REDIS_URL)
+      redis.ping
+
+      REDIS_UP = true
+    rescue Redis::BaseConnectionError
+      $stderr.puts "Skipping redis tests. Start redis and try again."
+      REDIS_UP = false
+    end
+  end
+
+  class LookupTest < ActiveSupport::TestCase
+    test "may be looked up as :deprecated_redis_cache_store" do
+      assert_kind_of ActiveSupport::Cache::DeprecatedRedisCacheStore,
+        ActiveSupport::Cache.lookup_store(:deprecated_redis_cache_store)
+    end
+  end
+
+  class InitializationTest < ActiveSupport::TestCase
+    test "omitted URL uses Redis client with default settings" do
+      assert_called_with Redis, :new, [
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
+      ] do
+        build
+      end
+    end
+
+    test "no URLs uses Redis client with default settings" do
+      assert_called_with Redis, :new, [
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
+      ] do
+        build url: []
+      end
+    end
+
+    test "singular URL uses Redis client" do
+      assert_called_with Redis, :new, [
+        url: REDIS_URL,
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
+      ] do
+        build url: REDIS_URL
+      end
+    end
+
+    test "one URL uses Redis client" do
+      assert_called_with Redis, :new, [
+        url: REDIS_URL,
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
+      ] do
+        build url: [ REDIS_URL ]
+      end
+    end
+
+    test "multiple URLs uses Redis::Distributed client" do
+      default_args = {
+        connect_timeout: 1,
+        read_timeout: 1,
+        write_timeout: 1
+      }
+
+      mock = Minitest::Mock.new
+      mock.expect(:call, Redis.new, [{ url: REDIS_URLS.first }.merge(default_args)])
+      mock.expect(:call, Redis.new, [{ url: REDIS_URLS.last }.merge(default_args)])
+
+      Redis.stub(:new, mock) do
+        @cache = build url: REDIS_URLS
+        assert_kind_of ::Redis::Distributed, @cache.redis
+      end
+
+      assert_mock(mock)
+    end
+
+    test "block argument uses yielded client" do
+      block = -> { :custom_redis_client }
+      assert_called block, :call do
+        build redis: block
+      end
+    end
+
+    test "instance of Redis uses given instance" do
+      redis_instance = Redis.new
+      @cache = build(redis: redis_instance)
+      assert_same @cache.redis, redis_instance
+    end
+
+    test "validate pool arguments" do
+      assert_raises TypeError do
+        build(url: REDIS_URL, pool: { size: [] })
+      end
+
+      assert_raises TypeError do
+        build(url: REDIS_URL, pool: { timeout: [] })
+      end
+
+      build(url: REDIS_URL, pool: { size: "12", timeout: "1.5" })
+    end
+
+    test "instantiating the store doesn't connect to Redis" do
+      assert_nothing_raised do
+        build(url: "redis://localhost:1")
+      end
+    end
+
+    test "inspect shows options and redis" do
+      store = build(url: REDIS_URL)
+
+      assert_match(/@options=/, store.inspect)
+      assert_match(/@redis=/, store.inspect)
+      assert_match(/\A#<ActiveSupport::Cache::DeprecatedRedisCacheStore:0x[0-9a-f]+/, store.inspect)
+    end
+
+    private
+      def build(**kwargs)
+        ActiveSupport::Cache::DeprecatedRedisCacheStore.new(pool: false, **kwargs).tap(&:redis)
+      end
+  end
+
+  class StoreTest < ActiveSupport::TestCase
+    setup do
+      @cache = nil
+      skip "Redis server is not up" unless REDIS_UP
+      @namespace = "test-#{SecureRandom.hex}"
+
+      @cache = lookup_store(expires_in: 60)
+      # @cache.logger = Logger.new($stdout)  # For test debugging
+
+      @cache_no_ttl = lookup_store
+
+      # For LocalCacheBehavior tests
+      @peek = lookup_store(expires_in: 60)
+    end
+
+    def lookup_store(options = {})
+      ActiveSupport::Cache.lookup_store(:deprecated_redis_cache_store, { timeout: 0.1, namespace: @namespace, pool: false }.merge(options))
+    end
+
+    teardown do
+      @cache.clear
+      @cache.redis.with do |r|
+        r.respond_to?(:on_each_node, true) ? r.send(:on_each_node, :disconnect!) : r.disconnect!
+      end
+    end
+  end
+
+  class DeprecatedRedisCacheStoreCommonBehaviorTest < StoreTest
+    include CacheStoreBehavior
+    include CacheStoreVersionBehavior
+    include CacheStoreCoderBehavior
+    include CacheStoreCompressionBehavior
+    include CacheStoreFormatVersionBehavior
+    include CacheStoreSerializerBehavior
+    include LocalCacheBehavior
+    include CacheIncrementDecrementBehavior
+    include CacheInstrumentationBehavior
+    include CacheLoggingBehavior
+    include EncodedKeyCacheBehavior
+
+    def test_fetch_multi_uses_redis_mget
+      assert_called(redis_backend, :mget, returns: []) do
+        @cache.fetch_multi("a", "b", "c") do |key|
+          key * 2
+        end
+      end
+    end
+
+    def test_fetch_multi_with_namespace
+      assert_called_with(redis_backend, :mget, ["custom-namespace:a", "custom-namespace:b", "custom-namespace:c"], returns: []) do
+        @cache.fetch_multi("a", "b", "c", namespace: "custom-namespace") do |key|
+          key * 2
+        end
+      end
+    end
+
+    def test_write_expires_at
+      @cache.write "key_with_expires_at", "bar", expires_at: 30.minutes.from_now
+      redis_backend do |r|
+        assert r.ttl("#{@namespace}:key_with_expires_at") > 0
+      end
+    end
+
+    def test_write_with_unless_exist
+      assert_equal true, @cache.write("foo", 1)
+      assert_equal false, @cache.write("foo", 1, unless_exist: true)
+    end
+
+    def test_increment_ttl
+      # existing key
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:jar", 10 }
+      @cache_no_ttl.increment "jar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:jar").to_i == 11
+        assert r.ttl("#{@namespace}:jar") < 0
+      end
+
+      # new key
+      @cache_no_ttl.increment "kar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:kar").to_i == 1
+        assert r.ttl("#{@namespace}:kar") < 0
+      end
+    end
+
+    def test_increment_expires_in
+      @cache.increment "foo", expires_in: 60
+      redis_backend do |r|
+        assert r.exists?("#{@namespace}:foo")
+        assert r.ttl("#{@namespace}:foo") > 0
+      end
+
+      # key and ttl exist
+      redis_backend { |r| r.setex "#{@namespace}:bar", 120, 1 }
+      @cache.increment "bar", expires_in: 60
+      redis_backend do |r|
+        assert r.ttl("#{@namespace}:bar") > 60
+      end
+
+      # key exist but not have expire
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:dar", 10 }
+      @cache_no_ttl.increment "dar", expires_in: 60
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.ttl("#{@namespace}:dar") > 0
+      end
+    end
+
+    def test_decrement_ttl
+      # existing key
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:jar", 10 }
+      @cache_no_ttl.decrement "jar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:jar").to_i == 9
+        assert r.ttl("#{@namespace}:jar") < 0
+      end
+
+      # new key
+      @cache_no_ttl.decrement "kar", 1
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.get("#{@namespace}:kar").to_i == -1
+        assert r.ttl("#{@namespace}:kar") < 0
+      end
+    end
+
+    def test_decrement_expires_in
+      @cache.decrement "foo", 1, expires_in: 60
+      redis_backend do |r|
+        assert r.exists?("#{@namespace}:foo")
+        assert r.ttl("#{@namespace}:foo") > 0
+      end
+
+      # key and ttl exist
+      redis_backend { |r| r.setex "#{@namespace}:bar", 120, 1 }
+      @cache.decrement "bar", 1, expires_in: 60
+      redis_backend do |r|
+        assert r.ttl("#{@namespace}:bar") > 60
+      end
+
+      # key exist but not have expire
+      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:dar", 10 }
+      @cache_no_ttl.decrement "dar", 1, expires_in: 60
+      redis_backend(@cache_no_ttl) do |r|
+        assert r.ttl("#{@namespace}:dar") > 0
+      end
+    end
+
+    test "fetch caches nil" do
+      @cache.write("foo", nil)
+      assert_not_called(@cache, :write) do
+        assert_nil @cache.fetch("foo") { "baz" }
+      end
+    end
+
+    test "skip_nil is passed to ActiveSupport::Cache" do
+      @cache = lookup_store(skip_nil: true)
+      assert_not_called(@cache, :write) do
+        assert_nil @cache.fetch("foo") { nil }
+        assert_equal false, @cache.exist?("foo")
+      end
+    end
+
+    def redis_backend(cache = @cache)
+      cache.redis.with do |r|
+        yield r if block_given?
+        return r
+      end
+    end
+  end
+
+  class DeprecatedRedisCacheStoreWithDistributedRedisTest < DeprecatedRedisCacheStoreCommonBehaviorTest
+    def lookup_store(options = {})
+      super(options.merge(pool: { size: 5 }, url: [ENV["REDIS_URL"] || "redis://localhost:6379/0"] * 2))
+    end
+  end
+
+  class ConnectionPoolBehaviorTest < StoreTest
+    include ConnectionPoolBehavior
+
+    def test_pool_options_work
+      cache = ActiveSupport::Cache.lookup_store(:deprecated_redis_cache_store, pool: { size: 2, timeout: 1 })
+      pool = cache.redis # loads 'connection_pool' gem
+      assert_kind_of ::ConnectionPool, pool
+      assert_equal 2, pool.size
+      assert_equal 1, pool.instance_variable_get(:@timeout)
+    end
+
+    def test_connection_pooling_by_default
+      cache = ActiveSupport::Cache.lookup_store(:deprecated_redis_cache_store)
+      pool = cache.redis
+      assert_kind_of ::ConnectionPool, pool
+      assert_equal 5, pool.size
+      assert_equal 5, pool.instance_variable_get(:@timeout)
+    end
+
+    def test_no_connection_pooling_by_default_when_already_a_pool
+      redis = ::ConnectionPool.new(size: 10, timeout: 2.5) { Redis.new }
+      cache = ActiveSupport::Cache.lookup_store(:deprecated_redis_cache_store, redis: redis)
+      pool = cache.redis
+      assert_kind_of ::ConnectionPool, pool
+      assert_same redis, pool
+      assert_equal 10, pool.size
+      assert_equal 2.5, pool.instance_variable_get(:@timeout)
+    end
+
+    def test_no_connection_pooling_by_default_when_already_wrapped_in_a_pool
+      redis = ::ConnectionPool::Wrapper.new(size: 10, timeout: 2.5) { Redis.new }
+      cache = ActiveSupport::Cache.lookup_store(:deprecated_redis_cache_store, redis: redis)
+      wrapped_redis = cache.redis
+      assert_kind_of ::Redis, wrapped_redis
+      assert_same redis, wrapped_redis
+      pool = wrapped_redis.wrapped_pool
+      assert_kind_of ::ConnectionPool, pool
+      assert_equal 10, pool.size
+      assert_equal 2.5, pool.instance_variable_get(:@timeout)
+    end
+
+    private
+      def store
+        [:deprecated_redis_cache_store]
+      end
+
+      def emulating_latency
+        old_redis = Object.send(:remove_const, :Redis)
+        Object.const_set(:Redis, SlowRedis)
+
+        yield
+      ensure
+        Object.send(:remove_const, :Redis)
+        Object.const_set(:Redis, old_redis)
+      end
+  end
+
+  class RedisDistributedConnectionPoolBehaviorTest < ConnectionPoolBehaviorTest
+    private
+      def store_options
+        { url: REDIS_URLS }
+      end
+  end
+
+  class StoreAPITest < StoreTest
+  end
+
+  class UnavailableRedisClient < Redis::Client
+    def ensure_connected(...)
+      raise Redis::BaseConnectionError
+    end
+  end
+
+  class MaxClientsReachedRedisClient < Redis::Client
+    def ensure_connected(...)
+      raise Redis::CommandError
+    end
+  end
+
+  class RedisClientErrorRedisClient < Redis::Client
+    def ensure_connected(...)
+      raise RedisClient::Error
+    end
+
+    def self.translate_error!(error, **)
+      raise error
+    end
+  end
+
+  class FailureRaisingFromUnavailableClientTest < StoreTest
+    include FailureRaisingBehavior
+
+    private
+      def emulating_unavailability
+        old_client = Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, UnavailableRedisClient)
+
+        yield ActiveSupport::Cache::DeprecatedRedisCacheStore.new(namespace: @namespace,
+                                                        error_handler: -> (method:, returning:, exception:) { raise exception })
+      ensure
+        Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, old_client)
+      end
+  end
+
+  class FailureRaisingFromMaxClientsReachedErrorTest < StoreTest
+    include FailureRaisingBehavior
+
+    private
+      def emulating_unavailability
+        old_client = Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, MaxClientsReachedRedisClient)
+
+        yield ActiveSupport::Cache::DeprecatedRedisCacheStore.new(
+          namespace: @namespace,
+          error_handler: -> (method:, returning:, exception:) { raise exception }
+        )
+      ensure
+        Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, old_client)
+      end
+  end
+
+  class FailureSafetyFromUnavailableClientTest < StoreTest
+    include FailureSafetyBehavior
+
+    private
+      def emulating_unavailability
+        old_client = Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, UnavailableRedisClient)
+
+        yield ActiveSupport::Cache::DeprecatedRedisCacheStore.new(namespace: @namespace)
+      ensure
+        Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, old_client)
+      end
+  end
+
+  class FailureSafetyFromMaxClientsReachedErrorTest < StoreTest
+    include FailureSafetyBehavior
+
+    private
+      def emulating_unavailability
+        old_client = Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, MaxClientsReachedRedisClient)
+
+        yield ActiveSupport::Cache::DeprecatedRedisCacheStore.new(namespace: @namespace)
+      ensure
+        Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, old_client)
+      end
+  end
+
+  class FailureSafetyFromRedisClientErrorTest < StoreTest
+    include FailureSafetyBehavior
+
+    private
+      def emulating_unavailability
+        old_client = Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, RedisClientErrorRedisClient)
+
+        yield ActiveSupport::Cache::DeprecatedRedisCacheStore.new(namespace: @namespace)
+      ensure
+        Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, old_client)
+      end
+  end
+
+  class DeleteMatchedTest < StoreTest
+    test "deletes keys matching glob" do
+      prefix = SecureRandom.alphanumeric
+      key = "#{prefix}#{SecureRandom.uuid}"
+      @cache.write(key, "bar")
+
+      other_key = SecureRandom.uuid
+      @cache.write(other_key, SecureRandom.alphanumeric)
+      @cache.delete_matched("#{prefix}*")
+      assert_not @cache.exist?(key)
+      assert @cache.exist?(other_key)
+    end
+
+    test "fails with regexp matchers" do
+      assert_raise ArgumentError do
+        @cache.delete_matched(/OO/i)
+      end
+    end
+  end
+
+  class ClearTest < StoreTest
+    test "clear all cache key" do
+      key = SecureRandom.uuid
+      other_key = SecureRandom.uuid
+      @cache.write(key, SecureRandom.uuid)
+      @cache.write(other_key, SecureRandom.uuid)
+      @cache.clear
+      assert_not @cache.exist?(key)
+      assert_not @cache.exist?(other_key)
+    end
+
+    test "only clear namespace cache key" do
+      key = SecureRandom.uuid
+      other_key = SecureRandom.uuid
+
+      @cache.write(key, SecureRandom.alphanumeric)
+      @cache.redis.set(other_key, SecureRandom.alphanumeric)
+      @cache.clear
+
+      assert_not @cache.exist?(key)
+      assert @cache.redis.exists?(other_key)
+      @cache.redis.del(other_key)
+    end
+
+    test "clear all cache key with Redis::Distributed" do
+      cache = ActiveSupport::Cache::DeprecatedRedisCacheStore.new(
+        url: REDIS_URLS,
+        timeout: 0.1, namespace: @namespace, expires_in: 60)
+      cache.write("foo", "bar")
+      cache.write("fu", "baz")
+      cache.clear
+      assert_not cache.exist?("foo")
+      assert_not cache.exist?("fu")
+    end
+  end
+
+  class RawTest < StoreTest
+    test "does not compress values read with \"raw\" enabled" do
+      @cache.write("foo", "bar", raw: true)
+
+      assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compressed do
+        @cache.read("foo", raw: true)
+      end
+    end
+  end
+
+  class ReadDeleteTest < StoreTest
+    test "read with delete: true returns the value and removes the key" do
+      @cache.write("foo", "bar")
+      assert_equal "bar", @cache.read("foo", delete: true)
+      assert_nil @cache.read("foo")
+    end
+
+    test "read with delete: true returns nil for missing key" do
+      assert_nil @cache.read("missing", delete: true)
+    end
+
+    test "read with delete: true removes the key from redis" do
+      @cache.write("foo", "bar")
+      @cache.read("foo", delete: true)
+      redis_backend do |r|
+        assert_not r.exists?("#{@namespace}:foo")
+      end
+    end
+
+    test "read with delete: true works with raw values" do
+      @cache.write("foo", "bar", raw: true)
+      assert_equal "bar", @cache.read("foo", raw: true, delete: true)
+      assert_nil @cache.read("foo", raw: true)
+    end
+
+    test "read without delete option still works normally" do
+      @cache.write("foo", "bar")
+      assert_equal "bar", @cache.read("foo")
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    test "read with delete: true on expired entry returns nil" do
+      @cache.write("foo", "bar", expires_in: 1)
+      travel(2.seconds) do
+        assert_nil @cache.read("foo", delete: true)
+      end
+    end
+
+    test "read with delete: true returns value and clears local cache" do
+      @cache.with_local_cache do
+        @cache.write("foo", "bar")
+        assert_equal "bar", @cache.read("foo", delete: true)
+        assert_nil @cache.read("foo")
+      end
+    end
+
+    test "read with delete: true clears remote cache within local cache scope" do
+      @cache.with_local_cache do
+        @cache.write("foo", "bar")
+        assert_equal "bar", @cache.read("foo", delete: true)
+      end
+      # After local cache scope ends, remote should also be gone
+      assert_nil @cache.read("foo")
+    end
+
+    test "read with delete: true bypasses stale local cache" do
+      @cache.with_local_cache do
+        @cache.write("foo", "bar")
+        # Overwrite in remote behind local cache's back
+        @cache.send(:bypass_local_cache) { @cache.write("foo", "baz") }
+        # Without delete, local cache returns stale value
+        assert_equal "bar", @cache.read("foo")
+        # With delete, it should bypass local cache and hit remote
+        assert_equal "baz", @cache.read("foo", delete: true)
+        # Both local and remote should be cleared
+        assert_nil @cache.read("foo")
+      end
+    end
+
+    def redis_backend(cache = @cache)
+      cache.redis.with do |r|
+        yield r if block_given?
+        return r
+      end
+    end
+  end
+end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -5,35 +5,20 @@ require "active_support/cache"
 require "active_support/cache/redis_cache_store"
 require_relative "../behaviors"
 
-# Emulates a latency on Redis's back-end for the key latency to facilitate
-# connection pool testing.
-class SlowRedis < Redis
-  def get(key)
-    if /latency/.match?(key)
-      sleep 0.2
-      super
-    else
-      super
-    end
-  end
-end
-
 module ActiveSupport::Cache::RedisCacheStoreTests
   REDIS_URL = ENV["REDIS_URL"] || "redis://localhost:6379/0"
   REDIS_URLS = ENV["REDIS_URLS"]&.split(",") || %w[ redis://localhost:6379/0 redis://localhost:6379/1 ]
 
-  if ENV["BUILDKITE"]
-    REDIS_UP = true
-  else
-    begin
-      redis = Redis.new(url: REDIS_URL)
-      redis.ping
+  redis_up = begin
+    RedisClient.new(url: REDIS_URL, protocol: 2).call("ping")
+    true
+  rescue RedisClient::ConnectionError
+    false
+  end
 
-      REDIS_UP = true
-    rescue Redis::BaseConnectionError
-      $stderr.puts "Skipping redis tests. Start redis and try again."
-      REDIS_UP = false
-    end
+  REDIS_UP = redis_up || ENV["BUILDKITE"]
+  unless REDIS_UP
+    $stderr.puts "Skipping redis tests. Start redis and try again."
   end
 
   class LookupTest < ActiveSupport::TestCase
@@ -45,69 +30,67 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
   class InitializationTest < ActiveSupport::TestCase
     test "omitted URL uses Redis client with default settings" do
-      assert_called_with Redis, :new, [
-        connect_timeout: 1, read_timeout: 1, write_timeout: 1
-      ] do
-        build
-      end
+      @cache = ActiveSupport::Cache::RedisCacheStore.new
+      assert_equal 1, @cache.redis.connect_timeout
+      assert_equal 1, @cache.redis.read_timeout
+      assert_equal 1, @cache.redis.write_timeout
+      assert_equal "redis://localhost:6379", @cache.redis.config.server_url
     end
 
     test "no URLs uses Redis client with default settings" do
-      assert_called_with Redis, :new, [
-        connect_timeout: 1, read_timeout: 1, write_timeout: 1
-      ] do
-        build url: []
-      end
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(url: [])
+      assert_equal 1, @cache.redis.connect_timeout
+      assert_equal 1, @cache.redis.read_timeout
+      assert_equal 1, @cache.redis.write_timeout
+      assert_equal "redis://localhost:6379", @cache.redis.config.server_url
     end
 
     test "singular URL uses Redis client" do
-      assert_called_with Redis, :new, [
-        url: REDIS_URL,
-        connect_timeout: 1, read_timeout: 1, write_timeout: 1
-      ] do
-        build url: REDIS_URL
-      end
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(url: REDIS_URL)
+      assert_equal 1, @cache.redis.connect_timeout
+      assert_equal 1, @cache.redis.read_timeout
+      assert_equal 1, @cache.redis.write_timeout
+      assert_equal REDIS_URL.delete_suffix("/0"), @cache.redis.config.server_url
     end
 
     test "one URL uses Redis client" do
-      assert_called_with Redis, :new, [
-        url: REDIS_URL,
-        connect_timeout: 1, read_timeout: 1, write_timeout: 1
-      ] do
-        build url: [ REDIS_URL ]
-      end
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(url: [REDIS_URL])
+      assert_equal 1, @cache.redis.connect_timeout
+      assert_equal 1, @cache.redis.read_timeout
+      assert_equal 1, @cache.redis.write_timeout
+      assert_equal REDIS_URL.delete_suffix("/0"), @cache.redis.config.server_url
     end
 
-    test "multiple URLs uses Redis::Distributed client" do
-      default_args = {
-        connect_timeout: 1,
-        read_timeout: 1,
-        write_timeout: 1
-      }
-
-      mock = Minitest::Mock.new
-      mock.expect(:call, Redis.new, [{ url: REDIS_URLS.first }.merge(default_args)])
-      mock.expect(:call, Redis.new, [{ url: REDIS_URLS.last }.merge(default_args)])
-
-      Redis.stub(:new, mock) do
-        @cache = build url: REDIS_URLS
-        assert_kind_of ::Redis::Distributed, @cache.redis
-      end
-
-      assert_mock(mock)
+    test "multiple URLs uses RedisClient::HashRing client" do
+      @cache = build url: REDIS_URLS
+      assert_kind_of ::RedisClient::HashRing, @cache.redis
+      assert_equal REDIS_URLS.size, @cache.redis.nodes.size
+      assert_equal REDIS_URLS.map { |u| u.delete_suffix("/0") }, @cache.redis.nodes.map { |n| n.config.server_url }
     end
 
-    test "block argument uses yielded client" do
-      block = -> { :custom_redis_client }
-      assert_called block, :call do
-        build redis: block
-      end
+    test "one :client Config" do
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(client: RedisClient.config(url: REDIS_URL))
+      assert_equal 1, @cache.redis.connect_timeout
+      assert_equal 1, @cache.redis.read_timeout
+      assert_equal 1, @cache.redis.write_timeout
+      assert_equal REDIS_URL.delete_suffix("/0"), @cache.redis.config.server_url
+      assert_kind_of ::RedisClient::Pooled, @cache.redis
     end
 
-    test "instance of Redis uses given instance" do
-      redis_instance = Redis.new
-      @cache = build(redis: redis_instance)
-      assert_same @cache.redis, redis_instance
+    test "one :client callback" do
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(client: -> { RedisClient.config(url: REDIS_URL) })
+      assert_equal 1, @cache.redis.connect_timeout
+      assert_equal 1, @cache.redis.read_timeout
+      assert_equal 1, @cache.redis.write_timeout
+      assert_equal REDIS_URL.delete_suffix("/0"), @cache.redis.config.server_url
+      assert_kind_of ::RedisClient::Pooled, @cache.redis
+    end
+
+    test "deprecated :redis argument" do
+      @cache = assert_deprecated(/Passing a Redis or ConnectionPool instance/, ActiveSupport.deprecator) do
+        ActiveSupport::Cache::RedisCacheStore.new(redis: -> { Redis.new(url: REDIS_URL) })
+      end
+      assert_kind_of ActiveSupport::Cache::DeprecatedRedisCacheStore, @cache
     end
 
     test "validate pool arguments" do
@@ -138,33 +121,43 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     private
       def build(**kwargs)
-        ActiveSupport::Cache::RedisCacheStore.new(pool: false, **kwargs).tap(&:redis)
+        ActiveSupport::Cache::RedisCacheStore.new(url: REDIS_URL, **kwargs).tap(&:redis)
       end
   end
 
   class StoreTest < ActiveSupport::TestCase
+    module NotificationMiddleware
+      def call(command, _redis_config)
+        ActiveSupport::Notifications.instrument("redis_query.active_support_test", commands: [command]) { super }
+      end
+
+      def call_pipelined(commands, _redis_config)
+        ActiveSupport::Notifications.instrument("redis_query.active_support_test", commands: commands) { super }
+      end
+    end
+
     setup do
       @cache = nil
       skip "Redis server is not up" unless REDIS_UP
       @namespace = "test-#{SecureRandom.hex}"
 
-      @cache = lookup_store(expires_in: 60)
+      @cache = lookup_store(url: REDIS_URL, expires_in: 60, middlewares: [NotificationMiddleware])
       # @cache.logger = Logger.new($stdout)  # For test debugging
 
-      @cache_no_ttl = lookup_store
+      @cache_no_ttl = lookup_store(url: REDIS_URL)
 
       # For LocalCacheBehavior tests
-      @peek = lookup_store(expires_in: 60)
+      @peek = lookup_store(url: REDIS_URL, expires_in: 60)
     end
 
     def lookup_store(options = {})
-      ActiveSupport::Cache.lookup_store(:redis_cache_store, { timeout: 0.1, namespace: @namespace, pool: false }.merge(options))
+      ActiveSupport::Cache.lookup_store(:redis_cache_store, { url: REDIS_URL, timeout: 0.1, namespace: @namespace, pool: false }.merge(options))
     end
 
     teardown do
-      @cache.clear
-      @cache.redis.with do |r|
-        r.respond_to?(:on_each_node, true) ? r.send(:on_each_node, :disconnect!) : r.disconnect!
+      if @cache
+        @cache.clear
+        @cache.redis.nodes.each(&:close)
       end
     end
   end
@@ -183,25 +176,31 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include EncodedKeyCacheBehavior
 
     def test_fetch_multi_uses_redis_mget
-      assert_called(redis_backend, :mget, returns: []) do
-        @cache.fetch_multi("a", "b", "c") do |key|
-          key * 2
+      commands = capture_redis_commands do
+        2.times do
+          result = @cache.fetch_multi("a", "b", "c") do |key|
+            key * 2
+          end
+          assert_equal({ "a" => "aa", "b" => "bb", "c" => "cc" }, result)
         end
       end
+      assert_includes commands.map(&:first), "mget"
     end
 
     def test_fetch_multi_with_namespace
-      assert_called_with(redis_backend, :mget, ["custom-namespace:a", "custom-namespace:b", "custom-namespace:c"], returns: []) do
-        @cache.fetch_multi("a", "b", "c", namespace: "custom-namespace") do |key|
+      commands = capture_redis_commands do
+        result = @cache.fetch_multi("a", "b", "c", namespace: "custom-namespace") do |key|
           key * 2
         end
+        assert_equal({ "a" => "aa", "b" => "bb", "c" => "cc" }, result)
       end
+      assert_equal ["custom-namespace:a", "custom-namespace:b", "custom-namespace:c"], commands.select { |c| c.shift if c.first == "mget" }.flatten.sort
     end
 
     def test_write_expires_at
       @cache.write "key_with_expires_at", "bar", expires_at: 30.minutes.from_now
-      redis_backend do |r|
-        assert r.ttl("#{@namespace}:key_with_expires_at") > 0
+      redis_node_for("#{@namespace}:key_with_expires_at") do |r, k|
+        assert r.call("ttl", k) > 0
       end
     end
 
@@ -212,79 +211,94 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     def test_increment_ttl
       # existing key
-      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:jar", 10 }
-      @cache_no_ttl.increment "jar", 1
-      redis_backend(@cache_no_ttl) do |r|
-        assert r.get("#{@namespace}:jar").to_i == 11
-        assert r.ttl("#{@namespace}:jar") < 0
+      redis_node_for("#{@namespace}:jar", @cache_no_ttl) do |r, key|
+        r.call("set", key, 10)
+
+        @cache_no_ttl.increment "jar", 1
+
+        assert r.call("get", key).to_i == 11
+        assert r.call("ttl", key) < 0
       end
 
       # new key
-      @cache_no_ttl.increment "kar", 1
-      redis_backend(@cache_no_ttl) do |r|
-        assert r.get("#{@namespace}:kar").to_i == 1
-        assert r.ttl("#{@namespace}:kar") < 0
+      redis_node_for("#{@namespace}:kar", @cache_no_ttl) do |r, new_key|
+        @cache_no_ttl.increment "kar", 1
+
+        assert r.call("get", new_key).to_i == 1
+        assert r.call("ttl", new_key) < 0
       end
     end
 
     def test_increment_expires_in
       @cache.increment "foo", expires_in: 60
-      redis_backend do |r|
-        assert r.exists?("#{@namespace}:foo")
-        assert r.ttl("#{@namespace}:foo") > 0
+      redis_node_for("#{@namespace}:foo") do |r, key|
+        assert_equal 1, r.call("exists", key)
+        assert r.call("ttl", key) > 0
       end
 
       # key and ttl exist
-      redis_backend { |r| r.setex "#{@namespace}:bar", 120, 1 }
-      @cache.increment "bar", expires_in: 60
-      redis_backend do |r|
-        assert r.ttl("#{@namespace}:bar") > 60
+      redis_node_for("#{@namespace}:bar") do |r, key|
+        r.call("setex", key, 120, 1)
+
+        @cache.increment "bar", expires_in: 60
+
+        assert r.call("ttl", key) > 60
       end
 
       # key exist but not have expire
-      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:dar", 10 }
-      @cache_no_ttl.increment "dar", expires_in: 60
-      redis_backend(@cache_no_ttl) do |r|
-        assert r.ttl("#{@namespace}:dar") > 0
+      redis_node_for("#{@namespace}:dar", @cache_no_ttl) do |r, key|
+        r.call("set", key, 10)
+
+        @cache_no_ttl.increment "dar", expires_in: 60
+
+        assert r.call("ttl", key) > 0
       end
     end
 
     def test_decrement_ttl
       # existing key
-      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:jar", 10 }
-      @cache_no_ttl.decrement "jar", 1
-      redis_backend(@cache_no_ttl) do |r|
-        assert r.get("#{@namespace}:jar").to_i == 9
-        assert r.ttl("#{@namespace}:jar") < 0
+      redis_node_for("#{@namespace}:jar", @cache_no_ttl) do |r, key|
+        r.call("set", key, 10)
+
+        @cache_no_ttl.decrement "jar", 1
+
+        assert r.call("get", key).to_i == 9
+        assert r.call("ttl", key) < 0
       end
 
       # new key
-      @cache_no_ttl.decrement "kar", 1
-      redis_backend(@cache_no_ttl) do |r|
-        assert r.get("#{@namespace}:kar").to_i == -1
-        assert r.ttl("#{@namespace}:kar") < 0
+      redis_node_for("#{@namespace}:kar", @cache_no_ttl) do |r, key|
+        @cache_no_ttl.decrement "kar", 1
+
+        assert r.call("get", key).to_i == -1
+        assert r.call("ttl", key) < 0
       end
     end
 
     def test_decrement_expires_in
       @cache.decrement "foo", 1, expires_in: 60
-      redis_backend do |r|
-        assert r.exists?("#{@namespace}:foo")
-        assert r.ttl("#{@namespace}:foo") > 0
+
+      redis_node_for("#{@namespace}:foo") do |r, key|
+        assert_equal 1, r.call("exists", key)
+        assert r.call("ttl", key) > 0
       end
 
       # key and ttl exist
-      redis_backend { |r| r.setex "#{@namespace}:bar", 120, 1 }
-      @cache.decrement "bar", 1, expires_in: 60
-      redis_backend do |r|
-        assert r.ttl("#{@namespace}:bar") > 60
+      redis_node_for("#{@namespace}:bar") do |r, key|
+        r.call "setex", key, 120, 1
+
+        @cache.decrement "bar", 1, expires_in: 60
+
+        assert r.call("ttl", "#{@namespace}:bar") > 60
       end
 
       # key exist but not have expire
-      redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:dar", 10 }
-      @cache_no_ttl.decrement "dar", 1, expires_in: 60
-      redis_backend(@cache_no_ttl) do |r|
-        assert r.ttl("#{@namespace}:dar") > 0
+      redis_node_for("#{@namespace}:dar", @cache_no_ttl) do |r, key|
+        r.call "set", "#{@namespace}:dar", 10
+
+        @cache_no_ttl.decrement "dar", 1, expires_in: 60
+
+        assert r.call("ttl", "#{@namespace}:dar") > 0
       end
     end
 
@@ -303,17 +317,26 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
-    def redis_backend(cache = @cache)
-      cache.redis.with do |r|
-        yield r if block_given?
-        return r
+    def redis_node_for(key, cache = @cache)
+      cache.redis.node_for(key).with do |c|
+        yield c, key
       end
+    end
+
+    def capture_redis_commands(&block)
+      capture_notifications("redis_query.active_support_test", &block).flat_map { |e| e.payload.fetch(:commands) }
     end
   end
 
   class RedisCacheStoreWithDistributedRedisTest < RedisCacheStoreCommonBehaviorTest
     def lookup_store(options = {})
-      super(options.merge(pool: { size: 5 }, url: [ENV["REDIS_URL"] || "redis://localhost:6379/0"] * 2))
+      url = URI(ENV["REDIS_URL"] || "redis://localhost:6379/0")
+      urls = [
+        url.dup.tap { |u| u.path = "/1" },
+        url.dup.tap { |u| u.path = "/2" },
+      ]
+
+      super(options.merge(pool: { size: 5 }, url: urls))
     end
   end
 
@@ -322,40 +345,8 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     def test_pool_options_work
       cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, pool: { size: 2, timeout: 1 })
-      pool = cache.redis # loads 'connection_pool' gem
-      assert_kind_of ::ConnectionPool, pool
-      assert_equal 2, pool.size
-      assert_equal 1, pool.instance_variable_get(:@timeout)
-    end
-
-    def test_connection_pooling_by_default
-      cache = ActiveSupport::Cache.lookup_store(:redis_cache_store)
-      pool = cache.redis
-      assert_kind_of ::ConnectionPool, pool
-      assert_equal 5, pool.size
-      assert_equal 5, pool.instance_variable_get(:@timeout)
-    end
-
-    def test_no_connection_pooling_by_default_when_already_a_pool
-      redis = ::ConnectionPool.new(size: 10, timeout: 2.5) { Redis.new }
-      cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, redis: redis)
-      pool = cache.redis
-      assert_kind_of ::ConnectionPool, pool
-      assert_same redis, pool
-      assert_equal 10, pool.size
-      assert_equal 2.5, pool.instance_variable_get(:@timeout)
-    end
-
-    def test_no_connection_pooling_by_default_when_already_wrapped_in_a_pool
-      redis = ::ConnectionPool::Wrapper.new(size: 10, timeout: 2.5) { Redis.new }
-      cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, redis: redis)
-      wrapped_redis = cache.redis
-      assert_kind_of ::Redis, wrapped_redis
-      assert_same redis, wrapped_redis
-      pool = wrapped_redis.wrapped_pool
-      assert_kind_of ::ConnectionPool, pool
-      assert_equal 10, pool.size
-      assert_equal 2.5, pool.instance_variable_get(:@timeout)
+      assert_kind_of ::RedisClient::Pooled, cache.redis
+      assert_equal 2, cache.redis.size
     end
 
     private
@@ -363,14 +354,13 @@ module ActiveSupport::Cache::RedisCacheStoreTests
         [:redis_cache_store]
       end
 
-      def emulating_latency
-        old_redis = Object.send(:remove_const, :Redis)
-        Object.const_set(:Redis, SlowRedis)
-
-        yield
-      ensure
-        Object.send(:remove_const, :Redis)
-        Object.const_set(:Redis, old_redis)
+      def emulating_latency(&block)
+        callback = ->(event) do
+          if event.payload[:commands].any? { |c| c.first.downcase == "get" && c.second.match?(/latency/) }
+            sleep 0.2
+          end
+        end
+        ActiveSupport::Notifications.subscribed(callback, "redis_query.active_support_test", &block)
       end
   end
 
@@ -384,25 +374,23 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   class StoreAPITest < StoreTest
   end
 
-  class UnavailableRedisClient < Redis::Client
-    def ensure_connected(...)
-      raise Redis::BaseConnectionError
+  module UnavailableRedisMiddleware
+    def call(...)
+      raise ::RedisClient::ConnectionError
+    end
+
+    def call_pipelined(...)
+      raise ::RedisClient::ConnectionError
     end
   end
 
-  class MaxClientsReachedRedisClient < Redis::Client
-    def ensure_connected(...)
-      raise Redis::CommandError
-    end
-  end
-
-  class RedisClientErrorRedisClient < Redis::Client
-    def ensure_connected(...)
-      raise RedisClient::Error
+  module MaxClientsReachedRedisMiddleware
+    def call(...)
+      raise ::RedisClient::CannotConnectError
     end
 
-    def self.translate_error!(error, **)
-      raise error
+    def call_pipelined(...)
+      raise ::RedisClient::CannotConnectError
     end
   end
 
@@ -410,15 +398,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include FailureRaisingBehavior
 
     private
-      def emulating_unavailability
-        old_client = Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, UnavailableRedisClient)
+      def assert_raise_redis_error(...)
+        assert_raise(RedisClient::ConnectionError, ...)
+      end
 
-        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace,
-                                                        error_handler: -> (method:, returning:, exception:) { raise exception })
-      ensure
-        Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, old_client)
+      def emulating_unavailability
+        yield ActiveSupport::Cache::RedisCacheStore.new(
+          namespace: @namespace,
+          middlewares: [UnavailableRedisMiddleware],
+          error_handler: -> (method:, returning:, exception:) { raise exception },
+        )
       end
   end
 
@@ -426,15 +415,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include FailureRaisingBehavior
 
     private
-      def emulating_unavailability
-        old_client = Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, MaxClientsReachedRedisClient)
+      def assert_raise_redis_error(...)
+        assert_raise(RedisClient::ConnectionError, ...)
+      end
 
-        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace,
-                                                        error_handler: -> (method:, returning:, exception:) { raise exception })
-      ensure
-        Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, old_client)
+      def emulating_unavailability
+        yield ActiveSupport::Cache::RedisCacheStore.new(
+          namespace: @namespace,
+          middlewares: [MaxClientsReachedRedisMiddleware],
+          error_handler: -> (method:, returning:, exception:) { raise exception },
+        )
       end
   end
 
@@ -443,13 +433,10 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     private
       def emulating_unavailability
-        old_client = Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, UnavailableRedisClient)
-
-        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace)
-      ensure
-        Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, old_client)
+        yield ActiveSupport::Cache::RedisCacheStore.new(
+          namespace: @namespace,
+          middlewares: [UnavailableRedisMiddleware],
+        )
       end
   end
 
@@ -458,28 +445,10 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     private
       def emulating_unavailability
-        old_client = Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, MaxClientsReachedRedisClient)
-
-        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace)
-      ensure
-        Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, old_client)
-      end
-  end
-
-  class FailureSafetyFromRedisClientErrorTest < StoreTest
-    include FailureSafetyBehavior
-
-    private
-      def emulating_unavailability
-        old_client = Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, RedisClientErrorRedisClient)
-
-        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace)
-      ensure
-        Redis.send(:remove_const, :Client)
-        Redis.const_set(:Client, old_client)
+        yield ActiveSupport::Cache::RedisCacheStore.new(
+          namespace: @namespace,
+          middlewares: [MaxClientsReachedRedisMiddleware],
+        )
       end
   end
 
@@ -519,15 +488,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       other_key = SecureRandom.uuid
 
       @cache.write(key, SecureRandom.alphanumeric)
-      @cache.redis.set(other_key, SecureRandom.alphanumeric)
+      @cache.redis.node_for(other_key).call("set", other_key, SecureRandom.alphanumeric)
       @cache.clear
 
       assert_not @cache.exist?(key)
-      assert @cache.redis.exists?(other_key)
-      @cache.redis.del(other_key)
+      r = @cache.redis.node_for(other_key)
+      assert_equal 1, r.call("exists", other_key)
+      r.call("del", other_key)
     end
 
-    test "clear all cache key with Redis::Distributed" do
+    test "clear all cache key with RedisClient::HashRing" do
       cache = ActiveSupport::Cache::RedisCacheStore.new(
         url: REDIS_URLS,
         timeout: 0.1, namespace: @namespace, expires_in: 60)
@@ -564,7 +534,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       @cache.write("foo", "bar")
       @cache.read("foo", delete: true)
       redis_backend do |r|
-        assert_not r.exists?("#{@namespace}:foo")
+        assert_equal 0, r.call("exists", "#{@namespace}:foo")
       end
     end
 


### PR DESCRIPTION
I've been meaning to do this for several years, but `Redis::Distributed` was a blocker. So I implemented `RedisClient.ring` to offer the same feature.

`redis-client` is configured to use RESP2 protocol, so there's no new server requirement compared to the previous version (that being said the first RESP3 release was 6 years ago).

To keep supporting the `redis:` configuration option, I decided to rename the old store as `DeprecatedRedisCacheStore`, to allow for a smoother transition. It does bloat the diff size though.

### Todo

- [x] ~~For now I've removed the `:redis` constructor argument, but I suspect some people do rely on it to pass a Redis cluster client, so I don't think I can actually entirely remove this option.~~
