### PR TITLE
Set auto_vacuum=incremental on new SQLite databases and add db:maintenance:vacuum

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -48,6 +48,44 @@
 
     *Eileen M. Uchitelle*, *Matthew Draper*
 
+*   Set `auto_vacuum=incremental` on new SQLite databases and introduce
+    `db:maintenance:vacuum` rake task.
+
+    SQLite does not return disk space to the operating system when rows are
+    deleted. With `auto_vacuum` set to `incremental`, freed pages are tracked
+    and can be reclaimed by running `PRAGMA incremental_vacuum`. This is
+    especially important for high-churn databases like Solid Cache, Solid
+    Queue, and Solid Cable.
+
+    New SQLite databases are now created with `auto_vacuum=incremental`
+    automatically. This is set during `db:create` before any other
+    connection pragmas are applied, because `auto_vacuum` must be
+    configured before `journal_mode=wal` initializes the database file.
+    Existing databases are not affected.
+
+    The new `db:maintenance:vacuum` rake task runs `PRAGMA
+    incremental_vacuum(1000)` and `PRAGMA wal_checkpoint(TRUNCATE)` on all
+    SQLite databases for the current environment. For databases that still
+    have `auto_vacuum=none`, it logs a warning and skips the incremental
+    vacuum (a one-time `VACUUM` is needed to switch modes).
+
+    ```bash
+    # Run maintenance manually or schedule it via Solid Queue
+    bin/rails db:maintenance:vacuum
+    ```
+
+    To override the default for new databases:
+
+    ```yaml
+    # config/database.yml
+    production:
+      adapter: sqlite3
+      pragmas:
+        auto_vacuum: none  # opt out of incremental auto_vacuum
+    ```
+
+    *Henrique Cardoso de Faria*
+
 *   MySQL error 1046 (`ER_NO_DB_ERROR: No database selected`) is now retryable as a `ConnectionFailed` exception
 
     *Clay Harmon*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -48,7 +48,20 @@ module ActiveRecord
 
       class << self
         def new_client(config)
-          ::SQLite3::Database.new(config[:database].to_s, config)
+          database = config[:database].to_s
+          new_database = !database.include?(":memory:") && !File.exist?(database)
+
+          db = ::SQLite3::Database.new(database, config)
+
+          # auto_vacuum must be set before journal_mode=wal (applied by
+          # configure_connection) because WAL initialization finalizes the
+          # database file format, after which auto_vacuum cannot be changed.
+          if new_database
+            pragmas = config[:pragmas] || {}
+            db.auto_vacuum = pragmas[:auto_vacuum] || pragmas["auto_vacuum"] || :incremental
+          end
+
+          db
         rescue Errno::ENOENT => error
           if error.message.include?("No such file or directory")
             raise ActiveRecord::NoDatabaseError

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -586,6 +586,58 @@ db_namespace = namespace :db do
       end
     end
   end
+
+  namespace :maintenance do
+    desc "Perform SQLite database maintenance (incremental vacuum and WAL checkpoint) for the current environment"
+    task vacuum: :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.with_temporary_pool_for_each do |pool|
+        db_config = pool.db_config
+        next unless db_config.adapter.include?("sqlite3")
+
+        pool.with_connection do |connection|
+          auto_vacuum = connection.execute("PRAGMA auto_vacuum").first["auto_vacuum"]
+
+          if auto_vacuum == 0
+            $stderr.puts "WARNING: Database #{db_config.database} has auto_vacuum=none. " \
+              "Incremental vacuum requires auto_vacuum=incremental. " \
+              "Set `pragmas: { auto_vacuum: incremental }` in database.yml and run VACUUM once to enable it. " \
+              "Skipping incremental vacuum."
+          else
+            connection.execute("PRAGMA incremental_vacuum(1000)")
+          end
+
+          connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        end
+      end
+    end
+
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Perform SQLite maintenance for #{name} database"
+      namespace :vacuum do
+        task name => :load_config do
+          ActiveRecord::Tasks::DatabaseTasks.with_temporary_pool_for_each(name: name) do |pool|
+            db_config = pool.db_config
+            next unless db_config.adapter.include?("sqlite3")
+
+            pool.with_connection do |connection|
+              auto_vacuum = connection.execute("PRAGMA auto_vacuum").first["auto_vacuum"]
+
+              if auto_vacuum == 0
+                $stderr.puts "WARNING: Database #{db_config.database} has auto_vacuum=none. " \
+                  "Incremental vacuum requires auto_vacuum=incremental. " \
+                  "Set `pragmas: { auto_vacuum: incremental }` in database.yml and run VACUUM once to enable it. " \
+                  "Skipping incremental vacuum."
+              else
+                connection.execute("PRAGMA incremental_vacuum(1000)")
+              end
+
+              connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            end
+          end
+        end
+      end
+    end
+  end
 end
 
 namespace :railties do

--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -244,4 +244,28 @@ module ActiveRecord
       FileUtils.rm_f(dbfile)
     end
   end
+
+  class SqliteDBCreateAutoVacuumTest < ActiveRecord::TestCase
+    def setup
+      @tmpdir = Dir.mktmpdir
+      @database = File.join(@tmpdir, "db_auto_vacuum.sqlite3")
+    end
+
+    def teardown
+      FileUtils.rm_rf(@tmpdir)
+    end
+
+    def test_create_sets_auto_vacuum_to_incremental_by_default
+      conn = ConnectionAdapters::SQLite3Adapter.new(adapter: "sqlite3", database: @database)
+      assert_equal [{ "auto_vacuum" => 2 }], conn.execute("PRAGMA auto_vacuum")
+      conn.disconnect!
+    end
+
+    def test_create_allows_overriding_auto_vacuum_via_pragmas
+      database = File.join(@tmpdir, "db_auto_vacuum_none.sqlite3")
+      conn = ConnectionAdapters::SQLite3Adapter.new(adapter: "sqlite3", database: database, pragmas: { auto_vacuum: :none })
+      assert_equal [{ "auto_vacuum" => 0 }], conn.execute("PRAGMA auto_vacuum")
+      conn.disconnect!
+    end
+  end
 end

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -1180,6 +1180,33 @@ Overwrite config/database.yml? (enter "h" for help) [Ynaqdhm] Y
 ...
 ```
 
+#### `db:maintenance:vacuum`
+
+The `db:maintenance:vacuum` command performs space reclamation on SQLite
+databases. It runs `PRAGMA incremental_vacuum` to return freed pages to the
+operating system and `PRAGMA wal_checkpoint(TRUNCATE)` to reset the WAL file.
+Non-SQLite databases are skipped automatically.
+
+```bash
+$ bin/rails db:maintenance:vacuum
+```
+
+In multi-database applications, you can target a specific database:
+
+```bash
+$ bin/rails db:maintenance:vacuum:cache
+```
+
+This task is designed to be run on a schedule (for example, hourly via Solid
+Queue's recurring tasks) to prevent SQLite databases from accumulating unused
+disk space — especially important for high-churn databases like cache, queue,
+and cable.
+
+NOTE: If a database has `auto_vacuum=none` (the SQLite default before Rails
+added `auto_vacuum: incremental`), the task will log a warning and skip the
+incremental vacuum for that database. A one-time `VACUUM` is needed to switch
+an existing database to incremental mode.
+
 #### `db:encryption:init`
 
 The `db:encryption:init` command generates a set of keys for configuring Active

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3829,6 +3829,31 @@ development:
 
 Many useful features can be added to SQLite through extensions. You may wish to browse the [SQLite extension hub](https://sqlpkg.org/) or use gems like [`sqlpkg-ruby`](https://github.com/fractaledmind/sqlpkg-ruby) and [`sqlean-ruby`](https://github.com/flavorjones/sqlean-ruby) that simplify extension management.
 
+Rails sets the following SQLite [pragmas](https://www.sqlite.org/pragma.html) by default to optimize performance and reliability:
+
+| Pragma | Default | Purpose |
+|--------|---------|---------|
+| `auto_vacuum` | `incremental` | Tracks freed pages for on-demand space reclamation |
+| `foreign_keys` | `true` | Enforces foreign key constraints |
+| `journal_mode` | `wal` | Enables concurrent reads during writes |
+| `synchronous` | `normal` | Balances safety with write performance |
+| `mmap_size` | `134217728` (128 MB) | Memory-maps the database file for faster reads |
+| `journal_size_limit` | `67108864` (64 MB) | Caps the WAL file size after checkpoints |
+| `cache_size` | `2000` | Number of pages held in memory |
+
+You can override any of these or add new pragmas via the `pragmas` key in `config/database.yml`:
+
+```yaml
+production:
+  adapter: sqlite3
+  database: storage/production.sqlite3
+  pragmas:
+    synchronous: full
+    cache_size: 5000
+```
+
+NOTE: The `auto_vacuum: incremental` pragma only takes effect on newly created databases. Existing databases require a one-time `VACUUM` to switch modes. See `db:maintenance:vacuum` for ongoing space reclamation.
+
 Other configuration options are described in the [SQLite3Adapter documentation]( https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SQLite3Adapter.html).
 
 #### Configuring a MySQL or MariaDB Database

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -45,6 +45,49 @@ module ApplicationTests
         db_create_and_drop db_config.database
       end
 
+      test "db:create sets auto_vacuum to incremental on new SQLite databases" do
+        require "#{app_path}/config/environment"
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
+        db_create_and_drop db_config.database do
+          auto_vacuum = `sqlite3 #{db_config.database} "PRAGMA auto_vacuum;"`.strip.to_i
+          assert_equal 2, auto_vacuum
+        end
+      end
+
+      test "db:maintenance:vacuum reclaims freed pages and truncates WAL" do
+        require "#{app_path}/config/environment"
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
+        Dir.chdir(app_path) do
+          rails "db:create"
+
+          # Insert and delete data to produce freelist pages
+          `sqlite3 #{db_config.database} "CREATE TABLE bloat(id INTEGER PRIMARY KEY, data TEXT)"`
+          `sqlite3 #{db_config.database} "INSERT INTO bloat(data) SELECT randomblob(1000) FROM generate_series(1, 1000)"`
+          `sqlite3 #{db_config.database} "DELETE FROM bloat"`
+
+          freelist_before = `sqlite3 #{db_config.database} "PRAGMA freelist_count;"`.strip.to_i
+          assert freelist_before > 0
+
+          rails "db:maintenance:vacuum"
+
+          freelist_after = `sqlite3 #{db_config.database} "PRAGMA freelist_count;"`.strip.to_i
+          assert freelist_after < freelist_before
+
+          wal_file = "#{db_config.database}-wal"
+          assert_equal 0, File.size(wal_file) if File.exist?(wal_file)
+        end
+      end
+
+      test "db:maintenance:vacuum warns when auto_vacuum is none" do
+        require "#{app_path}/config/environment"
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
+        Dir.chdir(app_path) do
+          `sqlite3 #{db_config.database} "CREATE TABLE schema_migrations(version VARCHAR NOT NULL PRIMARY KEY)"`
+          output = rails("db:maintenance:vacuum")
+          assert_match(/WARNING.*auto_vacuum=none/, output)
+        end
+      end
+
       test "db:create and db:drop with database URL" do
         require "#{app_path}/config/environment"
         delete_database_config!


### PR DESCRIPTION
## Summary

SQLite does not return disk space to the OS when rows are deleted. With the default `auto_vacuum=none`, database files grow monotonically regardless of actual data size. This is especially problematic for high-churn databases like Solid Cache, Solid Queue, and Solid Cable — production databases can balloon to many GBs while holding only MBs of real data.

This PR:

- **Sets `auto_vacuum=incremental` on new SQLite databases** — configured in `new_client` before `configure_connection` applies `journal_mode=wal`, because WAL initialization finalizes the database file format after which `auto_vacuum` cannot be changed. Existing databases are unaffected. Users can opt out via `pragmas: { auto_vacuum: none }` in `database.yml`.

- **Introduces `db:maintenance:vacuum` rake task** — runs `PRAGMA incremental_vacuum(1000)` (~4 MB of freed pages) and `PRAGMA wal_checkpoint(TRUNCATE)` (resets the WAL file) on all SQLite databases. Warns and skips databases still on `auto_vacuum=none`. Supports per-database variants for multi-DB apps (e.g. `db:maintenance:vacuum:cache`). Non-SQLite databases are skipped automatically.

- **Updates guides** — documents `auto_vacuum` as a creation-time default in the configuring guide, and adds `db:maintenance:vacuum` to the command line guide.

The task is designed to be scheduled (e.g. hourly via Solid Queue recurring tasks). A companion PR to `rails/solid_queue` could add a default entry to `config/recurring.yml` so new apps get this out of the box.

## Why `new_client` instead of `DEFAULT_PRAGMAS`?

`auto_vacuum` is a persistent database property, not a per-connection session pragma. It can only be set on a new, empty database and must be applied **before** `journal_mode=wal` (which initializes the database file format). Setting it in `DEFAULT_PRAGMAS` / `configure_connection` is too late — `journal_mode` runs first and locks in `auto_vacuum=none`. It also fails on readonly and locked connections.

The fix checks `!File.exist?(database)` in `new_client` to detect new databases, sets `auto_vacuum` before returning the raw connection, and lets `configure_connection` proceed normally.

## Context

Rails already sets 6 sensible SQLite defaults (WAL mode, foreign keys, mmap, etc.) but has no protection against unbounded disk growth. Real-world reports:
- [Solid Queue #560](https://github.com/rails/solid_queue/issues/560) — production server ran out of disk space
- [Solid Cache #116](https://github.com/rails/solid_cache/issues/116) — no DB-agnostic way to constrain cache storage size

## Test plan

- [x] `test_create_sets_auto_vacuum_to_incremental_by_default` — new database gets `auto_vacuum=2`
- [x] `test_create_allows_overriding_auto_vacuum_via_pragmas` — user can set `auto_vacuum: none`
- [x] Tests fail without the code change (expects `auto_vacuum=2`, gets `0`)
- [x] Full SQLite adapter suite passes (93 runs, 0 errors)
- [x] Transaction tests pass — no errors on readonly or shared-cache connections (8 runs, 0 errors)
- [x] Full SQLite rake suite passes (19 runs, 0 errors)
- [x] Verified with `rails new --dev` — new databases get `auto_vacuum=2`