### PR TITLE
Fix incompatibility in ActionView with ruby 3.3.0

### DIFF
--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -44,10 +44,10 @@ module ActionView
       #
       #   @greeting # => "Welcome to my shiny new web page! The date and time is 2018-09-06 11:09:16 -0500"
       #
-      def capture(*, **, &block)
+      def capture(*args, **kwargs, &block)
         value = nil
         @output_buffer ||= ActionView::OutputBuffer.new
-        buffer = @output_buffer.capture { value = yield(*, **) }
+        buffer = @output_buffer.capture { value = yield(*args, **kwargs) }
 
         string = if @output_buffer.equal?(value)
           buffer


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because in Ruby 3.3.0, anonymous rest parameter cannot be also used within block. Using latest Rails version (8.1.2) with ruby 3.3.0 raises the below error:

```
anonymous rest parameter is also used within block (SyntaxError)
```

### Detail

This Pull Request changes to use explicit parameter instead of rest parameter.

### Additional information

If Rails 8.1.2 doesn't support ruby 3.3.0, maybe we should update the restriction there.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
