### PR TITLE
De-anonymize generated attribute module for Store

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -103,7 +103,7 @@ module ActiveRecord
     end
 
     module ClassMethods
-      def inherited(subclass) # :nodoc
+      def inherited(subclass) # :nodoc:
         super
         subclass.instance_variable_set(:@local_stored_attributes, nil)
         subclass.instance_variable_set(:@_store_accessors_module, nil)

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -106,7 +106,6 @@ module ActiveRecord
       def inherited(subclass) # :nodoc:
         super
         subclass.instance_variable_set(:@local_stored_attributes, nil)
-        subclass.instance_variable_set(:@_store_accessors_module, nil)
       end
 
       def store(store_attribute, options = {})
@@ -137,7 +136,15 @@ module ActiveRecord
             ""
           end
 
-        _store_accessors_module.module_eval do
+        mod = if const_defined?(:GeneratedStoreMethods, false)
+          const_get(:GeneratedStoreMethods, false)
+        else
+          mod = const_set(:GeneratedStoreMethods, Module.new)
+          include mod
+          mod
+        end
+
+        mod.module_eval do
           keys.each do |key|
             accessor_key = "#{accessor_prefix}#{key}#{accessor_suffix}"
 
@@ -200,14 +207,6 @@ module ActiveRecord
         self.local_stored_attributes ||= {}
         self.local_stored_attributes[store_attribute] ||= []
         self.local_stored_attributes[store_attribute] |= keys
-      end
-
-      def _store_accessors_module # :nodoc:
-        @_store_accessors_module ||= begin
-          mod = Module.new
-          include mod
-          mod
-        end
       end
 
       def stored_attributes


### PR DESCRIPTION
(based on #57020)

```
❯ bin/rails c
Loading development environment (Rails 8.1.2)
Lobsters(dev):001> User.ancestors
=>
[User (call 'User.load_schema' to load schema informations),
 #<Module:0x0000000125bfcf40>,
```

Previously, ActiveRecord::Store would include an anonymous module into
models which holds the Store's generated attributes.

This commit names the module to make it obvious what the module is in
the list of ancestors, and then uses the name to reference it instead of
storing a reference to the module in an instance variable on the
singleton class.