### PR TITLE
Make fast behavior the default for NumberToDelimitedConverter

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -7,8 +7,6 @@ module ActiveSupport
     class NumberToDelimitedConverter < NumberConverter # :nodoc:
       self.validate_float = true
 
-      DEFAULT_DELIMITER_REGEX = /(\d)(?=(\d\d\d)+(?!\d))/
-
       def convert
         parts.join(options[:separator])
       end
@@ -38,7 +36,7 @@ module ActiveSupport
         end
 
         def delimiter_pattern
-          options.fetch(:delimiter_pattern, DEFAULT_DELIMITER_REGEX)
+          options[:delimiter_pattern]
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Although methods like `number_to_delimited` are optimized in https://github.com/rails/rails/commit/2d485aecf594da632b389e5f4ae87b302ea17fe0, the existing default value of `delimiter_pattern` causes the previous slower processing to run unless `delimiter_pattern: nil` is explicitly specified (e.g., `number_to_delimited(10000, delimiter_pattern: nil)`).

This behavior is likely unintended in the original commit, so change it to use the fast behavior by default.

### Detail

Remove DEFAULT_DELIMITER_REGEX to ensure the fast path is used when no options are specified (e.g., `number_to_delimited(10000)`)

