### PR TITLE
PostgreSQL Query Pipelining

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -521,7 +521,16 @@ module ActiveRecord
               @connections.each do |conn|
                 if conn.in_use?
                   conn.steal!
-                  checkin conn
+                  begin
+                    checkin conn
+                  rescue
+                    # Checkin may fail if the connection is dead (e.g.
+                    # broken socket with active pipeline mode). That's
+                    # fine during disconnect - we're tearing down the
+                    # pool. What matters is that disconnect! below gets
+                    # called so the raw connection is properly closed
+                    # and its file descriptor freed.
+                  end
                 end
                 conn.disconnect!
               end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -453,16 +453,34 @@ module ActiveRecord
 
         if lease.connection
           begin
+            lease.connection.increment_with_connection_depth
             yield lease.connection
           ensure
+            conn = lease.connection
+            conn&.decrement_with_connection_depth
             lease.sticky = sticky_was if prevent_permanent_checkout && !sticky_was
+            if conn&.with_connection_depth == 0 &&
+               conn&.deferred_pool_release &&
+               !conn&.pipeline_pending?
+              conn.deferred_pool_release = false
+              release_connection(lease) unless lease.sticky
+            end
           end
         else
           begin
-            yield lease.connection = checkout
+            conn = lease.connection = checkout
+            conn.increment_with_connection_depth
+            yield conn
           ensure
+            conn = lease.connection
+            conn&.decrement_with_connection_depth
             lease.sticky = sticky_was if prevent_permanent_checkout && !sticky_was
-            release_connection(lease) unless lease.sticky
+            if conn&.pipeline_pending?
+              conn.deferred_pool_release = true
+            else
+              conn&.deferred_pool_release = false
+              release_connection(lease) unless lease.sticky
+            end
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -616,7 +616,7 @@ module ActiveRecord
 
         log(intent) do |notification_payload|
           intent.notification_payload = notification_payload
-          with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false) do |conn|
+          with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false, pipeline_mode: false) do |conn|
             should_dirty = intent.materialize_transactions
             result = perform_query(conn, intent)
             intent.raw_result = result

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -603,7 +603,11 @@ module ActiveRecord
 
       # Lowest-level abstract execution of a query, called only from the intent itself.
       # Final wrapper around the subclass-specific +perform_query+. Populates the calling
-      # intent's raw_result.
+      # intent's raw_result via deliver_result/deliver_failure.
+      #
+      # Uses intent-driven retry: the intent tracks retry state and handles
+      # retries internally via deliver_failure, enabling coordinated retry
+      # of multiple intents (for pipeline mode).
       def execute_intent(intent) # :nodoc:
         should_dirty = false
 
@@ -614,14 +618,22 @@ module ActiveRecord
           materialize_transactions
         end
 
-        log(intent) do |notification_payload|
-          intent.notification_payload = notification_payload
-          with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false, pipeline_mode: false) do |conn|
-            should_dirty = intent.materialize_transactions
-            result = perform_query(conn, intent)
-            intent.raw_result = result
-            handle_warnings(result, intent.processed_sql)
-          end
+        start_intent_log(intent)
+        @lock.synchronize do
+          reconnectable = ensure_connection_ready(
+            allow_retry: intent.allow_retry,
+            materialize_transactions: false
+          )
+
+          should_dirty = intent.materialize_transactions
+
+          intent.initialize_retry_state(
+            retries: intent.allow_retry ? connection_retries : 0,
+            deadline: retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline,
+            reconnectable: reconnectable
+          )
+
+          perform_sync_attempt(intent)
         end
       ensure
         dirty_current_transaction if should_dirty
@@ -644,6 +656,63 @@ module ActiveRecord
           intent.execute!
           intent.finish
         end
+      end
+
+      # Perform one synchronous query attempt, delivering result or failure to intent
+      def perform_sync_attempt(intent) # :nodoc:
+        result =
+          begin
+            exit_pipeline_mode if pipeline_active?
+            perform_query(@raw_connection, intent)
+          rescue => e
+            # Use raise/rescue to establish cause chain for deferred raising
+            translated = translate_exception_with_cause(e, intent.processed_sql, intent.binds)
+            invalidate_transaction(translated)
+            intent.deliver_failure(translated)
+            return
+          end
+
+        intent.deliver_result(result)
+      end
+
+      # Start logging for an intent. Creates a notification handle and starts timing.
+      # The handle is stored on the intent for later finishing.
+      def start_intent_log(intent) # :nodoc:
+        payload = {
+          sql:               intent.processed_sql,
+          name:              intent.name,
+          binds:             intent.binds,
+          type_casted_binds: intent.type_casted_binds,
+          async:             intent.ran_async,
+          allow_retry:       intent.allow_retry,
+          connection:        self,
+          transaction:       current_transaction.user_transaction.presence,
+          affected_rows:     0,
+          row_count:         0,
+        }
+        intent.notification_payload = payload
+
+        # Use EventBuffer's deferred handle for async, real instrumenter handle for sync.
+        # Both provide the same interface but differ in when subscribers are notified.
+        instr = intent.event_buffer || instrumenter
+        handle = instr.build_handle("sql.active_record", payload)
+        handle.start
+        intent.log_handle = handle
+      end
+
+      # Finish logging for an intent. Stops timing and publishes the notification.
+      # Called when the intent reaches a final outcome (success or permanent failure).
+      def finish_intent_log(intent, exception: nil) # :nodoc:
+        handle = intent.log_handle
+        return unless handle
+
+        if exception
+          payload = intent.notification_payload
+          payload[:exception] = [exception.class.name, exception.message]
+          payload[:exception_object] = exception
+        end
+
+        handle.finish
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -700,6 +700,7 @@ module ActiveRecord
         handle = instr.build_handle("sql.active_record", payload)
         handle.start
         intent.log_handle = handle
+        @unfinalized_intents << intent
       end
 
       # Finish logging for an intent. Stops timing and publishes the notification.
@@ -715,6 +716,27 @@ module ActiveRecord
         end
 
         handle.finish
+      end
+
+      # Close out any intent logs that were started but never finalized.
+      # This handles intents that never reached ensure_result - e.g.
+      # because an earlier intent raised and unwound the stack past them.
+      def finalize_remaining_intents # :nodoc:
+        intents = @unfinalized_intents
+        @unfinalized_intents = []
+
+        intents.each do |intent|
+          next if intent.finalized?
+
+          exception = intent.error
+          if exception.nil? && intent.not_run_reason
+            exception = ActiveRecord::QueryNotRun.new(
+              "Query was not run due to pipeline failure (#{intent.not_run_reason})"
+            )
+          end
+
+          finish_intent_log(intent, exception: exception)
+        end
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -68,7 +68,7 @@ module ActiveRecord
       end
 
       # Returns an ActiveRecord::Result instance.
-      def select_all(arel, name = nil, binds = [], preparable: nil, async: false, allow_retry: false)
+      def select_all(arel, name = nil, binds = [], preparable: nil, async: false, allow_retry: false, pipeline: false)
         arel = arel_from_relation(arel)
         intent = QueryIntent.new(
           adapter: self,
@@ -77,12 +77,13 @@ module ActiveRecord
           binds: binds,
           prepare: preparable,
           allow_async: async,
+          prefer_pipeline: pipeline,
           allow_retry: allow_retry
         )
 
         intent.execute!
 
-        if async
+        if async || pipeline
           intent.future_result
         else
           intent.cast_result
@@ -91,13 +92,13 @@ module ActiveRecord
 
       # Returns a record hash with the column names as keys and column values
       # as values.
-      def select_one(arel, name = nil, binds = [], async: false)
-        select_all(arel, name, binds, async: async).then(&:first)
+      def select_one(arel, name = nil, binds = [], async: false, pipeline: false)
+        select_all(arel, name, binds, async: async, pipeline: pipeline).then(&:first)
       end
 
       # Returns a single value from a record
-      def select_value(arel, name = nil, binds = [], async: false)
-        select_rows(arel, name, binds, async: async).then { |rows| single_value_from_rows(rows) }
+      def select_value(arel, name = nil, binds = [], async: false, pipeline: false)
+        select_rows(arel, name, binds, async: async, pipeline: pipeline).then { |rows| single_value_from_rows(rows) }
       end
 
       # Returns an array of the values of the first column in a select:
@@ -108,8 +109,8 @@ module ActiveRecord
 
       # Returns an array of arrays containing the field values.
       # Order is the same as that returned by +columns+.
-      def select_rows(arel, name = nil, binds = [], async: false)
-        select_all(arel, name, binds, async: async).then(&:rows)
+      def select_rows(arel, name = nil, binds = [], async: false, pipeline: false)
+        select_all(arel, name, binds, async: async, pipeline: pipeline).then(&:rows)
       end
 
       def query_value(...) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -678,6 +678,8 @@ module ActiveRecord
       # Start logging for an intent. Creates a notification handle and starts timing.
       # The handle is stored on the intent for later finishing.
       def start_intent_log(intent) # :nodoc:
+        return if intent.log_handle
+
         payload = {
           sql:               intent.processed_sql,
           name:              intent.name,

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -260,7 +260,7 @@ module ActiveRecord
         pool.clear_query_cache
       end
 
-      def select_all(arel, name = nil, binds = [], preparable: nil, async: false, allow_retry: false) # :nodoc:
+      def select_all(arel, name = nil, binds = [], preparable: nil, async: false, allow_retry: false, pipeline: false) # :nodoc:
         arel = arel_from_relation(arel)
 
         # If arel is locked this is a SELECT ... FOR UPDATE or somesuch.
@@ -268,8 +268,8 @@ module ActiveRecord
         if query_cache_enabled && !(arel.respond_to?(:locked) && arel.locked)
           sql, binds, preparable, allow_retry = to_sql_and_binds(arel, binds, preparable, allow_retry)
 
-          if async
-            result = lookup_sql_cache(sql, name, binds) || super(sql, name, binds, preparable: preparable, async: async, allow_retry: allow_retry)
+          if async || pipeline
+            result = lookup_sql_cache(sql, name, binds) || super(sql, name, binds, preparable: preparable, async: async, allow_retry: allow_retry, pipeline: pipeline)
             FutureResult.wrap(result)
           else
             cache_sql(sql, name, binds) { super(sql, name, binds, preparable: preparable, async: async, allow_retry: allow_retry) }

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -193,6 +193,7 @@ module ActiveRecord
         @raw_connection_dirty = false
         @last_activity = nil
         @verified = false
+        @needs_reconnect = false
         @pipelining_locked = false
 
         @pool_jitter = rand * max_jitter
@@ -739,6 +740,7 @@ module ActiveRecord
             @allow_preconnect = false
 
             reconnect
+            @needs_reconnect = false
 
             enable_lazy_transactions!
             @raw_connection_dirty = false
@@ -778,6 +780,7 @@ module ActiveRecord
           @connected_since = nil
           @last_activity = nil
           @verified = false
+          @needs_reconnect = false
         end
       end
 
@@ -841,12 +844,13 @@ module ActiveRecord
       # This is done under the hood by calling #active?. If the connection
       # is no longer active, then this method will reconnect to the database.
       def verify!
-        unless active?
+        if @needs_reconnect || !active?
           @lock.synchronize do
             if @unconfigured_connection
               attempt_configure_connection do
                 @raw_connection = @unconfigured_connection
                 @unconfigured_connection = nil
+                @needs_reconnect = false
                 configure_connection
                 @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
                 @verified = true
@@ -878,6 +882,10 @@ module ActiveRecord
 
       def verified? # :nodoc:
         @verified
+      end
+
+      def needs_reconnect? # :nodoc:
+        @needs_reconnect
       end
 
       # Provides access to the underlying database driver for this adapter. For
@@ -1196,6 +1204,7 @@ module ActiveRecord
           unless retryable_query_error?(exception)
             @last_activity = nil
             @verified = false
+            @needs_reconnect = true
           end
         end
 
@@ -1209,7 +1218,11 @@ module ActiveRecord
             # Recently used, assume still good
             true
           elsif reconnectable
-            if allow_retry
+            if @needs_reconnect
+              # Connection has been flagged for replacement; must verify
+              # before use even though we could retry on failure
+              false
+            elsif allow_retry
               # Not sure about connection, but can retry if it fails
               true
             else

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1122,6 +1122,7 @@ module ActiveRecord
                   retry
                 when :retry_after_reconnect
                   retries_available -= 1
+                  abandon_pipelined_intents(translated_exception)
                   reconnect!(restore_transactions: true)
                   # Only allowed to reconnect once, because reconnect! has its own retry loop
                   reconnectable = false
@@ -1229,6 +1230,10 @@ module ActiveRecord
 
         def reconnect
           raise NotImplementedError.new("#{self.class} should define `reconnect` to implement adapter-specific logic for reconnecting to the database")
+        end
+
+        def abandon_pipelined_intents(connection_error = nil, allow_recovery: false)
+          # Override in adapters that support pipelining
         end
 
         # Returns a raw connection for internal use with methods that are known

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1147,7 +1147,7 @@ module ActiveRecord
                 end
               end
 
-              mark_connection_unhealthy_unless_query_error(translated_exception)
+              downgrade_connection_after_error(translated_exception)
 
               raise translated_exception
             ensure
@@ -1198,13 +1198,19 @@ module ActiveRecord
           end
         end
 
-        # Mark the connection as potentially broken after a non-retryable query error.
-        # This is shared logic used by both with_raw_connection and intent-driven execution.
-        def mark_connection_unhealthy_unless_query_error(exception)
+        # Flag the connection as potentially unhealthy after an error.
+        # Retryable query errors (deadlocks etc.) are expected and don't
+        # affect connection health. Other errors clear @verified to force
+        # an active? check on next use. Connection errors additionally
+        # set @needs_reconnect to force a full reconnect.
+        def downgrade_connection_after_error(exception)
           unless retryable_query_error?(exception)
             @last_activity = nil
             @verified = false
-            @needs_reconnect = true
+
+            if retryable_connection_error?(exception)
+              @needs_reconnect = true
+            end
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -193,6 +193,7 @@ module ActiveRecord
         @raw_connection_dirty = false
         @last_activity = nil
         @verified = false
+        @pipelining_locked = false
 
         @pool_jitter = rand * max_jitter
       end
@@ -1062,6 +1063,10 @@ module ActiveRecord
         #
         def with_raw_connection(allow_retry: false, materialize_transactions: true, pipeline_mode: nil)
           @lock.synchronize do
+            # Save pipeline state before any nested queries (connect!, materialize_transactions,
+            # verify! can all run nested queries that might change pipeline mode)
+            was_in_pipeline = pipeline_active?
+
             connect! if !connected? && reconnect_can_restore_state?
 
             self.materialize_transactions if materialize_transactions
@@ -1092,14 +1097,25 @@ module ActiveRecord
             end
 
             begin
-              # Handle pipeline mode transitions
+              # Handle pipeline mode: explicit request, or restore original state
               if pipeline_mode == true
                 enter_pipeline_mode
               elsif pipeline_mode == false
                 exit_pipeline_mode
+              elsif !was_in_pipeline && pipeline_active?
+                # Nested queries entered pipeline mode - exit to restore state
+                exit_pipeline_mode
               end
 
-              yield @raw_connection
+              # Lock pipelining while yielding to prevent nested queries from changing mode
+              was_pipelining_locked = @pipelining_locked
+              @pipelining_locked = true
+
+              begin
+                yield @raw_connection
+              ensure
+                @pipelining_locked = was_pipelining_locked
+              end
             rescue => original_exception
               translated_exception = translate_exception_class(original_exception, nil, nil)
               invalidate_transaction(translated_exception)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -876,7 +876,7 @@ module ActiveRecord
       # this client. If that is the case, generally you'll want to invalidate
       # the query cache using +ActiveRecord::Base.clear_query_cache+.
       def raw_connection
-        with_raw_connection do |conn|
+        with_raw_connection(pipeline_mode: false) do |conn|
           disable_lazy_transactions!
           @raw_connection_dirty = true
           conn
@@ -1060,7 +1060,7 @@ module ActiveRecord
         # still-yielded connection in the outer block), but we currently
         # provide no special enforcement there.
         #
-        def with_raw_connection(allow_retry: false, materialize_transactions: true)
+        def with_raw_connection(allow_retry: false, materialize_transactions: true, pipeline_mode: nil)
           @lock.synchronize do
             connect! if !connected? && reconnect_can_restore_state?
 
@@ -1092,6 +1092,13 @@ module ActiveRecord
             end
 
             begin
+              # Handle pipeline mode transitions
+              if pipeline_mode == true
+                enter_pipeline_mode
+              elsif pipeline_mode == false
+                exit_pipeline_mode
+              end
+
               yield @raw_connection
             rescue => original_exception
               translated_exception = translate_exception_class(original_exception, nil, nil)
@@ -1157,6 +1164,20 @@ module ActiveRecord
 
         def backoff(counter)
           sleep 0.1 * counter
+        end
+
+        # Pipeline mode stubs - overridden by adapters that support pipelining
+        def pipeline_active?
+          false
+        end
+
+        def enter_pipeline_mode
+        end
+
+        def exit_pipeline_mode
+        end
+
+        def flush_pipeline
         end
 
         def reconnect

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -196,6 +196,8 @@ module ActiveRecord
         @needs_reconnect = false
         @pipelining_locked = false
         @unfinalized_intents = []
+        @with_connection_depth = 0
+        @deferred_pool_release = false
 
         @pool_jitter = rand * max_jitter
       end
@@ -335,6 +337,18 @@ module ActiveRecord
         duration * (1.0 - @pool_jitter)
       end
 
+      attr_accessor :deferred_pool_release # :nodoc:
+
+      def increment_with_connection_depth # :nodoc:
+        @with_connection_depth += 1
+      end
+
+      def decrement_with_connection_depth # :nodoc:
+        @with_connection_depth -= 1
+      end
+
+      attr_reader :with_connection_depth # :nodoc:
+
       # this method must only be called while holding connection pool's mutex
       def expire(update_idle = true) # :nodoc:
         if in_use?
@@ -343,6 +357,8 @@ module ActiveRecord
               "it is owned by a different thread: #{@owner}. " \
               "Current thread: #{ActiveSupport::IsolatedExecutionState.context}."
           end
+
+          @deferred_pool_release = false
 
           _run_checkin_callbacks do
             @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC) if update_idle
@@ -453,6 +469,10 @@ module ActiveRecord
       end
 
       def pipeline_active?
+        false
+      end
+
+      def pipeline_pending?
         false
       end
 
@@ -926,6 +946,14 @@ module ActiveRecord
         true
       end
       private :can_perform_case_insensitive_comparison_for?
+
+      def maybe_deferred_release # :nodoc:
+        return unless @deferred_pool_release
+        return if pipeline_pending?
+        return if @with_connection_depth > 0
+        @deferred_pool_release = false
+        pool.checkin(self)
+      end
 
       # Check the connection back in to the connection pool
       def close

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1088,6 +1088,7 @@ module ActiveRecord
 
             retries_available = allow_retry ? connection_retries : 0
             deadline = retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline
+            replay_intents = nil
 
             begin
               # Handle pipeline mode: explicit request, or restore original state
@@ -1098,6 +1099,12 @@ module ActiveRecord
               elsif !was_in_pipeline && pipeline_active?
                 # Nested queries entered pipeline mode - exit to restore state
                 exit_pipeline_mode
+              end
+
+              # Re-queue any intents saved for replay from a previous attempt
+              if replay_intents
+                replay_intents.each { |intent| pipeline_add_query(intent) }
+                replay_intents = nil
               end
 
               # Lock pipelining while yielding to prevent nested queries from changing mode
@@ -1122,7 +1129,9 @@ module ActiveRecord
                   retry
                 when :retry_after_reconnect
                   retries_available -= 1
-                  abandon_pipelined_intents(translated_exception)
+                  replay_intents = pipeline_mode &&
+                    abandon_pipelined_intents(translated_exception, allow_recovery: true)
+                  abandon_pipelined_intents(translated_exception) unless replay_intents
                   reconnect!(restore_transactions: true)
                   # Only allowed to reconnect once, because reconnect! has its own retry loop
                   reconnectable = false

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1081,34 +1081,13 @@ module ActiveRecord
             # verify! can all run nested queries that might change pipeline mode)
             was_in_pipeline = pipeline_active?
 
-            connect! if !connected? && reconnect_can_restore_state?
-
-            self.materialize_transactions if materialize_transactions
+            reconnectable = ensure_connection_ready(
+              allow_retry: allow_retry,
+              materialize_transactions: materialize_transactions
+            )
 
             retries_available = allow_retry ? connection_retries : 0
             deadline = retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline
-            reconnectable = reconnect_can_restore_state?
-
-            if @verified
-              # Cool, we're confident the connection's ready to use. (Note this might have
-              # become true during the above #materialize_transactions.)
-            elsif (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
-              # We haven't actually verified the connection since we acquired it, but it
-              # has been used very recently. We're going to assume it's still okay.
-            elsif reconnectable
-              if allow_retry
-                # Not sure about the connection yet, but if anything goes wrong we can
-                # just reconnect and re-run our query
-              else
-                # We can reconnect if needed, but we don't trust the upcoming query to be
-                # safely re-runnable: let's verify the connection to be sure
-                verify!
-              end
-            else
-              # We don't know whether the connection is okay, but it also doesn't matter:
-              # we wouldn't be able to reconnect anyway. We're just going to run our query
-              # and hope for the best.
-            end
 
             begin
               # Handle pipeline mode: explicit request, or restore original state
@@ -1136,27 +1115,21 @@ module ActiveRecord
               retry_deadline_exceeded = deadline && deadline < Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
               if !retry_deadline_exceeded && retries_available > 0
-                retries_available -= 1
-
-                if retryable_query_error?(translated_exception)
+                case classify_retry_action(translated_exception, reconnectable: reconnectable)
+                when :retry_query
+                  retries_available -= 1
                   backoff(connection_retries - retries_available)
                   retry
-                elsif reconnectable && retryable_connection_error?(translated_exception)
+                when :retry_after_reconnect
+                  retries_available -= 1
                   reconnect!(restore_transactions: true)
-                  # Only allowed to reconnect once, because reconnect! has its own retry
-                  # loop
+                  # Only allowed to reconnect once, because reconnect! has its own retry loop
                   reconnectable = false
                   retry
                 end
               end
 
-              unless retryable_query_error?(translated_exception)
-                # Barring a known-retryable error inside the query (regardless of
-                # whether we were in a _position_ to retry it), we should infer that
-                # there's likely a real problem with the connection.
-                @last_activity = nil
-                @verified = false
-              end
+              mark_connection_unhealthy_unless_query_error(translated_exception)
 
               raise translated_exception
             ensure
@@ -1194,6 +1167,64 @@ module ActiveRecord
 
         def backoff(counter)
           sleep 0.1 * counter
+        end
+
+        # Classify an exception to determine what retry action to take.
+        # Returns :retry_query, :retry_after_reconnect, or nil (don't retry).
+        # This is shared logic used by both with_raw_connection and intent-driven execution.
+        def classify_retry_action(exception, reconnectable:)
+          if retryable_query_error?(exception)
+            :retry_query
+          elsif reconnectable && retryable_connection_error?(exception)
+            :retry_after_reconnect
+          end
+        end
+
+        # Mark the connection as potentially broken after a non-retryable query error.
+        # This is shared logic used by both with_raw_connection and intent-driven execution.
+        def mark_connection_unhealthy_unless_query_error(exception)
+          unless retryable_query_error?(exception)
+            @last_activity = nil
+            @verified = false
+          end
+        end
+
+        # Decide whether to verify the connection before executing a query.
+        # Returns true if verification should be skipped (connection is trusted).
+        def skip_verification?(allow_retry:, reconnectable:)
+          if @verified && connected?
+            # Connection is verified, ready to use
+            true
+          elsif (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
+            # Recently used, assume still good
+            true
+          elsif reconnectable
+            if allow_retry
+              # Not sure about connection, but can retry if it fails
+              true
+            else
+              # Can't retry, need to verify first
+              false
+            end
+          else
+            # Can't reconnect anyway, just try and hope
+            true
+          end
+        end
+
+        # Ensure the connection is ready to execute a query.
+        # Handles connect, materialize_transactions, and verify as needed.
+        # Returns whether reconnection is possible (for retry decisions).
+        def ensure_connection_ready(allow_retry:, materialize_transactions:)
+          connect! if !connected? && reconnect_can_restore_state?
+          self.materialize_transactions if materialize_transactions
+
+          reconnectable = reconnect_can_restore_state?
+          unless skip_verification?(allow_retry: allow_retry, reconnectable: reconnectable)
+            verify!
+          end
+
+          reconnectable
         end
 
         def reconnect
@@ -1246,6 +1277,16 @@ module ActiveRecord
           )
           active_record_error.set_backtrace(native_error.backtrace)
           active_record_error
+        end
+
+        # Translate an exception and establish the cause chain by raising/rescuing.
+        # Use this when you need to store an exception for later re-raising
+        # (e.g., for deferred pipeline errors) while preserving the cause.
+        def translate_exception_with_cause(native_error, sql, binds)
+          translated = translate_exception_class(native_error, sql, binds)
+          raise translated
+        rescue => e
+          e
         end
 
         def log(intent_or_sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -195,6 +195,7 @@ module ActiveRecord
         @verified = false
         @needs_reconnect = false
         @pipelining_locked = false
+        @unfinalized_intents = []
 
         @pool_jitter = rand * max_jitter
       end
@@ -348,6 +349,7 @@ module ActiveRecord
             @owner = nil
             enable_lazy_transactions!
             unset_query_cache!
+            finalize_remaining_intents
           end
         else
           raise ActiveRecordError, "Cannot expire connection, it is not currently leased."

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1181,7 +1181,9 @@ module ActiveRecord
 
               raise translated_exception
             ensure
-              dirty_current_transaction if materialize_transactions
+              # Pipeline enqueue only queues intent(s); transaction dirtiness should
+              # be decided when intents are actually resolved.
+              dirty_current_transaction if materialize_transactions && pipeline_mode != true
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -449,6 +449,20 @@ module ActiveRecord
         false
       end
 
+      def pipeline_active?
+        false
+      end
+
+      def enter_pipeline_mode
+        raise NotImplementedError
+      end
+
+      def exit_pipeline_mode
+      end
+
+      def flush_pipeline
+      end
+
       # Should primary key values be selected from their corresponding
       # sequence before the insert statement? If true, next_sequence_value
       # is called before each insert to set the record's primary key.
@@ -1180,20 +1194,6 @@ module ActiveRecord
 
         def backoff(counter)
           sleep 0.1 * counter
-        end
-
-        # Pipeline mode stubs - overridden by adapters that support pipelining
-        def pipeline_active?
-          false
-        end
-
-        def enter_pipeline_mode
-        end
-
-        def exit_pipeline_mode
-        end
-
-        def flush_pipeline
         end
 
         def reconnect

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -193,7 +193,7 @@ module ActiveRecord
 
             # Otherwise, don't pipeline by default
             # Future: add logic for starting pipeline mode based on transaction state
-            false
+            ENV["AR_POSTGRESQL_PIPELINE"] == "1"
           end
 
           def cancel_any_running_query

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -178,6 +178,16 @@ module ActiveRecord
             # Note: must check after has_binds?/processed_sql to ensure compile_arel! has run
             return false if intent.prepare
 
+            # Don't pipeline multi-statement SQL without binds
+            # send_query_params uses prepared statements which don't support multiple commands
+            # With binds, it's safe because the query likely doesn't have semicolons
+            if !intent.has_binds? && intent.processed_sql.include?(";")
+              return false
+            end
+
+            # If pipelining is locked, maintain current state (don't change mode)
+            return pipeline_active? if @pipelining_locked
+
             # Pipeline if already active (add to existing batch)
             return true if pipeline_active?
 
@@ -202,6 +212,10 @@ module ActiveRecord
           end
 
           def perform_query(raw_connection, intent)
+            if pipeline_active?
+              raise "BUG: perform_query called while in pipeline mode (sql: #{intent.processed_sql.inspect})"
+            end
+
             raw_connection.discard_results
 
             if intent.prepare

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -174,16 +174,17 @@ module ActiveRecord
             # Don't pipeline batch queries
             return false if intent.batch
 
-            # Don't pipeline prepared statements (they need different handling)
-            # Note: must check after has_binds?/processed_sql to ensure compile_arel! has run
-            return false if intent.prepare
-
             # Don't pipeline multi-statement SQL without binds
             # send_query_params uses prepared statements which don't support multiple commands
             # With binds, it's safe because the query likely doesn't have semicolons
+            # Note: has_binds? triggers compile_arel! which determines intent.prepare
             if !intent.has_binds? && intent.processed_sql.include?(";")
               return false
             end
+
+            # Don't pipeline prepared statements (they need different handling)
+            # Must check AFTER has_binds?/processed_sql to ensure compile_arel! has run
+            return false if intent.prepare
 
             # If pipelining is locked, maintain current state (don't change mode)
             return pipeline_active? if @pipelining_locked

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -164,11 +164,15 @@ module ActiveRecord
           end
 
           def perform_query(raw_connection, intent)
-            result = if intent.prepare
+            raw_connection.discard_results
+
+            if intent.prepare
               begin
                 stmt_key = prepare_statement(intent.processed_sql, intent.binds, raw_connection)
                 intent.notification_payload[:statement_name] = stmt_key
-                raw_connection.exec_prepared(stmt_key, intent.type_casted_binds)
+                raw_connection.send_query_prepared(stmt_key, intent.type_casted_binds)
+                result = get_result(raw_connection)
+                result&.check
               rescue PG::FeatureNotSupported => error
                 if is_cached_plan_failure?(error)
                   # Nothing we can do if we are in a transaction because all commands
@@ -186,10 +190,15 @@ module ActiveRecord
 
                 raise
               end
-            elsif intent.has_binds?
-              raw_connection.exec_params(intent.processed_sql, intent.type_casted_binds)
             else
-              raw_connection.async_exec(intent.processed_sql)
+              if intent.has_binds?
+                raw_connection.send_query_params(intent.processed_sql, intent.type_casted_binds)
+              else
+                raw_connection.send_query(intent.processed_sql)
+              end
+
+              result = get_result(raw_connection)
+              result&.check
             end
 
             verified!
@@ -267,6 +276,20 @@ module ActiveRecord
 
           def warning_ignored?(warning)
             ["WARNING", "ERROR", "FATAL", "PANIC"].exclude?(warning.level) || super
+          end
+
+          def get_result(raw_connection)
+            result = nil
+            while incoming = raw_connection.get_result
+              result&.clear
+              result = incoming
+
+              if result.result_status == PG::PGRES_FATAL_ERROR
+                severity = result.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED)
+                result.check if severity == "FATAL"
+              end
+            end
+            result
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -333,6 +333,12 @@ module ActiveRecord
           def get_result(raw_connection)
             result = nil
             while incoming = raw_connection.get_result
+              if block_given?
+                action = yield incoming
+                next if action == :skip
+                break if action == :break
+              end
+
               result&.clear
               result = incoming
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -144,9 +144,47 @@ module ActiveRecord
           intent.finish
         end
 
+        def execute_intent(intent) # :nodoc:
+          # Lock in bind values before routing decision; this also ensures
+          # timezone is current before we commit to running the query
+          intent.type_casted_binds
+
+          if should_pipeline?(intent)
+            with_raw_connection(allow_retry: false, materialize_transactions: intent.materialize_transactions, pipeline_mode: true) do |_conn|
+              pipeline_add_query(intent)
+            end
+
+            # No immediate result - will be populated when pipeline flushes
+            nil
+          else
+            # Normal immediate execution (exits pipeline mode if active)
+            super
+          end
+        end
+
         private
           IDLE_TRANSACTION_STATUSES = [PG::PQTRANS_IDLE, PG::PQTRANS_INTRANS, PG::PQTRANS_INERROR]
           private_constant :IDLE_TRANSACTION_STATUSES
+
+          # Decide whether this query should be pipelined
+          def should_pipeline?(intent)
+            # Don't pipeline if connection is dirty (userspace has raw connection)
+            return false if @raw_connection_dirty
+
+            # Don't pipeline batch queries
+            return false if intent.batch
+
+            # Don't pipeline prepared statements (they need different handling)
+            # Note: must check after has_binds?/processed_sql to ensure compile_arel! has run
+            return false if intent.prepare
+
+            # Pipeline if already active (add to existing batch)
+            return true if pipeline_active?
+
+            # Otherwise, don't pipeline by default
+            # Future: add logic for starting pipeline mode based on transaction state
+            false
+          end
 
           def cancel_any_running_query
             return if @raw_connection.nil? || IDLE_TRANSACTION_STATUSES.include?(@raw_connection.transaction_status)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -208,8 +208,9 @@ module ActiveRecord
             # Pipeline if already active (add to existing batch)
             return true if pipeline_active?
 
-            # Pipeline if explicitly requested by the caller
-            return true if intent.prefer_pipeline
+            # Pipeline if explicitly requested, or if the caller wanted
+            # deferred execution (async implies pipeline-eligible)
+            return true if intent.prefer_pipeline || intent.allow_async
 
             # Otherwise, don't pipeline by default
             ENV["AR_POSTGRESQL_PIPELINE"] == "1"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -157,7 +157,7 @@ module ActiveRecord
             end
 
             start_intent_log(intent)
-            with_raw_connection(allow_retry: false, materialize_transactions: false, pipeline_mode: true) do |_conn|
+            with_raw_connection(allow_retry: true, materialize_transactions: false, pipeline_mode: true) do |_conn|
               # Initialize retry state for this pipelined query
               intent.initialize_retry_state(
                 retries: intent.allow_retry ? connection_retries : 0,

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -270,8 +270,10 @@ module ActiveRecord
 
             verified!
 
-            intent.notification_payload[:affected_rows] = result.cmd_tuples
-            intent.notification_payload[:row_count] = result.ntuples
+            if intent.notification_payload
+              intent.notification_payload[:affected_rows] = result.cmd_tuples
+              intent.notification_payload[:row_count] = result.ntuples
+            end
             result
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -150,7 +150,14 @@ module ActiveRecord
           intent.type_casted_binds
 
           if should_pipeline?(intent)
-            with_raw_connection(allow_retry: false, materialize_transactions: intent.materialize_transactions, pipeline_mode: true) do |_conn|
+            if intent.materialize_transactions
+              # Validate before BEGIN - can raise locally (e.g. ReadOnlyError)
+              intent.processed_sql
+              materialize_transactions
+            end
+
+            start_intent_log(intent)
+            with_raw_connection(allow_retry: false, materialize_transactions: false, pipeline_mode: true) do |_conn|
               pipeline_add_query(intent)
             end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -171,6 +171,8 @@ module ActiveRecord
             # No immediate result - will be populated when pipeline flushes
             nil
           else
+            raise ArgumentError, "Cannot pipeline this query" if intent.prefer_pipeline
+
             # Normal immediate execution (exits pipeline mode if active)
             super
           end
@@ -206,8 +208,10 @@ module ActiveRecord
             # Pipeline if already active (add to existing batch)
             return true if pipeline_active?
 
+            # Pipeline if explicitly requested by the caller
+            return true if intent.prefer_pipeline
+
             # Otherwise, don't pipeline by default
-            # Future: add logic for starting pipeline mode based on transaction state
             ENV["AR_POSTGRESQL_PIPELINE"] == "1"
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -158,6 +158,13 @@ module ActiveRecord
 
             start_intent_log(intent)
             with_raw_connection(allow_retry: false, materialize_transactions: false, pipeline_mode: true) do |_conn|
+              # Initialize retry state for this pipelined query
+              intent.initialize_retry_state(
+                retries: intent.allow_retry ? connection_retries : 0,
+                deadline: retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline,
+                reconnectable: reconnect_can_restore_state?
+              )
+
               pipeline_add_query(intent)
             end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -27,7 +27,15 @@ module ActiveRecord
           @lock.synchronize do
             return unless pipeline_active?
 
-            flush_pipeline
+            begin
+              flush_pipeline
+            ensure
+              begin
+                @raw_connection.discard_results
+              rescue PG::Error
+                # Connection dead, can't discard
+              end
+            end
 
             @raw_connection.exit_pipeline_mode
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -126,13 +126,45 @@ module ActiveRecord
         end
 
         # Flush pending queries and collect results.
+        #
+        # Connection errors during sync/drain are handled with transparent
+        # replay when all outstanding intents are eligible, otherwise intents
+        # are abandoned with appropriate terminal states.
         def flush_pipeline
           @lock.synchronize do
             return unless pipeline_active?
             return unless pipeline_pending?
 
-            pipeline_sync
-            consume_pipeline
+            begin
+              pipeline_sync
+              consume_pipeline
+            rescue PG::Error => e
+              translated = translate_exception_class(e, nil, nil)
+
+              # A FATAL error means the server explicitly told us it's
+              # terminating the connection. Everything still in
+              # @pending_intents is definitively not-executed, so all
+              # are safe to replay regardless of allow_retry.
+              server_fatal = e.respond_to?(:result) &&
+                e.result&.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED) == "FATAL"
+
+              replayable = retryable_connection_error?(translated) &&
+                if server_fatal
+                  abandon_pipelined_intents(translated, allow_recovery: true, all_unsynced: true)
+                else
+                  abandon_pipelined_intents(translated, allow_recovery: true)
+                end
+
+              if replayable
+                reconnect!(restore_transactions: true)
+                enter_pipeline_mode
+                replayable.each { |intent| pipeline_add_query(intent) }
+                retry
+              end
+
+              abandon_pipelined_intents(translated)
+              raise translated
+            end
           end
         end
 
@@ -180,18 +212,56 @@ module ActiveRecord
         end
 
         private
-          def abandon_pipelined_intents
+          # Classify and deliver terminal states to all pending intents after
+          # a connection failure, based on sync boundaries.
+          #
+          # When +allow_recovery+ is true and every intent is eligible for
+          # replay (synced intents must have allow_retry; unsynced are always
+          # eligible), returns the intents instead of marking them so the
+          # caller can reconnect and replay. Returns nil otherwise.
+          def abandon_pipelined_intents(connection_error = nil, allow_recovery: false, all_unsynced: false)
             intents = @pending_intents
             @pending_intents = []
 
             return unless intents&.any?
 
-            error = ActiveRecord::ConnectionFailed.new("Connection lost during pipeline execution")
-            intents.each do |intent|
-              next if intent.is_a?(SyncIntent)
-              next if intent.raw_result_available?
-              intent.deliver_failure(error)
+            if all_unsynced
+              # Server sent FATAL - the connection is dying. The first
+              # pending intent (which received the FATAL) may have been
+              # partially executed, so it respects allow_retry like a
+              # synced intent. Everything after it is definitively
+              # not-run.
+              first_real = intents.index { |i| !i.is_a?(SyncIntent) }
+              synced = first_real ? [intents[first_real]] : []
+              unsynced = first_real ? intents[(first_real + 1)..].reject { |i| i.is_a?(SyncIntent) } : []
+            else
+              # Partition intents by sync state: intents before a SyncIntent
+              # were synced (server may have executed), intents after the last
+              # SyncIntent were never synced (definitely not executed).
+              synced = []
+              unsynced = []
+
+              intents.each do |intent|
+                if intent.is_a?(SyncIntent)
+                  synced.concat(unsynced)
+                  unsynced = []
+                else
+                  unsynced << intent
+                end
+              end
             end
+
+            if allow_recovery && synced.all? { |i| i.allow_retry }
+              all = synced + unsynced
+              all.each(&:reset_for_retry)
+              return all
+            end
+
+            error = connection_error || ActiveRecord::ConnectionFailed.new("Connection lost during pipeline execution")
+            synced.each { |intent| intent.deliver_failure(error) }
+            unsynced.each { |intent| intent.deliver_not_run(reason: :unsynced) }
+
+            nil
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -56,8 +56,22 @@ module ActiveRecord
             return unless pipeline_active?
 
             @pending_intents ||= []
-            @pending_intents << SyncIntent.new
 
+            # Probe the connection before recording a sync marker. Flush
+            # sends any buffered query data, then consume_input reads from
+            # the socket - either will raise on a dead connection while we
+            # still know no sync has been sent. (Flush alone isn't enough:
+            # libpq may have eagerly sent query data during send_query_params,
+            # leaving the write buffer empty. consume_input always has
+            # something to check on the read side.)
+            #
+            # If these probes succeed, we record the SyncIntent - the server
+            # may have received the queries. Then pipeline_sync sends the
+            # actual sync message. If *that* fails, the marker stays:
+            # conservatively assuming the sync might have reached the wire.
+            @raw_connection.flush
+            @raw_connection.consume_input
+            @pending_intents << SyncIntent.new
             @raw_connection.pipeline_sync
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -211,6 +211,8 @@ module ActiveRecord
               return
             end
           end
+        ensure
+          maybe_deferred_release
         end
 
         def consume_pipeline

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -171,6 +171,7 @@ module ActiveRecord
                   e.result&.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED) == "FATAL"
 
                 replayable = retryable_connection_error?(translated) &&
+                  reconnect_can_restore_state? &&
                   if server_fatal
                     abandon_pipelined_intents(translated, allow_recovery: true, all_unsynced: true, last_replayed_head: last_replayed_head)
                   else
@@ -198,7 +199,7 @@ module ActiveRecord
               # resolved intents keep their results.
               needs_replay = consumed&.select { |i| i.error || i.not_run_reason }
               if needs_replay&.any? { |i| i.error && retryable_connection_error?(i.error) }
-                if needs_replay.all?(&:allow_retry) && needs_replay.first != last_replayed_head
+                if reconnect_can_restore_state? && needs_replay.all?(&:allow_retry) && needs_replay.first != last_replayed_head
                   last_replayed_head = needs_replay.first
                   needs_replay.each(&:reset_for_retry)
                   reconnect!(restore_transactions: true)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      # Manages PostgreSQL's pipeline mode for batching multiple queries
+      # in a single network round-trip.
+      #
+      # Pipeline mode allows sending multiple queries without waiting for
+      # results, then collecting all results together. This reduces latency
+      # for sequences of queries that don't depend on each other's results.
+      module PipelineContext # :nodoc:
+        def pipeline_active?
+          @lock.synchronize do
+            connected? && @raw_connection.pipeline_status != PG::PQ_PIPELINE_OFF
+          end
+        end
+
+        def enter_pipeline_mode
+          @lock.synchronize do
+            return if pipeline_active?
+            @raw_connection.enter_pipeline_mode
+          end
+        end
+
+        def exit_pipeline_mode
+          @lock.synchronize do
+            return unless pipeline_active?
+
+            flush_pipeline
+
+            @raw_connection.exit_pipeline_mode
+          end
+        end
+
+        # Add a query intent to the pipeline.
+        # The intent's raw_result will be populated when the pipeline is flushed.
+        def pipeline_add_query(intent)
+          @lock.synchronize do
+            @pending_intents ||= []
+
+            # Send the query to the pipeline.
+            # Always use send_query_params in pipeline mode (even with empty binds array).
+            @raw_connection.send_query_params(
+              intent.processed_sql,
+              intent.type_casted_binds || []
+            )
+
+            # Only add to pending list after successful send to avoid misalignment
+            # if send_query_params raises an exception.
+            @pending_intents << intent
+          end
+
+          intent
+        end
+
+        # Flush pending queries and collect results.
+        def flush_pipeline
+          @lock.synchronize do
+            return unless pipeline_active?
+            @pending_intents ||= []
+            return if @pending_intents.empty?
+
+            @raw_connection.pipeline_sync
+
+            while intent = @pending_intents.shift
+              intent.raw_result = consume_next_pipeline_result
+            end
+          end
+        end
+
+        private
+          def consume_next_pipeline_result
+            result = nil
+
+            while true
+              r = @raw_connection.get_result
+              break unless r
+
+              # Skip PGRES_PIPELINE_SYNC markers
+              next if r.result_status == PG::PGRES_PIPELINE_SYNC
+
+              result = r
+            end
+
+            result
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -70,15 +70,34 @@ module ActiveRecord
             begin
               flush_pipeline if connected?
             ensure
-              begin
-                @raw_connection.discard_results if connected?
-              rescue PG::Error
-                # Connection dead, can't discard
+              abandon_pipelined_intents
+
+              if connected?
+                begin
+                  # Drain any unconsumed results (e.g. from replay or
+                  # a failed flush) so we can cleanly exit pipeline mode.
+                  @raw_connection.pipeline_sync
+                  loop do
+                    result = @raw_connection.get_result
+                    break unless result
+                  end
+                rescue PG::Error
+                  # Connection dead, can't discard
+                end
               end
             end
 
             if connected?
-              @raw_connection.exit_pipeline_mode
+              begin
+                @raw_connection.exit_pipeline_mode
+              rescue PG::Error
+                # Pipeline still dirty (e.g. unconsumed results from a
+                # failed flush). Close the connection so it gets
+                # re-established on next use.
+                @raw_connection.close rescue nil
+              end
+            else
+              @raw_connection&.check_socket
             end
           end
         end
@@ -141,6 +160,21 @@ module ActiveRecord
             end
           end
         end
+
+        private
+          def abandon_pipelined_intents
+            intents = @pending_intents
+            @pending_intents = []
+
+            return unless intents&.any?
+
+            error = ActiveRecord::ConnectionFailed.new("Connection lost during pipeline execution")
+            intents.each do |intent|
+              next if intent.is_a?(SyncIntent)
+              next if intent.raw_result_available?
+              intent.deliver_failure(error)
+            end
+          end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -149,35 +149,54 @@ module ActiveRecord
             return unless pipeline_active?
             return unless pipeline_pending?
 
-            begin
-              pipeline_sync
-              consume_pipeline
-            rescue PG::Error => e
-              translated = translate_exception_class(e, nil, nil)
+            loop do
+              begin
+                pipeline_sync
+                consumed = consume_pipeline
+              rescue PG::Error => e
+                translated = translate_exception_class(e, nil, nil)
 
-              # A FATAL error means the server explicitly told us it's
-              # terminating the connection. Everything still in
-              # @pending_intents is definitively not-executed, so all
-              # are safe to replay regardless of allow_retry.
-              server_fatal = e.respond_to?(:result) &&
-                e.result&.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED) == "FATAL"
+                # A FATAL error means the server explicitly told us it's
+                # terminating the connection. Everything still in
+                # @pending_intents is definitively not-executed, so all
+                # are safe to replay regardless of allow_retry.
+                server_fatal = e.respond_to?(:result) &&
+                  e.result&.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED) == "FATAL"
 
-              replayable = retryable_connection_error?(translated) &&
-                if server_fatal
-                  abandon_pipelined_intents(translated, allow_recovery: true, all_unsynced: true)
-                else
-                  abandon_pipelined_intents(translated, allow_recovery: true)
+                replayable = retryable_connection_error?(translated) &&
+                  if server_fatal
+                    abandon_pipelined_intents(translated, allow_recovery: true, all_unsynced: true)
+                  else
+                    abandon_pipelined_intents(translated, allow_recovery: true)
+                  end
+
+                if replayable
+                  reconnect!(restore_transactions: true)
+                  enter_pipeline_mode
+                  replayable.each { |intent| pipeline_add_query(intent) }
+                  next
                 end
 
-              if replayable
-                reconnect!(restore_transactions: true)
-                enter_pipeline_mode
-                replayable.each { |intent| pipeline_add_query(intent) }
-                retry
+                abandon_pipelined_intents(translated)
+                return
               end
 
-              abandon_pipelined_intents(translated)
-              raise translated
+              # Check if consume_pipeline encountered a connection error
+              # in a pipeline result (e.g., AdminShutdown). Only intents
+              # that failed or were not run need replay; successfully
+              # resolved intents keep their results.
+              needs_replay = consumed&.select { |i| i.error || i.not_run_reason }
+              if needs_replay&.any? { |i| i.error && retryable_connection_error?(i.error) }
+                if needs_replay.all?(&:allow_retry)
+                  needs_replay.each(&:reset_for_retry)
+                  reconnect!(restore_transactions: true)
+                  enter_pipeline_mode
+                  needs_replay.each { |intent| pipeline_add_query(intent) }
+                  next
+                end
+              end
+
+              return
             end
           end
         end
@@ -186,6 +205,8 @@ module ActiveRecord
           @lock.synchronize do
             @pending_intents ||= []
             return if @pending_intents.empty?
+
+            consumed = []
 
             while intent = @pending_intents.first
               if intent.is_a?(SyncIntent) && !TRACK_SYNCS
@@ -202,6 +223,7 @@ module ActiveRecord
 
               if raw_result&.result_status == PG::PGRES_PIPELINE_ABORTED
                 intent.deliver_not_run(reason: :server_aborted)
+                consumed << intent
                 next
               end
 
@@ -211,6 +233,7 @@ module ActiveRecord
               rescue => e
                 translated = translate_exception_with_cause(e, intent.processed_sql, intent.binds)
                 intent.deliver_failure(translated)
+                consumed << intent
                 next
               end
 
@@ -221,7 +244,10 @@ module ActiveRecord
               end
 
               intent.deliver_result(raw_result)
+              consumed << intent
             end
+
+            consumed
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -154,9 +154,22 @@ module ActiveRecord
               }
               @pending_intents.shift
 
-              # Assign the result (even if it contains an error). The intent will
-              # raise the error when the result is accessed (via cast_result, etc.)
-              intent.raw_result = raw_result
+              # Check if the result contains an error
+              begin
+                raw_result&.check
+              rescue => e
+                translated = translate_exception_with_cause(e, intent.processed_sql, intent.binds)
+                intent.deliver_failure(translated)
+                next
+              end
+
+              # Update notification payload (like perform_query does for sync path)
+              if intent.notification_payload && raw_result
+                intent.notification_payload[:affected_rows] = raw_result.cmd_tuples
+                intent.notification_payload[:row_count] = raw_result.ntuples
+              end
+
+              intent.deliver_result(raw_result)
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -10,6 +10,21 @@ module ActiveRecord
       # results, then collecting all results together. This reduces latency
       # for sequences of queries that don't depend on each other's results.
       module PipelineContext # :nodoc:
+        # When true, consume PGRES_PIPELINE_SYNC results explicitly.
+        # When false, skip them during result collection (using get_result loop).
+        # True is needed for concurrent result collection; false is simpler for now.
+        # SyncIntent markers are always recorded to track sync boundaries.
+        TRACK_SYNCS = false
+
+        # Marker for sync points in the pipeline.
+        class SyncIntent # :nodoc:
+          attr_accessor :raw_result
+
+          def raw_result_available?
+            !@raw_result.nil?
+          end
+        end
+
         def pipeline_active?
           @lock.synchronize do
             connected? && @raw_connection.pipeline_status != PG::PQ_PIPELINE_OFF
@@ -33,6 +48,17 @@ module ActiveRecord
             end
 
             @raw_connection.enter_pipeline_mode
+          end
+        end
+
+        def pipeline_sync
+          @lock.synchronize do
+            return unless pipeline_active?
+
+            @pending_intents ||= []
+            @pending_intents << SyncIntent.new
+
+            @raw_connection.pipeline_sync
           end
         end
 
@@ -84,33 +110,37 @@ module ActiveRecord
         def flush_pipeline
           @lock.synchronize do
             return unless pipeline_active?
-            @pending_intents ||= []
-            return if @pending_intents.empty?
+            return unless pipeline_pending?
 
-            @raw_connection.pipeline_sync
-
-            while intent = @pending_intents.shift
-              intent.raw_result = consume_next_pipeline_result
-            end
+            pipeline_sync
+            consume_pipeline
           end
         end
 
-        private
-          def consume_next_pipeline_result
-            result = nil
+        def consume_pipeline
+          @lock.synchronize do
+            @pending_intents ||= []
+            return if @pending_intents.empty?
 
-            while true
-              r = @raw_connection.get_result
-              break unless r
+            while intent = @pending_intents.first
+              if intent.is_a?(SyncIntent) && !TRACK_SYNCS
+                @pending_intents.shift
+                next
+              end
 
-              # Skip PGRES_PIPELINE_SYNC markers
-              next if r.result_status == PG::PGRES_PIPELINE_SYNC
+              raw_result = get_result(@raw_connection) { |result|
+                if result.result_status == PG::PGRES_PIPELINE_SYNC
+                  TRACK_SYNCS ? :break : :skip
+                end
+              }
+              @pending_intents.shift
 
-              result = r
+              # Assign the result (even if it contains an error). The intent will
+              # raise the error when the result is accessed (via cast_result, etc.)
+              intent.raw_result = raw_result
             end
-
-            result
           end
+        end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -154,6 +154,11 @@ module ActiveRecord
               }
               @pending_intents.shift
 
+              if raw_result&.result_status == PG::PGRES_PIPELINE_ABORTED
+                intent.deliver_not_run(reason: :server_aborted)
+                next
+              end
+
               # Check if the result contains an error
               begin
                 raw_result&.check

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -149,6 +149,13 @@ module ActiveRecord
             return unless pipeline_active?
             return unless pipeline_pending?
 
+            # Track which intent was at the head of the last replay
+            # attempt. If we come back around and the same intent is
+            # still leading, we're not making progress - give up.
+            # If the head has advanced (some intents succeeded), that's
+            # genuine progress and worth another attempt.
+            last_replayed_head = nil
+
             loop do
               begin
                 pipeline_sync
@@ -165,18 +172,22 @@ module ActiveRecord
 
                 replayable = retryable_connection_error?(translated) &&
                   if server_fatal
-                    abandon_pipelined_intents(translated, allow_recovery: true, all_unsynced: true)
+                    abandon_pipelined_intents(translated, allow_recovery: true, all_unsynced: true, last_replayed_head: last_replayed_head)
                   else
-                    abandon_pipelined_intents(translated, allow_recovery: true)
+                    abandon_pipelined_intents(translated, allow_recovery: true, last_replayed_head: last_replayed_head)
                   end
 
                 if replayable
+                  last_replayed_head = replayable.first
                   reconnect!(restore_transactions: true)
                   enter_pipeline_mode
                   replayable.each { |intent| pipeline_add_query(intent) }
                   next
                 end
 
+                # abandon_pipelined_intents already delivered terminal
+                # states if it was called (retryable error but recovery
+                # blocked). For non-retryable errors, abandon now.
                 abandon_pipelined_intents(translated)
                 return
               end
@@ -187,7 +198,8 @@ module ActiveRecord
               # resolved intents keep their results.
               needs_replay = consumed&.select { |i| i.error || i.not_run_reason }
               if needs_replay&.any? { |i| i.error && retryable_connection_error?(i.error) }
-                if needs_replay.all?(&:allow_retry)
+                if needs_replay.all?(&:allow_retry) && needs_replay.first != last_replayed_head
+                  last_replayed_head = needs_replay.first
                   needs_replay.each(&:reset_for_retry)
                   reconnect!(restore_transactions: true)
                   enter_pipeline_mode
@@ -259,7 +271,11 @@ module ActiveRecord
           # replay (synced intents must have allow_retry; unsynced are always
           # eligible), returns the intents instead of marking them so the
           # caller can reconnect and replay. Returns nil otherwise.
-          def abandon_pipelined_intents(connection_error = nil, allow_recovery: false, all_unsynced: false)
+          #
+          # +last_replayed_head+ gates progress: if the first intent in the
+          # replay list is the same as the last attempt, we're not making
+          # progress and fall through to deliver terminal states instead.
+          def abandon_pipelined_intents(connection_error = nil, allow_recovery: false, all_unsynced: false, last_replayed_head: nil)
             intents = @pending_intents
             @pending_intents = []
 
@@ -293,8 +309,10 @@ module ActiveRecord
 
             if allow_recovery && synced.all? { |i| i.allow_retry }
               all = synced + unsynced
-              all.each(&:reset_for_retry)
-              return all
+              if all.first != last_replayed_head
+                all.each(&:reset_for_retry)
+                return all
+              end
             end
 
             error = connection_error || ActiveRecord::ConnectionFailed.new("Connection lost during pipeline execution")

--- a/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/pipeline_context.rb
@@ -16,9 +16,22 @@ module ActiveRecord
           end
         end
 
+        def pipeline_pending?
+          @lock.synchronize do
+            @pending_intents ||= []
+            @pending_intents.any?
+          end
+        end
+
         def enter_pipeline_mode
           @lock.synchronize do
             return if pipeline_active?
+            raise "Cannot enter pipeline mode: pipelining is locked" if @pipelining_locked
+
+            unless connected?
+              raise ActiveRecord::ConnectionFailed, "Connection is not usable while entering pipeline mode"
+            end
+
             @raw_connection.enter_pipeline_mode
           end
         end
@@ -26,18 +39,21 @@ module ActiveRecord
         def exit_pipeline_mode
           @lock.synchronize do
             return unless pipeline_active?
+            raise "Cannot exit pipeline mode: pipelining is locked" if @pipelining_locked
 
             begin
-              flush_pipeline
+              flush_pipeline if connected?
             ensure
               begin
-                @raw_connection.discard_results
+                @raw_connection.discard_results if connected?
               rescue PG::Error
                 # Connection dead, can't discard
               end
             end
 
-            @raw_connection.exit_pipeline_mode
+            if connected?
+              @raw_connection.exit_pipeline_mode
+            end
           end
         end
 
@@ -45,6 +61,8 @@ module ActiveRecord
         # The intent's raw_result will be populated when the pipeline is flushed.
         def pipeline_add_query(intent)
           @lock.synchronize do
+            raise "Pipeline mode not active" unless pipeline_active?
+
             @pending_intents ||= []
 
             # Send the query to the pipeline.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -16,6 +16,7 @@ require "active_record/connection_adapters/postgresql/schema_creation"
 require "active_record/connection_adapters/postgresql/schema_definitions"
 require "active_record/connection_adapters/postgresql/schema_dumper"
 require "active_record/connection_adapters/postgresql/schema_statements"
+require "active_record/connection_adapters/postgresql/pipeline_context"
 require "active_record/connection_adapters/postgresql/type_metadata"
 require "active_record/connection_adapters/postgresql/utils"
 
@@ -202,6 +203,7 @@ module ActiveRecord
       include PostgreSQL::ReferentialIntegrity
       include PostgreSQL::SchemaStatements
       include PostgreSQL::DatabaseStatements
+      include PostgreSQL::PipelineContext
 
       def supports_bulk_alter?
         true

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -339,6 +339,7 @@ module ActiveRecord
             # accessed while holding the connection's lock. (And we
             # don't need the complication of with_raw_connection because
             # a reconnect would invalidate the entire statement pool.)
+            @connection.exit_pipeline_mode
             if (conn = @connection.instance_variable_get(:@raw_connection)) && conn.status == PG::CONNECTION_OK
               if @connection.supports_close_prepared?
                 conn.close_prepared key

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -383,10 +383,45 @@ module ActiveRecord
       def active?
         @lock.synchronize do
           return false unless connected?
-          @raw_connection.query ";"
+
+          restore_pipeline = false
+
+          if pipeline_active?
+            if pipeline_pending?
+              # Flush any pending work; connection errors surface while draining results
+              flush_pipeline
+            else
+              unless defined?(@pipelining_locked) && @pipelining_locked
+                restore_pipeline = true
+
+                begin
+                  exit_pipeline_mode
+                rescue PG::Error
+                  return false
+                end
+
+                begin
+                  @raw_connection.query ";"
+                rescue PG::Error
+                  return false
+                end
+              end
+            end
+          else
+            @raw_connection.query ";"
+          end
+
+          if restore_pipeline && connected?
+            begin
+              enter_pipeline_mode
+            rescue PG::Error
+              return false
+            end
+          end
+
           verified!
+          true
         end
-        true
       rescue PG::Error
         false
       end
@@ -408,6 +443,8 @@ module ActiveRecord
         @lock.synchronize do
           return connect! unless @raw_connection
 
+          exit_pipeline_mode
+
           unless @raw_connection.transaction_status == ::PG::PQTRANS_IDLE
             @raw_connection.query "ROLLBACK"
           end
@@ -426,6 +463,8 @@ module ActiveRecord
       # method does nothing.
       def disconnect!
         @lock.synchronize do
+          exit_pipeline_mode rescue nil
+
           super
           @raw_connection&.close rescue nil
           @raw_connection = nil
@@ -436,6 +475,11 @@ module ActiveRecord
         super
         @raw_connection&.socket_io&.reopen(IO::NULL) rescue nil
         @raw_connection = nil
+      end
+
+      def _run_checkin_callbacks(&block) # :nodoc:
+        exit_pipeline_mode
+        super
       end
 
       def self.native_database_types # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -871,7 +871,8 @@ module ActiveRecord
           when nil
             if exception.message.match?(/connection is closed/i) || exception.message.match?(/no connection to the server/i)
               ConnectionNotEstablished.new(exception, connection_pool: @pool)
-            elsif exception.is_a?(PG::ConnectionBad)
+            elsif exception.is_a?(PG::ConnectionBad) ||
+                  (exception.is_a?(PG::Error) && exception.connection&.status == PG::CONNECTION_BAD)
               # libpq message style always ends with a newline; the pg gem's internal
               # errors do not. We separate these cases because a pg-internal
               # ConnectionBad means it failed before it managed to send the query,

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -910,7 +910,11 @@ module ActiveRecord
           when QUERY_CANCELED
             QueryCanceled.new(message, sql: sql, binds: binds, connection_pool: @pool)
           else
-            super
+            if exception.result&.error_field(PG::PG_DIAG_SEVERITY_NONLOCALIZED) == "FATAL"
+              ConnectionFailed.new(exception, connection_pool: @pool)
+            else
+              super
+            end
           end
         end
 
@@ -1015,12 +1019,12 @@ module ActiveRecord
           unless @statements.key? sql_key
             nextkey = @statements.next_key
             begin
-              conn.prepare nextkey, sql
+              conn.send_prepare(nextkey, sql)
+              result = get_result(conn)
+              result&.check
             rescue => e
               raise translate_exception_class(e, sql, binds)
             end
-            # Clear the queue
-            conn.get_last_result
             @statements[sql_key] = nextkey
           end
           @statements[sql_key]

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1063,6 +1063,7 @@ module ActiveRecord
         # Prepare the statement if it hasn't been prepared, return
         # the statement key.
         def prepare_statement(sql, binds, conn)
+          raise "pipeline mode does not support prepared statements" if pipeline_active?
           sql_key = sql_key(sql)
           unless @statements.key? sql_key
             nextkey = @statements.next_key

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1088,6 +1088,8 @@ module ActiveRecord
         end
 
         def reconnect
+          abandon_pipelined_intents
+
           begin
             @raw_connection&.reset
           rescue PG::ConnectionBad

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -188,8 +188,10 @@ module ActiveRecord
 
       # Internal setter for raw result
       def raw_result=(value)
-        @raw_result = value
-        @raw_result_available = true
+        adapter.lock.synchronize do
+          @raw_result = value
+          @raw_result_available = true
+        end
       end
 
       # Check if result has been populated yet (without blocking)
@@ -208,12 +210,26 @@ module ActiveRecord
         if @session
           # Async was scheduled: wait for result (sets lock_wait)
           execute_or_wait
+        elsif !@raw_result_available
+          # Result not available - flush pipeline to get it
+          adapter.flush_pipeline
         end
 
         @event_buffer&.flush
 
         # Raise any error captured during deferred execution
         raise @error if @error
+
+        # Check if the result contains an error (for pipelined queries)
+        # Async queries (@session set) and regular sync queries raise errors immediately,
+        # but pipeline results defer errors until the result is accessed
+        if !@session && @raw_result.respond_to?(:check)
+          begin
+            @raw_result.check
+          rescue => e
+            raise adapter.send(:translate_exception_class, e, processed_sql, binds)
+          end
+        end
       end
 
       def cast_result

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -268,7 +268,7 @@ module ActiveRecord
         adapter.lock.synchronize do
           @error = exception
 
-          adapter.send(:mark_connection_unhealthy_unless_query_error, exception)
+          adapter.send(:downgrade_connection_after_error, exception)
           adapter.send(:dirty_current_transaction) if @materialize_transactions
 
           @raw_result_available = true

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -20,6 +20,18 @@ module ActiveRecord
           end
         end
 
+        # Build a deferred handle for split start/finish logging.
+        # Unlike the real instrumenter's build_handle (which notifies subscribers
+        # immediately), this captures timing and queues for later publishing.
+        def build_handle(name, payload)
+          DeferredHandle.new(self, @instrumenter, name, payload)
+        end
+
+        # Add a finished event to the buffer for later publishing
+        def add_event(event)
+          @events << event
+        end
+
         def flush
           events, @events = @events, []
           events.each do |event|
@@ -27,12 +39,36 @@ module ActiveRecord
             ActiveSupport::Notifications.publish_event(event)
           end
         end
+
+        # A handle that records timing but defers notification until buffer flush.
+        # Mirrors the interface of ActiveSupport::Notifications::Fanout::Handle.
+        class DeferredHandle
+          def initialize(buffer, instrumenter, name, payload)
+            @buffer = buffer
+            @event = instrumenter.new_event(name, payload)
+          end
+
+          def start
+            @event.start!
+          end
+
+          def finish
+            @event.finish!
+            @buffer.add_event(@event)
+          end
+
+          def payload
+            @event.payload
+          end
+        end
       end
 
       attr_reader :arel, :name, :prepare, :allow_retry, :allow_async,
-                  :materialize_transactions, :batch, :pool, :session, :lock_wait
+                  :materialize_transactions, :batch, :pool, :session, :lock_wait,
+                  :retries_remaining, :retry_deadline, :error, :reconnectable,
+                  :event_buffer
       attr_writer :raw_sql, :session
-      attr_accessor :adapter, :binds, :ran_async, :notification_payload
+      attr_accessor :adapter, :binds, :ran_async, :notification_payload, :log_handle
 
       def initialize(adapter:, arel: nil, raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, allow_async: false,
                      allow_retry: false, materialize_transactions: true, batch: false)
@@ -66,6 +102,12 @@ module ActiveRecord
         @error = nil
         @lock_wait = nil
         @event_buffer = nil
+        @log_handle = nil
+
+        # Retry tracking state (initialized when execution begins)
+        @retries_remaining = nil
+        @retry_deadline = nil
+        @reconnectable = nil
       end
 
       # Returns a hash representation of the QueryIntent for debugging/introspection
@@ -197,6 +239,96 @@ module ActiveRecord
         end
       end
 
+      # Deliver a successful result to this intent.
+      # Handles logging, transaction dirtying, and marks the intent complete.
+      def deliver_result(value)
+        adapter.lock.synchronize do
+          @raw_result = value
+          @error = nil
+
+          adapter.send(:handle_warnings, value, processed_sql)
+          adapter.send(:dirty_current_transaction) if @materialize_transactions
+
+          @raw_result_available = true
+        end
+
+        # Logging outside lock to avoid blocking other threads
+        adapter.finish_intent_log(self)
+      end
+
+      # Deliver a failure to this intent.
+      # Handles retry logic internally - if retriable, will attempt again.
+      # Otherwise marks as permanent failure with logging and transaction dirtying.
+      def deliver_failure(exception)
+        should_finish_log = false
+
+        adapter.lock.synchronize do
+          @error = exception
+
+          if retriable?
+            action = adapter.send(:classify_retry_action, exception, reconnectable: @reconnectable)
+            if action
+              consume_retry
+              reset_for_retry
+
+              case action
+              when :retry_query
+                adapter.send(:backoff, adapter.send(:connection_retries) - @retries_remaining)
+              when :retry_after_reconnect
+                adapter.reconnect!(restore_transactions: true)
+                @reconnectable = false
+              end
+
+              adapter.perform_sync_attempt(self)
+              return
+            end
+          end
+
+          # Permanent failure
+          adapter.send(:mark_connection_unhealthy_unless_query_error, exception)
+          adapter.send(:dirty_current_transaction) if @materialize_transactions
+
+          @raw_result_available = true
+          should_finish_log = true
+        end
+
+        # Logging outside lock to avoid blocking other threads
+        adapter.finish_intent_log(self, exception: exception) if should_finish_log
+      end
+
+      # Initialize retry tracking state from adapter configuration.
+      # Called when beginning execution attempts.
+      def initialize_retry_state(retries:, deadline:, reconnectable:)
+        @retries_remaining = retries
+        @retry_deadline = deadline
+        @reconnectable = reconnectable
+      end
+
+      # Decrement retries remaining. Returns true if retry is still possible.
+      def consume_retry
+        return false unless @retries_remaining && @retries_remaining > 0
+        return false if retry_deadline_exceeded?
+        @retries_remaining -= 1
+        true
+      end
+
+      # Check if the retry deadline has passed
+      def retry_deadline_exceeded?
+        @retry_deadline && @retry_deadline < Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      # Check if this intent can still be retried
+      def retriable?
+        @allow_retry && @retries_remaining && @retries_remaining > 0 && !retry_deadline_exceeded?
+      end
+
+      # Reset state to allow another attempt
+      def reset_for_retry
+        @raw_result = nil
+        @raw_result_available = false
+        @error = nil
+      end
+
       # Check if result has been populated yet (without blocking)
       def raw_result_available?
         @raw_result_available
@@ -254,15 +386,9 @@ module ActiveRecord
 
       private
         def flush_pipelined_result(connection)
-          connection.send(:log, self) do |notification_payload|
-            @notification_payload = notification_payload
-            connection.flush_pipeline
-
-            if @raw_result
-              notification_payload[:affected_rows] = @raw_result.cmd_tuples
-              notification_payload[:row_count] = @raw_result.ntuples
-            end
-          end
+          # Just flush the pipeline - logging is handled by start/finish_intent_log
+          # via deliver_result called from consume_pipeline
+          connection.flush_pipeline
         end
 
         def async_schedule!(session)

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -66,7 +66,7 @@ module ActiveRecord
       attr_reader :arel, :name, :prepare, :allow_retry, :allow_async,
                   :materialize_transactions, :batch, :pool, :session, :lock_wait,
                   :retries_remaining, :retry_deadline, :error, :reconnectable,
-                  :event_buffer
+                  :event_buffer, :not_run_reason
       attr_writer :raw_sql, :session
       attr_accessor :adapter, :binds, :ran_async, :notification_payload, :log_handle
 
@@ -93,6 +93,8 @@ module ActiveRecord
         @raw_result = nil
         @raw_result_available = false
         @executed = false
+        @not_run_reason = nil
+        @not_run_resettable = false
         @write_query = nil
 
         # Deferred execution state
@@ -296,6 +298,20 @@ module ActiveRecord
         adapter.finish_intent_log(self, exception: exception) if should_finish_log
       end
 
+      # Mark this intent as not run, with an explicit reason and reset policy.
+      #
+      # When +resettable+ is true, accessing the result will trigger on-demand
+      # re-execution rather than raising QueryNotRun.
+      #
+      # All current pipelining is AR-internal, so +resettable+ is always true
+      # today. A future manual batching API would set +resettable: false+ so
+      # that callers observe QueryNotRun for server-aborted queries.
+      def deliver_not_run(reason:, resettable: true)
+        @not_run_reason = reason
+        @not_run_resettable = resettable
+        @raw_result_available = true
+      end
+
       # Initialize retry tracking state from adapter configuration.
       # Called when beginning execution attempts.
       def initialize_retry_state(retries:, deadline:, reconnectable:)
@@ -352,6 +368,15 @@ module ActiveRecord
 
         @event_buffer&.flush
 
+        if @not_run_reason
+          if @not_run_resettable
+            reset_for_rerun
+            adapter.perform_sync_attempt(self)
+          else
+            raise ActiveRecord::QueryNotRun.new("Query was not run due to pipeline failure (#{@not_run_reason})")
+          end
+        end
+
         # Raise any error captured during deferred execution
         raise @error if @error
 
@@ -385,6 +410,16 @@ module ActiveRecord
       end
 
       private
+        def reset_for_rerun
+          @raw_result = nil
+          @raw_result_available = false
+          @error = nil
+          @not_run_reason = nil
+          @not_run_resettable = false
+          remove_instance_variable(:@cast_result) if defined?(@cast_result)
+          remove_instance_variable(:@affected_rows) if defined?(@affected_rows)
+        end
+
         def flush_pipelined_result(connection)
           # Just flush the pipeline - logging is handled by start/finish_intent_log
           # via deliver_result called from consume_pipeline

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -292,6 +292,8 @@ module ActiveRecord
       # Initialize retry tracking state from adapter configuration.
       # Called when beginning execution attempts.
       def initialize_retry_state(retries:, deadline:, reconnectable:)
+        return if @retries_remaining
+
         @retries_remaining = retries
         @retry_deadline = deadline
         @reconnectable = reconnectable
@@ -339,46 +341,48 @@ module ActiveRecord
         if @session
           # Async was scheduled: wait for result (sets lock_wait)
           execute_or_wait
-        elsif !@raw_result_available
-          # Result not available - flush pipeline to get it
-          flush_pipelined_result(adapter)
         end
 
-        @event_buffer&.flush
-
-        if @not_run_reason
-          if @not_run_resettable
-            reset_for_rerun
-            adapter.send(:ensure_connection_ready,
-              allow_retry: @allow_retry,
-              materialize_transactions: @materialize_transactions)
-            adapter.perform_sync_attempt(self)
-          else
-            raise ActiveRecord::QueryNotRun.new("Query was not run due to pipeline failure (#{@not_run_reason})")
-          end
-        end
-
-        # Retry loop for retryable errors. deliver_failure records the
-        # error; we handle reconnect and re-execution here, mirroring
-        # what with_raw_connection does for synchronous queries.
-        while @error && retriable?
-          action = adapter.send(:classify_retry_action, @error, reconnectable: @reconnectable)
-          break unless action
-
-          consume_retry
-          reset_for_retry
-
-          case action
-          when :retry_query
-            adapter.send(:backoff, adapter.send(:connection_retries) - @retries_remaining)
-          when :retry_after_reconnect
-            @reconnectable = false
+        loop do
+          unless @raw_result_available
+            # Result not available - flush pipeline to get it
+            flush_pipelined_result(adapter)
           end
 
-          adapter.send(:ensure_connection_ready,
-            allow_retry: @allow_retry,
-            materialize_transactions: @materialize_transactions)
-          adapter.perform_sync_attempt(self)
+          @event_buffer&.flush
+
+          if @not_run_reason
+            if @not_run_resettable
+              reset_for_rerun
+              adapter.execute_intent(self)
+              next
+            else
+              raise ActiveRecord::QueryNotRun.new("Query was not run due to pipeline failure (#{@not_run_reason})")
+            end
+          end
+
+          # Retry loop for retryable errors. deliver_failure records the
+          # error; we handle reconnect and re-execution here, mirroring
+          # what with_raw_connection does for synchronous queries.
+          if @error && retriable?
+            action = adapter.send(:classify_retry_action, @error, reconnectable: @reconnectable)
+            if action
+              consume_retry
+              reset_for_retry
+
+              case action
+              when :retry_query
+                adapter.send(:backoff, adapter.send(:connection_retries) - @retries_remaining)
+              when :retry_after_reconnect
+                @reconnectable = false
+              end
+
+              adapter.execute_intent(self)
+              next
+            end
+          end
+
+          break
         end
 
         if @error

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -71,7 +71,8 @@ module ActiveRecord
       attr_reader :arel, :name, :prepare, :allow_retry, :allow_async,
                   :materialize_transactions, :batch, :pool, :session, :lock_wait,
                   :retries_remaining, :retry_deadline, :error, :reconnectable,
-                  :event_buffer, :not_run_reason
+                  :event_buffer, :not_run_reason, :finalized
+      alias_method :finalized?, :finalized
       attr_writer :raw_sql, :session
       attr_accessor :adapter, :binds, :ran_async, :notification_payload, :log_handle
 
@@ -262,9 +263,12 @@ module ActiveRecord
           @raw_result_available = true
         end
 
-        # Logging outside lock to avoid blocking other threads
-        adapter.finish_intent_log(self)
+        # Logging outside lock to avoid blocking other threads.
+        # Set @finalized before finish_intent_log: the handle's state
+        # changes to :finished even if a subscriber raises, so our
+        # flag must reflect that to prevent double-finish in the sweep.
         @finalized = true
+        adapter.finish_intent_log(self)
       end
 
       # Deliver a failure to this intent.
@@ -400,8 +404,8 @@ module ActiveRecord
 
         if @error
           unless @finalized
-            adapter.finish_intent_log(self, exception: @error)
             @finalized = true
+            adapter.finish_intent_log(self, exception: @error)
           end
           raise @error
         end

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -66,6 +66,7 @@ module ActiveRecord
         @error = nil
         @lock_wait = nil
         @event_buffer = nil
+        @instrumented = false
       end
 
       # Returns a hash representation of the QueryIntent for debugging/introspection
@@ -212,7 +213,28 @@ module ActiveRecord
           execute_or_wait
         elsif !@raw_result_available
           # Result not available - flush pipeline to get it
-          adapter.flush_pipeline
+          # Instrument the flush if we haven't already
+          should_instrument = false
+          adapter.lock.synchronize do
+            if !@raw_result_available && !@instrumented
+              @instrumented = true
+              should_instrument = true
+            end
+          end
+
+          if should_instrument
+            adapter.send(:log, self) do |notification_payload|
+              @notification_payload = notification_payload
+              adapter.flush_pipeline
+
+              if @raw_result
+                notification_payload[:affected_rows] = @raw_result.cmd_tuples
+                notification_payload[:row_count] = @raw_result.ntuples
+              end
+            end
+          else
+            adapter.flush_pipeline
+          end
         end
 
         @event_buffer&.flush

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -349,6 +349,9 @@ module ActiveRecord
         if @not_run_reason
           if @not_run_resettable
             reset_for_rerun
+            adapter.send(:ensure_connection_ready,
+              allow_retry: @allow_retry,
+              materialize_transactions: @materialize_transactions)
             adapter.perform_sync_attempt(self)
           else
             raise ActiveRecord::QueryNotRun.new("Query was not run due to pipeline failure (#{@not_run_reason})")
@@ -369,10 +372,12 @@ module ActiveRecord
           when :retry_query
             adapter.send(:backoff, adapter.send(:connection_retries) - @retries_remaining)
           when :retry_after_reconnect
-            adapter.reconnect!(restore_transactions: true)
             @reconnectable = false
           end
 
+          adapter.send(:ensure_connection_ready,
+            allow_retry: @allow_retry,
+            materialize_transactions: @materialize_transactions)
           adapter.perform_sync_attempt(self)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -105,6 +105,7 @@ module ActiveRecord
         @lock_wait = nil
         @event_buffer = nil
         @log_handle = nil
+        @finalized = false
 
         # Retry tracking state (initialized when execution begins)
         @retries_remaining = nil
@@ -256,60 +257,22 @@ module ActiveRecord
 
         # Logging outside lock to avoid blocking other threads
         adapter.finish_intent_log(self)
+        @finalized = true
       end
 
       # Deliver a failure to this intent.
-      # Handles retry logic internally - if retriable, will attempt again.
-      # Otherwise marks as permanent failure with logging and transaction dirtying.
+      # Records the error; does not log. Logging is deferred to the
+      # final outcome in ensure_result (success via deliver_result, or
+      # permanent failure just before raising).
       def deliver_failure(exception)
-        should_finish_log = false
-
         adapter.lock.synchronize do
           @error = exception
 
-          if retriable?
-            action = adapter.send(:classify_retry_action, exception, reconnectable: @reconnectable)
-            if action
-              consume_retry
-              reset_for_retry
-
-              case action
-              when :retry_query
-                adapter.send(:backoff, adapter.send(:connection_retries) - @retries_remaining)
-              when :retry_after_reconnect
-                replayable = adapter.send(:abandon_pipelined_intents, exception, allow_recovery: true)
-                adapter.reconnect!(restore_transactions: true)
-                @reconnectable = false
-
-                if replayable
-                  # All intents are eligible for replay. Re-enter pipeline
-                  # mode and re-queue everything, preserving original order:
-                  # self was shifted off @pending_intents before deliver_failure
-                  # was called, so it precedes the replayable intents.
-                  # consume_pipeline will drain the replayed results.
-                  adapter.enter_pipeline_mode
-                  adapter.pipeline_add_query(self)
-                  replayable.each { |intent| adapter.pipeline_add_query(intent) }
-                  adapter.pipeline_sync
-                  return
-                end
-              end
-
-              adapter.perform_sync_attempt(self)
-              return
-            end
-          end
-
-          # Permanent failure
           adapter.send(:mark_connection_unhealthy_unless_query_error, exception)
           adapter.send(:dirty_current_transaction) if @materialize_transactions
 
           @raw_result_available = true
-          should_finish_log = true
         end
-
-        # Logging outside lock to avoid blocking other threads
-        adapter.finish_intent_log(self, exception: exception) if should_finish_log
       end
 
       # Mark this intent as not run, with an explicit reason and reset policy.
@@ -357,6 +320,7 @@ module ActiveRecord
         @raw_result = nil
         @raw_result_available = false
         @error = nil
+        @not_run_reason = nil
       end
 
       # Check if result has been populated yet (without blocking)
@@ -391,8 +355,34 @@ module ActiveRecord
           end
         end
 
-        # Raise any error captured during deferred execution
-        raise @error if @error
+        # Retry loop for retryable errors. deliver_failure records the
+        # error; we handle reconnect and re-execution here, mirroring
+        # what with_raw_connection does for synchronous queries.
+        while @error && retriable?
+          action = adapter.send(:classify_retry_action, @error, reconnectable: @reconnectable)
+          break unless action
+
+          consume_retry
+          reset_for_retry
+
+          case action
+          when :retry_query
+            adapter.send(:backoff, adapter.send(:connection_retries) - @retries_remaining)
+          when :retry_after_reconnect
+            adapter.reconnect!(restore_transactions: true)
+            @reconnectable = false
+          end
+
+          adapter.perform_sync_attempt(self)
+        end
+
+        if @error
+          unless @finalized
+            adapter.finish_intent_log(self, exception: @error)
+            @finalized = true
+          end
+          raise @error
+        end
 
         # Check if the result contains an error (for pipelined queries)
         # Pipeline results defer errors until the result is accessed.

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -3,6 +3,11 @@
 module ActiveRecord
   module ConnectionAdapters
     class QueryIntent # :nodoc:
+      # Raised when attempting to deliver to or reset a finalized intent.
+      # This is an internal invariant violation - finalization is terminal.
+      class FinalizedError < ActiveRecordError # :nodoc:
+      end
+
       # Buffers instrumentation events during background execution for later publishing
       class EventBuffer
         def initialize(intent, instrumenter)
@@ -245,6 +250,8 @@ module ActiveRecord
       # Deliver a successful result to this intent.
       # Handles logging, transaction dirtying, and marks the intent complete.
       def deliver_result(value)
+        raise FinalizedError, "delivering result to a finalized intent" if @finalized
+
         adapter.lock.synchronize do
           @raw_result = value
           @error = nil
@@ -265,6 +272,8 @@ module ActiveRecord
       # final outcome in ensure_result (success via deliver_result, or
       # permanent failure just before raising).
       def deliver_failure(exception)
+        raise FinalizedError, "delivering failure to a finalized intent" if @finalized
+
         adapter.lock.synchronize do
           @error = exception
 
@@ -284,6 +293,8 @@ module ActiveRecord
       # today. A future manual batching API would set +resettable: false+ so
       # that callers observe QueryNotRun for server-aborted queries.
       def deliver_not_run(reason:, resettable: true)
+        raise FinalizedError, "delivering not_run to a finalized intent" if @finalized
+
         @not_run_reason = reason
         @not_run_resettable = resettable
         @raw_result_available = true
@@ -319,6 +330,8 @@ module ActiveRecord
 
       # Reset state to allow another attempt
       def reset_for_retry
+        raise FinalizedError, "resetting a finalized intent" if @finalized
+
         @raw_result = nil
         @raw_result_available = false
         @error = nil
@@ -424,6 +437,8 @@ module ActiveRecord
 
       private
         def reset_for_rerun
+          raise FinalizedError, "resetting a finalized intent for rerun" if @finalized
+
           @raw_result = nil
           @raw_result_available = false
           @error = nil

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         end
       end
 
-      attr_reader :arel, :name, :prepare, :allow_retry, :allow_async,
+      attr_reader :arel, :name, :prepare, :allow_retry, :allow_async, :prefer_pipeline,
                   :materialize_transactions, :batch, :pool, :session, :lock_wait,
                   :retries_remaining, :retry_deadline, :error, :reconnectable,
                   :event_buffer, :not_run_reason, :finalized
@@ -77,7 +77,7 @@ module ActiveRecord
       attr_accessor :adapter, :binds, :ran_async, :notification_payload, :log_handle
 
       def initialize(adapter:, arel: nil, raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, allow_async: false,
-                     allow_retry: false, materialize_transactions: true, batch: false)
+                     prefer_pipeline: false, allow_retry: false, materialize_transactions: true, batch: false)
         if arel.nil? && raw_sql.nil? && processed_sql.nil?
           raise ArgumentError, "One of arel, raw_sql, or processed_sql must be provided"
         end
@@ -89,6 +89,7 @@ module ActiveRecord
         @binds = binds
         @prepare = prepare
         @allow_async = allow_async
+        @prefer_pipeline = prefer_pipeline
         @ran_async = nil
         @allow_retry = allow_retry
         @materialize_transactions = materialize_transactions
@@ -176,7 +177,7 @@ module ActiveRecord
 
       # Is this intent still pending (result not yet available)?
       def pending?
-        !@raw_result_available && @session&.active?
+        !@raw_result_available && (@session&.active? || @executed)
       end
 
       # Was this intent canceled?

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -66,7 +66,6 @@ module ActiveRecord
         @error = nil
         @lock_wait = nil
         @event_buffer = nil
-        @instrumented = false
       end
 
       # Returns a hash representation of the QueryIntent for debugging/introspection
@@ -110,6 +109,9 @@ module ActiveRecord
                 @adapter = connection
                 @ran_async = true
                 run_query!
+
+                # If pipelined, flush with instrumentation before releasing connection
+                flush_pipelined_result(connection) unless @raw_result_available
               end
             rescue => error
               @error = error
@@ -213,28 +215,7 @@ module ActiveRecord
           execute_or_wait
         elsif !@raw_result_available
           # Result not available - flush pipeline to get it
-          # Instrument the flush if we haven't already
-          should_instrument = false
-          adapter.lock.synchronize do
-            if !@raw_result_available && !@instrumented
-              @instrumented = true
-              should_instrument = true
-            end
-          end
-
-          if should_instrument
-            adapter.send(:log, self) do |notification_payload|
-              @notification_payload = notification_payload
-              adapter.flush_pipeline
-
-              if @raw_result
-                notification_payload[:affected_rows] = @raw_result.cmd_tuples
-                notification_payload[:row_count] = @raw_result.ntuples
-              end
-            end
-          else
-            adapter.flush_pipeline
-          end
+          flush_pipelined_result(adapter)
         end
 
         @event_buffer&.flush
@@ -243,9 +224,8 @@ module ActiveRecord
         raise @error if @error
 
         # Check if the result contains an error (for pipelined queries)
-        # Async queries (@session set) and regular sync queries raise errors immediately,
-        # but pipeline results defer errors until the result is accessed
-        if !@session && @raw_result.respond_to?(:check)
+        # Pipeline results defer errors until the result is accessed.
+        if @raw_result.respond_to?(:check)
           begin
             @raw_result.check
           rescue => e
@@ -257,20 +237,34 @@ module ActiveRecord
       def cast_result
         raise "Cannot call cast_result before query has executed" unless @executed
         raise "Cannot call cast_result after affected_rows has been called" if defined?(@affected_rows)
+        return @cast_result if defined?(@cast_result)
 
         ensure_result
-        @cast_result ||= adapter.send(:cast_result, @raw_result)
+        @cast_result = adapter.send(:cast_result, @raw_result)
       end
 
       def affected_rows
         raise "Cannot call affected_rows before query has executed" unless @executed
         raise "Cannot call affected_rows after cast_result has been called" if defined?(@cast_result)
+        return @affected_rows if defined?(@affected_rows)
 
         ensure_result
-        @affected_rows ||= adapter.send(:affected_rows, @raw_result)
+        @affected_rows = adapter.send(:affected_rows, @raw_result)
       end
 
       private
+        def flush_pipelined_result(connection)
+          connection.send(:log, self) do |notification_payload|
+            @notification_payload = notification_payload
+            connection.flush_pipeline
+
+            if @raw_result
+              notification_payload[:affected_rows] = @raw_result.cmd_tuples
+              notification_payload[:row_count] = @raw_result.ntuples
+            end
+          end
+        end
+
         def async_schedule!(session)
           if adapter.current_transaction.joinable?
             raise AsynchronousQueryInsideTransactionError, "Asynchronous queries are not allowed inside transactions"
@@ -340,6 +334,9 @@ module ActiveRecord
                 @adapter = connection
                 @ran_async = false  # Foreground fallback, not actually async
                 run_query!
+
+                # If pipelined, flush with instrumentation before releasing connection
+                flush_pipelined_result(connection) unless @raw_result_available
               end
             else
               # Result was computed by background thread while we waited for mutex

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -277,8 +277,22 @@ module ActiveRecord
               when :retry_query
                 adapter.send(:backoff, adapter.send(:connection_retries) - @retries_remaining)
               when :retry_after_reconnect
+                replayable = adapter.send(:abandon_pipelined_intents, exception, allow_recovery: true)
                 adapter.reconnect!(restore_transactions: true)
                 @reconnectable = false
+
+                if replayable
+                  # All intents are eligible for replay. Re-enter pipeline
+                  # mode and re-queue everything, preserving original order:
+                  # self was shifted off @pending_intents before deliver_failure
+                  # was called, so it precedes the replayable intents.
+                  # consume_pipeline will drain the replayed results.
+                  adapter.enter_pipeline_mode
+                  adapter.pipeline_add_query(self)
+                  replayable.each { |intent| adapter.pipeline_add_query(intent) }
+                  adapter.pipeline_sync
+                  return
+                end
               end
 
               adapter.perform_sync_attempt(self)

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -230,6 +230,11 @@ module ActiveRecord
   class WrappedDatabaseException < StatementInvalid
   end
 
+  # Raised when a query was not executed because an earlier query in the
+  # same pipeline failed. The query was definitively never run.
+  class QueryNotRun < StatementInvalid
+  end
+
   # Raised when a record cannot be inserted or updated because it would violate a uniqueness constraint.
   class RecordNotUnique < WrappedDatabaseException
   end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -973,6 +973,69 @@ module ActiveRecord
       ensure
         connection&.disconnect!
       end
+
+      test "needs_reconnect? starts false" do
+        assert_not_predicate @connection, :needs_reconnect?
+      end
+
+      test "needs_reconnect? is set for connection errors" do
+        @connection.send(:mark_connection_unhealthy_unless_query_error,
+          ActiveRecord::ConnectionFailed.new("connection lost"))
+        assert_predicate @connection, :needs_reconnect?
+      end
+
+      test "needs_reconnect? is not set for retryable query errors" do
+        @connection.send(:mark_connection_unhealthy_unless_query_error,
+          ActiveRecord::Deadlocked.new("deadlock detected"))
+        assert_not_predicate @connection, :needs_reconnect?
+      end
+
+      test "reconnect! clears needs_reconnect?" do
+        @connection.instance_variable_set(:@needs_reconnect, true)
+        @connection.reconnect!
+        assert_not_predicate @connection, :needs_reconnect?
+      end
+
+      test "disconnect! clears needs_reconnect?" do
+        @connection.instance_variable_set(:@needs_reconnect, true)
+        @connection.disconnect!
+        assert_not_predicate @connection, :needs_reconnect?
+      end
+
+      test "needs_reconnect? survives clean!" do
+        @connection.instance_variable_set(:@needs_reconnect, true)
+        @connection.clean!
+        assert_predicate @connection, :needs_reconnect?
+      end
+
+      test "verify! forces reconnect when needs_reconnect? even if connection is active" do
+        assert_predicate @connection, :active?
+        connected_since_before = @connection.instance_variable_get(:@connected_since)
+
+        @connection.instance_variable_set(:@needs_reconnect, true)
+        @connection.instance_variable_set(:@verified, false)
+        @connection.verify!
+
+        assert_not_predicate @connection, :needs_reconnect?
+        assert_predicate @connection, :active?
+        assert_operator @connection.instance_variable_get(:@connected_since), :>, connected_since_before
+      end
+
+      test "retryable query forces reconnect when needs_reconnect? is set" do
+        connected_since_before = @connection.instance_variable_get(:@connected_since)
+
+        # Simulate a connection error marking via the real mechanism
+        @connection.send(:mark_connection_unhealthy_unless_query_error,
+          ActiveRecord::ConnectionFailed.new("connection lost"))
+
+        # Use allow_retry: true to exercise the reconnectable+allow_retry
+        # branch in skip_verification?, which would normally skip verification
+        result = @connection.select_all("SELECT 1", "SQL", [], allow_retry: true)
+        assert_equal [[1]], result.rows
+
+        assert_not_predicate @connection, :needs_reconnect?
+        assert_operator @connection.instance_variable_get(:@connected_since), :>, connected_since_before
+      end
     end
   end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -979,15 +979,33 @@ module ActiveRecord
       end
 
       test "needs_reconnect? is set for connection errors" do
-        @connection.send(:mark_connection_unhealthy_unless_query_error,
+        @connection.send(:downgrade_connection_after_error,
           ActiveRecord::ConnectionFailed.new("connection lost"))
         assert_predicate @connection, :needs_reconnect?
       end
 
       test "needs_reconnect? is not set for retryable query errors" do
-        @connection.send(:mark_connection_unhealthy_unless_query_error,
+        @connection.send(:downgrade_connection_after_error,
           ActiveRecord::Deadlocked.new("deadlock detected"))
         assert_not_predicate @connection, :needs_reconnect?
+      end
+
+      test "needs_reconnect? is not set for statement errors" do
+        @connection.send(:downgrade_connection_after_error,
+          ActiveRecord::StatementInvalid.new("PG::UndefinedTable"))
+        assert_not_predicate @connection, :needs_reconnect?
+      end
+
+      test "query error does not force reconnect on next query" do
+        initial_connection_id = connection_id_from_server(@connection)
+
+        assert_raises(ActiveRecord::StatementInvalid) do
+          @connection.execute("SELECT * FROM nonexistent_table_abc")
+        end
+
+        @connection.execute("SELECT 1")
+
+        assert_equal initial_connection_id, connection_id_from_server(@connection)
       end
 
       test "reconnect! clears needs_reconnect?" do
@@ -1025,7 +1043,7 @@ module ActiveRecord
         connected_since_before = @connection.instance_variable_get(:@connected_since)
 
         # Simulate a connection error marking via the real mechanism
-        @connection.send(:mark_connection_unhealthy_unless_query_error,
+        @connection.send(:downgrade_connection_after_error,
           ActiveRecord::ConnectionFailed.new("connection lost"))
 
         # Use allow_retry: true to exercise the reconnectable+allow_retry

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -234,6 +234,9 @@ module ActiveRecord
 
     private
       def cause_server_side_disconnect
+        # Exit pipeline mode to get accurate transaction status
+        @connection.exit_pipeline_mode if @connection.pipeline_active?
+
         unless @connection.instance_variable_get(:@raw_connection).transaction_status == ::PG::PQTRANS_INTRANS
           @connection.execute("begin")
         end

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -16,7 +16,9 @@ module ActiveRecord
     end
 
     def test_pipeline_mode_lifecycle
-      assert_not @connection.pipeline_active?, "Pipeline should not be active initially"
+      unless ENV["AR_POSTGRESQL_PIPELINE"]
+        assert_not @connection.pipeline_active?, "Pipeline should not be active initially"
+      end
 
       @connection.enter_pipeline_mode
       assert @connection.pipeline_active?, "Pipeline should be active after entering"
@@ -53,7 +55,9 @@ module ActiveRecord
     end
 
     def test_queries_outside_pipeline_execute_immediately
-      assert_not @connection.pipeline_active?
+      unless ENV["AR_POSTGRESQL_PIPELINE"]
+        assert_not @connection.pipeline_active?
+      end
 
       result = @connection.exec_query("SELECT 1 AS n")
 

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  class PostgresqlPipelineTest < ActiveRecord::PostgreSQLTestCase
+    def setup
+      super
+      @connection = ActiveRecord::Base.lease_connection
+      @connection.materialize_transactions
+    end
+
+    def teardown
+      @connection.exit_pipeline_mode if @connection.pipeline_active?
+      super
+    end
+
+    def test_pipeline_mode_lifecycle
+      assert_not @connection.pipeline_active?, "Pipeline should not be active initially"
+
+      @connection.enter_pipeline_mode
+      assert @connection.pipeline_active?, "Pipeline should be active after entering"
+
+      @connection.exit_pipeline_mode
+      assert_not @connection.pipeline_active?, "Pipeline should not be active after exiting"
+    end
+
+    def test_queries_outside_pipeline_execute_immediately
+      assert_not @connection.pipeline_active?
+
+      result = @connection.exec_query("SELECT 1 AS n")
+
+      assert_equal [[1]], result.rows
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -469,6 +469,18 @@ module ActiveRecord
         test_pool.disconnect! rescue nil
       end
     end
+
+    def test_prepare_statement_raises_in_pipeline_mode
+      @connection.enter_pipeline_mode
+
+      raw_conn = @connection.instance_variable_get(:@raw_connection)
+      error = assert_raises(RuntimeError) do
+        @connection.send(:prepare_statement, "SELECT 42", [], raw_conn)
+      end
+      assert_match(/pipeline mode does not support prepared statements/, error.message)
+
+      @connection.exit_pipeline_mode
+    end
   end
 
   class PostgresqlPipelineBatchSemanticsTest < ActiveRecord::PostgreSQLTestCase

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -434,6 +434,41 @@ module ActiveRecord
       assert event, "Expected notification for pipelined query"
       assert_equal 1, event[:row_count]
     end
+
+    def test_statement_pool_eviction_during_pipeline_mode
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_config = pool_config.configuration_hash.merge(statement_limit: 2)
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", test_config),
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+
+        # Fill the statement cache to capacity
+        conn.exec_query("SELECT 1", "SQL", [], prepare: true)
+        conn.exec_query("SELECT 2", "SQL", [], prepare: true)
+
+        conn.enter_pipeline_mode
+
+        # Directly trigger statement pool eviction while in pipeline mode
+        statements = conn.instance_variable_get(:@statements)
+        first_key = statements.first[1]
+        statements["new_statement"] = "a999"
+
+        conn.exit_pipeline_mode
+        prepared = conn.select_values("SELECT name FROM pg_prepared_statements")
+        assert_not_includes prepared, first_key
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
   end
 
   class PostgresqlPipelineBatchSemanticsTest < ActiveRecord::PostgreSQLTestCase

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1356,6 +1356,96 @@ module ActiveRecord
       end
     end
 
+    def test_ensure_result_avoids_reconnect_storm
+      # When a non-retryable synced intent blocks batch replay, retryable
+      # intents fall back to individual retry in ensure_result. Without
+      # the needs_reconnect? check, each retryable intent independently
+      # calls reconnect!, tearing down the connection the previous intent
+      # just established.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        reconnect_count = 0
+        original_reconnect = conn.method(:reconnect!)
+        conn.define_singleton_method(:reconnect!) do |**kwargs|
+          reconnect_count += 1
+          original_reconnect.call(**kwargs)
+        end
+
+        conn.enter_pipeline_mode
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: false,  # blocks batch replay
+          materialize_transactions: false
+        )
+        intent3 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 3 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+
+        intent1.execute!
+        intent2.execute!
+        intent3.execute!
+
+        # Sync then close socket - all three intents are synced
+        conn.pipeline_sync
+
+        raw_conn = conn.instance_variable_get(:@raw_connection)
+        previous_stderr = $stderr
+        begin
+          $stderr = StringIO.new
+          fd = raw_conn.socket
+        ensure
+          $stderr = previous_stderr
+        end
+        IO.for_fd(fd).close
+
+        # intent1 retries individually and reconnects
+        assert_equal [[1]], intent1.cast_result.rows
+
+        # intent2 is non-retryable - gets ConnectionFailed
+        assert_raises(ActiveRecord::ConnectionFailed) { intent2.cast_result }
+
+        # intent3 retries individually - should NOT reconnect again
+        assert_equal [[3]], intent3.cast_result.rows
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+
+        # The storm: without the fix, this is 2 (one per retryable intent).
+        # With the fix, it should be 1.
+        assert_equal 1, reconnect_count,
+          "Expected a single reconnect, got #{reconnect_count} (reconnect storm)"
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
     def test_server_aborted_query_reruns_on_demand_outside_transaction
       # When a SQL error aborts subsequent queries in a pipeline and
       # there's no enclosing transaction, the aborted queries can

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -87,6 +87,26 @@ module ActiveRecord
       @connection.instance_variable_set(:@mapped_default_timezone, original_mapped)
     end
 
+    def test_notification_exceptions_propagate_from_pipeline
+      # Exceptions raised by notification subscribers should propagate directly,
+      # not be caught and re-wrapped by pipeline error handling.
+      original_error = StandardError.new("Subscriber error")
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") { raise original_error }
+
+      @connection.enter_pipeline_mode
+
+      intent = @connection.send(:internal_build_intent, "SELECT 1", "TEST")
+      intent.execute!
+
+      actual_error = assert_raises(StandardError) do
+        intent.cast_result
+      end
+      assert_equal original_error, actual_error
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      @connection.exit_pipeline_mode if @connection.pipeline_active?
+    end
+
     def test_auto_flush_on_result_access
       @connection.enter_pipeline_mode
 
@@ -467,6 +487,29 @@ module ActiveRecord
       event = events.find { |e| e[:sql] == "SELECT 1 AS n" }
       assert event, "Expected notification for pipelined query"
       assert_equal 1, event[:row_count]
+    end
+
+    def test_pipelined_sql_events_do_not_overlap_with_materialization
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+        events << event
+      end
+
+      @connection.transaction do
+        @connection.select_all("SELECT 1 AS n", "TEST", [], pipeline: true).to_a
+      end
+
+      savepoint_event = events.find { |e| e.payload[:sql].start_with?("SAVEPOINT") }
+      select_event = events.find { |e| e.payload[:sql] == "SELECT 1 AS n" }
+
+      assert savepoint_event, "Expected SAVEPOINT event"
+      assert select_event, "Expected SELECT event"
+
+      # Transaction materialization (SAVEPOINT) must complete before the
+      # pipelined query's own instrumentation event begins.
+      assert_operator savepoint_event.end, :<=, select_event.time
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
     end
 
     def test_statement_pool_eviction_during_pipeline_mode

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1678,6 +1678,78 @@ module ActiveRecord
       end
     end
 
+    def test_unfinalized_intent_logs_closed_at_checkin
+      # When pipelined intents are never accessed (ensure_result never
+      # called), their sql.active_record notifications are started but
+      # not finished. The checkin sweep should close them, recording
+      # the appropriate final state - errors for failed intents, clean
+      # close for not-run intents.
+      events = []
+      callback = ->(name, start, finish, id, payload) { events << payload }
+
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.connect!
+        conn.materialize_transactions
+
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          conn.enter_pipeline_mode
+
+          intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+            adapter: conn,
+            raw_sql: "SELECT * FROM nonexistent_table_xyz",
+            name: "FAILED_UNCONSUMED"
+          )
+          intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+            adapter: conn,
+            raw_sql: "SELECT 1 AS n",
+            name: "ABORTED_UNCONSUMED"
+          )
+
+          intent1.execute!
+          intent2.execute!
+
+          conn.flush_pipeline
+
+          # Neither intent is accessed - both have open logs
+          assert intent1.log_handle, "Failed intent should have a log handle"
+          assert_not intent1.finalized?, "Failed intent should not be finalized"
+          assert intent2.log_handle, "Not-run intent should have a log handle"
+          assert_not intent2.finalized?, "Not-run intent should not be finalized"
+
+          # Check in triggers finalize_remaining_intents
+          test_pool.checkin(conn)
+        end
+
+        # Failed intent's notification should record its error
+        failed_event = events.find { |e| e[:name] == "FAILED_UNCONSUMED" }
+        assert failed_event, "Failed intent notification should be finalized at checkin"
+        assert failed_event[:exception], "Failed intent should be logged with its error"
+        assert_match(/nonexistent_table_xyz/, failed_event[:exception].last)
+
+        # Server-aborted intent's notification should record QueryNotRun.
+        # Until the sweep, not_run is non-terminal (the caller might still
+        # access the result, triggering re-execution). At sweep time, that
+        # possibility is foreclosed and the log should reflect the failure.
+        aborted_event = events.find { |e| e[:name] == "ABORTED_UNCONSUMED" }
+        assert aborted_event, "Server-aborted intent notification should be finalized at checkin"
+        assert aborted_event[:exception], "Not-run intent should be logged with QueryNotRun at sweep"
+        assert_equal "ActiveRecord::QueryNotRun", aborted_event[:exception].first
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
     def test_server_aborted_query_reruns_on_demand_outside_transaction
       # When a SQL error aborts subsequent queries in a pipeline and
       # there's no enclosing transaction, the aborted queries can

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1446,6 +1446,121 @@ module ActiveRecord
       end
     end
 
+    def test_reconnectable_preserved_across_retry_in_ensure_result
+      # When ensure_result retries a pipelined query via execute_intent,
+      # the intent's @reconnectable flag must be preserved. The retry
+      # loop sets @reconnectable = false after the first reconnect
+      # attempt; initialize_retry_state's idempotent guard prevents
+      # execute_intent from resetting it to true on re-execution.
+      #
+      # Without this, connection_retries: 2 would allow the retry loop
+      # to reconnect twice (reconnect → fail → reconnect → fail) instead
+      # of giving up after the first reconnect fails.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_config = pool_config.configuration_hash.merge(connection_retries: 2)
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", test_config),
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.connect!
+        conn.materialize_transactions
+
+        conn.enter_pipeline_mode
+
+        # Non-retryable intent blocks batch replay in flush_pipeline,
+        # forcing intent2 to retry individually in ensure_result
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: false,
+          materialize_transactions: false
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+
+        intent1.execute!
+        intent2.execute!
+        conn.pipeline_sync
+
+        # Close socket - both intents are synced, connection is dead
+        raw_conn = conn.instance_variable_get(:@raw_connection)
+        previous_stderr = $stderr
+        begin
+          $stderr = StringIO.new
+          fd = raw_conn.socket
+        ensure
+          $stderr = previous_stderr
+        end
+        IO.for_fd(fd).close
+
+        assert_raises(ActiveRecord::ConnectionFailed) { intent1.cast_result }
+
+        # intent2 has a connection error from flush_pipeline's abandon.
+        # Verify initial state: reconnectable is true (from pipeline
+        # initialization), retries_remaining is 2.
+        assert intent2.reconnectable, "Should start reconnectable"
+        assert_equal 2, intent2.retries_remaining
+
+        # Intercept execute_intent to simulate what it does - call
+        # initialize_retry_state (the method under test) - then deliver
+        # a connection error. This exercises whether the idempotent
+        # guard preserves @reconnectable = false set by the retry loop.
+        #
+        # We cap at 5 invocations as a safety valve; without the
+        # idempotent guard this would infinite-loop (retries_remaining
+        # reset each time).
+        original_execute_intent = conn.method(:execute_intent)
+        reconnectable_after_init = []
+        conn.define_singleton_method(:execute_intent) do |i|
+          if i.equal?(intent2)
+            # Simulate the initialize_retry_state call that execute_intent makes
+            i.initialize_retry_state(
+              retries: i.allow_retry ? connection_retries : 0,
+              deadline: retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline,
+              reconnectable: send(:reconnect_can_restore_state?)
+            )
+            reconnectable_after_init << i.reconnectable
+
+            if reconnectable_after_init.size >= 5
+              # Safety: break infinite loop by making intent non-retriable
+              i.instance_variable_set(:@retries_remaining, 0)
+            end
+
+            i.deliver_failure(ActiveRecord::ConnectionFailed.new("Connection lost again"))
+            return
+          end
+          original_execute_intent.call(i)
+        end
+
+        assert_raises(ActiveRecord::ConnectionFailed) do
+          intent2.cast_result
+        end
+
+        # With the idempotent guard: execute_intent is called once,
+        # @reconnectable stays false, classify_retry_action returns nil,
+        # loop breaks. Without it: @reconnectable resets to true each
+        # time, causing repeated reconnect attempts.
+        assert_equal [false], reconnectable_after_init,
+          "@reconnectable should be preserved as false across re-execution; " \
+          "got #{reconnectable_after_init.inspect} (multiple calls = retry state leaked)"
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
     def test_server_aborted_query_reruns_on_demand_outside_transaction
       # When a SQL error aborts subsequent queries in a pipeline and
       # there's no enclosing transaction, the aborted queries can

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -598,6 +598,91 @@ module ActiveRecord
       end
     end
 
+    def test_pipelined_query_with_allow_retry_recovers_from_connection_death
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        # Queue a slow query so it's still in-flight when we kill the connection
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n FROM pg_sleep(2)",
+          name: "TEST",
+          allow_retry: true
+        )
+        intent.execute!
+
+        assert conn.pipeline_active?
+        assert_not intent.raw_result_available?
+
+        # Kill the connection while the query is running
+        @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
+
+        # Accessing the result should trigger flush, hit error, retry with reconnect, and succeed
+        result = intent.cast_result
+
+        assert_equal [[1]], result.rows
+
+        # Connection should have been replaced
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_pipelined_query_without_allow_retry_fails_on_connection_death
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        # Queue a slow non-retryable query so it's still in-flight when we kill the connection
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n FROM pg_sleep(2)",
+          name: "TEST",
+          allow_retry: false
+        )
+        intent.execute!
+
+        # Kill the connection while the query is running
+        @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
+
+        # Should fail without retry
+        assert_raises(ActiveRecord::ConnectionFailed) do
+          intent.cast_result
+        end
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
     def test_multiple_retryable_pipelined_queries_all_recover
       pool_config = ActiveRecord::Base.connection_pool.db_config
       test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -587,15 +587,9 @@ module ActiveRecord
 
         @connection.execute("SELECT pg_terminate_backend(#{pid})")
 
-        # Drain pending results to make connection realize it's dead
-        conn.instance_variable_get(:@raw_connection).tap do |raw_conn|
-          raw_conn.pipeline_sync
-          raw_conn.discard_results rescue nil
-        end
-
-        assert_raises(PG::ConnectionBad) do
-          conn.exit_pipeline_mode
-        end
+        # exit_pipeline_mode flushes the pipeline, discovers the FATAL
+        # error, reconnects, replays, and clears pending intents.
+        conn.exit_pipeline_mode
 
         assert_empty conn.instance_variable_get(:@pending_intents)
       ensure
@@ -746,6 +740,126 @@ module ActiveRecord
       end
     end
 
+    def test_transparent_replay_preserves_query_order
+      # Replay must preserve the original pipeline order, otherwise
+      # dependent queries (where a later query relies on side effects
+      # of an earlier one) will fail.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        # These queries have a dependency: the INSERT references the
+        # temp table created by the first query. If replay reorders
+        # them, the INSERT will fail with "relation does not exist".
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "CREATE TEMP TABLE pipeline_order_test (val int) ON COMMIT DROP",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "INSERT INTO pipeline_order_test VALUES (42)",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent3 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT val FROM pipeline_order_test",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+
+        intent1.execute!
+        intent2.execute!
+        intent3.execute!
+
+        # Kill the connection - all three queries are replayed as a batch
+        @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
+
+        intent1.affected_rows
+        intent2.affected_rows
+        assert_equal [[42]], intent3.cast_result.rows
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_non_retryable_synced_intent_prevents_transparent_replay
+      # When a synced intent does not have allow_retry, transparent replay
+      # is not possible. The synced intent gets ConnectionFailed (fate
+      # unknown), while other intents retry individually or re-execute
+      # on demand.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n FROM pg_sleep(2)",
+          name: "TEST",
+          allow_retry: true
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: false  # blocks transparent replay
+        )
+
+        intent1.execute!
+        intent2.execute!
+
+        @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
+
+        # intent1 is retryable, so it retries individually and succeeds
+        assert_equal [[1]], intent1.cast_result.rows
+
+        # intent2 was synced but not retryable - server may have executed
+        # it, so it gets ConnectionFailed
+        assert_raises(ActiveRecord::ConnectionFailed) do
+          intent2.cast_result
+        end
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
     def test_pipeline_failure_cascades_to_subsequent_queries
       # When a query fails in a pipeline, subsequent queries also fail.
       # This is the conservative default - we don't know if later queries
@@ -805,6 +919,202 @@ module ActiveRecord
         assert_equal [[2]], result2.rows
       ensure
         lock_holder.execute("ROLLBACK") rescue nil
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_abandon_distinguishes_synced_vs_unsynced_intents
+      # Test the sync-aware partitioning logic in abandon_pipelined_intents.
+      # Intents before a SyncIntent were synced (fate unknown), intents after
+      # the last SyncIntent were never synced (safe to retry).
+
+      # Simple stub that records which delivery method was called
+      stub_intent = Class.new do
+        attr_reader :delivered_failure, :not_run_reason
+
+        def deliver_failure(error)
+          @delivered_failure = error
+        end
+
+        def deliver_not_run(reason:, resettable: true)
+          @not_run_reason = reason
+        end
+      end
+
+      synced_intent = stub_intent.new
+      unsynced_intent = stub_intent.new
+      sync_marker = ActiveRecord::ConnectionAdapters::PostgreSQL::PipelineContext::SyncIntent.new
+
+      # Simulate: [synced_intent, SyncIntent, unsynced_intent]
+      # synced_intent is before the sync, unsynced_intent is after
+      @connection.instance_variable_set(:@pending_intents, [synced_intent, sync_marker, unsynced_intent])
+
+      @connection.send(:abandon_pipelined_intents)
+
+      # Synced intent receives ConnectionFailed (fate unknown)
+      assert_kind_of ActiveRecord::ConnectionFailed, synced_intent.delivered_failure
+      assert_nil synced_intent.not_run_reason
+
+      # Unsynced intent was definitely not run
+      assert_nil unsynced_intent.delivered_failure
+      assert_equal :unsynced, unsynced_intent.not_run_reason
+    end
+
+    def test_abandon_with_multiple_sync_markers
+      # With multiple sync markers, all intents before the LAST sync marker
+      # are considered synced (server may have executed). Only intents after
+      # the last sync marker are unsynced.
+      stub_intent = Class.new do
+        attr_reader :delivered_failure, :not_run_reason
+
+        def deliver_failure(error)
+          @delivered_failure = error
+        end
+
+        def deliver_not_run(reason:, resettable: true)
+          @not_run_reason = reason
+        end
+      end
+
+      intent1 = stub_intent.new
+      intent2 = stub_intent.new
+      intent3 = stub_intent.new
+      sync1 = ActiveRecord::ConnectionAdapters::PostgreSQL::PipelineContext::SyncIntent.new
+      sync2 = ActiveRecord::ConnectionAdapters::PostgreSQL::PipelineContext::SyncIntent.new
+
+      # [intent1, sync1, intent2, sync2, intent3]
+      # intent1 and intent2 are before the last sync → synced
+      # intent3 is after the last sync → unsynced
+      @connection.instance_variable_set(:@pending_intents, [intent1, sync1, intent2, sync2, intent3])
+
+      @connection.send(:abandon_pipelined_intents)
+
+      assert_kind_of ActiveRecord::ConnectionFailed, intent1.delivered_failure
+      assert_nil intent1.not_run_reason
+
+      assert_kind_of ActiveRecord::ConnectionFailed, intent2.delivered_failure
+      assert_nil intent2.not_run_reason
+
+      assert_nil intent3.delivered_failure
+      assert_equal :unsynced, intent3.not_run_reason
+    end
+
+    def test_synced_retryable_intents_replayed_after_connection_failure
+      # Tests the "synced but retryable" replay path: queries that have
+      # crossed a sync boundary (so the server may have executed them)
+      # but are all marked allow_retry, so replay is still safe.
+      #
+      # This complements test_connection_failure_while_enqueuing which
+      # tests the "unsynced" path (no sync boundary crossed, replay is
+      # safe regardless of allow_retry).
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: true
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: true
+        )
+
+        intent1.execute!
+        intent2.execute!
+
+        # Sync the pipeline - this succeeds, recording a SyncIntent
+        # marker. The server may have already processed the queries.
+        conn.pipeline_sync
+
+        # Now close the socket. The SyncIntent is already recorded,
+        # so these intents are "synced" (fate unknown).
+        raw_conn = conn.instance_variable_get(:@raw_connection)
+        previous_stderr = $stderr
+        begin
+          $stderr = StringIO.new
+          fd = raw_conn.socket
+        ensure
+          $stderr = previous_stderr
+        end
+        IO.for_fd(fd).close
+
+        # Accessing results triggers flush_pipeline, which detects
+        # the dead connection and replays because all synced intents
+        # have allow_retry.
+        assert_equal [[1]], intent1.cast_result.rows
+        assert_equal [[2]], intent2.cast_result.rows
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_server_aborted_query_reruns_on_demand_outside_transaction
+      # When a SQL error aborts subsequent queries in a pipeline and
+      # there's no enclosing transaction, the aborted queries can
+      # re-execute on demand when their results are accessed.
+      #
+      # Uses a separate connection to avoid the fixture transaction,
+      # which would leave the transaction in a failed state and block
+      # re-execution.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.connect!
+        conn.materialize_transactions
+
+        conn.enter_pipeline_mode
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn, raw_sql: "SELECT 1 AS n", name: "TEST")
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn, raw_sql: "SELECT * FROM nonexistent_table_xyz", name: "TEST")
+        intent3 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn, raw_sql: "SELECT 2 AS n", name: "TEST")
+
+        intent1.execute!
+        intent2.execute!
+        intent3.execute!
+
+        conn.flush_pipeline
+
+        assert_equal [[1]], intent1.cast_result.rows
+        assert_raises(ActiveRecord::StatementInvalid) { intent2.cast_result }
+
+        # intent3 was server-aborted (never ran). Since there's no enclosing
+        # transaction, on-demand re-execution succeeds.
+        assert_equal :server_aborted, intent3.not_run_reason
+        assert_equal [[2]], intent3.cast_result.rows
+      ensure
         test_pool.disconnect! rescue nil
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -481,6 +481,166 @@ module ActiveRecord
 
       @connection.exit_pipeline_mode
     end
+
+    def test_pending_intents_cleared_on_connection_failure
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        conn.send(:internal_build_intent, "SELECT 1", "TEST").execute!
+        conn.send(:internal_build_intent, "SELECT 2", "TEST").execute!
+
+        @connection.execute("SELECT pg_terminate_backend(#{pid})")
+
+        # Drain pending results to make connection realize it's dead
+        conn.instance_variable_get(:@raw_connection).tap do |raw_conn|
+          raw_conn.pipeline_sync
+          raw_conn.discard_results rescue nil
+        end
+
+        assert_raises(PG::ConnectionBad) do
+          conn.exit_pipeline_mode
+        end
+
+        assert_empty conn.instance_variable_get(:@pending_intents)
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_multiple_retryable_pipelined_queries_all_recover
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        # Queue three retryable queries; the first is slow to ensure connection dies mid-flight
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n FROM pg_sleep(2)",
+          name: "TEST",
+          allow_retry: true
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: true
+        )
+        intent3 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 3 AS n",
+          name: "TEST",
+          allow_retry: true
+        )
+
+        intent1.execute!
+        intent2.execute!
+        intent3.execute!
+
+        # Kill the connection while queries are running
+        @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
+
+        # All three should succeed after retry
+        assert_equal [[1]], intent1.cast_result.rows
+        assert_equal [[2]], intent2.cast_result.rows
+        assert_equal [[3]], intent3.cast_result.rows
+
+        # Connection should have been replaced
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_pipeline_failure_cascades_to_subsequent_queries
+      # When a query fails in a pipeline, subsequent queries also fail.
+      # This is the conservative default - we don't know if later queries
+      # depended on earlier ones affecting server state.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        lock_holder = test_pool.checkout
+        lock_holder.connect!
+        conn = test_pool.checkout
+        conn.connect!
+
+        # Create a table and lock a row from another connection
+        lock_holder.execute("CREATE TABLE IF NOT EXISTS pipeline_lock_test (id serial PRIMARY KEY)")
+        lock_holder.execute("INSERT INTO pipeline_lock_test DEFAULT VALUES ON CONFLICT DO NOTHING")
+        lock_holder.execute("BEGIN")
+        lock_holder.execute("SELECT * FROM pipeline_lock_test FOR UPDATE")
+
+        # Set lock_timeout before entering pipeline mode
+        conn.execute("SET lock_timeout = '100ms'")
+        conn.enter_pipeline_mode
+
+        # First query will fail (lock timeout)
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT * FROM pipeline_lock_test FOR UPDATE",
+          name: "TEST",
+          allow_retry: false
+        )
+        # Second query will be aborted due to first query's failure
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: true
+        )
+
+        intent1.execute!
+        intent2.execute!
+
+        # First query fails
+        assert_raises(ActiveRecord::LockWaitTimeout) do
+          intent1.cast_result
+        end
+
+        # Second query also fails due to pipeline abort
+        assert_raises(ActiveRecord::StatementInvalid) do
+          intent2.cast_result
+        end
+      ensure
+        lock_holder.execute("ROLLBACK") rescue nil
+        test_pool.disconnect! rescue nil
+      end
+    end
   end
 
   class PostgresqlPipelineBatchSemanticsTest < ActiveRecord::PostgreSQLTestCase

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -217,6 +217,31 @@ module ActiveRecord
       assert_equal [[2]], intent2.cast_result.rows
     end
 
+    def test_multi_statement_sql_not_pipelined
+      @connection.enter_pipeline_mode
+
+      # Queue a pipelined query
+      intent1 = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+      intent1.execute!
+
+      assert @connection.pipeline_active?
+      assert_not intent1.raw_result_available?
+
+      # Execute multi-statement SQL - should exit pipeline first
+      intent2 = @connection.send(:internal_build_intent, "SELECT 1; SELECT 2", "TEST")
+      intent2.execute!
+
+      # Pipeline should have been exited
+      assert_not @connection.pipeline_active?
+
+      # First intent should have been flushed
+      assert intent1.raw_result_available?
+      assert_equal [[1]], intent1.cast_result.rows
+
+      # Second intent should have executed immediately
+      assert intent2.raw_result_available?
+    end
+
     def test_concurrent_query_queueing
       @connection.enter_pipeline_mode
 
@@ -344,6 +369,42 @@ module ActiveRecord
       assert_not @connection.pipeline_active?
       assert intent2.raw_result_available?
       assert_equal [[2]], intent2.cast_result.rows
+    end
+
+    def test_auto_flush_on_checkin
+      @connection.enter_pipeline_mode
+
+      intent = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+      intent.execute!
+
+      assert_not intent.raw_result_available?
+      assert @connection.pipeline_active?
+
+      # Return connection to pool (simulates what happens at end of request)
+      @connection.send(:_run_checkin_callbacks) { }
+
+      # Pipeline should be flushed and exited
+      assert_not @connection.pipeline_active?
+      assert intent.raw_result_available?
+
+      result = @connection.send(:cast_result, intent.raw_result)
+      assert_equal [[1]], result.rows
+    end
+
+    def test_concurrent_pipeline_mode_transitions
+      threads = 10.times.map do
+        Thread.new do
+          5.times do
+            @connection.enter_pipeline_mode
+            Thread.pass
+            @connection.exit_pipeline_mode
+          end
+        end
+      end
+
+      threads.each(&:join)
+
+      assert_not @connection.pipeline_active?
     end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1801,6 +1801,274 @@ module ActiveRecord
     end
   end
 
+  class PostgresqlPipelineDeferredReleaseTest < ActiveRecord::PostgreSQLTestCase
+    self.use_transactional_tests = false
+
+    def setup
+      super
+      @connection = ActiveRecord::Base.lease_connection
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      @test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+    end
+
+    def teardown
+      @test_pool.disconnect! rescue nil
+      super
+    end
+
+    def test_connection_held_when_pipeline_pending
+      # When a with_connection block exits while pipeline queries are
+      # pending, the connection must stay leased (not returned to pool).
+      intent = nil
+
+      @test_pool.with_connection do |conn|
+        conn.connect!
+        conn.enter_pipeline_mode
+
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent.execute!
+
+        assert conn.pipeline_pending?, "Pipeline should have pending intents"
+      end
+
+      # Connection should still be in use - not returned to pool
+      assert_equal 0, @test_pool.num_available_in_queue,
+        "Connection should not be available in pool while pipeline is pending"
+
+      conn = @test_pool.connections.first
+      assert_predicate conn, :in_use?,
+        "Connection should still be in use"
+      assert conn.deferred_pool_release,
+        "Connection should be marked for deferred release"
+
+      # Clean up: access the result to drain pipeline, then release
+      assert_equal [[1]], intent.cast_result.rows
+    end
+
+    def test_connection_released_when_subsequent_block_drains_pipeline
+      # After a deferred release, entering a second with_connection that
+      # drains the pipeline should release the connection on block exit.
+      intent = nil
+
+      @test_pool.with_connection do |conn|
+        conn.connect!
+        conn.enter_pipeline_mode
+
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 42 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent.execute!
+      end
+
+      # Connection deferred - still in use
+      conn = @test_pool.connections.first
+      assert_predicate conn, :in_use?
+
+      # Second block accesses the result, draining the pipeline
+      @test_pool.with_connection do |conn2|
+        assert_equal conn, conn2, "Should reuse the same connection"
+        assert_equal [[42]], intent.cast_result.rows
+        assert_not conn2.pipeline_pending?, "Pipeline should be drained"
+      end
+
+      # Now the connection should be released
+      assert_not_predicate conn, :in_use?,
+        "Connection should be released after pipeline drained in subsequent block"
+    end
+
+    def test_connection_released_when_pipeline_drains_outside_block
+      # When the pipeline drains outside any with_connection block
+      # (e.g., by accessing intent results directly), the connection
+      # should be released via maybe_deferred_release.
+      intent = nil
+
+      @test_pool.with_connection do |conn|
+        conn.connect!
+        conn.enter_pipeline_mode
+
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 99 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent.execute!
+      end
+
+      conn = @test_pool.connections.first
+      assert_predicate conn, :in_use?
+
+      # Access result outside any with_connection block - triggers
+      # flush_pipeline → maybe_deferred_release
+      assert_equal [[99]], intent.cast_result.rows
+
+      assert_not_predicate conn, :in_use?,
+        "Connection should be released after pipeline drains outside block"
+    end
+
+    def test_nested_with_connection_does_not_release_at_inner_exit
+      # Pipeline drains in inner block, but connection should not be
+      # released until the outer block exits.
+      intent = nil
+
+      @test_pool.with_connection do |outer_conn|
+        outer_conn.connect!
+        outer_conn.enter_pipeline_mode
+
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: outer_conn,
+          raw_sql: "SELECT 7 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent.execute!
+
+        # Inner block drains the pipeline
+        @test_pool.with_connection do |inner_conn|
+          assert_equal outer_conn, inner_conn
+          assert_equal [[7]], intent.cast_result.rows
+          assert_not inner_conn.pipeline_pending?
+        end
+
+        # After inner block exits, connection should still be held
+        # (depth > 0 at inner exit, but now we're back in outer)
+        assert_predicate outer_conn, :in_use?,
+          "Connection should NOT be released at inner block exit"
+      end
+
+      # After outer block exits, connection should be released
+      conn = @test_pool.connections.first
+      assert_not_predicate conn, :in_use?,
+        "Connection should be released after outer block exits"
+    end
+
+    def test_request_end_flushes_and_releases_deferred_connection
+      # Simulating request end: pool.release_connection should flush
+      # the pipeline and return the connection to the pool.
+      @test_pool.with_connection do |conn|
+        conn.connect!
+        conn.enter_pipeline_mode
+
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent.execute!
+      end
+
+      conn = @test_pool.connections.first
+      assert_predicate conn, :in_use?
+
+      # release_connection is what ExecutorHooks.complete calls
+      @test_pool.release_connection
+
+      assert_not_predicate conn, :in_use?,
+        "Connection should be released after release_connection"
+    end
+
+    def test_lease_connection_not_affected_by_deferred_release
+      # lease_connection makes the lease sticky. Deferred release
+      # logic should not interfere with sticky leases.
+      conn = @test_pool.lease_connection
+      conn.connect!
+
+      @test_pool.with_connection do |wc_conn|
+        assert_equal conn, wc_conn, "Should reuse leased connection"
+
+        wc_conn.enter_pipeline_mode
+
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: wc_conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent.execute!
+      end
+
+      # Connection should still be in use (sticky via lease_connection)
+      assert_predicate conn, :in_use?,
+        "Sticky connection should remain leased"
+
+      # Clean up: drain pipeline and release
+      conn.flush_pipeline
+      conn.exit_pipeline_mode
+      @test_pool.release_connection
+    end
+
+    def test_no_deferred_release_when_pipeline_not_pending
+      # Normal case: when pipeline is not pending (or not active),
+      # with_connection should release normally.
+      @test_pool.with_connection do |conn|
+        result = conn.select_value("SELECT 1")
+        assert_equal 1, result
+      end
+
+      conn = @test_pool.connections.first
+      assert_not_predicate conn, :in_use?,
+        "Connection should be released normally when no pipeline is pending"
+      assert_not conn.deferred_pool_release,
+        "Deferred flag should not be set"
+    end
+
+    def test_deferred_release_does_not_make_connection_permanently_sticky
+      # After pipeline drains and connection is released, a subsequent
+      # with_connection should be able to check out and release normally.
+      intent = nil
+
+      @test_pool.with_connection do |conn|
+        conn.connect!
+        conn.enter_pipeline_mode
+
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent.execute!
+      end
+
+      # Drain outside block
+      intent.cast_result
+
+      conn = @test_pool.connections.first
+      assert_not_predicate conn, :in_use?
+
+      # A subsequent with_connection should check out and release normally
+      @test_pool.with_connection do |conn2|
+        conn2.select_value("SELECT 1")
+      end
+
+      assert_not_predicate conn, :in_use?,
+        "Connection should not become permanently sticky after deferred release"
+    end
+  end
+
   class PostgresqlPipelineBatchSemanticsTest < ActiveRecord::PostgreSQLTestCase
     self.use_transactional_tests = false
 

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1561,6 +1561,123 @@ module ActiveRecord
       end
     end
 
+    def test_flush_pipeline_stops_replaying_when_no_progress
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.connect!
+        conn.materialize_transactions
+        conn.enter_pipeline_mode
+
+        self_destruct_sql = "SELECT pg_terminate_backend(pg_backend_pid()), pg_sleep(5)"
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: self_destruct_sql,
+          name: "SELF_DESTRUCT",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "BYSTANDER",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+
+        intent1.execute!
+        intent2.execute!
+
+        reconnect_count = 0
+        conn.define_singleton_method(:reconnect!) do |**kwargs|
+          super(**kwargs)
+          reconnect_count += 1
+        end
+
+        conn.flush_pipeline
+
+        assert_equal 1, reconnect_count,
+          "Expected one replay attempt; without the progress check this would loop forever"
+        assert intent1.raw_result_available?
+        assert intent2.raw_result_available?
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_flush_pipeline_replays_successfully_after_transient_failure
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.connect!
+        conn.materialize_transactions
+
+        original_pid = conn.execute("SELECT pg_backend_pid() AS pid").first["pid"]
+        conn.enter_pipeline_mode
+
+        # Self-destructs on first run, but not after reconnect (PID changes).
+        self_destruct_once_sql = "SELECT" \
+          " CASE WHEN pg_backend_pid() = #{original_pid}" \
+          " THEN pg_terminate_backend(pg_backend_pid()) ELSE true END," \
+          " CASE WHEN pg_backend_pid() = #{original_pid}" \
+          " THEN pg_sleep(5) END"
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: self_destruct_once_sql,
+          name: "SELF_DESTRUCT_ONCE",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "BYSTANDER",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+
+        intent1.execute!
+        intent2.execute!
+
+        reconnect_count = 0
+        conn.define_singleton_method(:reconnect!) do |**kwargs|
+          super(**kwargs)
+          reconnect_count += 1
+        end
+
+        conn.flush_pipeline
+
+        assert_equal 1, reconnect_count
+        assert intent1.raw_result_available?
+        assert intent2.raw_result_available?
+        assert_nil intent1.error
+        assert_nil intent2.error
+        assert_equal 1, intent2.raw_result.first["n"].to_i
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
     def test_server_aborted_query_reruns_on_demand_outside_transaction
       # When a SQL error aborts subsequent queries in a pipeline and
       # there's no enclosing transaction, the aborted queries can

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1799,6 +1799,231 @@ module ActiveRecord
         test_pool.disconnect! rescue nil
       end
     end
+
+    def test_pipelined_intent_does_not_dirty_transaction_until_result_delivery
+      with_dedicated_connection do |conn|
+        with_rollback_transaction(conn) do
+          conn.enter_pipeline_mode
+
+          intent = build_intent(conn, "SELECT 1 AS n")
+          intent.execute!
+
+          assert_predicate conn.transaction_manager, :restorable?,
+            "Queued-but-unrun pipelined intent should not dirty transaction state"
+
+          assert_equal [[1]], intent.cast_result.rows
+
+          assert_not_predicate conn.transaction_manager, :restorable?,
+            "After result delivery, transaction should be dirty and non-restorable"
+        end
+      end
+    end
+
+    def test_unsynced_pipelined_queries_replay_in_clean_transaction
+      with_dedicated_connection do |conn|
+        initial_connection_id = connection_id_from_server(conn)
+
+        with_rollback_transaction(conn) do
+          conn.enter_pipeline_mode
+
+          intent1 = build_intent(conn, "SELECT 1 AS n", allow_retry: false, materialize_transactions: false)
+          intent2 = build_intent(conn, "SELECT 2 AS n", allow_retry: false, materialize_transactions: false)
+          intent1.execute!
+          intent2.execute!
+
+          close_client_socket(conn)
+
+          assert_equal [[1]], intent1.cast_result.rows
+          assert_equal [[2]], intent2.cast_result.rows
+          assert_connection_replaced(conn, initial_connection_id)
+        end
+      end
+    end
+
+    def test_synced_retryable_pipelined_queries_replay_in_clean_transaction
+      with_dedicated_connection do |conn|
+        initial_pid = connection_id_from_server(conn)
+
+        with_rollback_transaction(conn) do
+          conn.enter_pipeline_mode
+
+          intent1 = build_intent(conn, "SELECT 1 AS n", allow_retry: true, materialize_transactions: false)
+          intent2 = build_intent(conn, "SELECT 2 AS n", allow_retry: true, materialize_transactions: false)
+          intent1.execute!
+          intent2.execute!
+          conn.pipeline_sync
+
+          close_client_socket(conn)
+
+          assert_equal [[1]], intent1.cast_result.rows
+          assert_equal [[2]], intent2.cast_result.rows
+          assert_connection_replaced(conn, initial_pid)
+        end
+      end
+    end
+
+    def test_synced_non_retryable_intent_fails_in_clean_transaction
+      with_dedicated_connection do |conn|
+        initial_pid = connection_id_from_server(conn)
+
+        with_rollback_transaction(conn) do
+          conn.enter_pipeline_mode
+
+          retryable_intent = build_intent(conn, "SELECT 1 AS n", allow_retry: true, materialize_transactions: false)
+          non_retryable_intent = build_intent(conn, "SELECT 2 AS n", allow_retry: false, materialize_transactions: false)
+          retryable_intent.execute!
+          non_retryable_intent.execute!
+          conn.pipeline_sync
+
+          close_client_socket(conn)
+
+          assert_equal [[1]], retryable_intent.cast_result.rows
+          assert_raises(ActiveRecord::ConnectionFailed) { non_retryable_intent.cast_result }
+          assert_connection_replaced(conn, initial_pid)
+        end
+      end
+    end
+
+    def test_dirty_transaction_cannot_reconnect_during_pipeline_flush
+      with_dedicated_connection do |conn|
+        initial_connection_id = connection_id_from_server(conn)
+        invocations = 0
+
+        assert_raises(ActiveRecord::ConnectionFailed) do
+          conn.transaction do
+            invocations += 1
+
+            conn.select_value("SELECT 0")
+            assert_not_predicate conn.transaction_manager, :restorable?
+
+            conn.enter_pipeline_mode
+            intent = build_intent(conn, "SELECT 1 AS n FROM pg_sleep(2)", allow_retry: true)
+            intent.execute!
+
+            kill_connection_from_server(initial_connection_id, conn.pool)
+
+            intent.cast_result
+          end
+        end
+
+        assert_equal 1, invocations
+        assert_not_predicate conn, :active?
+        assert_equal 1, conn.select_value("SELECT 1")
+      end
+    end
+
+    def test_dirty_transaction_cannot_reconnect_after_synced_pipeline_failure
+      with_dedicated_connection do |conn|
+        invocations = 0
+        initial_connection_id = connection_id_from_server(conn)
+        reconnect_count = 0
+        original_reconnect = conn.method(:reconnect!)
+        conn.define_singleton_method(:reconnect!) do |**kwargs|
+          reconnect_count += 1
+          original_reconnect.call(**kwargs)
+        end
+
+        assert_raises(ActiveRecord::ConnectionFailed) do
+          conn.transaction do
+            invocations += 1
+
+            conn.select_value("SELECT 0")
+            assert_not_predicate conn.transaction_manager, :restorable?
+
+            conn.enter_pipeline_mode
+            intent = build_intent(conn, "SELECT 1 AS n FROM pg_sleep(2)", allow_retry: true)
+            intent.execute!
+            conn.pipeline_sync
+
+            kill_connection_from_server(initial_connection_id, conn.pool)
+            intent.cast_result
+          end
+        end
+
+        assert_equal 1, invocations
+        assert_equal 0, reconnect_count
+      end
+    end
+
+    def test_server_aborted_query_does_not_recover_inside_failed_transaction
+      with_dedicated_connection do |conn|
+        conn.transaction do
+          conn.enter_pipeline_mode
+
+          failing_intent = build_intent(conn, "SELECT * FROM nonexistent_table_xyz")
+          aborted_intent = build_intent(conn, "SELECT 2 AS n")
+          failing_intent.execute!
+          aborted_intent.execute!
+
+          conn.flush_pipeline
+
+          assert_raises(ActiveRecord::StatementInvalid) { failing_intent.cast_result }
+          assert_equal :server_aborted, aborted_intent.not_run_reason
+          assert_raises(ActiveRecord::StatementInvalid) { aborted_intent.cast_result }
+
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    private
+      def with_dedicated_connection(connection_retries: nil)
+        pool_config = ActiveRecord::Base.connection_pool.db_config
+        db_config =
+          if connection_retries.nil?
+            pool_config
+          else
+            ActiveRecord::DatabaseConfigurations::HashConfig.new(
+              "test",
+              "primary",
+              pool_config.configuration_hash.merge(connection_retries: connection_retries)
+            )
+          end
+
+        test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+          ActiveRecord::ConnectionAdapters::PoolConfig.new(
+            ActiveRecord::Base,
+            db_config,
+            :writing,
+            :default
+          )
+        )
+
+        begin
+          conn = test_pool.checkout
+          conn.connect!
+          conn.materialize_transactions
+          yield conn
+        ensure
+          test_pool.disconnect! rescue nil
+        end
+      end
+
+      def with_rollback_transaction(conn)
+        conn.transaction do
+          yield
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      def build_intent(conn, sql, allow_retry: false, materialize_transactions: true)
+        ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: sql,
+          name: "TEST",
+          allow_retry: allow_retry,
+          materialize_transactions: materialize_transactions
+        )
+      end
+
+      def assert_connection_replaced(conn, previous_pid)
+        assert_not_equal previous_pid, connection_id_from_server(conn)
+      end
+
+      def close_client_socket(conn)
+        raw_conn = conn.instance_variable_get(:@raw_connection)
+        raw_conn.socket_io.close
+      end
   end
 
   class PostgresqlPipelineDeferredReleaseTest < ActiveRecord::PostgreSQLTestCase

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -25,12 +25,412 @@ module ActiveRecord
       assert_not @connection.pipeline_active?, "Pipeline should not be active after exiting"
     end
 
+    def test_basic_pipeline_execution
+      @connection.enter_pipeline_mode
+      assert @connection.pipeline_active?
+
+      intent1 = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+      intent2 = @connection.send(:internal_build_intent, "SELECT 2 AS n", "TEST")
+
+      intent1.execute!
+      intent2.execute!
+
+      assert_not intent1.raw_result_available?
+      assert_not intent2.raw_result_available?
+
+      @connection.flush_pipeline
+
+      assert intent1.raw_result_available?
+      assert intent2.raw_result_available?
+
+      result1 = @connection.send(:cast_result, intent1.raw_result)
+      result2 = @connection.send(:cast_result, intent2.raw_result)
+
+      assert_equal [[1]], result1.rows
+      assert_equal [[2]], result2.rows
+
+      @connection.exit_pipeline_mode
+    end
+
     def test_queries_outside_pipeline_execute_immediately
       assert_not @connection.pipeline_active?
 
       result = @connection.exec_query("SELECT 1 AS n")
 
       assert_equal [[1]], result.rows
+    end
+
+    def test_timezone_mismatch_resolved_before_pipeline_routing
+      # Bind casting triggers timezone typemap update if ActiveRecord.default_timezone
+      # has changed. This must happen before the pipeline routing decision, otherwise
+      # the SET timezone query would execute mid-pipeline.
+      original_mapped = @connection.instance_variable_get(:@mapped_default_timezone)
+
+      # Force timezone mismatch to trigger update path
+      other_timezone = ActiveRecord.default_timezone == :utc ? :local : :utc
+      @connection.instance_variable_set(:@mapped_default_timezone, other_timezone)
+
+      @connection.enter_pipeline_mode
+
+      intent = @connection.send(:internal_build_intent, "SELECT $1::int", "TEST", [42])
+      intent.execute!
+
+      assert @connection.pipeline_active?, "Pipeline mode should remain active"
+
+      @connection.exit_pipeline_mode
+    ensure
+      @connection.instance_variable_set(:@mapped_default_timezone, original_mapped)
+    end
+
+    def test_auto_flush_on_result_access
+      @connection.enter_pipeline_mode
+
+      intent1 = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+      intent2 = @connection.send(:internal_build_intent, "SELECT 2 AS n", "TEST")
+
+      intent1.execute!
+      intent2.execute!
+
+      assert_not intent1.raw_result_available?
+      assert_not intent2.raw_result_available?
+      assert @connection.pipeline_active?
+
+      # Accessing cast_result should auto-flush via ensure_result
+      result1 = intent1.cast_result
+
+      # Pipeline should still be active
+      assert @connection.pipeline_active?
+
+      # Both results should now be available (flush got both)
+      assert intent1.raw_result_available?
+      assert intent2.raw_result_available?
+
+      assert_equal [[1]], result1.rows
+      assert_equal [[2]], intent2.cast_result.rows
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_syntax_error_in_pipelined_query
+      @connection.enter_pipeline_mode
+
+      intent = @connection.send(:internal_build_intent, "SELECT * FROM nonexistent_table_xyz", "TEST")
+      intent.execute!
+
+      assert_not intent.raw_result_available?
+      assert @connection.pipeline_active?
+
+      @connection.flush_pipeline
+
+      assert intent.raw_result_available?
+
+      error = assert_raises(ActiveRecord::StatementInvalid) do
+        intent.cast_result
+      end
+      assert_match(/nonexistent_table_xyz/, error.message)
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_error_in_one_query_aborts_pipeline
+      @connection.enter_pipeline_mode
+
+      intent1 = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+      intent2 = @connection.send(:internal_build_intent, "SELECT * FROM nonexistent_table_xyz", "TEST")
+      intent3 = @connection.send(:internal_build_intent, "SELECT 2 AS n", "TEST")
+
+      intent1.execute!
+      intent2.execute!
+      intent3.execute!
+
+      @connection.flush_pipeline
+
+      # First query should have succeeded
+      assert intent1.raw_result_available?
+      result1 = intent1.cast_result
+      assert_equal [[1]], result1.rows
+
+      # Second query should have error result
+      assert intent2.raw_result_available?
+      assert_raises(ActiveRecord::StatementInvalid) do
+        intent2.cast_result
+      end
+
+      # Third query should have pipeline aborted result
+      assert intent3.raw_result_available?
+      assert_raises(ActiveRecord::StatementInvalid) do
+        intent3.cast_result
+      end
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_error_deferred_until_result_access
+      @connection.enter_pipeline_mode
+
+      intent1 = @connection.send(:internal_build_intent, "SELECT * FROM nonexistent_table_xyz", "TEST")
+      intent2 = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+
+      intent1.execute!
+      intent2.execute!
+
+      # Flush pipeline - should not raise here
+      assert_nothing_raised do
+        @connection.flush_pipeline
+      end
+
+      # Both should have results populated
+      assert intent1.raw_result_available?
+      assert intent2.raw_result_available?
+
+      # Error is only raised when we try to access the failed result
+      assert_raises(ActiveRecord::StatementInvalid) do
+        intent1.cast_result
+      end
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_prepared_statement_not_pipelined
+      @connection.enter_pipeline_mode
+
+      # Queue a pipelined query
+      intent1 = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+      intent1.execute!
+
+      assert @connection.pipeline_active?
+      assert_not intent1.raw_result_available?
+
+      # Execute a prepared statement - should exit pipeline first
+      intent2 = @connection.send(:internal_build_intent, "SELECT 2 AS n", "TEST", [], prepare: true)
+      intent2.execute!
+
+      # Pipeline should have been exited
+      assert_not @connection.pipeline_active?
+
+      # First intent should have been flushed
+      assert intent1.raw_result_available?
+      assert_equal [[1]], intent1.cast_result.rows
+
+      # Second intent should have executed immediately
+      assert intent2.raw_result_available?
+      assert_equal [[2]], intent2.cast_result.rows
+    end
+
+    def test_concurrent_query_queueing
+      @connection.enter_pipeline_mode
+
+      threads = 4.times.map do |i|
+        Thread.new do
+          intent = @connection.send(:internal_build_intent, "SELECT #{i} AS n", "TEST")
+          intent.execute!
+          intent
+        end
+      end
+
+      intents = threads.map(&:value)
+
+      assert intents.all? { |intent| !intent.raw_result_available? }
+
+      @connection.flush_pipeline
+
+      assert intents.all?(&:raw_result_available?)
+
+      results = intents.map { |intent| intent.cast_result.rows.first.first }
+      assert_equal [0, 1, 2, 3].sort, results.sort
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_concurrent_result_access
+      @connection.enter_pipeline_mode
+
+      intents = 4.times.map do |i|
+        intent = @connection.send(:internal_build_intent, "SELECT #{i} AS n", "TEST")
+        intent.execute!
+        intent
+      end
+
+      threads = intents.map do |intent|
+        Thread.new do
+          intent.cast_result.rows.first.first
+        end
+      end
+
+      results = threads.map(&:value)
+
+      assert_equal [0, 1, 2, 3].sort, results.sort
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_concurrent_flush_calls
+      @connection.enter_pipeline_mode
+
+      intents = 4.times.map do |i|
+        intent = @connection.send(:internal_build_intent, "SELECT #{i} AS n", "TEST")
+        intent.execute!
+        intent
+      end
+
+      threads = 4.times.map do
+        Thread.new do
+          @connection.flush_pipeline
+        end
+      end
+
+      threads.each(&:join)
+
+      assert intents.all?(&:raw_result_available?)
+
+      results = intents.map { |intent| intent.cast_result.rows.first.first }
+      assert_equal [0, 1, 2, 3].sort, results.sort
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_concurrent_mixed_operations
+      @connection.enter_pipeline_mode
+
+      intents = 8.times.map do |i|
+        intent = @connection.send(:internal_build_intent, "SELECT #{i} AS n", "TEST")
+        intent.execute!
+        intent
+      end
+
+      threads = []
+
+      threads += intents.each_slice(2).map do |slice|
+        Thread.new do
+          slice.map { |intent| intent.cast_result.rows.first.first }
+        end
+      end
+
+      threads << Thread.new do
+        sleep 0.001
+        @connection.flush_pipeline
+      end
+
+      results = threads.flat_map(&:value).compact
+
+      assert intents.all?(&:raw_result_available?)
+      assert_equal 8, results.size
+      assert_equal (0..7).to_a.sort, results.sort
+
+      @connection.exit_pipeline_mode
+    end
+
+    def test_raw_connection_access_exits_pipeline
+      @connection.enter_pipeline_mode
+
+      intent = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+      intent.execute!
+
+      assert @connection.pipeline_active?
+      assert_not intent.raw_result_available?
+
+      # Access raw_connection - should exit pipeline and flush
+      raw_conn = @connection.raw_connection
+      assert_not_nil raw_conn
+
+      assert_not @connection.pipeline_active?
+      assert intent.raw_result_available?
+      assert_equal [[1]], intent.cast_result.rows
+
+      # Subsequent queries should execute immediately
+      intent2 = @connection.send(:internal_build_intent, "SELECT 2 AS n", "TEST")
+      intent2.execute!
+
+      assert_not @connection.pipeline_active?
+      assert intent2.raw_result_available?
+      assert_equal [[2]], intent2.cast_result.rows
+    end
+  end
+
+  class PostgresqlPipelineBatchSemanticsTest < ActiveRecord::PostgreSQLTestCase
+    self.use_transactional_tests = false
+
+    def setup
+      super
+      @connection = ActiveRecord::Base.lease_connection
+      @connection.execute("CREATE TABLE IF NOT EXISTS pipeline_batch_test (id serial PRIMARY KEY, value text)")
+      @connection.execute("TRUNCATE pipeline_batch_test")
+    end
+
+    def teardown
+      @connection.exit_pipeline_mode if @connection.pipeline_active?
+      @connection.execute("DROP TABLE IF EXISTS pipeline_batch_test")
+      super
+    end
+
+    def test_pipeline_batch_forms_implicit_transaction
+      @connection.enter_pipeline_mode
+
+      intent1 = @connection.send(:internal_build_intent,
+        "INSERT INTO pipeline_batch_test (value) VALUES ('first')", "TEST")
+      intent1.execute!
+
+      intent2 = @connection.send(:internal_build_intent,
+        "INSERT INTO pipeline_batch_test (value) VALUES ('second')", "TEST")
+      intent2.execute!
+
+      intent3 = @connection.send(:internal_build_intent,
+        "INSERT INTO nonexistent_table (value) VALUES ('fail')", "TEST")
+      intent3.execute!
+
+      @connection.flush_pipeline
+      @connection.exit_pipeline_mode
+
+      # The first two queries' results indicate success
+      assert intent1.raw_result_available?
+      assert_equal 1, intent1.raw_result.cmd_tuples
+
+      # But the data was rolled back when the batch failed
+      count = @connection.select_value("SELECT COUNT(*) FROM pipeline_batch_test")
+      assert_equal 0, count
+    end
+
+    def test_pipeline_results_reflect_execution_not_commit
+      @connection.enter_pipeline_mode
+
+      intent1 = @connection.send(:internal_build_intent,
+        "INSERT INTO pipeline_batch_test (value) VALUES ('tentative')", "TEST")
+      intent1.execute!
+
+      intent2 = @connection.send(:internal_build_intent,
+        "SELECT * FROM nonexistent_table", "TEST")
+      intent2.execute!
+
+      @connection.flush_pipeline
+      @connection.exit_pipeline_mode
+
+      # intent1 reports successful execution (1 row affected)
+      assert_equal 1, intent1.raw_result.cmd_tuples
+
+      # But the data doesn't exist due to batch rollback
+      count = @connection.select_value("SELECT COUNT(*) FROM pipeline_batch_test")
+      assert_equal 0, count
+    end
+
+    def test_explicit_transaction_has_same_tentative_result_semantics
+      @connection.transaction do
+        @connection.enter_pipeline_mode
+
+        intent1 = @connection.send(:internal_build_intent,
+          "INSERT INTO pipeline_batch_test (value) VALUES ('in_transaction')", "TEST")
+        intent1.execute!
+
+        @connection.flush_pipeline
+
+        assert_equal 1, intent1.raw_result.cmd_tuples
+
+        @connection.exit_pipeline_mode
+
+        raise ActiveRecord::Rollback
+      end
+
+      count = @connection.select_value("SELECT COUNT(*) FROM pipeline_batch_test")
+      assert_equal 0, count
     end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -804,11 +804,14 @@ module ActiveRecord
       end
     end
 
-    def test_non_retryable_synced_intent_prevents_transparent_replay
-      # When a synced intent does not have allow_retry, transparent replay
-      # is not possible. The synced intent gets ConnectionFailed (fate
-      # unknown), while other intents retry individually or re-execute
-      # on demand.
+    def test_pipeline_aborted_intent_reexecutes_despite_allow_retry_false
+      # When the server sends PGRES_PIPELINE_ABORTED, we trust it: the
+      # query was definitively not executed. Re-execution via the not_run
+      # path is safe regardless of allow_retry.
+      #
+      # This is distinct from the abandon path (socket close, no server
+      # response) where synced non-retryable intents get ConnectionFailed
+      # because fate is unknown. See test_synced_non_retryable_intent_blocks_replay.
       pool_config = ActiveRecord::Base.connection_pool.db_config
       test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
         ActiveRecord::ConnectionAdapters::PoolConfig.new(
@@ -836,7 +839,7 @@ module ActiveRecord
           adapter: conn,
           raw_sql: "SELECT 2 AS n",
           name: "TEST",
-          allow_retry: false  # blocks transparent replay
+          allow_retry: false
         )
 
         intent1.execute!
@@ -844,18 +847,148 @@ module ActiveRecord
 
         @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
 
-        # intent1 is retryable, so it retries individually and succeeds
+        # intent1 retries via ensure_result (retryable connection error)
         assert_equal [[1]], intent1.cast_result.rows
 
-        # intent2 was synced but not retryable - server may have executed
-        # it, so it gets ConnectionFailed
-        assert_raises(ActiveRecord::ConnectionFailed) do
-          intent2.cast_result
-        end
+        # intent2 got PIPELINE_ABORTED - the server confirms it was not
+        # executed. Re-executes on demand despite allow_retry: false.
+        assert_equal [[2]], intent2.cast_result.rows
 
         new_pid = conn.select_value("SELECT pg_backend_pid()")
         assert_not_equal initial_pid, new_pid
       ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_successful_non_retryable_intent_does_not_block_batch_replay
+      # When a fast query succeeds and a slow query gets AdminShutdown,
+      # the successful intent's allow_retry: false should not prevent
+      # batch replay of the failed retryable intent. The replay decision
+      # should only consider intents that actually failed or were not run.
+      #
+      # Uses connection_retries: 0 to disable individual retry in
+      # ensure_result, making batch replay the only recovery path.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_config = pool_config.configuration_hash.merge(connection_retries: 0)
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", test_config),
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        # Fast query, non-retryable - completes before the kill
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: false
+        )
+        # Slow query, retryable - server dies while processing
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n FROM pg_sleep(2)",
+          name: "TEST",
+          allow_retry: true
+        )
+
+        intent1.execute!
+        intent2.execute!
+        conn.pipeline_sync
+
+        @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
+
+        # intent1 succeeded before the kill
+        assert_equal [[1]], intent1.cast_result.rows
+
+        # intent2 should recover via batch replay, not blocked by
+        # intent1's allow_retry: false
+        assert_equal [[2]], intent2.cast_result.rows
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_successful_intent_not_replayed_during_batch_recovery
+      # When a retryable INSERT succeeds and is committed (via a
+      # completed sync group), it must not be re-executed during batch
+      # replay of a later failed intent. Replaying a committed write
+      # would double-execute it.
+      #
+      # Setup: intent1 (INSERT) in sync group 1 - committed before the
+      # kill. intent2 (slow SELECT) in sync group 2 - killed mid-flight.
+      # Batch replay should recover intent2 without touching intent1.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+
+        conn.execute("CREATE TABLE IF NOT EXISTS pipeline_replay_write_test (val int)")
+        conn.execute("TRUNCATE pipeline_replay_write_test")
+
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        # Sync group 1: retryable INSERT - fast, committed at sync point
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "INSERT INTO pipeline_replay_write_test VALUES (1)",
+          name: "TEST",
+          allow_retry: true,
+          materialize_transactions: false
+        )
+        intent1.execute!
+        conn.pipeline_sync
+
+        # Sync group 2: slow retryable query - server dies during sleep
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n FROM pg_sleep(2)",
+          name: "TEST",
+          allow_retry: true
+        )
+        intent2.execute!
+
+        @connection.execute("SELECT pg_terminate_backend(#{initial_pid})")
+
+        # intent2 recovers via batch replay
+        assert_equal [[1]], intent2.cast_result.rows
+
+        # intent1 already succeeded
+        assert_equal 1, intent1.affected_rows
+
+        # The INSERT was committed by sync group 1 and NOT replayed -
+        # exactly one row, not two.
+        count = conn.select_value("SELECT COUNT(*) FROM pipeline_replay_write_test")
+        assert_equal 1, count
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        conn&.execute("DROP TABLE IF EXISTS pipeline_replay_write_test") rescue nil
         test_pool.disconnect! rescue nil
       end
     end
@@ -1146,6 +1279,75 @@ module ActiveRecord
         assert conn.pipeline_active?
         assert_equal [[2]], intent2.cast_result.rows
         assert_equal [[3]], intent3.cast_result.rows
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
+    def test_synced_non_retryable_intent_blocks_replay
+      # When a synced intent is non-retryable, full replay is blocked.
+      # The retryable intent recovers via individual retry; the
+      # non-retryable one gets ConnectionFailed (fate unknown).
+      #
+      # Uses socket close for deterministic sync boundary placement,
+      # unlike the pg_terminate_backend variant which is timing-dependent.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: true
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: false  # blocks full replay
+        )
+
+        intent1.execute!
+        intent2.execute!
+
+        # Sync succeeds - both intents are now "synced"
+        conn.pipeline_sync
+
+        # Close socket after sync boundary is established
+        raw_conn = conn.instance_variable_get(:@raw_connection)
+        previous_stderr = $stderr
+        begin
+          $stderr = StringIO.new
+          fd = raw_conn.socket
+        ensure
+          $stderr = previous_stderr
+        end
+        IO.for_fd(fd).close
+
+        # intent1 is retryable - retries individually and succeeds
+        assert_equal [[1]], intent1.cast_result.rows
+
+        # intent2 was synced but not retryable - gets ConnectionFailed
+        assert_raises(ActiveRecord::ConnectionFailed) do
+          intent2.cast_result
+        end
 
         new_pid = conn.select_value("SELECT pg_backend_pid()")
         assert_not_equal initial_pid, new_pid

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -181,11 +181,16 @@ module ActiveRecord
         intent2.cast_result
       end
 
-      # Third query should have pipeline aborted result
+      # Third query was server-aborted (never ran). It's resettable, so
+      # accessing its result triggers on-demand re-execution. Inside the
+      # fixture transaction, the transaction is in a failed state, so the
+      # server rejects the re-execution attempt.
       assert intent3.raw_result_available?
-      assert_raises(ActiveRecord::StatementInvalid) do
+      assert_equal :server_aborted, intent3.not_run_reason
+      error = assert_raises(ActiveRecord::StatementInvalid) do
         intent3.cast_result
       end
+      assert_match(/current transaction is aborted/, error.message)
 
       @connection.exit_pipeline_mode
     end
@@ -794,10 +799,10 @@ module ActiveRecord
           intent1.cast_result
         end
 
-        # Second query also fails due to pipeline abort
-        assert_raises(ActiveRecord::StatementInvalid) do
-          intent2.cast_result
-        end
+        # Second query was server-aborted (never ran). It's resettable,
+        # so on-demand re-execution succeeds (no enclosing transaction).
+        result2 = intent2.cast_result
+        assert_equal [[2]], result2.rows
       ensure
         lock_holder.execute("ROLLBACK") rescue nil
         test_pool.disconnect! rescue nil

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -1069,6 +1069,91 @@ module ActiveRecord
       end
     end
 
+    def test_connection_failure_while_enqueuing_replays_unsynced_window
+      # Tests that when the connection breaks after some queries have been
+      # enqueued but before the pipeline is synced/flushed, all previously
+      # queued intents are transparently replayed on a new connection.
+      #
+      # This is distinct from the drain-phase tests (like
+      # test_multiple_retryable_pipelined_queries_all_recover) where the
+      # connection dies while we're reading results. Here the connection
+      # breaks while we're still writing queries into the pipeline.
+      #
+      # The setup: enqueue two queries, break the connection by closing
+      # the underlying socket fd, then enqueue a third. The third enqueue
+      # (or the subsequent flush) should detect the broken connection,
+      # reconnect, and replay all three queries on the new connection.
+      #
+      # All intents use allow_retry: false to verify that replay works
+      # based on the unsynced window status (no sync boundary was crossed,
+      # so the server definitively did not execute any of these queries),
+      # independent of the per-intent allow_retry flag.
+      pool_config = ActiveRecord::Base.connection_pool.db_config
+      test_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(
+        ActiveRecord::ConnectionAdapters::PoolConfig.new(
+          ActiveRecord::Base,
+          pool_config,
+          :writing,
+          :default
+        )
+      )
+
+      begin
+        conn = test_pool.checkout
+        conn.materialize_transactions
+        initial_pid = conn.select_value("SELECT pg_backend_pid()")
+
+        conn.enter_pipeline_mode
+
+        intent1 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 1 AS n",
+          name: "TEST",
+          allow_retry: false
+        )
+        intent2 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 2 AS n",
+          name: "TEST",
+          allow_retry: false
+        )
+
+        intent1.execute!
+        intent2.execute!
+
+        # Close the underlying socket to simulate a connection break.
+        raw_conn = conn.instance_variable_get(:@raw_connection)
+        previous_stderr = $stderr
+        begin
+          $stderr = StringIO.new  # suppress libpq warnings about the fd
+          fd = raw_conn.socket
+        ensure
+          $stderr = previous_stderr
+        end
+        IO.for_fd(fd).close
+
+        # Enqueueing another query should trigger error detection,
+        # reconnect, and replay the entire unsynced window.
+        intent3 = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: conn,
+          raw_sql: "SELECT 3 AS n",
+          name: "TEST",
+          allow_retry: false
+        )
+        intent3.execute!
+
+        assert_equal [[1]], intent1.cast_result.rows
+        assert conn.pipeline_active?
+        assert_equal [[2]], intent2.cast_result.rows
+        assert_equal [[3]], intent3.cast_result.rows
+
+        new_pid = conn.select_value("SELECT pg_backend_pid()")
+        assert_not_equal initial_pid, new_pid
+      ensure
+        test_pool.disconnect! rescue nil
+      end
+    end
+
     def test_server_aborted_query_reruns_on_demand_outside_transaction
       # When a SQL error aborts subsequent queries in a pipeline and
       # there's no enclosing transaction, the aborted queries can

--- a/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipeline_test.rb
@@ -406,6 +406,30 @@ module ActiveRecord
 
       assert_not @connection.pipeline_active?
     end
+
+    def test_pipelined_query_instrumentation
+      events = []
+      callback = ->(name, start, finish, id, payload) { events << payload }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        @connection.enter_pipeline_mode
+
+        intent = @connection.send(:internal_build_intent, "SELECT 1 AS n", "TEST")
+        intent.execute!
+
+        # No notification yet - query is queued but not flushed
+        assert events.none? { |e| e[:sql] == "SELECT 1 AS n" }
+
+        # Access result triggers flush and instrumentation
+        intent.cast_result
+
+        @connection.exit_pipeline_mode
+      end
+
+      event = events.find { |e| e[:sql] == "SELECT 1 AS n" }
+      assert event, "Expected notification for pipelined query"
+      assert_equal 1, event[:row_count]
+    end
   end
 
   class PostgresqlPipelineBatchSemanticsTest < ActiveRecord::PostgreSQLTestCase

--- a/activerecord/test/cases/adapters/postgresql/pipelined_queries_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipelined_queries_test.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class PipelinedQueriesTest < ActiveRecord::PostgreSQLTestCase
+  self.use_transactional_tests = false
+
+  def setup
+    super
+    @connection = ActiveRecord::Base.lease_connection
+  end
+
+  def teardown
+    @connection.exit_pipeline_mode if @connection.pipeline_active?
+    super
+  end
+
+  def test_select_all
+    future = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+    assert_kind_of ActiveRecord::FutureResult, future
+    assert_equal [{ "n" => 1 }], future.result.to_a
+  end
+
+  def test_select_one
+    promise = @connection.select_one("SELECT 1 AS n, 2 AS m", "TEST", pipeline: true)
+    assert promise.is_a?(ActiveRecord::Promise)
+    assert_equal({ "n" => 1, "m" => 2 }, promise.value)
+  end
+
+  def test_select_value
+    promise = @connection.select_value("SELECT 42", "TEST", pipeline: true)
+    assert promise.is_a?(ActiveRecord::Promise)
+    assert_equal 42, promise.value
+  end
+
+  def test_select_rows
+    promise = @connection.select_rows("SELECT 1, 2 UNION ALL SELECT 3, 4", "TEST", pipeline: true)
+    assert promise.is_a?(ActiveRecord::Promise)
+    assert_equal [[1, 2], [3, 4]], promise.value
+  end
+
+  def test_then_chain
+    promise = @connection.select_value("SELECT 7", "TEST", pipeline: true).then { |v| v * 6 }
+    assert promise.is_a?(ActiveRecord::Promise)
+    assert_equal 42, promise.value
+  end
+
+  def test_pending_before_result_access
+    future = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+    assert future.pending?
+
+    future.result
+    assert_not future.pending?
+  end
+
+  def test_multiple_queries_batch_together
+    future1 = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+    future2 = @connection.select_all("SELECT 2 AS n", "TEST", pipeline: true)
+
+    assert future1.pending?
+    assert future2.pending?
+    assert @connection.pipeline_active?
+
+    # Accessing the first result flushes all pending queries
+    assert_equal [{ "n" => 1 }], future1.result.to_a
+    assert_equal [{ "n" => 2 }], future2.result.to_a
+  end
+
+  def test_error_surfaces_on_result_access
+    future = @connection.select_all("SELECT * FROM nonexistent_table_xyz", "TEST", pipeline: true)
+    assert_kind_of ActiveRecord::FutureResult, future
+
+    assert_raises(ActiveRecord::StatementInvalid) do
+      future.result
+    end
+  end
+
+  def test_works_inside_transaction
+    # Unlike async, pipeline uses the same connection, so transactions work
+    @connection.transaction do
+      future = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+      assert_kind_of ActiveRecord::FutureResult, future
+      assert_equal [{ "n" => 1 }], future.result.to_a
+    end
+  end
+
+  def test_query_cache_hit_returns_complete
+    @connection.enable_query_cache!
+
+    # Prime the cache
+    @connection.select_all("SELECT 1 AS n")
+
+    # Cache hit with pipeline: true wraps the cached result
+    result = @connection.select_all("SELECT 1 AS n", pipeline: true)
+    assert_kind_of ActiveRecord::FutureResult::Complete, result
+    assert_not result.pending?
+    assert_equal [{ "n" => 1 }], result.result.to_a
+  ensure
+    @connection.disable_query_cache!
+  end
+
+  def test_mixed_select_methods_batch_together
+    future = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+    value  = @connection.select_value("SELECT 2", "TEST", pipeline: true)
+    row    = @connection.select_one("SELECT 3 AS n", "TEST", pipeline: true)
+    rows   = @connection.select_rows("SELECT 4, 5", "TEST", pipeline: true)
+
+    assert future.pending?
+    assert @connection.pipeline_active?
+
+    assert_equal [{ "n" => 1 }], future.result.to_a
+    assert_equal 2, value.value
+    assert_equal({ "n" => 3 }, row.value)
+    assert_equal [[4, 5]], rows.value
+  end
+
+  def test_accessing_later_result_first_flushes_all
+    future1 = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+    future2 = @connection.select_all("SELECT 2 AS n", "TEST", pipeline: true)
+
+    # Access the second result first - should still flush everything
+    assert_equal [{ "n" => 2 }], future2.result.to_a
+    assert_not future1.pending?
+    assert_equal [{ "n" => 1 }], future1.result.to_a
+  end
+
+  def test_synchronous_query_flushes_pending_pipeline
+    future1 = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+    future2 = @connection.select_all("SELECT 2 AS n", "TEST", pipeline: true)
+
+    assert @connection.pipeline_active?
+
+    # A non-pipelined query should flush the pipeline first
+    sync_result = @connection.select_value("SELECT 3")
+    assert_equal 3, sync_result
+
+    # Pipeline results should now be available
+    assert_not future1.pending?
+    assert_not future2.pending?
+    assert_equal [{ "n" => 1 }], future1.result.to_a
+    assert_equal [{ "n" => 2 }], future2.result.to_a
+  end
+
+  def test_pipeline_then_synchronous_then_pipeline
+    # First batch
+    future1 = @connection.select_value("SELECT 1", "TEST", pipeline: true)
+    future2 = @connection.select_value("SELECT 2", "TEST", pipeline: true)
+
+    # Synchronous query flushes first batch
+    sync = @connection.select_value("SELECT 3")
+    assert_equal 3, sync
+    assert_equal 1, future1.value
+    assert_equal 2, future2.value
+
+    # Second batch
+    future3 = @connection.select_value("SELECT 4", "TEST", pipeline: true)
+    future4 = @connection.select_value("SELECT 5", "TEST", pipeline: true)
+
+    assert_equal 4, future3.value
+    assert_equal 5, future4.value
+  end
+
+  def test_async_foreground_fallback_resolves_with_pipeline
+    skip unless @connection.async_enabled?
+
+    future1 = @connection.select_all("SELECT 1 AS n", "TEST", pipeline: true)
+    future2 = @connection.select_all("SELECT 2 AS n", "TEST", pipeline: true)
+
+    assert future1.pending?
+    assert future2.pending?
+    assert @connection.pipeline_active?
+
+    # Stub the executor so the background thread never runs; the async query
+    # will be enqueued but not executed until we access its result.
+    async_future = @connection.pool.stub(:schedule_query, proc { }) do
+      @connection.select_all("SELECT 3 AS n", "TEST", async: true)
+    end
+
+    # Enqueue should not have disturbed the pipeline
+    assert @connection.pipeline_active?
+    assert future1.pending?
+    assert future2.pending?
+
+    # Accessing the async result triggers execute_or_wait, which falls back
+    # to the foreground on our (pipelined) connection, flushing everything.
+    assert_equal [{ "n" => 3 }], async_future.result.to_a
+    assert_equal [{ "n" => 1 }], future1.result.to_a
+    assert_equal [{ "n" => 2 }], future2.result.to_a
+  end
+
+  def test_exclusion_checks_still_apply
+    # Multi-statement SQL cannot be pipelined even with pipeline: true
+    assert_raises(ArgumentError) do
+      @connection.select_all("SELECT 1; SELECT 2", "TEST", pipeline: true)
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/pipelined_queries_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/pipelined_queries_test.rb
@@ -189,6 +189,32 @@ class PipelinedQueriesTest < ActiveRecord::PostgreSQLTestCase
     assert_equal [{ "n" => 2 }], future2.result.to_a
   end
 
+  def test_async_pipelines_when_async_disabled
+    @connection.stub(:async_enabled?, false) do
+      # Async-eligible queries pipeline when async isn't available
+      future1 = @connection.select_all("SELECT 1 AS n", "TEST", async: true)
+      future2 = @connection.select_all("SELECT 2 AS n", "TEST", async: true)
+
+      assert future1.pending?
+      assert future2.pending?
+      assert @connection.pipeline_active?
+
+      assert_equal [{ "n" => 1 }], future1.result.to_a
+      assert_equal [{ "n" => 2 }], future2.result.to_a
+    end
+  end
+
+  def test_async_non_pipelineable_query_falls_back_to_sync
+    @connection.stub(:async_enabled?, false) do
+      # A preparable query can't be pipelined, but async: true shouldn't
+      # raise - it should silently fall back to synchronous execution
+      result = @connection.select_all(Post.where(id: 1).arel, "TEST", async: true)
+      assert_not @connection.pipeline_active?
+      assert_not result.pending?
+      assert_kind_of ActiveRecord::Result, result.result
+    end
+  end
+
   def test_exclusion_checks_still_apply
     # Multi-statement SQL cannot be pipelined even with pipeline: true
     assert_raises(ArgumentError) do

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -905,11 +905,14 @@ module ActiveRecord
         assert_raises ActiveRecord::ConnectionNotEstablished do
           @connection.execute("SELECT 1")
         end
+      ensure
+        @connection&.disconnect!
       end
 
       def test_translate_no_connection_exception_to_not_established
-        pid = @connection.execute("SELECT pg_backend_pid()").to_a[0]["pg_backend_pid"]
-        @connection.pool.checkout.execute("SELECT pg_terminate_backend(#{pid})")
+        raw_connection = @connection.raw_connection
+        pid = connection_id_from_server(@connection)
+        kill_connection_from_server(pid)
         # If you run `@connection.execute` after the backend process has been terminated,
         # you will get the "server closed the connection unexpectedly" rather than "no connection to the server".
         # Because what we want to test here is an error that occurs during `send_query`,
@@ -917,11 +920,63 @@ module ActiveRecord
         # The `send_query` changes the internal `PG::Connection#status` to `CONNECTION_BAD`,
         # so any subsequent queries will get the "no connection to the server" error.
         # https://github.com/postgres/postgres/blob/REL_17_0/src/interfaces/libpq/fe-exec.c#L1686-L1691
-        @connection.instance_variable_get(:@raw_connection).send_query("SELECT 1")
+        raw_connection.send_query("SELECT 1")
 
         assert_raise ActiveRecord::ConnectionNotEstablished do
           @connection.execute("SELECT 1")
         end
+      end
+
+      def test_terminate_backend_preserves_typed_exception
+        pid = connection_id_from_server(@connection)
+
+        # Put in a dirty transaction so auto-reconnect can't mask the error
+        @connection.execute("BEGIN")
+        @connection.execute("CREATE TEMP TABLE _typed_exception_probe()")
+
+        kill_connection_from_server(pid)
+        sleep 0.1
+
+        error = assert_raises(ActiveRecord::ConnectionFailed) { @connection.execute("SELECT 1") }
+        assert_kind_of PG::AdminShutdown, error.cause
+        assert_equal "57P01", error.cause.result.error_field(PG::PG_DIAG_SQLSTATE)
+      ensure
+        @connection&.disconnect!
+      end
+
+      def test_idle_in_transaction_timeout_preserves_typed_exception
+        @connection.execute("BEGIN")
+        @connection.execute("SET idle_in_transaction_session_timeout = '10ms'")
+        sleep 0.1
+
+        error = assert_raises(ActiveRecord::ConnectionFailed) { @connection.execute("SELECT 1") }
+        assert_kind_of PG::IdleInTransactionSessionTimeout, error.cause
+        assert_equal "25P03", error.cause.result.error_field(PG::PG_DIAG_SQLSTATE)
+      ensure
+        @connection&.disconnect!
+      end
+
+      def test_flush_on_dead_connection_translates_to_connection_failed
+        pid = connection_id_from_server(@connection)
+        raw_connection = @connection.raw_connection
+
+        # Queue a slow query, then kill the backend while it's running
+        raw_connection.send_query("SELECT pg_sleep(1)")
+        kill_connection_from_server(pid)
+        sleep 0.1
+
+        # Drain results: first the FATAL, then the socket death
+        loop do
+          raw_connection.get_result || break
+        rescue PG::Error
+          break
+        end
+
+        error = assert_raises(PG::Error) { raw_connection.flush }
+        assert_not_kind_of PG::ConnectionBad, error
+
+        translated = @connection.send(:translate_exception_class, error, nil, nil)
+        assert_kind_of ActiveRecord::ConnectionFailed, translated
       end
 
       def test_reload_type_map_for_newly_defined_types

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -895,7 +895,7 @@ module ActiveRecord
 
       def test_raise_error_when_cannot_translate_exception
         assert_raise TypeError do
-          @connection.execute(:not_a_query)
+          @connection.execute([:not_a_query])
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -19,6 +19,9 @@ module ActiveRecord
         def status
           PG::CONNECTION_BAD
         end
+
+        def exit_pipeline_mode
+        end
       end
 
       class StatementPoolTest < ActiveRecord::PostgreSQLTestCase
@@ -47,7 +50,7 @@ module ActiveRecord
         end
 
         def test_prepared_statements_do_not_get_stuck_on_query_interruption
-          pg_connection = ActiveRecord::Base.lease_connection.connect!.instance_variable_get(:@raw_connection)
+          pg_connection = ActiveRecord::Base.lease_connection.connect!.raw_connection
           pg_connection.stub(:get_result, -> { raise "random error" }) do
             assert_raises(RuntimeError) do
               Developer.where(name: "David").last

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -48,7 +48,7 @@ module ActiveRecord
 
         def test_prepared_statements_do_not_get_stuck_on_query_interruption
           pg_connection = ActiveRecord::Base.lease_connection.connect!.instance_variable_get(:@raw_connection)
-          pg_connection.stub(:get_last_result, -> { raise "random error" }) do
+          pg_connection.stub(:get_result, -> { raise "random error" }) do
             assert_raises(RuntimeError) do
               Developer.where(name: "David").last
             end

--- a/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
+++ b/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
@@ -20,7 +20,6 @@ module ActiveRecord
 
       def test_async_fallback
         result = @connection.select_all("SELECT 1", async: true)
-        assert_instance_of FutureResult::Complete, result
         assert_equal [[1]], result.result.rows
       end
 

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -155,17 +155,16 @@ module ActiveRecord
         latch1 = Concurrent::CountDownLatch.new
         latch2 = Concurrent::CountDownLatch.new
 
-        old_log = ActiveRecord::Base.connection.method(:log)
-        ActiveRecord::Base.connection.singleton_class.undef_method(:log)
+        connection = ActiveRecord::Base.connection
+        old_start_intent_log = connection.method(:start_intent_log)
+        connection.singleton_class.undef_method(:start_intent_log)
 
-        ActiveRecord::Base.connection.singleton_class.define_method(:log) do |intent, *args, **kwargs, &block|
-          unless intent.ran_async
-            return old_log.call(intent, *args, **kwargs, &block)
+        connection.singleton_class.define_method(:start_intent_log) do |intent|
+          if intent.ran_async
+            latch1.count_down
+            latch2.wait
           end
-
-          latch1.count_down
-          latch2.wait
-          old_log.call(intent, *args, **kwargs, &block)
+          old_start_intent_log.call(intent)
         end
 
         Post.async_count
@@ -176,8 +175,8 @@ module ActiveRecord
         end
       ensure
         latch2.count_down
-        ActiveRecord::Base.connection.singleton_class.undef_method(:log)
-        ActiveRecord::Base.connection.singleton_class.define_method(:log, old_log)
+        connection.singleton_class.undef_method(:start_intent_log)
+        connection.singleton_class.define_method(:start_intent_log, old_start_intent_log)
       end
     end
 


### PR DESCRIPTION
PostgreSQL's pipeline mode allows us to have multiple queries in flight, then collect them all afterwards, saving a network round-trip per query. The gain is proportional to latency, so it matters most for cloud-hosted or distributed databases where even a "nearby" server is a few milliseconds away.

This builds on the QueryIntent setup (#55897, #56129, #56267), which has already separated query submission from result consumption.

Currently:
* Explicit use: `pipeline: true` on query methods, paralleling `async:`. Uses the "current" connection, so it's usable in situations where async would not work.
* Automatic: async-eligible queries that can't actually go async (inside a transaction, or no executor thread available) are transparently pipelined instead, so they can still be non-blocking.

Future:
* More explicit APIs: making a model `save!` able to be fully pipelined within a surrounding transaction (?)
* More automatic behaviour: transparently pipelining Relation preload queries [for peer associations, where there's no data dependency]

The bulk of the work here is in robustness around connection failures. A dead connection mid-pipeline is trickier than the single-query case, because all the in-flight queries need to be considered for retry/replay, and that can get complicated.