### PR TITLE
Add test coverage for ActiveModel::Errors#import

### DIFF
--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -746,6 +746,47 @@ class ErrorsTest < ActiveModel::TestCase
     end
   end
 
+  test "import wraps error as NestedError" do
+    person = Person.new
+    original_error = ActiveModel::Error.new(Person.new, :name, :invalid)
+
+    person.errors.import(original_error)
+
+    assert_equal 1, person.errors.size
+    assert_instance_of ActiveModel::NestedError, person.errors.first
+  end
+
+  test "import retains reference to inner error" do
+    person = Person.new
+    original_error = ActiveModel::Error.new(Person.new, :name, :invalid)
+
+    person.errors.import(original_error)
+
+    assert_equal original_error, person.errors.first.inner_error
+  end
+
+  test "import with attribute override" do
+    person = Person.new
+    original_error = ActiveModel::Error.new(Person.new, :name, :invalid)
+
+    person.errors.import(original_error, attribute: "age")
+
+    imported = person.errors.first
+    assert_equal :age, imported.attribute
+    assert_equal :invalid, imported.type
+  end
+
+  test "import with type override" do
+    person = Person.new
+    original_error = ActiveModel::Error.new(Person.new, :name, :invalid)
+
+    person.errors.import(original_error, type: "blank")
+
+    imported = person.errors.first
+    assert_equal :name, imported.attribute
+    assert_equal :blank, imported.type
+  end
+
   test "merge errors" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)


### PR DESCRIPTION
### Motivation / Background

The `import` method on `ActiveModel::Errors` is a public API for importing individual errors from other objects, wrapping them as `NestedError` instances. It had no dedicated test coverage — it was only exercised indirectly through `merge!` tests.

### Detail

This adds tests for `ActiveModel::Errors#import` verifying:
- Imported errors are wrapped as `NestedError`
- The imported error retains a reference to the original `inner_error`
- Override `:attribute` option works and converts strings to symbols
- Override `:type` option works and converts strings to symbols

### Additional information

N/A

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests added for the previously untested public method.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. _(N/A — test-only change)_