### PR TITLE
Add test coverage for ActiveModel::Error#strict_match?

### DIFF
--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -85,6 +85,50 @@ class ErrorTest < ActiveModel::TestCase
     assert subject.match?(:mineral, :not_enough, count: 2)
   end
 
+  # strict_match?
+
+  test "strict_match? returns true when attribute, type, and options all match" do
+    error = ActiveModel::Error.new(Person.new, :name, :too_short, count: 5)
+    assert error.strict_match?(:name, :too_short, count: 5)
+  end
+
+  test "strict_match? returns false when attribute does not match" do
+    error = ActiveModel::Error.new(Person.new, :name, :too_short, count: 5)
+    assert_not error.strict_match?(:age, :too_short, count: 5)
+  end
+
+  test "strict_match? returns false when type does not match" do
+    error = ActiveModel::Error.new(Person.new, :name, :too_short, count: 5)
+    assert_not error.strict_match?(:name, :too_long, count: 5)
+  end
+
+  test "strict_match? returns false when option values differ" do
+    error = ActiveModel::Error.new(Person.new, :name, :too_short, count: 5)
+    assert_not error.strict_match?(:name, :too_short, count: 10)
+  end
+
+  test "strict_match? returns false when options are missing from check" do
+    error = ActiveModel::Error.new(Person.new, :name, :too_short, count: 5)
+    assert_not error.strict_match?(:name, :too_short)
+  end
+
+  test "strict_match? ignores callback and message options" do
+    error = ActiveModel::Error.new(
+      Person.new,
+      :name,
+      :too_short,
+      count: 5,
+      if: :foo,
+      unless: :bar,
+      on: :create,
+      allow_nil: true,
+      allow_blank: true,
+      strict: true,
+      message: "custom"
+    )
+    assert error.strict_match?(:name, :too_short, count: 5)
+  end
+
   # message
 
   test "message with type as a symbol" do


### PR DESCRIPTION
### Motivation / Background

The `strict_match?` method on `ActiveModel::Error` is a public API for checking if an error matches a given attribute, type, and options exactly, but had no dedicated test coverage.

The existing `match?` method has thorough tests, but `strict_match?` — which differs by requiring all options to match exactly (excluding callback and message options) — was untested.

### Detail

This adds tests for `ActiveModel::Error#strict_match?` verifying:
- Returns true when attribute, type, and options all match exactly
- Returns false when attribute does not match
- Returns false when type does not match
- Returns false when option values differ
- Returns false when options are missing from the check
- Correctly ignores callback options (`:if`, `:unless`, `:on`, `:allow_nil`, `:allow_blank`, `:strict`) and message options

### Additional information

N/A

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests added for the previously untested public method.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. _(N/A — test-only change)_