### PR TITLE
Fix has_one :through to use preloaded chain instead of querying

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix `has_one :through` to use preloaded associations instead of querying.
+
+    When a `has_one :through` association's entire chain was preloaded via
+    `includes`, accessing the association still fired a database query.
+    `HasOneThroughAssociation` now detects when the through chain is loaded
+    and resolves the target from memory. The optimization conservatively
+    disables itself for scoped and polymorphic-source (`source_type`)
+    associations, where chain-walking could return a record the query
+    would have excluded.
+
+    Fixes #56978.
+
+    *Tyler Wood*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -6,7 +6,33 @@ module ActiveRecord
     class HasOneThroughAssociation < HasOneAssociation # :nodoc:
       include ThroughAssociation
 
+      # Override reader to walk the loaded through chain when possible,
+      # avoiding an unnecessary database query for preloaded associations.
+      def reader
+        if !loaded? && !stale_target? && through_chain_loaded?
+          self.target = resolve_target_from_through_chain
+        end
+
+        super
+      end
+
       private
+        def through_chain_loaded?
+          through_assoc = through_association
+          return false unless through_assoc.loaded?
+
+          through_target = through_assoc.target
+          return true unless through_target
+
+          through_target.association(source_reflection.name).loaded?
+        end
+
+        def resolve_target_from_through_chain
+          through_target = through_association.target
+          return nil unless through_target
+          through_target.association(source_reflection.name).target
+        end
+
         def replace(record, save = true)
           create_through_record(record, save)
           self.target = record

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -11,7 +11,9 @@ module ActiveRecord
       #
       # The optimization conservatively disables itself for scoped and
       # polymorphic-source associations, where walking the chain could
-      # return a record the scoped/typed query would have excluded.
+      # return a record the scoped/typed query would have excluded, and
+      # for stale through associations, where the loaded chain no longer
+      # reflects the owner's foreign key.
       def reader
         if !loaded? && through_chain_loaded?
           self.target = resolve_target_from_through_chain
@@ -28,6 +30,10 @@ module ActiveRecord
 
           through_assoc = through_association
           return false unless through_assoc.loaded?
+          # A loaded but stale through association (e.g. the owner's foreign
+          # key changed after preloading) must fall back to querying, which
+          # resolves against the current foreign key.
+          return false if through_assoc.stale_target?
 
           through_target = through_assoc.target
           return true unless through_target

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -8,8 +8,12 @@ module ActiveRecord
 
       # Override reader to walk the loaded through chain when possible,
       # avoiding an unnecessary database query for preloaded associations.
+      #
+      # The optimization conservatively disables itself for scoped and
+      # polymorphic-source associations, where walking the chain could
+      # return a record the scoped/typed query would have excluded.
       def reader
-        if !loaded? && !stale_target? && through_chain_loaded?
+        if !loaded? && through_chain_loaded?
           self.target = resolve_target_from_through_chain
         end
 
@@ -18,6 +22,10 @@ module ActiveRecord
 
       private
         def through_chain_loaded?
+          # Bail when equivalence with the scoped query isn't guaranteed
+          return false if reflection.scope
+          return false if reflection.options[:source_type]
+
           through_assoc = through_association
           return false unless through_assoc.loaded?
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -257,6 +257,43 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_one_through_preloaded_returns_same_object_as_manual_chain
+    members = Member.includes(member_detail: :organization).where(name: "Groucho Marx").to_a
+    member = members.first
+
+    manual = member.member_detail.organization
+    through = member.organization
+
+    assert_same manual, through,
+      "has_one :through should return the exact same object as manual chain traversal"
+  end
+
+  def test_has_one_through_falls_back_to_query_when_scoped
+    member = Member.includes(membership: :club).where(name: "Groucho Marx").first
+
+    assert member.association(:membership).loaded?, "through association should be loaded"
+
+    # favorite_club has a scope (where favorite: true) — the optimization
+    # must bail out and query, because the preloaded chain was loaded
+    # without the scope applied.
+    assert_queries_count(1) do
+      member.favorite_club
+    end
+  end
+
+  def test_has_one_through_falls_back_to_query_with_source_type
+    club = Club.includes(sponsor: :sponsorable).where(name: "Moustache and Eyebrow Fancier Club").first
+
+    assert club.association(:sponsor).loaded?, "through association should be loaded"
+
+    # sponsored_member uses source_type: :Member — the optimization
+    # must bail out and query, because the chain could hold a record
+    # of a different type.
+    assert_queries_count(1) do
+      club.sponsored_member
+    end
+  end
+
   def test_has_one_through_polymorphic_with_source_type
     assert_equal members(:groucho), clubs(:moustache_club).sponsored_member
   end

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -257,6 +257,24 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_one_through_queries_when_through_foreign_key_mutated_after_preload
+    minivan = Minivan.includes(speedometer: :dashboard).find(minivans(:cool_first).minivan_id)
+
+    assert minivan.association(:speedometer).loaded?, "through association should be loaded"
+    assert minivan.speedometer.association(:dashboard).loaded?, "source association should be loaded"
+
+    # Mutating the foreign key to the through record makes the preloaded
+    # chain stale — the association must fall back to querying so it
+    # resolves against the new foreign key, as it does without preloading.
+    other_speedometer = speedometers(:second)
+    other_dashboard = dashboards(:second)
+    minivan.speedometer_id = other_speedometer.speedometer_id
+
+    assert_queries_count(1) do
+      assert_equal other_dashboard, minivan.dashboard
+    end
+  end
+
   def test_has_one_through_preloaded_returns_same_object_as_manual_chain
     members = Member.includes(member_detail: :organization).where(name: "Groucho Marx").to_a
     member = members.first

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -27,7 +27,7 @@ require "models/cpk"
 require "models/dats"
 
 class HasOneThroughAssociationsTest < ActiveRecord::TestCase
-  fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :minivans,
+  fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :member_details, :minivans,
            :dashboards, :speedometers, :authors, :author_addresses, :posts, :comments, :categories, :essays, :owners
 
   def setup
@@ -192,6 +192,69 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal clubs(:moustache_club), Member.all.merge!(includes: :hairy_club).find(@member.id).hairy_club
     clubs(:moustache_club).update_columns(name: "Association of Clean-Shaven Persons")
     assert_nil Member.all.merge!(includes: :hairy_club).find(@member.id).reload.hairy_club
+  end
+
+  def test_has_one_through_uses_preloaded_chain_without_query
+    members = Member.includes(member_detail: :organization).where(name: "Groucho Marx").to_a
+    member = members.first
+
+    assert member.association(:member_detail).loaded?, "member_detail should be loaded"
+    assert member.member_detail.association(:organization).loaded?, "member_detail.organization should be loaded"
+
+    assert_no_queries do
+      member.organization
+    end
+  end
+
+  def test_has_one_through_returns_nil_when_through_is_loaded_as_nil
+    member = Member.create!(name: "No Detail")
+    member = Member.includes(:member_detail).where(id: member.id).first
+
+    assert member.association(:member_detail).loaded?, "through association should be loaded"
+    assert_nil member.member_detail
+
+    assert_no_queries do
+      assert_nil member.organization
+    end
+  end
+
+  def test_has_one_through_queries_when_source_not_loaded
+    member = members(:groucho)
+    member.member_detail # load only the through association
+
+    assert member.association(:member_detail).loaded?, "through association should be loaded"
+    assert_not member.member_detail.association(:organization).loaded?,
+      "source association should NOT be loaded"
+
+    assert_queries_count(1) do
+      member.organization
+    end
+  end
+
+  def test_has_one_through_queries_when_nothing_loaded
+    member = members(:groucho)
+    member.association(:member_detail).reset
+    member.association(:organization).reset
+
+    assert_not member.association(:member_detail).loaded?
+    assert_not member.association(:organization).loaded?
+
+    assert_queries_count(1) do
+      member.organization
+    end
+  end
+
+  def test_has_one_through_explicit_reload_queries_even_when_chain_loaded
+    members = Member.includes(member_detail: :organization).where(name: "Groucho Marx").to_a
+    member = members.first
+
+    assert member.association(:member_detail).loaded?
+
+    # Explicit reload should always hit the database, even when the
+    # through chain is loaded in memory.
+    assert_queries_count(1) do
+      member.reload_organization
+    end
   end
 
   def test_has_one_through_polymorphic_with_source_type


### PR DESCRIPTION
### Motivation / Background

Fixes #56978. Also fixes #51817.

When a `has_one :through` association's entire chain has been preloaded (e.g., via `includes`), accessing the association still fires a database query. Manual chaining (`issue.report.account`) and `delegate` both correctly reuse loaded objects — only the `has_one :through` path ignores what's already in memory.

This happens because `SingularAssociation#reader` only checks whether the `has_one :through` association *itself* is marked `loaded?`. The preloader loads each link in the chain individually (`:report` and `:account`), but never sets the `loaded` flag on the top-level `has_one :through` — so `reader` always falls through to `reload`, which builds a scope and hits the database.

### Detail

`HasOneThroughAssociation` now overrides `reader` to check whether the through chain is already loaded before calling `super`. If it is, the target is resolved by walking the in-memory chain, and `self.target =` sets the `loaded` flag so that `super` returns the cached value without querying.

The check is conservative — it only short-circuits when:
1. The association isn't already loaded (no double-resolution)
2. The through association is loaded **and not stale** — if the owner's foreign key to the through record changed after preloading, we fall back to querying, which resolves against the current foreign key exactly as an un-preloaded association does
3. If the through target is present, the source association on that target is also loaded

If any condition fails (including scoped and polymorphic-source associations, where chain-walking could return a record the query would have excluded), we fall through to the existing `super` behavior unchanged.

**Why `reader` instead of `find_target`?** Overriding `find_target` would also work for the basic case, but `find_target` is called from within the `reload` path (`reader` → `reload` → `reset` → `load_target` → `find_target`). This means an explicit `reload_<association>` call would also short-circuit from memory instead of querying the database, because `reset` only clears `self` — not the through chain on the owner. Overriding `reader` avoids this: `force_reload_reader` and explicit `reload` calls bypass our override entirely, so they always hit the database as expected.

### Benchmark Results

Following the [contributing guide's benchmarking guidance](https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#benchmark-your-code) (script below, based on the guide's `benchmark.rb` template). Ruby 3.4.2, SQLite3 in-memory, 100 records, `benchmark-ips`; measured at main `3ac4702080` vs this branch `f5a1a19e87` — i.e. with the staleness guard included:

| Scenario | main | this PR |
|---|---|---|
| Queries firing `issue.account` across 100 preloaded records | **100** (the N+1) | **0** |
| `issue.account`, preloaded chain (find + access) | 2,282 i/s (438 μs) | 3,301 i/s (303 μs) — **1.45×** |
| `issue.report.account`, manual chain (baseline) | 3,367 i/s | 3,374 i/s — unchanged |
| `issue.account`, no preload | 5,331 i/s | 5,278 i/s — within noise (±2.7%), no regression |
| Stale FK after preload (guard path) | 2,249 i/s, requeries correctly | 2,234 i/s, requeries correctly — the guard is free |

Preloaded access now lands within 2% of the manual chain. (In the i/s rows, "no preload" appears fastest because every iteration includes its own `find`, and the preloaded variants pay for the 3-query `includes` inside it — a cost that amortizes across N records in real use, which is what the query-count row captures.)

<details>
<summary>Benchmark script (runnable; switch sides with <code>RAILS_REPO</code>/<code>RAILS_BRANCH</code> or point <code>RAILS_PATH</code> at a checkout)</summary>

```ruby
# frozen_string_literal: true

# Benchmark for rails/rails#57079 — has_one :through preloaded-chain reader.
# Modeled on guides/bug_report_templates/benchmark.rb.
#
# Run against main:
#   ruby hot_bench.rb
# Run against the PR branch:
#   RAILS_REPO=tylerwood-io/rails RAILS_BRANCH=fix-has-one-through-preloaded-n-plus-1 ruby hot_bench.rb
# Or against a local checkout:
#   RAILS_PATH=/path/to/rails ruby hot_bench.rb

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  if ENV["RAILS_PATH"]
    gem "rails", path: ENV["RAILS_PATH"]
  else
    gem "rails", github: ENV.fetch("RAILS_REPO", "rails/rails"),
                 branch: ENV.fetch("RAILS_BRANCH", "main")
  end
  gem "sqlite3"
  gem "benchmark-ips"
end

require "active_record"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :accounts, force: true
  create_table :reports, force: true do |t|
    t.integer :account_id
  end
  create_table :issues, force: true do |t|
    t.integer :report_id
  end
end

class Account < ActiveRecord::Base; end

class Report < ActiveRecord::Base
  belongs_to :account
end

class Issue < ActiveRecord::Base
  belongs_to :report
  has_one :account, through: :report
end

N = 100
N.times { Issue.create!(report: Report.create!(account: Account.create!)) }
ISSUE_ID = Issue.first.id
OTHER_REPORT_ID = Issue.last.report_id

$queries = 0
ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
  $queries += 1 unless payload[:name] == "SCHEMA"
end

def count_queries
  before = $queries
  yield
  $queries - before
end

puts RUBY_DESCRIPTION
puts "ActiveRecord #{ActiveRecord::VERSION::STRING}"

puts
puts " query counts (N = #{N} preloaded records) ".center(80, "=")
issues = Issue.includes(report: :account).to_a
q = count_queries { issues.each(&:account) }
puts "queries fired accessing issue.account across #{N} preloaded records: #{q}"

puts
puts " correctness: stale FK after preload must requery ".center(80, "=")
issue = Issue.includes(report: :account).find(ISSUE_ID)
issue.report_id = OTHER_REPORT_ID
q = count_queries { @stale_result = issue.account }
expected = Report.find(OTHER_REPORT_ID).account
puts "returned account for new FK: #{@stale_result.id == expected.id} (queries: #{q})"

puts
puts " benchmark-ips (each iteration includes the find) ".center(80, "=")
Benchmark.ips do |x|
  x.report("preloaded chain: issue.account") do
    Issue.includes(report: :account).find(ISSUE_ID).account
  end
  x.report("manual chain: issue.report.account") do
    Issue.includes(report: :account).find(ISSUE_ID).report.account
  end
  x.report("no preload: issue.account") do
    Issue.find(ISSUE_ID).account
  end
  x.report("stale FK then issue.account") do
    i = Issue.includes(report: :account).find(ISSUE_ID)
    i.report_id = OTHER_REPORT_ID
    i.account
  end
  x.compare!
end
```

</details>

### Test Plan

- [x] Preloaded intermediate + source chain → zero queries
- [x] Through loaded as nil (no intermediate record) → returns nil, zero queries
- [x] Through loaded but source not loaded → falls back to query (1 query)
- [x] Nothing loaded → existing query behavior unchanged (1 query)
- [x] Through foreign key mutated after preload (stale chain) → falls back to query and resolves against the new foreign key, matching un-preloaded behavior
- [x] Explicit `reload_<association>` still hits database when chain is loaded
- [x] All existing `has_one :through` tests pass (61 runs, 207 assertions, 0 failures)
- [x] Full `activerecord` sqlite3 suite passes after rebase on current main
- [x] RuboCop clean on changed files
- [x] CHANGELOG entry added
