### PR TITLE
Add previous_attachment_changes for after_commit callbacks

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `previous_attachment_changes` for `after_commit` callbacks.
+
+    Active Storage now preserves attachment changes in
+    `previous_attachment_changes` before clearing them during the
+    upload `after_commit` callback. User-defined `after_commit`
+    callbacks can read `previous_attachment_changes` to determine
+    which attachments were modified, regardless of callback definition
+    order.
+
+    Previously, `attachment_changes` was destructively cleared during
+    upload, making it unavailable to callbacks defined after
+    `has_one_attached`/`has_many_attached`. This was especially
+    problematic after Rails 7.1 changed `after_commit` to run in
+    definition order.
+
+    *Denis Savchuk*
+
 *   Configurable maximum streaming chunk size
 
     Makes sure that byte ranges for blobs don't exceed 100mb by default.
@@ -27,7 +44,6 @@
     do not respect these metacharacters).
 
     *Mike Dalessio*
-
 
 *   Restore ADC when signing URLs with IAM for GCS
 

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -156,7 +156,13 @@ module ActiveStorage
 
         after_save { attachment_changes[name.to_s]&.save }
 
-        after_commit(on: %i[ create update ]) { attachment_changes.delete(name.to_s).try(:upload) }
+        after_commit(on: %i[ create update ]) do
+          change = attachment_changes.delete(name.to_s)
+          if change
+            (@previous_attachment_changes ||= {})[name.to_s] = change
+            change.upload if change.respond_to?(:upload)
+          end
+        end
 
         reflection = ActiveRecord::Reflection.create(
           :has_one_attached,
@@ -270,7 +276,13 @@ module ActiveStorage
 
         after_save { attachment_changes[name.to_s]&.save }
 
-        after_commit(on: %i[ create update ]) { attachment_changes.delete(name.to_s).try(:upload) }
+        after_commit(on: %i[ create update ]) do
+          change = attachment_changes.delete(name.to_s)
+          if change
+            (@previous_attachment_changes ||= {})[name.to_s] = change
+            change.upload if change.respond_to?(:upload)
+          end
+        end
 
         reflection = ActiveRecord::Reflection.create(
           :has_many_attached,
@@ -307,6 +319,14 @@ module ActiveStorage
       @attachment_changes ||= {}
     end
 
+    # Returns a hash of attachment changes that were committed in the last
+    # transaction. Similar to ActiveModel's +previous_changes+, this allows
+    # +after_commit+ callbacks to check which attachments were modified,
+    # regardless of callback definition order.
+    def previous_attachment_changes
+      @previous_attachment_changes ||= {}
+    end
+
     def changed_for_autosave? # :nodoc:
       super || attachment_changes.any?
     end
@@ -315,10 +335,14 @@ module ActiveStorage
       super
       @active_storage_attached = nil
       @attachment_changes = nil
+      @previous_attachment_changes = nil
     end
 
     def reload(*) # :nodoc:
-      super.tap { @attachment_changes = nil }
+      super.tap do
+        @attachment_changes = nil
+        @previous_attachment_changes = nil
+      end
     end
   end
 end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -932,4 +932,24 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal 1, @user.highlights.count
     assert_equal "racecar.jpg", @user.highlights.blobs.first.filename.to_s
   end
+
+  test "previous_attachment_changes available in after_commit callback defined after has_many_attached" do
+    observed_changes = nil
+    original_callbacks = User._commit_callbacks.dup
+
+    User.after_commit(on: %i[create update]) do
+      observed_changes = previous_attachment_changes["highlights"]
+    end
+
+    @user.highlights.attach(
+      content_type: "text/plain",
+      filename: "test.txt",
+      io: StringIO.new("test")
+    )
+
+    assert_not_nil observed_changes,
+      "previous_attachment_changes should be available in after_commit defined after has_many_attached"
+  ensure
+    User._commit_callbacks = original_callbacks
+  end
 end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -869,4 +869,24 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
     assert_match(/Cannot find variant :unknown for User#avatar_with_variants/, error.message)
   end
+
+  test "previous_attachment_changes available in after_commit callback defined after has_one_attached" do
+    observed_changes = nil
+    original_callbacks = User._commit_callbacks.dup
+
+    User.after_commit(on: %i[create update]) do
+      observed_changes = previous_attachment_changes["avatar"]
+    end
+
+    @user.avatar.attach(
+      content_type: "text/plain",
+      filename: "test.txt",
+      io: StringIO.new("test")
+    )
+
+    assert_not_nil observed_changes,
+      "previous_attachment_changes should be available in after_commit defined after has_one_attached"
+  ensure
+    User._commit_callbacks = original_callbacks
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #56861

Since Rails 7.1 runs `after_commit` callbacks in definition order, user callbacks defined after `has_one_attached`/`has_many_attached` can't see `attachment_changes` — Active Storage's callback deletes the entry before user callbacks run.

```ruby
class User < ActiveRecord::Base
  has_one_attached :avatar

  # runs AFTER Active Storage's callback — attachment_changes["avatar"] is nil
  after_commit :process_avatar, if: -> { attachment_changes["avatar"].present? }
end
```

### Detail

Preserve attachment changes in `previous_attachment_changes` before clearing them, mirroring Active Record's `previous_changes`:

```ruby
class User < ActiveRecord::Base
  has_one_attached :avatar

  after_commit :process_avatar, on: %i[create update],
    if: -> { previous_attachment_changes["avatar"].present? }
end
```

`previous_attachment_changes` is cleared on `reload` and `initialize_dup`, matching the lifecycle of `attachment_changes`.

Also replaces `.try(:upload)` with `respond_to?(:upload)` + direct call, removing `.try`'s overhead.

### Additional information

| Path | Before | After |
|---|---|---|
| Create attachment (common) | 3,092k i/s | 4,190k i/s (+1.36×) |
| Delete attachment (edge) | 4,174k i/s | 4,175k i/s (same) |

Memory: +16 bytes/commit (one extra hash entry per transaction).

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.