### PR TITLE
Add test coverage for Errors#to_hash with full_messages and #uniq!

### DIFF
--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -803,6 +803,23 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal({}, errors.details)
   end
 
+  test "to_hash with full_messages" do
+    person = Person.new
+    person.errors.add(:name, "cannot be blank")
+
+    assert_equal({ name: ["name cannot be blank"] }, person.errors.to_hash(true))
+  end
+
+  test "uniq! removes duplicate errors" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors.add(:name, :invalid)
+
+    assert_equal 2, errors.size
+    errors.uniq!
+    assert_equal 1, errors.size
+  end
+
   test "inspect" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:base)


### PR DESCRIPTION
### Motivation / Background

The `to_hash` method's `full_messages` parameter path and the `uniq!` delegated method on `ActiveModel::Errors` had no dedicated test coverage. While `to_hash` was tested without arguments and `as_json(full_messages: true)` indirectly exercised the full messages path, `to_hash(true)` was never called directly. The `uniq!` delegate was completely untested.

### Detail

This adds tests for `ActiveModel::Errors` verifying:
- **`to_hash(true)`** — returns a hash with full messages (including attribute names) instead of just error messages
- **`uniq!`** — removes duplicate error objects from the errors collection

### Additional information

N/A

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests added for previously untested code paths.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. _(N/A — test-only change)_