### PR TITLE
Allow association scopes to override enum defaults when building records

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -217,7 +217,9 @@ module ActiveRecord
       def initialize_attributes(record, except_from_scope_attributes = nil) # :nodoc:
         except_from_scope_attributes ||= {}
         skip_assign = [reflection.foreign_key, reflection.type].compact
-        assigned_keys = record.changed_attribute_names_to_save
+        assigned_keys = record.send(:attributes_with_values, record.changed_attribute_names_to_save).each_with_object([]) do |(key, attribute), keys|
+          keys << key unless attribute.is_a?(ActiveModel::Attribute::UserProvidedDefault)
+        end
         assigned_keys += except_from_scope_attributes.keys.map(&:to_s)
         attributes = scope_for_create.except!(*(assigned_keys - skip_assign))
         record.send(:_assign_attributes, attributes) if attributes.any?

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -410,6 +410,31 @@ class EnumTest < ActiveRecord::TestCase
     assert_predicate Book.illustrator_visibility_invisible.build, :illustrator_visibility_invisible?
   end
 
+  test "building from association scope overrides enum default" do
+    Object.const_set(:AssociationEnumDefaultBook, Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+
+      belongs_to :author
+      enum :status, [:proposed, :written, :published], default: :published
+    end)
+
+    author_class = Class.new(Author) do
+      has_many :written_books, -> { written }, class_name: "AssociationEnumDefaultBook", foreign_key: :author_id
+
+      def self.name
+        "Author"
+      end
+    end
+
+    book = author_class.new.written_books.build
+
+    assert_predicate book, :written?
+    assert_equal "written", book.status
+    assert_equal 1, book.status_before_type_cast
+  ensure
+    Object.send(:remove_const, :AssociationEnumDefaultBook) if Object.const_defined?(:AssociationEnumDefaultBook)
+  end
+
   test "creating new objects with enum scopes" do
     assert_predicate Book.written.create, :written?
     assert_predicate Book.read.create, :read?


### PR DESCRIPTION
### Motivation / Background

Fixes #57061.

This Pull Request has been created because enum defaults currently interfere with scoped association builds.

When a model attribute is initialized from a `default:` value, Active Record treats that attribute as changed. During association initialization, `initialize_attributes` skips applying scoped values for already-changed attributes. As a result, building through a scoped association can incorrectly keep the model default instead of the scope value.

### Detail
This Pull Request changes association initialization so attributes backed only by UserProvidedDefault values are not treated as explicitly assigned when applying scope_for_create.

That allows scoped associations to override model defaults while still preserving explicitly passed attributes.

It also adds a regression test covering the reported enum default case when building through an association scope.

### Additional information
Validated with:

 - ARCONN=sqlite3 bundle exec ruby -w -Itest test/cases/enum_test.rb
 - ARCONN=sqlite3 bundle exec ruby -w -Itest test/cases/associations/has_many_associations_test.rb -i test_build_from_association_should_respect_scope
 - ARCONN=sqlite3 bundle exec ruby -w -Itest test/cases/associations/has_many_associations_test.rb -i test_build_and_create_from_association_should_respect_passed_attributes_over_default_scope