### PR TITLE
Strip whitespace from URL strings in redirect_to

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -211,8 +211,30 @@ module ActionController
       # https://tools.ietf.org/html/rfc3986#section-3.1 The protocol relative scheme
       # starts with a double slash "//".
       when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i
-        options.to_str
+        if options.is_a?(String)
+          # Strip trailing whitespace from URLs like "https://example.com/ "
+          # to avoid invalid Location headers. We use getbyte as a guard
+          # because String#strip always allocates a new string even when
+          # there's nothing to strip. Byte <= 32 covers all ASCII whitespace
+          # (space, tab, newline, carriage return, form feed).
+          last_byte = options.getbyte(-1)
+          (last_byte && last_byte <= 32) ? options.strip : options
+        else
+          options.to_str
+        end
       when String
+        # Strip leading whitespace from URLs like " https://example.com"
+        # that fail to match the scheme regex due to the leading space,
+        # then re-check if the stripped result is actually an absolute URL.
+        # Same getbyte guard as above to avoid allocating on clean strings.
+        first_byte = options.getbyte(0)
+        if first_byte && first_byte <= 32
+          options = options.strip
+          if options.match?(/\A([a-z][a-z\d\-+.]*:|\/\/).*/i)
+            return options.delete("\0\r\n")
+          end
+        end
+
         if !options.start_with?("/", "?") && !options.empty?
           _handle_path_relative_redirect(options)
         end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -38,7 +38,7 @@ class ACLogSubscriberTest < ActionController::TestCase
       end
 
       def filterable_redirector_bad_uri
-        redirect_to " s:/invalid-string0uri"
+        redirect_to "http://host:invalid/path"
       end
 
       def data_sender

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -167,6 +167,18 @@ class RedirectController < ActionController::Base
     redirect_to "?foo=bar"
   end
 
+  def redirect_to_url_with_leading_whitespace
+    redirect_to " https://www.example.com/"
+  end
+
+  def redirect_to_url_with_trailing_whitespace
+    redirect_to "https://www.example.com/ "
+  end
+
+  def redirect_to_path_with_leading_whitespace
+    redirect_to " /things/stuff"
+  end
+
   def redirect_to_existing_record
     redirect_to Workshop.new(5)
   end
@@ -370,6 +382,40 @@ class RedirectTest < ActionController::TestCase
     get :redirect_to_url_with_network_path_reference
     assert_response :redirect
     assert_equal "//www.rubyonrails.org/", redirect_to_url
+  end
+
+  def test_redirect_to_url_with_leading_whitespace
+    get :redirect_to_url_with_leading_whitespace
+    assert_response :redirect
+    assert_equal "https://www.example.com/", redirect_to_url
+  end
+
+  def test_redirect_to_url_with_trailing_whitespace
+    get :redirect_to_url_with_trailing_whitespace
+    assert_response :redirect
+    assert_equal "https://www.example.com/", redirect_to_url
+  end
+
+  def test_redirect_to_path_with_leading_whitespace
+    get :redirect_to_path_with_leading_whitespace
+    assert_response :redirect
+    assert_equal "http://test.host/things/stuff", redirect_to_url
+  end
+
+  def test_redirect_to_url_with_whitespace_does_not_trigger_path_relative_raise
+    with_path_relative_redirect(:raise) do
+      get :redirect_to_url_with_leading_whitespace
+      assert_response :redirect
+      assert_equal "https://www.example.com/", redirect_to_url
+    end
+  end
+
+  def test_redirect_to_path_with_whitespace_does_not_trigger_path_relative_raise
+    with_path_relative_redirect(:raise) do
+      get :redirect_to_path_with_leading_whitespace
+      assert_response :redirect
+      assert_equal "http://test.host/things/stuff", redirect_to_url
+    end
   end
 
   def test_redirect_back


### PR DESCRIPTION
## Summary

URLs with leading or trailing whitespace (e.g. `" https://example.com"`) passed to `redirect_to` were incorrectly classified as path-relative URLs, triggering `PathRelativeRedirectError` or warnings depending on `action_on_path_relative_redirect` config.

This happened because the leading space prevented the scheme regex (`/\A([a-z]...)/`) from matching, causing the URL to fall through to the `String` branch where it was treated as a relative path.

Fixes #57035

## Solution

Handle whitespace inside the existing `case/when` branches of `_compute_redirect_to_location` using `getbyte` guards:

- **Scheme-regex branch**: checks last byte for trailing whitespace (`"https://example.com/ "`)
- **String branch**: checks first byte for leading whitespace (`" https://example.com"`), strips, and re-checks the scheme regex

### Why `getbyte` instead of `String#strip`?

`String#strip` always allocates a new string even when there's nothing to strip. At high RPS this adds unnecessary GC pressure. `getbyte` is a zero-allocation integer comparison that lets us skip `.strip` entirely for the common case (clean URLs with no whitespace).

## Benchmark

```
=== Clean absolute URL (common case) ===
            original:  2.470M i/s  (405ns)
                 new:  2.266M i/s  (441ns) - 1.09x slower

=== Clean path ===
            original:  3.256M i/s  (307ns)
                 new:  3.031M i/s  (330ns) - 1.07x slower

=== Memory: 10k clean URLs ===
Original:  2480000 bytes, 20000 objects
New:       2480000 bytes, 20000 objects  (identical)
```

Overhead is ~20-36ns per call with zero extra memory allocations for clean URLs. At 20k RPS: ~0.72ms/sec total CPU overhead.

## Test Plan

- [x] 5 new tests covering leading whitespace on absolute URLs, trailing whitespace, leading whitespace on paths, and `:raise` mode for both URL types
- [x] Updated `test_filter_redirect_bad_uri` (old test relied on leading-space behavior)
- [x] Full actionpack suite: 4165 runs, 0 failures, 0 errors
- [x] RuboCop: 0 offenses