### PR TITLE
Ignore schemas when validating table name lengths for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1265,6 +1265,11 @@ module ActiveRecord
             super
           end
 
+          def validate_table_length!(table_name)
+            _schema, table_name = extract_schema_qualified_name(table_name)
+            super
+          end
+
           def exclusion_constraint_name(table_name, **options)
             options.fetch(:name) do
               expression = options.fetch(:expression)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -189,7 +189,12 @@ class MigrationTest < ActiveRecord::TestCase
     connection = Person.lease_connection
     name_limit = connection.table_name_length
     long_name = "a" * (name_limit + 1)
-    short_name = "a" * name_limit
+    short_name =
+      if current_adapter?(:PostgreSQLAdapter)
+        "public." + "a" * name_limit
+      else
+        "a" * name_limit
+      end
 
     error = assert_raises(ArgumentError) do
       connection.create_table(long_name)


### PR DESCRIPTION
Fixes #57093.