### PR TITLE
Fix enum default: preventing scoped association build from applying scope value

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Fix `enum` with `default:` preventing scoped association `.build` from applying scope values.
+
+    When an enum declared a `default:`, building a record through a scoped `has_many`
+    (e.g., `has_many :write_posts, -> { write }`) would silently ignore the scope's
+    value and use the enum default instead.
+
+    ```ruby
+    class Post < ActiveRecord::Base
+      enum :action, { write: 0, read: 1 }, default: :read
+    end
+
+    class User < ActiveRecord::Base
+      has_many :write_posts, -> { write }, class_name: "Post"
+    end
+
+    user = User.create!
+    post = user.write_posts.build
+    post.action # => "write" (was incorrectly "read")
+    ```
+
+    *Song Huang*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -217,7 +217,15 @@ module ActiveRecord
       def initialize_attributes(record, except_from_scope_attributes = nil) # :nodoc:
         except_from_scope_attributes ||= {}
         skip_assign = [reflection.foreign_key, reflection.type].compact
-        assigned_keys = record.changed_attribute_names_to_save
+        default_attributes = record.class._default_attributes
+        assigned_keys = record.changed_attribute_names_to_save.select { |attr_name|
+          # Only treat attributes as "already assigned" if they were explicitly
+          # set by the user (e.g., passed to build() or set in after_initialize),
+          # not merely defaulted via `attribute :name, default:`. Attributes
+          # still at their class-level default should not prevent scope values
+          # from being applied.
+          record.instance_variable_get(:@attributes)[attr_name] != default_attributes[attr_name]
+        }
         assigned_keys += except_from_scope_attributes.keys.map(&:to_s)
         attributes = scope_for_create.except!(*(assigned_keys - skip_assign))
         record.send(:_assign_attributes, attributes) if attributes.any?

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -235,6 +235,15 @@ module ActiveRecord
         detect_enum_conflict!(name, name)
         detect_enum_conflict!(name, "#{name}=")
 
+        if options.key?(:default)
+          default_label = options[:default]
+          if values.respond_to?(:each_pair)
+            options[:default] = ActiveSupport::HashWithIndifferentAccess.new(values)[default_label]
+          else
+            options[:default] = values.index { |v| v.to_s == default_label.to_s }
+          end
+        end
+
         attribute(name, **options)
 
         decorate_attributes([name]) do |_name, subtype|

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -855,6 +855,17 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "published", klass.new.status
   end
 
+  test "enum default resolves to database value for dirty tracking" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, { proposed: 0, written: 1, published: 2 }, default: :written
+    end
+
+    record = klass.new
+    assert_equal "written", record.status
+    assert_equal 1, record.read_attribute_before_type_cast(:status)
+  end
+
   test ":_default is invalid in the new API" do
     error = assert_raises(ArgumentError) do
       Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
### Motivation / Background

Fixes #57061

The `default:` option on `enum` silently breaks scoped association `.build` calls. When building a record through a scoped `has_many` (e.g., `has_many :write_posts, -> { write }`), the scope's value is ignored and the record gets the enum default instead.

This is a regression from the old `_default:` behavior. Since Rails 7.2 stable rejects `_default:` with `ArgumentError`, upgrading forces migration to `default:` which silently introduces this bug.

### Detail

**Root cause:** `enum :action, { write: 0, read: 1 }, default: :read` calls `attribute :action, default: :read`, storing the raw symbol `:read`. Dirty tracking sees this as "changed" compared to the DB column state. In `Association#initialize_attributes`, "changed" attributes are excluded from scope application, so the scope's value is silently skipped.

**Two changes fix this:**

1. **`activerecord/lib/active_record/enum.rb`** — Resolve the `default:` label (e.g., `:read`) to its mapped DB value (e.g., `1`) before passing to `attribute()`. This makes `value_before_type_cast` store the integer, not a raw symbol.

2. **`activerecord/lib/active_record/associations/association.rb`** — In `initialize_attributes`, only treat attributes as "already assigned" if they were explicitly set by the user (differing from the class-level default), not merely defaulted via `attribute default:`. This ensures scoped associations can override enum defaults during `.build`.

### Additional information

Reproduction script from the issue:

```ruby
class Post < ActiveRecord::Base
  belongs_to :user
  enum :action, { write: 0, read: 1 }, default: :read
end

class User < ActiveRecord::Base
  has_many :write_posts, -> { write }, class_name: "Post"
end

user = User.create!
post = user.write_posts.build
post.action # => "read" (BUG: should be "write")
```

Affected versions: Rails 7.0+ through main.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.