### PR TITLE
Prevent db:migrate from destroying data when schema_migrations is missing

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Raise `DatabaseNotManagedError` when `db:migrate` detects existing tables
+    but no `schema_migrations` table.
+
+    Previously, running `db:migrate` on a database that had tables but was
+    missing the `schema_migrations` table would silently load `schema.rb`,
+    dropping and recreating all tables, causing data loss. Now raises an
+    error with actionable guidance instead.
+
+    Fixes #56755.
+
+    *Denis Savchuk*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -370,6 +370,27 @@ module ActiveRecord
   class DatabaseAlreadyExists < StatementInvalid
   end
 
+  # Raised when db:migrate detects that the database contains tables but is
+  # missing the schema_migrations table, which would cause schema.rb to be
+  # loaded and potentially destroy existing data.
+  class DatabaseNotManagedError < ActiveRecordError
+    def initialize(db_config = nil)
+      db_name = db_config&.database
+      if db_name
+        super(<<~MSG.squish)
+          Unable to migrate database '#{db_name}': the database already contains
+          tables but is missing the `schema_migrations` table. Running `db:migrate`
+          in this state would load `schema.rb` and could destroy existing data.
+          To resolve this, either run `bin/rails db:schema:load` if this is a new
+          database, or manually create the `schema_migrations` table and register
+          already-applied migration versions.
+        MSG
+      else
+        super
+      end
+    end
+  end
+
   # Raised when PostgreSQL returns 'cached plan must not change result type' and
   # we cannot retry gracefully (e.g. inside a transaction)
   class PreparedStatementCacheExpired < StatementInvalid

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -666,15 +666,22 @@ module ActiveRecord
         def initialize_database(db_config)
           with_temporary_pool(db_config) do
             begin
-              database_already_initialized = migration_connection_pool.schema_migration.table_exists?
+              tables = migration_connection_pool.with_connection { |conn| conn.tables }
             rescue ActiveRecord::NoDatabaseError
               create(db_config)
               retry
             end
 
+            schema_migration_table = migration_connection_pool.schema_migration.table_name
+            database_already_initialized = tables.include?(schema_migration_table)
+
             unless database_already_initialized
               schema_dump_path = schema_dump_path(db_config)
               if schema_dump_path && File.exist?(schema_dump_path)
+                rails_tables = [schema_migration_table, "ar_internal_metadata"]
+                if (tables - rails_tables).any?
+                  raise DatabaseNotManagedError.new(db_config)
+                end
                 load_schema(db_config)
               end
             end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1257,6 +1257,86 @@ module ActiveRecord
     end
   end
 
+  class DatabaseTasksInitializeDatabaseTest < ActiveRecord::TestCase
+    if current_adapter?(:SQLite3Adapter) && !in_memory_db?
+      self.use_transactional_tests = false
+
+      setup do
+        @original_db_config = ActiveRecord::Base.connection_db_config
+        @tmp_db = "#{Dir.tmpdir}/init_db_test_#{$$}.sqlite3"
+        @db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+          "test", "primary", { adapter: "sqlite3", database: @tmp_db }
+        )
+      end
+
+      teardown do
+        ActiveRecord::Base.establish_connection(@original_db_config)
+        File.delete(@tmp_db) if File.exist?(@tmp_db)
+      end
+
+      def test_raises_error_when_non_rails_tables_exist_without_schema_migrations
+        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: @tmp_db)
+        ActiveRecord::Base.lease_connection.execute("CREATE TABLE users (id integer PRIMARY KEY, name varchar)")
+        ActiveRecord::Base.connection_handler.clear_all_connections!
+
+        assert_raises(ActiveRecord::DatabaseNotManagedError) do
+          with_schema_dump_path do
+            ActiveRecord::Tasks::DatabaseTasks.send(:initialize_database, @db_config)
+          end
+        end
+      end
+
+      def test_does_not_raise_when_database_is_empty
+        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: @tmp_db)
+        ActiveRecord::Base.connection_handler.clear_all_connections!
+
+        assert_nothing_raised do
+          with_schema_dump_path do
+            ActiveRecord::Tasks::DatabaseTasks.send(:initialize_database, @db_config)
+          end
+        end
+      end
+
+      def test_does_not_raise_when_schema_migrations_exists
+        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: @tmp_db)
+        ActiveRecord::Base.lease_connection.execute("CREATE TABLE schema_migrations (version varchar NOT NULL PRIMARY KEY)")
+        ActiveRecord::Base.lease_connection.execute("CREATE TABLE users (id integer PRIMARY KEY, name varchar)")
+        ActiveRecord::Base.connection_handler.clear_all_connections!
+
+        assert_nothing_raised do
+          with_schema_dump_path do
+            ActiveRecord::Tasks::DatabaseTasks.send(:initialize_database, @db_config)
+          end
+        end
+      end
+
+      def test_does_not_raise_when_only_ar_internal_metadata_exists
+        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: @tmp_db)
+        ActiveRecord::Base.lease_connection.execute("CREATE TABLE ar_internal_metadata (key varchar NOT NULL PRIMARY KEY, value varchar, created_at datetime(6), updated_at datetime(6))")
+        ActiveRecord::Base.connection_handler.clear_all_connections!
+
+        assert_nothing_raised do
+          with_schema_dump_path do
+            ActiveRecord::Tasks::DatabaseTasks.send(:initialize_database, @db_config)
+          end
+        end
+      end
+
+      private
+        def with_schema_dump_path(&block)
+          schema_file = Tempfile.new(["schema", ".rb"])
+          schema_file.write("ActiveRecord::Schema[8.1].define(version: 2024_01_01_000001) {}")
+          schema_file.close
+
+          ActiveRecord::Tasks::DatabaseTasks.stub(:schema_dump_path, ->(_) { schema_file.path }) do
+            ActiveRecord::Tasks::DatabaseTasks.stub(:load_schema, ->(_) { }, &block)
+          end
+        ensure
+          schema_file&.unlink
+        end
+    end
+  end
+
   class DatabaseTasksPurgeTest < ActiveRecord::TestCase
     include DatabaseTasksSetupper
 


### PR DESCRIPTION
### Motivation / Background

Fixes #56755

When `schema_migrations` is missing but user tables exist, `db:migrate` silently loads `schema.rb` and drops/recreates all tables — causing data loss in production. `initialize_database` uses the existence of `schema_migrations` as the sole signal for whether a database is initialized.

### Detail

Before loading schema, verify no user tables exist. If they do, raise `ActiveRecord::DatabaseNotManagedError` with actionable guidance. Uses a single `conn.tables` call (replacing the original `table_exists?`) so there is zero overhead on the normal migration path.

```
Unable to migrate database 'my_db': the database already contains tables but
is missing the `schema_migrations` table. Running `db:migrate` in this state
would load `schema.rb` and could destroy existing data. To resolve this,
either run `bin/rails db:schema:load` if this is a new database, or manually
create the `schema_migrations` table and register already-applied migration
versions.
```

### Additional information

| Path | Before | After |
|---|---|---|
| Normal (`schema_migrations` exists) | 2,857 i/s | 2,898 i/s (same) |
| Missing (`schema_migrations` absent) | 2,518 i/s | 2,440 i/s (same) |

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.