### PR TITLE
Adjust selenium sessons count for Capybara.using_session

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -28,6 +28,17 @@ services:
   selenium:
     image: selenium/standalone-chromium
     restart: unless-stopped
+
+    # Adjust SE_NODE_MAX_SESSIONS to limit the number of simultaneous Capybara sessions
+    # in system tests created by Capybara.using_session.
+    #
+    # See https://github.com/teamcapybara/capybara?tab=readme-ov-file#using-sessions and
+    # https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#increasing-session-concurrency-per-container
+    environment:
+      - SE_NODE_MAX_SESSIONS=3
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+      - SE_START_VNC=false
+
 <%- end -%>
 
 <%- if options[:redis] -%>

--- a/railties/test/commands/devcontainer_test.rb
+++ b/railties/test/commands/devcontainer_test.rb
@@ -50,6 +50,11 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
       expected_selenium_config = {
         "image" => "selenium/standalone-chromium",
         "restart" => "unless-stopped",
+        "environment" => [
+          "SE_NODE_MAX_SESSIONS=3",
+          "SE_NODE_OVERRIDE_MAX_SESSIONS=true",
+          "SE_START_VNC=false"
+        ]
       }
 
       assert_equal expected_selenium_config, content["services"]["selenium"]

--- a/railties/test/fixtures/.devcontainer/compose.yaml
+++ b/railties/test/fixtures/.devcontainer/compose.yaml
@@ -23,6 +23,16 @@ services:
     image: selenium/standalone-chromium
     restart: unless-stopped
 
+    # Adjust SE_NODE_MAX_SESSIONS to limit the number of simultaneous Capybara sessions
+    # in system tests created by Capybara.using_session.
+    #
+    # See https://github.com/teamcapybara/capybara?tab=readme-ov-file#using-sessions and
+    # https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#increasing-session-concurrency-per-container
+    environment:
+      - SE_NODE_MAX_SESSIONS=3
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+      - SE_START_VNC=false
+
   redis:
     image: valkey/valkey:9
     restart: unless-stopped

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1546,6 +1546,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
       expected_selenium_config = {
         "image" => "selenium/standalone-chromium",
         "restart" => "unless-stopped",
+        "environment" => [
+          "SE_NODE_MAX_SESSIONS=3",
+          "SE_NODE_OVERRIDE_MAX_SESSIONS=true",
+          "SE_START_VNC=false"
+        ]
       }
 
       assert_equal expected_selenium_config, compose_config["services"]["selenium"]


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

I just created an application with Action Cable and added system tests with [Capybara.using_session](https://github.com/teamcapybara/capybara?tab=readme-ov-file#using-sessions). The tests hung up because by default, Selenium has [only one session per container configured](https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#increasing-session-concurrency-per-container:~:text=only%20one%20session%20is%20configured%20to%20run%20per%20container). I fixed the issue by increasing the sessions count to 3; it is enough to run two sessions with Action Cable connections. Also, I've disabled VNC to [reduce](https://github.com/SeleniumHQ/docker-selenium?tab=readme-ov-file#disabling-vnc) resource usage.

I believe it is good default settings for every devcontainer because:

- It allows the use of `Capybara.using_session` in system tests without additional debugging and setup
- It still keeps resource usage low

### Detail

This Pull Request changes only `.devcontainer/compose.yaml` template and related tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
