### PR TITLE
Bump actions/upload-artifact from v6 to v7 in CI templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -1,0 +1,235 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ <%= user_default_branch %> ]
+
+permissions:
+  contents: read
+
+jobs:
+<%- unless skip_brakeman? && skip_bundler_audit? -%>
+  scan_ruby:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      <%- unless skip_brakeman? -%>
+
+      - name: Scan for common Rails security vulnerabilities using static analysis
+        run: bin/brakeman --no-pager
+      <% end -%>
+      <%- unless skip_bundler_audit? -%>
+
+      - name: Scan for known security vulnerabilities in gems used
+        run: bin/bundler-audit
+      <% end -%>
+
+<% end -%>
+<%- if using_importmap? -%>
+  scan_js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Scan for security vulnerabilities in JavaScript dependencies
+        run: bin/importmap audit
+
+<% end -%>
+<%- unless skip_rubocop? -%>
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      RUBOCOP_CACHE_ROOT: tmp/rubocop
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Prepare RuboCop cache
+        uses: actions/cache@v5
+        env:
+          DEPENDENCIES_HASH: ${{ hashFiles('.ruby-version', '**/.rubocop.yml', '**/.rubocop_todo.yml', 'Gemfile.lock') }}
+        with:
+          path: ${{ env.RUBOCOP_CACHE_ROOT }}
+          key: rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name == github.event.repository.default_branch && github.run_id || 'default' }}
+          restore-keys: |
+            rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-
+
+      - name: Lint code for consistent style
+        run: bin/rubocop -f github
+
+<% end -%>
+<% unless options[:skip_test] -%>
+  test:
+    runs-on: ubuntu-latest
+
+    <%- if options[:database] == "sqlite3" -%>
+    # services:
+    #  redis:
+    #    image: valkey/valkey:9
+    #    ports:
+    #      - 6379:6379
+    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    <%- else -%>
+    services:
+      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "postgresql" -%>
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end -%>
+
+      # redis:
+      #   image: valkey/valkey:9
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    <%- end -%>
+    steps:
+      <%- unless ci_packages.empty? -%>
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
+
+      <%- end -%>
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      <%- if using_bun? -%>
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: <%= dockerfile_bun_version %>
+      <%- end -%>
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          <%- if options[:database] == "mysql" -%>
+          DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "trilogy" -%>
+          DATABASE_URL: trilogy://127.0.0.1:3306
+          <%- elsif options[:database] == "postgresql" -%>
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- end -%>
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test
+  <%- unless options[:api] || options[:skip_system_test] -%>
+
+  system-test:
+    runs-on: ubuntu-latest
+
+    <%- if options[:database] == "sqlite3" -%>
+    # services:
+    #  redis:
+    #    image: valkey/valkey:9
+    #    ports:
+    #      - 6379:6379
+    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    <%- else -%>
+    services:
+      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "postgresql" -%>
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end -%>
+
+      # redis:
+      #   image: valkey/valkey:9
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    <%- end -%>
+    steps:
+      <%- unless ci_packages.empty? -%>
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
+
+      <%- end -%>
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      <%- if using_bun? -%>
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: <%= dockerfile_bun_version %>
+      <%- end -%>
+
+      - name: Run System Tests
+        env:
+          RAILS_ENV: test
+          <%- if options[:database] == "mysql" -%>
+          DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "trilogy" -%>
+          DATABASE_URL: trilogy://127.0.0.1:3306
+          <%- elsif options[:database] == "postgresql" -%>
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- end -%>
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test:system
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/screenshots
+          if-no-files-found: ignore
+  <%- end -%>
+<%- end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -1,0 +1,118 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ <%= user_default_branch %> ]
+
+permissions:
+  contents: read
+
+jobs:
+<%- unless skip_rubocop? -%>
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      RUBY_VERSION: <%= version_manager_ruby_version %>
+      RUBOCOP_CACHE_ROOT: tmp/rubocop
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Prepare RuboCop cache
+        uses: actions/cache@v5
+        env:
+          DEPENDENCIES_HASH: ${{ hashFiles('**/.rubocop.yml', '**/.rubocop_todo.yml', 'Gemfile.lock') }}
+        with:
+          path: ${{ env.RUBOCOP_CACHE_ROOT }}
+          key: rubocop-${{ runner.os }}-${{ env.RUBY_VERSION }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name == github.event.repository.default_branch && github.run_id || 'default' }}
+          restore-keys: |
+            rubocop-${{ runner.os }}-${{ env.RUBY_VERSION }}-${{ env.DEPENDENCIES_HASH }}-
+
+      - name: Lint code for consistent style
+        run: bin/rubocop -f github
+
+<% end -%>
+<% unless options[:skip_test] -%>
+  test:
+    runs-on: ubuntu-latest
+
+    <%- if options[:database] == "sqlite3" -%>
+    # services:
+    #  redis:
+    #    image: valkey/valkey:9
+    #    ports:
+    #      - 6379:6379
+    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    <%- else -%>
+    services:
+      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "postgresql" -%>
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end -%>
+
+      # redis:
+      #   image: valkey/valkey:9
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    <%- end -%>
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: <%= version_manager_ruby_version %>
+          bundler-cache: true
+      <%- if using_bun? -%>
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: <%= dockerfile_bun_version %>
+      <%- end -%>
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          <%- if options[:database] == "mysql" -%>
+          DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "trilogy" -%>
+          DATABASE_URL: trilogy://127.0.0.1:3306
+          <%- elsif options[:database] == "postgresql" -%>
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- end -%>
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          # REDIS_URL: redis://localhost:6379/0
+        run: <%= test_command %>
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/screenshots
+          if-no-files-found: ignore
+<% end -%>


### PR DESCRIPTION
Updates the GitHub Actions CI workflow templates for both `rails new` (app) and `rails plugin new` (plugin) generators to use `actions/upload-artifact@v7`.

This is a follow-up to #56773 which bumped v4 → v6. The v7 release is now available and new projects generated with `rails new` immediately get Dependabot PRs to bump this action.

### Checklist

- [x] App generator template (`railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt`)
- [x] Plugin generator template (`railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt`)