### PR TITLE
Fix has_many :through to use join model's custom attribute type

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix `has_many :through` to use join model's custom attribute type in queries.
+
+    When a join model declares a custom attribute type via
+    `attribute :col, MyType.new`, the through association's cross-table
+    WHERE clause silently ignored it, falling back to the database
+    schema's default type.
+
+    Fixes #56893.
+
+    *Tyler Wood*
+
 *   Deprecate the `strict` option in MySQL database configurations.
 
     The `strict` option for MySQL will be removed in Rails 8.3 because it is the default behavior.

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -162,7 +162,8 @@ module ActiveRecord
           if scope.table == table
             scope.where!(key => value)
           else
-            scope.where!(table.name => { key => value })
+            bind = Relation::QueryAttribute.new(key, value, table.type_for_attribute(key))
+            scope.where!(table[key].eq(bind))
           end
         end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1736,6 +1736,76 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
 end
 
+class HasManyThroughCustomAttributeTypeTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  # A custom type that multiplies values by 1000 when serializing to the
+  # database. This makes it easy to verify which type caster is being used
+  # in the generated SQL.
+  class ScaledInteger < ActiveRecord::Type::Integer
+    def serialize(value)
+      super(value.to_i * 1000)
+    end
+
+    def deserialize(value)
+      super(value.to_i / 1000)
+    end
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+
+    @connection.create_table :custom_type_authors, force: true
+    @connection.create_table :custom_type_readers, force: true do |t|
+      t.integer :custom_type_author_id
+      t.integer :custom_type_post_id
+    end
+    @connection.create_table :custom_type_posts, force: true
+
+    # The join model declares a custom attribute type on the FK column.
+    Object.const_set(:CustomTypeReader, Class.new(ActiveRecord::Base) {
+      self.table_name = "custom_type_readers"
+      attribute :custom_type_author_id, ScaledInteger.new
+      belongs_to :custom_type_author
+      belongs_to :custom_type_post
+    })
+
+    Object.const_set(:CustomTypeAuthor, Class.new(ActiveRecord::Base) {
+      self.table_name = "custom_type_authors"
+      has_many :custom_type_readers
+      has_many :custom_type_posts, through: :custom_type_readers
+    })
+
+    Object.const_set(:CustomTypePost, Class.new(ActiveRecord::Base) {
+      self.table_name = "custom_type_posts"
+    })
+  end
+
+  def teardown
+    @connection.drop_table :custom_type_readers, if_exists: true
+    @connection.drop_table :custom_type_authors, if_exists: true
+    @connection.drop_table :custom_type_posts, if_exists: true
+    Object.send(:remove_const, :CustomTypeReader)
+    Object.send(:remove_const, :CustomTypeAuthor)
+    Object.send(:remove_const, :CustomTypePost)
+  end
+
+  def test_through_association_uses_join_model_custom_attribute_type
+    author = CustomTypeAuthor.create!
+    post = CustomTypePost.create!
+    # Insert the reader row with the scaled FK value directly,
+    # matching what the custom type would serialize.
+    CustomTypeReader.insert!({
+      custom_type_author_id: author.id,
+      custom_type_post_id: post.id
+    })
+
+    # The through query should use the join model's ScaledInteger type
+    # to serialize author.id, producing author.id * 1000 in the WHERE clause.
+    assert_equal [post], author.custom_type_posts.to_a
+  end
+end
+
 class DeprecatedHasManyThroughAssociationsTest < ActiveRecord::TestCase
   include DeprecatedAssociationsTestHelpers
 


### PR DESCRIPTION
### Motivation / Background

Fixes #56893.

When a join model declares a custom attribute type via `attribute :col, MyType.new`, `has_many :through` queries silently ignore that type when building the WHERE clause for the cross-table FK condition. The value is serialized using the database schema's default type instead of the model's declared type.

This affects any application using custom attribute types on join model FK columns with `has_many :through`. A real-world example is the `ulid-rails` gem, which registers a `:ulid` type that serializes between ULID strings and 16-byte binary — without this fix, through queries encode the FK as ASCII instead of binary, returning empty results.

Previously reported as #54418 and #52135.

### Detail

`AssociationScope#apply_scope` has two branches:

```ruby
def apply_scope(scope, table, key, value)
  if scope.table == table
    scope.where!(key => value)          # same-table: uses join model's type ✓
  else
    scope.where!(table.name => { key => value })  # cross-table: uses target model's type ✗
  end
end
```

The cross-table branch uses a hash-form condition that resolves the column type via the outer scope's `PredicateBuilder`. Since the target model has no knowledge of custom types declared on the join model, it falls back to the database schema type.

The fix builds an explicit `QueryAttribute` using the join table's own type caster:

```ruby
bind = Relation::QueryAttribute.new(key, value, table.type_for_attribute(key))
scope.where!(table[key].eq(bind))
```

### Benchmark Results

Ruby 3.3.10, SQLite3 in-memory, 5 records, `benchmark-ips`:

```
                         i/s      per-iter
direct has_many:         7,170.0  139.47 μs
through association:     7,076.4  141.32 μs  — same-ish (within error)
```

No measurable regression from the `QueryAttribute` construction.

### Test Plan

- [x] Test with inline models using a custom `ScaledInteger` type that multiplies FK values by 1000 — verifies the through query uses the custom type (fails without fix: returns `[]`)
- [x] Full `has_many_through_associations_test.rb` suite passes (173 runs, 475 assertions, 0 failures)
- [x] Full `activerecord:sqlite3:test` suite passes (9,379 runs, 32,097 assertions, 0 failures)
- [x] RuboCop clean on changed files
- [x] CHANGELOG entry added