### PR TITLE
Fix parallel test shutdown hang when workers are stuck alive

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -65,6 +65,12 @@ module ActiveSupport
         @worker_count
       end
 
+      # How long to wait for workers to exit during shutdown before
+      # force-killing them. Must be long enough for normal cleanup
+      # (parallelize_teardown hooks, DRb deregistration) but short
+      # enough to avoid stalling CI pipelines indefinitely.
+      SHUTDOWN_TIMEOUT = 30 # seconds
+
       def shutdown
         dead_worker_pids = @worker_pool.filter_map do |pid|
           Process.waitpid(pid, Process::WNOHANG)
@@ -73,13 +79,64 @@ module ActiveSupport
         end
         @queue_server.remove_dead_workers(dead_worker_pids)
 
-        @queue_server.shutdown
-        @worker_pool.each do |pid|
-          Process.waitpid(pid)
+        @queue_server.shutdown(timeout: SHUTDOWN_TIMEOUT)
+
+        if @queue_server.active_workers?
+          force_kill_workers
+          @queue_server.remove_dead_workers(@worker_pool)
+        else
+          wait_for_workers
+        end
+      end
+
+      private
+        def wait_for_workers
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + SHUTDOWN_TIMEOUT
+
+          @worker_pool.each do |pid|
+            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+            if remaining <= 0
+              force_kill_workers
+              @queue_server.remove_dead_workers(@worker_pool)
+              return
+            end
+
+            wait_for_worker(pid, remaining)
+          end
+        end
+
+        def wait_for_worker(pid, timeout)
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+
+          loop do
+            return if Process.waitpid(pid, Process::WNOHANG)
+
+            if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+              force_kill_workers
+              @queue_server.remove_dead_workers(@worker_pool)
+              return
+            end
+
+            sleep 0.1
+          end
         rescue Errno::ECHILD
           nil
         end
-      end
+
+        def force_kill_workers
+          @worker_pool.each do |pid|
+            Process.kill("KILL", pid)
+          rescue Errno::ESRCH
+            nil
+          end
+
+          @worker_pool.each do |pid|
+            Process.waitpid(pid)
+          rescue Errno::ECHILD
+            nil
+          end
+        end
     end
   end
 end

--- a/activesupport/lib/active_support/testing/parallelization/server.rb
+++ b/activesupport/lib/active_support/testing/parallelization/server.rb
@@ -68,7 +68,7 @@ module ActiveSupport
           @distributor.interrupt
         end
 
-        def shutdown
+        def shutdown(timeout: nil)
           # Wait for initial queue to drain
           while @distributor.pending?
             sleep 0.1
@@ -76,7 +76,7 @@ module ActiveSupport
 
           @distributor.close
 
-          wait_for_active_workers
+          wait_for_active_workers(timeout: timeout)
 
           @in_flight.values.each do |(klass, name, reporter)|
             result = Minitest::Result.from(klass.new(name))
@@ -92,13 +92,18 @@ module ActiveSupport
 
           @distributor.close
 
-          wait_for_active_workers
+          wait_for_active_workers(timeout: timeout)
         end
 
         private
-          def wait_for_active_workers
+          def wait_for_active_workers(timeout: nil)
+            deadline = if timeout
+              Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+            end
+
             while active_workers?
               reap_dead_workers
+              break if deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
               sleep 0.1
             end
           end

--- a/activesupport/test/parallelization_test.rb
+++ b/activesupport/test/parallelization_test.rb
@@ -46,15 +46,16 @@ class ParallelizationTest < ActiveSupport::TestCase
 
     parallelization.start
 
-    sleep 0.5
+    assert_active_workers(server)
 
-    assert server.active_workers?
+    assert_predicate server, :active_workers?
 
     worker_pids = parallelization.instance_variable_get(:@worker_pool)
     Process.kill("KILL", worker_pids.first)
-    sleep 0.25
 
-    Timeout.timeout(2.5, Minitest::Assertion, "Expected shutdown to not hang") { parallelization.shutdown }
+    Timeout.timeout(2.5, Minitest::Assertion, "Expected shutdown to not hang") do
+      parallelization.shutdown
+    end
     assert_not server.active_workers?
   end
 
@@ -80,8 +81,7 @@ class ParallelizationTest < ActiveSupport::TestCase
     end
     parallelization.instance_variable_set(:@worker_pool, [worker_pid])
 
-    sleep 0.25
-    assert server.active_workers?
+    assert_active_workers(server)
 
     # Schedule the kill AFTER shutdown begins, so the initial WNOHANG sweep
     # in Parallelization#shutdown finds the worker still alive
@@ -92,6 +92,86 @@ class ParallelizationTest < ActiveSupport::TestCase
 
     Timeout.timeout(3, Minitest::Assertion, "Expected shutdown to not hang") { parallelization.shutdown }
     assert_not server.active_workers?
+  end
+
+  test "shutdown force-kills workers that are stuck alive without deregistering" do
+    # Regression test: if a worker hangs alive (e.g. stuck in a finalizer,
+    # DRb thread, or cleanup hook) without ever calling stop_worker, the
+    # reap_dead_workers fix (#57053) can't help because waitpid(WNOHANG)
+    # returns nil for live processes. Shutdown must time out and force-kill.
+    parallelization = ActiveSupport::Testing::Parallelization.new(1)
+    server = parallelization.instance_variable_get(:@queue_server)
+    url = parallelization.instance_variable_get(:@url)
+
+    blocking_distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+    server.instance_variable_set(:@distributor, blocking_distributor)
+
+    r, w = IO.pipe
+    worker_pid = fork do
+      DRb.stop_service
+      queue = DRbObject.new_with_uri(url)
+      queue.start_worker(0, Process.pid)
+      r.close
+      w.close
+      sleep(10) # stuck alive — never exits, never calls stop_worker
+      exit!(0)
+    end
+    parallelization.instance_variable_set(:@worker_pool, [worker_pid])
+
+    w.close
+    r.wait_readable(2) # wait for worker to register and deregister
+    r.close
+
+    assert server.active_workers?
+
+    stub_const(ActiveSupport::Testing::Parallelization, :SHUTDOWN_TIMEOUT, 0.1) do
+      Timeout.timeout(5, Minitest::Assertion, "Expected shutdown to not hang") do
+        parallelization.shutdown
+      end
+    end
+    assert_not server.active_workers?
+
+    # Worker should have been killed
+    assert_raises(Errno::ECHILD) { Process.waitpid(worker_pid, Process::WNOHANG) }
+  end
+
+  test "shutdown force-kills workers that deregistered but are stuck during exit" do
+    # Regression test: a worker calls stop_worker (so Server#shutdown
+    # completes) but then hangs alive during Ruby shutdown (finalizers,
+    # at_exit hooks). Parallelization#shutdown's final Process.waitpid(pid)
+    # would block forever without the timeout.
+    parallelization = ActiveSupport::Testing::Parallelization.new(1)
+    server = parallelization.instance_variable_get(:@queue_server)
+    url = parallelization.instance_variable_get(:@url)
+
+    blocking_distributor = ActiveSupport::Testing::Parallelization::SharedQueueDistributor.new
+    server.instance_variable_set(:@distributor, blocking_distributor)
+
+    r, w = IO.pipe
+    worker_pid = fork do
+      DRb.stop_service
+      queue = DRbObject.new_with_uri(url)
+      queue.start_worker(0, Process.pid)
+      queue.stop_worker(0, Process.pid) # deregisters successfully
+      r.close
+      w.close
+      sleep(10) # stuck alive during exit
+      exit!(0)
+    end
+    parallelization.instance_variable_set(:@worker_pool, [worker_pid])
+
+    w.close
+    r.wait_readable(2) # wait for worker to register and deregister
+    r.close
+
+    stub_const(ActiveSupport::Testing::Parallelization, :SHUTDOWN_TIMEOUT, 0.1) do
+      Timeout.timeout(5, Minitest::Assertion, "Expected shutdown to not hang") do
+        parallelization.shutdown
+      end
+    end
+    assert_not server.active_workers?
+
+    assert_raises(Errno::ECHILD) { Process.waitpid(worker_pid, Process::WNOHANG) }
   end
 
   test "seeded distribution assigns tests to workers round-robin" do
@@ -308,4 +388,16 @@ class ParallelizationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  private
+    def assert_active_workers(server, timeout: 1)
+      (timeout.to_f / 0.02).floor.times do
+        if server.active_workers?
+          break
+        else
+          sleep 0.02
+        end
+      end
+      assert_predicate server, :active_workers?
+    end
 end


### PR DESCRIPTION
### Motivation / Background

#57053 (fixing #57052) added `reap_dead_workers` inside `Server#shutdown`'s `wait_for_active_workers` loop to detect workers that have **died** (zombies) via `Process.waitpid(pid, WNOHANG)`. This works when workers are dead, but `waitpid(WNOHANG)` returns `nil` for processes that are still alive.

If a worker hangs without exiting — stuck in a finalizer, DRb thread, `at_exit` hook, or `parallelize_teardown` callback — shutdown hangs forever at one of two points:

1. `Server#shutdown` — worker is alive but never called `stop_worker`, `reap_dead_workers` finds nothing, loop repeats indefinitely.
2. `Parallelization#shutdown` — worker called `stop_worker`, so `Server#shutdown` completes, but the final blocking `Process.waitpid(pid)` hangs forever.

We're hitting this intermittently in CI with system tests (Capybara/Cuprite). Workers get stuck during Chrome cleanup or Ruby shutdown, and a watchdog has to kill everything ~90s later.

Fixes #57085

### Detail

Adds a 30-second timeout to `Parallelization#shutdown`'s worker wait. Instead of a blocking `Process.waitpid(pid)`, it polls with `waitpid(WNOHANG)` against a monotonic clock deadline. If workers don't exit within the timeout, they are force-killed with `SIGKILL` and reaped.

The timeout is defined as `SHUTDOWN_TIMEOUT = 30` on `Parallelization`, which is long enough for normal cleanup (teardown hooks, DRb deregistration) but short enough to avoid stalling CI pipelines.

### Additional information

Two regression tests are included:
1. Worker stuck alive without deregistering — `Server#shutdown` would hang in `wait_for_active_workers`
2. Worker deregistered but stuck during exit — final `Process.waitpid` would block forever

Both tests override `SHUTDOWN_TIMEOUT` to 1 second so they complete quickly. Without the fix, both hang; with it, shutdown completes cleanly via force-kill.