### PR TITLE
Don't report rescue_responses from Reloader to error reporter

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -19,7 +19,7 @@ module ActionDispatch
       begin
         response = @app.call(env)
 
-        if env["action_dispatch.report_exception"]
+        if env["action_dispatch.report_exception"] && !env["action_dispatch.exception_reported"]
           error = env["action_dispatch.exception"]
           @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
         end
@@ -33,7 +33,10 @@ module ActionDispatch
         request = ActionDispatch::Request.new env
         backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
         wrapper = ExceptionWrapper.new(backtrace_cleaner, error)
-        @executor.error_reporter.report(wrapper.unwrapped_exception, handled: false, source: "application.action_dispatch")
+        unless wrapper.rescue_response?
+          @executor.error_reporter.report(wrapper.unwrapped_exception, handled: false, source: "application.action_dispatch")
+          env["action_dispatch.exception_reported"] = true
+        end
         raise
       ensure
         if !returned && !response_finished

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -170,6 +170,78 @@ class ExecutorTest < ActiveSupport::TestCase
     end
   end
 
+  def test_reloader_does_not_report_rescue_responses
+    reloader = Class.new(ActiveSupport::Reloader) { self.check = -> { true } }
+
+    # Stack: Executor > ShowExceptions > Reloader > App (mimics real middleware order)
+    stack = Rack::Lint.new(
+      ActionDispatch::Executor.new(
+        ActionDispatch::ShowExceptions.new(
+          ActionDispatch::Reloader.new(
+            Rack::Lint.new(->(_env) { raise BusinessAsUsual }),
+            reloader,
+          ),
+          ->(env) { [418, { "content-type" => "text/plain" }, ["I'm a teapot"]] },
+        ),
+        executor,
+      )
+    )
+
+    env = Rack::MockRequest.env_for("", {})
+    env["action_dispatch.show_exceptions"] = :all
+    ActionDispatch::ExceptionWrapper.with(rescue_responses: { BusinessAsUsual.name => 418 }) do
+      assert_no_error_reported do
+        response = stack.call(env)
+        assert_equal 418, response[0]
+      end
+    end
+  end
+
+  def test_reloader_does_not_double_report_non_rescue_responses
+    reloader = Class.new(ActiveSupport::Reloader) { self.check = -> { true } }
+
+    # Stack: Executor > ShowExceptions > Reloader > App
+    stack = Rack::Lint.new(
+      ActionDispatch::Executor.new(
+        ActionDispatch::ShowExceptions.new(
+          ActionDispatch::Reloader.new(
+            Rack::Lint.new(->(_env) { raise RuntimeError, "boom" }),
+            reloader,
+          ),
+          ->(env) { [500, { "content-type" => "text/plain" }, ["Internal Server Error"]] },
+        ),
+        executor,
+      )
+    )
+
+    env = Rack::MockRequest.env_for("", {})
+    env["action_dispatch.show_exceptions"] = :all
+    reports = capture_error_reports(RuntimeError) do
+      stack.call(env)
+    end
+    assert_equal 1, reports.size
+  end
+
+  def test_reloader_reports_non_rescue_responses_without_show_exceptions
+    reloader = Class.new(ActiveSupport::Reloader) { self.check = -> { true } }
+
+    # Stack: Reloader > App (no ShowExceptions — custom stack backward compat)
+    stack = Rack::Lint.new(
+      ActionDispatch::Reloader.new(
+        Rack::Lint.new(->(_env) { raise RuntimeError, "boom" }),
+        reloader,
+      )
+    )
+
+    env = Rack::MockRequest.env_for("", {})
+    error_report = assert_error_reported(RuntimeError) do
+      assert_raises(RuntimeError) do
+        stack.call(env)
+      end
+    end
+    assert_equal "boom", error_report.error.message
+  end
+
   def test_complete_callbacks_are_called_on_rack_response_finished
     completed = false
     executor.to_complete { completed = true }


### PR DESCRIPTION
### Motivation / Background

Fixes #55040

`ActionDispatch::Reloader` sits inside `ShowExceptions` in the middleware stack. Its inherited `rescue` block unconditionally reports all exceptions to `Rails.error` — including `rescue_responses` (404s, 400s) that `ShowExceptions` would normally suppress. This causes those errors to be reported in development but silently suppressed in production.

### Detail

Two targeted changes to `ActionDispatch::Executor#call`:

1. Skip reporting for `rescue_response?` exceptions — let `ShowExceptions` decide.
2. Check a new `action_dispatch.exception_reported` env flag to prevent double-reporting when both Reloader and outer Executor process the same exception.

| Scenario | Reports |
|---|---|
| rescue_response (dev or prod) | 0 ✅ |
| non-rescue_response (dev) | 1 ✅ |
| non-rescue_response (prod) | 1 ✅ |

### Additional information

| Path | Before | After |
|---|---|---|
| Happy path (no exception) | 204.9k i/s | 204.6k i/s (same) |
| rescue_response (404) | 23.4k i/s | 25.3k i/s (+8%) |
| non-rescue_response (500) | 23.1k i/s | 23.4k i/s (same) |

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.