### PR TITLE
Fix flaky test failures caused by connection pool reaper

### DIFF
--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -46,7 +46,13 @@ module ActiveRecord
       # which could lead to some slow wait in a subsequent thread.
       leaked_conn = []
       ActiveRecord::Base.connection_handler.each_connection_pool do |pool|
-        # Ensure all in flights tasks are completed.
+        # Wait for any in-progress reaper maintenance to complete.
+        # The reaper temporarily checks out connections via
+        # checkout_for_maintenance during preconnect, keep_alive, etc.
+        # which would otherwise be flagged as leaks.
+        pool.reaper_lock { }
+
+        # Ensure all in-flight async executor tasks are completed.
         # Otherwise they may still hold a connection.
         if pool.async_executor
           if pool.async_executor.scheduled_task_count != pool.async_executor.completed_task_count

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -34,6 +34,14 @@ module ARTest
 
             connection[name]["database"] ||= dbname
             connection[name]["adapter"]  ||= adapter == "sqlite3_mem" ? "sqlite3" : adapter
+
+            # Disable the reaper in test pools to prevent flaky failures.
+            # The reaper thread can cause false-positive leak detections in
+            # check_connection_leaks and Trilogy::SynchronizationError when
+            # it accesses connections from its background thread during test
+            # setup/teardown. Reaper behavior is tested in reaper_test.rb
+            # with dedicated pools that set their own reaping_frequency.
+            connection[name]["reaping_frequency"] ||= 0
           end
         end
 


### PR DESCRIPTION
## Motivation

Fixes #57027

Fixes flaky CI failures caused by the connection pool reaper thread interfering with test lifecycle.

Two distinct failure modes:

**1. False-positive leak detection (PostgreSQL)**
```
RuntimeError: Found 1 leaked connection after
BelongsToAssociationsTest#test_belongs_to_counter_after_update
owner: #<Thread:... "AR Pool Reaper" sleep>
```
The reaper's `checkout_for_maintenance` temporarily leases connections. If `check_connection_leaks` runs at that moment, it flags the connection as leaked.

**2. Trilogy::SynchronizationError (MySQL/Trilogy)**
```
Trilogy::SynchronizationError: This connection is already in use by another thread or fiber
```
The reaper's `preconnect`/`keep_alive` accesses raw Trilogy sockets from its background thread while the test thread uses the same connection during `pin_connection!`/`unpin_connection!`.

## Root Cause

Both are race conditions between the reaper's background maintenance cycle and the test lifecycle (`setup_transactional_fixtures`, `pin_connection!`, `unpin_connection!`, `check_connection_leaks`).

## Solution

Two-part fix:

**1. Disable the reaper on test connection pools** (`test/support/config.rb`)

Set `reaping_frequency: 0` for all test database configs. This prevents the reaper thread from spawning for the main test pools, eliminating both race conditions at the source.

Reaper behavior is independently tested in `reaper_test.rb` with dedicated pools that set their own `reaping_frequency`.

**2. Safety net in `check_connection_leaks`** (`test/cases/test_case.rb`)

Acquire `pool.reaper_lock` before checking for leaks, in case any test creates a pool with reaping enabled. This ensures maintenance connections have been returned before we inspect them.

## Reproduction

The race condition was reproduced locally by simulating `checkout_for_maintenance` from a background thread:

```
=== Simulating reaper race condition ===
Results: 100/100 detected false-positive leaks (100.0%)
Race condition REPRODUCED!

=== Testing fix: pool.reaper_lock { } ===
Results with fix: 0/100 false positives (0.0%)
Fix WORKS!
```

## Test Plan

- [x] Connection pool tests pass (149 tests, 0 failures)
- [x] Reaper tests pass (9 tests, 0 failures) — they use their own pools
- [x] `test_belongs_to_counter_after_update` passes
- [x] RuboCop passes on changed files
- [x] Race condition reproduced and verified fixed locally