### PR TITLE
Fix parallel test shutdown hang when workers die during Server#shutdown

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization/server.rb
+++ b/activesupport/lib/active_support/testing/parallelization/server.rb
@@ -98,8 +98,19 @@ module ActiveSupport
         private
           def wait_for_active_workers
             while active_workers?
+              reap_dead_workers
               sleep 0.1
             end
+          end
+
+          def reap_dead_workers
+            dead_pids = @worker_pids.values.select do |pid|
+              Process.waitpid(pid, Process::WNOHANG)
+            rescue Errno::ECHILD
+              true
+            end
+
+            remove_dead_workers(dead_pids)
           end
       end
     end

--- a/activesupport/test/parallelization_test.rb
+++ b/activesupport/test/parallelization_test.rb
@@ -58,6 +58,42 @@ class ParallelizationTest < ActiveSupport::TestCase
     assert_not server.active_workers?
   end
 
+  test "shutdown handles workers that die during server shutdown" do
+    # Regression test: workers that exit without calling stop_worker AFTER
+    # the initial WNOHANG sweep in Parallelization#shutdown must still be
+    # detected inside Server#shutdown's wait_for_active_workers loop.
+    parallelization = ActiveSupport::Testing::Parallelization.new(1)
+    server = parallelization.instance_variable_get(:@queue_server)
+    url = parallelization.instance_variable_get(:@url)
+
+    # Use a shared queue distributor so the worker blocks waiting for work
+    blocking_distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+    server.instance_variable_set(:@distributor, blocking_distributor)
+
+    # Fork a worker that registers but will be killed mid-shutdown
+    worker_pid = fork do
+      DRb.stop_service
+      queue = DRbObject.new_with_uri(url)
+      queue.start_worker(0, Process.pid)
+      sleep 5
+      exit!(4)
+    end
+    parallelization.instance_variable_set(:@worker_pool, [worker_pid])
+
+    sleep 0.25
+    assert server.active_workers?
+
+    # Schedule the kill AFTER shutdown begins, so the initial WNOHANG sweep
+    # in Parallelization#shutdown finds the worker still alive
+    Thread.new do
+      sleep 0.5
+      Process.kill("KILL", worker_pid)
+    end
+
+    Timeout.timeout(3, Minitest::Assertion, "Expected shutdown to not hang") { parallelization.shutdown }
+    assert_not server.active_workers?
+  end
+
   test "seeded distribution assigns tests to workers round-robin" do
     worker_count = 2
 


### PR DESCRIPTION
### Motivation / Background

#55794 (fixing #55513) added a `Process.waitpid(pid, WNOHANG)` sweep in `Parallelization#shutdown` to detect dead workers **before** calling `Server#shutdown`. This helps when workers are already dead at shutdown time, but doesn't cover the case where workers exit **during** `Server#shutdown`'s `wait_for_active_workers` loop.

If a worker finishes its tests and exits without calling `stop_worker` over DRb (e.g. a `parallelize_teardown` hook raises, the DRb connection drops, or the worker is OOM-killed mid-cleanup), and this happens **after** the initial WNOHANG sweep, `Server#shutdown` loops forever on `while active_workers?`.

We're hitting this intermittently in CI with system tests (Capybara/Cuprite). Workers become zombies, but the parent hangs until a watchdog kills it ~90s later.

Fixes #57052

### Detail

Adds a `reap_dead_workers` method to `Server` that uses `Process.waitpid(pid, WNOHANG)` to detect exited worker processes, and calls it inside the `wait_for_active_workers` loop. This catches workers that die at any point during shutdown — before or during the wait.

### Additional information

A regression test is included that forks a worker, lets it register, then kills it *after* the parent enters `Server#shutdown`. Without the fix, the test hangs; with it, shutdown completes cleanly.