### PR TITLE
fix: breaking support of different table names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -785,8 +785,29 @@ module ActiveRecord
         end
 
         def extract_table_ref_from_insert_sql(sql)
-          if sql =~ /into\s("[-A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im
-            $1.delete('"').strip
+          quoted_ident  = /"(?:[^"]|"")*"/
+          bracket_ident = /\[(?:[^\]]|\]\])*\]/
+          bare_ident    = /[-A-Za-z0-9_]+/
+          ident_part    = /(?:#{quoted_ident.source}|#{bracket_ident.source}|#{bare_ident.source})/
+
+          into_target = /
+            \binto\s+
+            (?:
+              (?<qualified>#{ident_part.source}(?:\.#{ident_part.source})+) |
+              (?<single_quoted>#{quoted_ident.source}) |
+              (?<single_plain>#{bracket_ident.source}|#{bare_ident.source})
+            )
+            (?=\s|$|[,(;])
+          /imx
+
+          if (m = sql.match(into_target))
+            if m[:qualified]
+              m[:qualified].strip
+            elsif m[:single_quoted]
+              m[:single_quoted][1..-2].gsub('""', '"').strip
+            else
+              m[:single_plain].strip
+            end
           end
         end
     end

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -22,9 +22,47 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     assert_not_nil return_the_inserted_id(method: :create)
   end
 
-  def test_extract_table_ref_from_insert_sql_with_hyphen_in_table_name
-    sql = "INSERT INTO \"table-with-hyphen\" (column1, column2) VALUES (value1, value2)"
-    assert_equal "table-with-hyphen", @connection.send(:extract_table_ref_from_insert_sql, sql)
+  def test_extract_table_ref_from_insert_sql_with_quoting
+    [
+      "table-name",
+      "table with space",
+      "a" * 120, # long name
+      "таблица",
+      "日本語テーブル",
+      "clientes_ñ",
+      "select",
+      "table""with""quotes",
+      "table/with\\special",
+    ].each do |valid_table_name|
+      sql = "INSERT INTO \"#{valid_table_name}\" (column1, column2) VALUES (value1, value2)"
+
+      assert_equal valid_table_name, @connection.send(:extract_table_ref_from_insert_sql, sql)
+    end
+  end
+
+  def test_extract_table_ref_from_insert_sql_without_quoting
+    [
+      "table_name",
+      "[dbo].[users]",
+      "[users]",
+      "[My Table]",
+      "[dbo].[My Table]",
+      "[catalog].[schema].[table]",
+      "[test-table]",
+      "[select]",
+      "[таблица]",
+      "[table[with]]brackets]",
+      "[dbo].[test-table with spaces]",
+      "[dbo].[bracket]]name]",
+      "dbo.users",
+      "catalog.schema.table",
+      "schema1.table123",
+      '"public"."table"'
+    ].each do |valid_table_name|
+      sql = "INSERT INTO #{valid_table_name} (column1, column2) VALUES (value1, value2)"
+
+      assert_equal valid_table_name, @connection.send(:extract_table_ref_from_insert_sql, sql)
+    end
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

Hi, during our upgrade from Rails 7.0 to Rails 8.0 (and even Rails 8.1 and greater, though with different behavior), we noticed a **breaking change** in ActiveRecord.

Similar fix was already merged: https://github.com/rails/rails/pull/56828

Copying the reproducing step below:

The following code should reproduce the broken flow:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", "~> 8.0.0"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

# This connection will do for database-independent bug reports.
ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table "table-with-hyphen", force: true do |t|
  end
end

class BugTest < ActiveSupport::TestCase
  def test_insert_exec
    assert_nothing_raised do
      ActiveRecord::Base.connection.exec_insert("INSERT INTO [select] DEFAULT VALUES")
    end
  end
end
```

### Detail

In this Pull Request, we add support for many missing table names across different adapters (e.g., MSSQL) when quoted properly. 

### Additional information

Adding the following code to the example script makes it green.
Related commit: https://github.com/rails/rails/commit/9bbbf4b8b9bf3d7cb31c0425a6646cec49e4bc6c

Previously, `exec_insert` didn't try to derive private keys from the schema via parsing the table name from the SQL query. 

```ruby
# Rails 8.0 throws an error as primary_key for unknown table_ref raises an error
pk = primary_key(table_ref) if table_ref
```

I see that in main, we try to hit the schema cache instead, and return an empty private key, which is okay, though the returning statement is missing from the final SQL when it is expected to be there with a proper table name.   

```ruby
# in main branch, we access the cache, which is not throwning error when the table name is missing
pk = schema_cache.primary_keys(table_ref) if table_ref
```

```ruby
module ActiveRecord
  module ConnectionAdapters
    module DatabaseStatements
      def extract_table_ref_from_insert_sql(sql)
        if sql =~ /into\s((?:"(?:[^"]|"")+")|(?:\[(?:[^\]]|\]\])*\](?:\.\[(?:[^\]]|\]\])*\])*)|(?:[-A-Za-z0-9_.\[\]]+))\s*/im
          $1.gsub(/\A"|"\z/, "").gsub('""', '"').strip
        end
      end
    end
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
