### PR TITLE
Fix invalid HTML in routing error template

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
@@ -5,14 +5,12 @@
 <main role="main" id="container">
   <h2><%= h @exception_wrapper.message %></h2>
   <% unless @exception_wrapper.failures.empty? %>
-    <p>
-      <h2>Failure reasons:</h2>
-      <ol>
-      <% @exception_wrapper.failures.each do |route, reason| %>
-        <li><code><%= route.inspect.delete('\\') %></code> failed because <%= reason.downcase %></li>
-      <% end %>
-      </ol>
-    </p>
+    <h2>Failure reasons:</h2>
+    <ol>
+    <% @exception_wrapper.failures.each do |route, reason| %>
+      <li><code><%= route.inspect.delete('\\') %></code> failed because <%= reason.downcase %></li>
+    <% end %>
+    </ol>
   <% end %>
 
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show %>


### PR DESCRIPTION
## Summary
- Remove `<h2>` and `<ol>` tags from inside a `<p>` tag in the routing error rescue template, as these are not valid HTML elements within a paragraph

Per the [HTML spec](https://html.spec.whatwg.org/#the-p-element), `<p>` elements can only contain phrasing content. Block-level elements like `<h2>` and `<ol>` are not permitted inside `<p>` tags and cause implicit paragraph closure, leading to malformed DOM structure.