### PR TITLE
Deprecate the `strict` option in MySQL database configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Deprecate the `strict` option in MySQL database configurations.
+
+    The `strict` option for MySQL will be removed in Rails 8.3 because it is the default behavior.
+
+    To change the default behavior of `strict`, use `variables: { sql_mode: "..." }` to configure `sql_mode` directly.
+
+
+    `strict: false` can be replaced with `variables: { sql_mode: "" }`, and `strict: :default` can be replaced with `variables: { sql_mode: :default }`.
+
+    *Eileen M. Uchitelle*
+
 *   Allow configuring `SET` queriers for the PostgreSQL and MySQL adapters.
 
     Individual settings can be skipped by setting them to `false` in

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -722,6 +722,15 @@ module ActiveRecord
       end
 
       def strict_mode?
+        if @config.key?(:strict) && !@strict_mode_deprecation_warned
+          @strict_mode_deprecation_warned = true
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            The `strict` option in database configurations is deprecated and
+            will be removed in Rails 8.3. Use `variables: { sql_mode: "..." }`
+            to configure sql_mode directly instead.
+          MSG
+        end
+
         self.class.type_cast_config_to_boolean(@config.fetch(:strict, true))
       end
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -118,18 +118,22 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
 
   def test_mysql_strict_mode_disabled
     run_without_connection do |orig_connection|
-      ActiveRecord::Base.establish_connection(orig_connection.merge(strict: false))
-      result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
-      assert_no_match %r(STRICT_ALL_TABLES), result
+      assert_deprecated(ActiveRecord.deprecator) do
+        ActiveRecord::Base.establish_connection(orig_connection.merge(strict: false))
+        result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
+        assert_no_match %r(STRICT_ALL_TABLES), result
+      end
     end
   end
 
   def test_mysql_strict_mode_specified_default
     run_without_connection do |orig_connection|
-      ActiveRecord::Base.establish_connection(orig_connection.merge(strict: :default))
-      global_sql_mode = ActiveRecord::Base.lease_connection.select_value("SELECT @@GLOBAL.sql_mode")
-      session_sql_mode = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
-      assert_equal global_sql_mode, session_sql_mode
+      assert_deprecated(ActiveRecord.deprecator) do
+        ActiveRecord::Base.establish_connection(orig_connection.merge(strict: :default))
+        global_sql_mode = ActiveRecord::Base.lease_connection.select_value("SELECT @@GLOBAL.sql_mode")
+        session_sql_mode = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
+        assert_equal global_sql_mode, session_sql_mode
+      end
     end
   end
 

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -234,8 +234,10 @@ class DefaultsTestWithoutTransactionalFixtures < ActiveRecord::TestCase
     def using_strict(strict)
       db_config = ActiveRecord::Base.connection_pool.db_config
       conn_hash = db_config.configuration_hash
-      ActiveRecord::Base.establish_connection conn_hash.merge(strict: strict)
-      yield
+      ActiveRecord.deprecator.silence do
+        ActiveRecord::Base.establish_connection conn_hash.merge(strict: strict)
+        yield
+      end
     ensure
       ActiveRecord::Base.establish_connection db_config
     end


### PR DESCRIPTION
The `strict` config option for MySQL was introduced in Rails 4.2 to control sql_mode, but the same behavior can be achieved directly with `variables: { sql_mode: "..." }`.

As of 2026, there is no recommendation to run MySQL in non-strict mode, so this option is no longer needed. Users should migrate to:

- `strict: true`    → remove it (this is the default)
- `strict: false`   → `variables: { sql_mode: "" }`
- `strict: :default` → `variables: { sql_mode: :default }`

cc/ @kamipo 