### PR TITLE
Add credentials:set, credentials:list, and credentials:delete commands

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `credentials:set`, `credentials:list`, and `credentials:delete` commands.
+
+    These commands allow managing credentials without opening an interactive editor,
+    which is useful for CI/CD pipelines and AI coding agents.
+
+    ```bash
+    bin/rails credentials:set aws.access_key_id=AKIAIOSFODNN7EXAMPLE
+    bin/rails credentials:list
+    bin/rails credentials:list --show-values
+    bin/rails credentials:delete aws.access_key_id
+    ```
+
+    All commands support `--environment` for environment-specific credentials.
+
+    *Gyuha Wang*
+
 *   Avoid adding `Rack::Sendfile` to the middleware stack if `config.action_dispatch.x_sendfile_header` is `nil`.
 
     The middleware behave as a noop in such case so it's pointless to have it in the stack.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -12,7 +12,7 @@
 
     All commands support `--environment` for environment-specific credentials.
 
-    *Gyuha Wang*
+    *sebyx07*
 
 *   Avoid adding `Rack::Sendfile` to the middleware stack if `config.action_dispatch.x_sendfile_header` is `nil`.
 

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -55,6 +55,32 @@ Editing Credentials:
     `config/credentials.yml.enc` while the file itself is destroyed to prevent credentials
     from leaking.
 
+Setting Credentials Without an Editor:
+    `<%= executable(:set) %> KEY=VALUE` sets a single credential without opening an editor.
+    Use dot notation for nested keys:
+
+        <%= executable(:set) %> aws.access_key_id=AKIAIOSFODNN7EXAMPLE
+        <%= executable(:set) %> aws.secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+    This produces the following YAML structure:
+
+        aws:
+          access_key_id: AKIAIOSFODNN7EXAMPLE
+          secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+Listing Credentials:
+    `<%= executable(:list) %>` lists all credential keys without revealing values:
+
+        <%= executable(:list) %>
+        <%= executable(:list) %> --show-values
+
+Deleting Credentials:
+    `<%= executable(:delete) %> KEY` removes a credential. Dot notation is supported to
+    remove nested keys or entire subtrees:
+
+        <%= executable(:delete) %> aws.access_key_id
+        <%= executable(:delete) %> aws
+
 Environment Specific Credentials:
     The `credentials` command supports passing an `--environment` option to create an
     environment specific override. That override will take precedence over the

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -77,6 +77,99 @@ module Rails
         end
       end
 
+      desc "set KEY=VALUE", "Set a credential value (use dot notation for nesting, e.g. aws.access_key_id=VALUE)"
+      def set(assignment)
+        load_environment_config!
+        load_generators
+
+        unless assignment.include?("=")
+          say_error "Expected argument in the form KEY=VALUE, got: #{assignment}"
+          exit 1
+        end
+
+        key_path_str, value = assignment.split("=", 2)
+        keys = key_path_str.split(".")
+
+        if keys.any? { |k| k.empty? }
+          say_error "Invalid key path: #{key_path_str}"
+          exit 1
+        end
+
+        if environment_specified?
+          @content_path = "config/credentials/#{environment}.yml.enc" unless config.overridden?(:content_path)
+          @key_path = "config/credentials/#{environment}.key" unless config.overridden?(:key_path)
+        end
+
+        ensure_encryption_key_has_been_added
+        ensure_credentials_have_been_added
+
+        yaml = credentials.read.presence || ""
+        parsed = YAML.load(yaml).presence || {}
+
+        deep_set(parsed, keys, value)
+
+        credentials.write(YAML.dump(parsed))
+        say "#{key_path_str} was set."
+      rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+        say error.message
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
+      end
+
+      desc "list", "List credential keys"
+      option :show_values, type: :boolean, default: false,
+        desc: "Show decrypted values alongside keys"
+      def list
+        load_environment_config!
+
+        yaml = credentials.read.presence || missing_credentials!
+        parsed = YAML.load(yaml).presence
+
+        unless parsed
+          say "No credentials found."
+          return
+        end
+
+        flatten_keys(parsed).each do |key, value|
+          if options[:show_values]
+            say "#{key}=#{value}"
+          else
+            say key
+          end
+        end
+      rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+        say error.message
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
+      end
+
+      desc "delete KEY", "Delete a credential (use dot notation for nesting, e.g. aws.access_key_id)"
+      def delete(key_path_str)
+        load_environment_config!
+
+        keys = key_path_str.split(".")
+
+        if keys.any? { |k| k.empty? }
+          say_error "Invalid key path: #{key_path_str}"
+          exit 1
+        end
+
+        yaml = credentials.read.presence || missing_credentials!
+        parsed = YAML.load(yaml).presence || {}
+
+        if deep_delete(parsed, keys)
+          credentials.write(YAML.dump(parsed))
+          say "#{key_path_str} was deleted."
+        else
+          say_error "Key not found: #{key_path_str}"
+          exit 1
+        end
+      rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+        say error.message
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
+      end
+
       private
         def config
           Rails.application.config.credentials
@@ -153,6 +246,40 @@ module Rails
 
         def extract_custom_environment(path)
           path =~ %r{config/credentials/(.+)\.yml\.enc} && $1
+        end
+
+        def deep_set(hash, keys, value)
+          if keys.length == 1
+            hash[keys.first] = value
+          else
+            child = hash[keys.first]
+            hash[keys.first] = child = {} unless child.is_a?(Hash)
+            deep_set(child, keys[1..], value)
+          end
+        end
+
+        def deep_delete(hash, keys)
+          if keys.length == 1
+            hash.key?(keys.first) ? hash.delete(keys.first) || true : false
+          else
+            child = hash[keys.first]
+            return false unless child.is_a?(Hash)
+
+            result = deep_delete(child, keys[1..])
+            hash.delete(keys.first) if child.empty?
+            result
+          end
+        end
+
+        def flatten_keys(hash, prefix = nil)
+          hash.each_with_object([]) do |(key, value), result|
+            full_key = prefix ? "#{prefix}.#{key}" : key.to_s
+            if value.is_a?(Hash)
+              result.concat(flatten_keys(value, full_key))
+            else
+              result << [full_key, value]
+            end
+          end
         end
     end
   end

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -14,7 +14,7 @@ class Rails::Command::BaseTest < ActiveSupport::TestCase
   end
 
   test "printing commands returns namespaced commands" do
-    assert_equal %w(credentials:edit credentials:show credentials:diff credentials:fetch), Rails::Command::CredentialsCommand.printing_commands.map(&:first)
+    assert_equal %w(credentials:edit credentials:show credentials:diff credentials:fetch credentials:set credentials:list credentials:delete), Rails::Command::CredentialsCommand.printing_commands.map(&:first)
     assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands.map(&:first)
   end
 

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -367,6 +367,90 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     assert_match("Invalid or missing credential path: egg.spam", stderr_output)
   end
 
+
+  test "set a credential and read it back" do
+    output = run_set_command("api_key=secret123")
+
+    assert_match(/api_key was set/, output)
+    assert_match(/api_key: secret123/, run_show_command)
+  end
+
+  test "set nested credentials using dot notation" do
+    run_set_command("aws.access_key_id=AKIA123")
+    run_set_command("aws.secret_access_key=wJalr456")
+
+    show_output = run_show_command
+    assert_match(/access_key_id: AKIA123/, show_output)
+    assert_match(/secret_access_key: wJalr456/, show_output)
+  end
+
+  test "set preserves existing credentials" do
+    write_credentials({ "existing" => "keep_me" }.to_yaml)
+    run_set_command("new_key=new_value")
+
+    show_output = run_show_command
+    assert_match(/existing: keep_me/, show_output)
+    assert_match(/new_key: new_value/, show_output)
+  end
+
+  test "set with environment option" do
+    run_set_command("api_key=prod_secret", environment: "production")
+
+    assert_match(/api_key: prod_secret/, run_show_command(environment: "production"))
+  end
+
+  test "set rejects invalid arguments" do
+    stderr_output = capture(:stderr) { run_set_command("invalid_arg", allow_failure: true, stderr: true) }
+    assert_match(/Expected argument in the form KEY=VALUE/, stderr_output)
+  end
+
+
+  test "list credential keys without values" do
+    write_credentials({ "foo" => "bar", "nested" => { "key" => "value" } }.to_yaml)
+
+    output = run_list_command
+    assert_match(/foo/, output)
+    assert_match(/nested\.key/, output)
+    assert_no_match(/bar/, output)
+  end
+
+  test "list with --show-values" do
+    write_credentials({ "foo" => "bar", "nested" => { "key" => "value" } }.to_yaml)
+
+    output = run_list_command(show_values: true)
+    assert_match(/foo=bar/, output)
+    assert_match(/nested\.key=value/, output)
+  end
+
+
+  test "delete a credential" do
+    write_credentials({ "keep" => "this", "remove" => "that" }.to_yaml)
+
+    output = run_delete_command("remove")
+    assert_match(/remove was deleted/, output)
+
+    show_output = run_show_command
+    assert_match(/keep: this/, show_output)
+    assert_no_match(/remove/, show_output)
+  end
+
+  test "delete a nested credential" do
+    write_credentials({ "aws" => { "key" => "val", "secret" => "s" } }.to_yaml)
+
+    run_delete_command("aws.key")
+
+    show_output = run_show_command
+    assert_no_match(/key: val/, show_output)
+    assert_match(/secret: s/, show_output)
+  end
+
+  test "delete a missing key" do
+    write_credentials({ "foo" => "bar" }.to_yaml)
+
+    stderr_output = capture(:stderr) { run_delete_command("nonexistent", stderr: true, allow_failure: true) }
+    assert_match(/Key not found: nonexistent/, stderr_output)
+  end
+
   private
     DEFAULT_CREDENTIALS_PATTERN = /access_key_id: 123\n.*secret_key_base: \h{128}\n/m
 
@@ -391,6 +475,23 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
 
     def run_fetch_command(path, **options)
       rails "credentials:fetch", path, **options
+    end
+
+    def run_set_command(assignment, environment: nil, **options)
+      args = environment ? ["--environment", environment] : []
+      rails "credentials:set", assignment, args, **options
+    end
+
+    def run_list_command(environment: nil, show_values: false, **options)
+      args = []
+      args.push("--environment", environment) if environment
+      args.push("--show-values") if show_values
+      rails "credentials:list", args, **options
+    end
+
+    def run_delete_command(key, environment: nil, **options)
+      args = environment ? ["--environment", environment] : []
+      rails "credentials:delete", key, args, **options
     end
 
     def write_credentials(content, **options)


### PR DESCRIPTION
### Motivation / Background

Managing credentials currently requires an interactive editor via `credentials:edit`. This makes programmatic credential management difficult for CI/CD pipelines and AI coding agents (Cursor, Claude Code, Windsurf, etc.) that cannot interact with `$EDITOR`.

The `credentials:fetch` command already supports reading values without an editor, but there is no equivalent for writing or deleting.

### Detail

Adds three new subcommands to `bin/rails credentials`:

```bash
# Set or update a credential (nested keys via dot notation)
bin/rails credentials:set aws.access_key_id=AKIAIOSFODNN7EXAMPLE
bin/rails credentials:set stripe.secret_key=sk_live_abc --environment production

# List credential keys (values hidden by default)
bin/rails credentials:list
bin/rails credentials:list --show-values
bin/rails credentials:list --environment production

# Delete a credential (supports subtree removal)
bin/rails credentials:delete aws.access_key_id
bin/rails credentials:delete aws
```

All commands respect `--environment` consistent with existing subcommands. No new public Ruby API is introduced.

### Additional information

Together with the existing `credentials:fetch`, credentials can now be fully managed without opening an editor — useful for automated workflows and agent-based development tools that are becoming increasingly common.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.