### PR TITLE
Fix lazy ivars causing different model shapes

### DIFF
--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -9,6 +9,11 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     module ClassMethods # :nodoc:
+      def inherited(base)
+        super
+        base.instance_variable_set(:@pending_attribute_modifications, nil)
+      end
+
       def attribute(name, type = nil, default: (no_default = true), **options)
         name = resolve_attribute_name(name)
         type = resolve_type_name(type, **options) if type.is_a?(Symbol)

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -103,6 +103,12 @@ module ActiveRecord
     end
 
     module ClassMethods
+      def inherited(subclass) # :nodoc
+        super
+        subclass.instance_variable_set(:@local_stored_attributes, nil)
+        subclass.instance_variable_set(:@_store_accessors_module, nil)
+      end
+
       def store(store_attribute, options = {})
         coder = build_column_serializer(store_attribute, options[:coder], Object, options[:yaml])
         serialize store_attribute, coder: IndifferentCoder.new(store_attribute, coder)


### PR DESCRIPTION
These changes reduce the number of shapes of ActiveRecord::Base subclasses in the Lobsters benchmark of ruby-bench from 3 to 1.

Before:

 ```
┌───────┬──────────────────────────────────────────────────────────┬────────────────────────────────────────────┐
 │ Shape │ Models                                                   │ Cause                                      │
 ├───────┼──────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
 │ 2169  │ Category, Comment, Domain, Hat, HatRequest, HiddenStory, │ No @pending_attribute_modifications until  │
 │       │ Invitation, InvitationRequest, Keystore, ModNote,        │ attribute_types called                     │
 │       │ Moderation, ReadRibbon, SavedStory, Story, StoryText,    │                                            │
 │       │ SuggestedTagging, SuggestedTitle, Tag, TagFilter,        │                                            │
 │       │ Tagging, Vote (21)                                       │                                            │
 ├───────┼──────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
 │ 2175  │ Message, ReplyingComment (2)                             │ @pending_attribute_modifications set early │
 │       │                                                          │ by explicit attribute call in class body   │
 ├───────┼──────────────────────────────────────────────────────────┼────────────────────────────────────────────┤
 │ 2172  │ User (1)                                                 │ @pending_attribute_modifications +         │
 │       │                                                          │ @_store_accessors_module +                 │
 │       │                                                          │ @local_stored_attributes from typed_store  │
 └───────┴──────────────────────────────────────────────────────────┴────────────────────────────────────────────┘
```
 After:

 ```
┌───────┬────────────────────────────────────────────────────────────────────────────────────┬──────────────────┐
 │ Shape │ Models                                                                             │ Cause            │
 ├───────┼────────────────────────────────────────────────────────────────────────────────────┼──────────────────┤
 │ 1831  │ Category, Comment, Domain, Hat, HatRequest, HiddenStory, Invitation,               │ All ivars        │
 │       │ InvitationRequest, Keystore, Message, ModNote, Moderation, ReadRibbon,             │ established in   │
 │       │ ReplyingComment, SavedStory, Story, StoryText, SuggestedTagging, SuggestedTitle,   │ inherited        │
 │       │ Tag, TagFilter, Tagging, User, Vote (24)                                           │                  │
 └───────┴────────────────────────────────────────────────────────────────────────────────────┴──────────────────┘
```

(I will admit the method parameter names being different is silly but I followed what the rest of Active Model and Active Record typically named their `inherited` parameters)

cc @byroot is this backportable? I was thinking 8.1 but not further