### PR TITLE
Offload ActiveStorage::Blob#metadata sync to background

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Offload ActiveStorage::Blob#metadata sync to background
+
+    Problem:
+
+    A data race can occur when both a http server and a background worker (
+    `ActiveStorage::AnalyzeJob`) attempt to update a blob's metadata
+    simultaneously. This leads to a 409 conflict on GCS.
+
+    Solution:
+
+    Offload the metadata upload to a background job so the 409 no longer breaks
+    the request with a 500. Applications can add `retry_on` to
+    `ActiveStorage::SyncMetadataJob` to retry the conflict for their service.
+
+    `ActiveStorage::Service#update_metadata` now instruments the work and
+    delegates it to a new `update_metadata_for` method. Custom services that
+    overrode `update_metadata` should override `update_metadata_for` instead, so
+    the work runs inside the instrumentation.
+
+    *Shouichi Kamiya*
+
 *   Update Active Storage for ImageProcessing 2.0.
 
     ImageProcessing 2.0 now requires adding `ruby-vips` or `mini_magick` gems explicitly to the Gemfile.

--- a/activestorage/app/jobs/active_storage/sync_metadata_job.rb
+++ b/activestorage/app/jobs/active_storage/sync_metadata_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ActiveStorage::SyncMetadataJob < ActiveStorage::BaseJob
+  queue_as { ActiveStorage.queues[:sync_metadata] }
+
+  discard_on ActiveRecord::RecordNotFound
+  retry_on ActiveRecord::Deadlocked, attempts: 10, wait: :polynomially_longer
+
+  def perform(blob)
+    blob.sync_metadata
+  end
+end

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -57,7 +57,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
   after_update :touch_attachments
 
-  after_update_commit :update_service_metadata, if: -> { content_type_previously_changed? || metadata_previously_changed? }
+  after_update_commit :sync_metadata_later, if: -> { content_type_previously_changed? || metadata_previously_changed? }
 
   before_destroy(prepend: true) do
     raise ActiveRecord::InvalidForeignKey if attachments.exists?
@@ -378,6 +378,10 @@ class ActiveStorage::Blob < ActiveStorage::Record
     ActiveStorage::PurgeJob.perform_later(self)
   end
 
+  def sync_metadata # :nodoc:
+    service.update_metadata key, **service_metadata if service_metadata.any?
+  end
+
   # Returns an instance of service, which can be configured globally or per attachment
   def service
     services.fetch(service_name) if service_name
@@ -438,8 +442,8 @@ class ActiveStorage::Blob < ActiveStorage::Record
       end
     end
 
-    def update_service_metadata
-      service.update_metadata key, **service_metadata if service_metadata.any?
+    def sync_metadata_later
+      ActiveStorage::SyncMetadataJob.perform_later(self)
     end
 end
 

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -72,9 +72,10 @@ module ActiveStorage
     end
 
     # Update metadata for the file identified by +key+ in the service.
-    # Override in subclasses only if the service needs to store specific
-    # metadata that has to be updated upon identification.
     def update_metadata(key, **metadata)
+      instrument :update_metadata, key: key, **metadata do
+        update_metadata_for key, **metadata
+      end
     end
 
     # Return the content of the file at the +key+.
@@ -187,6 +188,11 @@ module ActiveStorage
 
       def custom_metadata_headers(metadata)
         raise NotImplementedError
+      end
+
+      # Override in subclasses only if the service needs to store specific
+      # metadata that has to be updated upon identification.
+      def update_metadata_for(key, **metadata)
       end
 
       def instrument(operation, payload = {}, &block)

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -45,16 +45,6 @@ module ActiveStorage
       end
     end
 
-    def update_metadata(key, content_type:, disposition: nil, filename: nil, custom_metadata: {})
-      instrument :update_metadata, key: key, content_type: content_type, disposition: disposition do
-        file_for(key).update do |file|
-          file.content_type = content_type
-          file.content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
-          file.metadata = custom_metadata
-        end
-      end
-    end
-
     def download_chunk(key, range)
       instrument :download_chunk, key: key, range: range do
         file_for(key).download(range: range).string
@@ -191,6 +181,14 @@ module ActiveStorage
 
       def file_for(key, skip_lookup: true)
         bucket.file(key, skip_lookup: skip_lookup)
+      end
+
+      def update_metadata_for(key, content_type:, disposition: nil, filename: nil, custom_metadata: {})
+        file_for(key).update do |file|
+          file.content_type = content_type
+          file.content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
+          file.metadata = custom_metadata
+        end
       end
 
       # Reads the file for the given key in chunks, yielding each to the block.

--- a/activestorage/test/jobs/sync_metadata_job_test.rb
+++ b/activestorage/test/jobs/sync_metadata_job_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::SyncMetadataJobTest < ActiveJob::TestCase
+  setup { @blob = create_blob }
+
+  test "syncs metadata" do
+    assert_notification("service_update_metadata.active_storage", key: @blob.key) do
+      ActiveStorage::SyncMetadataJob.perform_now @blob
+    end
+  end
+
+  test "ignores missing blob" do
+    @blob.purge
+
+    perform_enqueued_jobs do
+      assert_nothing_raised do
+        ActiveStorage::SyncMetadataJob.perform_later @blob
+      end
+    end
+  end
+end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -31,7 +31,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
 
     assert_not_predicate blob, :analyzed?
 
-    assert_no_enqueued_jobs do
+    assert_no_enqueued_jobs only: ActiveStorage::AnalyzeJob do
       @user.highlights.attach(blob)
     end
 

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -395,29 +395,26 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal ["is invalid"], blob.errors[:service_name]
   end
 
-  test "updating the content_type updates service metadata" do
+  test "sync_metadata uploads metadata to service" do
+    blob = directly_upload_file_blob(filename: "racecar.jpg")
+
+    assert_notification("service_update_metadata.active_storage", key: blob.key, content_type: "image/jpeg", custom_metadata: {}) do
+      blob.sync_metadata
+    end
+  end
+
+  test "updating the content_type enqueues sync metadata job" do
     blob = directly_upload_file_blob(filename: "racecar.jpg", content_type: "application/octet-stream")
 
-    assert_called_with(blob.service, :update_metadata, [blob.key], content_type: "image/jpeg", custom_metadata: {}) do
+    assert_enqueued_with(job: ActiveStorage::SyncMetadataJob, args: [blob]) do
       blob.update!(content_type: "image/jpeg")
     end
   end
 
-  test "updating the metadata updates service metadata" do
-    blob = directly_upload_file_blob(filename: "racecar.jpg", content_type: "application/octet-stream")
+  test "updating the metadata enqueues sync metadata job" do
+    blob = directly_upload_file_blob(filename: "racecar.jpg")
 
-    expected_arguments = [
-      blob.key
-    ]
-
-    expected_kwargs = {
-      content_type: "application/octet-stream",
-      disposition: :attachment,
-      filename: blob.filename,
-      custom_metadata: { "test" => true }
-    }
-
-    assert_called_with(blob.service, :update_metadata, expected_arguments, **expected_kwargs) do
+    assert_enqueued_with(job: ActiveStorage::SyncMetadataJob, args: [blob]) do
       blob.update!(metadata: { custom: { "test" => true } })
     end
   end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -806,14 +806,17 @@ is the same as `Rails.backtrace_cleaner`.
 
 #### `service_update_metadata.active_storage`
 
-This event is only emitted when using the Google Cloud Storage service.
+| Key                | Value                            |
+| ------------------ | -------------------------------- |
+| `:key`             | Secure token                     |
+| `:service`         | Name of the service              |
+| `:content_type`    | HTTP `Content-Type` field        |
+| `:disposition`     | HTTP `Content-Disposition` field |
+| `:filename`        | Name of the file                 |
+| `:custom_metadata` | Custom metadata of the file      |
 
-| Key             | Value                            |
-| --------------- | -------------------------------- |
-| `:key`          | Secure token                     |
-| `:service`      | Name of the service              |
-| `:content_type` | HTTP `Content-Type` field        |
-| `:disposition`  | HTTP `Content-Disposition` field |
+NOTE: Only the Google Cloud Storage service stores the metadata; for other
+services updating the metadata is a no-op, though the event is still emitted.
 
 ### Active Support: Caching
 


### PR DESCRIPTION
### Motivation / Background

A race condition can occur when a server and a worker both try to update blob metadata at the same time, leading to errors on services like GCS.

### Detail

This Pull Request offloads metadata updates to a background worker to avoid the data race.

### Additional information

Close https://github.com/rails/rails/issues/54919.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.