### PR TITLE
Report Postgres FATAL exceptions more clearly

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -193,6 +193,7 @@ module ActiveRecord
         @raw_connection_dirty = false
         @last_activity = nil
         @verified = false
+        @needs_reconnect = false
 
         @pool_jitter = rand * max_jitter
       end
@@ -737,6 +738,7 @@ module ActiveRecord
             @allow_preconnect = false
 
             reconnect
+            @needs_reconnect = false
 
             enable_lazy_transactions!
             @raw_connection_dirty = false
@@ -776,6 +778,7 @@ module ActiveRecord
           @connected_since = nil
           @last_activity = nil
           @verified = false
+          @needs_reconnect = false
         end
       end
 
@@ -839,12 +842,13 @@ module ActiveRecord
       # This is done under the hood by calling #active?. If the connection
       # is no longer active, then this method will reconnect to the database.
       def verify!
-        unless active?
+        if @needs_reconnect || !active?
           @lock.synchronize do
             if @unconfigured_connection
               attempt_configure_connection do
                 @raw_connection = @unconfigured_connection
                 @unconfigured_connection = nil
+                @needs_reconnect = false
                 configure_connection
                 @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
                 @verified = true
@@ -876,6 +880,10 @@ module ActiveRecord
 
       def verified? # :nodoc:
         @verified
+      end
+
+      def needs_reconnect? # :nodoc:
+        @needs_reconnect
       end
 
       # Provides access to the underlying database driver for this adapter. For
@@ -1083,14 +1091,18 @@ module ActiveRecord
             deadline = retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline
             reconnectable = reconnect_can_restore_state?
 
-            if @verified
+            if @verified && !@needs_reconnect
               # Cool, we're confident the connection's ready to use. (Note this might have
               # become true during the above #materialize_transactions.)
-            elsif (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
+            elsif !@needs_reconnect && (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
               # We haven't actually verified the connection since we acquired it, but it
               # has been used very recently. We're going to assume it's still okay.
             elsif reconnectable
-              if allow_retry
+              if @needs_reconnect
+                # This connection has been flagged for replacement; don't trust
+                # it even when the upcoming query would be retryable.
+                verify!
+              elsif allow_retry
                 # Not sure about the connection yet, but if anything goes wrong we can
                 # just reconnect and re-run our query
               else
@@ -1126,13 +1138,7 @@ module ActiveRecord
                 end
               end
 
-              unless retryable_query_error?(translated_exception)
-                # Barring a known-retryable error inside the query (regardless of
-                # whether we were in a _position_ to retry it), we should infer that
-                # there's likely a real problem with the connection.
-                @last_activity = nil
-                @verified = false
-              end
+              downgrade_connection_after_error(translated_exception)
 
               raise translated_exception
             ensure
@@ -1166,6 +1172,20 @@ module ActiveRecord
           return false if current_transaction.invalidated?
 
           exception.is_a?(Deadlocked) || exception.is_a?(LockWaitTimeout)
+        end
+
+        def downgrade_connection_after_error(exception)
+          unless retryable_query_error?(exception)
+            # Barring a known-retryable error inside the query (regardless of
+            # whether we were in a _position_ to retry it), we should infer that
+            # there's likely a real problem with the connection.
+            @last_activity = nil
+            @verified = false
+
+            if retryable_connection_error?(exception)
+              @needs_reconnect = true
+            end
+          end
         end
 
         def backoff(counter)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -164,6 +164,10 @@ module ActiveRecord
           end
 
           def perform_query(raw_connection, intent)
+            if fatal = consume_notice_receiver_fatal_error
+              raise fatal
+            end
+
             raw_connection.discard_results
 
             if intent.prepare

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -164,11 +164,15 @@ module ActiveRecord
           end
 
           def perform_query(raw_connection, intent)
-            result = if intent.prepare
+            raw_connection.discard_results
+
+            if intent.prepare
               begin
                 stmt_key = prepare_statement(intent.processed_sql, intent.binds, raw_connection)
                 intent.notification_payload[:statement_name] = stmt_key
-                raw_connection.exec_prepared(stmt_key, intent.type_casted_binds)
+                raw_connection.send_query_prepared(stmt_key, intent.type_casted_binds)
+                result = get_result(raw_connection)
+                result&.check
               rescue PG::FeatureNotSupported => error
                 if is_cached_plan_failure?(error)
                   # Nothing we can do if we are in a transaction because all commands
@@ -186,10 +190,15 @@ module ActiveRecord
 
                 raise
               end
-            elsif intent.has_binds?
-              raw_connection.exec_params(intent.processed_sql, intent.type_casted_binds)
             else
-              raw_connection.async_exec(intent.processed_sql)
+              if intent.has_binds?
+                raw_connection.send_query_params(intent.processed_sql, intent.type_casted_binds)
+              else
+                raw_connection.send_query(intent.processed_sql)
+              end
+
+              result = get_result(raw_connection)
+              result&.check
             end
 
             verified!
@@ -267,6 +276,19 @@ module ActiveRecord
 
           def warning_ignored?(warning)
             ["WARNING", "ERROR", "FATAL", "PANIC"].exclude?(warning.level) || super
+          end
+
+          def get_result(raw_connection)
+            result = nil
+            while incoming = raw_connection.get_result
+              result&.clear
+              result = incoming
+
+              if result.result_status == PG::PGRES_FATAL_ERROR
+                result.check if connection_terminating_severity?(result)
+              end
+            end
+            result
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -333,6 +333,25 @@ module ActiveRecord
         { concurrently: "CONCURRENTLY" }
       end
 
+      class ErrorResultSnapshot # :nodoc:
+        def initialize(result)
+          @fields = PG.constants.
+            grep(/\APG_DIAG_/).
+            map { PG.const_get(_1) }.
+            index_with { result.error_field(_1) }
+
+          @error_message = result.error_message
+        end
+
+        def error_field(field)
+          @fields[field]
+        end
+        alias :result_error_field :error_field
+
+        attr_reader :error_message
+        alias :result_error_message :error_message
+      end
+
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         def initialize(connection, max)
           super(max)
@@ -382,6 +401,7 @@ module ActiveRecord
         @type_map_queried = false
         @raw_connection = nil
         @notice_receiver_sql_warnings = []
+        @notice_receiver_fatal_error = nil
 
         @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
       end
@@ -440,6 +460,7 @@ module ActiveRecord
           super
           @raw_connection&.close rescue nil
           @raw_connection = nil
+          @notice_receiver_fatal_error = nil
         end
       end
 
@@ -817,6 +838,32 @@ module ActiveRecord
           severity == "FATAL" || severity == "PANIC"
         end
 
+        def capture_fatal_notice(result)
+          return false unless connection_terminating_severity?(result)
+
+          begin
+            result.check
+          rescue PG::Error => error
+            # result will be cleared when the notice handler returns, so
+            # we need to replace it on the exception with a snapshot.
+            snapshot = ErrorResultSnapshot.new(result)
+            error.define_singleton_method(:result) { snapshot }
+
+            @notice_receiver_fatal_error = error
+          end
+
+          @last_activity = nil
+          @verified = false
+          @needs_reconnect = true
+
+          true
+        end
+
+        def consume_notice_receiver_fatal_error
+          consumed, @notice_receiver_fatal_error = @notice_receiver_fatal_error, nil
+          consumed
+        end
+
         def initialize_type_map(m = type_map)
           self.class.initialize_type_map(m)
 
@@ -1083,8 +1130,11 @@ module ActiveRecord
             @raw_connection.set_client_encoding(@config[:encoding])
           end
 
-          unless ActiveRecord.db_warnings_action.nil?
-            @raw_connection.set_notice_receiver do |result|
+          @notice_receiver_fatal_error = nil
+          @raw_connection.set_notice_receiver do |result|
+            next if capture_fatal_notice(result)
+
+            if ActiveRecord.db_warnings_action
               message = result.error_field(PG::Result::PG_DIAG_MESSAGE_PRIMARY)
               code = result.error_field(PG::Result::PG_DIAG_SQLSTATE)
               level = result.error_field(PG::Result::PG_DIAG_SEVERITY)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -886,7 +886,8 @@ module ActiveRecord
           when nil
             if exception.message.match?(/connection is closed/i) || exception.message.match?(/no connection to the server/i)
               ConnectionNotEstablished.new(exception, connection_pool: @pool)
-            elsif exception.is_a?(PG::ConnectionBad)
+            elsif exception.is_a?(PG::ConnectionBad) ||
+                  (exception.is_a?(PG::Error) && exception.connection&.status == PG::CONNECTION_BAD)
               # libpq message style always ends with a newline; the pg gem's internal
               # errors do not. We separate these cases because a pg-internal
               # ConnectionBad means it failed before it managed to send the query,

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -812,6 +812,11 @@ module ActiveRecord
       private
         attr_reader :type_map
 
+        def connection_terminating_severity?(result)
+          severity = result&.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED)
+          severity == "FATAL" || severity == "PANIC"
+        end
+
         def initialize_type_map(m = type_map)
           self.class.initialize_type_map(m)
 
@@ -920,7 +925,11 @@ module ActiveRecord
           when QUERY_CANCELED
             QueryCanceled.new(message, sql: sql, binds: binds, connection_pool: @pool)
           else
-            super
+            if connection_terminating_severity?(exception.result)
+              ConnectionFailed.new(exception, connection_pool: @pool)
+            else
+              super
+            end
           end
         end
 
@@ -1025,12 +1034,12 @@ module ActiveRecord
           unless @statements.key? sql_key
             nextkey = @statements.next_key
             begin
-              conn.prepare nextkey, sql
+              conn.send_prepare(nextkey, sql)
+              result = get_result(conn)
+              result&.check
             rescue => e
               raise translate_exception_class(e, sql, binds)
             end
-            # Clear the queue
-            conn.get_last_result
             @statements[sql_key] = nextkey
           end
           @statements[sql_key]

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -722,6 +722,17 @@ module ActiveRecord
         end
       end
 
+      test "querying a connection marked for reconnect replaces it first" do
+        previous_connection_id = connection_id_from_server(@connection)
+        @connection.instance_variable_set(:@needs_reconnect, true)
+        @connection.clean! # this simulates a fresh checkout from the pool
+
+        assert_predicate @connection, :needs_reconnect?
+        assert_predicate Post, :exists?
+        assert_not_equal previous_connection_id, connection_id_from_server(@connection)
+        assert_not_predicate @connection, :needs_reconnect?
+      end
+
       test "quoting a string on a 'clean' failed connection will not prevent reconnecting" do
         remote_disconnect @connection
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -988,11 +988,14 @@ module ActiveRecord
         assert_raises ActiveRecord::ConnectionNotEstablished do
           @connection.execute("SELECT 1")
         end
+      ensure
+        @connection&.disconnect!
       end
 
       def test_translate_no_connection_exception_to_not_established
-        pid = @connection.execute("SELECT pg_backend_pid()").to_a[0]["pg_backend_pid"]
-        @connection.pool.checkout.execute("SELECT pg_terminate_backend(#{pid})")
+        raw_connection = @connection.raw_connection
+        pid = connection_id_from_server(@connection)
+        kill_connection_from_server(pid)
         # If you run `@connection.execute` after the backend process has been terminated,
         # you will get the "server closed the connection unexpectedly" rather than "no connection to the server".
         # Because what we want to test here is an error that occurs during `send_query`,
@@ -1000,7 +1003,7 @@ module ActiveRecord
         # The `send_query` changes the internal `PG::Connection#status` to `CONNECTION_BAD`,
         # so any subsequent queries will get the "no connection to the server" error.
         # https://github.com/postgres/postgres/blob/REL_17_0/src/interfaces/libpq/fe-exec.c#L1686-L1691
-        @connection.instance_variable_get(:@raw_connection).send_query("SELECT 1")
+        raw_connection.send_query("SELECT 1")
 
         assert_raise ActiveRecord::ConnectionNotEstablished do
           @connection.execute("SELECT 1")
@@ -1034,6 +1037,29 @@ module ActiveRecord
         assert_equal "25P03", error.cause.result.error_field(PG::PG_DIAG_SQLSTATE)
       ensure
         @connection&.disconnect!
+      end
+
+      def test_flush_on_dead_connection_translates_to_connection_failed
+        pid = connection_id_from_server(@connection)
+        raw_connection = @connection.raw_connection
+
+        # Queue a slow query, then kill the backend while it's running
+        raw_connection.send_query("SELECT pg_sleep(1)")
+        kill_connection_from_server(pid)
+        sleep 0.1
+
+        # Drain results: first the FATAL, then the socket death
+        loop do
+          raw_connection.get_result || break
+        rescue PG::Error
+          break
+        end
+
+        error = assert_raises(PG::Error) { raw_connection.flush }
+        assert_not_kind_of PG::ConnectionBad, error
+
+        translated = @connection.send(:translate_exception_class, error, nil, nil)
+        assert_kind_of ActiveRecord::ConnectionFailed, translated
       end
 
       def test_reload_type_map_for_newly_defined_types

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1007,6 +1007,35 @@ module ActiveRecord
         end
       end
 
+      def test_terminate_backend_preserves_typed_exception
+        pid = connection_id_from_server(@connection)
+
+        # Put in a dirty transaction so auto-reconnect can't mask the error
+        @connection.execute("BEGIN")
+        @connection.execute("CREATE TEMP TABLE _typed_exception_probe()")
+
+        kill_connection_from_server(pid)
+        sleep 0.1
+
+        error = assert_raises(ActiveRecord::ConnectionFailed) { @connection.execute("SELECT 1") }
+        assert_kind_of PG::AdminShutdown, error.cause
+        assert_equal "57P01", error.cause.result.error_field(PG::PG_DIAG_SQLSTATE)
+      ensure
+        @connection&.disconnect!
+      end
+
+      def test_idle_in_transaction_timeout_preserves_typed_exception
+        @connection.execute("BEGIN")
+        @connection.execute("SET idle_in_transaction_session_timeout = '10ms'")
+        sleep 0.1
+
+        error = assert_raises(ActiveRecord::ConnectionFailed) { @connection.execute("SELECT 1") }
+        assert_kind_of PG::IdleInTransactionSessionTimeout, error.cause
+        assert_equal "25P03", error.cause.result.error_field(PG::PG_DIAG_SQLSTATE)
+      ensure
+        @connection&.disconnect!
+      end
+
       def test_reload_type_map_for_newly_defined_types
         @connection.create_enum "feeling", ["good", "bad"]
         enum_oid = @connection.query_value("SELECT 'feeling'::regtype::oid").to_i

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1039,6 +1039,50 @@ module ActiveRecord
         @connection&.disconnect!
       end
 
+      def test_fatal_via_notice_channel_recovers_before_the_next_query
+        pid = connection_id_from_server(@connection)
+        kill_connection_from_server(pid)
+
+        # Force the FATAL through the notice channel rather than as a result:
+        # read it while idle (a bare get_result). Reach @raw_connection directly
+        # -- the #raw_connection accessor would mark the connection dirty and
+        # defeat recovery; in real use the notice is captured during AR's own
+        # get_result.
+        raw = @connection.instance_variable_get(:@raw_connection)
+        raw.socket_io.wait_readable(1)
+        raw.consume_input
+        assert_nil raw.get_result
+
+        # Having already learned the connection is dead, the next query doesn't
+        # pay for it: pre-query verification reconnects, exactly as it does for
+        # any connection we knew in advance had gone bad.
+        assert_equal 1, @connection.select_value("SELECT 1")
+        assert_not_equal pid, connection_id_from_server(@connection)
+      ensure
+        @connection&.disconnect!
+      end
+
+      def test_fatal_via_notice_channel_preserves_typed_cause_when_unrecoverable
+        pid = connection_id_from_server(@connection)
+        kill_connection_from_server(pid)
+
+        # Same notice-channel delivery as above, but reach the raw connection via
+        # the #raw_connection accessor, which marks it dirty -> non-recoverable.
+        # With no clean reconnect available, the next query surfaces the failure
+        # -- and it must carry the captured FATAL as its cause, not the generic
+        # socket error that merely tripped over the already-dead connection.
+        raw = @connection.raw_connection
+        raw.socket_io.wait_readable(1)
+        raw.consume_input
+        assert_nil raw.get_result
+
+        error = assert_raises(ActiveRecord::ConnectionFailed) { @connection.select_value("SELECT 1") }
+        assert_kind_of PG::AdminShutdown, error.cause
+        assert_equal "57P01", error.cause.result.error_field(PG::PG_DIAG_SQLSTATE)
+      ensure
+        @connection&.disconnect!
+      end
+
       def test_flush_on_dead_connection_translates_to_connection_failed
         pid = connection_id_from_server(@connection)
         raw_connection = @connection.raw_connection
@@ -1306,13 +1350,9 @@ module ActiveRecord
 
       def test_ignores_warnings_when_behavior_ignore
         with_db_warnings_action(:ignore) do
-          # libpq prints a warning to stderr from C, so we need to stub
-          # the whole file descriptors, not just Ruby's $stdout/$stderr.
-          _out, err = capture_subprocess_io do
-            result = @connection.execute("do $$ BEGIN RAISE WARNING 'foo'; END; $$")
-            assert_equal [], result.to_a
-          end
-          assert_match(/WARNING:  foo/, err)
+          result = @connection.execute("do $$ BEGIN RAISE WARNING 'foo'; END; $$")
+
+          assert_equal [], result.to_a
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -48,7 +48,7 @@ module ActiveRecord
 
         def test_prepared_statements_do_not_get_stuck_on_query_interruption
           pg_connection = ActiveRecord::Base.lease_connection.connect!.instance_variable_get(:@raw_connection)
-          pg_connection.stub(:get_last_result, -> { raise "random error" }) do
+          pg_connection.stub(:get_result, -> { raise "random error" }) do
             assert_raises(RuntimeError) do
               Developer.where(name: "David").last
             end


### PR DESCRIPTION
`FATAL` means the server is choosing to terminate the connection, so it's useful for us to clearly distinguish that type of error and correctly translate it to ConnectionFailed instead of general StatementInvalid (which would leave us with a broken connection, to only be noticed later).

To more reliably get hold of that more "real" exception: 
* use `send_query_params` and friends, followed by manually pumping `raw_connection.get_result` ourselves, instead of relying on `exec_params`'s built-in `get_last_result`
* listen for fatal errors reported via the notice receiver (less common, but depending on its internal state, libpq can deliver it here instead of returning it as a direct query result)

