### PR TITLE
Add test coverage for ActiveModel::Errors#where

### DIFF
--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -98,6 +98,65 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal false, errors.key?(:name), "errors should not have key :name"
   end
 
+  test "where returns errors filtered by attribute" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :blank)
+    errors.add(:name, :too_short, count: 5)
+    errors.add(:age, :blank)
+
+    name_errors = errors.where(:name)
+    assert_equal 2, name_errors.length
+    assert(name_errors.all? { |e| e.attribute == :name })
+
+    age_errors = errors.where(:age)
+    assert_equal 1, age_errors.length
+    assert_equal :age, age_errors.first.attribute
+  end
+
+  test "where returns errors filtered by attribute and type" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :blank)
+    errors.add(:name, :too_short, count: 5)
+    errors.add(:name, :invalid)
+
+    result = errors.where(:name, :too_short)
+    assert_equal 1, result.length
+    assert_equal :too_short, result.first.type
+  end
+
+  test "where returns errors filtered by attribute, type, and options" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :too_short, count: 2)
+    errors.add(:name, :too_short, count: 5)
+
+    result = errors.where(:name, :too_short, count: 2)
+    assert_equal 1, result.length
+    assert_equal 2, result.first.options[:count]
+  end
+
+  test "where returns empty array when no match" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :blank)
+
+    result = errors.where(:age)
+    assert_equal [], result
+
+    result = errors.where(:name, :too_short)
+    assert_equal [], result
+  end
+
+  test "where returns Error objects" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :blank)
+    errors.add(:name, :too_short, count: 5)
+
+    result = errors.where(:name)
+    assert_not_empty result
+    result.each do |error|
+      assert_kind_of ActiveModel::Error, error
+    end
+  end
+
   test "clear errors" do
     person = Person.new
     person.validate!


### PR DESCRIPTION
### Motivation / Background

The `ActiveModel::Errors#where` method is a public API for filtering errors by attribute, type, and options. It currently has no dedicated test coverage — confirmed by searching the entire `activemodel/test` directory for `.where(` calls on error objects, which returned zero matches.

### Detail

This Pull Request adds 5 focused tests for `Errors#where` in `activemodel/test/cases/errors_test.rb`:

- **Filtering by attribute** — adds errors on multiple attributes, verifies `where(:name)` returns only name errors
- **Filtering by attribute and type** — adds errors with different types on the same attribute, verifies type filtering
- **Filtering by attribute, type, and options** — verifies option-level filtering (e.g., `count: 2`)
- **Empty result** — verifies `where` returns `[]` for non-matching queries
- **Return type** — verifies all returned objects are `ActiveModel::Error` instances

### Additional information

All 97 tests in `errors_test.rb` pass with 0 failures.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.