### PR TITLE
Fix ids_writer when association PK is composite but model PK is scalar

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -65,7 +65,7 @@ module ActiveRecord
         ids = Array(ids).compact_blank
         ids.map! { |id| pk_type.cast(id) }
 
-        records = if klass.composite_primary_key?
+        records = if primary_key.is_a?(Array)
           klass.where(primary_key => ids).index_by do |record|
             primary_key.map { |primary_key| record._read_attribute(primary_key) }
           end

--- a/activerecord/test/cases/associations/composite_association_pk_ids_test.rb
+++ b/activerecord/test/cases/associations/composite_association_pk_ids_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+# Regression test for ids_writer when the association primary key is composite
+# but the target model has a scalar primary key.
+#
+# ThroughReflection#association_primary_key returns an array when the source
+# belongs_to has primary_key: [:col1, :col2]. But CollectionAssociation#ids_writer
+# checked klass.composite_primary_key? (the target model's PK) instead of
+# primary_key.is_a?(Array) to decide which code path to take. When the target
+# model has a scalar PK, it took the scalar branch and crashed.
+class CompositeAssociationPkIdsTest < ActiveRecord::TestCase
+  self.use_transactional_tests = true
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+
+    @connection.create_table :_test_series, force: true do |t|
+      t.string :name
+    end
+
+    @connection.create_table :_test_books, force: true do |t|
+      t.integer :series_id
+      t.string :title
+    end
+
+    @connection.create_table :_test_authorships, force: true do |t|
+      t.integer :series_id
+      t.integer :book_id
+      t.integer :author_id
+    end
+
+    @connection.create_table :_test_authors, force: true do |t|
+      t.string :name
+    end
+
+    Object.const_set(:TestBook, Class.new(ActiveRecord::Base) {
+      self.table_name = "_test_books"
+      self.primary_key = :id
+    })
+
+    Object.const_set(:TestAuthorship, Class.new(ActiveRecord::Base) {
+      self.table_name = "_test_authorships"
+
+      belongs_to :author, class_name: "TestAuthor"
+      belongs_to :book,
+        class_name: "TestBook",
+        primary_key: [:series_id, :id],
+        foreign_key: [:series_id, :book_id]
+    })
+
+    Object.const_set(:TestAuthor, Class.new(ActiveRecord::Base) {
+      self.table_name = "_test_authors"
+
+      has_many :authorships, class_name: "TestAuthorship", foreign_key: :author_id
+      has_many :books, through: :authorships, class_name: "TestBook", source: :book
+    })
+  end
+
+  def teardown
+    %w[TestAuthor TestAuthorship TestBook].each do |name|
+      Object.send(:remove_const, name) if Object.const_defined?(name)
+    end
+
+    @connection.drop_table :_test_authorships, if_exists: true
+    @connection.drop_table :_test_books, if_exists: true
+    @connection.drop_table :_test_series, if_exists: true
+    @connection.drop_table :_test_authors, if_exists: true
+  end
+
+  def test_ids_writer_with_composite_association_pk_and_scalar_model_pk
+    author = TestAuthor.create!(name: "Author")
+    book = TestBook.create!(series_id: 1, title: "Book 1")
+    TestAuthorship.create!(author_id: author.id, series_id: book.series_id, book_id: book.id)
+
+    # Verify: association PK is composite, model PK is scalar
+    reflection = TestAuthor.reflect_on_association(:books)
+    assert_equal ["series_id", "id"], reflection.association_primary_key
+    assert_not TestBook.composite_primary_key?
+
+    # ids_reader returns composite pairs — this is expected
+    ids = author.book_ids
+    assert_equal 1, ids.size
+    assert_kind_of Array, ids.first
+
+    # ids_writer should accept those same composite pairs back without crashing
+    author.book_ids = ids
+    author.reload
+
+    assert_equal ids, author.book_ids
+  end
+end


### PR DESCRIPTION
### Problem

`CollectionAssociation#ids_writer` crashes when the association primary key is composite but the target model has a scalar primary key.

This happens with `has_many :through` when the source `belongs_to` has a composite `primary_key:` option. `ThroughReflection#association_primary_key` returns an array (e.g. `["series_id", "id"]`), but `ids_writer` checks [`klass.composite_primary_key?`](https://github.com/rails/rails/blob/0f4b8ce0e9a0/activerecord/lib/active_record/associations/collection_association.rb#L68) — which reflects the target model's own PK declaration, not the association's. When the target model has a scalar PK, it takes the wrong branch and crashes.

`ids_reader` correctly returns composite pairs. But feeding those same pairs back into `ids_writer` raises `RecordNotFound`:

```ruby
author.book_ids        # => [[1, 42]]  (composite pairs — correct)
author.book_ids = ids  # => RecordNotFound: Couldn't find Book with '["series_id", "id"]'=[1, 42]
```

### Reproduction script

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new("/dev/null")
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :authors, force: true

  create_table :authorships, force: true do |t|
    t.integer :author_id
    t.integer :book_id
    t.integer :series_id
  end

  create_table :books, force: true do |t|
    t.integer :series_id
  end
end

class Book < ActiveRecord::Base
  self.primary_key = :id # scalar!
end

class Authorship < ActiveRecord::Base
  belongs_to :author
  belongs_to :book, primary_key: [:series_id, :id], foreign_key: [:series_id, :book_id]
end

class Author < ActiveRecord::Base
  has_many :authorships
  has_many :books, through: :authorships
end

# Bug: CollectionAssociation#ids_writer crashes when the association primary key
# is composite but the target model has a scalar primary key.
#
# ThroughReflection#association_primary_key returns [:series_id, :id] (from the
# source belongs_to's primary_key option). But ids_writer checks
# klass.composite_primary_key? (Book's own PK, which is scalar :id → false)
# to decide which code path to take. It takes the scalar branch and crashes.
#
# Fix — one line change at:
# https://github.com/rails/rails/blob/0f4b8ce0e9a0/activerecord/lib/active_record/associations/collection_association.rb#L68
#
#   -        records = if klass.composite_primary_key?
#   +        records = if primary_key.is_a?(Array)
#

class BugTest < ActiveSupport::TestCase
  test "ids_writer crashes when association PK is composite but model PK is scalar" do
    author = Author.create!
    book = Book.create!(series_id: 1)
    Authorship.create!(author: author, book_id: book.id, series_id: book.series_id)

    # ids_reader returns composite pairs — this is expected
    ids = author.book_ids
    assert_equal 1, ids.size
    assert_kind_of Array, ids.first

    # ids_writer crashes when given those same composite pairs back
    assert_raises(ActiveRecord::RecordNotFound) do
      author.book_ids = ids
    end
  end
end
```

### Fix

One-line change: `klass.composite_primary_key?` → `primary_key.is_a?(Array)`

`primary_key` is already assigned as `reflection.association_primary_key` at the top of `ids_writer`. Checking whether it's actually an array (rather than asking the model about its own PK) makes the method consistent with what `ids_reader` already does.