### PR TITLE
Fix titleize to capitalize unicode lowercase letters

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -190,7 +190,7 @@ module ActiveSupport
     #   titleize('raiders_of_the_lost_ark')                      # => "Raiders Of The Lost Ark"
     #   titleize('string_ending_with_id', keep_id_suffix: true)  # => "String Ending With Id"
     def titleize(word, keep_id_suffix: false)
-      humanize(underscore(word), keep_id_suffix: keep_id_suffix).gsub(/\b(?<!\w['’`()])[a-z]/) do |match|
+      humanize(underscore(word), keep_id_suffix: keep_id_suffix).gsub(/\b(?<!\w['’`()])\p{Lower}/) do |match|
         match.capitalize
       end
     end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -294,6 +294,7 @@ module InflectorTestCases
     "i've just seen a face" => "I've Just Seen A Face",
     "maybe you'll be there" => "Maybe You'll Be There",
     "¿por qué?"             => "¿Por Qué?",
+    "über ñoño"             => "Über Ñoño",
     "Fred’s"                => "Fred’s",
     "Fred`s"                => "Fred`s",
     "this was 'fake news'"  => "This Was 'Fake News'",


### PR DESCRIPTION

Inflector#titleize uses [a-z] in its regex to match word-initial lowercase letters for capitalization. This only matches ASCII characters, so Unicode lowercase letters like đ, é, ü, ñ, ć are silently skipped and left lowercase.

- Before
`titleize("ćasim đipa") # => "ćasim đipa"`

- After
`titleize("ćasim đipa") # => "Ćasim Đipa"`

Fix: Replace [a-z] with \p{Ll} in the titleize regex