### PR TITLE
Deprecate `schema_order` option in PostgreSQL database configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate the `schema_order` option in PostgreSQL database configurations.
+
+    Use `schema_search_path` instead. The `schema_order` alias will be
+    removed in Rails 8.3.
+
+    *Eileen M. Uchitelle*
+
 *   Deprecate the `strict` option in MySQL database configurations.
 
     The `strict` option for MySQL will be removed in Rails 8.3 because it is the default behavior.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -34,7 +34,7 @@ module ActiveRecord
     # * <tt>:password</tt> - Password to be used if the server demands password authentication.
     # * <tt>:database</tt> - Defaults to be the same as the username.
     # * <tt>:schema_search_path</tt> - An optional schema search path for the connection given
-    #   as a string of comma-separated schema names. This is backward-compatible with the <tt>:schema_order</tt> option.
+    #   as a string of comma-separated schema names.
     # * <tt>:encoding</tt> - An optional client encoding that is used in a <tt>SET client_encoding TO
     #   <encoding></tt> call on the connection.
     # * <tt>:min_messages</tt> - An optional client min messages that is used in a
@@ -1075,6 +1075,12 @@ module ActiveRecord
           # search_path uses unquoted, comma-separated identifiers so it
           # goes through the existing setter rather than internal_set_config.
           unless @config[:schema_search_path] == false
+            if @config[:schema_order]
+              ActiveRecord.deprecator.warn(<<~MSG.squish)
+                The `schema_order` option in PostgreSQL database configurations is
+                deprecated and will be removed in Rails 8.3. Use `schema_search_path` instead.
+              MSG
+            end
             self.schema_search_path = @config[:schema_search_path] || @config[:schema_order]
           end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -143,6 +143,18 @@ module ActiveRecord
         end
       end
 
+      def test_schema_order_deprecation
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        assert_deprecated(ActiveRecord.deprecator) do
+          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+            db_config.configuration_hash.merge(schema_order: "public")
+          )
+          connection.connect!
+          assert_equal "public", connection.schema_search_path
+          connection.disconnect!
+        end
+      end
+
       def test_configure_connection_sets_default_settings
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)


### PR DESCRIPTION
`schema_order` is an old alias for `schema_search_path` that predates the current naming. Use `schema_search_path` instead.
