### PR TITLE
Add test coverage for Error#initialize_dup, #hash, and #detail

### DIFF
--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -217,12 +217,41 @@ class ErrorTest < ActiveModel::TestCase
     assert_not_equal error, person
   end
 
+  test "hash is consistent with equality" do
+    person = Person.new
+    e1 = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+    e2 = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+
+    assert_equal e1, e2
+    assert_equal e1.hash, e2.hash
+  end
+
   test "full_message returns the given message when the attribute contains base" do
     error = ActiveModel::Error.new(Person.new, :"foo.base", "press the button")
     assert_equal "foo.base press the button", error.full_message
   end
 
+  # initialize_dup
+
+  test "duped error has independent options" do
+    person = Person.new
+    error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+    duped = error.dup
+
+    assert_equal error.attribute, duped.attribute
+    assert_equal error.type, duped.type
+    assert_equal error.options, duped.options
+    assert_not_same error.options, duped.options
+  end
+
   # details
+
+  test "detail is an alias for details" do
+    person = Person.new
+    error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+
+    assert_equal error.details, error.detail
+  end
 
   test "details which ignores callback and message options" do
     person = Person.new


### PR DESCRIPTION
### Motivation / Background

Several methods on `ActiveModel::Error` had no dedicated test coverage. This fills the remaining gaps to ensure full coverage of the `error.rb` source file.

### Detail

This adds tests for:
- **`initialize_dup`** — verifies duped errors have independent copies of options, preventing mutation leaks between original and dup
- **`hash` consistency with `==`** — verifies the contract that equal errors produce the same hash value, which is required for correct behavior in Hash keys and Sets
- **`detail` alias** — verifies it returns the same result as `details`

### Additional information

N/A

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests added for previously untested methods.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. _(N/A — test-only change)_