### PR TITLE
Add test coverage for Errors#delete with type and options

### DIFF
--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -717,6 +717,36 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["is invalid"], errors.delete(:name)
   end
 
+  test "delete with type removes only errors matching attribute and type" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :blank)
+    errors.add(:name, :invalid)
+
+    errors.delete(:name, :blank)
+
+    assert_not errors.added?(:name, :blank)
+    assert errors.added?(:name, :invalid)
+  end
+
+  test "delete with type and options removes only exact matches" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :too_short, count: 5)
+    errors.add(:name, :too_short, count: 10)
+
+    errors.delete(:name, :too_short, count: 5)
+
+    assert_equal 1, errors.where(:name, :too_short).size
+    assert errors.added?(:name, :too_short, count: 10)
+  end
+
+  test "delete with type returns deleted messages" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :blank)
+    errors.add(:name, :invalid)
+
+    assert_equal ["can't be blank"], errors.delete(:name, :blank)
+  end
+
   test "clear removes details" do
     person = Person.new
     person.errors.add(:name, :invalid)


### PR DESCRIPTION
### Motivation / Background

The `delete` method on `ActiveModel::Errors` accepts optional `type` and `**options` parameters for targeted removal of specific errors, but existing tests only covered `delete(:attribute)` without type or options filtering. This meant the filtering logic in `delete` had no direct test coverage.

### Detail

This adds tests for `ActiveModel::Errors#delete` with type and options verifying:
- `delete(:name, :blank)` removes only errors matching both attribute and type, preserving other errors on the same attribute
- `delete(:name, :too_short, count: 5)` removes only the exact match when multiple errors share the same attribute and type but differ in options
- `delete` with type returns the deleted messages

### Additional information

N/A

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests added for the previously untested code path.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. _(N/A — test-only change)_