### PR TITLE
Disconnect pools while cycling tests' connection handlers

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -263,19 +263,28 @@ module ActiveRecord
 
       def teardown_shared_connection_pool
         handler = ActiveRecord::Base.connection_handler
+        removed_pool_configs = []
+        pool_managers = handler.send(:connection_name_to_pool_manager)
 
         @saved_pool_configs.each_pair do |name, shards|
-          pool_manager = handler.send(:connection_name_to_pool_manager)[name]
+          pool_manager = pool_managers[name]
           shards.each_pair do |shard_name, roles|
             roles.each_pair do |role, pool_config|
-              next unless pool_manager.get_pool_config(role, shard_name)
-
-              pool_manager.set_pool_config(role, shard_name, pool_config)
+              if pool_manager.get_pool_config(role, shard_name)
+                pool_manager.set_pool_config(role, shard_name, pool_config)
+              else
+                removed_pool_configs << pool_config
+              end
             end
           end
         end
 
         @saved_pool_configs.clear
+
+        remaining_pool_configs = pool_managers.values.flat_map(&:pool_configs)
+        removed_pool_configs.compact.uniq.each do |pool_config|
+          pool_config.disconnect! unless remaining_pool_configs.include?(pool_config)
+        end
       end
 
       def load_fixtures(config)

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -336,6 +336,28 @@ module ActiveRecord
         assert_equal :reading, ActiveRecord.reading_role
       end
 
+      def test_clean_up_connection_handler_disconnects_pools
+        handler = ActiveRecord::Base.connection_handler
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        pool_manager = handler.instance_variable_get(:@connection_name_to_pool_manager)["ActiveRecord::Base"]
+
+        leaked_pools = []
+        assert_nothing_raised do # "too many clients"
+          25.times do
+            pool_config = ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :reading, :default)
+            pool_manager.set_pool_config(:reading, :default, pool_config)
+
+            pool = pool_config.pool
+            connections = 5.times.map { pool.checkout }
+            connections.each { |c| c.execute("SELECT 1") }
+            connections.each { |c| pool.checkin(c) }
+            leaked_pools << pool
+
+            clean_up_connection_handler
+          end
+        end
+      end
+
       if Process.respond_to?(:fork)
         def test_connection_pool_per_pid
           object_id = ActiveRecord::Base.lease_connection.object_id

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -292,14 +292,22 @@ module ActiveRecord
 
     def clean_up_connection_handler
       handler = ActiveRecord::Base.connection_handler
-      handler.instance_variable_get(:@connection_name_to_pool_manager).each do |owner, pool_manager|
+      pool_managers = handler.instance_variable_get(:@connection_name_to_pool_manager)
+      removed_pool_configs = []
+
+      pool_managers.each do |owner, pool_manager|
         pool_manager.role_names.each do |role_name|
           next if role_name == ActiveRecord::Base.default_role &&
                   # TODO: Remove this helper when `remove_connection` for different shards is fixed.
                   # See https://github.com/rails/rails/pull/49382.
                   ["ActiveRecord::Base", "ARUnit2Model", "Contact", "ContactSti"].include?(owner)
-          pool_manager.remove_role(role_name)
+          removed_pool_configs.concat(pool_manager.remove_role(role_name)&.values || [])
         end
+      end
+
+      remaining_pool_configs = pool_managers.values.flat_map(&:pool_configs)
+      removed_pool_configs.compact.uniq.each do |pool_config|
+        pool_config.disconnect! unless remaining_pool_configs.include?(pool_config)
       end
     end
 

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -71,6 +71,32 @@ class TestFixturesTest < ActiveRecord::TestCase
       FileUtils.rm_r(tmp_dir)
     end
 
+    def test_teardown_shared_connection_pool_disconnects_pool_configs_for_removed_roles
+      handler = ActiveRecord::Base.connection_handler
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      pool_manager = handler.instance_variable_get(:@connection_name_to_pool_manager)["ActiveRecord::Base"]
+      writing_pool_config = pool_manager.get_pool_config(:writing, :default)
+      reading_pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :reading, :default)
+      pool_manager.set_pool_config(:reading, :default, reading_pool_config)
+
+      reading_pool = reading_pool_config.pool
+      connection = reading_pool.checkout
+      connection.execute("SELECT 1")
+      reading_pool.checkin(connection)
+
+      setup_shared_connection_pool
+      assert_same writing_pool_config, pool_manager.get_pool_config(:reading, :default)
+
+      clean_up_connection_handler
+      teardown_shared_connection_pool
+
+      assert_predicate writing_pool_config.pool, :automatic_reconnect
+      assert_not_predicate reading_pool, :connected?
+    ensure
+      teardown_shared_connection_pool if defined?(@saved_pool_configs) && @saved_pool_configs.any?
+      clean_up_connection_handler
+    end
+
     def test_transactional_tests_per_db_explicitly_disabled
       tmp_dir = Dir.mktmpdir
       File.write(File.join(tmp_dir, "zines.yml"), <<~YML)


### PR DESCRIPTION
I'm hoping this will fix the recurring CI issue: 
https://buildkite.com/rails/rails/builds/127286#019d35fd-3ed3-488f-befa-f5dacb4ddf03/L1513

`ActiveRecord::ConnectionNotEstablished: connection to server at "172.16.0.4", port 5432 failed: FATAL:  sorry, too many clients already`