### PR TITLE
Consolidate configure_connection and allow skipping individual settings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Allow configuring `SET` queriers for the PostgreSQL and MySQL adapters.
+
+    Individual settings can be skipped by setting them to `false` in
+    `database.yml`, which is useful when connecting through a load balancer or
+    proxy that handles configuration:
+
+    PostgreSQL example:
+
+    ```yaml
+    production:
+      adapter: postgresql
+      standard_conforming_strings: false
+      intervalstyle: false
+      min_messages: false
+      schema_search_path: false
+    ```
+
+    MySQL example:
+
+    ```yaml
+    production:
+      adapter: mysql2
+      wait_timeout: false
+      variables:
+        sql_mode: false
+    ```
+
+    Also deprecates `set_standard_conforming_strings` — it is now handled
+    automatically through the consolidated settings hash.
+
+    *Eileen M. Uchitelle*, *Matthew Draper*
+
 *   MySQL error 1046 (`ER_NO_DB_ERROR: No database selected`) is now retryable as a `ConnectionFailed` exception
 
     *Clay Harmon*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1032,17 +1032,24 @@ module ActiveRecord
           variables = @config.fetch(:variables, {}).stringify_keys
 
           # Increase timeout so the server doesn't disconnect us.
-          wait_timeout = self.class.type_cast_config_to_integer(@config[:wait_timeout])
-          wait_timeout = 2147483 unless wait_timeout.is_a?(Integer)
-          variables["wait_timeout"] = wait_timeout
+          # Set to false in config to skip.
+          unless @config[:wait_timeout] == false
+            wait_timeout = self.class.type_cast_config_to_integer(@config[:wait_timeout])
+            wait_timeout = 2147483 unless wait_timeout.is_a?(Integer)
+            variables["wait_timeout"] = wait_timeout
+          end
 
           defaults = [":default", :default].to_set
 
           # Make MySQL reject illegal values rather than truncating or blanking them, see
           # https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_strict_all_tables
           # If the user has provided another value for sql_mode, don't replace it.
-          if sql_mode = variables.delete("sql_mode")
-            sql_mode = quote(sql_mode)
+          # Set sql_mode to false or :default in variables to skip.
+          if variables.key?("sql_mode")
+            sql_mode_value = variables.delete("sql_mode")
+            unless sql_mode_value == false || defaults.include?(sql_mode_value)
+              sql_mode = quote(sql_mode_value)
+            end
           elsif !defaults.include?(strict_mode?)
             if strict_mode?
               sql_mode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -307,7 +307,12 @@ module ActiveRecord
         def schema_search_path=(schema_csv)
           return if schema_csv == @schema_search_path
           if schema_csv
-            query_command("SET search_path TO #{schema_csv}", "SCHEMA")
+            # Check parameter_status to skip redundant SET when the server
+            # already has the desired search_path (e.g. on initial connection).
+            current = with_raw_connection(materialize_transactions: false) { |conn| conn.parameter_status("search_path") }
+            unless current == schema_csv
+              query_command("SET search_path TO #{schema_csv}", "SCHEMA")
+            end
             @schema_search_path = schema_csv
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -443,8 +443,9 @@ module ActiveRecord
       end
 
       def set_standard_conforming_strings
-        query_command("SET standard_conforming_strings = on", "SCHEMA")
+        internal_set_config("standard_conforming_strings", "on")
       end
+      deprecate :set_standard_conforming_strings, deprecator: ActiveRecord.deprecator
 
       def supports_ddl_transactions?
         true
@@ -1032,8 +1033,6 @@ module ActiveRecord
           if @config[:encoding]
             @raw_connection.set_client_encoding(@config[:encoding])
           end
-          self.client_min_messages = @config[:min_messages] || "warning"
-          self.schema_search_path = @config[:schema_search_path] || @config[:schema_order]
 
           unless ActiveRecord.db_warnings_action.nil?
             @raw_connection.set_notice_receiver do |result|
@@ -1044,23 +1043,39 @@ module ActiveRecord
             end
           end
 
-          # Use standard-conforming strings so we don't have to do the E'...' dance.
-          set_standard_conforming_strings
+          # Build a single hash of all settings we want to configure, then
+          # set them all through internal_set_config which can skip redundant
+          # SETs by checking parameter_status.
+          settings = {}
 
-          variables = @config.fetch(:variables, {}).stringify_keys
+          # Use standard-conforming strings so we don't have to do the E'...' dance.
+          settings["standard_conforming_strings"] = "on" unless @config[:standard_conforming_strings] == false
 
           # Set interval output format to ISO 8601 for ease of parsing by ActiveSupport::Duration.parse
-          query_command("SET intervalstyle = iso_8601", "SCHEMA")
+          settings["IntervalStyle"] = "iso_8601" unless @config[:intervalstyle] == false
 
-          # SET statements from :variables config hash
+          unless @config[:min_messages] == false
+            settings["client_min_messages"] = @config[:min_messages] || "warning"
+          end
+
+          # Merge in user-provided variables from :variables config hash.
           # https://www.postgresql.org/docs/current/static/sql-set.html
-          variables.map do |k, v|
+          @config.fetch(:variables, {}).stringify_keys.each do |k, v|
             if v == ":default" || v == :default
-              # Sets the value to the global or compile default
-              query_command("SET SESSION #{k} TO DEFAULT", "SCHEMA")
+              settings[k] = nil # nil signals "SET TO DEFAULT"
             elsif !v.nil?
-              query_command("SET SESSION #{k} TO #{quote(v)}", "SCHEMA")
+              settings[k] = v
             end
+          end
+
+          settings.each do |setting, value|
+            internal_set_config(setting, value)
+          end
+
+          # search_path uses unquoted, comma-separated identifiers so it
+          # goes through the existing setter rather than internal_set_config.
+          unless @config[:schema_search_path] == false
+            self.schema_search_path = @config[:schema_search_path] || @config[:schema_order]
           end
 
           add_pg_encoders
@@ -1090,6 +1105,20 @@ module ActiveRecord
             intent.execute!
             intent.finish
           end
+        end
+
+        # Sets a PostgreSQL session configuration variable. Uses parameter_status
+        # to skip redundant SET commands when the server already has the desired
+        # value. Pass nil as value to SET TO DEFAULT.
+        def internal_set_config(setting, value)
+          if value
+            with_raw_connection(allow_retry: false, materialize_transactions: false) do |conn|
+              return if conn.parameter_status(setting) == value.to_s
+            end
+          end
+
+          quoted_value = value ? quote(value) : "DEFAULT"
+          query_command("SET SESSION #{setting} TO #{quoted_value}", "SCHEMA")
         end
 
         # Returns the list of a table's column names, data types, and default values.

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -11,6 +11,32 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     @original_db_warnings_action = :ignore
   end
 
+  def test_configure_connection_skips_wait_timeout_when_false
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+    connection = ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
+      db_config.configuration_hash.merge(wait_timeout: false)
+    )
+    connection.connect!
+
+    # When wait_timeout is false, the server's default wait_timeout should
+    # be preserved instead of being overridden to 2147483.
+    wait_timeout = connection.query_value("SELECT @@SESSION.wait_timeout").to_i
+    assert_not_equal 2147483, wait_timeout
+  ensure
+    connection&.disconnect!
+  end
+
+  def test_configure_connection_sets_default_wait_timeout
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+    connection = ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(db_config.configuration_hash)
+    connection.connect!
+
+    wait_timeout = connection.query_value("SELECT @@SESSION.wait_timeout").to_i
+    assert_equal 2147483, wait_timeout
+  ensure
+    connection&.disconnect!
+  end
+
   def test_connection_error
     error = assert_raises ActiveRecord::ConnectionNotEstablished do
       ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(socket: File::NULL, prepared_statements: false).connect!

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -137,6 +137,140 @@ module ActiveRecord
         end
       end
 
+      def test_set_standard_conforming_strings_deprecation
+        assert_deprecated(ActiveRecord.deprecator) do
+          @connection.set_standard_conforming_strings
+        end
+      end
+
+      def test_configure_connection_sets_default_settings
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+        connection.connect!
+
+        assert_equal "on", connection.query_value("SHOW standard_conforming_strings")
+        assert_equal "iso_8601", connection.query_value("SHOW intervalstyle")
+        assert_equal "warning", connection.query_value("SHOW client_min_messages")
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_skips_standard_conforming_strings_when_false
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(standard_conforming_strings: false)
+        )
+
+        log = capture_sql(include_schema: true) do
+          connection.connect!
+        end
+
+        assert_not log.any? { |sql| sql.include?("standard_conforming_strings") },
+          "Expected no SET standard_conforming_strings query, but found one in: #{log.inspect}"
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_skips_intervalstyle_when_false
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(intervalstyle: false)
+        )
+
+        log = capture_sql(include_schema: true) do
+          connection.connect!
+        end
+
+        assert_not log.any? { |sql| sql.include?("IntervalStyle") },
+          "Expected no SET IntervalStyle query, but found one in: #{log.inspect}"
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_skips_client_min_messages_when_false
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(min_messages: false)
+        )
+
+        log = capture_sql(include_schema: true) do
+          connection.connect!
+        end
+
+        assert_not log.any? { |sql| sql.include?("client_min_messages") },
+          "Expected no SET client_min_messages query, but found one in: #{log.inspect}"
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_skips_schema_search_path_when_false
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(schema_search_path: false)
+        )
+
+        log = capture_sql(include_schema: true) do
+          connection.connect!
+        end
+
+        assert_not log.any? { |sql| sql.match?(/SET.*search_path/) },
+          "Expected no SET search_path query, but found one in: #{log.inspect}"
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_custom_min_messages
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(min_messages: "notice")
+        )
+        connection.connect!
+
+        assert_equal "notice", connection.query_value("SHOW client_min_messages")
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_variables_are_set
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(variables: { statement_timeout: "5000" })
+        )
+        connection.connect!
+
+        assert_equal "5s", connection.query_value("SHOW statement_timeout")
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_variables_can_override_defaults
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(variables: { client_min_messages: "error" })
+        )
+        connection.connect!
+
+        # The :variables hash entry should win over the default "warning"
+        assert_equal "error", connection.query_value("SHOW client_min_messages")
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_variables_with_default_value
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(
+            variables: { client_min_messages: :default }
+          )
+        )
+        connection.connect!
+
+        # :default resets to the server's compile-time default which is "notice"
+        assert_equal "notice", connection.query_value("SHOW client_min_messages")
+      ensure
+        connection&.disconnect!
+      end
+
       def test_schema_search_path_is_reapplied_after_reconnect
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 


### PR DESCRIPTION
Refactor PostgreSQL `configure_connection` to build a hash of all session settings, then set them in a single loop through `internal_set_config`. This method checks PostgreSQL's `parameter_status` before issuing SET commands, skipping queries when the server already has the desired value.

Individual settings can be skipped by setting them to `false` in config, which is useful when connecting through a load balancer or proxy:

```yaml
production:
  adapter: postgresql
  standard_conforming_strings: false
  intervalstyle: false
  min_messages: false
  schema_search_path: false
```

For MySQL, `wait_timeout` can be skipped with `wait_timeout: false`, and `sql_mode` can be skipped via `variables: { sql_mode: false }` (consistent with the existing `:default` behavior).

Also deprecate `set_standard_conforming_strings` which is now handled through the consolidated settings hash, and add a `parameter_status` check to `schema_search_path=` to skip redundant SET queries.

Related https://github.com/rails/rails/pull/57013