### PR TITLE
Fix bug with escaped characters when "Copy as text" is clicked

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -332,7 +332,7 @@
       return toggle('env_dump');
     }
     var copyAsText = function() {
-      const text = document.getElementById("exception-message-for-copy").textContent;
+      const text = document.getElementById("exception-message-for-copy").value;
 
       navigator.clipboard.writeText(text).then(() => {
         const beforeText = this.innerText;
@@ -345,7 +345,7 @@
 <body>
 
   <%= yield %>
-  <script type="text/plain" id="exception-message-for-copy"><%= @exception_message_for_copy %></script>
+  <textarea hidden id="exception-message-for-copy"><%= @exception_message_for_copy %></textarea>
 
 </body>
 </html>

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -997,7 +997,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_response 500
 
     assert_match %r{<button onclick="copyAsText\.bind\(this\)\(\)">Copy as text</button>}, body
-    assert_match %r{<script type="text/plain" id="exception-message-for-copy">.*RuntimeError \(puke}m, body
+    assert_match %r{<textarea hidden id="exception-message-for-copy">.*RuntimeError \(puke}m, body
   end
 
   test "copy button not shown for XHR requests" do
@@ -1010,6 +1010,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     assert_response 500
     assert_no_match %r{<button}, body
+    assert_no_match %r{<textarea}, body
   end
 
   test "exception message includes causes for nested exceptions" do
@@ -1017,9 +1018,9 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     get "/nested_exceptions", headers: { "action_dispatch.show_exceptions" => :all }
 
-    script_content = body[%r{<script type="text/plain" id="exception-message-for-copy">(.*?)</script>}m, 1]
-    assert_match %r{Third error}, script_content
-    assert_match %r{Caused by:.*Second error}m, script_content
+    content = body[%r{<textarea hidden id="exception-message-for-copy">(.*?)</textarea>}m, 1]
+    assert_match %r{Third error}, content
+    assert_match %r{Caused by:.*Second error}m, content
   end
 
   test "translate_path_for_editor returns original path when RAILS_HOST_APP_PATH is not set" do


### PR DESCRIPTION
Use textarea#value instead of script body
to prevent automatic escaping of the content.


### Motivation / Background

This Pull Request has been created because there is a bug

### Detail

This Pull Request changes "Copy as text" button text storage from `script` body to `textarea` value to prevent automatic escaping of HTML characters.


### Additional information

Here is how copied text looks like before the patch:

```
ActionController::UnpermittedParameters (found unpermitted parameter: :source):

app/controllers/admin/assets_uploads_controller.rb:73:in &#39;Admin::AssetsUploadsController#resource_params&#39;
app/controllers/admin/scaffold_controller.rb:36:in &#39;Admin::ScaffoldController#update&#39;
config/initializers/headers_sanitizer.rb:9:in &#39;HeadersSanitizer#call&#39;
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
