### PR TITLE
add a sanitize_url_string helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `sanitize_url_string` helper to prevent unsafe protocols in URLs. Example
+    usage:
+    ```
+        sanitize_url_string("javascript:alert(1)", fallback: root_url)
+    ```
+
+    *Greg Molnar and Darius Pirvulescu*
+
 *   Skip blank attribute names in tag helpers to avoid generating invalid HTML.
 
     *Mike Dalessio*

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -123,6 +123,25 @@ module ActionView
         self.class.safe_list_sanitizer.sanitize_css(style)
       end
 
+      # Sanitizes a URL or path string input against unsafe protocols with a
+      # fallback option
+      #
+      # It disallows unsafe protocols like +javascript:+ from a string, while also
+      # protecting against attempts to use Unicode, ASCII, and hex character
+      # references to work around these protocol filters.
+      #
+      # === Parameters
+      #
+      # * +fallback+ - a fallback to use in case of a disallowed URL, defaults to "/"
+      #
+      def sanitize_url_string(url, fallback: "/")
+        if Rails::HTML::Sanitizer.allowed_uri?(url)
+          url
+        else
+          fallback
+        end
+      end
+
       # Strips all HTML tags from +html+, including comments and special characters.
       #
       #   strip_tags("Strip <i>these</i> tags!")

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -343,6 +343,13 @@ module SanitizeHelperVendorTests
     assert_equal("Example of a fragment", result)
   end
 
+  def test_sanitize_url_string
+    input = "javascript:alert(1)"
+    result = @subject.sanitize_url_string(input, fallback: "/safe_url")
+
+    assert_equal("/safe_url", result)
+  end
+
   def test_strip_links
     input = %(<div><a href="http://www.example.com/">Example</a> of a fragment</div>)
     result = @subject.strip_links(input)


### PR DESCRIPTION
### Motivation / Background

The `sanitize` helper removes unsafe protocols from the src/href attribute of HTML elements, but if you just want to remove those from a raw URL string, `sanitize` wouldn't help. This actual misled me(and others) in the past and I was under the impression that I mitigated an XSS issue(https://github.com/rubyevents/rubyevents/pull/1558), but I didn't. 
This pull request introduces a `sanitize_url` helper that can be used in the quite common situation of using `link_to` with a block. In case of an unsafe protocol in the input, it returns a fallback that defaults to "/".


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
