### PR TITLE
Delay engine route building

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -542,8 +542,20 @@ module Rails
     # Defines the routes for this engine. If a block is given to
     # routes, it is appended to the engine.
     def routes(&block)
-      @routes ||= config.route_set_class.new_with_config(config)
-      @routes.append(&block) if block_given?
+      if block_given?
+        if @route_blocks
+          @route_blocks << block
+        else
+          @routes ||= config.route_set_class.new_with_config(config)
+          @routes.append(&block)
+        end
+      elsif @routes.nil?
+        @routes = config.route_set_class.new_with_config(config)
+        if @route_blocks
+          blocks, @route_blocks = @route_blocks, nil
+          blocks.each { |b| routes(&b) }
+        end
+      end
       @routes
     end
 
@@ -595,6 +607,7 @@ module Rails
 
     initializer :make_routes_lazy, before: :bootstrap_hook do |app|
       config.route_set_class = LazyRouteSet if Rails.env.local?
+      routes
     end
 
     initializer :add_routing_paths do |app|


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/52353

Engines that call `routes do` directly in their definition end up allocating the route object before `:make_routes_lazy` is invoked, entirely defeating the optimization.

That's the case of the `graphql` gem for instance: https://github.com/rmosolgo/graphql-ruby/blob/fa35e798c61683376b4b1bc050ffea29ece7d08c/lib/graphql/dashboard.rb#L47

Instead we can defer evaluating the route blocks to after the `route_set_class` has been configured.

FYI: @gmcgibbon 