### PR TITLE
Add test coverage for EnvironmentInquirer predicates

### DIFF
--- a/activesupport/test/environment_inquirer_test.rb
+++ b/activesupport/test/environment_inquirer_test.rb
@@ -9,6 +9,36 @@ class EnvironmentInquirerTest < ActiveSupport::TestCase
     assert_not ActiveSupport::EnvironmentInquirer.new("production").local?
   end
 
+  test "development predicate" do
+    assert_predicate ActiveSupport::EnvironmentInquirer.new("development"), :development?
+    assert_not ActiveSupport::EnvironmentInquirer.new("test").development?
+    assert_not ActiveSupport::EnvironmentInquirer.new("production").development?
+  end
+
+  test "test predicate" do
+    assert_predicate ActiveSupport::EnvironmentInquirer.new("test"), :test?
+    assert_not ActiveSupport::EnvironmentInquirer.new("development").test?
+    assert_not ActiveSupport::EnvironmentInquirer.new("production").test?
+  end
+
+  test "production predicate" do
+    assert_predicate ActiveSupport::EnvironmentInquirer.new("production"), :production?
+    assert_not ActiveSupport::EnvironmentInquirer.new("development").production?
+    assert_not ActiveSupport::EnvironmentInquirer.new("test").production?
+  end
+
+  test "custom environment falls back to StringInquirer" do
+    env = ActiveSupport::EnvironmentInquirer.new("staging")
+    assert_predicate env, :staging?
+    assert_not env.development?
+    assert_not env.test?
+    assert_not env.production?
+  end
+
+  test "local predicate returns false for non-local environments" do
+    assert_not ActiveSupport::EnvironmentInquirer.new("staging").local?
+  end
+
   test "prevent local from being used as an actual environment name" do
     assert_raises(ArgumentError) do
       ActiveSupport::EnvironmentInquirer.new("local")


### PR DESCRIPTION
### Motivation / Background

The `development?`, `test?`, and `production?` predicates on `ActiveSupport::EnvironmentInquirer` are optimized methods that bypass `StringInquirer`'s `method_missing` delegation, but had no dedicated test coverage. Only `local?` and the `"local"` argument error were tested.

### Detail

This adds tests for `ActiveSupport::EnvironmentInquirer` verifying:
- `development?` returns true for "development", false for "test" and "production"
- `test?` returns true for "test", false for "development" and "production"
- `production?` returns true for "production", false for "development" and "test"
- Custom environments (e.g., "staging") fall back to `StringInquirer` behavior and return false for all default predicates
- `local?` returns false for non-local environments like "staging"

### Additional information

N/A

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests added for the previously untested predicates.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. _(N/A — test-only change)_