### PR TITLE
Add update_all_returning: update_all that returns Result.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2,6 +2,23 @@
 
     *Clay Harmon*
 
+*   Add `update_all_returning` to `ActiveRecord::Relation`.
+
+    Like `update_all`, but uses `UPDATE ... RETURNING` to return the updated
+    rows as an `ActiveRecord::Result`. Supports PostgreSQL and SQLite.
+
+    ```ruby
+    # Update and return all columns
+    Job.where(status: :pending).limit(1).update_all_returning(status: :processing)
+    # => ActiveRecord::Result with all columns of the updated row
+
+    # Update and return specific columns
+    Job.select(:id, :status).where(status: :pending).update_all_returning(status: :processing)
+    # => ActiveRecord::Result with id and status columns
+    ```
+
+    *Keenan Brock*
+
 *   Batch SQL statements when creating tables to improve performance.
 
     *Andrew Novoselac*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -259,6 +259,15 @@ module ActiveRecord
         intent.affected_rows
       end
 
+      # Executes the update statement and returns the resulting rows as an ActiveRecord::Result.
+      # Used when the update includes a RETURNING clause.
+      def update_returning(arel, name = nil, binds = [])
+        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
+
+        intent.execute!
+        intent.cast_result
+      end
+
       # Executes the delete statement and returns the number of rows affected.
       def delete(arel, name = nil, binds = [])
         intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -587,6 +587,10 @@ module ActiveRecord
         false
       end
 
+      def supports_update_returning?
+        supports_insert_returning?
+      end
+
       def supports_insert_on_duplicate_skip?
         false
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -178,6 +178,11 @@ module ActiveRecord
         mariadb? && database_version >= "10.5.0"
       end
 
+      # MariaDB supports RETURNING for INSERT and DELETE, but not UPDATE.
+      def supports_update_returning?
+        false
+      end
+
       def return_value_after_insert?(column) # :nodoc:
         supports_insert_returning? ? column.auto_populated? : column.auto_increment?
       end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       :count, :average, :minimum, :maximum, :sum, :calculate,
       :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with, :with_recursive,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
-      :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all
+      :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all, :update_all_returning
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -612,29 +612,67 @@ module ActiveRecord
         MESSAGE
       end
 
-      if updates.is_a?(Hash)
-        if model.locking_enabled? &&
-            !updates.key?(model.locking_column) &&
-            !updates.key?(model.locking_column.to_sym)
-          attr = table[model.locking_column]
-          updates[attr.name] = _increment_attribute(attr)
-        end
-        values = _substitute_values(updates)
-      else
-        values = Arel.sql(model.sanitize_sql_for_assignment(updates, table.name))
+      model.with_connection do |c|
+        stmt = build_update_all_statement(updates)
+        c.update(stmt, "#{model} Update All").tap { reset }
+      end
+    end
+
+    # Updates all records in the current relation with details given and returns the updated rows
+    # as an ActiveRecord::Result. This method constructs a single SQL UPDATE ... RETURNING
+    # statement and sends it straight to the database. It does not instantiate the involved models and it does not
+    # trigger Active Record callbacks or validations. However, values passed to #update_all_returning will still go
+    # through Active Record's normal type casting and serialization.
+    #
+    # Requires the database to support UPDATE ... RETURNING (PostgreSQL, SQLite).
+    #
+    # Note: As Active Record callbacks are not triggered, this method will not automatically update +updated_at+/+updated_on+ columns.
+    #
+    # ==== Parameters
+    #
+    # * +updates+ - A string, array, or hash representing the SET part of an SQL statement. Any strings provided will
+    #   be type cast, unless you use +Arel.sql+. (Don't pass user-provided values to +Arel.sql+.)
+    #
+    # Use +select+ to specify which columns to return. Without +select+, all columns are returned.
+    #
+    # ==== Examples
+    #
+    #   # Update all customers and return all columns
+    #   Customer.update_all_returning(wants_email: true)
+    #   # => ActiveRecord::Result with all columns
+    #
+    #   # Update matching books and return only id and title
+    #   Book.select(:id, :title).where('title LIKE ?', '%Rails%').update_all_returning(author: 'David')
+    #   # => ActiveRecord::Result with id and title columns
+    #
+    #   # Claim the next pending job atomically
+    #   Job.where(status: :pending).limit(1).update_all_returning(status: :processing)
+    #   # => ActiveRecord::Result with all columns of the updated row
+    def update_all_returning(updates)
+      raise ArgumentError, "Empty list of attributes to change" if updates.blank?
+
+      return ActiveRecord::Result.empty if @none
+
+      invalid_methods = INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL.select do |method|
+        value = @values[method]
+        method == :distinct ? value : value&.any?
+      end
+      if invalid_methods.any?
+        raise ActiveRecordError.new("update_all_returning doesn't support #{invalid_methods.join(', ')}")
       end
 
       model.with_connection do |c|
-        arel = eager_loading? ? apply_join_dependency.arel : arel()
-        arel.source.left = table
-
-        key = if model.composite_primary_key?
-          primary_key.map { |pk| table[pk] }
-        else
-          table[primary_key]
+        unless c.supports_update_returning?
+          raise ArgumentError, "#{c.class} does not support :returning"
         end
-        stmt = arel.compile_update(values, key)
-        c.update(stmt, "#{model} Update All").tap { reset }
+
+        stmt = build_update_all_statement(updates)
+        stmt.ast.returning = if select_values.any?
+          arel_columns(select_values)
+        else
+          model.column_names.map { |field| table[field] }
+        end
+        c.update_returning(stmt, "#{model} Update All Returning").tap { reset }
       end
     end
 
@@ -1408,6 +1446,30 @@ module ActiveRecord
         if all_queries
           registry.set_global_current_scope(model, previous_global)
         end
+      end
+
+      def build_update_all_statement(updates)
+        if updates.is_a?(Hash)
+          if model.locking_enabled? &&
+              !updates.key?(model.locking_column) &&
+              !updates.key?(model.locking_column.to_sym)
+            attr = table[model.locking_column]
+            updates[attr.name] = _increment_attribute(attr)
+          end
+          values = _substitute_values(updates)
+        else
+          values = Arel.sql(model.sanitize_sql_for_assignment(updates, table.name))
+        end
+
+        arel = eager_loading? ? apply_join_dependency.arel : arel()
+        arel.source.left = table
+
+        key = if model.composite_primary_key?
+          primary_key.map { |pk| table[pk] }
+        else
+          table[primary_key]
+        end
+        arel.compile_update(values, key)
       end
 
       def _substitute_values(values)

--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :comment, :key
+      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :comment, :key, :returning
 
       def initialize(relation = nil)
         super()
@@ -17,6 +17,7 @@ module Arel # :nodoc: all
         @offset   = nil
         @comment  = nil
         @key      = nil
+        @returning = []
       end
 
       def initialize_copy(other)
@@ -26,7 +27,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @comment, @key].hash
+        [@relation, @wheres, @values, @orders, @limit, @offset, @comment, @key, @returning].hash
       end
 
       def eql?(other)
@@ -40,7 +41,8 @@ module Arel # :nodoc: all
           self.limit == other.limit &&
           self.offset == other.offset &&
           self.comment == other.comment &&
-          self.key == other.key
+          self.key == other.key &&
+          self.returning == other.returning
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -30,6 +30,8 @@ module Arel # :nodoc: all
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
           maybe_visit o.comment, collector
+          collect_nodes_for o.returning, collector, " RETURNING "
+          collector
         end
 
         # In the simple case, PostgreSQL allows us to place FROM or JOINs directly into the UPDATE

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -30,6 +30,8 @@ module Arel # :nodoc: all
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
           maybe_visit o.comment, collector
+          collect_nodes_for o.returning, collector, " RETURNING "
+          collector
         end
 
         def prepare_update_statement(o)

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -67,7 +67,7 @@ module ActiveRecord
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,
-        :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by,
+        :destroy, :destroy_all, :delete, :delete_all, :update_all, :update_all_returning, :touch_all, :delete_by, :destroy_by,
         :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all,
       ]
 

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -457,6 +457,68 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_update_all_returning
+    skip unless supports_update_returning?
+
+    david_posts = Post.where(author_id: authors(:david).id)
+    other_posts_count = Post.where.not(author_id: authors(:david).id).count
+    result = david_posts.update_all_returning(title: "updated")
+
+    assert_instance_of ActiveRecord::Result, result
+    assert_equal david_posts.count, result.length
+    result.each do |row|
+      assert_equal "updated", row["title"]
+    end
+    # Verify WHERE clause was respected — other posts unchanged
+    assert_equal other_posts_count, Post.where.not(title: "updated").count
+  end
+
+  def test_update_all_returning_with_select
+    skip unless supports_update_returning?
+
+    posts = Post.select(:id, :title).where(author_id: authors(:david).id)
+    result = posts.update_all_returning(title: "updated")
+
+    assert_instance_of ActiveRecord::Result, result
+    assert_equal %w[id title], result.columns.sort
+    assert_operator result.length, :>, 0
+  end
+
+  def test_update_all_returning_with_limit
+    skip unless supports_update_returning?
+
+    posts = Post.where(author_id: authors(:david).id).order(:id).limit(1)
+    result = posts.update_all_returning(title: "updated")
+
+    assert_instance_of ActiveRecord::Result, result
+    assert_equal 1, result.length
+    assert_equal "updated", result.first["title"]
+  end
+
+  def test_update_all_returning_with_none
+    skip unless supports_update_returning?
+
+    result = Post.none.update_all_returning(title: "updated")
+
+    assert_instance_of ActiveRecord::Result, result
+    assert_equal 0, result.length
+  end
+
+  def test_update_all_returning_with_blank_argument
+    skip unless supports_update_returning?
+
+    error = assert_raises(ArgumentError) { Post.all.update_all_returning({}) }
+    assert_equal "Empty list of attributes to change", error.message
+  end
+
+  def test_update_all_returning_with_unpermitted_relation
+    skip unless supports_update_returning?
+
+    assert_raises(ActiveRecord::ActiveRecordError) do
+      Author.distinct.update_all_returning(name: "Bob")
+    end
+  end
+
   def test_update_all_composite_model_with_join_subquery
     agreement = cpk_order_agreements(:order_agreement_three)
     join_scope = Cpk::Order.joins(:order_agreements).where(order_agreements: { signature: agreement.signature })

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -70,6 +70,7 @@ module AdapterHelper
     supports_expression_index?
     supports_index_include?
     supports_insert_returning?
+    supports_update_returning?
     supports_insert_on_duplicate_skip?
     supports_insert_on_duplicate_update?
     supports_insert_conflict_target?

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -557,6 +557,15 @@ validations**, you can update the database directly using `update_all`:
 Book.update_all(status: "already own")
 ```
 
+If you need the updated rows back, use `update_all_returning`, which uses
+`UPDATE ... RETURNING` to return the results in a single query (PostgreSQL
+and SQLite):
+
+```ruby
+result = Book.where(status: "available").limit(1).update_all_returning(status: "claimed")
+# => ActiveRecord::Result with all columns of the updated row
+```
+
 ### Delete
 
 Likewise, once retrieved, an Active Record object can be destroyed, which


### PR DESCRIPTION
### Motivation / Background

- `destroy_all`, `insert_all`, and `upsert_all` support `RETURNING` and return an `ActiveRecord::Result`.
- `update_all`, `delete_all` returns an `Integer` row count.

I would like an `update_all` that returns a `Result`.
 
### Use Case

Job queues, task assignment, and reservation patterns all share the same problem: select a record, mark it claimed, and hope nobody else claimed it first. Under contention, this requires retry loops across multiple queries.

PostgreSQL and SQLite support `UPDATE ... RETURNING`, which atomically updates rows and returns the result in a single round trip. This PR exposes that capability as `update_all_returning`.

### Before

```ruby
ticket = Ticket.unassigned.first
ticket.update!(status: :assigned, user: user) # race condition
ticket
```

### After

```ruby
Ticket.unassigned
      .limit(1)
      .update_all_returning(status: :assigned, user: user)
# => ActiveRecord::Result with the claimed row
```

### Detail

- `update_all_returning` mirrors `update_all` but returns an `ActiveRecord::Result` instead of a count
- Implemented via Arel with a new `update_returning` method at the connection adapter layer, following the same pattern as `insert_returning` used by `upsert`
- Use `select()` on the relation to control which columns are returned; defaults to all columns

### Database Support

| Database   | `UPDATE ... RETURNING` | Status                     |
|------------|------------------------|----------------------------|
| PostgreSQL | Yes                    | Supported                  |
| SQLite     | Yes                    | Supported                  |
| MariaDB    | INSERT only            | Raises `ActiveRecordError` |
| MySQL      | No                     | Raises `ActiveRecordError` |

Added `supports_update_returning` to the adapter interface. MariaDB supports `RETURNING` for `INSERT`/`DELETE` but not `UPDATE`, so the existing `supports_insert_returning` was insufficient.

Unsupported adapters raise rather than falling back to a multi-query shim — the atomicity guarantee is the point.

### Additional Information

- Arel conversion of existing SQL string construction is deferred to a follow-up PR to keep this scoped to one change
