### PR TITLE
Fix `insert_all` and `upsert_all` log messages for anonymous classes

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -47,7 +47,7 @@ module ActiveRecord
     def execute
       return ActiveRecord::Result.empty if inserts.empty?
 
-      message = +"#{model} "
+      message = +"#{model.name} "
       message << "Bulk " if inserts.many?
       message << (on_duplicate == :update ? "Upsert" : "Insert")
       connection.exec_insert_all self, message

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -352,6 +352,21 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_logs_message_including_model_name_from_anonymous_class
+    skip unless supports_insert_conflict_target?
+
+    anonymous_book_klass = Class.new(Book) do
+      def self.name
+        "AnonymousBook"
+      end
+    end
+
+    capture_log_output do |output|
+      anonymous_book_klass.insert({ name: "Rework", author_id: 1 })
+      assert_match "AnonymousBook Insert", output.string
+    end
+  end
+
   def test_insert_all_logs_message_including_model_name
     skip unless supports_insert_conflict_target?
 


### PR DESCRIPTION
Rebase and cleanup of: https://github.com/rails/rails/pull/57018
Author: @sobrinho

Ensure bulk insert/upsert log messages use the model name for anonymous classes, producing readable entries such as `AnonymousBook Bulk Insert` and `AnonymousBook Bulk Upsert`.
