### PR TITLE
Allow social preview unfurlers to bypass allow_browser blocking

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow known social preview unfurlers to bypass `allow_browser` version blocking.
+
+    Some social preview fetchers present Safari-style user agents that can look
+    older than the `:modern` minimums. We now treat common unfurler tokens
+    (for example `facebookexternalhit`, `twitterbot`, and `MobileSMS`) as
+    bot-like traffic so Open Graph previews are not blocked by 406 responses.
+
+    *Trevor Turk*
+
 *   Add `content_type` option to HTTP authentication methods.
 
     `request_http_basic_authentication`, `request_http_digest_authentication`,

--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -13,6 +13,9 @@ module ActionController # :nodoc:
       # versions specified. This means that all other browsers, as well as agents that
       # aren't reporting a user-agent header, will be allowed access.
       #
+      # Known social preview unfurlers that present older browser user-agents are
+      # also treated as bot traffic and won't be blocked.
+      #
       # A browser that's blocked will by default be served the file in
       # public/406-unsupported-browser.html with an HTTP status code of "406 Not
       # Acceptable".
@@ -74,6 +77,19 @@ module ActionController # :nodoc:
         SETS = {
           modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, ie: false }
         }
+        SOCIAL_PREVIEW_USER_AGENT_TOKENS = %w[
+          applebot
+          discordbot
+          facebot
+          facebookexternalhit
+          linkedinbot
+          mobilesms
+          skypeuripreview
+          slackbot
+          telegrambot
+          twitterbot
+          whatsapp
+        ].freeze
 
         attr_reader :request, :versions
 
@@ -103,7 +119,14 @@ module ActionController # :nodoc:
           end
 
           def bot?
-            parsed_user_agent.bot?
+            parsed_user_agent.bot? || social_preview_unfurler?
+          end
+
+          def social_preview_unfurler?
+            user_agent = request.user_agent.to_s.downcase
+            return false if user_agent.empty?
+
+            SOCIAL_PREVIEW_USER_AGENT_TOKENS.any? { |token| user_agent.include?(token) }
           end
 
           def version_below_minimum_required?

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -29,11 +29,14 @@ class AllowBrowserTest < ActionController::TestCase
 
   CHROME_118    = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118 Safari/537.36"
   CHROME_120    = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36"
+  SAFARI_16_6   = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1"
   SAFARI_17_2_0 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.0 Safari/605.1.15"
   FIREFOX_114   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/114.0"
   IE_11         = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
   OPERA_106     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
   GOOGLE_BOT    = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+  SOCIAL_PREVIEW_FACEBOOK_WITH_OLD_SAFARI = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/601.2.4 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.4 facebookexternalhit/1.1 Facebot Twitterbot/1.0"
+  SOCIAL_PREVIEW_MOBILE_SMS_WITH_OLD_SAFARI = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1 MobileSMS/1.0"
 
   test "blocked browser below version limit with callable" do
     get_with_agent :hello, FIREFOX_114
@@ -65,6 +68,9 @@ class AllowBrowserTest < ActionController::TestCase
     get_with_agent :modern, SAFARI_17_2_0
     assert_response :ok
 
+    get_with_agent :modern, SAFARI_16_6
+    assert_response :upgrade_required
+
     get_with_agent :modern, CHROME_118
     assert_response :upgrade_required
 
@@ -80,6 +86,14 @@ class AllowBrowserTest < ActionController::TestCase
     assert_response :ok
 
     get_with_agent :modern, GOOGLE_BOT
+    assert_response :ok
+  end
+
+  test "social preview unfurlers with old safari user agents are allowed" do
+    get_with_agent :hello, SOCIAL_PREVIEW_FACEBOOK_WITH_OLD_SAFARI
+    assert_response :ok
+
+    get_with_agent :modern, SOCIAL_PREVIEW_MOBILE_SMS_WITH_OLD_SAFARI
     assert_response :ok
   end
 

--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -123,6 +123,8 @@ end
 
 Browsers matched in the hash passed to `versions:` will be blocked if they’re below the versions specified. This means that all other browsers not mentioned in `versions:` (Chrome and Opera in the above example), as well as agents that aren’t reporting a user-agent header, _will be_ allowed access.
 
+Rails also allows known social preview unfurlers (for example iMessage/social bots that include tokens like `facebookexternalhit`, `twitterbot`, or `MobileSMS`) even when their user-agent string otherwise looks like an older blocked browser version.
+
 You can also use `allow_browser` in a given controller and specify actions using `only` or `except`. For example:
 
 ```ruby


### PR DESCRIPTION
## Summary
This PR extends `allow_browser` bot-bypass behavior to include **known social preview unfurlers** that often present Safari-style user agents below `:modern` thresholds.

### What changes
- `ActionController::AllowBrowser::BrowserBlocker#bot?` now returns true when the request UA includes a known social preview token.
- Added Action Pack tests covering:
  - social preview Safari-like unfurler UA passes
  - plain Safari 16.6 still blocked by `:modern`
- Added guide documentation describing this behavior.
- Added Action Pack changelog entry.

## Problem
`allow_browser` currently bypasses blocking when `parsed_user_agent.bot?` is true. That helps many crawlers, but not all social unfurlers.

In practice, some unfurlers (including iMessage/social preview fetches) can send Safari-like user agents that parse as Safari and `bot? == false`, so they are blocked by `:modern` Safari minimums.

That can cause link previews to fail because metadata fetches get a 406 response instead of app HTML/Open Graph tags.

## Reproduction Context
Example UA shapes that can be blocked by `:modern` today:
- Safari-like social preview UA with `facebookexternalhit/facebot/twitterbot` appended
- iMessage-like Safari UA with `MobileSMS/1.0`

These can parse as Safari below minimum version and not as bots.

## Proposed Fix
Inside `BrowserBlocker`, keep existing `useragent` behavior and add a fallback token check for social preview unfurlers:

```ruby
def bot?
  parsed_user_agent.bot? || social_preview_unfurler?
end
```

Token list included in this PR:
- `applebot`
- `discordbot`
- `facebot`
- `facebookexternalhit`
- `linkedinbot`
- `mobilesms`
- `skypeuripreview`
- `slackbot`
- `telegrambot`
- `twitterbot`
- `whatsapp`

## Tests
Updated `actionpack/test/controller/allow_browser_test.rb`:
- keeps existing bot and modern-browser assertions
- adds explicit assertion that plain Safari 16.6 is still blocked by `:modern`
- adds assertion that social-preview Safari-like UAs with unfurler tokens are allowed

## Documentation
- `guides/source/action_controller_advanced_topics.md` now documents that known social preview unfurlers are allowed even when the UA otherwise resembles an older blocked browser.
- `actionpack/CHANGELOG.md` includes the behavior change.

## References
- Rails issue: allow_browser may prevent crawling
  - https://github.com/rails/rails/issues/50981
- Rails PR: Let allow_browser allow bots
  - https://github.com/rails/rails/pull/52531
- Rails issue: default modern threshold confusion
  - https://github.com/rails/rails/issues/52534
- Rails issue: modern filter and emulation/406 friction
  - https://github.com/rails/rails/issues/53576
- Rails PR discussion: bot/crawler edge cases (Lighthouse/PageSpeed)
  - https://github.com/rails/rails/pull/53853
- Current `allow_browser` implementation (main)
  - https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/allow_browser.rb
- useragent Lighthouse bot detection update
  - https://github.com/gshutler/useragent/pull/67
