### PR TITLE
Add test coverage for IsolatedExecutionState#key?, #delete, and #context

### DIFF
--- a/activesupport/test/isolated_execution_state_test.rb
+++ b/activesupport/test/isolated_execution_state_test.rb
@@ -120,4 +120,40 @@ class IsolatedExecutionStateTest < ActiveSupport::TestCase
     assert_nil result[:secret2]
     assert_equal "keep this", result[:keep]
   end
+
+  test "#key? returns true for existing key" do
+    ActiveSupport::IsolatedExecutionState[:test] = 42
+    assert ActiveSupport::IsolatedExecutionState.key?(:test)
+  end
+
+  test "#key? returns false for non-existing key" do
+    assert_not ActiveSupport::IsolatedExecutionState.key?(:nonexistent)
+  end
+
+  test "#key? returns false/nil when no state initialized" do
+    ActiveSupport::IsolatedExecutionState.clear
+    Thread.current.active_support_execution_state = nil
+    assert_not ActiveSupport::IsolatedExecutionState.key?(:anything)
+  end
+
+  test "#delete removes key and returns its value" do
+    ActiveSupport::IsolatedExecutionState[:test] = 42
+    result = ActiveSupport::IsolatedExecutionState.delete(:test)
+    assert_equal 42, result
+    assert_nil ActiveSupport::IsolatedExecutionState[:test]
+  end
+
+  test "#delete returns nil for non-existing key" do
+    assert_nil ActiveSupport::IsolatedExecutionState.delete(:nonexistent)
+  end
+
+  test "#context returns the current thread when isolation level is :thread" do
+    ActiveSupport::IsolatedExecutionState.isolation_level = :thread
+    assert_equal Thread.current, ActiveSupport::IsolatedExecutionState.context
+  end
+
+  test "#context returns the current fiber when isolation level is :fiber" do
+    ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+    assert_equal Fiber.current, ActiveSupport::IsolatedExecutionState.context
+  end
 end


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::IsolatedExecutionState` has tests for `#[]`, `#[]=`, isolation level switching, and `#share_with`, but the `#key?`, `#delete`, and `#context` public methods have no dedicated test coverage.

### Detail

This Pull Request adds 7 tests to `activesupport/test/isolated_execution_state_test.rb`:

- **`#key?` returns true for existing key** — sets a key, verifies `key?` returns true
- **`#key?` returns false for non-existing key** — verifies `key?` returns false for missing key
- **`#key?` handles nil state gracefully** — clears state, verifies no error when state is uninitialized
- **`#delete` removes key and returns its value** — sets a key, deletes it, verifies return value and absence
- **`#delete` returns nil for non-existing key** — deletes a missing key, asserts nil
- **`#context` returns current thread** — under `:thread` isolation, verifies `context == Thread.current`
- **`#context` returns current fiber** — under `:fiber` isolation, verifies `context == Fiber.current`

### Additional information

All 13 tests in `isolated_execution_state_test.rb` pass with 0 failures, 27 assertions.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.