### PR TITLE
Document that `:if` and `:unless` options on validations accept arrays [ci skip]

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -85,11 +85,16 @@ module ActiveModel
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
       #   proc or string should return or evaluate to a +true+ or +false+ value.
+      #   Multiple methods or procs can be passed as an array to check multiple
+      #   conditions, all of which must pass for validation to occur
+      #   (e.g. <tt>if: [:allow_validation, Proc.new { |user| user.signup_step > 2 }]</tt>)
       # * <tt>:unless</tt> - Specifies a method, proc, or string to call to
       #   determine if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
       #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method, proc, or string should return or evaluate to a +true+ or +false+
-      #   value.
+      #   value. Multiple methods or procs can be passed as an array to check
+      #   multiple conditions, all of which must pass for validation not to occur
+      #   (e.g. <tt>unless: [:skip_validation, Proc.new { |user| user.signup_step <= 2 }]</tt>)
       def validates_each(*attr_names, &block)
         validates_with BlockValidator, _merge_attributes(attr_names), &block
       end
@@ -155,11 +160,16 @@ module ActiveModel
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method or
       #   proc should return or evaluate to a +true+ or +false+ value.
+      #   Multiple methods or procs can be passed as an array to check multiple
+      #   conditions, all of which must pass for validation to occur
+      #   (e.g. <tt>if: [:allow_validation, Proc.new { |user| user.signup_step > 2 }]</tt>)
       # * <tt>:unless</tt> - Specifies a method or proc to call to
       #   determine if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
       #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method or proc should return or evaluate to a +true+ or +false+
-      #   value.
+      #   value. Multiple methods or procs can be passed as an array to check
+      #   multiple conditions, all of which must pass for validation not to occur
+      #   (e.g. <tt>unless: [:skip_validation, Proc.new { |user| user.signup_step <= 2 }]</tt>)
       #
       # NOTE: Calling +validate+ multiple times on the same method will overwrite previous definitions.
       #

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -87,11 +87,16 @@ module ActiveModel
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
       #   proc or string should return or evaluate to a +true+ or +false+ value.
+      #   Multiple methods or procs can be passed as an array to check multiple
+      #   conditions, all of which must pass for validation to occur
+      #   (e.g. <tt>if: [:allow_validation, Proc.new { |user| user.signup_step > 2 }]</tt>)
       # * <tt>:unless</tt> - Specifies a method, proc, or string to call to determine
       #   if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
       #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
       #   method, proc, or string should return or evaluate to a +true+ or
-      #   +false+ value.
+      #   +false+ value. Multiple methods or procs can be passed as an array to
+      #   check multiple conditions, all of which must pass for validation not to occur
+      #   (e.g. <tt>unless: [:skip_validation, Proc.new { |user| user.signup_step <= 2 }]</tt>)
       # * <tt>:allow_nil</tt> - Skip validation if the attribute is +nil+.
       # * <tt>:allow_blank</tt> - Skip validation if the attribute is blank.
       # * <tt>:strict</tt> - If the <tt>:strict</tt> option is set to true

--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -62,13 +62,17 @@ module ActiveModel
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>).
       #   The method, proc, or string should return or evaluate to a +true+ or
-      #   +false+ value.
+      #   +false+ value. Multiple methods or procs can be passed as an array to
+      #   check multiple conditions, all of which must pass for validation to occur
+      #   (e.g. <tt>if: [:allow_validation, Proc.new { |user| user.signup_step > 2 }]</tt>)
       # * <tt>:unless</tt> - Specifies a method, proc, or string to call to
       #   determine if the validation should not occur
       #   (e.g. <tt>unless: :skip_validation</tt>, or
       #   <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>).
       #   The method, proc, or string should return or evaluate to a +true+ or
-      #   +false+ value.
+      #   +false+ value. Multiple methods or procs can be passed as an array to
+      #   check multiple conditions, all of which must pass for validation not to occur
+      #   (e.g. <tt>unless: [:skip_validation, Proc.new { |user| user.signup_step <= 2 }]</tt>)
       # * <tt>:strict</tt> - Specifies whether validation should be strict.
       #   See <tt>ActiveModel::Validations#validates!</tt> for more information.
       #


### PR DESCRIPTION
Validations are built on `ActiveSupport::Callbacks.set_callback`, where the `:if` and `:unless` options come from, which documents the array support, but that connection isn't obvious when reading validation documentation where it's helpful to know arrays are supported.

Follow up to #57050, and referencing #55761.

See the last sentence of each for the "after":
<img width="961" height="182" alt="Screenshot 2026-03-27 at 5 26 33 PM" src="https://github.com/user-attachments/assets/af6dc2df-647e-4607-a0e2-21efa7a8dca7" />
