### PR TITLE
ActiveStorage: skip associated tests when a dependency is missing

### DIFF
--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -6,6 +6,12 @@ require "database/setup"
 require "active_storage/analyzer/video_analyzer"
 
 class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
+  setup do
+    if !ENV["BUILDKITE"] && !system("command", "-v", ActiveStorage.paths[:ffprobe] || "ffprobe")
+      skip("ffprobe isn't available")
+    end
+  end
+
   test "analyzing a video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
     metadata = extract_metadata_from(blob)

--- a/activestorage/test/previewer/mupdf_previewer_test.rb
+++ b/activestorage/test/previewer/mupdf_previewer_test.rb
@@ -6,6 +6,12 @@ require "database/setup"
 require "active_storage/previewer/mupdf_previewer"
 
 class ActiveStorage::Previewer::MuPDFPreviewerTest < ActiveSupport::TestCase
+  setup do
+    if !ENV["BUILDKITE"] && !system("command", "-v", ActiveStorage.paths[:mutool] || "mutool")
+      skip("mutool isn't available")
+    end
+  end
+
   test "previewing a PDF document" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
 

--- a/activestorage/test/previewer/video_previewer_test.rb
+++ b/activestorage/test/previewer/video_previewer_test.rb
@@ -6,6 +6,12 @@ require "database/setup"
 require "active_storage/previewer/video_previewer"
 
 class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
+  setup do
+    if !ENV["BUILDKITE"] && !system("command", "-v", ActiveStorage.paths[:ffmpeg] || "ffmpeg")
+      skip("ffmpeg isn't available")
+    end
+  end
+
   test "previewing an MP4 video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
 


### PR DESCRIPTION
Makes it a bit easier to make small changes Active Storage without installing lots of dependencies.