### PR TITLE
Allow retry_on wait to accept callable objects

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Allow `retry_on` `wait` to accept any callable object.
+
+    In addition to procs, `wait:` now accepts callables such as `Method`
+    objects and strategy objects that implement `#call`.
+
+    ```ruby
+    class RetryDelay
+      def call(executions, error)
+        if error.message =~ /retry in (\d+)s/
+          $1.to_i
+        else
+          executions * 2
+        end
+      end
+    end
+
+    class RemoteServiceJob < ActiveJob::Base
+      retry_on CustomError, wait: RetryDelay.new
+    end
+    ```
+
+    *Andrey Samsonov*
+
 *   Deprecate built-in `queue_classic` Active Job adapter.
 
     *Harun Sabljaković, Wojciech Wnętrzak*

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -26,7 +26,8 @@ module ActiveJob
       #
       # ==== Options
       # * <tt>:wait</tt> - Re-enqueues the job with a delay specified either in seconds (default: 3 seconds),
-      #   as a computing proc that takes the number of executions so far as an argument (and optionally the error),
+      #   as a callable that takes the number of executions so far as an argument (and optionally the error),
+      #   such as a proc, lambda, Method, or object that responds to <tt>#call</tt>,
       #   or as a symbol reference of
       #   <tt>:polynomially_longer</tt>, which applies the wait algorithm of <tt>((executions**4) + (Kernel.rand * (executions**4) * jitter)) + 2</tt>
       #   (first wait ~3s, then ~18s, then ~83s, etc)
@@ -183,12 +184,19 @@ module ActiveJob
           delay = seconds_or_duration_or_algorithm.to_i
           delay_jitter = determine_jitter_for_delay(delay, jitter)
           delay + delay_jitter
-        when Proc
-          algorithm = seconds_or_duration_or_algorithm
-          algorithm.arity == 1 ? algorithm.call(executions) : algorithm.call(executions, error)
         else
-          raise "Couldn't determine a delay based on #{seconds_or_duration_or_algorithm.inspect}"
+          if seconds_or_duration_or_algorithm.respond_to?(:call)
+            determine_callable_delay(seconds_or_duration_or_algorithm, executions, error)
+          else
+            raise "Couldn't determine a delay based on #{seconds_or_duration_or_algorithm.inspect}"
+          end
         end
+      end
+
+      def determine_callable_delay(callable, executions, error)
+        arity = callable.respond_to?(:arity) ? callable.arity : callable.method(:call).arity
+
+        arity == 1 ? callable.call(executions) : callable.call(executions, error)
       end
 
       def determine_jitter_for_delay(delay, jitter)

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -266,6 +266,24 @@ class ExceptionsTest < ActiveSupport::TestCase
       ], JobBuffer.values
     end
 
+    test "custom wait object can use the execution count" do
+      travel_to Time.now
+
+      RetryJob.perform_later "CallableWaitTenAttemptsError", 5, :log_scheduled_at
+
+      assert_equal [
+        "Raised CallableWaitTenAttemptsError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 2.seconds).to_f}",
+        "Raised CallableWaitTenAttemptsError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 4.seconds).to_f}",
+        "Raised CallableWaitTenAttemptsError for the 3rd time",
+        "Next execution scheduled at #{(Time.now + 6.seconds).to_f}",
+        "Raised CallableWaitTenAttemptsError for the 4th time",
+        "Next execution scheduled at #{(Time.now + 8.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+
     test "custom wait proc can use the error" do
       travel_to Time.now
 
@@ -276,6 +294,38 @@ class ExceptionsTest < ActiveSupport::TestCase
         "Next execution scheduled at #{(Time.now + 11.seconds).to_f}",
         "Raised RetryWaitIncludedInError for the 2nd time",
         "Next execution scheduled at #{(Time.now + 12.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+
+    test "custom wait object can use the error" do
+      travel_to Time.now
+
+      RetryJob.perform_later "CallableWaitIncludedInError", 3, :log_scheduled_at
+
+      assert_equal [
+        "Raised CallableWaitIncludedInError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 11.seconds).to_f}",
+        "Raised CallableWaitIncludedInError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 12.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+
+    test "custom wait method can use the execution count" do
+      travel_to Time.now
+
+      RetryJob.perform_later "MethodWaitTenAttemptsError", 5, :log_scheduled_at
+
+      assert_equal [
+        "Raised MethodWaitTenAttemptsError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 2.seconds).to_f}",
+        "Raised MethodWaitTenAttemptsError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 4.seconds).to_f}",
+        "Raised MethodWaitTenAttemptsError for the 3rd time",
+        "Next execution scheduled at #{(Time.now + 6.seconds).to_f}",
+        "Raised MethodWaitTenAttemptsError for the 4th time",
+        "Next execution scheduled at #{(Time.now + 8.seconds).to_f}",
         "Successfully completed job"
       ], JobBuffer.values
     end

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -12,11 +12,18 @@ class LongWaitError < StandardError; end
 class ShortWaitTenAttemptsError < StandardError; end
 class PolynomialWaitTenAttemptsError < StandardError; end
 class CustomWaitTenAttemptsError < StandardError; end
+class CallableWaitTenAttemptsError < StandardError; end
+class CallableWaitIncludedInError < StandardError
+  def retry_after
+    10
+  end
+end
 class RetryWaitIncludedInError < StandardError
   def retry_after
     10
   end
 end
+class MethodWaitTenAttemptsError < StandardError; end
 class CustomCatchError < StandardError; end
 class DiscardableError < StandardError; end
 class FirstDiscardableErrorOfTwo < StandardError; end
@@ -26,7 +33,25 @@ class UnlimitedRetryError < StandardError; end
 class ReportedError < StandardError; end
 class HeavyError < StandardError; end
 
+class ExecutionCountWait
+  def call(executions)
+    executions * 2
+  end
+end
+
+class RetryAfterWait
+  def call(executions, error)
+    error.retry_after + executions
+  end
+end
+
 class RetryJob < ActiveJob::Base
+  class << self
+    def delay_from_executions(executions)
+      executions * 2
+    end
+  end
+
   retry_on DefaultsError
   retry_on DisabledJitterError, jitter: nil
   retry_on ZeroJitterError, jitter: 0.0
@@ -35,7 +60,10 @@ class RetryJob < ActiveJob::Base
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10
   retry_on PolynomialWaitTenAttemptsError, wait: :polynomially_longer, attempts: 10
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10
+  retry_on CallableWaitTenAttemptsError, wait: ExecutionCountWait.new, attempts: 10
   retry_on RetryWaitIncludedInError, wait: ->(executions, error) { error.retry_after + executions }
+  retry_on CallableWaitIncludedInError, wait: RetryAfterWait.new
+  retry_on MethodWaitTenAttemptsError, wait: method(:delay_from_executions), attempts: 10
   retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
   retry_on(ActiveJob::DeserializationError) { |job, error| JobBuffer.add("Raised #{error.class} for the #{job.executions} time") }
   retry_on UnlimitedRetryError, attempts: :unlimited


### PR DESCRIPTION
`ActiveJob#retry_on` currently accepts `Proc` values for `wait:`, but it
rejects other Ruby callables such as `Method` objects and objects that
implement `#call`.

This change allows `wait:` to accept any callable object, while keeping
the existing behavior for proc-based wait handlers.

It also updates the `retry_on` API docs, adds tests for callable
objects and `Method` values, and documents the change in the Active Job
changelog.

Example:

```ruby
class RetryDelay
  def call(executions, error)
    if error.message =~ /retry in (\d+)s/
      $1.to_i
    else
      executions * 2
    end
  end
end

class RemoteServiceJob < ActiveJob::Base
  retry_on CustomError, wait: RetryDelay.new
end
```

Testing:

```bash
AJ_ADAPTER=test bin/test activejob/test/cases/exceptions_test.rb
```
