### PR TITLE
Rewrite Layouts and Rendering guide

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -53,9 +53,35 @@ end
 Given the above `ClientsController`, if a user goes to `/clients/new` in your
 application to add a new client, Rails will create an instance of
 `ClientsController` and call its `new` method. If the `new` method is empty, Rails
-will automatically render the `new.html.erb` view by default.
+will automatically render `app/views/clients/new.html.erb` by default.
 
 NOTE: The `new` method is an instance method here, called on an instance of `ClientsController`. This should not be confused with the `new` class method (i.e., `ClientsController.new`).
+
+You can explicity define the template to render using the `render` method:
+
+```ruby
+class ClientsController < ApplicationController
+  def new
+    # Renders `app/views/clients/form.html.erb`
+    render "form"
+  end
+end
+```
+
+To enable rendering of additional formats, not just HTML, use a `respond_to` block. This will choose the correct template based on the `Accept` header in the HTTP request:
+
+```ruby
+class ClientsController < ApplicationController
+  def new
+    respond_to do |format|
+      format.html   # renders `app/views/clients/new.html.erb`
+      format.xml    # renders `app/views/clients/new.xml.erb`
+    end
+  end
+end
+```
+
+See the [Layouts and Rendering](layouts_and_rendering.html) guide for futher details.
 
 In the `new` method, the controller would typically create an instance of the
 `Client` model, and make it available as an instance variable called `@client`
@@ -139,7 +165,7 @@ class ClientsController < ApplicationController
     if @client.save
       redirect_to @client
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 end
@@ -1233,54 +1259,6 @@ access to the various parameters.
 [`path_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html#method-i-path_parameters
 [`query_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-query_parameters
 [`request_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters
-
-#### `request.variant`
-
-Controllers might need to tailor a response based on context-specific
-information in a request. For example, controllers responding to requests from a
-mobile platform might need to render different content than requests from a
-desktop browser. One strategy to accomplish this is by customizing a request's
-variant. Variant names are arbitrary, and can communicate anything from the
-request's platform (`:android`, `:ios`, `:linux`, `:macos`, `:windows`) to its
-browser (`:chrome`, `:edge`, `:firefox`, `:safari`), to the type of user
-(`:admin`, `:guest`, `:user`).
-
-You can set the [`request.variant`](https://api.rubyonrails.org/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-variant-3D) in a `before_action`:
-
-```ruby
-request.variant = :tablet if request.user_agent.include?("iPad")
-```
-
-Responding with a variant in a controller action is like responding with a format:
-
-```ruby
-# app/controllers/projects_controller.rb
-
-def show
-  # ...
-  respond_to do |format|
-    format.html do |html|
-      html.tablet                         # renders app/views/projects/show.html+tablet.erb
-      html.phone { extra_setup; render }  # renders app/views/projects/show.html+phone.erb
-    end
-  end
-end
-```
-
-A separate template should be created for each format and variant:
-
-* `app/views/projects/show.html.erb`
-* `app/views/projects/show.html+tablet.erb`
-* `app/views/projects/show.html+phone.erb`
-
-You can also simplify the variants definition using the inline syntax:
-
-```ruby
-respond_to do |format|
-  format.html.tablet
-  format.html.phone  { extra_setup; render }
-end
-```
 
 ### The `response` Object
 

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -247,17 +247,21 @@ method within the view:
 ```
 
 This will look for a file named `_product.html.erb` in the same folder to render
-within that view. Partial file names start with leading underscore character by
+within that view. If no such file exists, Rails will look for it under the
+`app/view/application/` folder. This makes `app/views/application/` a great
+place for your shared partials
+
+Partial file names start with leading underscore character by
 convention. The file name distinguishes partials from regular views. However, no
 underscore is used when referring to partials for rendering within a view. This
 is true even when you reference a partial from another directory:
 
 ```erb
-<%= render "application/product" %>
+<%= render "admin/control_panel" %>
 ```
 
-That code will look for and display a partial file named `_product.html.erb` in
-`app/views/application/`.
+That code will look for and render a partial named `_control_panel.html.erb` in
+`app/views/admin/`.
 
 ### Using Partials to Simplify Views
 
@@ -399,6 +403,7 @@ You can also use this shorthand based on conventions:
 This will look for a partial named `_product.html.erb` in `app/views/products/`,
 as well as pass a local named `product` set to the value `@product`.
 
+NOTE: Under the hood, Rails calls `to_partial_path` on the model to determine which partial to render. You can override this method to customize the partial if required.
 
 ### The `as` and `object` Options
 
@@ -476,19 +481,40 @@ variable named after the partial. In this case, since the partial is
 `_product.html.erb`, you can use `product` to refer to the collection member
 that is being rendered.
 
-You can also use the following conventions based shorthand syntax for rendering
-collections.
+When the collection you wish to render contains objects that respond to `to_partial_path`,
+such as Active Record and Active Model instances, you can use the following shorthand:
 
-```erb
+```html+erb
 <%= render @products %>
 ```
 
-The above assumes that `@products` is a collection of `Product` instances. Rails
-uses naming conventions to determine the name of the partial to use by looking
-at the model name in the collection, `Product` in this case. In fact, you can
-even render a collection made up of instances of different models using this
-shorthand, and Rails will choose the proper partial for each member of the
-collection.
+Rails determines the partial for each object by calling `to_partial_path` on it.
+Conventionally, for Active Record objects, this is the name of the model:
+`products/_product.html.erb` for `Product`.
+
+A collection can be composed of different types of objects and Rails will render
+the corresponding partial for each one.
+
+```html+erb
+<%# customers/_customer.html.erb -%>
+<p>Customer: <%= customer.name %></p>
+
+<%# employees/_employee.html.erb -%>
+<p>Employee: <%= employee.name %></p>
+
+<%# index.html.erb -%>
+<h1>Contacts</h1>
+
+<%# Rails will render the matching partial for customer and employee objects -%>
+<%= render [customer1, employee1, customer2, employee2] %>
+```
+
+If the collection is empty, `render` will return nil so you can define a fallback.
+
+```html+erb
+<h1>Products</h1>
+<%= render(@products) || "There are no products available." %>
+```
 
 ### Spacer Templates
 
@@ -502,31 +528,31 @@ main partial by using the `:spacer_template` option:
 Rails will render the `_product_ruler.html.erb` partial (with no data passed to
 it) between each pair of `_product.html.erb` partials.
 
-### Counter Variables
+### Metadata Variables
 
-Rails also makes a counter variable available within a partial called by the
-collection. The variable is named after the title of the partial followed by
-`_counter`. For example, when rendering a collection `@products` the partial
-`_product.html.erb` can access the variable `product_counter`. The variable
-indexes the number of times the partial has been rendered within the enclosing
-view, starting with a value of `0` on the first render.
+Rails injects two additional variables into each partial when rendering
+a collection: `<object>_counter` and `<object>_iteration`.
 
-```erb
-<%# index.html.erb %>
-<%= render partial: "product", collection: @products %>
+```html+erb
+<%# app/views/products/index.html.erb -%>
+<%= render @products %>
+
+<%# app/views/products/_product.html.erb -%>
+<ul>
+  <li>Counter: <%= product_counter %></li>
+  <li>Iteration: <%= product_iteration %></li>
+</ul>
 ```
 
-```erb
-<%# _product.html.erb %>
-<%= product_counter %> # 0 for the first product, 1 for the second product...
-```
+The `product_counter` is the index of the element being rendered within the collection.
+The `product_iteration` is an instance of [`ActionView::PartialIteration`](https://api.rubyonrails.org/classes/ActionView/PartialIteration.html) which can be used to determine if it's the
+first or last element in the collection.
 
-This also works when the local variable name is changed using the `as:` option.
-So if you did `as: :item`, the counter variable would be `item_counter`.
+When using the `as:` option, these variable names will also change.
+For example, using `as: :item` will create variables
+called `item_counter` and `item_iteration`.
 
-NOTE: When rendering collections with instances of different models, the counter variable increments for each partial, regardless of the class of the model being rendered.
-
-Note: The following two sections, [Strict Locals](#strict-locals) and [Local
+NOTE: The following two sections, [Strict Locals](#strict-locals) and [Local
 Assigns with Pattern Matching](#local-assigns-with-pattern-matching) are more
 advanced features of using partials, included here for completeness.
 
@@ -607,11 +633,11 @@ enables compact partial-local default variable assignments:
 ### Strict Locals
 
 Action View partials are compiled into regular Ruby methods under the hood.
-Because it is impossible in Ruby to dynamically create local variables, every single combination of `locals` passed to
-a partial requires compiling another version:
+Because it is impossible in Ruby to dynamically create local variables, every single combination of `locals` passed to a partial requires compiling another version:
 
 ```html+erb
-<%# app/views/articles/show.html.erb %>
+<!-- app/views/articles/show.html.erb -->
+
 <%= render partial: "article", layout: "box", locals: { article: @article } %>
 <%= render partial: "article", layout: "box", locals: { article: @article, theme: "dark" } %>
 ```
@@ -643,7 +669,7 @@ values, and more with a `locals:` signature, using the same syntax as Ruby metho
 Here are some examples of the `locals:` signature:
 
 ```html+erb
-<%# app/views/messages/_message.html.erb %>
+<!-- app/views/messages/_message.html.erb -->
 
 <%# locals: (message:) -%>
 <%= message %>
@@ -661,7 +687,7 @@ If a default value is set then it can be used if `message` is not passed in
 `locals:`:
 
 ```erb
-<%# app/views/messages/_message.html.erb %>
+<!-- app/views/messages/_message.html.erb -->
 
 <%# locals: (message: "Hello, world!") -%>
 <%= message %>
@@ -686,8 +712,7 @@ You can allow optional local variable arguments with the double splat `**`
 operator:
 
 ```erb
-
-<%# app/views/messages/_message.html.erb %>
+<!-- app/views/messages/_message.html.erb -->
 
 <%# locals: (message: "Hello, world!", **attributes) -%>
 <%= tag.p(message, **attributes) %>
@@ -696,7 +721,7 @@ operator:
 Or you can disable `locals` entirely by setting the `locals:` to empty `()`:
 
 ```erb
-<%# app/views/messages/_message.html.erb %>
+<!-- app/views/messages/_message.html.erb -->
 
 <%# locals: () %>
 ```
@@ -708,6 +733,8 @@ exception:
 render "messages/message", unknown_local: "will raise"
 # => ActionView::Template::Error: no locals accepted for app/views/messages/_message.html.erb
 ```
+
+WARNING: When using strict locals in conjunction with collection rendering, you need to explicity allow the `<object>_counter` and `<object>_iteration` variables or they will not be set: `<%# locals: (product_counter: nil, product_iteration: nil)`. The `nil` default values are needed so the partial doesn't break when rendered outside of collections, where these two variables will not be set.
 
 Action View will process the `locals:` signature in any templating engine
 that supports `#`-prefixed comments, and will read the signature from any
@@ -747,7 +774,7 @@ example, rendering actions from the `ProductsController` class will use
 
 Rails will use `app/views/layouts/application.html.erb` if a controller-specific layout does not exist.
 
-Here is an example of a simple layout in `application.html.erb` file:
+Here is an example of a basic layout in `application.html.erb` file:
 
 ```html+erb
 <!DOCTYPE html>
@@ -779,9 +806,156 @@ Here is an example of a simple layout in `application.html.erb` file:
 In the above example layout, view content will be rendered in place of `<%=
 yield %>`, and surrounded by the same `<head>`, `<nav>`, and `<footer>` content.
 
-Rails provides more ways to assign specific layouts to individual controllers
-and actions. You can learn more about layouts in general in the [Layouts and
-Rendering in Rails](layouts_and_rendering.html) guide.
+To learn more about controller-specific layouts, see the [Layouts and
+Rendering in Rails](layouts_and_rendering.html#setting_layouts_in_controllers) guide.
+
+### Structuring Layouts
+
+Layouts can provide one or more slots into which views can render content. They can also incorporate partials just like regular views to offer better structure.
+
+Slots can be defined using `yield` and [`content_for`][].
+
+[`content_for`]: https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-content_for
+
+#### Understanding `yield`
+
+Within a layout, `yield` provides the slot where content from the view should be inserted.
+
+```html+erb
+<html>
+  <head>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>
+```
+
+You can also create a layout with multiple yielding regions:
+
+```html+erb
+<html>
+  <head>
+    <%= yield :head %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>
+```
+
+The main body of the view will always render into the unnamed `yield`. To render content into a named `yield`, call `content_for` with the same argument as the named `yield`.
+
+#### Slotting content with `content_for`
+
+The [`content_for`][] method allows you to insert content into a named `yield` block in your layout. For example, consider following layout and view:
+
+```html+erb
+<html>
+  <head>
+    <title>The page title</title>
+  </head>
+  <body>
+    <header>
+      <%= yield :header %>
+    </header>
+
+    <main>
+      <%= yield %>
+    </main>
+  </body>
+</html>
+```
+
+```html+erb
+<% content_for :header do %>
+  <h1>A simple page</h1>
+<% end %>
+
+<p>Hello, Rails!</p>
+```
+
+This will render out:
+
+```html
+<html>
+  <head>
+    <title>The page title</title>
+  </head>
+  <body>
+    <header>
+      <h1>A simple page</h1>
+    </header>
+    <main>
+      <p>Hello, Rails!</p>
+    </main>
+  </body>
+</html>
+```
+
+You can also use `content_for` in the layout instead of `yield`, using a check to inquire whether content for that particular slot was provided:
+
+```html+erb
+<html>
+  <head>
+    <title>The page title</title>
+  </head>
+  <body>
+    <header>
+      <%= content_for :header if content_for?(:header) %>
+    </header>
+
+    <main>
+      <%= yield %>
+    </main>
+  </body>
+</html>
+```
+
+This example is functionally equivalent to the previous one where we used `yield :head`.
+
+TIP: The `content_for` method is very helpful when your layout contains distinct regions such as sidebars and footers that should get their own blocks of content inserted. It's also useful for inserting page-specific JavaScript and CSS, context-specific `<meta>` elements, or any other elements into an otherwise generic layout.
+
+#### Nested Layouts
+
+Layouts can inherit from other layouts when you need to make minor changes for certain controllers. Let's say your application has an _admin_ area which displays an extra _admin panel_ but the rest of the layout is the same.
+
+Instead of duplicating your `application.html.erb` layout with the addition of the admin panel, you can create an `admin.html.erb` layout which inherits from `application.html.erb`.
+
+```html+erb
+<%# app/views/layouts/application.html.erb -%>
+
+<html>
+  <%# ... -%>
+  <body>
+    <header>
+      <nav>Navigation menu items here</nav>
+    </header>
+
+    <main>
+      <% if content_for(:main) -%>
+        <%= yield :content %>
+      <% else %>
+        <%= yield %>
+      <% end %>
+    </main>
+  </body>
+</html>
+```
+
+```html+erb
+<%# app/views/layouts/admin.html.erb -%>
+
+<% content_for :main do %>
+  <aside>Admin panel goes here</aside>
+
+  <%= yield %>
+<% end %>
+
+<%= render template: "layouts/application" %>
+```
+
+You can then set all the controllers serving the _admin area_ of the application to layout using `admin.html.erb`, and your view code remains DRY.
 
 ### Partial Layouts
 

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -3,61 +3,67 @@
 Layouts and Rendering in Rails
 ==============================
 
-This guide covers the basic layout features of Action Controller and Action View.
+This guide covers the rendering features of Action Controller and its relationship with Action View.
 
 After reading this guide, you will know:
 
 * How to use the various rendering methods built into Rails.
-* How to create layouts with multiple content sections.
-* How to use partials to DRY up your views.
-* How to use nested layouts (sub-templates).
+* How to render views in multiple formats and variants.
+* How to send HTTP redirect responses.
+* How to set the layout in Rails controllers.
 
 --------------------------------------------------------------------------------
 
-Overview: How the Pieces Fit Together
--------------------------------------
+Introduction
+------------
 
-This guide focuses on the interaction between Controller and View in the Model-View-Controller triangle. As you know, the Controller is responsible for orchestrating the whole process of handling a request in Rails, though it normally hands off any heavy code to the Model. But then, when it's time to send a response back to the user, the Controller hands things off to the View. It's that handoff that is the subject of this guide.
+This guide focuses on the relationship between the **Controller** and the **View**, and the process of rendering a response to send back to the client. It assumes a basic understanding of [HTTP requests and responses](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Overview), [Action View](action_view_overview.html), [Rails controller conventions](action_controller_overview.html), and [Rails routing](routing.html).
 
-In broad strokes, this involves deciding what should be sent as the response and calling an appropriate method to create that response. If the response is a full-blown view, Rails also does some extra work to wrap the view in a layout and possibly to pull in partial views. You'll see all of those paths later in this guide.
+The controller is responsible for orchestrating how an HTTP request is handled in Rails. It reads the parameters from an incoming request, then hands off to the model layer for any complex business logic. Finally, it hands off to the view to send a response back to the user.
 
-Creating Responses
-------------------
+There are four ways to create an HTTP response in a Rails controller:
 
-From the controller's point of view, there are three ways to create an HTTP response:
-
-* Call [`render`][controller.render] to create a full response to send back to the browser
-* Call [`redirect_to`][] to send an HTTP redirect status code to the browser
-* Call [`head`][] to create a response consisting solely of HTTP headers to send back to the browser
+* [`render`][controller.render] to create a full response with a body, usually with a `2xx` status code.
+* [`redirect_to`][] to redirect the user to another path using an HTTP redirect status code.
+* [`respond_to`][] to enable rendering of multiple formats based on the HTTP request's `Accept` header.
+* [`head`][] to create a response consisting solely of HTTP headers without a body.
 
 [controller.render]: https://api.rubyonrails.org/classes/ActionController/Rendering.html#method-i-render
 [`redirect_to`]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
 [`head`]: https://api.rubyonrails.org/classes/ActionController/Head.html#method-i-head
+[`respond_to`]: https://api.rubyonrails.org/classes/ActionController/MimeResponds.html#method-i-respond_to
 
-### Rendering by Default: Convention Over Configuration in Action
+`render`ing Responses
+---------------------
 
-You've heard that Rails promotes "convention over configuration". Default rendering is an excellent example of this. By default, controllers in Rails automatically render views with names that correspond to valid routes. For example, if you have this code in your `BooksController` class:
+The majority of responses in your Rails application will likely be created using the [`render`][controller.render] method. It's used to create a fully-formed response with a body which usually contains an HTML document.
+
+### The Basics
+
+Consider the below controller class and the route pointing to it. We also have a view for the `index` action.
 
 ```ruby
+# app/controllers/books_controller.rb
+
 class BooksController < ApplicationController
 end
 ```
 
-And the following in your routes file:
-
 ```ruby
+# config/routes.rb
+
 resources :books
 ```
 
-And you have a view file `app/views/books/index.html.erb`:
-
 ```html+erb
+<%# app/views/books/index.html.erb -%>
+
 <h1>Books are coming soon!</h1>
 ```
 
-Rails will automatically render `app/views/books/index.html.erb` when you navigate to `/books` and you will see "Books are coming soon!" on your screen.
+Navigating to `/books` will render the heading "Books are coming soon!". This works due to Rails conventions. We don't even need to define an `index` method in the controller — it is implicit.
 
-However, a coming soon screen is only minimally useful, so you will soon create your `Book` model and add the index action to `BooksController`:
+Next, we define the `index` action and load all `Book` records from our database to render in the view.
 
 ```ruby
 class BooksController < ApplicationController
@@ -67,18 +73,16 @@ class BooksController < ApplicationController
 end
 ```
 
-Note that we don't have explicit render at the end of the index action in accordance with "convention over configuration" principle. The rule is that if you do not explicitly render something at the end of a controller action, Rails will automatically look for the `action_name.html.erb` template in the controller's view path and render it. So in this case, Rails will render the `app/views/books/index.html.erb` file.
-
-If we want to display the properties of all the books in our view, we can do so with an ERB template like this:
+The view to display all the books might look like:
 
 ```html+erb
-<h1>Listing Books</h1>
+<h1>Books</h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Content</th>
+      <th>Name</th>
+      <th>Synopsis</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -86,8 +90,8 @@ If we want to display the properties of all the books in our view, we can do so 
   <tbody>
     <% @books.each do |book| %>
       <tr>
-        <td><%= book.title %></td>
-        <td><%= book.content %></td>
+        <td><%= book.name %></td>
+        <td><%= book.synopsis %></td>
         <td><%= link_to "Show", book %></td>
         <td><%= link_to "Edit", edit_book_path(book) %></td>
         <td><%= link_to "Destroy", book, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %></td>
@@ -101,258 +105,254 @@ If we want to display the properties of all the books in our view, we can do so 
 <%= link_to "New book", new_book_path %>
 ```
 
-NOTE: The actual rendering is done by nested classes of the module [`ActionView::Template::Handlers`](https://api.rubyonrails.org/classes/ActionView/Template/Handlers.html). This guide does not dig into that process, but it's important to know that the file extension on your view controls the choice of template handler.
+We'll now see this table at `/books`. We don't need to explicitly call `render` in the action. The `index` action implicitly renders the `index.html.erb` template.
 
-### Using `render`
+### Rendering Templates
 
-In most cases, the controller's [`render`][controller.render] method does the heavy lifting of rendering your application's content for use by a browser. There are a variety of ways to customize the behavior of `render`. You can render the default view for a Rails template, or a specific template, or a file, or inline code, or nothing at all. You can render text, JSON, or XML. You can specify the content type or HTTP status of the rendered response as well.
-
-TIP: If you want to see the exact results of a call to `render` without needing to inspect it in a browser, you can call `render_to_string`. This method takes exactly the same options as `render`, but it returns a string instead of sending a response back to the browser.
-
-#### Rendering an Action's View
-
-If you want to render the view that corresponds to a different template within the same controller, you can use `render` with the name of the view:
+When you want to render a different template within a controller action, or set the HTTP response code, you'll need to explicitly call `render`.
 
 ```ruby
 def update
   @book = Book.find(params[:id])
   if @book.update(book_params)
-    redirect_to(@book)
+    redirect_to @book
   else
-    render "edit"
+    render "edit", status: :unprocessable_content
   end
 end
 ```
 
-If the call to `update` fails, calling the `update` action in this controller will render the `edit.html.erb` template belonging to the same controller.
-
-If you prefer, you can use a symbol instead of a string to specify the action to render:
+You can also use a symbol instead of a string to specify the name of the template:
 
 ```ruby
-def update
-  @book = Book.find(params[:id])
-  if @book.update(book_params)
-    redirect_to(@book)
-  else
-    render :edit, status: :unprocessable_entity
-  end
-end
+render :edit, status: :unprocessable_content
 ```
 
-#### Rendering an Action's Template from Another Controller
+If you wish to be more explicit, you can use the `action:` option:
 
-What if you want to render a template from an entirely different controller from the one that contains the action code? You can also do that with `render`, which accepts the full path (relative to `app/views`) of the template to render. For example, if you're running code in an `AdminProductsController` that lives in `app/controllers/admin`, you can render the results of an action to a template in `app/views/products` this way:
+```ruby
+render action: :edit, status: :unprocessable_content
+```
+
+NOTE: We render with the HTTP status `303 Unprocessable Content` in the above example since it's the idiomatically correct HTTP response code for a form submission error. It's also required by the [Turbo](https://turbo.hotwired.dev) JavaScript library which Rails includes by default.
+
+To render a template which belongs to a different controller, you can use its relative path from the `app/views/` directory. For example, to render `app/views/products/show.html.erb` from the `BooksController`, you'd invoke:
 
 ```ruby
 render "products/show"
 ```
 
-Rails knows that this view belongs to a different controller because of the embedded slash character in the string. If you want to be explicit, you can use the `:template` option (which was required on Rails 2.2 and earlier):
+Optionally, you can include the `template:` keyword argument:
 
 ```ruby
 render template: "products/show"
 ```
 
-#### Wrapping it up
+### Template Lookup Hierarcy
 
-The above two ways of rendering (rendering the template of another action in the same controller, and rendering the template of another action in a different controller) are actually variants of the same operation.
-
-In fact, in the `BooksController` class, inside of the update action where we want to render the edit template if the book does not update successfully, all of the following render calls would all render the `edit.html.erb` template in the `views/books` directory:
+When there isn't an explicit call to `render`, Rails follows the controller's inheritance chain to find the appropriate template. Consider the below controllers:
 
 ```ruby
-render :edit
-render action: :edit
-render "edit"
-render action: "edit"
-render "books/edit"
-render template: "books/edit"
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+end
+
+# app/controllers/admin_controller.rb
+class AdminController < ApplicationController
+end
+
+# app/controllers/admin/products_controller.rb
+class Admin::ProductsController < AdminController
+  def index
+  end
+end
 ```
 
-Which one you use is really a matter of style and convention, but the rule of thumb is to use the simplest one that makes sense for the code you are writing.
+The lookup order for an `admin/products#index` action will be:
 
-#### Using `render` with `:inline`
+* `app/views/admin/products/index.html.erb`
+* `app/views/admin/index.html.erb`
+* `app/views/application/index.html.erb`
 
-The `render` method can do without a view completely, if you're willing to use the `:inline` option to supply ERB as part of the method call. This is perfectly valid:
+### Inline `render`ing
 
-```ruby
-render inline: "<% products.each do |p| %><p><%= p.name %></p><% end %>"
-```
+The `render` method can be used to define the response body within the controller itself. This technique can be used to render reponses in a variety of formats such as _plain text_, _JSON_, _XML_ etc.
 
-WARNING: There is seldom any good reason to use this option. Mixing ERB into your controllers defeats the MVC orientation of Rails and will make it harder for other developers to follow the logic of your project. Use a separate erb view instead.
+A key difference when rendering inline is that the response is rendered without a [layout](action_view_overview.html#layouts) by default. For HTML and plain text responses, you can use the `layout:` option to explicity define a layout template; but, all other formats have [custom renderers](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/renderers.rb#L169) which don't incorporate a layout.
 
-By default, inline rendering uses ERB. You can force it to use Builder instead with the `:type` option:
+Let's look at some examples to understand what this means.
 
-```ruby
-render inline: "xml.p {'Horrid coding practice!'}", type: :builder
-```
+#### HTML
 
-#### Rendering Text
-
-You can send plain text - with no markup at all - back to the browser by using
-the `:plain` option to `render`:
-
-```ruby
-render plain: "OK"
-```
-
-TIP: Rendering pure text is most useful when you're responding to Ajax or web
-service requests that are expecting something other than proper HTML.
-
-NOTE: By default, if you use the `:plain` option, the text is rendered without
-using the current layout. If you want Rails to put the text into the current
-layout, you need to add the `layout: true` option and use the `.text.erb`
-extension for the layout file.
-
-#### Rendering HTML
-
-You can send an HTML string back to the browser by using the `:html` option to
-`render`:
+Use the `html:` option to render an HTML string inline.
 
 ```ruby
 render html: helpers.tag.strong("Not Found")
 ```
 
-TIP: This is useful when you're rendering a small snippet of HTML code.
-However, you might want to consider moving it to a template file if the markup
-is complex.
+The response will be rendered without a layout by default. Use the `layout:` option render within a layout template:
 
-NOTE: When using `html:` option, HTML entities will be escaped if the string is not composed with `html_safe`-aware APIs.
+```ruby
+# Renders within the default layout for the controller, usually: `app/views/layouts/application.html.erb`.
+render html: helpers.tag.strong("Not Found"), layout: true
 
-#### Rendering JSON
+# Explitly define rendering within the `app/views/layouts/admin.html.erb` layout template.
+render html: helpers.tag.strong("Not Found"), layout: "admin"
+```
 
-JSON is a JavaScript data format used by many Ajax libraries. Rails has built-in support for converting objects to JSON and rendering that JSON back to the browser:
+NOTE: There's rarely a good reason to do this in practice. Use a template file to render HTML responses.
+
+WARNING: When using `html:` option, HTML entities will be escaped if the string is not composed with `html_safe`-aware APIs.
+
+#### Plain Text
+
+You can send plain text - with no markup at all - back to the browser:
+
+```ruby
+render plain: "OK"
+```
+
+To wrap this response in layout, you'll need a `.text.erb` layout file and then use the `layout:` option:
+
+```ruby
+# Inserts the text "OK" into the controller's default layout, usually:
+# `app/views/layouts/application.text.erb`
+render plain: "OK", layout: true
+
+# Inserts the text "OK" into `app/views/layouts/plain_text_wrapper.text.erb`
+render plain: "OK", layout: "plain_text_wrapper"
+```
+
+TIP: Rendering text is most useful when you're responding to Ajax or web service requests that are expecting something other than HTML.
+
+#### JSON
+
+Use the `json:` option to format JSON reponses. It will automatically call `to_json` on any object passed into it.
 
 ```ruby
 render json: @product
 ```
 
-TIP: You don't need to call `to_json` on the object that you want to render. If you use the `:json` option, `render` will automatically call `to_json` for you.
+#### XML
 
-#### Rendering XML
-
-Rails also has built-in support for converting objects to XML and rendering that XML back to the caller:
+XML can be rendered with the `xml:` option. Any object passed in will be converted to XML using `to_xml`
 
 ```ruby
 render xml: @product
 ```
 
-TIP: You don't need to call `to_xml` on the object that you want to render. If you use the `:xml` option, `render` will automatically call `to_xml` for you.
+#### Raw Body
 
-#### Rendering Vanilla JavaScript
-
-Rails can render vanilla JavaScript:
-
-```ruby
-render js: "alert('Hello Rails');"
-```
-
-This will send the supplied string to the browser with a MIME type of `text/javascript`.
-
-#### Rendering Raw Body
-
-You can send a raw content back to the browser, without setting any content
-type, by using the `:body` option to `render`:
+You can create a response using a raw string using the `body:` option:
 
 ```ruby
 render body: "raw"
 ```
 
-TIP: This option should be used only if you don't care about the content type of
-the response. Using `:plain` or `:html` might be more appropriate most of the
-time.
+WARNING: There's unlikely to be a practical scenario where this option fits the bill.
+Use one of the alternate rendering options such as JSON or XML to create stucturally sound reponses
+and all the security benefits that come with it.
 
-NOTE: Unless overridden, your response returned from this render option will be
-`text/plain`, as that is the default content type of Action Dispatch response.
+#### Files
 
-#### Rendering Raw File
+Rails can render a file from an absolute path. This is useful for rendering static files like error pages. ERB and other templating engines are not supported.
 
-Rails can render a raw file from an absolute path. This is useful for
-conditionally rendering static files like error pages.
+```ruby
+render file: "#{Rails.root}/public/404.html"
+```
+
+If a layout file matching the file's format exists, it will be rendered within that layout by default. For example, the above example will render the `404.html` page within the `app/views/layouts/application.html.erb` layout. This can be disabled using `layout: false`:
 
 ```ruby
 render file: "#{Rails.root}/public/404.html", layout: false
 ```
 
-This renders the raw file (it doesn't support ERB or other handlers). By
-default it is rendered within the current layout.
-
 WARNING: Using the `:file` option in combination with users input can lead to security problems
 since an attacker could use this action to access security sensitive files in your file system.
 
-TIP: `send_file` is often a faster and better option if a layout isn't required.
+TIP: [`send_file`](action_controller_advanced_topics.html#sending-files) is often a faster and better option if a layout isn't required.
 
 #### Rendering Objects
 
-Rails can render objects responding to `#render_in`. The format can be controlled by defining `#format` on the object.
+Rails can render objects responding to `render_in`. The format is defined by a `format` method on the object.
 
 ```ruby
 class Greeting
+  include ActionView::Helpers::TagHelper
+
   def render_in(view_context)
-    view_context.render html: "Hello, World"
+    view_context.render html: tag.h1("Hello, world")
   end
 
   def format
     :html
   end
 end
-
-render Greeting.new
-# => "Hello World"
 ```
 
-This calls `render_in` on the provided object with the current view context. You can also provide the object by using the `:renderable` option to `render`:
+Render the above object in a controller action using:
+
+```ruby
+render Greeting.new
+```
+
+This calls `render_in` on the provided object with the current [view context][]. You can specify the `renderable:` option to be more explicit:
 
 ```ruby
 render renderable: Greeting.new
-# => "Hello World"
 ```
 
-#### Options for `render`
+[view context]: https://api.rubyonrails.org/classes/ActionView/Base.html
 
-Calls to the [`render`][controller.render] method generally accept six options:
+#### Inline Templating
 
-* `:content_type`
-* `:layout`
-* `:location`
-* `:status`
-* `:formats`
-* `:variants`
+ERB or a similar templating string can be rendered inline using the `inline:` option:
 
-##### The `:content_type` Option
+```ruby
+render inline: "<% products.each do |p| %><p><%= p.name %></p><% end %>"
+```
 
-By default, Rails will serve the results of a rendering operation with the MIME content-type of `text/html` (or `application/json` if you use the `:json` option, or `application/xml` for the `:xml` option.). There are times when you might like to change this, and you can do so by setting the `:content_type` option:
+Supply `type:` to use other templating engines:
+
+```ruby
+render inline: "xml.p 'This is a bad idea...'", type: :builder
+```
+
+```ruby
+render inline: "json.content 'This is a bad idea...'", type: :jbuilder
+```
+
+WARNING: There is seldom any good reason to use this technique. Mixing templating logic into your controllers defeats the MVC orientation of Rails and will make it harder for other developers to follow the logic of your project. Use a separate view instead.
+
+### Customizing Responses
+
+HTTP responses can be customized by passing additional options to [`render`][controller.render].
+
+#### `content_type:`
+
+This sets the [`content-type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type) HTTP header for the response. It needs to be set to a valid [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types) so the browser understands how the response is formatted.
+
+Rails automatically sets this in most cases. For example, rendering an HTML ERB template will set it to `text/html`, and rendering a JSON object will set it to `application/json`.
+
+It can be explicity set if needed:
 
 ```ruby
 render template: "feed", content_type: "application/rss"
 ```
 
-##### The `:layout` Option
+#### `location:`
 
-With most of the options to `render`, the rendered content is displayed as part of the current layout. You'll learn more about layouts and how to use them later in this guide.
-
-You can use the `:layout` option to tell Rails to use a specific file as the layout for the current action:
+Use this option to set the HTTP [`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Location) header:
 
 ```ruby
-render layout: "special_layout"
+render plain: "Redirecting...", location: root_path, status: :see_other
 ```
 
-You can also tell Rails to render with no layout at all:
+WARNING:  While this is valid code, using [`redirect_to`](#redirecting-requests) is the canonical way to send redirect responses in Rails.
 
-```ruby
-render layout: false
-```
+#### `status:`
 
-##### The `:location` Option
-
-You can use the `:location` option to set the HTTP `Location` header:
-
-```ruby
-render xml: photo, location: photo_url(photo)
-```
-
-##### The `:status` Option
-
-Rails will automatically generate a response with the correct HTTP status code (in most cases, this is `200 OK`). You can use the `:status` option to change this:
+Rails automatically sets the HTTP status code — in most cases, this is `200 OK`. Change it by supplying a `status:`:
 
 ```ruby
 render status: 500
@@ -366,6 +366,7 @@ Rails understands both numeric status codes and the corresponding symbols shown 
 | **Informational**   | 100              | :continue                        |
 |                     | 101              | :switching_protocols             |
 |                     | 102              | :processing                      |
+|                     | 103              | :early_hints                     |
 | **Success**         | 200              | :ok                              |
 |                     | 201              | :created                         |
 |                     | 202              | :accepted                        |
@@ -397,13 +398,13 @@ Rails understands both numeric status codes and the corresponding symbols shown 
 |                     | 410              | :gone                            |
 |                     | 411              | :length_required                 |
 |                     | 412              | :precondition_failed             |
-|                     | 413              | :payload_too_large               |
+|                     | 413              | :content_too_large               |
 |                     | 414              | :uri_too_long                    |
 |                     | 415              | :unsupported_media_type          |
 |                     | 416              | :range_not_satisfiable           |
 |                     | 417              | :expectation_failed              |
 |                     | 421              | :misdirected_request             |
-|                     | 422              | :unprocessable_entity            |
+|                     | 422              | :unprocessable_content           |
 |                     | 423              | :locked                          |
 |                     | 424              | :failed_dependency               |
 |                     | 426              | :upgrade_required                |
@@ -423,374 +424,417 @@ Rails understands both numeric status codes and the corresponding symbols shown 
 |                     | 510              | :not_extended                    |
 |                     | 511              | :network_authentication_required |
 
-NOTE:  If you try to render content along with a non-content status code
-(100-199, 204, 205, or 304), it will be dropped from the response.
+NOTE: The mapping between the codes and symbols is [defined within Rack](https://github.com/rack/rack/blob/main/lib/rack/utils.rb#L498). If you try to render content along with a non-content status code (100-199, 204, 205, or 304), it will be dropped from the response.
 
-##### The `:formats` Option
+### Avoiding Double Render Errors
 
-Rails uses the format specified in the request (or `:html` by default). You can
-change this passing the `:formats` option with a symbol or an array:
+The `render` method **does not** `return` from the current scope. Lines after a `render` call will still be executed. Calling `render` multiple times in the same controller action is not allowed and will raise a `AbstractController::DoubleRenderError`.
 
-```ruby
-render formats: :xml
-render formats: [:json, :xml]
-```
-
-If a template with the specified format does not exist an `ActionView::MissingTemplate` error is raised.
-
-##### The `:variants` Option
-
-This tells Rails to look for template variations of the same format.
-You can specify a list of variants by passing the `:variants` option with a symbol or an array.
-
-An example of use would be this.
-
-```ruby
-# called in HomeController#index
-render variants: [:mobile, :desktop]
-```
-
-With this set of variants Rails will look for the following set of templates and use the first that exists.
-
-- `app/views/home/index.html+mobile.erb`
-- `app/views/home/index.html+desktop.erb`
-- `app/views/home/index.html.erb`
-
-If a template with the specified format does not exist an `ActionView::MissingTemplate` error is raised.
-
-Instead of setting the variant on the render call you may also set
-[`request.variant`](https://api.rubyonrails.org/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-variant-3D)
-in your controller action. Learn more about variants in the [Action Controller
-Overview](./action_controller_overview.html#request-variant) guides.
-
-```ruby
-def index
-  request.variant = determine_variant
-end
-
-private
-  def determine_variant
-    variant = nil
-    # some code to determine the variant(s) to use
-    variant = :mobile if session[:use_mobile]
-
-    variant
-  end
-```
-
-NOTE: Adding many new variant templates with similarities to existing template
-files can make maintaining your view code more difficult.
-
-#### Finding Layouts
-
-To find the current layout, Rails first looks for a file in `app/views/layouts` with the same base name as the controller. For example, rendering actions from the `PhotosController` class will use `app/views/layouts/photos.html.erb` (or `app/views/layouts/photos.builder`). If there is no such controller-specific layout, Rails will use `app/views/layouts/application.html.erb` or `app/views/layouts/application.builder`. If there is no `.erb` layout, Rails will use a `.builder` layout if one exists. Rails also provides several ways to more precisely assign specific layouts to individual controllers and actions.
-
-##### Specifying Layouts for Controllers
-
-You can override the default layout conventions in your controllers by using the [`layout`][] declaration. For example:
-
-```ruby
-class ProductsController < ApplicationController
-  layout "inventory"
-  #...
-end
-```
-
-With this declaration, all of the views rendered by the `ProductsController` will use `app/views/layouts/inventory.html.erb` as their layout.
-
-To assign a specific layout for the entire application, use a `layout` declaration in your `ApplicationController` class:
-
-```ruby
-class ApplicationController < ActionController::Base
-  layout "main"
-  #...
-end
-```
-
-With this declaration, all of the views in the entire application will use `app/views/layouts/main.html.erb` for their layout.
-
-[`layout`]: https://api.rubyonrails.org/classes/ActionView/Layouts/ClassMethods.html#method-i-layout
-
-##### Choosing Layouts at Runtime
-
-You can use a symbol to defer the choice of layout until a request is processed:
-
-```ruby
-class ProductsController < ApplicationController
-  layout :products_layout
-
-  def show
-    @product = Product.find(params[:id])
-  end
-
-  private
-    def products_layout
-      @current_user.special? ? "special" : "products"
-    end
-end
-```
-
-Now, if the current user is a special user, they'll get a special layout when viewing a product.
-
-You can even use an inline method, such as a Proc, to determine the layout. For example, if you pass a Proc object, the block you give the Proc will be given the `controller` instance, so the layout can be determined based on the current request:
-
-```ruby
-class ProductsController < ApplicationController
-  layout Proc.new { |controller| controller.request.xhr? ? "popup" : "application" }
-end
-```
-
-##### Conditional Layouts
-
-Layouts specified at the controller level support the `:only` and `:except` options. These options take either a method name, or an array of method names, corresponding to method names within the controller:
-
-```ruby
-class ProductsController < ApplicationController
-  layout "product", except: [:index, :rss]
-end
-```
-
-With this declaration, the `product` layout would be used for everything but the `rss` and `index` methods.
-
-##### Layout Inheritance
-
-Layout declarations cascade downward in the hierarchy, and more specific layout declarations always override more general ones. For example:
-
-* `application_controller.rb`
-
-    ```ruby
-    class ApplicationController < ActionController::Base
-      layout "main"
-    end
-    ```
-
-* `articles_controller.rb`
-
-    ```ruby
-    class ArticlesController < ApplicationController
-    end
-    ```
-
-* `special_articles_controller.rb`
-
-    ```ruby
-    class SpecialArticlesController < ArticlesController
-      layout "special"
-    end
-    ```
-
-* `old_articles_controller.rb`
-
-    ```ruby
-    class OldArticlesController < SpecialArticlesController
-      layout false
-
-      def show
-        @article = Article.find(params[:id])
-      end
-
-      def index
-        @old_articles = Article.older
-        render layout: "old"
-      end
-      # ...
-    end
-    ```
-
-In this application:
-
-* In general, views will be rendered in the `main` layout
-* `ArticlesController#index` will use the `main` layout
-* `SpecialArticlesController#index` will use the `special` layout
-* `OldArticlesController#show` will use no layout at all
-* `OldArticlesController#index` will use the `old` layout
-
-##### Template Inheritance
-
-Similar to the Layout Inheritance logic, if a template or partial is not found in the conventional path, the controller will look for a template or partial to render in its inheritance chain. For example:
-
-```ruby
-# app/controllers/application_controller.rb
-class ApplicationController < ActionController::Base
-end
-```
-
-```ruby
-# app/controllers/admin_controller.rb
-class AdminController < ApplicationController
-end
-```
-
-```ruby
-# app/controllers/admin/products_controller.rb
-class Admin::ProductsController < AdminController
-  def index
-  end
-end
-```
-
-The lookup order for an `admin/products#index` action will be:
-
-* `app/views/admin/products/`
-* `app/views/admin/`
-* `app/views/application/`
-
-This makes `app/views/application/` a great place for your shared partials, which can then be rendered in your ERB as such:
-
-```erb
-<%# app/views/admin/products/index.html.erb %>
-<%= render @products || "empty_list" %>
-
-<%# app/views/application/_empty_list.html.erb %>
-There are no items in this list <em>yet</em>.
-```
-
-#### Avoiding Double Render Errors
-
-Sooner or later, most Rails developers will see the error message "Can only render or redirect once per action". While this is annoying, it's relatively easy to fix. Usually it happens because of a fundamental misunderstanding of the way that `render` works.
-
-For example, here's some code that will trigger this error:
-
-```ruby
-def show
-  @book = Book.find(params[:id])
-  if @book.special?
-    render action: "special_show"
-  end
-  render action: "regular_show"
-end
-```
-
-If `@book.special?` evaluates to `true`, Rails will start the rendering process to dump the `@book` variable into the `special_show` view. But this will _not_ stop the rest of the code in the `show` action from running, and when Rails hits the end of the action, it will start to render the `regular_show` view - and throw an error. The solution is simple: make sure that you have only one call to `render` or `redirect` in a single code path. One thing that can help is `return`. Here's a patched version of the method:
-
-```ruby
-def show
-  @book = Book.find(params[:id])
-  if @book.special?
-    render action: "special_show"
-    return
-  end
-  render action: "regular_show"
-end
-```
-
-Note that the implicit render done by ActionController detects if `render` has been called, so the following will work without errors:
-
-```ruby
-def show
-  @book = Book.find(params[:id])
-  if @book.special?
-    render action: "special_show"
-  end
-end
-```
-
-This will render a book with `special?` set with the `special_show` template, while other books will render with the default `show` template.
-
-### Using `redirect_to`
-
-Another way to handle returning responses to an HTTP request is with [`redirect_to`][]. As you've seen, `render` tells Rails which view (or other asset) to use in constructing a response. The `redirect_to` method does something completely different: it tells the browser to send a new request for a different URL. For example, you could redirect from wherever you are in your code to the index of photos in your application with this call:
-
-```ruby
-redirect_to photos_url
-```
-
-You can use [`redirect_back`][] to return the user to the page they just came from.
-This location is pulled from the `HTTP_REFERER` header which is not guaranteed
-to be set by the browser, so you must provide the `fallback_location`
-to use in this case.
-
-```ruby
-redirect_back(fallback_location: root_path)
-```
-
-NOTE: `redirect_to` and `redirect_back` do not halt and return immediately from method execution, but simply set HTTP responses. Statements occurring after them in a method will be executed. You can halt by an explicit `return` or some other halting mechanism, if needed.
-
-[`redirect_back`]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back
-
-#### Getting a Different Redirect Status Code
-
-Rails uses HTTP status code 302, a temporary redirect, when you call `redirect_to`. If you'd like to use a different status code, perhaps 301, a permanent redirect, you can use the `:status` option:
-
-```ruby
-redirect_to photos_path, status: 301
-```
-
-Just like the `:status` option for `render`, `:status` for `redirect_to` accepts both numeric and symbolic header designations.
-
-#### The Difference Between `render` and `redirect_to`
-
-Sometimes inexperienced developers think of `redirect_to` as a sort of `goto`
-command, moving execution from one place to another in your Rails code. This is
-_not_ correct.
-
-The current action will complete, returning a response to the browser. After
-this your code stops running and waits for a new request, it just happens that
-you've told the browser what request it should make next by sending back an
-HTTP 302 status code.
-
-Consider these actions to see the difference:
+For example, this action will trigger a double render error:
 
 ```ruby
 def index
   @books = Book.all
-end
-
-def show
-  @book = Book.find_by(id: params[:id])
-  if @book.nil?
-    render action: "index"
+  if Current.user.admin?
+    render "admin/books/index"
   end
+
+  render "index"
 end
 ```
 
-With the code in this form, there will likely be a problem if the `@book` variable is `nil`. Remember, a `render :action` doesn't run any code in the target action, so nothing will set up the `@books` variable that the `index` view will probably require. One way to fix this is to redirect instead of rendering:
+If the user is an admin, the `render` within the `if` statement will be called, but so will `render "index"`.
+
+You can fix this by adding an explicit `return`:
 
 ```ruby
 def index
   @books = Book.all
-end
-
-def show
-  @book = Book.find_by(id: params[:id])
-  if @book.nil?
-    redirect_to action: :index
+  if Current.user.admin?
+    return render "admin/books/index"
   end
+
+  render "index"
 end
 ```
 
-With this code, the browser will make a fresh request for the index page, the code in the `index` method will run, and all will be well.
-
-The only downside to this code is that it requires a round trip to the browser: the browser requested the show action with `/books/1` and the controller finds that there are no books, so the controller sends out a 302 redirect response to the browser telling it to go to `/books/`, the browser complies and sends a new request back to the controller asking now for the `index` action, the controller then gets all the books in the database and renders the index template, sending it back down to the browser which then shows it on your screen.
-
-While in a small application, this added latency might not be a problem, it is something to think about if response time is a concern. We can demonstrate one way to handle this with a contrived example:
+Or by using an `else` branch:
 
 ```ruby
 def index
   @books = Book.all
-end
-
-def show
-  @book = Book.find_by(id: params[:id])
-  if @book.nil?
-    @books = Book.all
-    flash.now[:alert] = "Your book was not found"
+  if Current.user.admin?
+    render "admin/books/index"
+  else
     render "index"
   end
 end
 ```
 
-This would detect that there are no books with the specified ID, populate the `@books` instance variable with all the books in the model, and then directly render the `index.html.erb` template, returning it to the browser with a flash alert message to tell the user what happened.
+Implicit rendering is unaffected by this. The controller action will only render the conventional template if `render` wasn't called when the action executed. The below example will not raise a double render error and is functionally equivalent to the previous example.
 
-### Using `head` to Build Header-Only Responses
+```ruby
+def index
+  @books = Book.all
+  if Current.user.admin?
+    render "admin/books/index"
+  end
+end
+```
 
-The [`head`][] method can be used to send responses with only headers to the browser. The `head` method accepts a number or symbol (see [reference table](#the-status-option)) representing an HTTP status code. The options argument is interpreted as a hash of header names and values. For example, you can return only an error header:
+Multi-Format Responses
+----------------------
+
+Rails templates [can be written in a variety of formats](action_view_overview.html#templates), not just HTML. For example, consider the below JSON and XML templates:
+
+```ruby
+# app/views/books/index.json.jbuilder
+
+json.array! @books do |book|
+  json.name(book.name)
+  json.synopsis(book.synopsis)
+end
+```
+
+```erb
+<%# app/views/books/index.xml.erb -%>
+
+<books>
+  <% @books.each do |book| %>
+  <book>
+    <name><%= book.name %></name>
+    <synopsis><%= book.synopsis %></synopsis>
+  </book>
+  <% end %>
+</books>
+```
+
+NOTE: In these examples, we're building the JSON template using [`jbuilder`](action_view_overview.html#jbuilder) for security and convenience, but still using ERB for the XML template. Rails also includes [`builder`](action_view_overview.html#builder), which provides a DSL to create XML templates if you wish to use it.
+
+These templates can co-exist alongside an HTML ERB template:
+
+```html+erb
+<%# app/views/books/index.html.erb -%>
+
+<h1>Books</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Synopsis</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @books.each do |book| %>
+    <tr>
+      <td><%= book.name %></td>
+      <td><%= book.synopsis %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+```
+
+This means there are 3 template formats available for the `index` action on the `BooksController`. Without an explicit `render`, Rails will automatically choose the correct format based on the request.
+
+The request can control the response format by specifying an `Accept` HTTP header with the appropriate [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types):
+
+```
+GET /books.json HTTP/1.1
+Accept: application/json
+```
+
+or it can set an extension on the path:
+
+```
+/books.json
+/books.xml
+```
+
+The default format is HTML. For more fine-grained control over formats, Rails controllers offer two methods:
+
+* Supplying `formats:` when calling `render`.
+* Using `respond_to`.
+
+### The `formats:` option
+
+The `formats:` option on `render` overrides any definitions in the request and forces the controller to render the specified format:
+
+```ruby
+render formats: :json
+```
+
+An array can be passed to define fallbacks if the template for a given format doesn't exist. The below example will attempt to render the JSON template, but fallback to XML if it doesn't exist.
+
+```ruby
+render formats: [:json, :xml]
+```
+
+An `ActionView::MissingTemplate` error is raised when a template with the required format doesn't exist.
+
+### Advanced Format Handling Using `respond_to`
+
+[`respond_to`][] explicitly defines the formats available to the controller.
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to :html, :xml, :json
+  end
+end
+```
+
+The above is functionally equivalent to an implicit render when templates for all 3 formats exist:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+  end
+end
+```
+
+It can also be expressed using a block:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html
+      format.json
+      format.xml
+    end
+  end
+end
+```
+
+The above 3 code snippets are functionally equivalent. However, within this block structure, you can define custom handling for each format. For example, you might want to render a different template for HTML requests:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { render "carousel" }
+      format.json
+      format.xml
+    end
+  end
+end
+```
+
+HTML requests will render `carousel.html.erb`, whereas JSON and XML requests will render `index.json.jbuilder` and `index.xml.erb` respectively.
+
+You can even redirect requests based on the format:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { redirect_to books_grid_path }
+      format.json
+      format.xml
+    end
+  end
+end
+```
+
+Now requests for HTML pages will be redirected, but JSON and XML requests will be rendered.
+
+You can create a handler for multiple formats using `format.any`:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { redirect_to books_grid_path }
+      format.any(:xml, :json)
+    end
+  end
+end
+```
+
+Omit the format definitions passed to `format.any` to create a catch-all handler. The below example will redirect HTML requests and render the appropriate `index` template for all other request types, where available.
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { redirect_to books_grid_path }
+      format.any
+    end
+  end
+end
+```
+
+If the requested format isn't available when using `respond_to`, Rails will respond with the HTTP status `406 Not Acceptable`.
+
+### Template Variants
+
+Rails allows you to create multiple variants of the same template. Controllers responding to requests from a mobile platform might need to render different content than requests from a desktop browser. One strategy to accomplish this is to set a request variant.
+
+Variant names are arbitrary, and can communicate anything from the request's platform (`:android`, `:ios`, `:linux`, `:macos`, `:windows`) to its device (`:mobile`, `:desktop`), to the type of user (`:admin`, `:guest`, `:user`).
+
+The variant name is included in the file's extension.
+
+- `app/views/books/index.html+mobile.erb`
+- `app/views/books/index.html+desktop.erb`
+- `app/views/books/index.html.erb`
+
+Render a variant using the `variants:` option.
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    # `variants:` accepts a single symbol or an array of symbols
+    render variants: [:mobile, :desktop]
+  end
+end
+```
+
+Rails will render the first available template variant from the array supplied, falling back to the default `.html.erb` if no matching variant is found.
+
+Rails automatically renders the appropriate variant when [`request.variant`](https://api.rubyonrails.org/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-variant-3D) is set. It's a good idea to add the logic to set the variant to your `ApplicationController` so all your controllers get this functionality. Rails will always render the default template so variants can be added only where necessary.
+
+
+```ruby
+# app/controllers/concerns/set_request_variant.rb
+module SetRequestVariant
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_request_variant
+  end
+
+  private
+
+    def set_request_variant
+      # App-specific logic to determine which variant is requested
+      request.variant = # ...
+    end
+end
+
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  include SetRequestVariant
+end
+
+# app/controllers/books_controller.rb
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+  end
+end
+```
+
+An explicit `render variants:` call isn't required when using `request.variant`.
+
+You can add custom handling for variants within a `respond_to` block:
+
+```ruby
+respond_to do |format|
+  format.html do |html|
+    html.desktop { render "dashboard" }
+    html.mobile
+  end
+  format.json
+  format.xml
+end
+```
+
+```ruby
+respond_to do |format|
+  format.html.desktop { render "dashboard" }
+  format.html
+  format.json
+  format.xml
+end
+```
+
+### Custom MIME types
+
+Rails registers several common [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) [by default](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/http/mime_types.rb). All these types can be used to in conjunction with `respond_to`. Your application can additionally define custom MIME types.
+
+```ruby
+# config/initializers/mime_types.rb
+
+Mime::Type.register "text/vnd.my-mime-type", :my_mime_type
+```
+
+The above definition follows the convention for naming custom MIME types. This can now be used to render responses:
+
+```ruby
+respond_to do |format|
+  format.my_mime_type { render plain: "This is a custom MIME type" }
+  format.any
+end
+```
+
+Even though we're using `render plain:`, the `content-type` HTTP header in the response will be set to `text/vnd.my-mime-type` since it's a format-specific handler.
+
+NOTE: This is exactly how [Rails' integration](https://github.com/hotwired/turbo-rails) with [Turbo](https://turbo.hotwired.dev) creates Turbo Stream responses. It registers the `text/vnd.turbo-stream.html` MIME type which allows us to create `.turbo_stream.html` templates and use `format.turbo_stream` in `respond_to` blocks.
+
+Redirecting Requests
+--------------------
+
+Instead of `render`ing a response, you might want to redirect the user to a different path. An [HTTP redirection status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#redirection_messages) can be used for this. Rails' [`redirect_to`][] method uses `302 Found` by default.
+
+```ruby
+redirect_to photos_url
+```
+
+This will send a `302` HTTP response to the browser with `photos_url` in the response's `Location` header. The browser will then make a new `GET` request to the `photos_url`.
+
+Alternatively, you can use [`redirect_back`][] to return the user to the page they just came from.
+The location is pulled from the `HTTP_REFERER` header which is not guaranteed
+to be set by the browser, so you must provide a `fallback_location`.
+
+```ruby
+redirect_back(fallback_location: root_path)
+# or
+redirect_back_or_to root_path
+```
+
+WARNING: Similar to `render`, `redirect_to` and `redirect_back` do not automatically `return` from the current scope, instead they simply set the HTTP response. Statements occurring after them will still be executed.
+
+[`redirect_to`]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
+[`redirect_back`]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back
+
+Use the `status:` option to use a different HTTP response code. Just like `render`, you can use both numeric and symbolic values.
+
+```ruby
+redirect_to photos_path, status: :see_other
+```
+
+NOTE: It's worth being aware that `redirect_to` doesn't move execution to a different method within the same request. It sends an HTTP response and then the browser makes a new request to the redirected location which won't have any context from the previous request.
+
+Header-Only Responses
+---------------------
+
+The [`head`][] method can be used to send responses with only headers to the browser. This is usually in response to an [HTTP `HEAD`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/HEAD) request.
+
+The `head` method accepts a number or symbol representing an HTTP status code.
 
 ```ruby
 head :bad_request
 ```
 
-This would produce the following header:
+This would produce the following headers:
 
 ```http
 HTTP/1.1 400 Bad Request
@@ -803,7 +847,7 @@ Set-Cookie: _blog_session=...snip...; path=/; HttpOnly
 Cache-Control: no-cache
 ```
 
-Or you can use other HTTP headers to convey other information:
+You can add additional HTTP headers if you wish.
 
 ```ruby
 head :created, location: photo_path(@photo)
@@ -823,617 +867,128 @@ Set-Cookie: _blog_session=...snip...; path=/; HttpOnly
 Cache-Control: no-cache
 ```
 
-Structuring Layouts
--------------------
+Setting Layouts In Controllers
+-------------------------------
 
-When Rails renders a view as a response, it does so by combining the view with the current layout, using the rules for finding the current layout that were covered earlier in this guide. Within a layout, you have access to three tools for combining different bits of output to form the overall response:
+Layouts provide a common structure into which responses are `render`ed. If a layout isn't explicitly defined, Rails will automatically select it.
 
-* Asset tags
-* `yield` and [`content_for`][]
-* Partials
+### Automatic Layout Selection
 
-[`content_for`]: https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-content_for
+All layout files must be placed within `app/views/layouts`. Rails will first look for a layout file with the same base name as the controller — for example, `photos.html.erb` for a `PhotosController`. If such a file doesn't exist, it will fall back to the default `application.html.erb`.
 
-### Asset Tag Helpers
+### Specifying Layouts for Controllers
 
-Asset tag helpers provide methods for generating HTML that link views to feeds, JavaScript, stylesheets, images, videos, and audios. There are six asset tag helpers available in Rails:
+Explicity define a layout for a controller with the [`layout`][] declaration.
 
-* [`auto_discovery_link_tag`][]
-* [`javascript_include_tag`][]
-* [`stylesheet_link_tag`][]
-* [`image_tag`][]
-* [`video_tag`][]
-* [`audio_tag`][]
+```ruby
+class ProductsController < ApplicationController
+  layout "inventory"
 
-You can use these tags in layouts or other views, although the `auto_discovery_link_tag`, `javascript_include_tag`, and `stylesheet_link_tag`, are most commonly used in the `<head>` section of a layout.
-
-WARNING: The asset tag helpers do _not_ verify the existence of the assets at the specified locations; they simply assume that you know what you're doing and generate the link.
-
-[`auto_discovery_link_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-auto_discovery_link_tag
-[`javascript_include_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-javascript_include_tag
-[`stylesheet_link_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-stylesheet_link_tag
-[`image_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-image_tag
-[`video_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-video_tag
-[`audio_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-audio_tag
-
-#### Linking to Feeds with the `auto_discovery_link_tag`
-
-The [`auto_discovery_link_tag`][] helper builds HTML that most browsers and feed readers can use to detect the presence of RSS, Atom, or JSON feeds. It takes the type of the link (`:rss`, `:atom`, or `:json`), a hash of options that are passed through to url_for, and a hash of options for the tag:
-
-```erb
-<%= auto_discovery_link_tag(:rss, {action: "feed"},
-  {title: "RSS Feed"}) %>
+  # ...
+end
 ```
 
-There are three tag options available for the `auto_discovery_link_tag`:
+With this declaration, all views rendered by the `ProductsController` will be inserted into `app/views/layouts/inventory.html.erb`.
 
-* `:rel` specifies the `rel` value in the link. The default value is "alternate".
-* `:type` specifies an explicit MIME type. Rails will generate an appropriate MIME type automatically.
-* `:title` specifies the title of the link. The default value is the uppercase `:type` value, for example, "ATOM" or "RSS".
+Use a `layout` declaration in your `ApplicationController` to change the default layout for your entire application:
 
-#### Linking to JavaScript Files with the `javascript_include_tag`
+```ruby
+class ApplicationController < ActionController::Base
+  layout "main"
 
-The [`javascript_include_tag`][] helper returns an HTML `script` tag for each source provided.
-
-If you are using Rails with the [Asset Pipeline](asset_pipeline.html) enabled, this helper will generate a link to `/assets/javascripts/` rather than `public/javascripts` which was used in earlier versions of Rails. This link is then served by the asset pipeline.
-
-A JavaScript file within a Rails application or Rails engine goes in one of three locations: `app/assets`, `lib/assets` or `vendor/assets`. These locations are explained in detail in the [Asset Organization section in the Asset Pipeline Guide](asset_pipeline.html#asset-organization).
-
-You can specify a full path relative to the document root, or a URL, if you prefer. For example, to link to a JavaScript file `main.js` that is inside one of `app/assets/javascripts`, `lib/assets/javascripts` or `vendor/assets/javascripts`, you would do this:
-
-```erb
-<%= javascript_include_tag "main" %>
+  # ...
+end
 ```
 
-Rails will then output a `script` tag such as this:
+[`layout`]: https://api.rubyonrails.org/classes/ActionView/Layouts/ClassMethods.html#method-i-layout
 
-```html
-<script src='/assets/main.js'></script>
+### Setting Layouts Dynamically
+
+Invoke the `layout` method with a symbol denoting a method name to select a layout dynamically at runtime.
+
+```ruby
+class ProductsController < ApplicationController
+  layout :products_layout
+
+  def show
+    @product = Product.find(params[:id])
+  end
+
+  private
+    def products_layout
+      Current.user.admin? ? "admin" : "products"
+    end
+end
 ```
 
-The request to this asset is then served by the Sprockets gem.
+Now, if the current user is a administrator, they'll get the admin-specific layout when viewing a product.
 
-To include multiple files such as `app/assets/javascripts/main.js` and `app/assets/javascripts/columns.js` at the same time:
+You can also invoke `layout` with a `Proc` or `lambda`. The controller instance will be passed into it.
 
-```erb
-<%= javascript_include_tag "main", "columns" %>
+```ruby
+class ProductsController < ApplicationController
+  layout ->(controller) { controller.request.xhr? ? "popup" : "application" }
+end
 ```
 
-To include `app/assets/javascripts/main.js` and `app/assets/javascripts/photos/columns.js`:
+### Conditional Layouts
 
-```erb
-<%= javascript_include_tag "main", "/photos/columns" %>
+Layouts defined at the controller level support the `:only` and `:except` options. You can use these options to specify layouts for a subset of the controller's actions.
+
+```ruby
+class ProductsController < ApplicationController
+  # The `product` layout is used for all actions except `index` and `rss`.
+  layout "product", except: [:index, :rss]
+end
 ```
 
-To include `http://example.com/main.js`:
-
-```erb
-<%= javascript_include_tag "http://example.com/main.js" %>
+```ruby
+class ProductsController < ApplicationController
+  # The `product` layout is used only for the `show` and `edit` actions.
+  layout "product", only: [:show, :edit]
+end
 ```
 
-#### Linking to CSS Files with the `stylesheet_link_tag`
+### Layout Hierarchy
 
-The [`stylesheet_link_tag`][] helper returns an HTML `<link>` tag for each source provided.
+Layout declarations cascade downward in the hierarchy, and more specific layout declarations always override more general ones. For example:
 
-If you are using Rails with the "Asset Pipeline" enabled, this helper will generate a link to `/assets/stylesheets/`. This link is then processed by the Sprockets gem. A stylesheet file can be stored in one of three locations: `app/assets`, `lib/assets`, or `vendor/assets`.
+```ruby
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  layout "main"
+end
 
-You can specify a full path relative to the document root, or a URL. For example, to link to a stylesheet file that is inside a directory called `stylesheets` inside of one of `app/assets`, `lib/assets`, or `vendor/assets`, you would do this:
+# app/controllers/articles_controller.rb
+class ArticlesController < ApplicationController
+end
 
-```erb
-<%= stylesheet_link_tag "main" %>
+# app/controllers/products_controller.rb
+class ProductsController < ArticlesController
+  layout "product"
+end
+
+# app/controllers/profiles_controller.rb
+class ProfilesController < ApplicationController
+  layout false
+
+  def show
+    @profile = Profile.find(params[:id])
+    render layout: "profile"
+  end
+
+  def index
+    @profiles = Profile.all
+  end
+
+  # ...
+end
 ```
 
-To include `app/assets/stylesheets/main.css` and `app/assets/stylesheets/columns.css`:
-
-```erb
-<%= stylesheet_link_tag "main", "columns" %>
-```
-
-To include `app/assets/stylesheets/main.css` and `app/assets/stylesheets/photos/columns.css`:
-
-```erb
-<%= stylesheet_link_tag "main", "photos/columns" %>
-```
-
-To include `http://example.com/main.css`:
-
-```erb
-<%= stylesheet_link_tag "http://example.com/main.css" %>
-```
-
-By default, the `stylesheet_link_tag` creates links with `rel="stylesheet"`. You can override this default by specifying an appropriate option (`:rel`):
-
-```erb
-<%= stylesheet_link_tag "main_print", media: "print" %>
-```
-
-#### Linking to Images with the `image_tag`
-
-The [`image_tag`][] helper builds an HTML `<img />` tag to the specified file. By default, files are loaded from `public/images`.
-
-WARNING: Note that you must specify the extension of the image.
-
-```erb
-<%= image_tag "header.png" %>
-```
-
-You can supply a path to the image if you like:
-
-```erb
-<%= image_tag "icons/delete.gif" %>
-```
-
-You can supply a hash of additional HTML options:
-
-```erb
-<%= image_tag "icons/delete.gif", {height: 45} %>
-```
-
-You can supply alternate text for the image which will be used if the user has images turned off in their browser. If you do not specify an alt text explicitly, it defaults to the file name of the file, capitalized and with no extension. For example, these two image tags would return the same code:
-
-```erb
-<%= image_tag "home.gif" %>
-<%= image_tag "home.gif", alt: "Home" %>
-```
-
-You can also specify a special size tag, in the format "{width}x{height}":
-
-```erb
-<%= image_tag "home.gif", size: "50x20" %>
-```
-
-In addition to the above special tags, you can supply a final hash of standard HTML options, such as `:class`, `:id`, or `:name`:
-
-```erb
-<%= image_tag "home.gif", alt: "Go Home",
-                          id: "HomeImage",
-                          class: "nav_bar" %>
-```
-
-#### Linking to Videos with the `video_tag`
-
-The [`video_tag`][] helper builds an HTML5 `<video>` tag to the specified file. By default, files are loaded from `public/videos`.
-
-```erb
-<%= video_tag "movie.ogg" %>
-```
-
-Produces
-
-```erb
-<video src="/videos/movie.ogg" />
-```
-
-Like an `image_tag` you can supply a path, either absolute, or relative to the `public/videos` directory. Additionally you can specify the `size: "#{width}x#{height}"` option just like an `image_tag`. Video tags can also have any of the HTML options specified at the end (`id`, `class` et al).
-
-The video tag also supports all of the `<video>` HTML options through the HTML options hash, including:
-
-* `poster: "image_name.png"`, provides an image to put in place of the video before it starts playing.
-* `autoplay: true`, starts playing the video on page load.
-* `loop: true`, loops the video once it gets to the end.
-* `controls: true`, provides browser supplied controls for the user to interact with the video.
-* `autobuffer: true`, the video will pre load the file for the user on page load.
-
-You can also specify multiple videos to play by passing an array of videos to the `video_tag`:
-
-```erb
-<%= video_tag ["trailer.ogg", "movie.ogg"] %>
-```
-
-This will produce:
-
-```erb
-<video>
-  <source src="/videos/trailer.ogg">
-  <source src="/videos/movie.ogg">
-</video>
-```
-
-#### Linking to Audio Files with the `audio_tag`
-
-The [`audio_tag`][] helper builds an HTML5 `<audio>` tag to the specified file. By default, files are loaded from `public/audios`.
-
-```erb
-<%= audio_tag "music.mp3" %>
-```
-
-You can supply a path to the audio file if you like:
-
-```erb
-<%= audio_tag "music/first_song.mp3" %>
-```
-
-You can also supply a hash of additional options, such as `:id`, `:class`, etc.
-
-Like the `video_tag`, the `audio_tag` has special options:
-
-* `autoplay: true`, starts playing the audio on page load
-* `controls: true`, provides browser supplied controls for the user to interact with the audio.
-* `autobuffer: true`, the audio will pre load the file for the user on page load.
-
-### Understanding `yield`
-
-Within the context of a layout, `yield` identifies a section where content from the view should be inserted. The simplest way to use this is to have a single `yield`, into which the entire contents of the view currently being rendered is inserted:
-
-```html+erb
-<html>
-  <head>
-  </head>
-  <body>
-    <%= yield %>
-  </body>
-</html>
-```
-
-You can also create a layout with multiple yielding regions:
-
-```html+erb
-<html>
-  <head>
-    <%= yield :head %>
-  </head>
-  <body>
-    <%= yield %>
-  </body>
-</html>
-```
-
-The main body of the view will always render into the unnamed `yield`. To render content into a named `yield`, call the `content_for` method with the same argument as the named `yield`.
-
-NOTE: Newly generated applications will include `<%= yield :head %>` within the `<head>` element of its `app/views/layouts/application.html.erb` template.
-
-### Using the `content_for` Method
-
-The [`content_for`][] method allows you to insert content into a named `yield` block in your layout. For example, this view would work with the layout that you just saw:
-
-```html+erb
-<% content_for :head do %>
-  <title>A simple page</title>
-<% end %>
-
-<p>Hello, Rails!</p>
-```
-
-The result of rendering this page into the supplied layout would be this HTML:
-
-```html+erb
-<html>
-  <head>
-    <title>A simple page</title>
-  </head>
-  <body>
-    <p>Hello, Rails!</p>
-  </body>
-</html>
-```
-
-The `content_for` method is very helpful when your layout contains distinct regions such as sidebars and footers that should get their own blocks of content inserted. It's also useful for inserting page-specific JavaScript `<script>` elements, CSS `<link>` elements, context-specific `<meta>` elements, or any other elements into the `<head>` of an otherwise generic layout.
-
-### Using Partials
-
-Partial templates - usually just called "partials" - are another device for breaking the rendering process into more manageable chunks. With a partial, you can move the code for rendering a particular piece of a response to its own file.
-
-#### Naming Partials
-
-To render a partial as part of a view, you use the [`render`][view.render] method within the view:
-
-```html+erb
-<%= render "menu" %>
-```
-
-This will render a file named `_menu.html.erb` at that point within the view being rendered. Note the leading underscore character: partials are named with a leading underscore to distinguish them from regular views, even though they are referred to without the underscore. This holds true even when you're pulling in a partial from another folder:
-
-```html+erb
-<%= render "application/menu" %>
-```
-
-Since view partials rely on the same [Template Inheritance](#template-inheritance)
-as templates and layouts, that code will pull in the partial from `app/views/application/_menu.html.erb`.
-
-[view.render]: https://api.rubyonrails.org/classes/ActionView/Helpers/RenderingHelper.html#method-i-render
-
-#### Using Partials to Simplify Views
-
-One way to use partials is to treat them as the equivalent of subroutines: as a way to move details out of a view so that you can grasp what's going on more easily. For example, you might have a view that looked like this:
-
-```erb
-<%= render "application/ad_banner" %>
-
-<h1>Products</h1>
-
-<p>Here are a few of our fine products:</p>
-<%# ... %>
-
-<%= render "application/footer" %>
-```
-
-Here, the `_ad_banner.html.erb` and `_footer.html.erb` partials could contain
-content that is shared by many pages in your application. You don't need to see
-the details of these sections when you're concentrating on a particular page.
-
-As seen in the previous sections of this guide, `yield` is a very powerful tool
-for cleaning up your layouts. Keep in mind that it's pure Ruby, so you can use
-it almost everywhere. For example, we can use it to DRY up form layout
-definitions for several similar resources:
-
-* `users/index.html.erb`
-
-    ```html+erb
-    <%= render "application/search_filters", search: @q do |form| %>
-      <p>
-        Name contains: <%= form.text_field :name_contains %>
-      </p>
-    <% end %>
-    ```
-
-* `roles/index.html.erb`
-
-    ```html+erb
-    <%= render "application/search_filters", search: @q do |form| %>
-      <p>
-        Title contains: <%= form.text_field :title_contains %>
-      </p>
-    <% end %>
-    ```
-
-* `application/_search_filters.html.erb`
-
-    ```html+erb
-    <%= form_with model: search do |form| %>
-      <h1>Search form:</h1>
-      <fieldset>
-        <%= yield form %>
-      </fieldset>
-      <p>
-        <%= form.submit "Search" %>
-      </p>
-    <% end %>
-    ```
-
-TIP: For content that is shared among all pages in your application, you can use partials directly from layouts.
-
-#### Partial Layouts
-
-A partial can use its own layout file, just as a view can use a layout. For example, you might call a partial like this:
-
-```erb
-<%= render partial: "link_area", layout: "graybar" %>
-```
-
-This would look for a partial named `_link_area.html.erb` and render it using the layout `_graybar.html.erb`. Note that layouts for partials follow the same leading-underscore naming as regular partials, and are placed in the same folder with the partial that they belong to (not in the master `layouts` folder).
-
-Also note that explicitly specifying `:partial` is required when passing additional options such as `:layout`.
-
-#### Passing Local Variables
-
-You can also pass local variables into partials, making them even more powerful and flexible. For example, you can use this technique to reduce duplication between new and edit pages, while still keeping a bit of distinct content:
-
-* `new.html.erb`
-
-    ```html+erb
-    <h1>New zone</h1>
-    <%= render partial: "form", locals: {zone: @zone} %>
-    ```
-
-* `edit.html.erb`
-
-    ```html+erb
-    <h1>Editing zone</h1>
-    <%= render partial: "form", locals: {zone: @zone} %>
-    ```
-
-* `_form.html.erb`
-
-    ```html+erb
-    <%= form_with model: zone do |form| %>
-      <p>
-        <b>Zone name</b><br>
-        <%= form.text_field :name %>
-      </p>
-      <p>
-        <%= form.submit %>
-      </p>
-    <% end %>
-    ```
-
-Although the same partial will be rendered into both views, Action View's submit helper will return "Create Zone" for the new action and "Update Zone" for the edit action.
-
-To pass a local variable to a partial in only specific cases use the `local_assigns`.
-
-* `index.html.erb`
-
-    ```erb
-    <%= render user.articles %>
-    ```
-
-* `show.html.erb`
-
-    ```erb
-    <%= render article, full: true %>
-    ```
-
-* `_article.html.erb`
-
-    ```erb
-    <h2><%= article.title %></h2>
-
-    <% if local_assigns[:full] %>
-      <%= simple_format article.body %>
-    <% else %>
-      <%= truncate article.body %>
-    <% end %>
-    ```
-
-This way it is possible to use the partial without the need to declare all local variables.
-
-Every partial also has a local variable with the same name as the partial (minus the leading underscore). You can pass an object in to this local variable via the `:object` option:
-
-```erb
-<%= render partial: "customer", object: @new_customer %>
-```
-
-Within the `customer` partial, the `customer` variable will refer to `@new_customer` from the parent view.
-
-If you have an instance of a model to render into a partial, you can use a shorthand syntax:
-
-```erb
-<%= render @customer %>
-```
-
-Assuming that the `@customer` instance variable contains an instance of the `Customer` model, this will use `_customer.html.erb` to render it and will pass the local variable `customer` into the partial which will refer to the `@customer` instance variable in the parent view.
-
-#### Rendering Collections
-
-Partials are very useful in rendering collections. When you pass a collection to a partial via the `:collection` option, the partial will be inserted once for each member in the collection:
-
-* `index.html.erb`
-
-    ```html+erb
-    <h1>Products</h1>
-    <%= render partial: "product", collection: @products %>
-    ```
-
-* `_product.html.erb`
-
-    ```html+erb
-    <p>Product Name: <%= product.name %></p>
-    ```
-
-When a partial is called with a pluralized collection, then the individual instances of the partial have access to the member of the collection being rendered via a variable named after the partial. In this case, the partial is `_product`, and within the `_product` partial, you can refer to `product` to get the instance that is being rendered.
-
-There is also a shorthand for this. Assuming `@products` is a collection of `Product` instances, you can simply write this in the `index.html.erb` to produce the same result:
-
-```html+erb
-<h1>Products</h1>
-<%= render @products %>
-```
-
-Rails determines the name of the partial to use by looking at the model name in the collection. In fact, you can even create a heterogeneous collection and render it this way, and Rails will choose the proper partial for each member of the collection:
-
-* `index.html.erb`
-
-    ```html+erb
-    <h1>Contacts</h1>
-    <%= render [customer1, employee1, customer2, employee2] %>
-    ```
-
-* `customers/_customer.html.erb`
-
-    ```html+erb
-    <p>Customer: <%= customer.name %></p>
-    ```
-
-* `employees/_employee.html.erb`
-
-    ```html+erb
-    <p>Employee: <%= employee.name %></p>
-    ```
-
-In this case, Rails will use the customer or employee partials as appropriate for each member of the collection.
-
-In the event that the collection is empty, `render` will return nil, so it should be fairly simple to provide alternative content.
-
-```html+erb
-<h1>Products</h1>
-<%= render(@products) || "There are no products available." %>
-```
-
-#### Local Variables
-
-To use a custom local variable name within the partial, specify the `:as` option in the call to the partial:
-
-```erb
-<%= render partial: "product", collection: @products, as: :item %>
-```
-
-With this change, you can access an instance of the `@products` collection as the `item` local variable within the partial.
-
-You can also pass in arbitrary local variables to any partial you are rendering with the `locals: {}` option:
-
-```erb
-<%= render partial: "product", collection: @products,
-           as: :item, locals: {title: "Products Page"} %>
-```
-
-In this case, the partial will have access to a local variable `title` with the value "Products Page".
-
-#### Counter Variables
-
-Rails also makes a counter variable available within a partial called by the collection. The variable is named after the title of the partial followed by `_counter`. For example, when rendering a collection `@products` the partial `_product.html.erb` can access the variable `product_counter`. The variable indexes the number of times the partial has been rendered within the enclosing view, starting with a value of `0` on the first render.
-
-```erb
-# index.html.erb
-<%= render partial: "product", collection: @products %>
-```
-
-```erb
-# _product.html.erb
-<%= product_counter %> # 0 for the first product, 1 for the second product...
-```
-
-This also works when the local variable name is changed using the `as:` option. So if you did `as: :item`, the counter variable would be `item_counter`.
-
-#### Spacer Templates
-
-You can also specify a second partial to be rendered between instances of the main partial by using the `:spacer_template` option:
-
-```erb
-<%= render partial: @products, spacer_template: "product_ruler" %>
-```
-
-Rails will render the `_product_ruler` partial (with no data passed in to it) between each pair of `_product` partials.
-
-#### Collection Partial Layouts
-
-When rendering collections it is also possible to use the `:layout` option:
-
-```erb
-<%= render partial: "product", collection: @products, layout: "special_layout" %>
-```
-
-The layout will be rendered together with the partial for each item in the collection. The current object and object_counter variables will be available in the layout as well, the same way they are within the partial.
-
-### Using Nested Layouts
-
-You may find that your application requires a layout that differs slightly from your regular application layout to support one particular controller. Rather than repeating the main layout and editing it, you can accomplish this by using nested layouts (sometimes called sub-templates). Here's an example:
-
-Suppose you have the following `ApplicationController` layout:
-
-* `app/views/layouts/application.html.erb`
-
-    ```html+erb
-    <html>
-    <head>
-      <title><%= @page_title or "Page Title" %></title>
-      <%= stylesheet_link_tag "layout" %>
-      <%= yield :head %>
-    </head>
-    <body>
-      <div id="top_menu">Top menu items here</div>
-      <div id="menu">Menu items here</div>
-      <div id="content"><%= content_for?(:content) ? yield(:content) : yield %></div>
-    </body>
-    </html>
-    ```
-
-On pages generated by `NewsController`, you want to hide the top menu and add a right menu:
-
-* `app/views/layouts/news.html.erb`
-
-    ```html+erb
-    <% content_for :head do %>
-      <style>
-        #top_menu {display: none}
-        #right_menu {float: right; background-color: yellow; color: black}
-      </style>
-    <% end %>
-    <% content_for :content do %>
-      <div id="right_menu">Right menu items here</div>
-      <%= content_for?(:news_content) ? yield(:news_content) : yield %>
-    <% end %>
-    <%= render template: "layouts/application" %>
-    ```
-
-That's it. The News views will use the new layout, hiding the top menu and adding a new right menu inside the "content" div.
-
-There are several ways of getting similar results with different sub-templating schemes using this technique. Note that there is no limit in nesting levels. One can use the `ActionView::render` method via `render template: 'layouts/news'` to base a new layout on the News layout. If you are sure you will not subtemplate the `News` layout, you can replace the `content_for?(:news_content) ? yield(:news_content) : yield` with simply `yield`.
+In this application:
+
+* All `ArticlesController` actions will use the `main` layout.
+* All `ProductsController` actions will use the `product` layout.
+* `ProfilesController#show` will use the `profile` layout.
+* `ProfilesController#index` and all other actions in that controller will not use a layout.
+* All other actions across the application will default to the `main` layout.


### PR DESCRIPTION
### Motivation / Background

A complete rewrite of the Layouts and Rendering guide. It covered a lot of topics already covered in other guides, and the narrative flow went off on numerous tangents. I've moved content to other guides and removed information as I saw fit.

### Detail

I've rewritten the guide to focus heavily on the _relationship_ between the controller and the view. 

A lot of detail about rendering partials was already covered in the Action View Overview guide, so I've removed it. I moved the information about structuring layouts and similar view related detail into the Action View Overview with it fits a lot better with the narrative.

I've moved the section on request variants out of the Action Controller Overview and added it to this guide where I feel it fits a lot better. I also took the opportunity to add a brief intro about rendering to the Action Controller Overview and signpost this guide since they are very closely related.

### Internal Audit

Section 1: "though it normally hands off any heavy code to the Model" - 'heavy code' is possibly a bit unhelpful for beginners. How about 'it normally hands off more complex logic to methods on the model' or something like that?
Section 2: Creating responses. I almost want to go one step even further back and be sure to cover what we mean by HTTP responses, for those just starting out. Not in massive depth, because it isn't the right place for that, but just a little bit more clarification. Something like: "there are three ways to create an HTTP response in order to display information to the user on the page".

"Call [render](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Rendering.html#method-i-render) to create a full response to send back to the browser". Perhaps we could just add one more sentence here to break down what a 'full response' really is in terms of what a new developer/user would experience.

"Call [head](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Head.html#method-i-head) to create a response consisting solely of HTTP headers to send back to the browser" - maybe we could add examples of why we might do this?
[New boost](https://3.basecamp.com/3076981/buckets/35498807/boosts/new?boost%5Bboostable_gid%5D=Z2lkOi8vYmMzL1JlY29yZGluZy83Njk3MzY5MTA4)Section 1: "though it normally hands off any heavy code to the Model" - 'heavy code' is possibly a bit unhelpful for beginners. How about 'it normally hands off more complex logic to methods on the model' or something like that?

Section 2: Creating responses. I almost want to go one step even further back and be sure to cover what we mean by HTTP responses, for those just starting out. Not in massive depth, because it isn't the right place for that, but just a little bit more clarification. Something like: "there are three ways to create an HTTP response in order to display information to the user on the page".

"Call [render](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Rendering.html#method-i-render) to create a full response to send back to the browser". Perhaps we could just add one more sentence here to break down what a 'full response' really is in terms of what a new developer/user would experience.

"Call [head](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Head.html#method-i-head) to create a response consisting solely of HTTP headers to send back to the browser" - maybe we could add examples of why we might do this?
[New boost](https://3.basecamp.com/3076981/buckets/35498807/boosts/new?boost%5Bboostable_gid%5D=Z2lkOi8vYmMzL1JlY29yZGluZy83Njk3MzY5MTA4)

End of section 2.1.1 we mention `status: :unprocessable_entity`. Worth expanding out this slightly to point out that we can render a template with a specific status code etc., and briefly why we might want to do this. We've got more info on this in section 2.2.13.4, so maybe just worth linking to this.

2.2.4 - I feel like this section is slightly confusing. We are told that it's valid to use `render inline:`, but the warning box tells us that there is seldom any reason to use this. Maybe it would be better to find a reason why we would need this, but if not, make it short and clear - more like 'this is here but probably won't be needed'.

2.2.7 and 2.2.8 feel repetitive. Can we combine these into one section and say that it's applicable to both XML and JSON?
2.2.13.1 MIME content type - worth a link to the MDN web docs or similar for explanation.

2.2.14 Finding Layouts - this is mostly a repeat of information at the beginning of the guide - the only difference is the addition of the builder information. We can probably re-organise this to make both sections more DRY.

At the start of Section 3, it mentions 'the rules for finding layouts that were mentioned earlier in this guide'. It would be more user-friendly to also link to them at this point.

3.1.1 - let's provide links to more information about RSS/Atom if possible?
Likewise, would be good to provide a link to the Sprockets gem repo when we mention it, for context.

- I think the "Using `render`" section could be it's own top section. This probably applies to all sections ("Rendering by Default", "Using `redirect_to`" and "Using `head`"). All these sections have interesting sub section that currently don't show up in the sidebar and this guide doesn't have that much sub sections as of yet.

- "Rendering an Action's View" shows an example of explicitly rendering a view (the "edit" view in the "update" action). Maybe rename this section to: "Explicitly Rendering an Action's View"? Maybe the example could be simpler as well with a "show" action that renders for example a "details" view?
- "Ajax libraries" is probably an outdated term? Maybe replace with something about an API end-point?

- The "Finding Layouts" section should probably be a top section in a "Layout and Rendering" guide?
- Some examples here could benefit from having the filename as a comment in the example code.

- The whole "Asset Tag Helpers" section can probably be removed as these are already described the in the "Action View Helpers" guide. I'm not sure it adds anything here.
- Maybe move the "Understanding yield" section to the "Action View Overview" guide under "Layouts" which also handles `yield`?
- The above also applies to "Using the content_for method".
- The "Using Partials" section can probably be removed as this is already described in the "Action View Overview" guide. Partials don't really know anything about Controllers, so it makes more sense to have it in a Action View guide.
- I'm not sure if the "Nested Layouts" adds anything or if that is a commonly used pattern.