### PR TITLE
Classify mysql error 1046 (ER_NO_DB_ERROR) as ConnectionFailed

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   MySQL error 1046 (`ER_NO_DB_ERROR: No database selected`) is now retryable as a `ConnectionFailed` exception
+
+    *Clay Harmon*
+
 *   Batch SQL statements when creating tables to improve performance.
 
     *Andrew Novoselac*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -896,6 +896,7 @@ module ActiveRecord
         # See https://dev.mysql.com/doc/mysql-errors/en/server-error-reference.html
         ER_DB_CREATE_EXISTS     = 1007
         ER_FILSORT_ABORT        = 1028
+        ER_NO_DB_ERROR          = 1046
         ER_DUP_ENTRY            = 1062
         ER_SERVER_SHUTDOWN      = 1053
         ER_NOT_NULL_VIOLATION   = 1048
@@ -928,7 +929,7 @@ module ActiveRecord
             else
               super
             end
-          when ER_CONNECTION_KILLED, ER_SERVER_SHUTDOWN, CR_SERVER_GONE_ERROR, CR_SERVER_LOST, ER_CLIENT_INTERACTION_TIMEOUT
+          when ER_CONNECTION_KILLED, ER_SERVER_SHUTDOWN, CR_SERVER_GONE_ERROR, CR_SERVER_LOST, ER_CLIENT_INTERACTION_TIMEOUT, ER_NO_DB_ERROR
             ConnectionFailed.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when ER_DB_CREATE_EXISTS
             DatabaseAlreadyExists.new(message, sql: sql, binds: binds, connection_pool: @pool)

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -299,6 +299,16 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     assert_equal @conn.pool, error.connection_pool
   end
 
+  def test_no_database_selected_error_translates_to_connection_failed
+    raw_conn = @conn.raw_connection
+    error = assert_raises(ActiveRecord::ConnectionFailed) do
+      raw_conn.stub(:query, ->(_sql) { raise Mysql2::Error.new("No database selected", 50700, ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::ER_NO_DB_ERROR) }) {
+        @conn.execute("SELECT 1")
+      }
+    end
+    assert_equal @conn.pool, error.connection_pool
+  end
+
   def test_database_timezone_changes_synced_to_connection
     with_timezone_config default: :local do
       assert_changes(-> { @conn.raw_connection.query_options[:database_timezone] }, from: :utc, to: :local) do


### PR DESCRIPTION
### Motivation / Background

When a MySQL TCP connection is silently re-established by mysql2 (like a proxy reset), the new connection does not reissue `USE database_name`. The next query fails with MySQL error 1046: `No database selected`.

Currently, `translate_exception` has no case for error 1046, so it falls through to `StatementInvalid`. Since `StatementInvalid` is not recognized by `retryable_connection_error?`, the built-in `with_raw_connection` retry loop never fires.

This affects any Rails app using MySQL with connection pooling and network infrastructure that can silently reset TCP connections.

### Detail

This is the same class of problem as errors 2006 (`CR_SERVER_GONE_ERROR`) and 2013 (`CR_SERVER_LOST`), which are classified as `ConnectionFailed`.

The change adds `ER_NO_DB_ERROR = 1046` to the error constants and includes it in the `ConnectionFailed` branch of `translate_exception`. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
