### PR TITLE
Fix has_many_inversing for composite foreign key associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `has_many_inversing` for associations with composite foreign keys.
+
+    `matches_foreign_key?` passed composite foreign key arrays directly to
+    `read_attribute`, which returned nil. Use `Array()` and map over each
+    component, matching the pattern used by `foreign_key_for?`.
+
+    Fixes #56829.
+
+    *Tyler Wood*
+
 *   Deprecate the `strict` option in MySQL database configurations.
 
     The `strict` option for MySQL will be removed in Rails 8.3 because it is the default behavior.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -409,12 +409,16 @@ module ActiveRecord
         end
 
         def matches_foreign_key?(record)
-          if foreign_key_for?(record)
-            record.read_attribute(reflection.foreign_key) == owner.id ||
-              (foreign_key_for?(owner) && owner.read_attribute(reflection.foreign_key) == record.id)
-          else
-            owner.read_attribute(reflection.foreign_key) == record.id
-          end
+          (foreign_key_for?(record) && foreign_key_values(record) == primary_key_values(owner)) ||
+            (foreign_key_for?(owner) && foreign_key_values(owner) == primary_key_values(record))
+        end
+
+        def foreign_key_values(record)
+          Array(reflection.foreign_key).map { |key| record.read_attribute(key) }
+        end
+
+        def primary_key_values(record)
+          Array(reflection.association_primary_key(record.class)).map { |key| record.read_attribute(key) }
         end
     end
   end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -1076,3 +1076,60 @@ class InverseMultipleHasManyInversesForSameModel < ActiveRecord::TestCase
     end
   end
 end
+
+class InverseCompositeForeignKeyTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+
+    @connection.create_table :cpk_blog_posts, force: true do |t|
+      t.integer :blog_id, null: false
+    end
+
+    @connection.create_table :cpk_comments, force: true do |t|
+      t.integer :blog_id, null: false
+      t.integer :cpk_blog_post_id, null: false
+    end
+
+    Object.const_set(:CpkBlogPost, Class.new(ActiveRecord::Base) {
+      self.table_name = "cpk_blog_posts"
+      has_many :cpk_comments, -> { order(:id) },
+        primary_key: [:blog_id, :id],
+        foreign_key: [:blog_id, :cpk_blog_post_id],
+        inverse_of: :cpk_blog_post
+    })
+
+    Object.const_set(:CpkComment, Class.new(ActiveRecord::Base) {
+      self.table_name = "cpk_comments"
+      belongs_to :cpk_blog_post,
+        foreign_key: [:blog_id, :cpk_blog_post_id],
+        primary_key: [:blog_id, :id],
+        inverse_of: :cpk_comments
+    })
+  end
+
+  def teardown
+    @connection.drop_table :cpk_comments, if_exists: true
+    @connection.drop_table :cpk_blog_posts, if_exists: true
+    Object.send(:remove_const, :CpkComment)
+    Object.send(:remove_const, :CpkBlogPost)
+  end
+
+  def test_has_many_inversing_with_composite_foreign_key
+    with_has_many_inversing do
+      blog_post = CpkBlogPost.create!(blog_id: 1)
+      CpkComment.create!(blog_id: 1, cpk_blog_post_id: blog_post.id)
+
+      # The scope on cpk_comments forces exec_queries path, which uses
+      # inversed_from_queries → inversable? → matches_foreign_key?
+      comments = blog_post.cpk_comments.to_a
+      comment = comments.first
+      assert_not_nil comment
+
+      assert comment.association(:cpk_blog_post).loaded?,
+        "belongs_to inverse should be set when loading scoped has_many with composite FK"
+      assert_equal blog_post, comment.cpk_blog_post
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Fixes #56829. Related: #56662, #56664.

When `has_many_inversing` is enabled and an association uses composite foreign keys, `inversable?` always returns false because `matches_foreign_key?` passes the composite key array directly to `read_attribute`, which returns nil for array arguments. This breaks identity preservation — loading a scoped collection returns fresh objects instead of reusing already-loaded ones.

**Note:** #56664 by @masom addresses the same issue with an equivalent approach. This PR converges on the same implementation after independent investigation. Happy to close in favor of #56664 if core prefers — see [comment](https://github.com/rails/rails/pull/56664#issuecomment-4145834261).

### Detail

`matches_foreign_key?` compared FK values using `record.read_attribute(reflection.foreign_key)`, which works for scalar keys but returns nil when `foreign_key` is an array (composite key). Similarly, it compared against `owner.id` / `record.id`, which returns the model's single primary key — not the association-declared composite primary key columns.

The fix extracts two helpers:

```ruby
def foreign_key_values(record)
  Array(reflection.foreign_key).map { |key| record.read_attribute(key) }
end

def primary_key_values(record)
  Array(reflection.association_primary_key(record.class)).map { |key| record.read_attribute(key) }
end
```

These correctly read each component individually and return arrays for comparison. `association_primary_key(record.class)` resolves the correct target columns for both has_many and belongs_to reflections.

### Benchmark Results

Ruby 3.3.10, SQLite3 in-memory, 5 records, `benchmark-ips`:

```
                         i/s      per-iter
scalar FK (baseline):    4,959.5  201.63 μs
composite FK (fix):      4,628.0  216.07 μs  — same-ish (within error)
```

No measurable regression from the `Array().map` wrapping for scalar keys.

### Test Plan

- [x] Test with inline composite FK models (`[:blog_id, :id]` / `[:blog_id, :cpk_blog_post_id]`)
- [x] Scoped has_many (with `order`) forces the `exec_queries` → `inversed_from_queries` → `inversable?` → `matches_foreign_key?` path
- [x] Verifies inverse is loaded and set correctly after collection load
- [x] Fails without fix (inverse not set), passes with fix
- [x] Full `inverse_associations_test.rb` passes (94 runs, 348 assertions, 0 failures)
- [x] RuboCop clean on changed files
- [x] CHANGELOG entry added