### PR TITLE
Refactor solid installation commands and add tests for gem configuration

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -753,10 +753,30 @@ module Rails
       def run_solid
         return if skip_solid? || !bundle_install?
 
-        commands = "solid_cache:install solid_queue:install"
-        commands += " solid_cable:install" unless skip_action_cable?
+        solid_install_commands.each do |command|
+          rails_command command
+        end
+      end
 
-        rails_command commands
+      def solid_install_commands
+        commands = []
+        commands << "solid_cache:install" if solid_gem_configured?("solid_cache")
+        commands << "solid_queue:install" if solid_gem_configured?("solid_queue")
+        commands << "solid_cable:install" if !skip_action_cable? && solid_gem_configured?("solid_cable")
+        commands
+      end
+
+      def solid_gem_configured?(gem_name)
+        gem_declared_in_gemfile?(gem_name)
+      end
+
+      def gem_declared_in_gemfile?(gem_name)
+        in_root do
+          return false unless File.exist?("Gemfile")
+
+          gem_declaration_pattern = /^\s*gem\s+["']#{Regexp.escape(gem_name)}["'](?:\s|,|$)/
+          File.foreach("Gemfile").any? { |line| line.match?(gem_declaration_pattern) }
+        end
       end
 
       def add_bundler_platforms

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -759,6 +759,72 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_generation_skips_solid_cache_installer_when_solid_cache_gem_is_absent
+    template_path = File.join(destination_root, "remove_solid_cache.rb")
+    File.write(template_path, <<~RUBY)
+      gsub_file "Gemfile", /^gem "solid_cache"\\n/, ""
+    RUBY
+
+    generator [destination_root], ["--template", template_path]
+
+    @rails_command_stub = ->(command, *_) do
+      if command == "solid_cache:install"
+        raise Rails::Command::UnrecognizedCommandError.new("solid_cache:install")
+      end
+
+      @rails_commands << command
+    end
+
+    run_generator_instance
+
+    assert_no_gem "solid_cache"
+    assert_gem "solid_queue"
+    assert_gem "solid_cable"
+
+    assert_not_includes @rails_commands, "solid_cache:install"
+    assert_includes @rails_commands, "solid_queue:install"
+    assert_includes @rails_commands, "solid_cable:install"
+  end
+
+  def test_run_solid_supports_all_solid_gem_combinations
+    all_solid_gems = %w[solid_cache solid_queue solid_cable]
+    combinations = (0..all_solid_gems.length).flat_map { |size| all_solid_gems.combination(size).to_a }
+
+    combinations.each do |configured_gems|
+      generator [destination_root]
+
+      executed_commands = []
+
+      generator.stub(:solid_gem_configured?, ->(gem_name) { configured_gems.include?(gem_name) }) do
+        generator.stub(:rails_command, ->(command, *_) { executed_commands << command }) do
+          generator.send(:run_solid)
+        end
+      end
+
+      expected_commands = []
+      expected_commands << "solid_cache:install" if configured_gems.include?("solid_cache")
+      expected_commands << "solid_queue:install" if configured_gems.include?("solid_queue")
+      expected_commands << "solid_cable:install" if configured_gems.include?("solid_cable")
+
+      assert_equal expected_commands, executed_commands,
+        "Expected #{configured_gems.inspect} to map to #{expected_commands.inspect}, got #{executed_commands.inspect}"
+    end
+  end
+
+  def test_run_solid_does_not_run_cable_installer_when_action_cable_is_skipped
+    generator [destination_root], ["--skip-action-cable"]
+
+    executed_commands = []
+
+    generator.stub(:solid_gem_configured?, ->(_gem_name) { true }) do
+      generator.stub(:rails_command, ->(command, *_) { executed_commands << command }) do
+        generator.send(:run_solid)
+      end
+    end
+
+    assert_equal ["solid_cache:install", "solid_queue:install"], executed_commands
+  end
+
   def test_inclusion_of_kamal_files
     generator [destination_root]
     run_generator_instance
@@ -950,7 +1016,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     generator([destination_root], skip_solid: true)
     run_generator_instance
 
-    assert_not_includes @rails_commands, "solid_cache:install solid_queue:install solid_cable:install", "`solid_cache:install solid_queue:install solid_cable:install` expected to not be called."
+    assert_not_includes @rails_commands, "solid_cache:install"
+    assert_not_includes @rails_commands, "solid_queue:install"
+    assert_not_includes @rails_commands, "solid_cable:install"
     assert_no_gem "solid_cache"
     assert_no_gem "solid_queue"
     assert_no_gem "solid_cable"
@@ -1180,7 +1248,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator_instance
 
     expected_commands = [
-      "credentials:diff --enroll", "importmap:install", "turbo:install stimulus:install", "solid_cache:install solid_queue:install solid_cable:install"
+      "credentials:diff --enroll", "importmap:install", "turbo:install stimulus:install",
+      "solid_cache:install", "solid_queue:install", "solid_cable:install"
     ]
     assert_equal expected_commands, @rails_commands
   end


### PR DESCRIPTION
### Motivation / Background

This `rails new` command can fail during `run_solid` when a customized generation flow (Rails application template, generators, etc.) includes `solid_queue`/`solid_cable` but omits `solid_cache`.

`run_solid` currently invokes a fixed command sequence (`solid_cache:install solid_queue:install ...`) without checking whether each gem is actually present in the generated app. In template/custom app generator workflows, this can raise:

`Unrecognized command "solid_cache:install" (Rails::Command::UnrecognizedCommandError)`

This bug was discovered while creating a custom app generator (template-based flow), which can produce the same partial Solid setup.

### Detail

This Pull Request changes `run_solid` to install Solid components individually and only when their gem is declared in `Gemfile`.

Changes included:

- Refactor `run_solid` to run per-component installers instead of one hard-coded combined command.
- Add regression test for template/customization scenario where `solid_cache` is removed from `Gemfile` but other Solid gems remain.
  - Add coverage for all combinations of:
    - `solid_cache`
    - `solid_queue`
    - `solid_cable`
  - Add explicit test for `--skip-action-cable` interaction.

### Additional information

This change is intentionally defensive for template-driven/custom generator flows (`rails new -m ...`) where `Gemfile` can be modified before `run_solid` executes.

With default `rails new` behavior, all Solid gems are present unless `--skip-solid` is used. However, template/customization workflows can produce partial Solid configurations and should not fail generator execution.