### PR TITLE
Only set Postgres timezone when needed

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1049,6 +1049,16 @@ module ActiveRecord
           connect unless @raw_connection
         end
 
+        # Canonical spellings for PostgreSQL GUC names that use non-lowercase
+        # casing. parameter_status is case-sensitive, so we need the exact
+        # name the server reports.
+        CANONICAL_GUC_NAMES = {
+          "datestyle" => "DateStyle",
+          "intervalstyle" => "IntervalStyle",
+          "timezone" => "TimeZone",
+        }.freeze
+        private_constant :CANONICAL_GUC_NAMES
+
         # Configures the encoding, verbosity, schema search path, and time zone of the connection.
         # This is called by #connect and should not be called manually.
         def configure_connection
@@ -1072,28 +1082,44 @@ module ActiveRecord
           # SETs by checking parameter_status.
           settings = {}
 
+          # We normalize to lowercase to dedup against built-ins, but retain
+          # the user's spelling just in case.
+          original_variable_names = CANONICAL_GUC_NAMES.dup
+
           # Use standard-conforming strings so we don't have to do the E'...' dance.
           settings["standard_conforming_strings"] = "on" unless @config[:standard_conforming_strings] == false
 
           # Set interval output format to ISO 8601 for ease of parsing by ActiveSupport::Duration.parse
-          settings["IntervalStyle"] = "iso_8601" unless @config[:intervalstyle] == false
+          settings["intervalstyle"] = "iso_8601" unless @config[:intervalstyle] == false
 
           unless @config[:min_messages] == false
             settings["client_min_messages"] = @config[:min_messages] || "warning"
           end
 
-          # Merge in user-provided variables from :variables config hash.
           # https://www.postgresql.org/docs/current/static/sql-set.html
           @config.fetch(:variables, {}).stringify_keys.each do |k, v|
-            if v == ":default" || v == :default
-              settings[k] = nil # nil signals "SET TO DEFAULT"
-            elsif !v.nil?
-              settings[k] = v
+            lower = k.dup
+            original_variable_names[lower] ||= k if lower.downcase!
+
+            case v
+            when :default, ":default"
+              # Server default; remove any Rails-default we've set above
+              settings.delete(lower)
+            when nil
+              # Rails default
+            else
+              settings[lower] = v
             end
           end
 
-          settings.each do |setting, value|
-            internal_set_config(setting, value)
+          server_default_tz = @raw_connection.parameter_status("TimeZone")
+          @static_timezone = settings.key?("timezone") ||
+            %w[UTC Etc/UTC].include?(server_default_tz)
+
+          settings["timezone"] = "UTC" if default_timezone == :utc && !@static_timezone
+
+          settings.each do |lower, value|
+            internal_set_config(original_variable_names[lower] || lower, value)
           end
 
           # search_path uses unquoted, comma-separated identifiers so it
@@ -1116,38 +1142,17 @@ module ActiveRecord
           reload_type_map
         end
 
-        def reconfigure_connection_timezone
-          variables = @config.fetch(:variables, {}).stringify_keys
-
-          # If it's been directly configured as a connection variable, we don't
-          # need to do anything here; it will be set up by configure_connection
-          # and then never changed.
-          return if variables["timezone"]
-
-          # If using Active Record's time zone support configure the connection
-          # to return TIMESTAMP WITH ZONE types in UTC.
-          if default_timezone == :utc
-            intent = QueryIntent.new(adapter: self, processed_sql: "SET SESSION timezone TO 'UTC'", name: "SCHEMA")
-            intent.execute!
-            intent.finish
-          else
-            intent = QueryIntent.new(adapter: self, processed_sql: "SET SESSION timezone TO DEFAULT", name: "SCHEMA")
-            intent.execute!
-            intent.finish
-          end
-        end
-
         # Sets a PostgreSQL session configuration variable. Uses parameter_status
         # to skip redundant SET commands when the server already has the desired
         # value. Pass nil as value to SET TO DEFAULT.
         def internal_set_config(setting, value)
-          if value
+          unless value.nil?
             with_raw_connection(allow_retry: false, materialize_transactions: false) do |conn|
-              return if conn.parameter_status(setting) == value.to_s
+              return if (conn.parameter_status(setting) || conn.parameter_status(setting.downcase)) == value.to_s
             end
           end
 
-          quoted_value = value ? quote(value) : "DEFAULT"
+          quoted_value = value.nil? ? "DEFAULT" : quote(value)
           query_command("SET SESSION #{setting} TO #{quoted_value}", "SCHEMA")
         end
 
@@ -1228,21 +1233,20 @@ module ActiveRecord
         end
 
         def update_typemap_for_default_timezone
-          if @raw_connection && @mapped_default_timezone != default_timezone && @timestamp_decoder
-            decoder_class = default_timezone == :utc ?
-              PG::TextDecoder::TimestampUtc :
-              PG::TextDecoder::TimestampWithoutTimeZone
+          return unless @raw_connection && @timestamp_decoder && @mapped_default_timezone != default_timezone
 
-            @timestamp_decoder = decoder_class.new(**@timestamp_decoder.to_h)
-            @raw_connection.type_map_for_results.add_coder(@timestamp_decoder)
+          initial_setup = @mapped_default_timezone.nil?
+          @mapped_default_timezone = default_timezone
 
-            @mapped_default_timezone = default_timezone
+          decoder_class = default_timezone == :utc ?
+            PG::TextDecoder::TimestampUtc :
+            PG::TextDecoder::TimestampWithoutTimeZone
 
-            # if default timezone has changed, we need to reconfigure the connection
-            # (specifically, the session time zone)
-            reconfigure_connection_timezone
+          @timestamp_decoder = decoder_class.new(**@timestamp_decoder.to_h)
+          @raw_connection.type_map_for_results.add_coder(@timestamp_decoder)
 
-            true
+          unless initial_setup || @static_timezone
+            internal_set_config("timezone", default_timezone == :utc ? "UTC" : nil)
           end
         end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -15,6 +15,11 @@ module ActiveRecord
       include DdlHelper
       include ConnectionHelper
 
+      # Force known GUC defaults at connect time so query-count
+      # assertions are deterministic regardless of server configuration.
+      # TimeZone must be non-UTC so the :utc/:local distinction is visible.
+      KNOWN_SERVER_DEFAULTS = "-c TimeZone=US/Eastern -c IntervalStyle=postgres -c standard_conforming_strings=on -c client_min_messages=notice"
+
       def setup
         @connection = ActiveRecord::Base.lease_connection
         @original_db_warnings_action = :ignore
@@ -286,6 +291,74 @@ module ActiveRecord
         connection&.disconnect!
       end
 
+      def test_configure_connection_variables_with_nil_value
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(
+            variables: { client_min_messages: nil }
+          )
+        )
+        connection.connect!
+
+        # nil is a no-op: Rails' default "warning" should still be applied
+        assert_equal "warning", connection.query_value("SHOW client_min_messages")
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_variables_with_false_value
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(
+            variables: { enable_seqscan: false }
+          )
+        )
+        connection.connect!
+
+        assert_equal "off", connection.query_value("SHOW enable_seqscan")
+      ensure
+        connection&.disconnect!
+      end
+
+      def test_configure_connection_preserves_user_supplied_variable_casing
+        run_without_connection do |config|
+          connection = PostgreSQLAdapter.new(
+            config.merge(variables: { "my_app.SomeOption" => "hello" })
+          )
+          queries = capture_sql(include_schema: true) do
+            connection.select_value("SELECT 1")
+          end.map(&:squish)
+
+          assert_includes queries, "SET SESSION my_app.SomeOption TO 'hello'"
+        end
+      end
+
+      def test_configure_connection_skips_redundant_set_via_downcase_fallback
+        run_without_connection do |config|
+          queries = with_timezone_config(default: :local) do
+            connection = PostgreSQLAdapter.new(
+              config.merge(
+                options: KNOWN_SERVER_DEFAULTS,
+                variables: { "sTaNdArD_cOnFoRmInG_StRiNgS" => "on" },
+              )
+            )
+            capture_sql(include_schema: true) do
+              connection.select_value("SELECT 1")
+            end
+          end.map(&:squish)
+
+          expected_queries = [
+            "SET SESSION IntervalStyle TO 'iso_8601'",
+            "SET SESSION client_min_messages TO 'warning'",
+            ("SHOW search_path" if @connection.database_version < 18_00_00),
+            "SELECT 1",
+          ].compact
+
+          assert_equal expected_queries.size, queries.size
+          assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
+        end
+      end
+
       def test_schema_search_path_is_reapplied_after_reconnect
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 
@@ -323,54 +396,51 @@ module ActiveRecord
       end
 
       def test_queries_executed_on_fresh_connection_through_first_select
-        reset_pool
+        run_without_connection do |config|
+          ActiveRecord::Base.establish_connection(config.merge(options: KNOWN_SERVER_DEFAULTS))
 
-        queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
-          with_timezone_config(default: :utc) do
+          queries = with_timezone_config(default: :utc) do
             capture_sql(include_schema: true) do
               ActiveRecord::Base.lease_connection.select_value("SELECT 1+2")
             end
-          end
-        end.map(&:squish)
+          end.map(&:squish)
 
-        expected_queries = [
-          "SET SESSION IntervalStyle TO 'iso_8601'",
-          "SET SESSION client_min_messages TO 'warning'",
-          "SET SESSION timezone TO 'UTC'",
-          ("SHOW search_path" if @connection.database_version < 18_00_00),
-          "SELECT 1+2",
-        ].compact
+          expected_queries = [
+            "SET SESSION IntervalStyle TO 'iso_8601'",
+            "SET SESSION client_min_messages TO 'warning'",
+            "SET SESSION TimeZone TO 'UTC'",
+            ("SHOW search_path" if @connection.database_version < 18_00_00),
+            "SELECT 1+2",
+          ].compact
 
-        assert_equal expected_queries.size, queries.size
-        assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
-      ensure
-        reset_pool
+          assert_equal expected_queries.size, queries.size
+          assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
+        end
       end
 
       def test_queries_executed_on_fresh_connection_with_all_settings_skipped
-        reset_pool
-
-        queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
-          with_timezone_config(default: :utc) do
-            db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-            with_postgresql_adapter(db_config.configuration_hash.merge(intervalstyle: false, min_messages: false)) do |connection|
-              capture_sql(include_schema: true) do
-                connection.select_value("SELECT 1+2")
-              end
+        run_without_connection do |config|
+          queries = with_timezone_config(default: :local) do
+            connection = PostgreSQLAdapter.new(
+              config.merge(
+                options: KNOWN_SERVER_DEFAULTS,
+                intervalstyle: false,
+                min_messages: false,
+              )
+            )
+            capture_sql(include_schema: true) do
+              connection.select_value("SELECT 1+2")
             end
-          end
-        end.map(&:squish)
+          end.map(&:squish)
 
-        expected_queries = [
-          "SET SESSION timezone TO 'UTC'",
-          ("SHOW search_path" if @connection.database_version < 18_00_00),
-          "SELECT 1+2",
-        ].compact
+          expected_queries = [
+            ("SHOW search_path" if @connection.database_version < 18_00_00),
+            "SELECT 1+2",
+          ].compact
 
-        assert_equal expected_queries.size, queries.size
-        assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
-      ensure
-        reset_pool
+          assert_equal expected_queries.size, queries.size
+          assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
+        end
       end
 
       def test_queries_executed_on_fresh_connection_with_first_custom_type_lookup
@@ -379,32 +449,32 @@ module ActiveRecord
           t.column :value, :postgresql_startup_lookup_enum
         end
         @connection.execute "INSERT INTO postgresql_startup_lookup_enums (value) VALUES ('good')"
-        reset_pool
 
-        queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
-          with_timezone_config(default: :utc) do
+        run_without_connection do |config|
+          ActiveRecord::Base.establish_connection(config.merge(options: KNOWN_SERVER_DEFAULTS))
+
+          queries = with_timezone_config(default: :utc) do
             capture_sql(include_schema: true) do
               result = ActiveRecord::Base.lease_connection.select_all("SELECT value FROM postgresql_startup_lookup_enums LIMIT 1")
               result.column_types["value"]
             end
-          end
-        end.map(&:squish)
+          end.map(&:squish)
 
-        expected_queries = [
-          "SET SESSION IntervalStyle TO 'iso_8601'",
-          "SET SESSION client_min_messages TO 'warning'",
-          "SET SESSION timezone TO 'UTC'",
-          ("SHOW search_path" if @connection.database_version < 18_00_00),
-          "SELECT value FROM postgresql_startup_lookup_enums LIMIT 1",
-          oid_lookup_query_regex(initial_bulk_load: true),
-        ].compact
+          expected_queries = [
+            "SET SESSION IntervalStyle TO 'iso_8601'",
+            "SET SESSION client_min_messages TO 'warning'",
+            "SET SESSION TimeZone TO 'UTC'",
+            ("SHOW search_path" if @connection.database_version < 18_00_00),
+            "SELECT value FROM postgresql_startup_lookup_enums LIMIT 1",
+            oid_lookup_query_regex(initial_bulk_load: true),
+          ].compact
 
-        assert_equal expected_queries.size, queries.size
-        assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
+          assert_equal expected_queries.size, queries.size
+          assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
+        end
       ensure
         @connection.drop_table "postgresql_startup_lookup_enums", if_exists: true
         @connection.drop_enum "postgresql_startup_lookup_enum", if_exists: true
-        reset_pool
       end
 
       def test_queries_executed_on_fresh_connection_with_two_multi_oid_type_lookups
@@ -413,11 +483,12 @@ module ActiveRecord
 
         first_sql = "SELECT 'one'::postgresql_startup_lookup_one_a AS value_a, 'one'::postgresql_startup_lookup_one_b AS value_b"
         second_sql = "SELECT 'one'::postgresql_startup_lookup_two_a AS value_a, 'one'::postgresql_startup_lookup_two_b AS value_b"
-        reset_pool
 
-        first_queries = nil
-        second_queries = nil
-        PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
+        run_without_connection do |config|
+          ActiveRecord::Base.establish_connection(config.merge(options: KNOWN_SERVER_DEFAULTS))
+
+          first_queries = nil
+          second_queries = nil
           with_timezone_config(default: :utc) do
             first_queries = capture_sql(include_schema: true) do
               connection = ActiveRecord::Base.lease_connection
@@ -432,32 +503,31 @@ module ActiveRecord
               connection.select_all(second_sql)
             end.map(&:squish)
           end
+
+          expected_first_queries = [
+            "SET SESSION IntervalStyle TO 'iso_8601'",
+            "SET SESSION client_min_messages TO 'warning'",
+            "SET SESSION TimeZone TO 'UTC'",
+            ("SHOW search_path" if @connection.database_version < 18_00_00),
+            first_sql,
+            oid_lookup_query_regex(initial_bulk_load: true),
+          ].compact
+
+          expected_second_queries = [
+            second_sql,
+            oid_lookup_query_regex(initial_bulk_load: false),
+          ]
+
+          assert_equal expected_first_queries.size, first_queries.size
+          assert expected_first_queries.zip(first_queries).all? { |expected, actual| expected === actual }
+          assert_equal expected_second_queries.size, second_queries.size
+          assert expected_second_queries.zip(second_queries).all? { |expected, actual| expected === actual }
         end
-
-        expected_first_queries = [
-          "SET SESSION IntervalStyle TO 'iso_8601'",
-          "SET SESSION client_min_messages TO 'warning'",
-          "SET SESSION timezone TO 'UTC'",
-          ("SHOW search_path" if @connection.database_version < 18_00_00),
-          first_sql,
-          oid_lookup_query_regex(initial_bulk_load: true),
-        ].compact
-
-        expected_second_queries = [
-          second_sql,
-          oid_lookup_query_regex(initial_bulk_load: false),
-        ]
-
-        assert_equal expected_first_queries.size, first_queries.size
-        assert expected_first_queries.zip(first_queries).all? { |expected, actual| expected === actual }
-        assert_equal expected_second_queries.size, second_queries.size
-        assert expected_second_queries.zip(second_queries).all? { |expected, actual| expected === actual }
       ensure
         @connection.drop_enum "postgresql_startup_lookup_one_a", if_exists: true
         @connection.drop_enum "postgresql_startup_lookup_one_b", if_exists: true
         @connection.drop_enum "postgresql_startup_lookup_two_a", if_exists: true
         @connection.drop_enum "postgresql_startup_lookup_two_b", if_exists: true
-        reset_pool
       end
 
       def test_schema_search_path_uses_parameter_status_on_pg18


### PR DESCRIPTION
Follow-up for #57070: `TimeZone` needed a bit of extra help to work with the parameter_status check, including needing to treat `variables` keys case-insensitively.