### PR TITLE
Set inverse before attribute assignment in association build

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Set inverse association before assigning attributes in `build` on
+    `has_many` and `has_one` associations.
+
+    Previously, when calling `parent.children.build(attrs)`, the child's
+    attributes were assigned before the inverse association (back-reference
+    to the parent) was set. This caused issues when attribute setters or
+    callbacks needed to access the parent, such as ActiveStorage's dynamic
+    service resolution.
+
+    Fixes #57042.
+
+    *Denis Savchuk*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -381,10 +381,25 @@ module ActiveRecord
         end
 
         def build_record(attributes)
-          reflection.build_association(attributes) do |record|
+          sti_attrs = _sti_type_for_build(attributes)
+
+          reflection.build_association(sti_attrs) do |record|
+            set_inverse_instance(record)
+            record.assign_attributes(attributes) if attributes
             initialize_attributes(record, attributes)
             yield(record) if block_given?
           end
+        end
+
+        def _sti_type_for_build(attributes)
+          return unless attributes
+
+          klass = reflection.klass
+          inheritance_col = klass.inheritance_column
+          return unless klass._has_attribute?(inheritance_col)
+
+          type_value = attributes[inheritance_col] || attributes[inheritance_col.to_sym]
+          { inheritance_col => type_value } if type_value
         end
 
         # Returns true if statement cache should be skipped on the association reader.

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -119,6 +119,7 @@ module ActiveRecord
             target = through_association.target
 
             if inverse && target && !target.is_a?(Array)
+              attributes ||= {}
               Array(target.id).zip(Array(inverse.foreign_key)).map do |primary_key_value, foreign_key_column|
                 attributes[foreign_key_column] = primary_key_value
               end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -421,6 +421,26 @@ class InverseHasOneTests < ActiveRecord::TestCase
     assert_match "Did you mean?", error.detailed_message
     assert_equal "confused_human", error.corrections.first
   end
+
+  def test_inverse_is_available_during_attribute_assignment_on_has_one_build
+    human = Human.create!
+
+    inverse_during_assignment = nil
+
+    Face.class_eval do
+      define_method(:description_for_inverse_test=) do |value|
+        inverse_during_assignment = self.human
+        self.description = value
+      end
+    end
+
+    human.build_face(description_for_inverse_test: "Smiling")
+
+    assert_equal human, inverse_during_assignment,
+      "inverse association should be available when attributes are assigned during has_one build"
+  ensure
+    Face.remove_method(:description_for_inverse_test=) if Face.method_defined?(:description_for_inverse_test=)
+  end
 end
 
 class InverseHasManyTests < ActiveRecord::TestCase
@@ -713,6 +733,26 @@ class InverseHasManyTests < ActiveRecord::TestCase
     comment.update!(post_id: post2.id)
 
     assert_equal post2, comment.post
+  end
+
+  def test_inverse_is_available_during_attribute_assignment_on_has_many_build
+    human = Human.create!
+
+    inverse_during_assignment = nil
+
+    Interest.class_eval do
+      define_method(:topic_for_inverse_test=) do |value|
+        inverse_during_assignment = self.human
+        self.topic = value
+      end
+    end
+
+    human.interests.build(topic_for_inverse_test: "Music")
+
+    assert_equal human, inverse_during_assignment,
+      "inverse association should be available when attributes are assigned during build"
+  ensure
+    Interest.remove_method(:topic_for_inverse_test=) if Interest.method_defined?(:topic_for_inverse_test=)
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Fixes #57042.

When using ActiveStorage's dynamic service resolution (`service: ->(record) { ... }`), the lambda cannot access the inverse association when building a record through an association with attributes:

```ruby
class Attachment < ActiveRecord::Base
  belongs_to :user, inverse_of: :attachments
  has_one_attached :file, service: ->(record) { record.user&.eu? ? :eu_storage : :us_storage }
end

# Works — build first, assign later:
attachment = user.attachments.build
attachment.file = { io: StringIO.new("data"), filename: "test.txt" }

# Broken — user is nil when the service lambda runs:
attachment = user.attachments.build(file: { io: StringIO.new("data"), filename: "test.txt" })
```

### Root Cause

Inside `ActiveRecord::Core#initialize`, the execution order is:

1. `assign_attributes(attrs)` — triggers the dynamic service lambda
2. `yield self` (block) — `initialize_attributes` → `set_inverse_instance` sets the inverse

The inverse (`record.user`) is set in step 2, but step 1 already needed it.

### Solution

In `Association#build_record`, pass only STI type attributes (if any) to `klass.new`, then inside the block:

1. `set_inverse_instance(record)` — inverse available immediately
2. `record.assign_attributes(attributes)` — attribute setters can access the inverse
3. `initialize_attributes(record, attributes)` — scope/FK protection runs last

This preserves:
- **STI class resolution** — `type` attribute is still passed to `new` for proper subclass instantiation
- **Foreign key protection** — `initialize_attributes` runs after `assign_attributes` and overwrites any user-provided FK with the correct scope value
- **Through association FK** — `through_association.rb` handles `nil` attributes when adding source FK

### Benchmark Results

**CPU (iterations/second, Ruby 4.0.1):**

| Scenario | Before (main) | After | Delta |
|---|---|---|---|
| `build` no attrs | 20,206 i/s | 19,862 i/s | same-ish |
| `build` with attrs | 17,143 i/s | 17,302 i/s | same-ish |
| `build` nested | 19,737 i/s | 20,392 i/s | same-ish |
| `build` STI | 14,696 i/s | 15,272 i/s | same-ish |

**Memory (allocations per call):**

| Scenario | Before | After | Delta |
|---|---|---|---|
| `build` no attrs | 61 | 61 | identical |
| `build` with attrs | 71 | 71 | identical |
| `build` nested | 64 | 64 | identical |
| `build` STI | 80 | 80 | identical |

Zero performance regression on both CPU and memory.

### Checklist

- [x] Tests added for `has_many` and `has_one` inverse availability during `build`
- [x] Full ActiveRecord sqlite3 test suite passes (9,380 runs, 0 failures)
- [x] STI, FK protection, polymorphic, and through association tests pass
- [x] RuboCop clean
- [x] CHANGELOG entry added
- [x] Benchmarked before and after (CPU + memory)