### PR TITLE
Update yarn install command to support immutable and frozen-lockfile in Dockerfile.tt

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -72,7 +72,7 @@ RUN bundle install && \
 <% if using_node? -%>
 # Install node modules
 COPY package.json yarn.lock ./
-RUN yarn install --immutable
+RUN yarn install --<%= yarn_through_corepack? ? "immutable" : "frozen-lockfile" %>
 
 <% end -%>
 <% if using_bun? -%>


### PR DESCRIPTION
### Motivation / Background

This pull request makes a minor update to the `Dockerfile.tt` template to improve compatibility with different Yarn installation methods. The change ensures the correct Yarn flag is used depending on whether Yarn is managed through Corepack.

### Detail

- Dockerfile generation:
  * Updated the Yarn install command to use `--immutable` if Yarn is managed by Corepack, otherwise use `--frozen-lockfile`. This improves compatibility with various project setups.

### Additional information

https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile
https://yarnpkg.com/cli/install
