### PR TITLE
Passkeys

### DIFF
--- a/actionpack/.babelrc
+++ b/actionpack/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    ["env", { "modules": false, "loose": true } ]
+  ],
+  "plugins": [
+    "external-helpers"
+  ]
+}

--- a/actionpack/.gitignore
+++ b/actionpack/.gitignore
@@ -1,0 +1,1 @@
+/test/javascript/compiled/

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add support for passkeys
+
+    Passkeys are a modern, phishing-resistant authentication method that uses public key cryptography.
+    It's built on the WebAuthn standard and supported by all major platforms and browsers.
+    This adds support for decoding WebAuthn requests and provides a Passkey implementation and helpers
+    for adding passkey-based authentication to Rails applications.
+
+    *Stanko Krtalic Rusendic* and *David Heinemeier Hansson*
+
 *   Add `config.action_dispatch.strict_accept_header` to stop forcing an
     HTML response when the `Accept` header contains the `*/*` wildcard.
 

--- a/actionpack/karma.conf.js
+++ b/actionpack/karma.conf.js
@@ -1,0 +1,64 @@
+const config = {
+  browsers: ["ChromeHeadless"],
+  frameworks: ["qunit"],
+  files: [
+    "test/javascript/compiled/test.js",
+  ],
+
+  client: {
+    clearContext: false,
+    qunit: {
+      showUI: true,
+      testTimeout: 5000
+    }
+  },
+
+  singleRun: true,
+  autoWatch: false,
+
+  captureTimeout: 180000,
+  browserDisconnectTimeout: 180000,
+  browserDisconnectTolerance: 3,
+  browserNoActivityTimeout: 300000,
+}
+
+if (process.env.CI) {
+  config.customLaunchers = {
+    sl_chrome: sauce("chrome", 70),
+    sl_ff: sauce("firefox", 63),
+    sl_safari: sauce("safari", "16", "macOS 13"),
+    sl_edge: sauce("microsoftedge", "latest", "Windows 11"),
+  }
+
+  config.browsers = Object.keys(config.customLaunchers)
+  config.reporters = ["dots", "saucelabs"]
+
+  config.sauceLabs = {
+    testName: "ActionPack JS Client",
+    retryLimit: 3,
+    build: buildId(),
+  }
+
+  function sauce(browserName, version, platform) {
+    const options = {
+      base: "SauceLabs",
+      browserName: browserName.toString(),
+      version: version.toString(),
+    }
+    if (platform) {
+      options.platform = platform.toString()
+    }
+    return options
+  }
+
+  function buildId() {
+    const { BUILDKITE_JOB_ID } = process.env
+    return BUILDKITE_JOB_ID
+      ? `Buildkite ${BUILDKITE_JOB_ID}`
+      : ""
+  }
+}
+
+module.exports = function(karmaConfig) {
+  karmaConfig.set(config)
+}

--- a/actionpack/lib/action_pack/passkeys.rb
+++ b/actionpack/lib/action_pack/passkeys.rb
@@ -12,6 +12,7 @@ module ActionPack
     mattr_accessor :registration_challenge_expiration, default: 10.minutes
     mattr_accessor :authentication_challenge_expiration, default: 5.minutes
     mattr_accessor :challenge_url
+    mattr_accessor :related_origins, default: []
 
     autoload :Engine
     autoload :FormHelper

--- a/actionpack/lib/action_pack/passkeys.rb
+++ b/actionpack/lib/action_pack/passkeys.rb
@@ -9,8 +9,8 @@ module ActionPack
     mattr_accessor :parent_class_name, default: "ApplicationRecord"
     mattr_accessor :default_registration_options, default: {}
     mattr_accessor :default_authentication_options, default: {}
-    mattr_accessor :registration_challenge_expiration, default: 10.minutes
-    mattr_accessor :authentication_challenge_expiration, default: 5.minutes
+    mattr_accessor :registration_timeout, default: 10.minutes
+    mattr_accessor :authentication_timeout, default: 5.minutes
     mattr_accessor :challenge_url
     mattr_accessor :related_origins, default: []
 

--- a/actionpack/lib/action_pack/passkeys.rb
+++ b/actionpack/lib/action_pack/passkeys.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/numeric/time"
-
 module ActionPack
   module Passkeys # :nodoc:
     extend ActiveSupport::Autoload
@@ -9,8 +7,6 @@ module ActionPack
     mattr_accessor :parent_class_name, default: "ApplicationRecord"
     mattr_accessor :default_registration_options, default: {}
     mattr_accessor :default_authentication_options, default: {}
-    mattr_accessor :registration_timeout, default: 10.minutes
-    mattr_accessor :authentication_timeout, default: 5.minutes
     mattr_accessor :challenge_url
     mattr_accessor :related_origins, default: []
 

--- a/actionpack/lib/action_pack/passkeys.rb
+++ b/actionpack/lib/action_pack/passkeys.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/numeric/time"
+
+module ActionPack
+  module Passkeys # :nodoc:
+    extend ActiveSupport::Autoload
+
+    mattr_accessor :parent_class_name, default: "ApplicationRecord"
+    mattr_accessor :default_registration_options, default: {}
+    mattr_accessor :default_authentication_options, default: {}
+    mattr_accessor :registration_challenge_expiration, default: 10.minutes
+    mattr_accessor :authentication_challenge_expiration, default: 5.minutes
+    mattr_accessor :challenge_url
+
+    autoload :Engine
+    autoload :FormHelper
+    autoload :Holder
+    autoload :Request
+  end
+end

--- a/actionpack/lib/action_pack/passkeys/engine.rb
+++ b/actionpack/lib/action_pack/passkeys/engine.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "active_record/railtie"
+require_relative "../passkeys"
+require_relative "../web_authn"
+require "active_support/core_ext/numeric/bytes"
+
+module ActionPack
+  class Passkeys::Engine < Rails::Engine # :nodoc:
+    def self.find_root(from)
+      Pathname.new(File.expand_path("../../passkeys", __dir__))
+    end
+
+    isolate_namespace ActionPack::Passkeys
+
+    config.action_pack = ActiveSupport::OrderedOptions.new unless config.respond_to?(:action_pack)
+    config.action_pack.passkey = ActiveSupport::OrderedOptions.new
+    config.action_pack.passkey.parent_class_name = "ApplicationRecord"
+    config.action_pack.passkey.routes_prefix = "/rails/action_pack/passkey"
+    config.action_pack.passkey.draw_routes = true
+    config.action_pack.passkey.challenge_url = nil
+    config.action_pack.passkey.default_registration_options = {}
+    config.action_pack.passkey.default_authentication_options = {}
+    config.action_pack.passkey.registration_challenge_expiration = 10.minutes
+    config.action_pack.passkey.authentication_challenge_expiration = 5.minutes
+    config.action_pack.passkey.cbor_max_depth = 16
+    config.action_pack.passkey.cbor_max_size = 10.megabytes
+
+    initializer "action_pack.passkey.config" do
+      passkey_config = config.action_pack.passkey
+
+      ActionPack::Passkeys.parent_class_name = passkey_config.parent_class_name
+      ActionPack::Passkeys.default_registration_options = passkey_config.default_registration_options
+      ActionPack::Passkeys.default_authentication_options = passkey_config.default_authentication_options
+      ActionPack::Passkeys.registration_challenge_expiration = passkey_config.registration_challenge_expiration
+      ActionPack::Passkeys.authentication_challenge_expiration = passkey_config.authentication_challenge_expiration
+      ActionPack::Passkeys.challenge_url = passkey_config.challenge_url
+    end
+
+    initializer "action_pack.passkey.verifier" do
+      config.after_initialize do |app|
+        ActionPack::WebAuthn.challenge_verifier = app.message_verifier("action_pack.webauthn.challenge")
+        ActionPack::WebAuthn.application_name = app.name
+      end
+    end
+
+    initializer "action_pack.passkey.routes" do |app|
+      passkey_config = config.action_pack.passkey
+
+      app.routes.prepend do
+        if passkey_config.draw_routes
+          scope passkey_config.routes_prefix, as: :passkey do
+            post "/challenge" => "action_pack/passkeys/challenges#create", as: :challenge
+          end
+        end
+      end
+    end
+
+    initializer "action_pack.passkey.cbor" do
+      require "action_pack/web_authn/cbor_decoder"
+      ActionPack::WebAuthn::CborDecoder.max_depth = config.action_pack.passkey.cbor_max_depth
+      ActionPack::WebAuthn::CborDecoder.max_size = config.action_pack.passkey.cbor_max_size
+    end
+
+    initializer "action_pack.passkey.holder" do
+      ActiveSupport.on_load(:active_record) do
+        include ActionPack::Passkeys::Holder
+      end
+    end
+
+    initializer "action_pack.passkey.form_helper" do
+      ActiveSupport.on_load(:action_view) do
+        include ActionPack::Passkeys::FormHelper
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/passkeys/engine.rb
+++ b/actionpack/lib/action_pack/passkeys/engine.rb
@@ -23,8 +23,8 @@ module ActionPack
     config.action_pack.passkey.related_origins = []
     config.action_pack.passkey.default_registration_options = {}
     config.action_pack.passkey.default_authentication_options = {}
-    config.action_pack.passkey.registration_challenge_expiration = 10.minutes
-    config.action_pack.passkey.authentication_challenge_expiration = 5.minutes
+    config.action_pack.passkey.registration_timeout = 10.minutes
+    config.action_pack.passkey.authentication_timeout = 5.minutes
     config.action_pack.passkey.cbor_max_depth = 16
     config.action_pack.passkey.cbor_max_size = 10.megabytes
 
@@ -34,8 +34,8 @@ module ActionPack
       ActionPack::Passkeys.parent_class_name = passkey_config.parent_class_name
       ActionPack::Passkeys.default_registration_options = passkey_config.default_registration_options
       ActionPack::Passkeys.default_authentication_options = passkey_config.default_authentication_options
-      ActionPack::Passkeys.registration_challenge_expiration = passkey_config.registration_challenge_expiration
-      ActionPack::Passkeys.authentication_challenge_expiration = passkey_config.authentication_challenge_expiration
+      ActionPack::Passkeys.registration_timeout = passkey_config.registration_timeout
+      ActionPack::Passkeys.authentication_timeout = passkey_config.authentication_timeout
       ActionPack::Passkeys.challenge_url = passkey_config.challenge_url
       ActionPack::Passkeys.related_origins = passkey_config.related_origins
     end

--- a/actionpack/lib/action_pack/passkeys/engine.rb
+++ b/actionpack/lib/action_pack/passkeys/engine.rb
@@ -16,9 +16,11 @@ module ActionPack
     config.action_pack = ActiveSupport::OrderedOptions.new unless config.respond_to?(:action_pack)
     config.action_pack.passkey = ActiveSupport::OrderedOptions.new
     config.action_pack.passkey.parent_class_name = "ApplicationRecord"
+    config.action_pack.passkey.relying_party_id = nil
     config.action_pack.passkey.routes_prefix = "/rails/action_pack/passkey"
     config.action_pack.passkey.draw_routes = true
     config.action_pack.passkey.challenge_url = nil
+    config.action_pack.passkey.related_origins = []
     config.action_pack.passkey.default_registration_options = {}
     config.action_pack.passkey.default_authentication_options = {}
     config.action_pack.passkey.registration_challenge_expiration = 10.minutes
@@ -35,12 +37,14 @@ module ActionPack
       ActionPack::Passkeys.registration_challenge_expiration = passkey_config.registration_challenge_expiration
       ActionPack::Passkeys.authentication_challenge_expiration = passkey_config.authentication_challenge_expiration
       ActionPack::Passkeys.challenge_url = passkey_config.challenge_url
+      ActionPack::Passkeys.related_origins = passkey_config.related_origins
     end
 
     initializer "action_pack.passkey.verifier" do
       config.after_initialize do |app|
         ActionPack::WebAuthn.challenge_verifier = app.message_verifier("action_pack.webauthn.challenge")
         ActionPack::WebAuthn.application_name = app.name
+        ActionPack::WebAuthn.relying_party_id = config.action_pack.passkey.relying_party_id
       end
     end
 
@@ -51,6 +55,10 @@ module ActionPack
         if passkey_config.draw_routes
           scope passkey_config.routes_prefix, as: :passkey do
             post "/challenge" => "action_pack/passkeys/challenges#create", as: :challenge
+          end
+
+          if passkey_config.related_origins.any?
+            get "/.well-known/webauthn" => "action_pack/well_known/webauthn#show"
           end
         end
       end

--- a/actionpack/lib/action_pack/passkeys/engine.rb
+++ b/actionpack/lib/action_pack/passkeys/engine.rb
@@ -23,8 +23,6 @@ module ActionPack
     config.action_pack.passkey.related_origins = []
     config.action_pack.passkey.default_registration_options = {}
     config.action_pack.passkey.default_authentication_options = {}
-    config.action_pack.passkey.registration_timeout = 10.minutes
-    config.action_pack.passkey.authentication_timeout = 5.minutes
     config.action_pack.passkey.cbor_max_depth = 16
     config.action_pack.passkey.cbor_max_size = 10.megabytes
 
@@ -34,8 +32,6 @@ module ActionPack
       ActionPack::Passkeys.parent_class_name = passkey_config.parent_class_name
       ActionPack::Passkeys.default_registration_options = passkey_config.default_registration_options
       ActionPack::Passkeys.default_authentication_options = passkey_config.default_authentication_options
-      ActionPack::Passkeys.registration_timeout = passkey_config.registration_timeout
-      ActionPack::Passkeys.authentication_timeout = passkey_config.authentication_timeout
       ActionPack::Passkeys.challenge_url = passkey_config.challenge_url
       ActionPack::Passkeys.related_origins = passkey_config.related_origins
     end

--- a/actionpack/lib/action_pack/passkeys/form_helper.rb
+++ b/actionpack/lib/action_pack/passkeys/form_helper.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module ActionPack
+  # = Action Pack Passkey Form Helper
+  #
+  # View helpers for rendering passkey registration and sign-in buttons.
+  module Passkeys::FormHelper
+    # Renders a button for registering a new passkey. Accepts a +label+ string or a block
+    # for button content.
+    #
+    # Options:
+    # - +options+ - WebAuthn creation options (JSON-serializable hash).
+    # - +challenge_url+ - Endpoint to refresh the challenge nonce.
+    # - +wrapper+ - HTML attributes for the outer web component element.
+    # - +form+ - Additional HTML attributes for the +<form>+ tag. Supports a +:param+ key
+    #   to set the form parameter namespace (default: +:passkey+).
+    # - +error+ - HTML attributes for the error message +<div>+. Supports a +:message+ key
+    #   to override the default error text.
+    # - +cancellation+ - HTML attributes for the cancellation message +<div>+. Supports a
+    #   +:message+ key to override the default cancellation text.
+    # - All other options are passed to the +<button>+ tag.
+    def passkey_registration_button(name = nil, url = nil, **options, &block)
+      url, name = name, block ? capture(&block) : nil if block_given?
+      component_options, form_options, button_options, error_options = partition_passkey_options(url, options)
+      error_options[:error][:message] ||= I18n.t("helpers.passkeys.registration.error", default: "Something went wrong while registering your passkey.")
+      error_options[:cancellation][:message] ||= I18n.t("helpers.passkeys.registration.cancelled", default: "Passkey registration was cancelled. Try again when you are ready.")
+      error_options[:duplicate][:message] ||= I18n.t("helpers.passkeys.registration.duplicate", default: "You already have a passkey registered on this device. Remove the existing one first and try again.")
+      param = form_options.delete(:param)
+
+      content_tag("rails-passkey-registration-button", **component_options.transform_keys { |key| key.to_s.dasherize }) do
+        tag.form(**form_options) do
+          hidden_field_tag(:authenticity_token, form_authenticity_token) +
+            hidden_field_tag("#{param}[client_data_json]", nil, id: nil, data: { passkey_field: "client_data_json" }) +
+            hidden_field_tag("#{param}[attestation_object]", nil, id: nil, data: { passkey_field: "attestation_object" }) +
+            hidden_field_tag("#{param}[transports][]", nil, id: nil, data: { passkey_field: "transports" }) +
+            tag.button(name, type: :button, data: { passkey: "register" }, **button_options)
+        end + passkey_error_messages(**error_options)
+      end
+    end
+
+    # Renders a button for signing in with a passkey. Accepts a +label+ string or a block
+    # for button content.
+    #
+    # Options:
+    # - +options+ - WebAuthn request options (JSON-serializable hash).
+    # - +challenge_url+ - Endpoint to refresh the challenge nonce.
+    # - +mediation+ - WebAuthn mediation hint (e.g. +"conditional"+ for autofill-assisted sign in).
+    # - +wrapper+ - HTML attributes for the outer web component element.
+    # - +form+ - Additional HTML attributes for the +<form>+ tag. Supports a +:param+ key
+    #   to set the form parameter namespace (default: +:passkey+).
+    # - +error+ - HTML attributes for the error message +<div>+. Supports a +:message+ key
+    #   to override the default error text.
+    # - +cancellation+ - HTML attributes for the cancellation message +<div>+. Supports a
+    #   +:message+ key to override the default cancellation text.
+    # - All other options are passed to the +<button>+ tag.
+    def passkey_sign_in_button(name = nil, url = nil, **options, &block)
+      url, name = name, block ? capture(&block) : nil if block_given?
+      component_options, form_options, button_options, error_options = partition_passkey_options(url, options)
+      error_options[:error][:message] ||= I18n.t("helpers.passkeys.sign_in.error", default: "Something went wrong while signing in with your passkey.")
+      error_options[:cancellation][:message] ||= I18n.t("helpers.passkeys.sign_in.cancelled", default: "Passkey sign in was cancelled. Try again when you are ready.")
+      param = form_options.delete(:param)
+
+      content_tag("rails-passkey-sign-in-button", **component_options.transform_keys { |key| key.to_s.dasherize }) do
+        tag.form(**form_options) do
+          hidden_field_tag(:authenticity_token, form_authenticity_token) +
+            hidden_field_tag("#{param}[id]", nil, id: nil, data: { passkey_field: "id" }) +
+            hidden_field_tag("#{param}[client_data_json]", nil, id: nil, data: { passkey_field: "client_data_json" }) +
+            hidden_field_tag("#{param}[authenticator_data]", nil, id: nil, data: { passkey_field: "authenticator_data" }) +
+            hidden_field_tag("#{param}[signature]", nil, id: nil, data: { passkey_field: "signature" }) +
+            tag.button(name, type: :button, data: { passkey: "sign_in" }, **button_options)
+        end + passkey_error_messages(**error_options)
+      end
+    end
+
+    private
+      def partition_passkey_options(url, options)
+        passkey_options = options.fetch(:options, {})
+        wrapper_options = options.fetch(:wrapper, {})
+
+        component_options = options
+          .slice(:challenge_url, :mediation)
+          .reverse_merge(challenge_url: default_passkey_challenge_url, options: passkey_options.to_json(except: :challenge))
+
+        form_options = options
+          .fetch(:form, {})
+          .reverse_merge(method: :post, action: url, class: "button_to", param: :passkey)
+
+        error_options = options.slice(:error, :cancellation, :duplicate).reverse_merge(error: {}, cancellation: {}, duplicate: {})
+
+        button_options = options.except(:options, :form, :wrapper, *component_options.keys, *error_options.keys)
+
+        [ wrapper_options.merge(component_options), form_options, button_options, error_options ]
+      end
+
+      def default_passkey_challenge_url
+        if challenge_url = ActionPack::Passkeys.challenge_url
+          instance_exec(&challenge_url)
+        else
+          passkey_challenge_path
+        end
+      end
+
+      def passkey_error_messages(error: {}, cancellation: {}, duplicate: {})
+        error_message, error_attributes = build_passkey_error_options("error", error)
+        cancellation_message, cancellation_attributes = build_passkey_error_options("cancelled", cancellation)
+
+        messages = tag.div(error_message, hidden: true, **error_attributes) +
+          tag.div(cancellation_message, hidden: true, **cancellation_attributes)
+
+        if duplicate[:message]
+          duplicate_message, duplicate_attributes = build_passkey_error_options("duplicate", duplicate)
+          messages += tag.div(duplicate_message, hidden: true, **duplicate_attributes)
+        end
+
+        messages
+      end
+
+      def build_passkey_error_options(type, options)
+        message = options[:message]
+
+        attributes = options.except(:message)
+        attributes[:data] ||= {}
+        attributes[:data][:passkey_error] = type
+
+        [ message, attributes ]
+      end
+  end
+end

--- a/actionpack/lib/action_pack/passkeys/holder.rb
+++ b/actionpack/lib/action_pack/passkeys/holder.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module ActionPack
+  # = Action Pack Passkey Holder
+  #
+  # Adds passkey support to an Active Record model (the "holder" of passkeys).
+  #
+  # == Usage
+  #
+  #   class User < ApplicationRecord
+  #     has_passkeys name: :email_address, display_name: :name
+  #   end
+  #
+  # This sets up a polymorphic +has_many :passkeys+ association and defines two methods on the
+  # model that supply holder-specific options for the WebAuthn ceremonies:
+  #
+  # * +passkey_registration_options+ — merged into ActionPack::Passkeys::Passkey.registration_options
+  # * +passkey_authentication_options+ — merged into ActionPack::Passkeys::Passkey.authentication_options
+  #
+  # == Options
+  #
+  # +has_passkeys+ accepts keyword arguments that map to WebAuthn creation or request option
+  # fields. Values can be symbols (sent to the record), procs (evaluated in the record's context),
+  # or plain values:
+  #
+  # [+name+]
+  #   A human-readable account identifier (typically an email or username) shown by the
+  #   authenticator when the user selects a passkey. Maps to the WebAuthn +user.name+ field.
+  #
+  # [+display_name+]
+  #   A friendly label for the user (typically their full name) shown by the authenticator
+  #   during passkey registration. Maps to the WebAuthn +user.displayName+ field.
+  #
+  #   has_passkeys name: :email, display_name: :name
+  #
+  # For more complex configuration, pass a block that receives an ActionPack::Passkeys::Passkeys::Holder::Config:
+  #
+  #   has_passkeys do |config|
+  #     config.registration_options { { name: email, display_name: name } }
+  #     config.authentication_options  { { user_verification: "required" } }
+  #   end
+  module Passkeys::Holder
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Declares that this model can hold passkeys. Sets up a polymorphic +has_many+ association
+      # and defines +passkey_registration_options+ and +passkey_authentication_options+ instance methods used
+      # by ActionPack::Passkeys::Passkey to build ceremony options.
+      #
+      # Keyword arguments matching CreationOptions or RequestOptions fields are extracted and
+      # turned into holder-scoped option procs automatically. An optional block yields a Config
+      # for more complex setup.
+      def has_passkeys(**options, &block)
+        config = Config.new(**options)
+        block&.call(config)
+
+        has_many config.association_name,
+          as: :holder,
+          dependent: config.dependent,
+          class_name: "ActionPack::Passkeys::Passkey"
+
+        define_method(:passkey_registration_options) do
+          {
+            id: id,
+            exclude_credentials: public_send(config.association_name)
+          }.merge(config.evaluate_registration_options(self))
+        end
+
+        define_method(:passkey_authentication_options) do
+          { credentials: public_send(config.association_name) }.merge(config.evaluate_authentication_options(self))
+        end
+      end
+    end
+
+    # Configuration object yielded by +has_passkeys+ when a block is given. Allows setting
+    # custom association options and ceremony option blocks.
+    class Config
+      attr_accessor :association_name, :dependent
+
+      def initialize(**options) # :nodoc:
+        @association_name = options.delete(:association_name) || :passkeys
+        @dependent = options.delete(:dependent) || :destroy
+
+        if creation_opts = extract_options_for(ActionPack::WebAuthn::PublicKeyCredential::CreationOptions, options)
+          @registration_options = options_to_proc(creation_opts)
+        end
+
+        if request_opts = extract_options_for(ActionPack::WebAuthn::PublicKeyCredential::RequestOptions, options)
+          @authentication_options = options_to_proc(request_opts)
+        end
+      end
+
+      # Sets a block to evaluate in the holder's context to produce additional authentication options.
+      #
+      #   config.authentication_options { { user_verification: "required" } }
+      def authentication_options(&block)
+        @authentication_options = block
+      end
+
+      # Sets a block to evaluate in the holder's context to produce additional registration options.
+      #
+      #   config.registration_options { { name: email, display_name: name } }
+      def registration_options(&block)
+        @registration_options = block
+      end
+
+      def evaluate_authentication_options(record) # :nodoc:
+        if @authentication_options
+          record.instance_exec(&@authentication_options)
+        else
+          {}
+        end
+      end
+
+      def evaluate_registration_options(record) # :nodoc:
+        if @registration_options
+          record.instance_exec(&@registration_options)
+        else
+          {}
+        end
+      end
+
+      private
+        def extract_options_for(klass, options)
+          keys = klass.attribute_names.map(&:to_sym)
+
+          extracted = options.slice(*keys)
+          options.except!(*keys)
+          extracted if extracted.any?
+        end
+
+        def options_to_proc(options)
+          proc do
+            options.transform_values do |value|
+              case value
+              when Symbol then send(value)
+              when Proc then instance_exec(&value)
+              else value
+              end
+            end
+          end
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/passkeys/request.rb
+++ b/actionpack/lib/action_pack/passkeys/request.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module ActionPack
+  # = Action Pack Passkey Request
+  #
+  # Controller concern that sets up the WebAuthn request context and provides
+  # helper methods for passkey registration and authentication. Include this
+  # in any controller that handles passkey form submissions.
+  #
+  # == Registration Example
+  #
+  #   class PasskeysController < ApplicationController
+  #     include ActionPack::Passkeys::Request
+  #
+  #     def new
+  #       @registration_options = passkey_registration_options(holder: Current.user)
+  #     end
+  #
+  #     def create
+  #       @passkey = ActionPack::Passkeys::Passkey.register(
+  #         passkey_registration_params, holder: Current.user
+  #       )
+  #       redirect_to settings_path
+  #     end
+  #   end
+  #
+  # == Authentication Example
+  #
+  #   class SessionsController < ApplicationController
+  #     include ActionPack::Passkeys::Request
+  #
+  #     def new
+  #       @authentication_options = passkey_authentication_options
+  #     end
+  #
+  #     def create
+  #       if passkey = ActionPack::Passkeys::Passkey.authenticate(passkey_authentication_params)
+  #         sign_in passkey.holder
+  #         redirect_to root_path
+  #       else
+  #         redirect_to new_session_path, alert: "Authentication failed"
+  #       end
+  #     end
+  #   end
+  #
+  # == Before Action
+  #
+  # Automatically populates +ActionPack::WebAuthn::Current+ with the request
+  # host and origin.
+  #
+  module Passkeys::Request
+    extend ActiveSupport::Concern
+
+    included do
+      before_action do
+        ActionPack::WebAuthn::Current.host = request.host
+        ActionPack::WebAuthn::Current.origin = request.base_url
+      end
+    end
+
+    # Returns strong parameters for the passkey registration ceremony.
+    def passkey_registration_params(param: :passkey)
+      params.expect(param => [ :client_data_json, :attestation_object, transports: [] ])
+    end
+
+    # Returns strong parameters for the passkey authentication ceremony.
+    def passkey_authentication_params(param: :passkey)
+      params.expect(param => [ :id, :client_data_json, :authenticator_data, :signature ])
+    end
+
+    # Returns RequestOptions for the authentication ceremony.
+    def passkey_authentication_options(**options)
+      ActionPack::Passkeys::Passkey.authentication_options(**options)
+    end
+
+    # Returns CreationOptions for the registration ceremony.
+    def passkey_registration_options(**options)
+      ActionPack::Passkeys::Passkey.registration_options(**options)
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn.rb
+++ b/actionpack/lib/action_pack/web_authn.rb
@@ -32,6 +32,16 @@ module ActionPack
   #
   #   ActionPack::WebAuthn.register_attestation_verifier("packed", MyPackedVerifier.new)
   #
+  # == Extending Key Formats
+  #
+  # By default the ES256, EdDSA, and RS256 COSE key formats are supported.
+  # Register additional formats with:
+  #
+  #   ActionPack::WebAuthn.register_key_format(MyKeyFormat)
+  #
+  # The format must respond to +algorithm+, +to_public_key_credential_param+,
+  # and +build(cose_key)+.
+  #
   module WebAuthn
     extend ActiveSupport::Autoload
 
@@ -85,6 +95,22 @@ module ActionPack
       # The +verifier+ must respond to +verify!(attestation, client_data_json:)+.
       def register_attestation_verifier(format, verifier)
         attestation_verifiers[format.to_s] = verifier
+      end
+
+      # Returns the registry of COSE key formats, keyed by COSE algorithm
+      # identifier. ES256, EdDSA, and RS256 are registered by default.
+      def key_formats
+        @key_formats ||= {
+          CoseKey::ES256.algorithm => CoseKey::ES256,
+          CoseKey::EdDSA.algorithm => CoseKey::EdDSA,
+          CoseKey::RS256.algorithm => CoseKey::RS256
+        }
+      end
+
+      # Registers a custom COSE key format. The +format+ must respond to
+      # +algorithm+, +to_public_key_credential_param+, and +build(cose_key)+.
+      def register_key_format(format)
+        key_formats[format.algorithm] = format
       end
     end
   end

--- a/actionpack/lib/action_pack/web_authn.rb
+++ b/actionpack/lib/action_pack/web_authn.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module ActionPack
+  # = Action Pack WebAuthn
+  #
+  # Provides a pure-Ruby implementation of the WebAuthn (Web Authentication)
+  # specification for passkey registration and authentication. This module
+  # is the top-level namespace for all WebAuthn components and provides
+  # shared utilities used across ceremonies.
+  #
+  # == Components
+  #
+  # [ActionPack::WebAuthn::RelyingParty]
+  #   Identifies the application to authenticators.
+  #
+  # [ActionPack::WebAuthn::PublicKeyCredential]
+  #   Orchestrates registration and authentication ceremonies.
+  #
+  # [ActionPack::WebAuthn::Authenticator]
+  #   Parses and validates authenticator responses.
+  #
+  # [ActionPack::WebAuthn::CborDecoder]
+  #   Decodes CBOR-encoded data from authenticators.
+  #
+  # [ActionPack::WebAuthn::CoseKey]
+  #   Parses COSE public keys into OpenSSL key objects.
+  #
+  # == Extending Attestation Formats
+  #
+  # By default only the "none" attestation format is supported. Register
+  # additional verifiers with:
+  #
+  #   ActionPack::WebAuthn.register_attestation_verifier("packed", MyPackedVerifier.new)
+  #
+  module WebAuthn
+    extend ActiveSupport::Autoload
+
+    mattr_accessor :challenge_verifier
+    mattr_accessor :application_name
+
+    class InvalidResponseError < StandardError; end
+    class InvalidCborError < StandardError; end
+    class InvalidKeyError < StandardError; end
+    class UnsupportedKeyTypeError < StandardError; end
+    class InvalidOptionsError < StandardError; end
+
+    autoload :CborDecoder
+    autoload :CoseKey
+    autoload :Current
+    autoload :PublicKeyCredential
+    autoload :RelyingParty
+
+    module Authenticator
+      extend ActiveSupport::Autoload
+
+      autoload :AssertionResponse
+      autoload :Attestation
+      autoload :AttestationResponse
+      autoload :Data
+      autoload :Response
+
+      module AttestationVerifiers
+        extend ActiveSupport::Autoload
+
+        autoload :None
+      end
+    end
+
+    class << self
+      # Returns a new RelyingParty configured from the current request context.
+      def relying_party
+        RelyingParty.new
+      end
+
+      # Returns the registry of attestation format verifiers, keyed by format
+      # string (e.g., "none", "packed"). Only "none" is registered by default.
+      def attestation_verifiers
+        @attestation_verifiers ||= {
+          "none" => Authenticator::AttestationVerifiers::None.new
+        }
+      end
+
+      # Registers a custom attestation verifier for the given +format+.
+      # The +verifier+ must respond to +verify!(attestation, client_data_json:)+.
+      def register_attestation_verifier(format, verifier)
+        attestation_verifiers[format.to_s] = verifier
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn.rb
+++ b/actionpack/lib/action_pack/web_authn.rb
@@ -42,12 +42,23 @@ module ActionPack
   # The format must respond to +algorithm+, +to_public_key_credential_param+,
   # and +build(cose_key)+.
   #
+  # == Native App Origins
+  #
+  # Responses are verified against the request's origin. Native apps assert
+  # with a platform origin instead — Android's Credential Manager reports the
+  # app's signing certificate as the origin. Allow those origins with:
+  #
+  #   ActionPack::WebAuthn.allowed_origins = [
+  #     "android:apk-key-hash:pNiP5iKyQ8JwgGOaKA1zGPUPJIS-0H1xKCQcfIoGLck"
+  #   ]
+  #
   module WebAuthn
     extend ActiveSupport::Autoload
 
     mattr_accessor :challenge_verifier
     mattr_accessor :application_name
     mattr_accessor :relying_party_id
+    mattr_accessor :allowed_origins, default: []
 
     class InvalidResponseError < StandardError; end
     class InvalidCborError < StandardError; end

--- a/actionpack/lib/action_pack/web_authn.rb
+++ b/actionpack/lib/action_pack/web_authn.rb
@@ -37,6 +37,7 @@ module ActionPack
 
     mattr_accessor :challenge_verifier
     mattr_accessor :application_name
+    mattr_accessor :relying_party_id
 
     class InvalidResponseError < StandardError; end
     class InvalidCborError < StandardError; end

--- a/actionpack/lib/action_pack/web_authn/authenticator/assertion_response.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/assertion_response.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    module Authenticator
+      # = Action Pack WebAuthn Assertion Response
+      #
+      # Handles the authenticator response from a WebAuthn authentication ceremony.
+      # When a user authenticates with an existing credential, the authenticator
+      # returns an assertion response containing a signature that proves possession
+      # of the private key.
+      #
+      # == Usage
+      #
+      #   # Look up the credential by ID
+      #   credential = user.credentials.find_by!(
+      #     credential_id: params[:id]
+      #   )
+      #
+      #   response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      #     client_data_json: params[:response][:clientDataJSON],
+      #     authenticator_data: params[:response][:authenticatorData],
+      #     signature: params[:response][:signature],
+      #     credential: credential.to_public_key_credential,
+      #     origin: "https://example.com"
+      #   )
+      #
+      #   response.validate!
+      #
+      # == Validation
+      #
+      # In addition to the base Response validations, this class verifies:
+      #
+      # * The client data type is "webauthn.get"
+      # * The signature is valid for the credential's public key
+      #
+      class AssertionResponse < Response
+        attr_reader :credential, :authenticator_data, :signature
+
+        validate :client_data_type_must_be_get
+        validate :signature_must_be_valid
+        validate :sign_count_must_increase
+
+        def initialize(credential:, authenticator_data:, signature:, **attributes) # :nodoc:
+          super(**attributes)
+          @credential = credential
+          @signature = signature
+          @signature = Base64.urlsafe_decode64(@signature) unless @signature.encoding == Encoding::BINARY
+          @authenticator_data = ActionPack::WebAuthn::Authenticator::Data.wrap(authenticator_data)
+        rescue ArgumentError
+          raise ActionPack::WebAuthn::InvalidResponseError, "Invalid base64 encoding in signature"
+        end
+
+        private
+          def challenge_purpose
+            "authentication"
+          end
+
+          def client_data_type_must_be_get
+            unless client_data["type"] == "webauthn.get"
+              errors.add(:base, "Client data type is not webauthn.get")
+            end
+          end
+
+          def signature_must_be_valid
+            client_data_hash = Digest::SHA256.digest(client_data_json)
+            signed_data = authenticator_data.bytes.pack("C*") + client_data_hash
+            digest = credential.public_key.oid == "ED25519" ? nil : "SHA256"
+
+            unless credential.public_key.verify(digest, signature, signed_data)
+              errors.add(:base, "Invalid signature")
+            end
+          rescue OpenSSL::PKey::PKeyError
+            errors.add(:base, "Invalid signature")
+          end
+
+          def sign_count_must_increase
+            unless sign_count_increased?
+              errors.add(:base, "Sign count did not increase")
+            end
+          end
+
+          def sign_count_increased?
+            if authenticator_data.sign_count.zero? && credential.sign_count.zero?
+              # Some authenticators always return 0 for the sign count, even after multiple authentications.
+              # In that case, we have to check that both the stored and returned sign counts are 0,
+              # which indicates that the authenticator is likely not updating the sign count.
+              true
+            else
+              authenticator_data.sign_count > credential.sign_count
+            end
+          end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/authenticator/attestation.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/attestation.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    module Authenticator
+      # = Action Pack WebAuthn Attestation
+      #
+      # Decodes and represents the attestation object returned by an authenticator
+      # during registration. The attestation object is CBOR-encoded and contains
+      # the authenticator data along with an optional attestation statement.
+      #
+      # == Usage
+      #
+      #   attestation = ActionPack::WebAuthn::Authenticator::Attestation.decode(
+      #     attestation_object_bytes
+      #   )
+      #
+      #   attestation.credential_id  # => "abc123..."
+      #   attestation.public_key     # => OpenSSL::PKey::EC
+      #   attestation.sign_count     # => 0
+      #
+      # == Attributes
+      #
+      # [+authenticator_data+]
+      #   The parsed Data containing credential information.
+      #
+      # [+format+]
+      #   The attestation statement format (e.g., "none", "packed", "fido-u2f").
+      #
+      # [+attestation_statement+]
+      #   The attestation statement, which may contain a signature from the
+      #   authenticator manufacturer. Empty for "none" format.
+      #
+      # == Delegated Methods
+      #
+      # The following methods are delegated to +authenticator_data+:
+      #
+      # * +credential_id+ - Base64URL-encoded credential identifier
+      # * +public_key+ - OpenSSL public key object
+      # * +public_key_bytes+ - Raw COSE key bytes
+      # * +sign_count+ - Signature counter for replay detection
+      #
+      class Attestation
+        attr_reader :authenticator_data, :format, :attestation_statement
+
+        delegate :credential_id, :public_key, :public_key_bytes, :sign_count, :aaguid, :backed_up?, to: :authenticator_data
+
+        # Wraps raw attestation data into an Attestation instance. Accepts an
+        # existing Attestation object (returned as-is), a Base64URL-encoded string,
+        # or raw binary.
+        def self.wrap(data)
+          if data.is_a?(self)
+            data
+          else
+            data = Base64.urlsafe_decode64(data) unless data.encoding == Encoding::BINARY
+            decode(data)
+          end
+        rescue ArgumentError
+          raise ActionPack::WebAuthn::InvalidResponseError, "Invalid base64 encoding in attestation object"
+        end
+
+        # Decodes a CBOR-encoded attestation object into an Attestation instance.
+        def self.decode(bytes)
+          cbor = ActionPack::WebAuthn::CborDecoder.decode(bytes)
+
+          new(
+            authenticator_data: ActionPack::WebAuthn::Authenticator::Data.decode(cbor["authData"]),
+            format: cbor["fmt"],
+            attestation_statement: cbor["attStmt"]
+          )
+        end
+
+        def initialize(authenticator_data:, format:, attestation_statement:) # :nodoc:
+          @authenticator_data = authenticator_data
+          @format = format
+          @attestation_statement = attestation_statement
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/authenticator/attestation.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/attestation.rb
@@ -43,7 +43,7 @@ module ActionPack
       class Attestation
         attr_reader :authenticator_data, :format, :attestation_statement
 
-        delegate :credential_id, :public_key, :public_key_bytes, :sign_count, :aaguid, :backed_up?, to: :authenticator_data
+        delegate :credential_id, :public_key, :public_key_bytes, :sign_count, :aaguid, :backup_eligible?, :backed_up?, to: :authenticator_data
 
         # Wraps raw attestation data into an Attestation instance. Accepts an
         # existing Attestation object (returned as-is), a Base64URL-encoded string,

--- a/actionpack/lib/action_pack/web_authn/authenticator/attestation_response.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/attestation_response.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    module Authenticator
+      # = Action Pack WebAuthn Attestation Response
+      #
+      # Handles the authenticator response from a WebAuthn registration ceremony.
+      # When a user registers a new credential, the authenticator returns an
+      # attestation response containing the new public key and credential ID.
+      #
+      # == Usage
+      #
+      #   response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      #     client_data_json: params[:response][:clientDataJSON],
+      #     attestation_object: params[:response][:attestationObject],
+      #     origin: "https://example.com"
+      #   )
+      #
+      #   response.validate!
+      #
+      #   # Store the credential
+      #   credential_id = response.attestation.credential_id
+      #   public_key = response.attestation.public_key
+      #
+      # == Validation
+      #
+      # In addition to the base Response validations, this class verifies:
+      #
+      # * The client data type is "webauthn.create"
+      # * The attestation format has a registered verifier
+      # * The attestation statement passes format-specific verification
+      #
+      class AttestationResponse < Response
+        attr_reader :attestation_object
+
+        validate :client_data_type_must_be_create
+        validate :attestation_must_be_valid
+
+        def initialize(attestation_object:, **attributes) # :nodoc:
+          super(**attributes)
+          @attestation_object = attestation_object
+        end
+
+        # Returns the decoded Attestation object, lazily parsed from the raw
+        # attestation object bytes.
+        def attestation
+          @attestation ||= ActionPack::WebAuthn::Authenticator::Attestation.wrap(attestation_object)
+        end
+
+        # Returns the authenticator data extracted from the attestation object.
+        def authenticator_data
+          attestation.authenticator_data
+        end
+
+        private
+          def challenge_purpose
+            "registration"
+          end
+
+          def client_data_type_must_be_create
+            unless client_data["type"] == "webauthn.create"
+              errors.add(:base, "Client data type is not webauthn.create")
+            end
+          end
+
+          def attestation_must_be_valid
+            verifier = ActionPack::WebAuthn.attestation_verifiers[attestation.format]
+
+            if verifier
+              verifier.verify!(attestation, client_data_json: client_data_json)
+            else
+              errors.add(:base, "Unsupported attestation format: #{attestation.format}")
+            end
+          end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/authenticator/attestation_verifiers/none.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/attestation_verifiers/none.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    module Authenticator
+      module AttestationVerifiers
+        # = Action Pack WebAuthn None Attestation Verifier
+        #
+        # Verifies attestation responses with the "none" format, which indicates the
+        # authenticator did not provide any attestation statement. This is the default
+        # format used by most consumer authenticators.
+        #
+        # == Implementing Custom Verifiers
+        #
+        # To support other attestation formats (e.g., "packed", "fido-u2f"), implement
+        # a class with the same +verify!+ interface and register it:
+        #
+        #   ActionPack::WebAuthn.register_attestation_verifier("packed", MyPackedVerifier.new)
+        #
+        # The +verify!+ method receives the decoded +Attestation+ object and the raw
+        # +client_data_json+ bytes. Raise +InvalidResponseError+ if verification fails.
+        #
+        class None
+          def verify!(attestation, client_data_json:)
+            if attestation.attestation_statement.present?
+              raise ActionPack::WebAuthn::InvalidResponseError,
+                "Attestation statement must be empty for 'none' format"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/authenticator/data.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/data.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    module Authenticator
+      # = Action Pack WebAuthn Authenticator Data
+      #
+      # Decodes and represents the authenticator data structure from WebAuthn
+      # responses. This binary format contains information about the authenticator
+      # and, during registration, the newly created credential.
+      #
+      # == Structure
+      #
+      # The authenticator data consists of:
+      #
+      # * RP ID Hash (32 bytes) - SHA-256 hash of the relying party ID
+      # * Flags (1 byte) - Bit flags for user presence, verification, etc.
+      # * Sign Count (4 bytes) - Signature counter for replay detection
+      # * Attested Credential Data (variable) - Present only during registration
+      #
+      # == Usage
+      #
+      #   data = ActionPack::WebAuthn::Authenticator::Data.decode(bytes)
+      #
+      #   data.user_present?   # => true
+      #   data.user_verified?  # => true
+      #   data.sign_count      # => 42
+      #   data.credential_id   # => "abc123..." (registration only)
+      #   data.public_key      # => OpenSSL::PKey::EC (registration only)
+      #
+      # == Flags
+      #
+      # [+user_present?+]
+      #   Returns true if the user performed a test of user presence (e.g., touched
+      #   the authenticator).
+      #
+      # [+user_verified?+]
+      #   Returns true if the user was verified through biometrics, PIN, or other
+      #   method. This is stronger than mere presence.
+      #
+      # [+backup_eligible?+]
+      #   Returns true if the credential can be backed up (e.g., synced passkeys
+      #   from Apple, Google, or Microsoft). Indicates multi-device credential support.
+      #
+      # [+backed_up?+]
+      #   Returns true if the credential is currently backed up to cloud storage.
+      #   Useful for risk assessment—backed-up credentials may be accessible from
+      #   multiple devices.
+      #
+      class Data
+        # Segment lengths
+        RELYING_PARTY_ID_HASH_LENGTH = 32
+        FLAGS_LENGTH = 1
+        SIGN_COUNT_LENGTH = 4
+        AAGUID_LENGTH = 16
+        CREDENTIAL_ID_LENGTH_BYTES = 2
+
+        # Flags
+        USER_PRESENT_FLAG = 0x01
+        USER_VERIFIED_FLAG = 0x04
+        BACKUP_ELIGIBLE_FLAG = 0x08
+        BACKUP_STATE_FLAG = 0x10
+        ATTESTED_CREDENTIAL_DATA_FLAG = 0x40
+
+        attr_reader :bytes, :relying_party_id_hash, :flags, :sign_count, :aaguid, :credential_id, :public_key_bytes
+
+        class << self
+          # Wraps raw authenticator data into a Data instance. Accepts an existing
+          # Data object (returned as-is), a Base64URL-encoded string, or raw binary.
+          def wrap(data)
+            if data.is_a?(self)
+              data
+            else
+              data = Base64.urlsafe_decode64(data) unless data.encoding == Encoding::BINARY
+              decode(data)
+            end
+          rescue ArgumentError
+            raise ActionPack::WebAuthn::InvalidResponseError, "Invalid base64 encoding in authenticator data"
+          end
+
+          # Decodes raw authenticator data bytes into a Data instance, parsing the
+          # RP ID hash, flags, sign count, and (if present) attested credential data.
+          def decode(bytes)
+            bytes = bytes.bytes if bytes.is_a?(String)
+
+            minimum_length = RELYING_PARTY_ID_HASH_LENGTH + FLAGS_LENGTH + SIGN_COUNT_LENGTH
+            if bytes.length < minimum_length
+              raise ActionPack::WebAuthn::InvalidResponseError, "Authenticator data is too short"
+            end
+
+            position = 0
+
+            relying_party_id_hash = bytes[position, RELYING_PARTY_ID_HASH_LENGTH].pack("C*")
+            position += RELYING_PARTY_ID_HASH_LENGTH
+
+            flags = bytes[position]
+            position += FLAGS_LENGTH
+
+            sign_count = bytes[position, SIGN_COUNT_LENGTH].pack("C*").unpack1("N")
+            position += SIGN_COUNT_LENGTH
+
+            aaguid = nil
+            credential_id = nil
+            public_key_bytes = nil
+
+            if flags & ATTESTED_CREDENTIAL_DATA_FLAG != 0
+              if bytes.length < position + AAGUID_LENGTH + CREDENTIAL_ID_LENGTH_BYTES
+                raise ActionPack::WebAuthn::InvalidResponseError, "Authenticator data is too short for attested credential data"
+              end
+
+              aaguid_bytes = bytes[position, AAGUID_LENGTH].pack("C*")
+              aaguid = aaguid_bytes.unpack("H8H4H4H4H12").join("-")
+              position += AAGUID_LENGTH
+
+              credential_id_length = bytes[position, CREDENTIAL_ID_LENGTH_BYTES].pack("C*").unpack1("n")
+              position += CREDENTIAL_ID_LENGTH_BYTES
+
+              if bytes.length < position + credential_id_length + 1
+                raise ActionPack::WebAuthn::InvalidResponseError, "Authenticator data is too short for credential ID and public key"
+              end
+
+              credential_id = Base64.urlsafe_encode64(bytes[position, credential_id_length].pack("C*"), padding: false)
+              position += credential_id_length
+
+              public_key_bytes = bytes[position..].pack("C*")
+            end
+
+            new(
+              bytes: bytes,
+              relying_party_id_hash: relying_party_id_hash,
+              flags: flags,
+              sign_count: sign_count,
+              aaguid: aaguid,
+              credential_id: credential_id,
+              public_key_bytes: public_key_bytes
+            )
+          end
+        end
+
+        def initialize(bytes:, relying_party_id_hash:, flags:, sign_count:, aaguid: nil, credential_id:, public_key_bytes:) # :nodoc:
+          @bytes = bytes
+          @relying_party_id_hash = relying_party_id_hash
+          @flags = flags
+          @sign_count = sign_count
+          @aaguid = aaguid
+          @credential_id = credential_id
+          @public_key_bytes = public_key_bytes
+        end
+
+        # Returns true if the user performed a test of presence (e.g., touched the
+        # authenticator).
+        def user_present?
+          flags & USER_PRESENT_FLAG != 0
+        end
+
+        # Returns true if the user was verified via biometrics, PIN, or similar.
+        def user_verified?
+          flags & USER_VERIFIED_FLAG != 0
+        end
+
+        # Returns true if the credential is eligible for backup (e.g., synced passkey).
+        # This indicates the authenticator supports multi-device credentials.
+        def backup_eligible?
+          flags & BACKUP_ELIGIBLE_FLAG != 0
+        end
+
+        # Returns true if the credential is currently backed up to cloud storage.
+        # Only meaningful when +backup_eligible?+ is true.
+        def backed_up?
+          flags & BACKUP_STATE_FLAG != 0
+        end
+
+        # Decodes the COSE public key bytes into an OpenSSL key object.
+        # Returns +nil+ when no attested credential data is present (authentication
+        # responses).
+        def public_key
+          @public_key ||= ActionPack::WebAuthn::CoseKey.decode(public_key_bytes).to_openssl_key if public_key_bytes
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/authenticator/response.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/response.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    module Authenticator
+      # = Action Pack WebAuthn Authenticator Response
+      #
+      # Abstract base class for WebAuthn authenticator responses. Provides common
+      # validation logic for both registration (attestation) and authentication
+      # (assertion) ceremonies.
+      #
+      # This class should not be instantiated directly. Use AttestationResponse for
+      # registration or AssertionResponse for authentication.
+      #
+      # == Validation
+      #
+      # The +validate!+ method performs security checks required by the WebAuthn
+      # specification:
+      #
+      # * Challenge verification - ensures the response contains a valid, signed challenge
+      # * Origin verification - ensures the response comes from the expected origin
+      # * User verification - optionally requires biometric or PIN verification
+      #
+      # == Example
+      #
+      #   response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      #     client_data_json: client_data_json,
+      #     authenticator_data: authenticator_data,
+      #     signature: signature,
+      #     credential: credential,
+      #     origin: "https://example.com",
+      #     user_verification: :required
+      #   )
+      #
+      #   response.validate!
+      #
+      class Response
+        include ActiveModel::Validations
+
+        attr_reader :client_data_json
+        attr_accessor :origin, :user_verification
+
+        validate :challenge_must_be_present
+        validate :challenge_must_not_be_expired
+        validate :origin_must_match
+        validate :must_not_be_cross_origin
+        validate :must_not_have_token_binding
+        validate :relying_party_id_must_match
+        validate :user_must_be_present
+        validate :user_must_be_verified_when_required
+
+        def initialize(client_data_json:, origin: nil, user_verification: :preferred) # :nodoc:
+          @client_data_json = client_data_json
+          @origin = origin
+          @user_verification = user_verification.to_sym
+        end
+
+        def validate!
+          super
+        rescue ActiveModel::ValidationError
+          raise ActionPack::WebAuthn::InvalidResponseError, errors.full_messages.join(", ")
+        end
+
+        # Returns the RelyingParty used for RP ID validation.
+        def relying_party
+          ActionPack::WebAuthn.relying_party
+        end
+
+        # Parses the client data JSON string into a Hash. Raises
+        # +InvalidResponseError+ if the JSON is malformed.
+        def client_data
+          @client_data ||= JSON.parse(client_data_json)
+        rescue JSON::ParserError
+          raise ActionPack::WebAuthn::InvalidResponseError, "Client data is not valid JSON"
+        end
+
+        def authenticator_data # :nodoc:
+          nil
+        end
+
+        private
+          def challenge_must_be_present
+            if client_data["challenge"].blank?
+              errors.add(:base, "Challenge missing")
+            end
+          end
+
+          def challenge_must_not_be_expired
+            return if errors.any?
+
+            signed_message = Base64.urlsafe_decode64(client_data["challenge"])
+
+            unless ActionPack::WebAuthn.challenge_verifier.verified(signed_message, purpose: challenge_purpose)
+              errors.add(:base, "Challenge has expired")
+            end
+          rescue ArgumentError
+            errors.add(:base, "Challenge is invalid")
+          end
+
+          def challenge_purpose
+            nil
+          end
+
+          def origin_must_match
+            if origin.blank?
+              errors.add(:base, "Origin missing")
+            elsif client_data["origin"].blank?
+              errors.add(:base, "Origin missing in client data")
+            elsif !ActiveSupport::SecurityUtils.secure_compare(origin.to_s, client_data["origin"].to_s)
+              errors.add(:base, "Origin does not match")
+            end
+          end
+
+          def must_not_be_cross_origin
+            if client_data["crossOrigin"] == true
+              errors.add(:base, "Cross-origin requests are not supported")
+            end
+          end
+
+          def must_not_have_token_binding
+            if client_data.dig("tokenBinding", "status") == "present"
+              errors.add(:base, "Token binding is not supported")
+            end
+          end
+
+          def relying_party_id_must_match
+            unless ActiveSupport::SecurityUtils.secure_compare(
+              Digest::SHA256.digest(relying_party.id),
+              authenticator_data&.relying_party_id_hash || ""
+            )
+              errors.add(:base, "Relying party ID does not match")
+            end
+          end
+
+          def user_must_be_present
+            unless authenticator_data&.user_present?
+              errors.add(:base, "User presence is required")
+            end
+          end
+
+          def user_must_be_verified_when_required
+            if user_verification == :required && !authenticator_data&.user_verified?
+              errors.add(:base, "User verification is required")
+            end
+          end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/authenticator/response.rb
+++ b/actionpack/lib/action_pack/web_authn/authenticator/response.rb
@@ -18,7 +18,8 @@ module ActionPack
       # specification:
       #
       # * Challenge verification - ensures the response contains a valid, signed challenge
-      # * Origin verification - ensures the response comes from the expected origin
+      # * Origin verification - ensures the response comes from the expected origin,
+      #   or one of the configured ActionPack::WebAuthn.allowed_origins
       # * User verification - optionally requires biometric or PIN verification
       #
       # == Example
@@ -106,8 +107,14 @@ module ActionPack
               errors.add(:base, "Origin missing")
             elsif client_data["origin"].blank?
               errors.add(:base, "Origin missing in client data")
-            elsif !ActiveSupport::SecurityUtils.secure_compare(origin.to_s, client_data["origin"].to_s)
+            elsif !origin_allowed?
               errors.add(:base, "Origin does not match")
+            end
+          end
+
+          def origin_allowed?
+            [ origin.to_s, *ActionPack::WebAuthn.allowed_origins ].any? do |allowed|
+              ActiveSupport::SecurityUtils.secure_compare(allowed, client_data["origin"].to_s)
             end
           end
 

--- a/actionpack/lib/action_pack/web_authn/cbor_decoder.rb
+++ b/actionpack/lib/action_pack/web_authn/cbor_decoder.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn CBOR Decoder
+    #
+    # Decodes Concise Binary Object Representation (CBOR) data as specified in
+    # RFC 8949[https://tools.ietf.org/html/rfc8949]. CBOR is a binary data format
+    # used by WebAuthn for encoding authenticator data and attestation objects.
+    #
+    # == Usage
+    #
+    # The decoder accepts either a binary string or an array of bytes:
+    #
+    #   # From binary string
+    #   ActionPack::WebAuthn::CborDecoder.decode("\x83\x01\x02\x03")
+    #   # => [1, 2, 3]
+    #
+    #   # From byte array
+    #   ActionPack::WebAuthn::CborDecoder.decode([0x83, 0x01, 0x02, 0x03])
+    #   # => [1, 2, 3]
+    #
+    # == Supported Types
+    #
+    # The decoder supports the following CBOR types:
+    #
+    # [Integers]
+    #   Unsigned (major type 0) and negative (major type 1) integers of any size.
+    #
+    # [Byte strings]
+    #   Binary data (major type 2), returned as ASCII-8BIT encoded strings.
+    #
+    # [Text strings]
+    #   UTF-8 text (major type 3), returned as UTF-8 encoded strings.
+    #
+    # [Arrays]
+    #   Ordered collections (major type 4) of any CBOR values.
+    #
+    # [Maps]
+    #   Key-value pairs (major type 5) with any CBOR values as keys and values.
+    #
+    # [Floats]
+    #   IEEE 754 half (16-bit), single (32-bit), and double (64-bit) precision.
+    #
+    # [Simple values]
+    #   +false+, +true+, +null+, and +undefined+ (both decoded as +nil+).
+    #
+    # [Indefinite length]
+    #   Streaming byte strings, text strings, arrays, and maps.
+    #
+    # Tags (major type 6) are recognized but their semantic meaning is ignored;
+    # the tagged value is returned directly.
+    #
+    # == Errors
+    #
+    # Raises +InvalidCborError+ when encountering malformed or unsupported CBOR data.
+    class CborDecoder
+      # Major types
+      UNSIGNED_INTEGER_TYPE = 0
+      NEGATIVE_INTEGER_TYPE = 1
+      BYTE_STRING_TYPE = 2
+      TEXT_STRING_TYPE = 3
+      ARRAY_TYPE = 4
+      MAP_TYPE = 5
+      TAG_TYPE = 6
+      FLOAT_OR_SIMPLE_TYPE = 7
+
+      # Additional information values
+      SIMPLE_VALUE_RANGE = 0..23
+      SINGLE_BYTE_VALUE_FOLLOWS = 24
+      TWO_BYTE_VALUE_FOLLOWS = 25
+      FOUR_BYTE_VALUE_FOLLOWS = 26
+      EIGHT_BYTE_VALUE_FOLLOWS = 27
+      RESERVED_VALUE_RANGE = 28..30
+      INDEFINITE_LENGTH_MAJOR_TYPE = 31
+
+      # Simple values
+      SIMPLE_FALSE_VALUE = 20
+      SIMPLE_TRUE_VALUE = 21
+      SIMPLE_NULL_VALUE = 22
+      SIMPLE_UNDEFINED_VALUE = 23
+
+      # Flow control
+      BREAK_CODE = 0xFF
+
+      # Limits
+      MAX_DEPTH = 16
+      MAX_SIZE = 10.megabytes
+
+      # Tags
+      POSITIVE_BIGNUM_TAG = 2
+      NEGATIVE_BIGNUM_TAG = 3
+
+      class << self
+        attr_accessor :max_depth, :max_size
+
+        # Decodes a CBOR-encoded byte sequence into a Ruby object.
+        #
+        #   ActionPack::WebAuthn::CborDecoder.decode("\xa2\x61a\x01\x61b\x02")
+        #   # => {"a" => 1, "b" => 2}
+        def decode(bytes, **args)
+          bytes = bytes.bytes if bytes.respond_to?(:bytes)
+          new(bytes, **args).decode
+        end
+      end
+
+      def initialize(bytes, max_depth: self.class.max_depth, max_size: self.class.max_size) # :nodoc:
+        max_size ||= MAX_SIZE
+        raise ActionPack::WebAuthn::InvalidCborError, "Input exceeds maximum size" if bytes.length > max_size
+
+        @bytes = bytes
+        @max_depth = max_depth || MAX_DEPTH
+        @position = 0
+        @depth = 0
+      end
+
+      # Decodes the next CBOR data item from the byte sequence.
+      def decode
+        raise ActionPack::WebAuthn::InvalidCborError, "Unexpected end of input" if @position >= @bytes.length
+        raise ActionPack::WebAuthn::InvalidCborError, "Maximum nesting depth exceeded" if @depth >= @max_depth
+
+        @depth += 1
+
+        result = case major_type
+        when UNSIGNED_INTEGER_TYPE then decode_unsigned_integer
+        when NEGATIVE_INTEGER_TYPE then decode_negative_integer
+        when BYTE_STRING_TYPE then decode_byte_string
+        when TEXT_STRING_TYPE then decode_text_string
+        when ARRAY_TYPE then decode_array
+        when MAP_TYPE then decode_map
+        when TAG_TYPE then decode_tag
+        when FLOAT_OR_SIMPLE_TYPE then decode_float_or_simple
+        end
+
+        @depth -= 1
+        result
+      end
+
+      private
+        def major_type
+          peek >> 5
+        end
+
+        def peek
+          @bytes[@position]
+        end
+
+        def decode_unsigned_integer
+          read_argument
+        end
+
+        def decode_negative_integer
+          -1 - read_argument
+        end
+
+        def decode_byte_string
+          if indefinite_length?
+            String.new(encoding: Encoding::ASCII_8BIT).tap { |str| str << decode_byte_string until break_code? }
+          else
+            read_bytes(read_argument).pack("C*")
+          end
+        end
+
+        def decode_text_string
+          if indefinite_length?
+            String.new(encoding: Encoding::UTF_8).tap { |str| str << decode_text_string until break_code? }
+          else
+            read_bytes(read_argument).pack("C*").force_encoding(Encoding::UTF_8)
+          end
+        end
+
+        def decode_array
+          if indefinite_length?
+            Array.new.tap { |arr| arr << decode until break_code? }
+          else
+            Array.new(read_argument) { decode }
+          end
+        end
+
+        def decode_map
+          if indefinite_length?
+            Hash.new.tap { |hash| hash[decode] = decode until break_code? }
+          else
+            Hash.new.tap do |hash|
+              read_argument.times do
+                hash[decode] = decode
+              end
+            end
+          end
+        end
+
+        def decode_float_or_simple
+          case info = additional_info
+          when SIMPLE_FALSE_VALUE then false
+          when SIMPLE_TRUE_VALUE then true
+          when SIMPLE_NULL_VALUE, SIMPLE_UNDEFINED_VALUE then nil
+          when TWO_BYTE_VALUE_FOLLOWS then decode_half_float
+          when FOUR_BYTE_VALUE_FOLLOWS then read_bytes(4).pack("C*").unpack1("g")
+          when EIGHT_BYTE_VALUE_FOLLOWS then read_bytes(8).pack("C*").unpack1("G")
+          else
+            raise ActionPack::WebAuthn::InvalidCborError, "Invalid simple value: #{info}"
+          end
+        end
+
+        def decode_tag
+          tag = read_argument
+          value = decode
+
+          case tag
+          when POSITIVE_BIGNUM_TAG then value.bytes.inject(0) { |n, b| (n << 8) | b }
+          when NEGATIVE_BIGNUM_TAG then -1 - value.bytes.inject(0) { |n, b| (n << 8) | b }
+          else value
+          end
+        end
+
+        def decode_half_float
+          half = read_bytes(2).pack("C*").unpack1("n")
+
+          sign = (half >> 15) & 0x1
+          exponent = (half >> 10) & 0x1F
+          mantissa = half & 0x3FF
+
+          value = if exponent == 0
+            Math.ldexp(mantissa, -24)
+          elsif exponent == 31
+            mantissa == 0 ? Float::INFINITY : Float::NAN
+          else
+            Math.ldexp(mantissa + 1024, exponent - 25)
+          end
+
+          sign == 1 ? -value : value
+        end
+
+        def read_argument
+          case info = additional_info
+          when SIMPLE_VALUE_RANGE then info
+          when SINGLE_BYTE_VALUE_FOLLOWS then read_byte
+          when TWO_BYTE_VALUE_FOLLOWS then read_bytes(2).pack("C*").unpack1("n")
+          when FOUR_BYTE_VALUE_FOLLOWS then read_bytes(4).pack("C*").unpack1("N")
+          when EIGHT_BYTE_VALUE_FOLLOWS then read_bytes(8).pack("C*").unpack1("Q>")
+          when RESERVED_VALUE_RANGE
+            raise ActionPack::WebAuthn::InvalidCborError, "Reserved additional info: #{info}"
+          else
+            raise ActionPack::WebAuthn::InvalidCborError, "Invalid additional info: #{info}"
+          end
+        end
+
+        def additional_info(consume: true)
+          byte = consume ? read_byte : peek
+          byte & 0b00011111
+        end
+
+        def indefinite_length?
+          read_byte if additional_info(consume: false) == INDEFINITE_LENGTH_MAJOR_TYPE
+        end
+
+        def break_code?
+          read_byte if peek == BREAK_CODE
+        end
+
+        def read_bytes(length)
+          raise ActionPack::WebAuthn::InvalidCborError, "Unexpected end of input" if @position + length > @bytes.length
+
+          bytes = @bytes[@position, length]
+          @position += length
+          bytes
+        end
+
+        def read_byte
+          raise ActionPack::WebAuthn::InvalidCborError, "Unexpected end of input" if @position >= @bytes.length
+
+          byte = @bytes[@position]
+          @position += 1
+          byte
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/cose_key.rb
+++ b/actionpack/lib/action_pack/web_authn/cose_key.rb
@@ -20,6 +20,11 @@ module ActionPack
     #
     # == Supported Algorithms
     #
+    # Key formats are pluggable: +to_openssl_key+ looks up the format for the
+    # key's algorithm in ActionPack::WebAuthn.key_formats. The following
+    # formats are registered by default, and additional ones can be added with
+    # ActionPack::WebAuthn.register_key_format:
+    #
     # [ES256]
     #   ECDSA with P-256 curve and SHA-256. The most common algorithm for WebAuthn.
     #
@@ -40,38 +45,15 @@ module ActionPack
     # [+parameters+]
     #   The full COSE key parameters map, including curve and coordinate data.
     class CoseKey
-      P256_COORDINATE_LENGTH = 32
-      MINIMUM_RSA_KEY_BITS = 2048
+      extend ActiveSupport::Autoload
+
+      autoload :ES256
+      autoload :EdDSA, "action_pack/web_authn/cose_key/eddsa"
+      autoload :RS256
 
       # COSE key labels
       KEY_TYPE_LABEL = 1
       ALGORITHM_LABEL = 3
-      EC2_CURVE_LABEL = -1
-      EC2_X_LABEL = -2
-      EC2_Y_LABEL = -3
-      RSA_N_LABEL = -1
-      RSA_E_LABEL = -2
-      OKP_CURVE_LABEL = -1
-      OKP_X_LABEL = -2
-
-      # COSE key types
-      OKP = 1
-      EC2 = 2
-      RSA = 3
-
-      # COSE algorithms
-      ES256 = -7
-      EDDSA = -8
-      RS256 = -257
-
-      # COSE EC2 curves
-      P256 = 1
-
-      # COSE OKP curves
-      ED25519 = 6
-
-      # OpenSSL types
-      UNCOMPRESSED_POINT_MARKER = 0x04
 
       attr_reader :key_type, :algorithm, :parameters
 
@@ -102,88 +84,16 @@ module ActionPack
       # RSA keys, or an Ed25519 key for OKP keys, suitable for use with
       # +OpenSSL::PKey#verify+.
       #
-      # Raises +UnsupportedKeyTypeError+ if the key type, algorithm, or curve
-      # is not supported.
+      # Raises +UnsupportedKeyTypeError+ if no key format is registered for
+      # the key's algorithm, or if the key type or curve is not supported by
+      # the format.
       def to_openssl_key
-        case [ key_type, algorithm ]
-        when [ EC2, ES256 ] then build_ec2_es256_key
-        when [ OKP, EDDSA ] then build_okp_eddsa_key
-        when [ RSA, RS256 ] then build_rsa_rs256_key
-        else raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported COSE key type/algorithm: #{key_type}/#{algorithm}"
+        if format = ActionPack::WebAuthn.key_formats[algorithm]
+          format.build(self)
+        else
+          raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported COSE algorithm: #{algorithm}"
         end
       end
-
-      private
-        def build_ec2_es256_key
-          curve = parameters[EC2_CURVE_LABEL]
-          raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported EC curve: #{curve}" unless curve == P256
-
-          x = parameters[EC2_X_LABEL]
-          y = parameters[EC2_Y_LABEL]
-          raise ActionPack::WebAuthn::InvalidKeyError, "Missing EC2 key coordinates" if x.nil? || y.nil?
-          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid EC2 coordinate length" unless x.bytesize == P256_COORDINATE_LENGTH && y.bytesize == P256_COORDINATE_LENGTH
-
-          # Uncompressed point format: 0x04 || x || y
-          public_key_bytes = [ UNCOMPRESSED_POINT_MARKER, *x.bytes, *y.bytes ].pack("C*")
-
-          asn1 = OpenSSL::ASN1::Sequence([
-            OpenSSL::ASN1::Sequence([
-              OpenSSL::ASN1::ObjectId("id-ecPublicKey"),
-              OpenSSL::ASN1::ObjectId("prime256v1")
-            ]),
-            OpenSSL::ASN1::BitString(public_key_bytes)
-          ])
-
-          OpenSSL::PKey::EC.new(asn1.to_der)
-        rescue OpenSSL::PKey::PKeyError => error
-          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid EC2 key: #{error.message}"
-        end
-
-        def build_okp_eddsa_key
-          curve = parameters[OKP_CURVE_LABEL]
-          raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported OKP curve: #{curve}" unless curve == ED25519
-
-          x = parameters[OKP_X_LABEL]
-          raise ActionPack::WebAuthn::InvalidKeyError, "Missing OKP key coordinate" if x.nil?
-
-          asn1 = OpenSSL::ASN1::Sequence([
-            OpenSSL::ASN1::Sequence([
-              OpenSSL::ASN1::ObjectId("ED25519")
-            ]),
-            OpenSSL::ASN1::BitString(x)
-          ])
-
-          OpenSSL::PKey.read(asn1.to_der)
-        rescue OpenSSL::PKey::PKeyError => error
-          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid OKP key: #{error.message}"
-        end
-
-        def build_rsa_rs256_key
-          n_bytes = parameters[RSA_N_LABEL]
-          e_bytes = parameters[RSA_E_LABEL]
-          raise ActionPack::WebAuthn::InvalidKeyError, "Missing RSA key parameters" if n_bytes.nil? || e_bytes.nil?
-          raise ActionPack::WebAuthn::InvalidKeyError, "RSA key must be at least #{MINIMUM_RSA_KEY_BITS} bits" if n_bytes.bytesize * 8 < MINIMUM_RSA_KEY_BITS
-
-          n = OpenSSL::BN.new(n_bytes, 2)
-          e = OpenSSL::BN.new(e_bytes, 2)
-
-          asn1 = OpenSSL::ASN1::Sequence([
-            OpenSSL::ASN1::Sequence([
-              OpenSSL::ASN1::ObjectId("rsaEncryption"),
-              OpenSSL::ASN1::Null.new(nil)
-            ]),
-            OpenSSL::ASN1::BitString(
-              OpenSSL::ASN1::Sequence([
-                OpenSSL::ASN1::Integer(n),
-                OpenSSL::ASN1::Integer(e)
-              ]).to_der
-            )
-          ])
-
-          OpenSSL::PKey::RSA.new(asn1.to_der)
-        rescue OpenSSL::PKey::PKeyError => error
-          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid RSA key: #{error.message}"
-        end
     end
   end
 end

--- a/actionpack/lib/action_pack/web_authn/cose_key.rb
+++ b/actionpack/lib/action_pack/web_authn/cose_key.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn COSE Key
+    #
+    # Parses COSE (CBOR Object Signing and Encryption) public keys as specified in
+    # RFC 9053[https://datatracker.ietf.org/doc/html/rfc9053]. WebAuthn authenticators
+    # return public keys in COSE format, which must be converted to a standard format
+    # for signature verification.
+    #
+    # == Usage
+    #
+    #   # Decode a COSE key from CBOR bytes (e.g., from authenticator data)
+    #   cose_key = ActionPack::WebAuthn::CoseKey.decode(cbor_bytes)
+    #
+    #   # Convert to OpenSSL key for signature verification
+    #   openssl_key = cose_key.to_openssl_key
+    #   openssl_key.verify("SHA256", signature, signed_data)
+    #
+    # == Supported Algorithms
+    #
+    # [ES256]
+    #   ECDSA with P-256 curve and SHA-256. The most common algorithm for WebAuthn.
+    #
+    # [EdDSA]
+    #   EdDSA with Ed25519 curve. Increasingly supported by modern authenticators.
+    #
+    # [RS256]
+    #   RSASSA-PKCS1-v1_5 with SHA-256. Used by some security keys and platforms.
+    #
+    # == Attributes
+    #
+    # [+key_type+]
+    #   The COSE key type (1 for OKP, 2 for EC2, 3 for RSA).
+    #
+    # [+algorithm+]
+    #   The COSE algorithm identifier (-7 for ES256, -8 for EdDSA, -257 for RS256).
+    #
+    # [+parameters+]
+    #   The full COSE key parameters map, including curve and coordinate data.
+    class CoseKey
+      P256_COORDINATE_LENGTH = 32
+      MINIMUM_RSA_KEY_BITS = 2048
+
+      # COSE key labels
+      KEY_TYPE_LABEL = 1
+      ALGORITHM_LABEL = 3
+      EC2_CURVE_LABEL = -1
+      EC2_X_LABEL = -2
+      EC2_Y_LABEL = -3
+      RSA_N_LABEL = -1
+      RSA_E_LABEL = -2
+      OKP_CURVE_LABEL = -1
+      OKP_X_LABEL = -2
+
+      # COSE key types
+      OKP = 1
+      EC2 = 2
+      RSA = 3
+
+      # COSE algorithms
+      ES256 = -7
+      EDDSA = -8
+      RS256 = -257
+
+      # COSE EC2 curves
+      P256 = 1
+
+      # COSE OKP curves
+      ED25519 = 6
+
+      # OpenSSL types
+      UNCOMPRESSED_POINT_MARKER = 0x04
+
+      attr_reader :key_type, :algorithm, :parameters
+
+      class << self
+        # Decodes a COSE key from CBOR-encoded bytes.
+        #
+        #   cose_key = ActionPack::WebAuthn::CoseKey.decode(cbor_bytes)
+        #   cose_key.algorithm # => -7 (ES256)
+        def decode(bytes)
+          data = ActionPack::WebAuthn::CborDecoder.decode(bytes)
+          new(
+            key_type: data[KEY_TYPE_LABEL],
+            algorithm: data[ALGORITHM_LABEL],
+            parameters: data
+          )
+        end
+      end
+
+      def initialize(key_type:, algorithm:, parameters:) # :nodoc:
+        @key_type = key_type
+        @algorithm = algorithm
+        @parameters = parameters
+      end
+
+      # Converts the COSE key to an OpenSSL public key object.
+      #
+      # Returns an +OpenSSL::PKey::EC+ for EC2 keys, +OpenSSL::PKey::RSA+ for
+      # RSA keys, or an Ed25519 key for OKP keys, suitable for use with
+      # +OpenSSL::PKey#verify+.
+      #
+      # Raises +UnsupportedKeyTypeError+ if the key type, algorithm, or curve
+      # is not supported.
+      def to_openssl_key
+        case [ key_type, algorithm ]
+        when [ EC2, ES256 ] then build_ec2_es256_key
+        when [ OKP, EDDSA ] then build_okp_eddsa_key
+        when [ RSA, RS256 ] then build_rsa_rs256_key
+        else raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported COSE key type/algorithm: #{key_type}/#{algorithm}"
+        end
+      end
+
+      private
+        def build_ec2_es256_key
+          curve = parameters[EC2_CURVE_LABEL]
+          raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported EC curve: #{curve}" unless curve == P256
+
+          x = parameters[EC2_X_LABEL]
+          y = parameters[EC2_Y_LABEL]
+          raise ActionPack::WebAuthn::InvalidKeyError, "Missing EC2 key coordinates" if x.nil? || y.nil?
+          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid EC2 coordinate length" unless x.bytesize == P256_COORDINATE_LENGTH && y.bytesize == P256_COORDINATE_LENGTH
+
+          # Uncompressed point format: 0x04 || x || y
+          public_key_bytes = [ UNCOMPRESSED_POINT_MARKER, *x.bytes, *y.bytes ].pack("C*")
+
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Sequence([
+              OpenSSL::ASN1::ObjectId("id-ecPublicKey"),
+              OpenSSL::ASN1::ObjectId("prime256v1")
+            ]),
+            OpenSSL::ASN1::BitString(public_key_bytes)
+          ])
+
+          OpenSSL::PKey::EC.new(asn1.to_der)
+        rescue OpenSSL::PKey::PKeyError => error
+          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid EC2 key: #{error.message}"
+        end
+
+        def build_okp_eddsa_key
+          curve = parameters[OKP_CURVE_LABEL]
+          raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported OKP curve: #{curve}" unless curve == ED25519
+
+          x = parameters[OKP_X_LABEL]
+          raise ActionPack::WebAuthn::InvalidKeyError, "Missing OKP key coordinate" if x.nil?
+
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Sequence([
+              OpenSSL::ASN1::ObjectId("ED25519")
+            ]),
+            OpenSSL::ASN1::BitString(x)
+          ])
+
+          OpenSSL::PKey.read(asn1.to_der)
+        rescue OpenSSL::PKey::PKeyError => error
+          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid OKP key: #{error.message}"
+        end
+
+        def build_rsa_rs256_key
+          n_bytes = parameters[RSA_N_LABEL]
+          e_bytes = parameters[RSA_E_LABEL]
+          raise ActionPack::WebAuthn::InvalidKeyError, "Missing RSA key parameters" if n_bytes.nil? || e_bytes.nil?
+          raise ActionPack::WebAuthn::InvalidKeyError, "RSA key must be at least #{MINIMUM_RSA_KEY_BITS} bits" if n_bytes.bytesize * 8 < MINIMUM_RSA_KEY_BITS
+
+          n = OpenSSL::BN.new(n_bytes, 2)
+          e = OpenSSL::BN.new(e_bytes, 2)
+
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Sequence([
+              OpenSSL::ASN1::ObjectId("rsaEncryption"),
+              OpenSSL::ASN1::Null.new(nil)
+            ]),
+            OpenSSL::ASN1::BitString(
+              OpenSSL::ASN1::Sequence([
+                OpenSSL::ASN1::Integer(n),
+                OpenSSL::ASN1::Integer(e)
+              ]).to_der
+            )
+          ])
+
+          OpenSSL::PKey::RSA.new(asn1.to_der)
+        rescue OpenSSL::PKey::PKeyError => error
+          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid RSA key: #{error.message}"
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/cose_key/eddsa.rb
+++ b/actionpack/lib/action_pack/web_authn/cose_key/eddsa.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn COSE Key \EdDSA
+    #
+    # Builds OpenSSL public keys from COSE EdDSA keys (Ed25519 curve),
+    # increasingly supported by modern authenticators. Registered by
+    # default in ActionPack::WebAuthn.key_formats.
+    module CoseKey::EdDSA
+      KEY_TYPE = 1 # OKP
+      ALGORITHM = -8
+
+      # COSE OKP key labels
+      CURVE_LABEL = -1
+      X_LABEL = -2
+
+      # COSE OKP curves
+      ED25519 = 6
+
+      class << self
+        def algorithm
+          ALGORITHM
+        end
+
+        def to_public_key_credential_param
+          { type: "public-key", alg: algorithm }
+        end
+
+        def build(cose_key)
+          unless cose_key.key_type == KEY_TYPE
+            raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported COSE key type for EdDSA: #{cose_key.key_type}"
+          end
+
+          curve = cose_key.parameters[CURVE_LABEL]
+          unless curve == ED25519
+            raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported OKP curve: #{curve}"
+          end
+
+          x = cose_key.parameters[X_LABEL]
+          if x.nil?
+            raise ActionPack::WebAuthn::InvalidKeyError, "Missing OKP key coordinate"
+          end
+
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Sequence([
+              OpenSSL::ASN1::ObjectId("ED25519")
+            ]),
+            OpenSSL::ASN1::BitString(x)
+          ])
+
+          OpenSSL::PKey.read(asn1.to_der)
+        rescue OpenSSL::PKey::PKeyError => error
+          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid OKP key: #{error.message}"
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/cose_key/es256.rb
+++ b/actionpack/lib/action_pack/web_authn/cose_key/es256.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn COSE Key \ES256
+    #
+    # Builds OpenSSL public keys from COSE ES256 keys (ECDSA with the P-256
+    # curve and SHA-256), the most common WebAuthn algorithm. Registered by
+    # default in ActionPack::WebAuthn.key_formats.
+    module CoseKey::ES256
+      KEY_TYPE = 2 # EC2
+      ALGORITHM = -7
+
+      # COSE EC2 key labels
+      CURVE_LABEL = -1
+      X_LABEL = -2
+      Y_LABEL = -3
+
+      # COSE EC2 curves
+      P256 = 1
+
+      P256_COORDINATE_LENGTH = 32
+      UNCOMPRESSED_POINT_MARKER = 0x04
+
+      class << self
+        def algorithm
+          ALGORITHM
+        end
+
+        def to_public_key_credential_param
+          { type: "public-key", alg: algorithm }
+        end
+
+        def build(cose_key)
+          unless cose_key.key_type == KEY_TYPE
+            raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported COSE key type for ES256: #{cose_key.key_type}"
+          end
+
+          curve = cose_key.parameters[CURVE_LABEL]
+
+          unless curve == P256
+            raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported EC curve: #{curve}"
+          end
+
+          x = cose_key.parameters[X_LABEL]
+          y = cose_key.parameters[Y_LABEL]
+
+          if x.nil? || y.nil?
+            raise ActionPack::WebAuthn::InvalidKeyError, "Missing EC2 key coordinates"
+          end
+
+          unless x.bytesize == P256_COORDINATE_LENGTH && y.bytesize == P256_COORDINATE_LENGTH
+            raise ActionPack::WebAuthn::InvalidKeyError, "Invalid EC2 coordinate length"
+          end
+
+          # Uncompressed point format: 0x04 || x || y
+          public_key_bytes = [ UNCOMPRESSED_POINT_MARKER, *x.bytes, *y.bytes ].pack("C*")
+
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Sequence([
+              OpenSSL::ASN1::ObjectId("id-ecPublicKey"),
+              OpenSSL::ASN1::ObjectId("prime256v1")
+            ]),
+            OpenSSL::ASN1::BitString(public_key_bytes)
+          ])
+
+          OpenSSL::PKey::EC.new(asn1.to_der)
+        rescue OpenSSL::PKey::PKeyError => error
+          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid EC2 key: #{error.message}"
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/cose_key/rs256.rb
+++ b/actionpack/lib/action_pack/web_authn/cose_key/rs256.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn COSE Key \RS256
+    #
+    # Builds OpenSSL public keys from COSE RS256 keys (RSASSA-PKCS1-v1_5
+    # with SHA-256), used by some security keys and platforms. Registered
+    # by default in ActionPack::WebAuthn.key_formats.
+    module CoseKey::RS256
+      KEY_TYPE = 3 # RSA
+      ALGORITHM = -257
+
+      # COSE RSA key labels
+      N_LABEL = -1
+      E_LABEL = -2
+
+      MINIMUM_KEY_BITS = 2048
+
+      class << self
+        def algorithm
+          ALGORITHM
+        end
+
+        def to_public_key_credential_param
+          { type: "public-key", alg: algorithm }
+        end
+
+        def build(cose_key)
+          unless cose_key.key_type == KEY_TYPE
+            raise ActionPack::WebAuthn::UnsupportedKeyTypeError, "Unsupported COSE key type for RS256: #{cose_key.key_type}"
+          end
+
+          n_bytes = cose_key.parameters[N_LABEL]
+          e_bytes = cose_key.parameters[E_LABEL]
+
+          if n_bytes.nil? || e_bytes.nil?
+            raise ActionPack::WebAuthn::InvalidKeyError, "Missing RSA key parameters"
+          end
+
+          if n_bytes.bytesize * 8 < MINIMUM_KEY_BITS
+            raise ActionPack::WebAuthn::InvalidKeyError, "RSA key must be at least #{MINIMUM_KEY_BITS} bits"
+          end
+
+          n = OpenSSL::BN.new(n_bytes, 2)
+          e = OpenSSL::BN.new(e_bytes, 2)
+
+          asn1 = OpenSSL::ASN1::Sequence([
+            OpenSSL::ASN1::Sequence([
+              OpenSSL::ASN1::ObjectId("rsaEncryption"),
+              OpenSSL::ASN1::Null.new(nil)
+            ]),
+            OpenSSL::ASN1::BitString(
+              OpenSSL::ASN1::Sequence([
+                OpenSSL::ASN1::Integer(n),
+                OpenSSL::ASN1::Integer(e)
+              ]).to_der
+            )
+          ])
+
+          OpenSSL::PKey::RSA.new(asn1.to_der)
+        rescue OpenSSL::PKey::PKeyError => error
+          raise ActionPack::WebAuthn::InvalidKeyError, "Invalid RSA key: #{error.message}"
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/current.rb
+++ b/actionpack/lib/action_pack/web_authn/current.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn Current Attributes
+    #
+    # Thread-isolated request-scoped attributes for WebAuthn ceremonies. These are
+    # set automatically by ActionPack::Passkeys::Request at the start of each
+    # request and consumed by the registration/authentication flows.
+    #
+    # == Attributes
+    #
+    # [+host+]
+    #   The relying party identifier (typically +request.host+). Used as the
+    #   default RelyingParty ID.
+    #
+    # [+origin+]
+    #   The expected origin (typically +request.base_url+). Validated against the
+    #   +origin+ field in the authenticator's client data.
+    #
+    class Current < ActiveSupport::CurrentAttributes
+      attribute :host, :origin
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential.rb
@@ -51,6 +51,9 @@ module ActionPack
     # [+aaguid+]
     #   The authenticator attestation GUID (set during registration).
     #
+    # [+relying_party_id+]
+    #   The relying party ID the credential is scoped to. This is set during registration.
+    #
     # [+backed_up+]
     #   Whether the credential is backed up to cloud storage (synced passkey).
     #
@@ -64,7 +67,7 @@ module ActionPack
       autoload :Options
       autoload :RequestOptions
 
-      attr_reader :id, :public_key, :sign_count, :aaguid, :backed_up, :transports
+      attr_reader :id, :public_key, :sign_count, :aaguid, :relying_party_id, :backed_up, :transports
 
       class << self
         # Returns a RequestOptions object for the authentication ceremony.
@@ -103,6 +106,7 @@ module ActionPack
             public_key: response.attestation.public_key,
             sign_count: response.attestation.sign_count,
             aaguid: response.attestation.aaguid,
+            relying_party_id: response.relying_party.id,
             backed_up: response.attestation.backed_up?,
             transports: Array(params[:transports])
           )
@@ -120,12 +124,13 @@ module ActionPack
           end
       end
 
-      def initialize(id:, public_key:, sign_count:, aaguid: nil, backed_up: nil, transports: []) # :nodoc:
+      def initialize(id:, public_key:, sign_count:, aaguid: nil, relying_party_id: nil, backed_up: nil, transports: []) # :nodoc:
         @id = id
         @public_key = public_key
         @public_key = OpenSSL::PKey.read(public_key) unless public_key.is_a?(OpenSSL::PKey::PKey)
         @sign_count = sign_count
         @aaguid = aaguid
+        @relying_party_id = relying_party_id
         @backed_up = backed_up
         @transports = transports
       end
@@ -156,6 +161,7 @@ module ActionPack
           public_key: public_key.to_der,
           sign_count: sign_count,
           aaguid: aaguid,
+          relying_party_id: relying_party_id,
           backed_up: backed_up,
           transports: transports
         }

--- a/actionpack/lib/action_pack/web_authn/public_key_credential.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential.rb
@@ -54,6 +54,10 @@ module ActionPack
     # [+relying_party_id+]
     #   The relying party ID the credential is scoped to. This is set during registration.
     #
+    # [+backup_eligible+]
+    #   Whether the credential is eligible for backup (a multi-device, syncable
+    #   passkey). Set during registration and immutable thereafter.
+    #
     # [+backed_up+]
     #   Whether the credential is backed up to cloud storage (synced passkey).
     #
@@ -67,7 +71,7 @@ module ActionPack
       autoload :Options
       autoload :RequestOptions
 
-      attr_reader :id, :public_key, :sign_count, :aaguid, :relying_party_id, :backed_up, :transports
+      attr_reader :id, :public_key, :sign_count, :aaguid, :relying_party_id, :backup_eligible, :backed_up, :transports
 
       class << self
         # Returns a RequestOptions object for the authentication ceremony.
@@ -107,6 +111,7 @@ module ActionPack
             sign_count: response.attestation.sign_count,
             aaguid: response.attestation.aaguid,
             relying_party_id: response.relying_party.id,
+            backup_eligible: response.attestation.backup_eligible?,
             backed_up: response.attestation.backed_up?,
             transports: Array(params[:transports])
           )
@@ -124,13 +129,14 @@ module ActionPack
           end
       end
 
-      def initialize(id:, public_key:, sign_count:, aaguid: nil, relying_party_id: nil, backed_up: nil, transports: []) # :nodoc:
+      def initialize(id:, public_key:, sign_count:, aaguid: nil, relying_party_id: nil, backup_eligible: nil, backed_up: nil, transports: []) # :nodoc:
         @id = id
         @public_key = public_key
         @public_key = OpenSSL::PKey.read(public_key) unless public_key.is_a?(OpenSSL::PKey::PKey)
         @sign_count = sign_count
         @aaguid = aaguid
         @relying_party_id = relying_party_id
+        @backup_eligible = backup_eligible
         @backed_up = backed_up
         @transports = transports
       end
@@ -162,6 +168,7 @@ module ActionPack
           sign_count: sign_count,
           aaguid: aaguid,
           relying_party_id: relying_party_id,
+          backup_eligible: backup_eligible,
           backed_up: backed_up,
           transports: transports
         }

--- a/actionpack/lib/action_pack/web_authn/public_key_credential.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn Public Key Credential
+    #
+    # Represents a WebAuthn public key credential and orchestrates the registration
+    # and authentication ceremonies. During registration (+.register+), it verifies
+    # the attestation response and returns a new credential. During authentication
+    # (+#authenticate+), it verifies the assertion response against the stored
+    # public key.
+    #
+    # == Registration
+    #
+    #   credential = ActionPack::WebAuthn::PublicKeyCredential.register(
+    #     params[:passkey],
+    #     origin: ActionPack::WebAuthn::Current.origin
+    #   )
+    #
+    #   credential.id         # => Base64URL-encoded credential ID
+    #   credential.public_key # => OpenSSL::PKey::EC
+    #   credential.sign_count # => 0
+    #
+    # == Authentication
+    #
+    #   credential = ActionPack::WebAuthn::PublicKeyCredential.new(
+    #     id: stored_credential_id,
+    #     public_key: stored_public_key,
+    #     sign_count: stored_sign_count
+    #   )
+    #
+    #   credential.authenticate(params[:passkey])
+    #
+    # == Ceremony Options
+    #
+    # Use +.creation_options+ and +.request_options+ to generate the JSON options
+    # passed to the browser's +navigator.credentials.create()+ and
+    # +navigator.credentials.get()+ calls.
+    #
+    # == Attributes
+    #
+    # [+id+]
+    #   The Base64URL-encoded credential identifier.
+    #
+    # [+public_key+]
+    #   The OpenSSL public key for signature verification.
+    #
+    # [+sign_count+]
+    #   The signature counter, used for replay detection.
+    #
+    # [+aaguid+]
+    #   The authenticator attestation GUID (set during registration).
+    #
+    # [+backed_up+]
+    #   Whether the credential is backed up to cloud storage (synced passkey).
+    #
+    # [+transports+]
+    #   Transport hints (e.g., "internal", "usb", "ble", "nfc").
+    #
+    class PublicKeyCredential
+      extend ActiveSupport::Autoload
+
+      autoload :CreationOptions
+      autoload :Options
+      autoload :RequestOptions
+
+      attr_reader :id, :public_key, :sign_count, :aaguid, :backed_up, :transports
+
+      class << self
+        # Returns a RequestOptions object for the authentication ceremony.
+        # Credentials responding to +to_public_key_credential+ are automatically
+        # transformed.
+        def request_options(**attributes)
+          attributes[:credentials] = transform_credentials(attributes[:credentials]) if attributes[:credentials]
+
+          ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(**attributes)
+        end
+
+        # Returns a CreationOptions object for the registration ceremony.
+        # Credentials in +exclude_credentials+ responding to
+        # +to_public_key_credential+ are automatically transformed.
+        def creation_options(**attributes)
+          attributes[:exclude_credentials] = transform_credentials(attributes[:exclude_credentials]) if attributes[:exclude_credentials]
+
+          ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(**attributes)
+        end
+
+        # Verifies an attestation response from the browser and returns a new
+        # PublicKeyCredential with the registered credential data.
+        #
+        # Raises +InvalidResponseError+ if the attestation is invalid.
+        def register(params, origin: ActionPack::WebAuthn::Current.origin)
+          response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+            client_data_json: params[:client_data_json],
+            attestation_object: params[:attestation_object],
+            origin: origin
+          )
+
+          response.validate!
+
+          new(
+            id: response.attestation.credential_id,
+            public_key: response.attestation.public_key,
+            sign_count: response.attestation.sign_count,
+            aaguid: response.attestation.aaguid,
+            backed_up: response.attestation.backed_up?,
+            transports: Array(params[:transports])
+          )
+        end
+
+        private
+          def transform_credentials(credentials)
+            Array(credentials).map do |credential|
+              if credential.respond_to?(:to_public_key_credential)
+                credential.to_public_key_credential
+              else
+                credential
+              end
+            end
+          end
+      end
+
+      def initialize(id:, public_key:, sign_count:, aaguid: nil, backed_up: nil, transports: []) # :nodoc:
+        @id = id
+        @public_key = public_key
+        @public_key = OpenSSL::PKey.read(public_key) unless public_key.is_a?(OpenSSL::PKey::PKey)
+        @sign_count = sign_count
+        @aaguid = aaguid
+        @backed_up = backed_up
+        @transports = transports
+      end
+
+      # Verifies an assertion response against this credential's public key.
+      # Updates +sign_count+ and +backed_up+ on success.
+      #
+      # Raises +InvalidResponseError+ if the assertion is invalid.
+      def authenticate(params, origin: ActionPack::WebAuthn::Current.origin)
+        response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+          client_data_json: params[:client_data_json],
+          authenticator_data: params[:authenticator_data],
+          signature: params[:signature],
+          credential: self,
+          origin: origin
+        )
+
+        response.validate!
+
+        @sign_count = response.authenticator_data.sign_count
+        @backed_up = response.authenticator_data.backed_up?
+      end
+
+      # Returns a Hash of the credential data suitable for persisting.
+      def to_h
+        {
+          credential_id: id,
+          public_key: public_key.to_der,
+          sign_count: sign_count,
+          aaguid: aaguid,
+          backed_up: backed_up,
+          transports: transports
+        }
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential.rb
@@ -96,11 +96,12 @@ module ActionPack
         # PublicKeyCredential with the registered credential data.
         #
         # Raises +InvalidResponseError+ if the attestation is invalid.
-        def register(params, origin: ActionPack::WebAuthn::Current.origin)
+        def register(params, **options)
           response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
             client_data_json: params[:client_data_json],
             attestation_object: params[:attestation_object],
-            origin: origin
+            origin: options.fetch(:origin, ActionPack::WebAuthn::Current.origin),
+            user_verification: options.fetch(:user_verification, :preferred)
           )
 
           response.validate!
@@ -145,13 +146,14 @@ module ActionPack
       # Updates +sign_count+ and +backed_up+ on success.
       #
       # Raises +InvalidResponseError+ if the assertion is invalid.
-      def authenticate(params, origin: ActionPack::WebAuthn::Current.origin)
+      def authenticate(params, **options)
         response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
           client_data_json: params[:client_data_json],
           authenticator_data: params[:authenticator_data],
           signature: params[:signature],
           credential: self,
-          origin: origin
+          origin: options.fetch(:origin, ActionPack::WebAuthn::Current.origin),
+          user_verification: options.fetch(:user_verification, :preferred)
         )
 
         response.validate!

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -53,9 +53,6 @@ module ActionPack
     # (Ed25519), and RS256 (RSASSA-PKCS1-v1_5 with SHA-256), which cover
     # the vast majority of authenticators.
     class PublicKeyCredential::CreationOptions < PublicKeyCredential::Options
-      ES256 = { type: "public-key", alg: -7 }.freeze
-      EDDSA = { type: "public-key", alg: -8 }.freeze
-      RS256 = { type: "public-key", alg: -257 }.freeze
       RESIDENT_KEY_OPTIONS = %i[ preferred required discouraged ].freeze
       ATTESTATION_PREFERENCES = %i[ none indirect direct enterprise ].freeze
       AUTHENTICATOR_ATTACHMENTS = %w[ platform cross-platform ].freeze
@@ -97,9 +94,9 @@ module ActionPack
             displayName: display_name
           },
           pubKeyCredParams: [
-            ES256,
-            EDDSA,
-            RS256
+            { type: "public-key", alg: CoseKey::ES256 },
+            { type: "public-key", alg: CoseKey::EDDSA },
+            { type: "public-key", alg: CoseKey::RS256 }
           ],
           authenticatorSelection: authenticator_selection_json,
           attestation: attestation.to_s

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn Public Key Credential Creation Options
+    #
+    # Generates options for the WebAuthn registration ceremony (creating a new
+    # credential). These options are passed to +navigator.credentials.create()+ in
+    # the browser to prompt the user to register an authenticator.
+    #
+    # == Usage
+    #
+    #   options = ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+    #     id: current_user.id,
+    #     name: current_user.email,
+    #     display_name: current_user.name
+    #   )
+    #
+    #   # Return as JSON for the JavaScript WebAuthn API
+    #   render json: { publicKey: options.as_json }
+    #
+    # == Attributes
+    #
+    # [+id+]
+    #   A unique identifier for the user account. Will be Base64URL-encoded in the
+    #   output. This should be an opaque identifier (like a primary key), not
+    #   personally identifiable information.
+    #
+    # [+name+]
+    #   A human-readable identifier for the user account, typically an email
+    #   address or username. Displayed by the authenticator.
+    #
+    # [+display_name+]
+    #   A human-friendly name for the user, typically their full name. Displayed
+    #   by the authenticator during registration.
+    #
+    # [+relying_party+]
+    #   The relying party (application) configuration. Defaults to
+    #   +ActionPack::WebAuthn.relying_party+.
+    #
+    # == Supported Algorithms
+    #
+    # By default, supports ES256 (ECDSA with P-256 and SHA-256), EdDSA
+    # (Ed25519), and RS256 (RSASSA-PKCS1-v1_5 with SHA-256), which cover
+    # the vast majority of authenticators.
+    class PublicKeyCredential::CreationOptions < PublicKeyCredential::Options
+      ES256 = { type: "public-key", alg: -7 }.freeze
+      EDDSA = { type: "public-key", alg: -8 }.freeze
+      RS256 = { type: "public-key", alg: -257 }.freeze
+      RESIDENT_KEY_OPTIONS = %i[ preferred required discouraged ].freeze
+      ATTESTATION_PREFERENCES = %i[ none indirect direct enterprise ].freeze
+
+      attribute :id
+      attribute :name
+      attribute :display_name
+      attribute :resident_key, default: :required
+      attribute :exclude_credentials, default: -> { [] }
+      attribute :attestation, default: :none
+      attribute :challenge_expiration, default: 10.minutes
+      attribute :challenge_purpose, default: "registration"
+
+      validates :id, :name, :display_name, presence: true
+      validates :resident_key, inclusion: { in: RESIDENT_KEY_OPTIONS }
+      validates :attestation, inclusion: { in: ATTESTATION_PREFERENCES }
+
+      def initialize(attributes = {}) # :nodoc:
+        super
+        self.resident_key = resident_key.to_sym
+        self.attestation = attestation.to_sym
+        validate!
+      end
+
+      # Returns a Hash suitable for JSON serialization and passing to the
+      # WebAuthn JavaScript API.
+      def as_json(options = {})
+        json = {
+          challenge: challenge,
+          rp: relying_party.as_json,
+          user: {
+            id: Base64.urlsafe_encode64(id.to_s, padding: false),
+            name: name,
+            displayName: display_name
+          },
+          pubKeyCredParams: [
+            ES256,
+            EDDSA,
+            RS256
+          ],
+          authenticatorSelection: {
+            residentKey: resident_key.to_s,
+            requireResidentKey: resident_key == :required,
+            userVerification: user_verification.to_s
+          }
+        }
+
+        if exclude_credentials.any?
+          json[:excludeCredentials] = exclude_credentials.map { |credential| exclude_credential_json(credential) }
+        end
+
+        if attestation != :none
+          json[:attestation] = attestation.to_s
+        end
+
+        json.as_json(options)
+      end
+
+      private
+        def exclude_credential_json(credential)
+          hash = { type: "public-key", id: credential.id }
+          hash[:transports] = credential.transports if credential.transports.any?
+          hash
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -59,6 +59,7 @@ module ActionPack
       RESIDENT_KEY_OPTIONS = %i[ preferred required discouraged ].freeze
       ATTESTATION_PREFERENCES = %i[ none indirect direct enterprise ].freeze
       AUTHENTICATOR_ATTACHMENTS = %w[ platform cross-platform ].freeze
+      DEFAULT_TIMEOUT = 10.minutes
 
       attribute :id
       attribute :name
@@ -68,7 +69,7 @@ module ActionPack
       attribute :exclude_credentials, default: -> { [] }
       attribute :attestation, default: :none
       attribute :attestation_formats, default: -> { [] }
-      attribute :timeout, default: 10.minutes
+      attribute :timeout, default: DEFAULT_TIMEOUT
       attribute :challenge_purpose, default: "registration"
 
       validates :id, :name, :display_name, presence: true

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -93,11 +93,7 @@ module ActionPack
             name: name,
             displayName: display_name
           },
-          pubKeyCredParams: [
-            { type: "public-key", alg: CoseKey::ES256 },
-            { type: "public-key", alg: CoseKey::EDDSA },
-            { type: "public-key", alg: CoseKey::RS256 }
-          ],
+          pubKeyCredParams: ActionPack::WebAuthn.key_formats.values.map(&:to_public_key_credential_param),
           authenticatorSelection: authenticator_selection_json,
           attestation: attestation.to_s
         }

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -99,13 +99,11 @@ module ActionPack
           attestation: attestation.to_s
         }
 
-        json[:timeout] = timeout.in_milliseconds.to_i if timeout
-
         if exclude_credentials.any?
           json[:excludeCredentials] = exclude_credentials.map { |credential| exclude_credential_json(credential) }
         end
 
-        json.as_json(options)
+        super.merge(json).as_json(options)
       end
 
       private

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -38,6 +38,11 @@ module ActionPack
     #   The relying party (application) configuration. Defaults to
     #   +ActionPack::WebAuthn.relying_party+.
     #
+    # [+authenticator_attachment+]
+    #   Restricts the kind of authenticator the user may register. Either
+    #   +"platform"+ (built-in, e.g. Touch ID) or +"cross-platform"+ (roaming,
+    #   e.g. a security key). Omitted by default, which allows both.
+    #
     # == Supported Algorithms
     #
     # By default, supports ES256 (ECDSA with P-256 and SHA-256), EdDSA
@@ -49,24 +54,28 @@ module ActionPack
       RS256 = { type: "public-key", alg: -257 }.freeze
       RESIDENT_KEY_OPTIONS = %i[ preferred required discouraged ].freeze
       ATTESTATION_PREFERENCES = %i[ none indirect direct enterprise ].freeze
+      AUTHENTICATOR_ATTACHMENTS = %w[ platform cross-platform ].freeze
 
       attribute :id
       attribute :name
       attribute :display_name
       attribute :resident_key, default: :required
+      attribute :authenticator_attachment
       attribute :exclude_credentials, default: -> { [] }
       attribute :attestation, default: :none
-      attribute :challenge_expiration, default: 10.minutes
+      attribute :timeout, default: 10.minutes
       attribute :challenge_purpose, default: "registration"
 
       validates :id, :name, :display_name, presence: true
       validates :resident_key, inclusion: { in: RESIDENT_KEY_OPTIONS }
       validates :attestation, inclusion: { in: ATTESTATION_PREFERENCES }
+      validates :authenticator_attachment, inclusion: { in: AUTHENTICATOR_ATTACHMENTS }, allow_nil: true
 
       def initialize(attributes = {}) # :nodoc:
         super
         self.resident_key = resident_key.to_sym
         self.attestation = attestation.to_sym
+        self.authenticator_attachment = authenticator_attachment&.to_s
         validate!
       end
 
@@ -86,12 +95,10 @@ module ActionPack
             EDDSA,
             RS256
           ],
-          authenticatorSelection: {
-            residentKey: resident_key.to_s,
-            requireResidentKey: resident_key == :required,
-            userVerification: user_verification.to_s
-          }
+          authenticatorSelection: authenticator_selection_json
         }
+
+        json[:timeout] = timeout.in_milliseconds.to_i if timeout
 
         if exclude_credentials.any?
           json[:excludeCredentials] = exclude_credentials.map { |credential| exclude_credential_json(credential) }
@@ -105,6 +112,17 @@ module ActionPack
       end
 
       private
+        def authenticator_selection_json
+          json = {
+            residentKey: resident_key.to_s,
+            requireResidentKey: resident_key == :required,
+            userVerification: user_verification.to_s
+          }
+
+          json[:authenticatorAttachment] = authenticator_attachment if authenticator_attachment
+          json
+        end
+
         def exclude_credential_json(credential)
           hash = { type: "public-key", id: credential.id }
           hash[:transports] = credential.transports if credential.transports.any?

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -95,17 +95,14 @@ module ActionPack
             EDDSA,
             RS256
           ],
-          authenticatorSelection: authenticator_selection_json
+          authenticatorSelection: authenticator_selection_json,
+          attestation: attestation.to_s
         }
 
         json[:timeout] = timeout.in_milliseconds.to_i if timeout
 
         if exclude_credentials.any?
           json[:excludeCredentials] = exclude_credentials.map { |credential| exclude_credential_json(credential) }
-        end
-
-        if attestation != :none
-          json[:attestation] = attestation.to_s
         end
 
         json.as_json(options)

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/creation_options.rb
@@ -43,6 +43,10 @@ module ActionPack
     #   +"platform"+ (built-in, e.g. Touch ID) or +"cross-platform"+ (roaming,
     #   e.g. a security key). Omitted by default, which allows both.
     #
+    # [+attestation_formats+]
+    #   An ordered list of preferred attestation statement formats. Omitted when
+    #   empty.
+    #
     # == Supported Algorithms
     #
     # By default, supports ES256 (ECDSA with P-256 and SHA-256), EdDSA
@@ -63,6 +67,7 @@ module ActionPack
       attribute :authenticator_attachment
       attribute :exclude_credentials, default: -> { [] }
       attribute :attestation, default: :none
+      attribute :attestation_formats, default: -> { [] }
       attribute :timeout, default: 10.minutes
       attribute :challenge_purpose, default: "registration"
 
@@ -102,6 +107,8 @@ module ActionPack
         if exclude_credentials.any?
           json[:excludeCredentials] = exclude_credentials.map { |credential| exclude_credential_json(credential) }
         end
+
+        json[:attestationFormats] = attestation_formats if attestation_formats.any?
 
         super.merge(json).as_json(options)
       end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn Public Key Credential Options
+    #
+    # Abstract base class for WebAuthn ceremony options. Provides shared
+    # attributes and challenge generation for both CreationOptions (registration)
+    # and RequestOptions (authentication).
+    #
+    # This class should not be instantiated directly. Use CreationOptions or
+    # RequestOptions instead.
+    #
+    # == Challenge Generation
+    #
+    # Each options object generates a signed, expiring challenge via
+    # +ActionPack::WebAuthn.challenge_verifier+. The challenge is Base64URL-encoded
+    # and includes an embedded timestamp so the server can reject stale challenges.
+    #
+    # == Attributes
+    #
+    # [+user_verification+]
+    #   Controls whether user verification (biometrics/PIN) is required. One of
+    #   +:required+, +:preferred+, or +:discouraged+. Defaults to +:preferred+.
+    #
+    # [+relying_party+]
+    #   The RelyingParty configuration. Defaults to +ActionPack::WebAuthn.relying_party+.
+    #
+    # [+challenge_expiration+]
+    #   How long the challenge remains valid. Defaults vary by ceremony type
+    #   (configured in the Railtie).
+    #
+    class PublicKeyCredential::Options
+      include ActiveModel::API
+      include ActiveModel::Attributes
+
+      CHALLENGE_LENGTH = 32
+      USER_VERIFICATION_OPTIONS = %i[ required preferred discouraged ].freeze
+
+      attribute :user_verification, default: :preferred
+      attribute :relying_party, default: -> { ActionPack::WebAuthn.relying_party }
+      attribute :challenge_expiration
+      attribute :challenge_purpose
+
+      validates :user_verification, inclusion: { in: USER_VERIFICATION_OPTIONS }
+
+      def initialize(attributes = {}) # :nodoc:
+        super
+        self.user_verification = user_verification.to_sym
+      end
+
+      # Validates the options, raising +InvalidOptionsError+ if any are invalid.
+      def validate!
+        super
+      rescue ActiveModel::ValidationError
+        raise ActionPack::WebAuthn::InvalidOptionsError, errors.full_messages.to_sentence
+      end
+
+      # Returns a human-readable representation of the options.
+      def inspect
+        attributes_string = attributes.map { |name, value| "#{name}: #{value.inspect}" }.join(", ")
+        "#<#{self.class.name} #{attributes_string}>"
+      end
+
+      # Returns a Base64URL-encoded signed challenge containing a random nonce and
+      # an embedded timestamp. The challenge is generated once and memoized for the
+      # lifetime of this object.
+      #
+      # The timestamp allows the server to reject stale challenges. The expiration
+      # window is configurable per-ceremony via
+      # +config.action_pack.passkey.registration_challenge_expiration+ and
+      # +config.action_pack.passkey.authentication_challenge_expiration+, or per-instance
+      # via the +challenge_expiration+ attribute.
+      def challenge
+        @challenge ||= Base64.urlsafe_encode64(
+          ActionPack::WebAuthn.challenge_verifier.generate(
+            Base64.strict_encode64(SecureRandom.random_bytes(CHALLENGE_LENGTH)),
+            expires_in: challenge_expiration,
+            purpose: challenge_purpose
+          ),
+          padding: false
+        )
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
@@ -14,8 +14,7 @@ module ActionPack
     # == Challenge Generation
     #
     # Each options object generates a signed, expiring challenge via
-    # +ActionPack::WebAuthn.challenge_verifier+. The challenge is Base64URL-encoded
-    # and includes an embedded timestamp so the server can reject stale challenges.
+    # +ActionPack::WebAuthn.challenge_verifier+.
     #
     # == Attributes
     #
@@ -26,9 +25,12 @@ module ActionPack
     # [+relying_party+]
     #   The RelyingParty configuration. Defaults to +ActionPack::WebAuthn.relying_party+.
     #
-    # [+challenge_expiration+]
-    #   How long the challenge remains valid. Defaults vary by ceremony type
-    #   (configured in the Railtie).
+    # [+timeout+]
+    #   How long the ceremony may take. Sent to the browser as the WebAuthn +timeout+,
+    #   and used server-side as the challenge's expiry so it can't outlive the prompt.
+    #   Integer values are treated as seconds, +ActiveSupport::Duration+ values
+    #   (e.g. `10.minutes`) can also be used.
+    #   Defaults vary by ceremony type (configured in the Railtie).
     #
     class PublicKeyCredential::Options
       include ActiveModel::API
@@ -39,7 +41,7 @@ module ActionPack
 
       attribute :user_verification, default: :preferred
       attribute :relying_party, default: -> { ActionPack::WebAuthn.relying_party }
-      attribute :challenge_expiration
+      attribute :timeout
       attribute :challenge_purpose
 
       validates :user_verification, inclusion: { in: USER_VERIFICATION_OPTIONS }
@@ -66,16 +68,16 @@ module ActionPack
       # an embedded timestamp. The challenge is generated once and memoized for the
       # lifetime of this object.
       #
-      # The timestamp allows the server to reject stale challenges. The expiration
+      # The timestamp allows the server to reject stale challenges. The validity
       # window is configurable per-ceremony via
-      # +config.action_pack.passkey.registration_challenge_expiration+ and
-      # +config.action_pack.passkey.authentication_challenge_expiration+, or per-instance
-      # via the +challenge_expiration+ attribute.
+      # +config.action_pack.passkey.registration_timeout+ and
+      # +config.action_pack.passkey.authentication_timeout+, or per-instance via
+      # the +timeout+ attribute.
       def challenge
         @challenge ||= Base64.urlsafe_encode64(
           ActionPack::WebAuthn.challenge_verifier.generate(
             Base64.strict_encode64(SecureRandom.random_bytes(CHALLENGE_LENGTH)),
-            expires_in: challenge_expiration,
+            expires_in: timeout,
             purpose: challenge_purpose
           ),
           padding: false

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
@@ -36,6 +36,10 @@ module ActionPack
     #   A Hash of WebAuthn client extension inputs passed through to the
     #   authenticator. Omitted when blank.
     #
+    # [+hints+]
+    #   An ordered list of hints guiding the browser's authenticator UI, e.g.
+    #   "security-key", "client-device", or "hybrid". Omitted when empty.
+    #
     class PublicKeyCredential::Options
       include ActiveModel::API
       include ActiveModel::Attributes
@@ -47,6 +51,7 @@ module ActionPack
       attribute :relying_party, default: -> { ActionPack::WebAuthn.relying_party }
       attribute :timeout
       attribute :extensions
+      attribute :hints, default: -> { [] }
       attribute :challenge_purpose
 
       validates :user_verification, inclusion: { in: USER_VERIFICATION_OPTIONS }
@@ -95,6 +100,7 @@ module ActionPack
         json = {}
         json[:timeout] = timeout.in_milliseconds.to_i if timeout
         json[:extensions] = extensions if extensions.present?
+        json[:hints] = hints if hints.any?
         json
       end
     end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
@@ -32,6 +32,10 @@ module ActionPack
     #   (e.g. `10.minutes`) can also be used.
     #   Defaults vary by ceremony type (configured in the Railtie).
     #
+    # [+extensions+]
+    #   A Hash of WebAuthn client extension inputs passed through to the
+    #   authenticator. Omitted when blank.
+    #
     class PublicKeyCredential::Options
       include ActiveModel::API
       include ActiveModel::Attributes
@@ -42,6 +46,7 @@ module ActionPack
       attribute :user_verification, default: :preferred
       attribute :relying_party, default: -> { ActionPack::WebAuthn.relying_party }
       attribute :timeout
+      attribute :extensions
       attribute :challenge_purpose
 
       validates :user_verification, inclusion: { in: USER_VERIFICATION_OPTIONS }
@@ -82,6 +87,15 @@ module ActionPack
           ),
           padding: false
         )
+      end
+
+      # Returns a Hash representation of the options that's suitable for JSON
+      # serialization and which can be passed to the WebAuthn JavaScript API.
+      def as_json(*)
+        json = {}
+        json[:timeout] = timeout.in_milliseconds.to_i if timeout
+        json[:extensions] = extensions if extensions.present?
+        json
       end
     end
   end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/options.rb
@@ -30,7 +30,8 @@ module ActionPack
     #   and used server-side as the challenge's expiry so it can't outlive the prompt.
     #   Integer values are treated as seconds, +ActiveSupport::Duration+ values
     #   (e.g. `10.minutes`) can also be used.
-    #   Defaults vary by ceremony type (configured in the Railtie).
+    #   Defaults to +CreationOptions::DEFAULT_TIMEOUT+ or +RequestOptions::DEFAULT_TIMEOUT+,
+    #   depending on ceremony type.
     #
     # [+extensions+]
     #   A Hash of WebAuthn client extension inputs passed through to the
@@ -80,8 +81,8 @@ module ActionPack
       #
       # The timestamp allows the server to reject stale challenges. The validity
       # window is configurable per-ceremony via
-      # +config.action_pack.passkey.registration_timeout+ and
-      # +config.action_pack.passkey.authentication_timeout+, or per-instance via
+      # +config.action_pack.passkey.default_registration_options+ and
+      # +config.action_pack.passkey.default_authentication_options+, or per-instance via
       # the +timeout+ attribute.
       def challenge
         @challenge ||= Base64.urlsafe_encode64(

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
@@ -28,8 +28,10 @@ module ActionPack
     #   The relying party (application) configuration. Defaults to
     #   +ActionPack::WebAuthn.relying_party+.
     class PublicKeyCredential::RequestOptions < PublicKeyCredential::Options
+      DEFAULT_TIMEOUT = 5.minutes
+
       attribute :credentials, default: -> { [] }
-      attribute :timeout, default: 5.minutes
+      attribute :timeout, default: DEFAULT_TIMEOUT
       attribute :challenge_purpose, default: "authentication"
 
       def initialize(attributes = {}) # :nodoc:

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn Public Key Credential Request Options
+    #
+    # Generates options for the WebAuthn authentication ceremony (using an existing
+    # credential). These options are passed to +navigator.credentials.get()+ in
+    # the browser to prompt the user to authenticate with a registered authenticator.
+    #
+    # == Usage
+    #
+    #   options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+    #     credentials: current_user.webauthn_credentials
+    #   )
+    #
+    #   # Return as JSON for the JavaScript WebAuthn API
+    #   render json: { publicKey: options.as_json }
+    #
+    # == Attributes
+    #
+    # [+credentials+]
+    #   A collection of credential records for the user. Each credential must
+    #   respond to +id+ returning the Base64URL-encoded credential ID, and
+    #   +transports+ returning an array of transport strings.
+    #
+    # [+relying_party+]
+    #   The relying party (application) configuration. Defaults to
+    #   +ActionPack::WebAuthn.relying_party+.
+    class PublicKeyCredential::RequestOptions < PublicKeyCredential::Options
+      attribute :credentials, default: -> { [] }
+      attribute :challenge_expiration, default: 5.minutes
+      attribute :challenge_purpose, default: "authentication"
+
+      def initialize(attributes = {}) # :nodoc:
+        super
+        validate!
+      end
+
+      # Returns a Hash suitable for JSON serialization and passing to the
+      # WebAuthn JavaScript API.
+      def as_json(options = {})
+        json = {
+          challenge: challenge,
+          rpId: relying_party.id,
+          allowCredentials: credentials.map { |credential| allow_credential_json(credential) },
+          userVerification: user_verification.to_s
+        }
+
+        json.as_json(options)
+      end
+
+      private
+        def allow_credential_json(credential)
+          hash = { type: "public-key", id: credential.id }
+          hash[:transports] = credential.transports if credential.transports.any?
+          hash
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
@@ -47,9 +47,7 @@ module ActionPack
           userVerification: user_verification.to_s
         }
 
-        json[:timeout] = timeout.in_milliseconds.to_i if timeout
-
-        json.as_json(options)
+        super.merge(json).as_json(options)
       end
 
       private

--- a/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
+++ b/actionpack/lib/action_pack/web_authn/public_key_credential/request_options.rb
@@ -29,7 +29,7 @@ module ActionPack
     #   +ActionPack::WebAuthn.relying_party+.
     class PublicKeyCredential::RequestOptions < PublicKeyCredential::Options
       attribute :credentials, default: -> { [] }
-      attribute :challenge_expiration, default: 5.minutes
+      attribute :timeout, default: 5.minutes
       attribute :challenge_purpose, default: "authentication"
 
       def initialize(attributes = {}) # :nodoc:
@@ -46,6 +46,8 @@ module ActionPack
           allowCredentials: credentials.map { |credential| allow_credential_json(credential) },
           userVerification: user_verification.to_s
         }
+
+        json[:timeout] = timeout.in_milliseconds.to_i if timeout
 
         json.as_json(options)
       end

--- a/actionpack/lib/action_pack/web_authn/relying_party.rb
+++ b/actionpack/lib/action_pack/web_authn/relying_party.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WebAuthn
+    # = Action Pack WebAuthn Relying Party
+    #
+    # Represents the relying party (the application) in WebAuthn ceremonies. The
+    # relying party identity is sent to authenticators during registration and
+    # authentication to scope credentials to the application.
+    #
+    # == Usage
+    #
+    #   # Using defaults (host from Current, name from Rails application)
+    #   relying_party = ActionPack::WebAuthn::RelyingParty.new
+    #
+    #   # With explicit values
+    #   relying_party = ActionPack::WebAuthn::RelyingParty.new(
+    #     id: "example.com",
+    #     name: "Example Application"
+    #   )
+    #
+    # == Attributes
+    #
+    # [+id+]
+    #   The relying party identifier, typically the application's domain name
+    #   (e.g., "example.com"). This must match the origin's effective domain
+    #   or be a registrable domain suffix of it. Credentials are scoped to this
+    #   identifier. Defaults to +ActionPack::WebAuthn::Current.host+.
+    #
+    # [+name+]
+    #   A human-readable name for the application, displayed by authenticators
+    #   during ceremonies. Defaults to +ActionPack::WebAuthn.application_name+.
+    class RelyingParty
+      attr_reader :id, :name
+
+      # Creates a new relying party configuration.
+      #
+      # ==== Options
+      #
+      # [+:id+]
+      #   Optional. The relying party identifier (domain).
+      #
+      # [+:name+]
+      #   Optional. The application display name.
+      def initialize(id: nil, name: nil)
+        @id = id || ActionPack::WebAuthn::Current.host
+        @name = name || ActionPack::WebAuthn.application_name
+      end
+
+      # Returns a Hash suitable for JSON serialization.
+      def as_json(*)
+        { id: id, name: name }
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_pack/web_authn/relying_party.rb
+++ b/actionpack/lib/action_pack/web_authn/relying_party.rb
@@ -25,7 +25,8 @@ module ActionPack
     #   The relying party identifier, typically the application's domain name
     #   (e.g., "example.com"). This must match the origin's effective domain
     #   or be a registrable domain suffix of it. Credentials are scoped to this
-    #   identifier. Defaults to +ActionPack::WebAuthn::Current.host+.
+    #   identifier. Defaults to +ActionPack::WebAuthn.relying_party_id+ when set,
+    #   otherwise to +ActionPack::WebAuthn::Current.host+.
     #
     # [+name+]
     #   A human-readable name for the application, displayed by authenticators
@@ -43,7 +44,7 @@ module ActionPack
       # [+:name+]
       #   Optional. The application display name.
       def initialize(id: nil, name: nil)
-        @id = id || ActionPack::WebAuthn::Current.host
+        @id = id || ActionPack::WebAuthn.relying_party_id || ActionPack::WebAuthn::Current.host
         @name = name || ActionPack::WebAuthn.application_name
       end
 

--- a/actionpack/lib/passkeys/app/assets/javascripts/actionpack-passkeys.esm.js
+++ b/actionpack/lib/passkeys/app/assets/javascripts/actionpack-passkeys.esm.js
@@ -1,0 +1,278 @@
+async function register(options) {
+  const publicKey = prepareCreationOptions(options);
+  const credential = await navigator.credentials.create({
+    publicKey: publicKey
+  });
+  return {
+    client_data_json: (new TextDecoder).decode(credential.response.clientDataJSON),
+    attestation_object: bufferToBase64url(credential.response.attestationObject),
+    transports: credential.response.getTransports?.() || []
+  };
+}
+
+async function authenticate(options, {signal: signal, mediation: mediation} = {}) {
+  const publicKey = prepareRequestOptions(options);
+  const credential = await navigator.credentials.get({
+    publicKey: publicKey,
+    signal: signal,
+    mediation: mediation
+  });
+  return {
+    id: credential.id,
+    client_data_json: (new TextDecoder).decode(credential.response.clientDataJSON),
+    authenticator_data: bufferToBase64url(credential.response.authenticatorData),
+    signature: bufferToBase64url(credential.response.signature)
+  };
+}
+
+function prepareCreationOptions(options) {
+  return {
+    ...options,
+    challenge: base64urlToBuffer(options.challenge),
+    user: {
+      ...options.user,
+      id: base64urlToBuffer(options.user.id)
+    },
+    excludeCredentials: (options.excludeCredentials || []).map((cred => ({
+      ...cred,
+      id: base64urlToBuffer(cred.id)
+    })))
+  };
+}
+
+function prepareRequestOptions(options) {
+  const prepared = {
+    ...options,
+    challenge: base64urlToBuffer(options.challenge)
+  };
+  if (options.allowCredentials?.length) {
+    prepared.allowCredentials = options.allowCredentials.map((cred => ({
+      ...cred,
+      id: base64urlToBuffer(cred.id)
+    })));
+  } else {
+    delete prepared.allowCredentials;
+  }
+  return prepared;
+}
+
+function base64urlToBuffer(base64url) {
+  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - base64.length % 4) % 4);
+  const binary = atob(base64 + padding);
+  return Uint8Array.from(binary, (c => c.charCodeAt(0))).buffer;
+}
+
+function bufferToBase64url(buffer) {
+  const bytes = new Uint8Array(buffer);
+  const binary = String.fromCharCode(...bytes);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+class PasskeyButton extends HTMLElement {
+  connectedCallback() {
+    this._performBound = () => this._performCeremony();
+    this.button.addEventListener("click", this._performBound);
+  }
+  disconnectedCallback() {
+    this.abortConditionalMediation?.();
+    this.button.removeEventListener("click", this._performBound);
+    this.button.disabled = false;
+    hideErrors(this);
+  }
+  get button() {
+    return this.querySelector("[data-passkey]");
+  }
+  get form() {
+    return this.querySelector("form");
+  }
+  get options() {
+    return JSON.parse(this.getAttribute("options"));
+  }
+  get challengeUrl() {
+    return this.getAttribute("challenge-url");
+  }
+  async _performCeremony() {
+    await (this.abortConditionalMediation?.());
+    this.button.disabled = true;
+    hideErrors(this);
+    this.button.dispatchEvent(new CustomEvent("passkey:start", {
+      bubbles: true
+    }));
+    try {
+      const options = this.options;
+      if (!passkeysAvailable()) throw new Error("Passkeys are not supported by this browser");
+      if (!options) throw new Error("Missing passkey options");
+      await refreshChallenge(options, this.challengeUrl, this.purpose);
+      const passkey = await this.perform(options);
+      this.button.dispatchEvent(new CustomEvent("passkey:success", {
+        bubbles: true
+      }));
+      this.fillForm(passkey);
+      this.form.submit();
+    } catch (error) {
+      this.button.disabled = false;
+      handleError(this, error);
+    }
+  }
+}
+
+class PasskeyRegistrationButton extends PasskeyButton {
+  get purpose() {
+    return "registration";
+  }
+  async perform(options) {
+    return await register(options);
+  }
+  fillForm(passkey) {
+    fillRegistrationForm(this.form, passkey);
+  }
+}
+
+class PasskeySignInButton extends PasskeyButton {
+  get purpose() {
+    return "authentication";
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this._conditionalMediationController = null;
+    this._conditionalMediationPromise = null;
+    if (this.mediation === "conditional") this._attemptConditionalMediation();
+  }
+  get mediation() {
+    return this.getAttribute("mediation");
+  }
+  async perform(options, {signal: signal, mediation: mediation} = {}) {
+    return await authenticate(options, {
+      signal: signal,
+      mediation: mediation
+    });
+  }
+  fillForm(passkey) {
+    fillSignInForm(this.form, passkey);
+  }
+  async abortConditionalMediation() {
+    if (this._conditionalMediationController) {
+      this._conditionalMediationController.abort();
+      await this._conditionalMediationPromise;
+    }
+  }
+  async _attemptConditionalMediation() {
+    const available = this.options && passkeysAvailable() && await (window.PublicKeyCredential.isConditionalMediationAvailable?.());
+    if (available) {
+      const options = this.options;
+      this.form.dispatchEvent(new CustomEvent("passkey:start", {
+        bubbles: true
+      }));
+      this._conditionalMediationController = new AbortController;
+      this._conditionalMediationPromise = this._runConditionalMediation(options);
+    }
+  }
+  async _runConditionalMediation(options) {
+    try {
+      await refreshChallenge(options, this.challengeUrl, this.purpose);
+      const passkey = await this.perform(options, {
+        signal: this._conditionalMediationController.signal,
+        mediation: this.mediation
+      });
+      this.form.dispatchEvent(new CustomEvent("passkey:success", {
+        bubbles: true
+      }));
+      this.fillForm(passkey);
+      this.form.submit();
+    } catch (error) {
+      if (error.name === "AbortError") return;
+      const type = errorType(error);
+      this.button.dispatchEvent(new CustomEvent("passkey:error", {
+        bubbles: true,
+        detail: {
+          error: error,
+          type: type
+        }
+      }));
+    } finally {
+      this._conditionalMediationController = null;
+      this._conditionalMediationPromise = null;
+    }
+  }
+}
+
+customElements.define("rails-passkey-registration-button", PasskeyRegistrationButton);
+
+customElements.define("rails-passkey-sign-in-button", PasskeySignInButton);
+
+function handleError(component, error) {
+  const type = errorType(error);
+  showError(component, type);
+  component.button.dispatchEvent(new CustomEvent("passkey:error", {
+    bubbles: true,
+    detail: {
+      error: error,
+      type: type
+    }
+  }));
+}
+
+function errorType(error) {
+  switch (error.name) {
+   case "AbortError":
+   case "NotAllowedError":
+    return "cancelled";
+
+   case "InvalidStateError":
+    return "duplicate";
+
+   default:
+    return "error";
+  }
+}
+
+function showError(component, type) {
+  const el = component.querySelector(`[data-passkey-error="${type}"]`);
+  if (el) el.hidden = false;
+}
+
+function hideErrors(component) {
+  for (const el of component.querySelectorAll("[data-passkey-error]")) el.hidden = true;
+}
+
+function passkeysAvailable() {
+  return !!window.PublicKeyCredential;
+}
+
+async function refreshChallenge(options, challengeUrl, purpose) {
+  if (!challengeUrl) throw new Error("Missing passkey challenge URL");
+  const body = new URLSearchParams;
+  if (purpose) body.append("purpose", purpose);
+  const response = await fetch(challengeUrl, {
+    method: "POST",
+    headers: {
+      Accept: "application/json"
+    },
+    body: body
+  });
+  if (!response.ok) throw new Error("Failed to refresh challenge");
+  const {challenge: challenge} = await response.json();
+  options.challenge = challenge;
+}
+
+function fillRegistrationForm(form, passkey) {
+  form.querySelector('[data-passkey-field="client_data_json"]').value = passkey.client_data_json;
+  form.querySelector('[data-passkey-field="attestation_object"]').value = passkey.attestation_object;
+  const template = form.querySelector('[data-passkey-field="transports"]');
+  for (const transport of passkey.transports) {
+    const input = template.cloneNode();
+    input.value = transport;
+    template.before(input);
+  }
+  template.remove();
+}
+
+function fillSignInForm(form, passkey) {
+  form.querySelector('[data-passkey-field="id"]').value = passkey.id;
+  form.querySelector('[data-passkey-field="client_data_json"]').value = passkey.client_data_json;
+  form.querySelector('[data-passkey-field="authenticator_data"]').value = passkey.authenticator_data;
+  form.querySelector('[data-passkey-field="signature"]').value = passkey.signature;
+}
+
+export { authenticate, register };

--- a/actionpack/lib/passkeys/app/assets/javascripts/actionpack-passkeys.js
+++ b/actionpack/lib/passkeys/app/assets/javascripts/actionpack-passkeys.js
@@ -1,0 +1,269 @@
+(function(global, factory) {
+  typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define([ "exports" ], factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, 
+  factory(global.ActionPack = {}));
+})(this, (function(exports) {
+  "use strict";
+  async function register(options) {
+    const publicKey = prepareCreationOptions(options);
+    const credential = await navigator.credentials.create({
+      publicKey: publicKey
+    });
+    return {
+      client_data_json: (new TextDecoder).decode(credential.response.clientDataJSON),
+      attestation_object: bufferToBase64url(credential.response.attestationObject),
+      transports: credential.response.getTransports?.() || []
+    };
+  }
+  async function authenticate(options, {signal: signal, mediation: mediation} = {}) {
+    const publicKey = prepareRequestOptions(options);
+    const credential = await navigator.credentials.get({
+      publicKey: publicKey,
+      signal: signal,
+      mediation: mediation
+    });
+    return {
+      id: credential.id,
+      client_data_json: (new TextDecoder).decode(credential.response.clientDataJSON),
+      authenticator_data: bufferToBase64url(credential.response.authenticatorData),
+      signature: bufferToBase64url(credential.response.signature)
+    };
+  }
+  function prepareCreationOptions(options) {
+    return {
+      ...options,
+      challenge: base64urlToBuffer(options.challenge),
+      user: {
+        ...options.user,
+        id: base64urlToBuffer(options.user.id)
+      },
+      excludeCredentials: (options.excludeCredentials || []).map((cred => ({
+        ...cred,
+        id: base64urlToBuffer(cred.id)
+      })))
+    };
+  }
+  function prepareRequestOptions(options) {
+    const prepared = {
+      ...options,
+      challenge: base64urlToBuffer(options.challenge)
+    };
+    if (options.allowCredentials?.length) {
+      prepared.allowCredentials = options.allowCredentials.map((cred => ({
+        ...cred,
+        id: base64urlToBuffer(cred.id)
+      })));
+    } else {
+      delete prepared.allowCredentials;
+    }
+    return prepared;
+  }
+  function base64urlToBuffer(base64url) {
+    const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+    const padding = "=".repeat((4 - base64.length % 4) % 4);
+    const binary = atob(base64 + padding);
+    return Uint8Array.from(binary, (c => c.charCodeAt(0))).buffer;
+  }
+  function bufferToBase64url(buffer) {
+    const bytes = new Uint8Array(buffer);
+    const binary = String.fromCharCode(...bytes);
+    return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+  class PasskeyButton extends HTMLElement {
+    connectedCallback() {
+      this._performBound = () => this._performCeremony();
+      this.button.addEventListener("click", this._performBound);
+    }
+    disconnectedCallback() {
+      this.abortConditionalMediation?.();
+      this.button.removeEventListener("click", this._performBound);
+      this.button.disabled = false;
+      hideErrors(this);
+    }
+    get button() {
+      return this.querySelector("[data-passkey]");
+    }
+    get form() {
+      return this.querySelector("form");
+    }
+    get options() {
+      return JSON.parse(this.getAttribute("options"));
+    }
+    get challengeUrl() {
+      return this.getAttribute("challenge-url");
+    }
+    async _performCeremony() {
+      await (this.abortConditionalMediation?.());
+      this.button.disabled = true;
+      hideErrors(this);
+      this.button.dispatchEvent(new CustomEvent("passkey:start", {
+        bubbles: true
+      }));
+      try {
+        const options = this.options;
+        if (!passkeysAvailable()) throw new Error("Passkeys are not supported by this browser");
+        if (!options) throw new Error("Missing passkey options");
+        await refreshChallenge(options, this.challengeUrl, this.purpose);
+        const passkey = await this.perform(options);
+        this.button.dispatchEvent(new CustomEvent("passkey:success", {
+          bubbles: true
+        }));
+        this.fillForm(passkey);
+        this.form.submit();
+      } catch (error) {
+        this.button.disabled = false;
+        handleError(this, error);
+      }
+    }
+  }
+  class PasskeyRegistrationButton extends PasskeyButton {
+    get purpose() {
+      return "registration";
+    }
+    async perform(options) {
+      return await register(options);
+    }
+    fillForm(passkey) {
+      fillRegistrationForm(this.form, passkey);
+    }
+  }
+  class PasskeySignInButton extends PasskeyButton {
+    get purpose() {
+      return "authentication";
+    }
+    connectedCallback() {
+      super.connectedCallback();
+      this._conditionalMediationController = null;
+      this._conditionalMediationPromise = null;
+      if (this.mediation === "conditional") this._attemptConditionalMediation();
+    }
+    get mediation() {
+      return this.getAttribute("mediation");
+    }
+    async perform(options, {signal: signal, mediation: mediation} = {}) {
+      return await authenticate(options, {
+        signal: signal,
+        mediation: mediation
+      });
+    }
+    fillForm(passkey) {
+      fillSignInForm(this.form, passkey);
+    }
+    async abortConditionalMediation() {
+      if (this._conditionalMediationController) {
+        this._conditionalMediationController.abort();
+        await this._conditionalMediationPromise;
+      }
+    }
+    async _attemptConditionalMediation() {
+      const available = this.options && passkeysAvailable() && await (window.PublicKeyCredential.isConditionalMediationAvailable?.());
+      if (available) {
+        const options = this.options;
+        this.form.dispatchEvent(new CustomEvent("passkey:start", {
+          bubbles: true
+        }));
+        this._conditionalMediationController = new AbortController;
+        this._conditionalMediationPromise = this._runConditionalMediation(options);
+      }
+    }
+    async _runConditionalMediation(options) {
+      try {
+        await refreshChallenge(options, this.challengeUrl, this.purpose);
+        const passkey = await this.perform(options, {
+          signal: this._conditionalMediationController.signal,
+          mediation: this.mediation
+        });
+        this.form.dispatchEvent(new CustomEvent("passkey:success", {
+          bubbles: true
+        }));
+        this.fillForm(passkey);
+        this.form.submit();
+      } catch (error) {
+        if (error.name === "AbortError") return;
+        const type = errorType(error);
+        this.button.dispatchEvent(new CustomEvent("passkey:error", {
+          bubbles: true,
+          detail: {
+            error: error,
+            type: type
+          }
+        }));
+      } finally {
+        this._conditionalMediationController = null;
+        this._conditionalMediationPromise = null;
+      }
+    }
+  }
+  customElements.define("rails-passkey-registration-button", PasskeyRegistrationButton);
+  customElements.define("rails-passkey-sign-in-button", PasskeySignInButton);
+  function handleError(component, error) {
+    const type = errorType(error);
+    showError(component, type);
+    component.button.dispatchEvent(new CustomEvent("passkey:error", {
+      bubbles: true,
+      detail: {
+        error: error,
+        type: type
+      }
+    }));
+  }
+  function errorType(error) {
+    switch (error.name) {
+     case "AbortError":
+     case "NotAllowedError":
+      return "cancelled";
+
+     case "InvalidStateError":
+      return "duplicate";
+
+     default:
+      return "error";
+    }
+  }
+  function showError(component, type) {
+    const el = component.querySelector(`[data-passkey-error="${type}"]`);
+    if (el) el.hidden = false;
+  }
+  function hideErrors(component) {
+    for (const el of component.querySelectorAll("[data-passkey-error]")) el.hidden = true;
+  }
+  function passkeysAvailable() {
+    return !!window.PublicKeyCredential;
+  }
+  async function refreshChallenge(options, challengeUrl, purpose) {
+    if (!challengeUrl) throw new Error("Missing passkey challenge URL");
+    const body = new URLSearchParams;
+    if (purpose) body.append("purpose", purpose);
+    const response = await fetch(challengeUrl, {
+      method: "POST",
+      headers: {
+        Accept: "application/json"
+      },
+      body: body
+    });
+    if (!response.ok) throw new Error("Failed to refresh challenge");
+    const {challenge: challenge} = await response.json();
+    options.challenge = challenge;
+  }
+  function fillRegistrationForm(form, passkey) {
+    form.querySelector('[data-passkey-field="client_data_json"]').value = passkey.client_data_json;
+    form.querySelector('[data-passkey-field="attestation_object"]').value = passkey.attestation_object;
+    const template = form.querySelector('[data-passkey-field="transports"]');
+    for (const transport of passkey.transports) {
+      const input = template.cloneNode();
+      input.value = transport;
+      template.before(input);
+    }
+    template.remove();
+  }
+  function fillSignInForm(form, passkey) {
+    form.querySelector('[data-passkey-field="id"]').value = passkey.id;
+    form.querySelector('[data-passkey-field="client_data_json"]').value = passkey.client_data_json;
+    form.querySelector('[data-passkey-field="authenticator_data"]').value = passkey.authenticator_data;
+    form.querySelector('[data-passkey-field="signature"]').value = passkey.signature;
+  }
+  exports.authenticate = authenticate;
+  exports.register = register;
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+}));

--- a/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
+++ b/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
@@ -33,7 +33,7 @@ module ActionPack
     private
       def create_passkey_challenge
         ActionPack::WebAuthn::PublicKeyCredential::Options.new(
-          challenge_expiration: challenge_expiration,
+          timeout: timeout,
           challenge_purpose: challenge_purpose
         ).challenge
       end
@@ -46,11 +46,11 @@ module ActionPack
         end
       end
 
-      def challenge_expiration
+      def timeout
         if challenge_purpose == "registration"
-          ActionPack::Passkeys.registration_challenge_expiration
+          ActionPack::Passkeys.registration_timeout
         else
-          ActionPack::Passkeys.authentication_challenge_expiration
+          ActionPack::Passkeys.authentication_timeout
         end
       end
   end

--- a/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
+++ b/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module ActionPack
+  # = Action Pack Passkey Challenges Controller
+  #
+  # Generates fresh WebAuthn challenges for passkey ceremonies. The companion
+  # JavaScript calls this endpoint before initiating a registration or
+  # authentication ceremony so that the challenge is issued just-in-time rather
+  # than embedded in the initial page load.
+  #
+  # The generated challenge is returned in the JSON response body. The challenge
+  # is a signed, expiring token that the server can verify on the subsequent
+  # form submission without needing server-side state — the challenge is
+  # extracted from the authenticator's +clientDataJSON+ response.
+  #
+  # == Route
+  #
+  # By default mounted at +/rails/action_pack/passkey/challenge+ (configurable
+  # via +config.action_pack.passkey.routes_prefix+).
+  #
+  class Passkeys::ChallengesController < ActionController::Base
+    include ActionPack::Passkeys::Request
+
+    skip_forgery_protection
+
+    # Generates a fresh challenge and returns it as JSON. Accepts an optional
+    # +purpose+ parameter ("registration" or "authentication") to select the
+    # appropriate challenge expiration. Defaults to "authentication".
+    def create
+      render json: { challenge: create_passkey_challenge }
+    end
+
+    private
+      def create_passkey_challenge
+        ActionPack::WebAuthn::PublicKeyCredential::Options.new(
+          challenge_expiration: challenge_expiration,
+          challenge_purpose: challenge_purpose
+        ).challenge
+      end
+
+      def challenge_purpose
+        if params[:purpose] == "registration"
+          "registration"
+        else
+          "authentication"
+        end
+      end
+
+      def challenge_expiration
+        if challenge_purpose == "registration"
+          ActionPack::Passkeys.registration_challenge_expiration
+        else
+          ActionPack::Passkeys.authentication_challenge_expiration
+        end
+      end
+  end
+end

--- a/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
+++ b/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
@@ -48,9 +48,13 @@ module ActionPack
 
       def timeout
         if challenge_purpose == "registration"
-          ActionPack::Passkeys.registration_timeout
+          ActionPack::Passkeys.default_registration_options.to_h.fetch(
+            :timeout, ActionPack::WebAuthn::PublicKeyCredential::CreationOptions::DEFAULT_TIMEOUT
+          )
         else
-          ActionPack::Passkeys.authentication_timeout
+          ActionPack::Passkeys.default_authentication_options.to_h.fetch(
+            :timeout, ActionPack::WebAuthn::PublicKeyCredential::RequestOptions::DEFAULT_TIMEOUT
+          )
         end
       end
   end

--- a/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
+++ b/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb
@@ -23,11 +23,13 @@ module ActionPack
 
     skip_forgery_protection
 
-    # Generates a fresh challenge and returns it as JSON. Accepts an optional
-    # +purpose+ parameter ("registration" or "authentication") to select the
-    # appropriate challenge expiration. Defaults to "authentication".
+    # Generates a fresh challenge and returns it as JSON, alongside the
+    # timeout (in milliseconds) the client should pass to the WebAuthn
+    # ceremony. Accepts an optional +purpose+ parameter ("registration" or
+    # "authentication") to select the appropriate challenge expiration and
+    # timeout. Defaults to "authentication".
     def create
-      render json: { challenge: create_passkey_challenge }
+      render json: { challenge: create_passkey_challenge, timeout: timeout&.in_milliseconds&.to_i }
     end
 
     private

--- a/actionpack/lib/passkeys/app/controllers/action_pack/well_known/webauthn_controller.rb
+++ b/actionpack/lib/passkeys/app/controllers/action_pack/well_known/webauthn_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module WellKnown
+    # = Action Pack Well-Known WebAuthn Controller
+    #
+    # Serves the WebAuthn document at +/.well-known/webauthn+. Browsers fetch
+    # this file from the relying party ID's host to learn which other origins
+    # may use credentials scoped to that relying party ID, letting a single set
+    # of passkeys work across several domains via Related Origin Requests.
+    #
+    # == Route
+    #
+    # Mounted at +/.well-known/webauthn+ when
+    # +config.action_pack.passkey.related_origins+ is configured.
+    #
+    class WebauthnController < ActionController::Base
+      def show
+        render json: { origins: ActionPack::Passkeys.related_origins }
+      end
+    end
+  end
+end

--- a/actionpack/lib/passkeys/app/javascript/action_pack/index.js
+++ b/actionpack/lib/passkeys/app/javascript/action_pack/index.js
@@ -1,0 +1,7 @@
+import { register, authenticate } from "./webauthn"
+import "./passkey"
+
+export {
+  register,
+  authenticate,
+}

--- a/actionpack/lib/passkeys/app/javascript/action_pack/passkey.js
+++ b/actionpack/lib/passkeys/app/javascript/action_pack/passkey.js
@@ -1,0 +1,226 @@
+// Web components for the ActionPack::Passkey Ruby helpers.
+//
+// <rails-passkey-registration-button> — wraps a registration ceremony form
+// <rails-passkey-sign-in-button>  — wraps an authentication ceremony form
+//
+// The Ruby form helpers render the component markup including the inner form,
+// hidden fields, button, and error messages. The components handle the WebAuthn
+// ceremony lifecycle (challenge refresh, credential creation/authentication,
+// form submission) and error state toggling.
+//
+// Custom events (all bubble):
+//   passkey:start   — ceremony begun
+//   passkey:success — credential obtained, form about to submit
+//   passkey:error   — ceremony failed; detail: { error, type }
+//
+// Attributes (rendered by the Ruby form helpers):
+//   options       — JSON WebAuthn options (creation or request, on both)
+//   challenge-url — endpoint to refresh the challenge nonce (on both)
+//   mediation     — WebAuthn mediation hint, e.g. "conditional" (on rails-passkey-sign-in-button)
+
+import { register, authenticate } from "./webauthn"
+
+// Base class for passkey web components. Manages the shared ceremony lifecycle:
+// challenge refresh, button state, error display, and event dispatch.
+// Subclasses implement `perform()` to run the specific WebAuthn ceremony
+// and `fillForm()` to populate hidden fields before submission.
+class PasskeyButton extends HTMLElement {
+  connectedCallback() {
+    this._performBound = () => this._performCeremony()
+    this.button.addEventListener("click", this._performBound)
+  }
+
+  disconnectedCallback() {
+    this.abortConditionalMediation?.()
+    this.button.removeEventListener("click", this._performBound)
+    this.button.disabled = false
+    hideErrors(this)
+  }
+
+  get button() {
+    return this.querySelector("[data-passkey]")
+  }
+
+  get form() {
+    return this.querySelector("form")
+  }
+
+  get options() {
+    return JSON.parse(this.getAttribute("options"))
+  }
+
+  get challengeUrl() {
+    return this.getAttribute("challenge-url")
+  }
+
+  async _performCeremony() {
+    await this.abortConditionalMediation?.()
+    this.button.disabled = true
+    hideErrors(this)
+    this.button.dispatchEvent(new CustomEvent("passkey:start", { bubbles: true }))
+
+    try {
+      const options = this.options
+
+      if (!passkeysAvailable()) throw new Error("Passkeys are not supported by this browser")
+      if (!options) throw new Error("Missing passkey options")
+
+      await refreshChallenge(options, this.challengeUrl, this.purpose)
+      const passkey = await this.perform(options)
+
+      this.button.dispatchEvent(new CustomEvent("passkey:success", { bubbles: true }))
+      this.fillForm(passkey)
+      this.form.submit()
+    } catch (error) {
+      this.button.disabled = false
+      handleError(this, error)
+    }
+  }
+}
+
+class PasskeyRegistrationButton extends PasskeyButton {
+  get purpose() { return "registration" }
+
+  async perform(options) {
+    return await register(options)
+  }
+
+  fillForm(passkey) {
+    fillRegistrationForm(this.form, passkey)
+  }
+}
+
+class PasskeySignInButton extends PasskeyButton {
+  get purpose() { return "authentication" }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this._conditionalMediationController = null
+    this._conditionalMediationPromise = null
+    if (this.mediation === "conditional") this._attemptConditionalMediation()
+  }
+
+  get mediation() {
+    return this.getAttribute("mediation")
+  }
+
+  async perform(options, { signal, mediation } = {}) {
+    return await authenticate(options, { signal, mediation })
+  }
+
+  fillForm(passkey) {
+    fillSignInForm(this.form, passkey)
+  }
+
+  async abortConditionalMediation() {
+    if (this._conditionalMediationController) {
+      this._conditionalMediationController.abort()
+      await this._conditionalMediationPromise
+    }
+  }
+
+  async _attemptConditionalMediation() {
+    const available = this.options &&
+      passkeysAvailable() &&
+      await window.PublicKeyCredential.isConditionalMediationAvailable?.()
+
+    if (available) {
+      const options = this.options
+
+      this.form.dispatchEvent(new CustomEvent("passkey:start", { bubbles: true }))
+
+      this._conditionalMediationController = new AbortController()
+      this._conditionalMediationPromise = this._runConditionalMediation(options)
+    }
+  }
+
+  async _runConditionalMediation(options) {
+    try {
+      await refreshChallenge(options, this.challengeUrl, this.purpose)
+      const passkey = await this.perform(options, { signal: this._conditionalMediationController.signal, mediation: this.mediation })
+
+      this.form.dispatchEvent(new CustomEvent("passkey:success", { bubbles: true }))
+      this.fillForm(passkey)
+      this.form.submit()
+    } catch (error) {
+      if (error.name === "AbortError") return
+
+      const type = errorType(error)
+      this.button.dispatchEvent(new CustomEvent("passkey:error", { bubbles: true, detail: { error, type } }))
+    } finally {
+      this._conditionalMediationController = null
+      this._conditionalMediationPromise = null
+    }
+  }
+}
+
+customElements.define("rails-passkey-registration-button", PasskeyRegistrationButton)
+customElements.define("rails-passkey-sign-in-button", PasskeySignInButton)
+
+// -- Shared helpers ----------------------------------------------------------
+
+function handleError(component, error) {
+  const type = errorType(error)
+  showError(component, type)
+  component.button.dispatchEvent(new CustomEvent("passkey:error", { bubbles: true, detail: { error, type } }))
+}
+
+function errorType(error) {
+  switch (error.name) {
+    case "AbortError":
+    case "NotAllowedError": return "cancelled"
+    case "InvalidStateError": return "duplicate"
+    default: return "error"
+  }
+}
+
+function showError(component, type) {
+  const el = component.querySelector(`[data-passkey-error="${type}"]`)
+  if (el) el.hidden = false
+}
+
+function hideErrors(component) {
+  for (const el of component.querySelectorAll("[data-passkey-error]")) el.hidden = true
+}
+
+function passkeysAvailable() {
+  return !!window.PublicKeyCredential
+}
+
+async function refreshChallenge(options, challengeUrl, purpose) {
+  if (!challengeUrl) throw new Error("Missing passkey challenge URL")
+
+  const body = new URLSearchParams()
+  if (purpose) body.append("purpose", purpose)
+
+  const response = await fetch(challengeUrl, {
+    method: "POST",
+    headers: { "Accept": "application/json" },
+    body
+  })
+
+  if (!response.ok) throw new Error("Failed to refresh challenge")
+
+  const { challenge } = await response.json()
+  options.challenge = challenge
+}
+
+function fillRegistrationForm(form, passkey) {
+  form.querySelector("[data-passkey-field=\"client_data_json\"]").value = passkey.client_data_json
+  form.querySelector("[data-passkey-field=\"attestation_object\"]").value = passkey.attestation_object
+
+  const template = form.querySelector("[data-passkey-field=\"transports\"]")
+  for (const transport of passkey.transports) {
+    const input = template.cloneNode()
+    input.value = transport
+    template.before(input)
+  }
+  template.remove()
+}
+
+function fillSignInForm(form, passkey) {
+  form.querySelector("[data-passkey-field=\"id\"]").value = passkey.id
+  form.querySelector("[data-passkey-field=\"client_data_json\"]").value = passkey.client_data_json
+  form.querySelector("[data-passkey-field=\"authenticator_data\"]").value = passkey.authenticator_data
+  form.querySelector("[data-passkey-field=\"signature\"]").value = passkey.signature
+}

--- a/actionpack/lib/passkeys/app/javascript/action_pack/webauthn.js
+++ b/actionpack/lib/passkeys/app/javascript/action_pack/webauthn.js
@@ -1,0 +1,83 @@
+// Thin wrapper around the browser WebAuthn API (navigator.credentials).
+//
+// Handles the base64url ↔ ArrayBuffer conversions required by the spec so
+// callers can work with plain JSON objects from the server-rendered meta tags.
+
+// Call navigator.credentials.create() with the given creation options.
+// Returns { client_data_json, attestation_object, transports } with all
+// binary fields encoded as base64url strings ready for form submission.
+export async function register(options) {
+  const publicKey = prepareCreationOptions(options)
+  const credential = await navigator.credentials.create({ publicKey })
+
+  return {
+    client_data_json: new TextDecoder().decode(credential.response.clientDataJSON),
+    attestation_object: bufferToBase64url(credential.response.attestationObject),
+    transports: credential.response.getTransports?.() || []
+  }
+}
+
+// Call navigator.credentials.get() with the given request options.
+// Accepts an optional signal (AbortSignal) and mediation hint ("conditional"
+// for autofill UI). Returns { id, client_data_json, authenticator_data, signature }
+// with binary fields encoded as base64url strings.
+export async function authenticate(options, { signal, mediation } = {}) {
+  const publicKey = prepareRequestOptions(options)
+  const credential = await navigator.credentials.get({ publicKey, signal, mediation })
+
+  return {
+    id: credential.id,
+    client_data_json: new TextDecoder().decode(credential.response.clientDataJSON),
+    authenticator_data: bufferToBase64url(credential.response.authenticatorData),
+    signature: bufferToBase64url(credential.response.signature)
+  }
+}
+
+// Convert JSON creation options into the format expected by the browser:
+// decode base64url challenge, user.id, and excludeCredentials[].id into ArrayBuffers.
+function prepareCreationOptions(options) {
+  return {
+    ...options,
+    challenge: base64urlToBuffer(options.challenge),
+    user: { ...options.user, id: base64urlToBuffer(options.user.id) },
+    excludeCredentials: (options.excludeCredentials || []).map(cred => ({
+      ...cred,
+      id: base64urlToBuffer(cred.id)
+    }))
+  }
+}
+
+// Convert JSON request options into the format expected by the browser:
+// decode base64url challenge and allowCredentials[].id into ArrayBuffers.
+// Strips allowCredentials entirely when empty so the browser prompts for
+// any available credential (required for conditional mediation).
+function prepareRequestOptions(options) {
+  const prepared = {
+    ...options,
+    challenge: base64urlToBuffer(options.challenge)
+  }
+
+  if (options.allowCredentials?.length) {
+    prepared.allowCredentials = options.allowCredentials.map(cred => ({
+      ...cred,
+      id: base64urlToBuffer(cred.id)
+    }))
+  } else {
+    delete prepared.allowCredentials
+  }
+
+  return prepared
+}
+
+function base64urlToBuffer(base64url) {
+  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/")
+  const padding = "=".repeat((4 - base64.length % 4) % 4)
+  const binary = atob(base64 + padding)
+  return Uint8Array.from(binary, c => c.charCodeAt(0)).buffer
+}
+
+function bufferToBase64url(buffer) {
+  const bytes = new Uint8Array(buffer)
+  const binary = String.fromCharCode(...bytes)
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}

--- a/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
+++ b/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module ActionPack
+  module Passkeys
+    # = Action Pack Passkey
+    #
+    # Provides WebAuthn passkey registration and authentication backed by Active Record.
+    #
+    # Passkeys are scoped to a polymorphic +holder+ (typically a User or Identity) and store the
+    # credential ID, public key, sign count, and transport hints needed for the WebAuthn ceremonies.
+    #
+    # == Registration
+    #
+    # Generate options for the browser's +navigator.credentials.create()+ call, then register the
+    # response:
+    #
+    #   options = ActionPack::Passkeys::Passkey.registration_options(holder: current_user)
+    #   # Pass options to the browser
+    #
+    #   passkey = ActionPack::Passkeys::Passkey.register(params[:passkey], holder: current_user)
+    #
+    # == Authentication
+    #
+    # Generate options for the browser's +navigator.credentials.get()+ call, then authenticate the
+    # response:
+    #
+    #   options = ActionPack::Passkeys::Passkey.authentication_options
+    #   # Pass options to the browser
+    #
+    #   passkey = ActionPack::Passkeys::Passkey.authenticate(params[:passkey])
+    #
+    # == Holder Integration
+    #
+    # Call +has_passkeys+ in the model to set up the association and configure ceremony options
+    # per-holder. See ActionPack::Passkeys::Holder for details.
+    class Passkey < ActionPack::Passkeys.parent_class_name.constantize
+      belongs_to :holder, polymorphic: true
+      serialize :transports, coder: JSON, type: Array, default: []
+
+      class << self
+        # Returns a CreationOptions object for the given +holder+, suitable for passing to the
+        # browser's +navigator.credentials.create()+ call. Merges global defaults from the Rails
+        # configuration, holder-specific options from +holder.passkey_registration_options+, and any
+        # additional +options+ overrides.
+        def registration_options(holder:, **options)
+          ActionPack::WebAuthn::PublicKeyCredential.creation_options(
+            challenge_expiration: ActionPack::Passkeys.registration_challenge_expiration,
+            **ActionPack::Passkeys.default_registration_options.to_h,
+            **holder.passkey_registration_options.to_h,
+            **options
+          )
+        end
+
+        # Verifies the attestation response from the browser and persists a new passkey record.
+        # The +passkey+ hash should contain +client_data_json+, +attestation_object+, and +transports+
+        # as submitted by the registration form. The challenge is extracted from the authenticator's
+        # +clientDataJSON+ response and verified server-side. Any additional +attributes+ (e.g. +holder+)
+        # are passed through to +create!+.
+        #
+        # Raises ActionPack::WebAuthn::InvalidResponseError if the attestation is invalid.
+        def register(passkey, **attributes)
+          credential = ActionPack::WebAuthn::PublicKeyCredential.register(passkey)
+
+          create!(**credential.to_h, **attributes)
+        end
+
+        # Returns a RequestOptions object suitable for passing to the browser's
+        # +navigator.credentials.get()+ call. When a +holder+ is provided, their existing credentials
+        # are included so the browser can offer them for selection. Merges global defaults, holder
+        # options, and any additional +options+ overrides.
+        def authentication_options(holder: nil, **options)
+          ActionPack::WebAuthn::PublicKeyCredential.request_options(
+            challenge_expiration: ActionPack::Passkeys.authentication_challenge_expiration,
+            **ActionPack::Passkeys.default_authentication_options.to_h,
+            **holder&.passkey_authentication_options.to_h,
+            **options
+          )
+        end
+
+        # Looks up a passkey by credential ID and verifies the assertion response from the browser.
+        # Returns the authenticated Passkey record, or +nil+ if the credential is not found or
+        # verification fails.
+        def authenticate(passkey)
+          find_by(credential_id: passkey[:id])&.authenticate(passkey)
+        end
+      end
+
+      # Verifies the assertion response against this passkey's stored credential and updates the
+      # +sign_count+ and +backed_up+ attributes. Returns +self+ on success, or +nil+ if the
+      # response is invalid.
+      def authenticate(passkey)
+        credential = to_public_key_credential
+        credential.authenticate(passkey)
+        update!(sign_count: credential.sign_count, backed_up: credential.backed_up)
+        self
+      rescue ActionPack::WebAuthn::InvalidResponseError
+        nil
+      end
+
+      # Returns an ActionPack::WebAuthn::PublicKeyCredential initialized from this record's stored
+      # credential data.
+      def to_public_key_credential
+        ActionPack::WebAuthn::PublicKeyCredential.new(
+          id: credential_id,
+          public_key: public_key,
+          sign_count: sign_count,
+          transports: transports
+        )
+      end
+    end
+  end
+end

--- a/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
+++ b/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
@@ -67,10 +67,22 @@ module ActionPack
 
         # Same as #register, but raises ActionPack::WebAuthn::InvalidResponseError instead of
         # returning +nil+ if the attestation is invalid.
-        def register!(passkey, **attributes)
-          credential = ActionPack::WebAuthn::PublicKeyCredential.register(passkey)
+        #
+        # The user_verification requirement enforced during verification is the same one that
+        # would be used to build this holder's #registration_options (global defaults overridden
+        # by the holder's own +passkey_registration_options+).
+        def register!(passkey_params, **attributes)
+          passkey = new(**attributes)
+          registration_options = self.registration_options(holder: passkey.holder)
 
-          create!(**credential.to_h, **attributes)
+          credential = ActionPack::WebAuthn::PublicKeyCredential.register(
+            passkey_params,
+            user_verification: registration_options.user_verification
+          )
+
+          passkey.assign_attributes(**credential.to_h, **attributes)
+          passkey.save!
+          passkey
         end
 
         # Returns a RequestOptions object suitable for passing to the browser's
@@ -112,10 +124,17 @@ module ActionPack
 
       # Same as #authenticate, but raises ActionPack::WebAuthn::InvalidResponseError instead of
       # returning +nil+ if the response is invalid.
+      #
+      # The user_verification requirement enforced during verification is the same one that
+      # would be used to build this holder's #authentication_options (global defaults overridden
+      # by the holder's own +passkey_authentication_options+).
       def authenticate!(passkey)
         credential = to_public_key_credential
-        credential.authenticate(passkey)
+        authentication_options = self.class.authentication_options(holder: holder)
+
+        credential.authenticate(passkey, user_verification: authentication_options.user_verification)
         update!(sign_count: credential.sign_count, backed_up: credential.backed_up)
+
         self
       end
 

--- a/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
+++ b/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
@@ -44,7 +44,7 @@ module ActionPack
         # additional +options+ overrides.
         def registration_options(holder:, **options)
           ActionPack::WebAuthn::PublicKeyCredential.creation_options(
-            challenge_expiration: ActionPack::Passkeys.registration_challenge_expiration,
+            timeout: ActionPack::Passkeys.registration_timeout,
             **ActionPack::Passkeys.default_registration_options.to_h,
             **holder.passkey_registration_options.to_h,
             **options
@@ -70,7 +70,7 @@ module ActionPack
         # options, and any additional +options+ overrides.
         def authentication_options(holder: nil, **options)
           ActionPack::WebAuthn::PublicKeyCredential.request_options(
-            challenge_expiration: ActionPack::Passkeys.authentication_challenge_expiration,
+            timeout: ActionPack::Passkeys.authentication_timeout,
             **ActionPack::Passkeys.default_authentication_options.to_h,
             **holder&.passkey_authentication_options.to_h,
             **options

--- a/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
+++ b/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
@@ -57,13 +57,20 @@ module ActionPack
         # +clientDataJSON+ response and verified server-side. Any additional +attributes+ (e.g. +holder+)
         # are passed through to +create!+.
         #
-        # Returns the persisted Passkey record, or +nil+ if the attestation is invalid.
+        # Returns the persisted Passkey record, or +nil+ if the attestation is invalid. Use #register!
+        # to raise ActionPack::WebAuthn::InvalidResponseError instead.
         def register(passkey, **attributes)
+          register!(passkey, **attributes)
+        rescue ActionPack::WebAuthn::InvalidResponseError
+          nil
+        end
+
+        # Same as #register, but raises ActionPack::WebAuthn::InvalidResponseError instead of
+        # returning +nil+ if the attestation is invalid.
+        def register!(passkey, **attributes)
           credential = ActionPack::WebAuthn::PublicKeyCredential.register(passkey)
 
           create!(**credential.to_h, **attributes)
-        rescue ActionPack::WebAuthn::InvalidResponseError
-          nil
         end
 
         # Returns a RequestOptions object suitable for passing to the browser's
@@ -81,22 +88,35 @@ module ActionPack
 
         # Looks up a passkey by credential ID and verifies the assertion response from the browser.
         # Returns the authenticated Passkey record, or +nil+ if the credential is not found or
-        # verification fails.
+        # verification fails. Use #authenticate! to raise instead.
         def authenticate(passkey)
           find_by(credential_id: passkey[:id])&.authenticate(passkey)
+        end
+
+        # Same as #authenticate, but raises ActiveRecord::RecordNotFound if the credential is not
+        # found, or ActionPack::WebAuthn::InvalidResponseError if verification fails.
+        def authenticate!(passkey)
+          find_by!(credential_id: passkey[:id]).authenticate!(passkey)
         end
       end
 
       # Verifies the assertion response against this passkey's stored credential and updates the
       # +sign_count+ and +backed_up+ attributes. Returns +self+ on success, or +nil+ if the
-      # response is invalid.
+      # response is invalid. Use #authenticate! to raise ActionPack::WebAuthn::InvalidResponseError
+      # instead.
       def authenticate(passkey)
+        authenticate!(passkey)
+      rescue ActionPack::WebAuthn::InvalidResponseError
+        nil
+      end
+
+      # Same as #authenticate, but raises ActionPack::WebAuthn::InvalidResponseError instead of
+      # returning +nil+ if the response is invalid.
+      def authenticate!(passkey)
         credential = to_public_key_credential
         credential.authenticate(passkey)
         update!(sign_count: credential.sign_count, backed_up: credential.backed_up)
         self
-      rescue ActionPack::WebAuthn::InvalidResponseError
-        nil
       end
 
       # Returns an ActionPack::WebAuthn::PublicKeyCredential initialized from this record's stored

--- a/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
+++ b/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
@@ -44,7 +44,6 @@ module ActionPack
         # additional +options+ overrides.
         def registration_options(holder:, **options)
           ActionPack::WebAuthn::PublicKeyCredential.creation_options(
-            timeout: ActionPack::Passkeys.registration_timeout,
             **ActionPack::Passkeys.default_registration_options.to_h,
             **holder.passkey_registration_options.to_h,
             **options
@@ -91,7 +90,6 @@ module ActionPack
         # options, and any additional +options+ overrides.
         def authentication_options(holder: nil, **options)
           ActionPack::WebAuthn::PublicKeyCredential.request_options(
-            timeout: ActionPack::Passkeys.authentication_timeout,
             **ActionPack::Passkeys.default_authentication_options.to_h,
             **holder&.passkey_authentication_options.to_h,
             **options

--- a/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
+++ b/actionpack/lib/passkeys/app/models/action_pack/passkeys/passkey.rb
@@ -57,11 +57,13 @@ module ActionPack
         # +clientDataJSON+ response and verified server-side. Any additional +attributes+ (e.g. +holder+)
         # are passed through to +create!+.
         #
-        # Raises ActionPack::WebAuthn::InvalidResponseError if the attestation is invalid.
+        # Returns the persisted Passkey record, or +nil+ if the attestation is invalid.
         def register(passkey, **attributes)
           credential = ActionPack::WebAuthn::PublicKeyCredential.register(passkey)
 
           create!(**credential.to_h, **attributes)
+        rescue ActionPack::WebAuthn::InvalidResponseError
+          nil
         end
 
         # Returns a RequestOptions object suitable for passing to the browser's

--- a/actionpack/lib/passkeys/db/migrate/20260213154740_create_action_pack_passkeys.rb
+++ b/actionpack/lib/passkeys/db/migrate/20260213154740_create_action_pack_passkeys.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateActionPackPasskeysPasskeys < ActiveRecord::Migration[8.2]
+  def change
+    create_table :action_pack_passkeys_passkeys do |t|
+      t.belongs_to :holder, polymorphic: true, null: false
+      t.string :credential_id, null: false
+      t.binary :public_key, null: false
+      t.integer :sign_count, null: false, default: 0
+      t.string :name
+      t.text :transports
+      t.string :aaguid, limit: 36
+      t.boolean :backed_up
+
+      t.timestamps
+
+      t.index :credential_id, unique: true
+    end
+  end
+end

--- a/actionpack/lib/passkeys/db/migrate/20260213154740_create_action_pack_passkeys.rb
+++ b/actionpack/lib/passkeys/db/migrate/20260213154740_create_action_pack_passkeys.rb
@@ -9,6 +9,7 @@ class CreateActionPackPasskeysPasskeys < ActiveRecord::Migration[8.2]
       t.integer :sign_count, null: false, default: 0
       t.string :name
       t.text :transports
+      t.string :relying_party_id
       t.string :aaguid, limit: 36
       t.boolean :backed_up
 

--- a/actionpack/lib/passkeys/db/migrate/20260213154740_create_action_pack_passkeys.rb
+++ b/actionpack/lib/passkeys/db/migrate/20260213154740_create_action_pack_passkeys.rb
@@ -11,6 +11,7 @@ class CreateActionPackPasskeysPasskeys < ActiveRecord::Migration[8.2]
       t.text :transports
       t.string :relying_party_id
       t.string :aaguid, limit: 36
+      t.boolean :backup_eligible
       t.boolean :backed_up
 
       t.timestamps

--- a/actionpack/package.json
+++ b/actionpack/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rails/actionpack-passkeys",
+  "version": "8.2.0-alpha",
+  "description": "Passkey and WebAuthn support for Ruby on Rails.",
+  "module": "app/assets/javascripts/actionpack-passkeys.esm.js",
+  "main": "app/assets/javascripts/actionpack-passkeys.js",
+  "files": [
+    "app/assets/javascripts/*.js",
+    "src/*.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rails/rails.git"
+  },
+  "keywords": [
+    "passkeys",
+    "webauthn",
+    "actionpack",
+    "rails"
+  ],
+  "author": "David Heinemeier Hansson <david@loudthinking.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rails/rails/issues"
+  },
+  "homepage": "https://rubyonrails.org/",
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@rollup/plugin-node-resolve": "^11.0.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "globals": "^14.0.0",
+    "karma": "^6.4.2",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-qunit": "^2.1.0",
+    "karma-sauce-launcher": "^1.2.0",
+    "qunit": "^2.8.0",
+    "rollup": "^2.35.1",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "scripts": {
+    "prebuild": "yarn lint",
+    "build": "rollup --config rollup.config.js",
+    "lint": "eslint lib/passkeys/app/javascript",
+    "prepublishOnly": "rm -rf src && cp -R lib/passkeys/app/javascript/action_pack src",
+    "pretest": "rollup --config rollup.config.test.js",
+    "test": "karma start"
+  }
+}

--- a/actionpack/rollup.config.js
+++ b/actionpack/rollup.config.js
@@ -1,0 +1,38 @@
+import resolve from "@rollup/plugin-node-resolve"
+import { terser } from "rollup-plugin-terser"
+
+const terserOptions = {
+  mangle: false,
+  compress: false,
+  format: {
+    beautify: true,
+    indent_level: 2
+  }
+}
+
+export default [
+  {
+    input: "lib/passkeys/app/javascript/action_pack/index.js",
+    output: {
+      file: "lib/passkeys/app/assets/javascripts/actionpack-passkeys.js",
+      format: "umd",
+      name: "ActionPack"
+    },
+    plugins: [
+      resolve(),
+      terser(terserOptions)
+    ]
+  },
+
+  {
+    input: "lib/passkeys/app/javascript/action_pack/index.js",
+    output: {
+      file: "lib/passkeys/app/assets/javascripts/actionpack-passkeys.esm.js",
+      format: "es"
+    },
+    plugins: [
+      resolve(),
+      terser(terserOptions)
+    ]
+  }
+]

--- a/actionpack/rollup.config.test.js
+++ b/actionpack/rollup.config.test.js
@@ -1,0 +1,14 @@
+import resolve from "@rollup/plugin-node-resolve"
+
+export default {
+  input: "test/javascript/src/test.js",
+
+  output: {
+    file: "test/javascript/compiled/test.js",
+    format: "iife"
+  },
+
+  plugins: [
+    resolve()
+  ]
+}

--- a/actionpack/test/javascript/src/test.js
+++ b/actionpack/test/javascript/src/test.js
@@ -1,0 +1,2 @@
+import "./unit/webauthn_test"
+import "./unit/passkey_test"

--- a/actionpack/test/javascript/src/test_helpers/index.js
+++ b/actionpack/test/javascript/src/test_helpers/index.js
@@ -1,0 +1,113 @@
+// Stub navigator.credentials for WebAuthn tests.
+// Returns predictable credential objects so we can assert on form field values.
+
+const encoder = new TextEncoder()
+const originalCredentials = navigator.credentials
+
+export function stubCredentialsCreate(response = {}) {
+  const fake = {
+    create: async () => ({
+      id: "credential-id",
+      rawId: encoder.encode("credential-id").buffer,
+      type: "public-key",
+      response: {
+        clientDataJSON: encoder.encode(JSON.stringify({
+          challenge: "test-challenge",
+          origin: "https://example.com",
+          type: "webauthn.create"
+        })).buffer,
+        attestationObject: new Uint8Array([1, 2, 3]).buffer,
+        getTransports: () => response.transports || ["internal", "hybrid"]
+      }
+    }),
+    get: originalCredentials?.get?.bind(originalCredentials)
+  }
+
+  Object.defineProperty(navigator, "credentials", { value: fake, writable: true, configurable: true })
+  return () => Object.defineProperty(navigator, "credentials", { value: originalCredentials, writable: true, configurable: true })
+}
+
+export function stubCredentialsGet(response = {}) {
+  const fake = {
+    create: originalCredentials?.create?.bind(originalCredentials),
+    get: async () => ({
+      id: response.id || "credential-id",
+      rawId: encoder.encode("credential-id").buffer,
+      type: "public-key",
+      response: {
+        clientDataJSON: encoder.encode(JSON.stringify({
+          challenge: "test-challenge",
+          origin: "https://example.com",
+          type: "webauthn.get"
+        })).buffer,
+        authenticatorData: new Uint8Array([4, 5, 6]).buffer,
+        signature: new Uint8Array([7, 8, 9]).buffer
+      }
+    })
+  }
+
+  Object.defineProperty(navigator, "credentials", { value: fake, writable: true, configurable: true })
+  return () => Object.defineProperty(navigator, "credentials", { value: originalCredentials, writable: true, configurable: true })
+}
+
+export function stubFetch(responseBody = { challenge: "fresh-challenge" }, status = 200) {
+  const original = window.fetch
+  window.fetch = async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => responseBody
+  })
+  return () => { window.fetch = original }
+}
+
+export function createMetaTag(name, content) {
+  const meta = document.createElement("meta")
+  meta.setAttribute("name", name)
+  meta.setAttribute("content", content)
+  document.head.appendChild(meta)
+  return () => document.head.removeChild(meta)
+}
+
+export function createComponent(tagName, attributes = {}, innerHTML = "") {
+  const el = document.createElement(tagName)
+  for (const [key, value] of Object.entries(attributes)) {
+    el.setAttribute(key, value)
+  }
+  el.innerHTML = innerHTML
+  document.body.appendChild(el)
+  return el
+}
+
+export function removeComponent(el) {
+  if (el.parentNode) el.parentNode.removeChild(el)
+}
+
+export function registrationFormHTML(action = "/passkeys") {
+  return `
+    <form method="post" action="${action}">
+      <input type="hidden" name="authenticity_token" value="test-token">
+      <input type="hidden" name="passkey[client_data_json]" data-passkey-field="client_data_json">
+      <input type="hidden" name="passkey[attestation_object]" data-passkey-field="attestation_object">
+      <input type="hidden" name="passkey[transports][]" data-passkey-field="transports">
+      <button type="button" data-passkey="register">Register</button>
+    </form>
+    <div hidden data-passkey-error="error">Error</div>
+    <div hidden data-passkey-error="cancelled">Cancelled</div>
+    <div hidden data-passkey-error="duplicate">Duplicate</div>
+  `
+}
+
+export function signInFormHTML(action = "/session/passkey") {
+  return `
+    <form method="post" action="${action}">
+      <input type="hidden" name="authenticity_token" value="test-token">
+      <input type="hidden" name="passkey[id]" data-passkey-field="id">
+      <input type="hidden" name="passkey[client_data_json]" data-passkey-field="client_data_json">
+      <input type="hidden" name="passkey[authenticator_data]" data-passkey-field="authenticator_data">
+      <input type="hidden" name="passkey[signature]" data-passkey-field="signature">
+      <button type="button" data-passkey="sign_in">Sign in</button>
+    </form>
+    <div hidden data-passkey-error="error">Error</div>
+    <div hidden data-passkey-error="cancelled">Cancelled</div>
+  `
+}

--- a/actionpack/test/javascript/src/unit/passkey_test.js
+++ b/actionpack/test/javascript/src/unit/passkey_test.js
@@ -1,0 +1,263 @@
+import "../../../../lib/passkeys/app/javascript/action_pack/passkey"
+import {
+  stubCredentialsCreate,
+  stubCredentialsGet,
+  stubFetch,
+  createComponent,
+  removeComponent,
+  registrationFormHTML,
+  signInFormHTML
+} from "../test_helpers/index"
+
+const { module, test } = QUnit
+
+function waitForEvent(target, eventName) {
+  return new Promise(resolve => {
+    target.addEventListener(eventName, resolve, { once: true })
+  })
+}
+
+module("PasskeyRegistrationButton", hooks => {
+  let element, restoreFetch, restoreCredentials
+
+  hooks.beforeEach(() => {
+    restoreFetch = stubFetch()
+    restoreCredentials = stubCredentialsCreate()
+  })
+
+  hooks.afterEach(() => {
+    if (element) removeComponent(element)
+    restoreFetch()
+    restoreCredentials()
+  })
+
+  test("renders as a custom element", assert => {
+    element = createComponent("rails-passkey-registration-button", {
+      options: JSON.stringify({ rp: { id: "example.com" } }),
+      "challenge-url": "/challenge"
+    }, registrationFormHTML())
+
+    assert.ok(element instanceof HTMLElement)
+    assert.ok(element.querySelector("[data-passkey]"), "has a passkey button")
+    assert.ok(element.querySelector("form"), "has a form")
+  })
+
+  test("dispatches passkey:start on click", async assert => {
+    element = createComponent("rails-passkey-registration-button", {
+      options: JSON.stringify({
+        challenge: btoa("test"),
+        rp: { id: "example.com", name: "Example App" },
+        user: { id: btoa("user-1"), name: "jane@example.com", displayName: "Jane Doe" },
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+      }),
+      "challenge-url": "/challenge"
+    }, registrationFormHTML())
+
+    element.querySelector("form").submit = () => {}
+
+    const eventPromise = waitForEvent(element, "passkey:start")
+    element.querySelector("[data-passkey]").click()
+    await eventPromise
+
+    assert.ok(true, "passkey:start was dispatched")
+  })
+
+  test("fills form fields after ceremony", async assert => {
+    element = createComponent("rails-passkey-registration-button", {
+      options: JSON.stringify({
+        challenge: btoa("test"),
+        rp: { id: "example.com", name: "Example App" },
+        user: { id: btoa("user-1"), name: "jane@example.com", displayName: "Jane Doe" },
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+      }),
+      "challenge-url": "/challenge"
+    }, registrationFormHTML())
+
+    const form = element.querySelector("form")
+    const submitted = new Promise(resolve => { form.submit = resolve })
+
+    element.querySelector("[data-passkey]").click()
+    await submitted
+
+    const clientDataJson = form.querySelector("[data-passkey-field=\"client_data_json\"]").value
+    const attestationObject = form.querySelector("[data-passkey-field=\"attestation_object\"]").value
+
+    assert.ok(clientDataJson, "client_data_json is filled")
+    assert.ok(attestationObject, "attestation_object is filled")
+  })
+
+  test("shows error message on failure", async assert => {
+    restoreFetch()
+    restoreFetch = stubFetch({}, 500)
+
+    element = createComponent("rails-passkey-registration-button", {
+      options: JSON.stringify({ rp: { id: "example.com" } }),
+      "challenge-url": "/challenge"
+    }, registrationFormHTML())
+
+    const eventPromise = waitForEvent(element, "passkey:error")
+    element.querySelector("[data-passkey]").click()
+    const { detail } = await eventPromise
+
+    assert.equal(detail.type, "error", "error type is 'error'")
+
+    const errorDiv = element.querySelector("[data-passkey-error=\"error\"]")
+    assert.false(errorDiv.hidden, "error message is visible")
+  })
+
+  test("disables button during ceremony", async assert => {
+    element = createComponent("rails-passkey-registration-button", {
+      options: JSON.stringify({
+        challenge: btoa("test"),
+        rp: { id: "example.com", name: "Example App" },
+        user: { id: btoa("user-1"), name: "jane@example.com", displayName: "Jane Doe" },
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+      }),
+      "challenge-url": "/challenge"
+    }, registrationFormHTML())
+
+    const button = element.querySelector("[data-passkey]")
+    const form = element.querySelector("form")
+
+    const startPromise = waitForEvent(element, "passkey:start")
+    const submitted = new Promise(resolve => { form.submit = resolve })
+
+    button.click()
+    await startPromise
+
+    assert.true(button.disabled, "button is disabled during ceremony")
+    await submitted
+  })
+})
+
+module("PasskeySignInButton", hooks => {
+  let element, restoreFetch, restoreCredentials
+
+  hooks.beforeEach(() => {
+    restoreFetch = stubFetch()
+    restoreCredentials = stubCredentialsGet({ id: "cred-42" })
+  })
+
+  hooks.afterEach(() => {
+    if (element) removeComponent(element)
+    restoreFetch()
+    restoreCredentials()
+  })
+
+  test("renders as a custom element", assert => {
+    element = createComponent("rails-passkey-sign-in-button", {
+      options: JSON.stringify({ rpId: "example.com" }),
+      "challenge-url": "/challenge"
+    }, signInFormHTML())
+
+    assert.ok(element instanceof HTMLElement)
+    assert.ok(element.querySelector("[data-passkey]"), "has a passkey button")
+  })
+
+  test("fills sign-in form fields", async assert => {
+    element = createComponent("rails-passkey-sign-in-button", {
+      options: JSON.stringify({
+        challenge: btoa("test"),
+        rpId: "example.com",
+        allowCredentials: []
+      }),
+      "challenge-url": "/challenge"
+    }, signInFormHTML())
+
+    const form = element.querySelector("form")
+    const submitted = new Promise(resolve => { form.submit = resolve })
+
+    element.querySelector("[data-passkey]").click()
+    await submitted
+
+    assert.equal(form.querySelector("[data-passkey-field=\"id\"]").value, "cred-42", "credential id is filled")
+    assert.ok(form.querySelector("[data-passkey-field=\"client_data_json\"]").value, "client_data_json is filled")
+    assert.ok(form.querySelector("[data-passkey-field=\"authenticator_data\"]").value, "authenticator_data is filled")
+    assert.ok(form.querySelector("[data-passkey-field=\"signature\"]").value, "signature is filled")
+  })
+
+  test("refreshes challenge before ceremony", async assert => {
+    let fetchedURL, fetchedMethod
+
+    restoreFetch()
+    const originalFetch = window.fetch
+    window.fetch = async (url, opts) => {
+      fetchedURL = url
+      fetchedMethod = opts.method
+      return { ok: true, json: async () => ({ challenge: "new-challenge" }) }
+    }
+    restoreFetch = () => { window.fetch = originalFetch }
+
+    element = createComponent("rails-passkey-sign-in-button", {
+      options: JSON.stringify({
+        challenge: btoa("old"),
+        rpId: "example.com",
+        allowCredentials: []
+      }),
+      "challenge-url": "/challenge"
+    }, signInFormHTML())
+
+    const form = element.querySelector("form")
+    const submitted = new Promise(resolve => { form.submit = resolve })
+    const errorEvent = waitForEvent(element, "passkey:error")
+
+    element.querySelector("[data-passkey]").click()
+
+    await Promise.race([submitted, errorEvent])
+
+    assert.equal(fetchedURL, "/challenge", "fetches challenge URL")
+    assert.equal(fetchedMethod, "POST", "uses POST")
+  })
+
+  test("shows cancelled message on NotAllowedError", async assert => {
+    restoreCredentials()
+    const orig = navigator.credentials
+    Object.defineProperty(navigator, "credentials", {
+      value: {
+        get: async () => { throw new DOMException("User cancelled", "NotAllowedError") }
+      },
+      writable: true,
+      configurable: true
+    })
+    restoreCredentials = () => Object.defineProperty(navigator, "credentials", { value: orig, writable: true, configurable: true })
+
+    element = createComponent("rails-passkey-sign-in-button", {
+      options: JSON.stringify({
+        challenge: btoa("test"),
+        rpId: "example.com",
+        allowCredentials: []
+      }),
+      "challenge-url": "/challenge"
+    }, signInFormHTML())
+
+    const eventPromise = waitForEvent(element, "passkey:error")
+    element.querySelector("[data-passkey]").click()
+    const { detail } = await eventPromise
+
+    assert.equal(detail.type, "cancelled", "error type is cancelled")
+
+    const cancelledDiv = element.querySelector("[data-passkey-error=\"cancelled\"]")
+    assert.false(cancelledDiv.hidden, "cancelled message is visible")
+
+    const errorDiv = element.querySelector("[data-passkey-error=\"error\"]")
+    assert.true(errorDiv.hidden, "error message stays hidden")
+  })
+
+  test("re-enables button after error", async assert => {
+    restoreFetch()
+    restoreFetch = stubFetch({}, 500)
+
+    element = createComponent("rails-passkey-sign-in-button", {
+      options: JSON.stringify({ rpId: "example.com" }),
+      "challenge-url": "/challenge"
+    }, signInFormHTML())
+
+    const button = element.querySelector("[data-passkey]")
+    const eventPromise = waitForEvent(element, "passkey:error")
+
+    button.click()
+    await eventPromise
+
+    assert.false(button.disabled, "button is re-enabled after error")
+  })
+})

--- a/actionpack/test/javascript/src/unit/webauthn_test.js
+++ b/actionpack/test/javascript/src/unit/webauthn_test.js
@@ -1,0 +1,48 @@
+import { register, authenticate } from "../../../../lib/passkeys/app/javascript/action_pack/webauthn"
+import { stubCredentialsCreate, stubCredentialsGet } from "../test_helpers/index"
+
+const { module, test } = QUnit
+
+module("WebAuthn", () => {
+  module("#register", () => {
+    test("returns client_data_json, attestation_object, and transports", async assert => {
+      const restore = stubCredentialsCreate({ transports: ["internal"] })
+
+      try {
+        const result = await register({
+          challenge: btoa("test-challenge"),
+          rp: { id: "example.com", name: "Example App" },
+          user: { id: btoa("user-1"), name: "jane@example.com", displayName: "Jane Doe" },
+          pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+        })
+
+        assert.ok(result.client_data_json, "has client_data_json")
+        assert.ok(result.attestation_object, "has attestation_object")
+        assert.deepEqual(result.transports, ["internal"], "has transports")
+      } finally {
+        restore()
+      }
+    })
+  })
+
+  module("#authenticate", () => {
+    test("returns id, client_data_json, authenticator_data, and signature", async assert => {
+      const restore = stubCredentialsGet({ id: "cred-123" })
+
+      try {
+        const result = await authenticate({
+          challenge: btoa("test-challenge"),
+          rpId: "example.com",
+          allowCredentials: []
+        })
+
+        assert.equal(result.id, "cred-123", "has credential id")
+        assert.ok(result.client_data_json, "has client_data_json")
+        assert.ok(result.authenticator_data, "has authenticator_data")
+        assert.ok(result.signature, "has signature")
+      } finally {
+        restore()
+      }
+    })
+  })
+})

--- a/actionpack/test/passkey/challenges_controller_test.rb
+++ b/actionpack/test/passkey/challenges_controller_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative "../web_authn_test_helper"
+require "action_pack/passkeys"
+require_relative "../../lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller"
+
+class ActionPack::Passkeys::ChallengesControllerTest < ActionController::TestCase
+  tests ActionPack::Passkeys::ChallengesController
+
+  setup do
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw do
+      post "/rails/action_pack/passkey/challenge" => "action_pack/passkeys/challenges#create"
+    end
+  end
+
+  teardown do
+    ActionPack::Passkeys.default_registration_options = {}
+    ActionPack::Passkeys.default_authentication_options = {}
+  end
+
+  test "create returns a fresh challenge and the authentication timeout, in milliseconds, by default" do
+    post :create
+
+    assert_response :success
+    assert_equal "application/json", response.media_type
+
+    assert response.parsed_body["challenge"].present?
+    assert_equal ActionPack::WebAuthn::PublicKeyCredential::RequestOptions::DEFAULT_TIMEOUT.in_milliseconds.to_i, response.parsed_body["timeout"]
+  end
+
+  test "create returns the registration timeout, in milliseconds, for a registration purpose" do
+    post :create, params: { purpose: "registration" }
+
+    assert_response :success
+    assert_equal ActionPack::WebAuthn::PublicKeyCredential::CreationOptions::DEFAULT_TIMEOUT.in_milliseconds.to_i, response.parsed_body["timeout"]
+  end
+
+  test "create returns the configured default timeout, in milliseconds, for each purpose" do
+    ActionPack::Passkeys.default_registration_options = { timeout: 42 }
+    ActionPack::Passkeys.default_authentication_options = { timeout: 24 }
+
+    post :create, params: { purpose: "registration" }
+    assert_equal 42_000, response.parsed_body["timeout"]
+
+    post :create
+    assert_equal 24_000, response.parsed_body["timeout"]
+  end
+
+  test "create returns a nil timeout when the purpose's default timeout is configured as nil" do
+    ActionPack::Passkeys.default_authentication_options = { timeout: nil }
+
+    post :create
+
+    assert_response :success
+    assert_nil response.parsed_body["timeout"]
+  end
+
+  test "create returns a different challenge on every request" do
+    post :create
+    first_challenge = response.parsed_body["challenge"]
+
+    post :create
+    second_challenge = response.parsed_body["challenge"]
+
+    assert_not_equal first_challenge, second_challenge
+  end
+end

--- a/actionpack/test/passkey/passkey_test.rb
+++ b/actionpack/test/passkey/passkey_test.rb
@@ -65,6 +65,7 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
         t.text :transports
         t.string :relying_party_id
         t.string :aaguid
+        t.boolean :backup_eligible
         t.boolean :backed_up
 
         t.timestamps
@@ -115,7 +116,7 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     assert @passkey.backed_up?
   end
 
-  test "register persists relying_party_id" do
+  test "register persists relying_party_id and backup_eligible" do
     ActionPack::WebAuthn::Current.host = "example.com"
     ActionPack::WebAuthn::Current.origin = "https://example.com"
 
@@ -132,6 +133,7 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     )
 
     assert_equal "example.com", passkey.relying_party_id
+    assert_equal false, passkey.backup_eligible
   end
 
   test "to_public_key_credential" do

--- a/actionpack/test/passkey/passkey_test.rb
+++ b/actionpack/test/passkey/passkey_test.rb
@@ -120,6 +120,28 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     ActionPack::Passkeys.default_authentication_options = {}
   end
 
+  test "registration_options defaults timeout to CreationOptions::DEFAULT_TIMEOUT" do
+    assert_equal ActionPack::WebAuthn::PublicKeyCredential::CreationOptions::DEFAULT_TIMEOUT,
+      ActionPack::Passkeys::Passkey.registration_options(holder: @user).timeout
+  end
+
+  test "registration_options honors a global timeout override" do
+    ActionPack::Passkeys.default_registration_options = { timeout: 2.minutes }
+
+    assert_equal 2.minutes, ActionPack::Passkeys::Passkey.registration_options(holder: @user).timeout
+  end
+
+  test "authentication_options defaults timeout to RequestOptions::DEFAULT_TIMEOUT" do
+    assert_equal ActionPack::WebAuthn::PublicKeyCredential::RequestOptions::DEFAULT_TIMEOUT,
+      ActionPack::Passkeys::Passkey.authentication_options.timeout
+  end
+
+  test "authentication_options honors a global timeout override" do
+    ActionPack::Passkeys.default_authentication_options = { timeout: 2.minutes }
+
+    assert_equal 2.minutes, ActionPack::Passkeys::Passkey.authentication_options.timeout
+  end
+
   test "authenticate with valid assertion" do
     challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
     assertion = build_assertion(challenge: challenge, authenticator_data: AUTHENTICATOR_DATA)

--- a/actionpack/test/passkey/passkey_test.rb
+++ b/actionpack/test/passkey/passkey_test.rb
@@ -39,6 +39,15 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     "1d00000005"
   ].pack("H*").freeze
 
+  # {"fmt": "none", "attStmt": {}, "authData": rp_id_hash=SHA-256("example.com"),
+  #  flags: 0x45 (UP+UV+AT), aaguid 00010203-..., credential_id 0x00..0x1f, ES256 key}
+  ATTESTATION_NONE_VERIFIED = [ "a363666d74646e6f6e656761747453746d74a068617574684461" \
+    "746158a4a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947" \
+    "4500000000000102030405060708090a0b0c0d0e0f0020000102030405060708090a0b0c" \
+    "0d0e0f101112131415161718191a1b1c1d1e1fa50102032620012158202ba472104c686f" \
+    "39d4b623cc9324953e7053b47cae818e8cf774203a4f51af7122582069cb8ac519bdd929" \
+    "e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*").freeze
+
   setup do
     ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
     ActiveRecord::Schema.define do
@@ -54,6 +63,7 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
         t.integer :sign_count, null: false, default: 0
         t.string :name
         t.text :transports
+        t.string :relying_party_id
         t.string :aaguid
         t.boolean :backed_up
 
@@ -103,6 +113,25 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
 
     assert_equal 5, @passkey.reload.sign_count
     assert @passkey.backed_up?
+  end
+
+  test "register persists relying_party_id" do
+    ActionPack::WebAuthn::Current.host = "example.com"
+    ActionPack::WebAuthn::Current.origin = "https://example.com"
+
+    challenge = ActionPack::Passkeys::Passkey.registration_options(holder: @user).challenge
+    client_data_json = { challenge: challenge, origin: "https://example.com", type: "webauthn.create" }.to_json
+
+    passkey = @user.passkeys.register(
+      {
+        client_data_json: client_data_json,
+        attestation_object: Base64.urlsafe_encode64(ATTESTATION_NONE_VERIFIED, padding: false),
+        transports: [ "internal" ]
+      },
+      id: SecureRandom.uuid
+    )
+
+    assert_equal "example.com", passkey.relying_party_id
   end
 
   test "to_public_key_credential" do

--- a/actionpack/test/passkey/passkey_test.rb
+++ b/actionpack/test/passkey/passkey_test.rb
@@ -21,6 +21,17 @@ class PasskeyUser < PasskeyApplicationRecord
   has_passkeys name: :name, display_name: :name
 end
 
+class StrictPasskeyUser < PasskeyApplicationRecord
+  include ActionPack::Passkeys::Holder
+
+  self.table_name = "users"
+
+  has_passkeys do |config|
+    config.registration_options { { name: name, display_name: name, user_verification: :required } }
+    config.authentication_options { { user_verification: :required } }
+  end
+end
+
 class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
   include WebauthnTestHelper
 
@@ -39,6 +50,12 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     "1d00000005"
   ].pack("H*").freeze
 
+  # rp_id_hash(32) + flags 0x01 (UP only, no UV) + sign_count 1
+  UNVERIFIED_AUTHENTICATOR_DATA = [
+    "80fc0fb9266db7b83f85850fa0e6548b6d70ee68c8b5b412f1deea6ebdef0404" \
+    "0100000001"
+  ].pack("H*").freeze
+
   # {"fmt": "none", "attStmt": {}, "authData": rp_id_hash=SHA-256("example.com"),
   #  flags: 0x45 (UP+UV+AT), aaguid 00010203-..., credential_id 0x00..0x1f, ES256 key}
   ATTESTATION_NONE_VERIFIED = [ "a363666d74646e6f6e656761747453746d74a068617574684461" \
@@ -47,6 +64,15 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     "0d0e0f101112131415161718191a1b1c1d1e1fa50102032620012158202ba472104c686f" \
     "39d4b623cc9324953e7053b47cae818e8cf774203a4f51af7122582069cb8ac519bdd929" \
     "e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*").freeze
+
+  # {"fmt": "none", "attStmt": {}, "authData": rp_id_hash=SHA-256("example.com"),
+  #  flags: 0x41 (UP+AT, no UV), aaguid 00010203-..., credential_id 0x00..0x1f, ES256 key}
+  ATTESTATION_NONE_NOT_VERIFIED = [ "a363666d74646e6f6e656761747453746d74a06861757468" \
+    "4461746158a4a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce" \
+    "19474100000000000102030405060708090a0b0c0d0e0f0020000102030405060708090a" \
+    "0b0c0d0e0f101112131415161718191a1b1c1d1e1fa50102032620012158202ba472104c" \
+    "686f39d4b623cc9324953e7053b47cae818e8cf774203a4f51af7122582069cb8ac519bd" \
+    "d929e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*").freeze
 
   setup do
     ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
@@ -89,6 +115,11 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     )
   end
 
+  teardown do
+    ActionPack::Passkeys.default_registration_options = {}
+    ActionPack::Passkeys.default_authentication_options = {}
+  end
+
   test "authenticate with valid assertion" do
     challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
     assertion = build_assertion(challenge: challenge, authenticator_data: AUTHENTICATOR_DATA)
@@ -113,6 +144,50 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
 
     assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
       @passkey.authenticate!(assertion)
+    end
+  end
+
+  test "authenticate! raises when user_verification is required globally and assertion is not verified" do
+    ActionPack::Passkeys.default_authentication_options = { user_verification: :required }
+
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
+    assertion = build_assertion(challenge: challenge, authenticator_data: UNVERIFIED_AUTHENTICATOR_DATA)
+
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      @passkey.authenticate!(assertion)
+    end
+  end
+
+  test "authenticate! succeeds when user_verification is required globally and assertion is verified" do
+    ActionPack::Passkeys.default_authentication_options = { user_verification: :required }
+
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
+    assertion = build_assertion(challenge: challenge, authenticator_data: AUTHENTICATOR_DATA)
+
+    assert_equal @passkey, @passkey.authenticate!(assertion)
+  end
+
+  test "authenticate! honors a holder's user_verification override" do
+    strict_user = StrictPasskeyUser.create!(id: SecureRandom.uuid, name: "Nadia")
+    strict_passkey = strict_user.passkeys.create!(
+      id: SecureRandom.uuid,
+      credential_id: Base64.urlsafe_encode64("\x02" * 32, padding: false),
+      public_key: PUBLIC_KEY_DER,
+      sign_count: 0,
+      transports: [ "internal" ]
+    )
+
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ strict_passkey ]).challenge
+    client_data_json = { challenge: challenge, origin: "http://www.example.com", type: "webauthn.get" }.to_json
+    assertion = {
+      id: strict_passkey.credential_id,
+      client_data_json: client_data_json,
+      authenticator_data: Base64.urlsafe_encode64(UNVERIFIED_AUTHENTICATOR_DATA, padding: false),
+      signature: Base64.urlsafe_encode64(webauthn_sign(UNVERIFIED_AUTHENTICATOR_DATA, client_data_json), padding: false)
+    }
+
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      strict_passkey.authenticate!(assertion)
     end
   end
 
@@ -185,6 +260,63 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
       assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
         @user.passkeys.register!(invalid, id: SecureRandom.uuid)
       end
+    end
+  end
+
+  test "register! raises when user_verification is required globally and attestation is not verified" do
+    ActionPack::Passkeys.default_registration_options = { user_verification: :required }
+
+    ActionPack::WebAuthn::Current.host = "example.com"
+    ActionPack::WebAuthn::Current.origin = "https://example.com"
+
+    unverified = {
+      client_data_json: { challenge: webauthn_challenge(purpose: "registration"), origin: "https://example.com", type: "webauthn.create" }.to_json,
+      attestation_object: Base64.urlsafe_encode64(ATTESTATION_NONE_NOT_VERIFIED, padding: false),
+      transports: [ "internal" ]
+    }
+
+    assert_no_difference -> { ActionPack::Passkeys::Passkey.count } do
+      assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+        @user.passkeys.register!(unverified, id: SecureRandom.uuid)
+      end
+    end
+  end
+
+  test "register! succeeds when user_verification is required globally and attestation is verified" do
+    ActionPack::Passkeys.default_registration_options = { user_verification: :required }
+
+    ActionPack::WebAuthn::Current.host = "example.com"
+    ActionPack::WebAuthn::Current.origin = "https://example.com"
+
+    challenge = ActionPack::Passkeys::Passkey.registration_options(holder: @user).challenge
+    client_data_json = { challenge: challenge, origin: "https://example.com", type: "webauthn.create" }.to_json
+
+    passkey = @user.passkeys.register!(
+      {
+        client_data_json: client_data_json,
+        attestation_object: Base64.urlsafe_encode64(ATTESTATION_NONE_VERIFIED, padding: false),
+        transports: [ "internal" ]
+      },
+      id: SecureRandom.uuid
+    )
+
+    assert_predicate passkey, :persisted?
+  end
+
+  test "register! honors a holder's user_verification override" do
+    strict_user = StrictPasskeyUser.create!(id: SecureRandom.uuid, name: "Nadia")
+
+    ActionPack::WebAuthn::Current.host = "example.com"
+    ActionPack::WebAuthn::Current.origin = "https://example.com"
+
+    unverified = {
+      client_data_json: { challenge: webauthn_challenge(purpose: "registration"), origin: "https://example.com", type: "webauthn.create" }.to_json,
+      attestation_object: Base64.urlsafe_encode64(ATTESTATION_NONE_NOT_VERIFIED, padding: false),
+      transports: [ "internal" ]
+    }
+
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      strict_user.passkeys.register!(unverified, id: SecureRandom.uuid)
     end
   end
 

--- a/actionpack/test/passkey/passkey_test.rb
+++ b/actionpack/test/passkey/passkey_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative "../web_authn_test_helper"
+require "active_record"
+require "action_pack/passkeys"
+
+class PasskeyApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+
+ActionPack::Passkeys.parent_class_name = "PasskeyApplicationRecord"
+
+require_relative "../../lib/passkeys/app/models/action_pack/passkeys/passkey"
+
+ActionPack::Passkeys::Passkey.table_name = "action_pack_passkeys_passkeys"
+
+class PasskeyUser < PasskeyApplicationRecord
+  include ActionPack::Passkeys::Holder
+
+  self.table_name = "users"
+  has_passkeys name: :name, display_name: :name
+end
+
+class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
+  include WebauthnTestHelper
+
+  CREDENTIAL_ID = Base64.urlsafe_encode64("\x01" * 32, padding: false).freeze
+  PUBLIC_KEY_DER = WebauthnTestHelper::WEBAUTHN_PRIVATE_KEY.public_to_der.freeze
+
+  # rp_id_hash(32) + flags 0x05 (UP+UV) + sign_count 1
+  AUTHENTICATOR_DATA = [
+    "80fc0fb9266db7b83f85850fa0e6548b6d70ee68c8b5b412f1deea6ebdef0404" \
+    "0500000001"
+  ].pack("H*").freeze
+
+  # rp_id_hash(32) + flags 0x1D (UP+UV+BE+BS) + sign_count 5
+  BACKED_UP_AUTHENTICATOR_DATA = [
+    "80fc0fb9266db7b83f85850fa0e6548b6d70ee68c8b5b412f1deea6ebdef0404" \
+    "1d00000005"
+  ].pack("H*").freeze
+
+  setup do
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+    ActiveRecord::Schema.define do
+      create_table :users, id: :string, force: true do |t|
+        t.string :name
+      end
+
+      create_table :action_pack_passkeys_passkeys, id: :string, force: true do |t|
+        t.string :holder_id, null: false
+        t.string :holder_type, null: false
+        t.string :credential_id, null: false
+        t.binary :public_key, null: false
+        t.integer :sign_count, null: false, default: 0
+        t.string :name
+        t.text :transports
+        t.string :aaguid
+        t.boolean :backed_up
+
+        t.timestamps
+
+        t.index [ :holder_type, :holder_id ]
+        t.index :credential_id, unique: true
+      end
+    end
+
+    @user = PasskeyUser.create!(id: SecureRandom.uuid, name: "Kevin")
+
+    ActionPack::WebAuthn::Current.host = "www.example.com"
+    ActionPack::WebAuthn::Current.origin = "http://www.example.com"
+
+    @passkey = @user.passkeys.create!(
+      id: SecureRandom.uuid,
+      credential_id: CREDENTIAL_ID,
+      public_key: PUBLIC_KEY_DER,
+      sign_count: 0,
+      transports: [ "internal" ]
+    )
+  end
+
+  test "authenticate with valid assertion" do
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
+    assertion = build_assertion(challenge: challenge, authenticator_data: AUTHENTICATOR_DATA)
+
+    result = @passkey.authenticate(assertion)
+
+    assert_equal @passkey, result
+  end
+
+  test "authenticate returns nil with invalid signature" do
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
+    assertion = build_assertion(challenge: challenge, authenticator_data: AUTHENTICATOR_DATA)
+    assertion[:signature] = Base64.urlsafe_encode64("invalid", padding: false)
+
+    assert_nil @passkey.authenticate(assertion)
+  end
+
+  test "authenticate updates sign count and backed_up" do
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
+    assertion = build_assertion(challenge: challenge, authenticator_data: BACKED_UP_AUTHENTICATOR_DATA)
+
+    @passkey.authenticate(assertion)
+
+    assert_equal 5, @passkey.reload.sign_count
+    assert @passkey.backed_up?
+  end
+
+  test "to_public_key_credential" do
+    credential = @passkey.to_public_key_credential
+
+    assert_equal @passkey.credential_id, credential.id
+    assert_equal @passkey.sign_count, credential.sign_count
+    assert_equal @passkey.transports, credential.transports
+  end
+
+  private
+    def build_assertion(challenge:, authenticator_data:)
+      client_data_json = { challenge: challenge, origin: "http://www.example.com", type: "webauthn.get" }.to_json
+
+      {
+        id: @passkey.credential_id,
+        client_data_json: client_data_json,
+        authenticator_data: Base64.urlsafe_encode64(authenticator_data, padding: false),
+        signature: Base64.urlsafe_encode64(webauthn_sign(authenticator_data, client_data_json), padding: false)
+      }
+    end
+end

--- a/actionpack/test/passkey/passkey_test.rb
+++ b/actionpack/test/passkey/passkey_test.rb
@@ -136,6 +136,21 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     assert_equal false, passkey.backup_eligible
   end
 
+  test "register returns nil with invalid attestation" do
+    ActionPack::WebAuthn::Current.host = "example.com"
+    ActionPack::WebAuthn::Current.origin = "https://example.com"
+
+    invalid = {
+      client_data_json: { challenge: "invalid", origin: "https://example.com", type: "webauthn.create" }.to_json,
+      attestation_object: Base64.urlsafe_encode64(ATTESTATION_NONE_VERIFIED, padding: false),
+      transports: [ "internal" ]
+    }
+
+    assert_no_difference -> { ActionPack::Passkeys::Passkey.count } do
+      assert_nil @user.passkeys.register(invalid, id: SecureRandom.uuid)
+    end
+  end
+
   test "to_public_key_credential" do
     credential = @passkey.to_public_key_credential
 

--- a/actionpack/test/passkey/passkey_test.rb
+++ b/actionpack/test/passkey/passkey_test.rb
@@ -106,6 +106,26 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
     assert_nil @passkey.authenticate(assertion)
   end
 
+  test "authenticate! raises with invalid signature" do
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
+    assertion = build_assertion(challenge: challenge, authenticator_data: AUTHENTICATOR_DATA)
+    assertion[:signature] = Base64.urlsafe_encode64("invalid", padding: false)
+
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      @passkey.authenticate!(assertion)
+    end
+  end
+
+  test "class authenticate! raises RecordNotFound for an unknown credential" do
+    challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
+    assertion = build_assertion(challenge: challenge, authenticator_data: AUTHENTICATOR_DATA)
+    assertion[:id] = Base64.urlsafe_encode64("\x02" * 32, padding: false)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      ActionPack::Passkeys::Passkey.authenticate!(assertion)
+    end
+  end
+
   test "authenticate updates sign count and backed_up" do
     challenge = ActionPack::Passkeys::Passkey.authentication_options(credentials: [ @passkey ]).challenge
     assertion = build_assertion(challenge: challenge, authenticator_data: BACKED_UP_AUTHENTICATOR_DATA)
@@ -148,6 +168,23 @@ class ActionPack::Passkeys::PasskeyTest < ActiveSupport::TestCase
 
     assert_no_difference -> { ActionPack::Passkeys::Passkey.count } do
       assert_nil @user.passkeys.register(invalid, id: SecureRandom.uuid)
+    end
+  end
+
+  test "register! raises with invalid attestation" do
+    ActionPack::WebAuthn::Current.host = "example.com"
+    ActionPack::WebAuthn::Current.origin = "https://example.com"
+
+    invalid = {
+      client_data_json: { challenge: "invalid", origin: "https://example.com", type: "webauthn.create" }.to_json,
+      attestation_object: Base64.urlsafe_encode64(ATTESTATION_NONE_VERIFIED, padding: false),
+      transports: [ "internal" ]
+    }
+
+    assert_no_difference -> { ActionPack::Passkeys::Passkey.count } do
+      assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+        @user.passkeys.register!(invalid, id: SecureRandom.uuid)
+      end
     end
   end
 

--- a/actionpack/test/web_authn/authenticator/assertion_response_test.rb
+++ b/actionpack/test/web_authn/authenticator/assertion_response_test.rb
@@ -129,6 +129,36 @@ class ActionPack::WebAuthn::Authenticator::AssertionResponseTest < ActiveSupport
     assert_equal "Origin does not match", error.message
   end
 
+  test "validate! accepts a native app origin listed in allowed_origins" do
+    native_origin = "android:apk-key-hash:pNiP5iKyQ8JwgGOaKA1zGPUPJIS-0H1xKCQcfIoGLck"
+    client_data_json = {
+      challenge: @challenge,
+      origin: native_origin,
+      type: "webauthn.get"
+    }.to_json
+
+    response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: client_data_json,
+      authenticator_data: USER_PRESENT_AND_VERIFIED_AUTH_DATA,
+      signature: webauthn_sign(USER_PRESENT_AND_VERIFIED_AUTH_DATA, client_data_json),
+      credential: @credential,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+    assert_equal "Origin does not match", error.message
+
+    ActionPack::WebAuthn.allowed_origins = [ native_origin ]
+
+    assert_nothing_raised do
+      response.validate!
+    end
+  ensure
+    ActionPack::WebAuthn.allowed_origins = []
+  end
+
   test "validate! succeeds with user_verification preferred when not verified" do
     response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
       client_data_json: @client_data_json,

--- a/actionpack/test/web_authn/authenticator/assertion_response_test.rb
+++ b/actionpack/test/web_authn/authenticator/assertion_response_test.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require_relative "../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::Authenticator::AssertionResponseTest < ActiveSupport::TestCase
+  include WebauthnTestHelper
+
+  # rp_id_hash("example.com") + flags USER_PRESENT + sign_count 0
+  USER_PRESENT_AUTH_DATA = [
+    "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947" \
+    "0100000000"
+  ].pack("H*").freeze
+
+  # rp_id_hash("example.com") + flags USER_PRESENT|USER_VERIFIED + sign_count 0
+  USER_PRESENT_AND_VERIFIED_AUTH_DATA = [
+    "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947" \
+    "0500000000"
+  ].pack("H*").freeze
+
+  setup do
+    ActionPack::WebAuthn::Current.host = "example.com"
+
+    @challenge = webauthn_challenge(purpose: "authentication")
+    @origin = "https://example.com"
+    @client_data_json = {
+      challenge: @challenge,
+      origin: @origin,
+      type: "webauthn.get"
+    }.to_json
+
+    @credential = Struct.new(:public_key, :sign_count).new(
+      WebauthnTestHelper::WEBAUTHN_PRIVATE_KEY, 0
+    )
+
+    @response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: USER_PRESENT_AND_VERIFIED_AUTH_DATA,
+      signature: webauthn_sign(USER_PRESENT_AND_VERIFIED_AUTH_DATA, @client_data_json),
+      credential: @credential,
+      origin: @origin
+    )
+  end
+
+  test "initializes with credential, authenticator data, and signature" do
+    assert_equal @credential, @response.credential
+    assert_instance_of ActionPack::WebAuthn::Authenticator::Data, @response.authenticator_data
+  end
+
+  test "validate! succeeds with valid challenge, origin, type, and signature" do
+    assert_nothing_raised do
+      @response.validate!
+    end
+  end
+
+  test "validate! raises when type is not webauthn.get" do
+    client_data_json = {
+      challenge: @challenge,
+      origin: @origin,
+      type: "webauthn.create"
+    }.to_json
+
+    response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: client_data_json,
+      authenticator_data: USER_PRESENT_AND_VERIFIED_AUTH_DATA,
+      signature: webauthn_sign(USER_PRESENT_AND_VERIFIED_AUTH_DATA, client_data_json),
+      credential: @credential,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "Client data type is not webauthn.get", error.message
+  end
+
+  test "validate! raises when signature is invalid" do
+    response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: USER_PRESENT_AND_VERIFIED_AUTH_DATA,
+      signature: Base64.urlsafe_encode64("invalid-signature", padding: false),
+      credential: @credential,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "Invalid signature", error.message
+  end
+
+  test "validate! raises when challenge has expired" do
+    expired_challenge = ActionPack::WebAuthn::PublicKeyCredential::Options.new(
+      challenge_expiration: 0.seconds,
+      challenge_purpose: "authentication"
+    ).challenge
+
+    travel 1.second do
+      client_data_json = {
+        challenge: expired_challenge,
+        origin: @origin,
+        type: "webauthn.get"
+      }.to_json
+
+      response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+        client_data_json: client_data_json,
+        authenticator_data: USER_PRESENT_AND_VERIFIED_AUTH_DATA,
+        signature: webauthn_sign(USER_PRESENT_AND_VERIFIED_AUTH_DATA, client_data_json),
+        credential: @credential,
+        origin: @origin
+      )
+
+      error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+        response.validate!
+      end
+
+      assert_equal "Challenge has expired", error.message
+    end
+  end
+
+  test "validate! raises when origin does not match" do
+    @response.origin = "https://evil.com"
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      @response.validate!
+    end
+
+    assert_equal "Origin does not match", error.message
+  end
+
+  test "validate! succeeds with user_verification preferred when not verified" do
+    response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: USER_PRESENT_AUTH_DATA,
+      signature: webauthn_sign(USER_PRESENT_AUTH_DATA, @client_data_json),
+      credential: @credential,
+      origin: @origin,
+      user_verification: :preferred
+    )
+
+    assert_nothing_raised do
+      response.validate!
+    end
+  end
+
+  test "validate! succeeds with user_verification required when verified" do
+    response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: USER_PRESENT_AND_VERIFIED_AUTH_DATA,
+      signature: webauthn_sign(USER_PRESENT_AND_VERIFIED_AUTH_DATA, @client_data_json),
+      credential: @credential,
+      origin: @origin,
+      user_verification: :required
+    )
+
+    assert_nothing_raised do
+      response.validate!
+    end
+  end
+
+  test "validate! raises with user_verification required when not verified" do
+    response = ActionPack::WebAuthn::Authenticator::AssertionResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: USER_PRESENT_AUTH_DATA,
+      signature: webauthn_sign(USER_PRESENT_AUTH_DATA, @client_data_json),
+      credential: @credential,
+      origin: @origin,
+      user_verification: :required
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "User verification is required", error.message
+  end
+end

--- a/actionpack/test/web_authn/authenticator/assertion_response_test.rb
+++ b/actionpack/test/web_authn/authenticator/assertion_response_test.rb
@@ -92,7 +92,7 @@ class ActionPack::WebAuthn::Authenticator::AssertionResponseTest < ActiveSupport
 
   test "validate! raises when challenge has expired" do
     expired_challenge = ActionPack::WebAuthn::PublicKeyCredential::Options.new(
-      challenge_expiration: 0.seconds,
+      timeout: 0.seconds,
       challenge_purpose: "authentication"
     ).challenge
 

--- a/actionpack/test/web_authn/authenticator/attestation_response_test.rb
+++ b/actionpack/test/web_authn/authenticator/attestation_response_test.rb
@@ -127,7 +127,7 @@ class ActionPack::WebAuthn::Authenticator::AttestationResponseTest < ActiveSuppo
 
   test "validate! raises when challenge has expired" do
     expired_challenge = ActionPack::WebAuthn::PublicKeyCredential::Options.new(
-      challenge_expiration: 0.seconds,
+      timeout: 0.seconds,
       challenge_purpose: "registration"
     ).challenge
 

--- a/actionpack/test/web_authn/authenticator/attestation_response_test.rb
+++ b/actionpack/test/web_authn/authenticator/attestation_response_test.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require_relative "../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::Authenticator::AttestationResponseTest < ActiveSupport::TestCase
+  # Auth data in all objects contains:
+  #   rp_id_hash: SHA-256("example.com") (32 bytes)
+  #   sign_count: 0
+  #   aaguid: 00010203-0405-0607-0809-0a0b0c0d0e0f (16 bytes)
+  #   credential_id: 32 sequential bytes 0x00..0x1f
+  #   cose_key: EC2/ES256 P-256 {1: 2, 3: -7, -1: 1, -2: <x>, -3: <y>}
+
+  # {"fmt": "none", "attStmt": {}, "authData": <flags: 0x45 (UP+UV+AT)>}
+  ATTESTATION_NONE_VERIFIED = [ "a363666d74646e6f6e656761747453746d74a068617574684461" \
+    "746158a4a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947" \
+    "4500000000000102030405060708090a0b0c0d0e0f0020000102030405060708090a0b0c" \
+    "0d0e0f101112131415161718191a1b1c1d1e1fa50102032620012158202ba472104c686f" \
+    "39d4b623cc9324953e7053b47cae818e8cf774203a4f51af7122582069cb8ac519bdd929" \
+    "e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*")
+
+  # {"fmt": "none", "attStmt": {}, "authData": <flags: 0x41 (UP+AT)>}
+  ATTESTATION_NONE_NOT_VERIFIED = [ "a363666d74646e6f6e656761747453746d74a06861757468" \
+    "4461746158a4a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce" \
+    "19474100000000000102030405060708090a0b0c0d0e0f0020000102030405060708090a" \
+    "0b0c0d0e0f101112131415161718191a1b1c1d1e1fa50102032620012158202ba472104c" \
+    "686f39d4b623cc9324953e7053b47cae818e8cf774203a4f51af7122582069cb8ac519bd" \
+    "d929e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*")
+
+  # {"fmt": "packed", "attStmt": {}, "authData": <flags: 0x45 (UP+UV+AT)>}
+  ATTESTATION_PACKED_VERIFIED = [ "a363666d74667061636b65646761747453746d74a068617574" \
+    "684461746158a4a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586" \
+    "ce19474500000000000102030405060708090a0b0c0d0e0f0020000102030405060708090" \
+    "a0b0c0d0e0f101112131415161718191a1b1c1d1e1fa50102032620012158202ba472104" \
+    "c686f39d4b623cc9324953e7053b47cae818e8cf774203a4f51af7122582069cb8ac519b" \
+    "dd929e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*")
+
+  include WebauthnTestHelper
+
+  setup do
+    ActionPack::WebAuthn::Current.host = "example.com"
+
+    @challenge = webauthn_challenge(purpose: "registration")
+    @origin = "https://example.com"
+    @client_data_json = {
+      challenge: @challenge,
+      origin: @origin,
+      type: "webauthn.create"
+    }.to_json
+
+    @response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: ATTESTATION_NONE_VERIFIED,
+      origin: @origin
+    )
+  end
+
+  test "initializes with attestation object" do
+    assert_not_nil @response.attestation_object
+  end
+
+  test "validate! succeeds with valid challenge, origin, and type" do
+    assert_nothing_raised do
+      @response.validate!
+    end
+  end
+
+  test "validate! succeeds with user_verification preferred when not verified" do
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: ATTESTATION_NONE_NOT_VERIFIED,
+      origin: @origin,
+      user_verification: :preferred
+    )
+
+    assert_nothing_raised do
+      response.validate!
+    end
+  end
+
+  test "validate! succeeds with user_verification required when verified" do
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: ATTESTATION_NONE_VERIFIED,
+      origin: @origin,
+      user_verification: :required
+    )
+
+    assert_nothing_raised do
+      response.validate!
+    end
+  end
+
+  test "validate! raises with user_verification required when not verified" do
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: ATTESTATION_NONE_NOT_VERIFIED,
+      origin: @origin,
+      user_verification: :required
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "User verification is required", error.message
+  end
+
+  test "validate! raises when type is not webauthn.create" do
+    client_data_json = {
+      challenge: @challenge,
+      origin: @origin,
+      type: "webauthn.get"
+    }.to_json
+
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: client_data_json,
+      attestation_object: ATTESTATION_NONE_VERIFIED,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "Client data type is not webauthn.create", error.message
+  end
+
+  test "validate! raises when challenge has expired" do
+    expired_challenge = ActionPack::WebAuthn::PublicKeyCredential::Options.new(
+      challenge_expiration: 0.seconds,
+      challenge_purpose: "registration"
+    ).challenge
+
+    travel 1.second do
+      client_data_json = {
+        challenge: expired_challenge,
+        origin: @origin,
+        type: "webauthn.create"
+      }.to_json
+
+      response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+        client_data_json: client_data_json,
+        attestation_object: ATTESTATION_NONE_VERIFIED,
+        origin: @origin
+      )
+
+      error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+        response.validate!
+      end
+
+      assert_equal "Challenge has expired", error.message
+    end
+  end
+
+  test "validate! raises when origin does not match" do
+    @response.origin = "https://evil.com"
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      @response.validate!
+    end
+
+    assert_equal "Origin does not match", error.message
+  end
+
+  test "validate! raises when attestation format is not registered" do
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: ATTESTATION_PACKED_VERIFIED,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "Unsupported attestation format: packed", error.message
+  end
+
+  test "validate! calls registered verifier for custom format" do
+    verified = false
+    custom_verifier = Object.new
+    custom_verifier.define_singleton_method(:verify!) { |_attestation, client_data_json:| verified = true }
+
+    ActionPack::WebAuthn.register_attestation_verifier("packed", custom_verifier)
+
+    response = ActionPack::WebAuthn::Authenticator::AttestationResponse.new(
+      client_data_json: @client_data_json,
+      attestation_object: ATTESTATION_PACKED_VERIFIED,
+      origin: @origin
+    )
+
+    response.validate!
+    assert verified
+  ensure
+    ActionPack::WebAuthn.attestation_verifiers.delete("packed")
+  end
+end

--- a/actionpack/test/web_authn/authenticator/attestation_test.rb
+++ b/actionpack/test/web_authn/authenticator/attestation_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::Authenticator::AttestationTest < ActiveSupport::TestCase
+  # Attestation object: {"fmt": "none", "attStmt": {}, "authData": <164 bytes>}
+  # Auth data contains:
+  #   rp_id_hash: SHA-256("example.com") (32 bytes)
+  #   flags: 0x41 (user present + attested credential)
+  #   sign_count: 42
+  #   aaguid: 00010203-0405-0607-0809-0a0b0c0d0e0f (16 bytes)
+  #   credential_id: 32 sequential bytes 0x00..0x1f
+  #   cose_key: EC2/ES256 P-256 {1: 2, 3: -7, -1: 1, -2: <x>, -3: <y>}
+  ATTESTATION_CBOR = [ "a363666d74646e6f6e656761747453746d74a068617574684461746158a4a3" \
+    "79a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947410000002a" \
+    "000102030405060708090a0b0c0d0e0f0020000102030405060708090a0b0c0d0e0f1011" \
+    "12131415161718191a1b1c1d1e1fa50102032620012158202ba472104c686f39d4b623cc" \
+    "9324953e7053b47cae818e8cf774203a4f51af7122582069cb8ac519bdd929e2bdbe79e9" \
+    "f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*")
+
+  CREDENTIAL_ID_BASE64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+  SIGN_COUNT = 42
+
+  test "decodes attestation object" do
+    attestation = ActionPack::WebAuthn::Authenticator::Attestation.decode(ATTESTATION_CBOR)
+
+    assert_equal "none", attestation.format
+    assert_equal({}, attestation.attestation_statement)
+    assert_instance_of ActionPack::WebAuthn::Authenticator::Data, attestation.authenticator_data
+  end
+
+  test "delegates credential_id to authenticator_data" do
+    attestation = ActionPack::WebAuthn::Authenticator::Attestation.decode(ATTESTATION_CBOR)
+
+    assert_equal CREDENTIAL_ID_BASE64, attestation.credential_id
+  end
+
+  test "delegates sign_count to authenticator_data" do
+    attestation = ActionPack::WebAuthn::Authenticator::Attestation.decode(ATTESTATION_CBOR)
+
+    assert_equal SIGN_COUNT, attestation.sign_count
+  end
+
+  test "delegates public_key to authenticator_data" do
+    attestation = ActionPack::WebAuthn::Authenticator::Attestation.decode(ATTESTATION_CBOR)
+
+    assert_instance_of OpenSSL::PKey::EC, attestation.public_key
+  end
+end

--- a/actionpack/test/web_authn/authenticator/attestation_verifiers/none_test.rb
+++ b/actionpack/test/web_authn/authenticator/attestation_verifiers/none_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::Authenticator::AttestationVerifiers::NoneTest < ActiveSupport::TestCase
+  setup do
+    @verifier = ActionPack::WebAuthn::Authenticator::AttestationVerifiers::None.new
+  end
+
+  test "verify! passes with nil attestation statement" do
+    attestation = Minitest::Mock.new
+    attestation.expect :attestation_statement, nil
+
+    assert_nothing_raised do
+      @verifier.verify!(attestation, client_data_json: "")
+    end
+  end
+
+  test "verify! passes with empty attestation statement" do
+    attestation = Minitest::Mock.new
+    attestation.expect :attestation_statement, {}
+
+    assert_nothing_raised do
+      @verifier.verify!(attestation, client_data_json: "")
+    end
+  end
+
+  test "verify! raises with non-empty attestation statement" do
+    attestation = Minitest::Mock.new
+    attestation.expect :attestation_statement, { "sig" => "abc" }
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      @verifier.verify!(attestation, client_data_json: "")
+    end
+
+    assert_equal "Attestation statement must be empty for 'none' format", error.message
+  end
+end

--- a/actionpack/test/web_authn/authenticator/data_test.rb
+++ b/actionpack/test/web_authn/authenticator/data_test.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require_relative "../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::Authenticator::DataTest < ActiveSupport::TestCase
+  USER_PRESENT = ActionPack::WebAuthn::Authenticator::Data::USER_PRESENT_FLAG
+  USER_VERIFIED = ActionPack::WebAuthn::Authenticator::Data::USER_VERIFIED_FLAG
+  BACKUP_ELIGIBLE = ActionPack::WebAuthn::Authenticator::Data::BACKUP_ELIGIBLE_FLAG
+  BACKUP_STATE = ActionPack::WebAuthn::Authenticator::Data::BACKUP_STATE_FLAG
+  ATTESTED_CREDENTIAL = ActionPack::WebAuthn::Authenticator::Data::ATTESTED_CREDENTIAL_DATA_FLAG
+
+  # Common values:
+  #   rp_id_hash: SHA-256("example.com") (32 bytes)
+  #   sign_count: 42
+  #   aaguid: 00010203-0405-0607-0809-0a0b0c0d0e0f (16 bytes)
+  #   credential_id: 32 sequential bytes 0x00..0x1f
+  #   cose_key: EC2/ES256 P-256 {1: 2, 3: -7, -1: 1, -2: <x>, -3: <y>}
+
+  RP_ID_HASH = [ "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947" ].pack("H*")
+  SIGN_COUNT = 42
+  CREDENTIAL_ID_BASE64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+
+  COSE_KEY_CBOR = [ "a50102032620012158202ba472104c686f39d4b623cc9324953e7053b47cae81" \
+    "8e8cf774203a4f51af7122582069cb8ac519bdd929e2bdbe79e9f9b8d14c2d89a7cbd324" \
+    "647a1ccd68b8de3ca0" ].pack("H*")
+
+  # rp_id_hash(32) + flags USER_PRESENT + sign_count 42
+  AUTH_DATA_NO_CREDENTIAL = [ "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2" \
+    "125586ce1947010000002a" ].pack("H*")
+
+  # rp_id_hash(32) + flags USER_PRESENT|ATTESTED_CREDENTIAL + sign_count 42 + aaguid(16) +
+  # credential_id_len 32 (2 bytes) + credential_id(32) + cose_key CBOR
+  AUTH_DATA_WITH_CREDENTIAL = [ "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13" \
+    "d2125586ce1947410000002a000102030405060708090a0b0c0d0e0f0020000102030405" \
+    "060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fa5010203262001215820" \
+    "2ba472104c686f39d4b623cc9324953e7053b47cae818e8cf774203a4f51af7122582069" \
+    "cb8ac519bdd929e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*")
+
+  # Error test data: ATTESTED_CREDENTIAL flag set but no attested credential data after header
+  # rp_id_hash(32) + flags USER_PRESENT|ATTESTED_CREDENTIAL + sign_count 42
+  AUTH_DATA_AT_FLAG_NO_CREDENTIAL = [ "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30" \
+    "ab13d2125586ce1947410000002a" ].pack("H*")
+
+  # rp_id_hash(32) + flags USER_PRESENT|ATTESTED_CREDENTIAL + sign_count 0 + aaguid(16), missing credential_id_len
+  AUTH_DATA_TRUNCATED_BEFORE_CRED_LEN = [ "a379a6f6eeafb9a55e378c118034e2751e682fab9f" \
+    "2d30ab13d2125586ce19474100000000000102030405060708090a0b0c0d0e0f" ].pack("H*")
+
+  # rp_id_hash(32) + flags USER_PRESENT|ATTESTED_CREDENTIAL + sign_count 0 + aaguid(16) + credential_id_len 9999
+  AUTH_DATA_HUGE_CRED_LEN = [ "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2" \
+    "125586ce19474100000000000102030405060708090a0b0c0d0e0f270f" ].pack("H*")
+
+  test "decodes authenticator data without attested credential" do
+    data = ActionPack::WebAuthn::Authenticator::Data.decode(AUTH_DATA_NO_CREDENTIAL)
+
+    assert_equal RP_ID_HASH, data.relying_party_id_hash
+    assert_equal USER_PRESENT, data.flags
+    assert_equal SIGN_COUNT, data.sign_count
+    assert_nil data.credential_id
+    assert_nil data.public_key_bytes
+  end
+
+  test "decodes authenticator data with attested credential" do
+    data = ActionPack::WebAuthn::Authenticator::Data.decode(AUTH_DATA_WITH_CREDENTIAL)
+
+    assert_equal RP_ID_HASH, data.relying_party_id_hash
+    assert_equal USER_PRESENT | ATTESTED_CREDENTIAL, data.flags
+    assert_equal SIGN_COUNT, data.sign_count
+    assert_equal CREDENTIAL_ID_BASE64, data.credential_id
+    assert_equal COSE_KEY_CBOR, data.public_key_bytes
+  end
+
+  test "user_present? returns true when flag is set" do
+    data = build_data_with_flags(USER_PRESENT)
+    assert data.user_present?
+  end
+
+  test "user_present? returns false when flag is not set" do
+    data = build_data_with_flags(0)
+    assert_not data.user_present?
+  end
+
+  test "user_verified? returns true when flag is set" do
+    data = build_data_with_flags(USER_VERIFIED)
+    assert data.user_verified?
+  end
+
+  test "user_verified? returns false when flag is not set" do
+    data = build_data_with_flags(0)
+    assert_not data.user_verified?
+  end
+
+  test "backup_eligible? returns true when flag is set" do
+    data = build_data_with_flags(BACKUP_ELIGIBLE)
+    assert data.backup_eligible?
+  end
+
+  test "backup_eligible? returns false when flag is not set" do
+    data = build_data_with_flags(0)
+    assert_not data.backup_eligible?
+  end
+
+  test "backed_up? returns true when flag is set" do
+    data = build_data_with_flags(BACKUP_STATE)
+    assert data.backed_up?
+  end
+
+  test "backed_up? returns false when flag is not set" do
+    data = build_data_with_flags(0)
+    assert_not data.backed_up?
+  end
+
+  test "public_key returns OpenSSL key when public_key_bytes present" do
+    data = ActionPack::WebAuthn::Authenticator::Data.decode(AUTH_DATA_WITH_CREDENTIAL)
+
+    assert_instance_of OpenSSL::PKey::EC, data.public_key
+  end
+
+  test "public_key returns nil when public_key_bytes not present" do
+    data = ActionPack::WebAuthn::Authenticator::Data.decode(AUTH_DATA_NO_CREDENTIAL)
+
+    assert_nil data.public_key
+  end
+
+  test "raises when attested credential flag set but data truncated before AAGUID" do
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::Data.decode(AUTH_DATA_AT_FLAG_NO_CREDENTIAL)
+    end
+  end
+
+  test "raises when attested credential flag set but data truncated before credential ID" do
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::Data.decode(AUTH_DATA_TRUNCATED_BEFORE_CRED_LEN)
+    end
+  end
+
+  test "raises when credential ID length exceeds remaining bytes" do
+    assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      ActionPack::WebAuthn::Authenticator::Data.decode(AUTH_DATA_HUGE_CRED_LEN)
+    end
+  end
+
+  private
+    def build_data_with_flags(flags)
+      ActionPack::WebAuthn::Authenticator::Data.new(
+        bytes: [],
+        relying_party_id_hash: RP_ID_HASH,
+        flags: flags,
+        sign_count: 0,
+        credential_id: nil,
+        public_key_bytes: nil
+      )
+    end
+end

--- a/actionpack/test/web_authn/authenticator/response_test.rb
+++ b/actionpack/test/web_authn/authenticator/response_test.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require_relative "../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::Authenticator::ResponseTest < ActiveSupport::TestCase
+  include WebauthnTestHelper
+
+  # rp_id_hash("example.com") + flags 0x05 (UP+UV) + sign_count 0
+  AUTHENTICATOR_DATA_BYTES = [
+    "a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947" \
+    "0500000000"
+  ].pack("H*").freeze
+
+  # rp_id_hash("evil.com") + flags 0x05 (UP+UV) + sign_count 0
+  WRONG_RP_AUTHENTICATOR_DATA_BYTES = [
+    "1867b49abe26b512d11cb45294e41afa6f728697705714911c5c001179f7f2bb" \
+    "0500000000"
+  ].pack("H*").freeze
+
+  class TestableResponse < ActionPack::WebAuthn::Authenticator::Response
+    attr_reader :authenticator_data
+
+    def initialize(authenticator_data:, **attrs)
+      super(**attrs)
+      @authenticator_data = authenticator_data
+    end
+  end
+
+  setup do
+    ActionPack::WebAuthn::Current.host = "example.com"
+
+    @challenge = webauthn_challenge
+    @origin = "https://example.com"
+    @client_data_json = {
+      challenge: @challenge,
+      origin: @origin,
+      type: "webauthn.create"
+    }.to_json
+
+    @authenticator_data = ActionPack::WebAuthn::Authenticator::Data.decode(AUTHENTICATOR_DATA_BYTES)
+    @response = TestableResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: @authenticator_data,
+      origin: @origin
+    )
+  end
+
+  test "parses client data JSON" do
+    assert_equal @challenge, @response.client_data["challenge"]
+    assert_equal @origin, @response.client_data["origin"]
+  end
+
+  test "valid? returns true when challenge and origin match" do
+    assert @response.valid?
+  end
+
+  test "valid? returns false when challenge is missing" do
+    client_data_json = { origin: @origin, type: "webauthn.create" }.to_json
+
+    response = TestableResponse.new(
+      client_data_json: client_data_json,
+      authenticator_data: @authenticator_data,
+      origin: @origin
+    )
+
+    assert_not response.valid?
+  end
+
+  test "valid? returns false when origin does not match" do
+    @response.origin = "https://evil.com"
+    assert_not @response.valid?
+  end
+
+  test "validate! raises when challenge has expired" do
+    expired_challenge = ActionPack::WebAuthn::PublicKeyCredential::Options.new(
+      challenge_expiration: 0.seconds
+    ).challenge
+
+    travel 1.second do
+      client_data_json = {
+        challenge: expired_challenge,
+        origin: @origin,
+        type: "webauthn.create"
+      }.to_json
+
+      response = TestableResponse.new(
+        client_data_json: client_data_json,
+        authenticator_data: @authenticator_data,
+        origin: @origin
+      )
+
+      error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+        response.validate!
+      end
+
+      assert_equal "Challenge has expired", error.message
+    end
+  end
+
+  test "validate! raises when origin does not match" do
+    @response.origin = "https://evil.com"
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      @response.validate!
+    end
+
+    assert_equal "Origin does not match", error.message
+  end
+
+  test "validate! raises when crossOrigin is true" do
+    client_data_json = {
+      challenge: @challenge,
+      origin: @origin,
+      type: "webauthn.create",
+      crossOrigin: true
+    }.to_json
+
+    response = TestableResponse.new(
+      client_data_json: client_data_json,
+      authenticator_data: @authenticator_data,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "Cross-origin requests are not supported", error.message
+  end
+
+  test "validate! raises when relying party ID does not match" do
+    wrong_rp_data = ActionPack::WebAuthn::Authenticator::Data.decode(WRONG_RP_AUTHENTICATOR_DATA_BYTES)
+
+    response = TestableResponse.new(
+      client_data_json: @client_data_json,
+      authenticator_data: wrong_rp_data,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "Relying party ID does not match", error.message
+  end
+
+  test "validate! raises when tokenBinding status is present" do
+    client_data_json = {
+      challenge: @challenge,
+      origin: @origin,
+      type: "webauthn.create",
+      tokenBinding: { status: "present", id: "some-id" }
+    }.to_json
+
+    response = TestableResponse.new(
+      client_data_json: client_data_json,
+      authenticator_data: @authenticator_data,
+      origin: @origin
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidResponseError) do
+      response.validate!
+    end
+
+    assert_equal "Token binding is not supported", error.message
+  end
+end

--- a/actionpack/test/web_authn/authenticator/response_test.rb
+++ b/actionpack/test/web_authn/authenticator/response_test.rb
@@ -73,7 +73,7 @@ class ActionPack::WebAuthn::Authenticator::ResponseTest < ActiveSupport::TestCas
 
   test "validate! raises when challenge has expired" do
     expired_challenge = ActionPack::WebAuthn::PublicKeyCredential::Options.new(
-      challenge_expiration: 0.seconds
+      timeout: 0.seconds
     ).challenge
 
     travel 1.second do

--- a/actionpack/test/web_authn/cbor_decoder_test.rb
+++ b/actionpack/test/web_authn/cbor_decoder_test.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require_relative "../web_authn_test_helper"
+
+class ActionPack::WebAuthn::CborDecoderTest < ActiveSupport::TestCase
+  test "decodes unsigned integer 0" do
+    assert_equal 0, decode("00")
+  end
+
+  test "decodes unsigned integer 1" do
+    assert_equal 1, decode("01")
+  end
+
+  test "decodes unsigned integer 10" do
+    assert_equal 10, decode("0a")
+  end
+
+  test "decodes unsigned integer 23" do
+    assert_equal 23, decode("17")
+  end
+
+  test "decodes unsigned integer 24 (single byte follows)" do
+    assert_equal 24, decode("1818")
+  end
+
+  test "decodes unsigned integer 25" do
+    assert_equal 25, decode("1819")
+  end
+
+  test "decodes unsigned integer 100" do
+    assert_equal 100, decode("1864")
+  end
+
+  test "decodes unsigned integer 1000 (two bytes follow)" do
+    assert_equal 1000, decode("1903e8")
+  end
+
+  test "decodes unsigned integer 1000000 (four bytes follow)" do
+    assert_equal 1000000, decode("1a000f4240")
+  end
+
+  test "decodes unsigned integer 1000000000000 (eight bytes follow)" do
+    assert_equal 1000000000000, decode("1b000000e8d4a51000")
+  end
+
+  test "decodes negative integer -1" do
+    assert_equal(-1, decode("20"))
+  end
+
+  test "decodes negative integer -10" do
+    assert_equal(-10, decode("29"))
+  end
+
+  test "decodes negative integer -100" do
+    assert_equal(-100, decode("3863"))
+  end
+
+  test "decodes negative integer -1000" do
+    assert_equal(-1000, decode("3903e7"))
+  end
+
+  test "decodes empty byte string" do
+    assert_equal "", decode("40")
+  end
+
+  test "decodes byte string with 4 bytes" do
+    assert_equal "\x01\x02\x03\x04".b, decode("4401020304")
+  end
+
+  test "decodes empty text string" do
+    result = decode("60")
+    assert_equal "", result
+    assert_equal Encoding::UTF_8, result.encoding
+  end
+
+  test "decodes text string 'a'" do
+    result = decode("6161")
+    assert_equal "a", result
+    assert_equal Encoding::UTF_8, result.encoding
+  end
+
+  test "decodes text string 'IETF'" do
+    result = decode("6449455446")
+    assert_equal "IETF", result
+    assert_equal Encoding::UTF_8, result.encoding
+  end
+
+  test "decodes text string with unicode" do
+    result = decode("62c3bc")
+    assert_equal "ü", result
+    assert_equal Encoding::UTF_8, result.encoding
+  end
+
+  test "decodes empty array" do
+    assert_equal [], decode("80")
+  end
+
+  test "decodes array [1, 2, 3]" do
+    assert_equal [ 1, 2, 3 ], decode("83010203")
+  end
+
+  test "decodes nested array [1, [2, 3], [4, 5]]" do
+    assert_equal [ 1, [ 2, 3 ], [ 4, 5 ] ], decode("8301820203820405")
+  end
+
+  test "decodes array with 25 elements" do
+    expected = (1..25).to_a
+    # 0x9819 = array with 25 elements (0x98 = type 4 + additional 24, 0x19 = 25)
+    # integers 1-23 encode as single bytes, 24 = 0x1818, 25 = 0x1819
+    elements = (1..23).map { |n| format("%02x", n) }.join + "18181819"
+    assert_equal expected, decode("9819" + elements)
+  end
+
+  test "decodes empty map" do
+    assert_equal({}, decode("a0"))
+  end
+
+  test "decodes map {1: 2, 3: 4}" do
+    assert_equal({ 1 => 2, 3 => 4 }, decode("a201020304"))
+  end
+
+  test "decodes map with string keys" do
+    assert_equal({ "a" => 1, "b" => 2 }, decode("a2616101616202"))
+  end
+
+  test "decodes nested map" do
+    assert_equal({ "a" => { "b" => 1 } }, decode("a16161a1616201"))
+  end
+
+  test "decodes false" do
+    assert_equal false, decode("f4")
+  end
+
+  test "decodes true" do
+    assert_equal true, decode("f5")
+  end
+
+  test "decodes null" do
+    assert_nil decode("f6")
+  end
+
+  test "decodes undefined as nil" do
+    assert_nil decode("f7")
+  end
+
+  test "decodes tagged value, ignoring tag" do
+    # 0xc0 = tag 0 (date/time string), followed by text "2013-03-21T20:04:00Z"
+    assert_equal "2013-03-21T20:04:00Z", decode("c074323031332d30332d32315432303a30343a30305a")
+  end
+
+  test "decodes tagged integer" do
+    # 0xc1 = tag 1 (epoch time), followed by integer 1363896240
+    assert_equal 1363896240, decode("c11a514b67b0")
+  end
+
+  test "raises error for reserved additional info values" do
+    assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("1c")
+    end
+  end
+
+  test "decodes indefinite length array" do
+    assert_equal [ 1, 2, 3 ], decode("9f010203ff")
+  end
+
+  test "decodes empty indefinite length array" do
+    assert_equal [], decode("9fff")
+  end
+
+  test "decodes empty indefinite length map" do
+    assert_equal({}, decode("bfff"))
+  end
+
+  test "decodes indefinite length map" do
+    assert_equal({ "a" => 1, "b" => 2 }, decode("bf616101616202ff"))
+  end
+
+  test "decodes indefinite length byte string" do
+    assert_equal "\x01\x02\x03".b, decode("5f4201024103ff")
+  end
+
+  test "decodes indefinite length text string" do
+    result = decode("7f657374726561646d696e67ff")
+    assert_equal "streaming", result
+    assert_equal Encoding::UTF_8, result.encoding
+  end
+
+  test "decodes half-precision float 0.0" do
+    assert_equal 0.0, decode("f90000")
+  end
+
+  test "decodes half-precision float 1.0" do
+    assert_equal 1.0, decode("f93c00")
+  end
+
+  test "decodes half-precision float 1.5" do
+    assert_equal 1.5, decode("f93e00")
+  end
+
+  test "decodes half-precision float -4.0" do
+    assert_equal(-4.0, decode("f9c400"))
+  end
+
+  test "decodes half-precision positive infinity" do
+    assert_equal Float::INFINITY, decode("f97c00")
+  end
+
+  test "decodes half-precision NaN" do
+    assert_predicate decode("f97e00"), :nan?
+  end
+
+  test "decodes single-precision float 100000.0" do
+    assert_equal 100000.0, decode("fa47c35000")
+  end
+
+  test "decodes single-precision positive infinity" do
+    assert_equal Float::INFINITY, decode("fa7f800000")
+  end
+
+  test "decodes double-precision float 1.1" do
+    assert_in_delta 1.1, decode("fb3ff199999999999a"), 0.0001
+  end
+
+  test "decodes double-precision float -4.1" do
+    assert_in_delta(-4.1, decode("fbc010666666666666"), 0.0001)
+  end
+
+  test "decodes double-precision positive infinity" do
+    assert_equal Float::INFINITY, decode("fb7ff0000000000000")
+  end
+
+  test "decodes double-precision negative infinity" do
+    assert_equal(-Float::INFINITY, decode("fbfff0000000000000"))
+  end
+
+  test "raises error for unsupported simple value" do
+    assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("e0")
+    end
+  end
+
+  test "decode accepts string input" do
+    bytes = [ 0x01 ].pack("C*")
+    assert_equal 1, ActionPack::WebAuthn::CborDecoder.decode(bytes)
+  end
+
+  test "decode accepts array input" do
+    assert_equal 1, ActionPack::WebAuthn::CborDecoder.decode([ 0x01 ])
+  end
+
+  test "raises error for empty input" do
+    assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode([])
+    end
+  end
+
+  test "raises error for truncated byte string" do
+    # 0x44 = byte string of length 4, but only 2 bytes follow
+    assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("440102")
+    end
+  end
+
+  test "raises error for truncated integer" do
+    # 0x19 = 2-byte integer follows, but only 1 byte provided
+    assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("19ff")
+    end
+  end
+
+  test "raises error for truncated array" do
+    # 0x82 = array of 2 items, but only 1 provided
+    assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode("8201")
+    end
+  end
+
+  test "raises error for deeply nested structure" do
+    # Build array nested 20 levels deep: [[[[...]]]]
+    # 0x81 = array of 1 item
+    deeply_nested = "81" * 20 + "01"
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      decode(deeply_nested)
+    end
+
+    assert_equal "Maximum nesting depth exceeded", error.message
+  end
+
+  test "raises error for input exceeding max size" do
+    error = assert_raises(ActionPack::WebAuthn::InvalidCborError) do
+      ActionPack::WebAuthn::CborDecoder.decode([ 0x01 ], max_size: 0)
+    end
+
+    assert_equal "Input exceeds maximum size", error.message
+  end
+
+  private
+    def decode(hex)
+      bytes = [ hex ].pack("H*").bytes
+      ActionPack::WebAuthn::CborDecoder.decode(bytes)
+    end
+end

--- a/actionpack/test/web_authn/cose_key_test.rb
+++ b/actionpack/test/web_authn/cose_key_test.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require_relative "../web_authn_test_helper"
+
+class ActionPack::WebAuthn::CoseKeyTest < ActiveSupport::TestCase
+  # EC2/ES256 P-256 public key (32-byte x and y coordinates)
+  EC2_X = [ "2ba472104c686f39d4b623cc9324953e7053b47cae818e8cf774203a4f51af71" ].pack("H*")
+  EC2_Y = [ "69cb8ac519bdd929e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*")
+
+  # CBOR: {1: 2, 3: -7, -1: 1, -2: <x 32 bytes>, -3: <y 32 bytes>}
+  EC2_CBOR = [ "a50102032620012158202ba472104c686f39d4b623cc9324953e7053b47cae81" \
+    "8e8cf774203a4f51af7122582069cb8ac519bdd929e2bdbe79e9f9b8d14c2d89a7cbd324" \
+    "647a1ccd68b8de3ca0" ].pack("H*")
+
+  # Ed25519 public key (32 bytes)
+  ED25519_X = [ "a95ee02872a2c5224b394832767bea746620e50776e845872228716065f16005" ].pack("H*")
+
+  # CBOR: {1: 1, 3: -8, -1: 6, -2: <x 32 bytes>}
+  OKP_CBOR = [ "a4010103272006215820a95ee02872a2c5224b394832767bea746620e50776e8" \
+    "45872228716065f16005" ].pack("H*")
+
+  # RSA 2048-bit public key (256-byte modulus, 3-byte exponent 65537)
+  RSA_N = [ "d388adb3aa7812402281c57ce870821b17558f0a247a771834892d85399ecd4f" \
+    "830dd35f65e7afe5030d9ee10f4873567039976486202cce8ac499114194d32fe615026e" \
+    "7eeee5b2ff564041d68b9b33c35a2ac17210c69c9e85fa74249b06e4ffa6b38ff5ef54e" \
+    "1860aa59a6fb043e2b65ecf0ce8d0ff90d25683ca2da016618308f3fa7f74efc178ec46" \
+    "e0224f10cf0eed7d46cc6167210f088cc6b77fc08a7fcd14536aa9c726519806a96ea00" \
+    "517ce1ed1336ae6962338a6c4cc4754d953ebbffb5d6b1bc76368b552b628adb788b0bc" \
+    "9f895dff6b1c74d79ce210b5941995beb1f498a1e9123666bdc92bc6b0f2a04fdb40cf1" \
+    "d253ba1582673ec293113" ].pack("H*")
+  RSA_E = [ "010001" ].pack("H*")
+
+  # CBOR: {1: 3, 3: -257, -1: <n 256 bytes>, -2: <e 3 bytes>}
+  RSA_CBOR = [ "a401030339010020590100d388adb3aa7812402281c57ce870821b17558f0a24" \
+    "7a771834892d85399ecd4f830dd35f65e7afe5030d9ee10f4873567039976486202cce8a" \
+    "c499114194d32fe615026e7eeee5b2ff564041d68b9b33c35a2ac17210c69c9e85fa742" \
+    "49b06e4ffa6b38ff5ef54e1860aa59a6fb043e2b65ecf0ce8d0ff90d25683ca2da01661" \
+    "8308f3fa7f74efc178ec46e0224f10cf0eed7d46cc6167210f088cc6b77fc08a7fcd145" \
+    "36aa9c726519806a96ea00517ce1ed1336ae6962338a6c4cc4754d953ebbffb5d6b1bc7" \
+    "6368b552b628adb788b0bc9f895dff6b1c74d79ce210b5941995beb1f498a1e9123666b" \
+    "dc92bc6b0f2a04fdb40cf1d253ba1582673ec2931132143010001" ].pack("H*")
+
+  setup do
+    @ec2_parameters = {
+      1 => 2,    # kty: EC2
+      3 => -7,   # alg: ES256
+      -1 => 1,   # crv: P-256
+      -2 => EC2_X,
+      -3 => EC2_Y
+    }
+
+    @rsa_parameters = {
+      1 => 3,     # kty: RSA
+      3 => -257,  # alg: RS256
+      -1 => RSA_N,
+      -2 => RSA_E
+    }
+
+    @okp_parameters = {
+      1 => 1,    # kty: OKP
+      3 => -8,   # alg: EdDSA
+      -1 => 6,   # crv: Ed25519
+      -2 => ED25519_X
+    }
+  end
+
+  test "initializes with key type, algorithm, and parameters" do
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 2,
+      algorithm: -7,
+      parameters: @ec2_parameters
+    )
+
+    assert_equal 2, key.key_type
+    assert_equal(-7, key.algorithm)
+    assert_equal @ec2_parameters, key.parameters
+  end
+
+  test "decodes EC2/ES256 key from CBOR" do
+    key = ActionPack::WebAuthn::CoseKey.decode(EC2_CBOR)
+
+    assert_equal 2, key.key_type
+    assert_equal(-7, key.algorithm)
+  end
+
+  test "decodes OKP/EdDSA key from CBOR" do
+    key = ActionPack::WebAuthn::CoseKey.decode(OKP_CBOR)
+
+    assert_equal 1, key.key_type
+    assert_equal(-8, key.algorithm)
+  end
+
+  test "decodes RSA/RS256 key from CBOR" do
+    key = ActionPack::WebAuthn::CoseKey.decode(RSA_CBOR)
+
+    assert_equal 3, key.key_type
+    assert_equal(-257, key.algorithm)
+  end
+
+  test "converts EC2/ES256 key to OpenSSL EC key" do
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 2,
+      algorithm: -7,
+      parameters: @ec2_parameters
+    )
+
+    openssl_key = key.to_openssl_key
+
+    assert_instance_of OpenSSL::PKey::EC, openssl_key
+    assert_equal "prime256v1", openssl_key.group.curve_name
+  end
+
+  test "converts OKP/EdDSA key to OpenSSL Ed25519 key" do
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 1,
+      algorithm: -8,
+      parameters: @okp_parameters
+    )
+
+    openssl_key = key.to_openssl_key
+
+    assert_equal "ED25519", openssl_key.oid
+  end
+
+  test "converts RSA/RS256 key to OpenSSL RSA key" do
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 3,
+      algorithm: -257,
+      parameters: @rsa_parameters
+    )
+
+    openssl_key = key.to_openssl_key
+
+    assert_instance_of OpenSSL::PKey::RSA, openssl_key
+    assert_equal 65537, openssl_key.e.to_i
+  end
+
+  test "raises error for unsupported key type/algorithm combination" do
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 99,
+      algorithm: -7,
+      parameters: {}
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::UnsupportedKeyTypeError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/99\/-7/, error.message)
+  end
+
+  test "raises error for unsupported OKP curve" do
+    parameters = @okp_parameters.merge(-1 => 5) # Ed448 instead of Ed25519
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 1,
+      algorithm: -8,
+      parameters: parameters
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::UnsupportedKeyTypeError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/curve/, error.message.downcase)
+  end
+
+  test "raises error for unsupported EC curve" do
+    parameters = @ec2_parameters.merge(-1 => 2) # P-384 instead of P-256
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 2,
+      algorithm: -7,
+      parameters: parameters
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::UnsupportedKeyTypeError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/curve/, error.message.downcase)
+  end
+
+  test "raises error for EC2 key with missing coordinates" do
+    parameters = @ec2_parameters.except(-3) # missing y coordinate
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 2,
+      algorithm: -7,
+      parameters: parameters
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidKeyError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/missing ec2 key coordinates/i, error.message)
+  end
+
+  test "raises error for EC2 key with wrong coordinate length" do
+    parameters = @ec2_parameters.merge(-2 => "\x00" * 16) # 16 bytes instead of 32
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 2,
+      algorithm: -7,
+      parameters: parameters
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidKeyError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/invalid ec2 coordinate length/i, error.message)
+  end
+
+  test "raises error for OKP key with missing coordinate" do
+    parameters = @okp_parameters.except(-2) # missing x coordinate
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 1,
+      algorithm: -8,
+      parameters: parameters
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidKeyError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/missing okp key coordinate/i, error.message)
+  end
+
+  test "raises error for RSA key with missing parameters" do
+    parameters = @rsa_parameters.except(-1) # missing n
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 3,
+      algorithm: -257,
+      parameters: parameters
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidKeyError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/missing rsa key parameters/i, error.message)
+  end
+
+  test "raises error for RSA key smaller than 2048 bits" do
+    small_n = "\x01" + ("\x00" * 127) # 1024-bit modulus
+    parameters = @rsa_parameters.merge(-1 => small_n)
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 3,
+      algorithm: -257,
+      parameters: parameters
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::InvalidKeyError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/at least 2048 bits/i, error.message)
+  end
+end

--- a/actionpack/test/web_authn/cose_key_test.rb
+++ b/actionpack/test/web_authn/cose_key_test.rb
@@ -3,6 +3,24 @@
 require_relative "../web_authn_test_helper"
 
 class ActionPack::WebAuthn::CoseKeyTest < ActiveSupport::TestCase
+  module FakeKeyFormat
+    ALGORITHM = -65535
+
+    class << self
+      def algorithm
+        ALGORITHM
+      end
+
+      def to_public_key_credential_param
+        { type: "public-key", alg: algorithm }
+      end
+
+      def build(cose_key)
+        :fake_openssl_key
+      end
+    end
+  end
+
   # EC2/ES256 P-256 public key (32-byte x and y coordinates)
   EC2_X = [ "2ba472104c686f39d4b623cc9324953e7053b47cae818e8cf774203a4f51af71" ].pack("H*")
   EC2_Y = [ "69cb8ac519bdd929e2bdbe79e9f9b8d14c2d89a7cbd324647a1ccd68b8de3ca0" ].pack("H*")
@@ -135,7 +153,7 @@ class ActionPack::WebAuthn::CoseKeyTest < ActiveSupport::TestCase
     assert_equal 65537, openssl_key.e.to_i
   end
 
-  test "raises error for unsupported key type/algorithm combination" do
+  test "raises error for mismatched key type" do
     key = ActionPack::WebAuthn::CoseKey.new(
       key_type: 99,
       algorithm: -7,
@@ -146,7 +164,36 @@ class ActionPack::WebAuthn::CoseKeyTest < ActiveSupport::TestCase
       key.to_openssl_key
     end
 
-    assert_match(/99\/-7/, error.message)
+    assert_match(/key type/i, error.message)
+    assert_match(/99/, error.message)
+  end
+
+  test "raises error for unregistered algorithm" do
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 2,
+      algorithm: -65536,
+      parameters: {}
+    )
+
+    error = assert_raises(ActionPack::WebAuthn::UnsupportedKeyTypeError) do
+      key.to_openssl_key
+    end
+
+    assert_match(/Unsupported COSE algorithm: -65536/, error.message)
+  end
+
+  test "registering a custom key format makes to_openssl_key dispatch to it" do
+    ActionPack::WebAuthn.register_key_format(FakeKeyFormat)
+
+    key = ActionPack::WebAuthn::CoseKey.new(
+      key_type: 42,
+      algorithm: FakeKeyFormat.algorithm,
+      parameters: {}
+    )
+
+    assert_equal :fake_openssl_key, key.to_openssl_key
+  ensure
+    ActionPack::WebAuthn.key_formats.delete(FakeKeyFormat.algorithm)
   end
 
   test "raises error for unsupported OKP curve" do

--- a/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require_relative "../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSupport::TestCase
+  include WebauthnTestHelper
+
+  setup do
+    @relying_party = ActionPack::WebAuthn::RelyingParty.new(id: "example.com", name: "Example App")
+    @options = ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+      id: "user-123",
+      name: "user@example.com",
+      display_name: "Test User",
+      relying_party: @relying_party
+    )
+  end
+
+  test "initializes with required parameters" do
+    assert_equal "user-123", @options.id
+    assert_equal "user@example.com", @options.name
+    assert_equal "Test User", @options.display_name
+    assert_equal @relying_party, @options.relying_party
+  end
+
+  test "defaults challenge_purpose to registration" do
+    assert_equal "registration", @options.challenge_purpose
+  end
+
+  test "generates base64url encoded challenge" do
+    assert_match(/\A[A-Za-z0-9_-]+\z/, @options.challenge)
+  end
+
+  test "generates signed challenge containing nonce" do
+    signed_message = Base64.urlsafe_decode64(@options.challenge)
+    nonce = ActionPack::WebAuthn.challenge_verifier.verified(signed_message, purpose: "registration")
+
+    assert_not_nil nonce
+    assert_equal 32, Base64.strict_decode64(nonce).bytesize
+  end
+
+  test "as_json" do
+    json = @options.as_json
+
+    assert_equal @options.challenge, json["challenge"]
+
+    assert_equal({ "id" => "example.com", "name" => "Example App" }, json["rp"])
+
+    user = json["user"]
+    assert_equal Base64.urlsafe_encode64("user-123", padding: false), user["id"]
+    assert_equal "user@example.com", user["name"]
+    assert_equal "Test User", user["displayName"]
+
+    assert_equal [
+      { "type" => "public-key", "alg" => -7 },
+      { "type" => "public-key", "alg" => -8 },
+      { "type" => "public-key", "alg" => -257 }
+    ], json["pubKeyCredParams"]
+
+    assert_equal "required", json["authenticatorSelection"]["residentKey"]
+    assert_equal true, json["authenticatorSelection"]["requireResidentKey"]
+    assert_equal "preferred", json["authenticatorSelection"]["userVerification"]
+  end
+
+  test "as_json supports except option" do
+    json = @options.as_json(except: :challenge)
+
+    assert_nil json["challenge"]
+    assert_not_nil json["rp"]
+  end
+
+  test "as_json includes residentKey in authenticatorSelection" do
+    options = ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+      id: "user-123",
+      name: "user@example.com",
+      display_name: "Test User",
+      resident_key: :required,
+      relying_party: @relying_party
+    )
+
+    assert_equal "required", options.as_json["authenticatorSelection"]["residentKey"]
+    assert_equal true, options.as_json["authenticatorSelection"]["requireResidentKey"]
+  end
+
+  test "as_json excludes excludeCredentials when empty" do
+    assert_nil @options.as_json["excludeCredentials"]
+  end
+
+  test "as_json includes excludeCredentials" do
+    credentials = [
+      build_credential(id: "cred-1", transports: [ "usb", "nfc" ]),
+      build_credential(id: "cred-2", transports: [ "internal" ])
+    ]
+
+    options = ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+      id: "user-123",
+      name: "user@example.com",
+      display_name: "Test User",
+      exclude_credentials: credentials,
+      relying_party: @relying_party
+    )
+
+    assert_equal [
+      { "type" => "public-key", "id" => "cred-1", "transports" => [ "usb", "nfc" ] },
+      { "type" => "public-key", "id" => "cred-2", "transports" => [ "internal" ] }
+    ], options.as_json["excludeCredentials"]
+  end
+
+  test "as_json excludes attestation when none" do
+    assert_nil @options.as_json["attestation"]
+  end
+
+  test "as_json includes attestation when not none" do
+    options = ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+      id: "user-123",
+      name: "user@example.com",
+      display_name: "Test User",
+      attestation: :direct,
+      relying_party: @relying_party
+    )
+
+    assert_equal "direct", options.as_json["attestation"]
+  end
+
+  test "raises with invalid attestation preference" do
+    assert_raises(ActionPack::WebAuthn::InvalidOptionsError) do
+      ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+        id: "user-123",
+        name: "user@example.com",
+        display_name: "Test User",
+        attestation: :invalid,
+        relying_party: @relying_party
+      )
+    end
+  end
+
+  test "as_json excludeCredentials omits transports when empty" do
+    options = ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+      id: "user-123",
+      name: "user@example.com",
+      display_name: "Test User",
+      exclude_credentials: [ build_credential(id: "cred-1") ],
+      relying_party: @relying_party
+    )
+
+    assert_equal [
+      { "type" => "public-key", "id" => "cred-1" }
+    ], options.as_json["excludeCredentials"]
+  end
+end

--- a/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
@@ -105,8 +105,8 @@ class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSup
     ], options.as_json["excludeCredentials"]
   end
 
-  test "as_json excludes attestation when none" do
-    assert_nil @options.as_json["attestation"]
+  test "as_json includes attestation none by default" do
+    assert_equal "none", @options.as_json["attestation"]
   end
 
   test "as_json includes attestation when not none" do

--- a/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
@@ -192,6 +192,20 @@ class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSup
     assert_equal({ "credProps" => true }, json["extensions"])
   end
 
+  test "as_json omits hints and attestationFormats by default" do
+    json = @options.as_json
+
+    assert_nil json["hints"]
+    assert_nil json["attestationFormats"]
+  end
+
+  test "as_json includes hints and attestationFormats when present" do
+    json = build_options(hints: [ "security-key" ], attestation_formats: [ "packed" ]).as_json
+
+    assert_equal [ "security-key" ], json["hints"]
+    assert_equal [ "packed" ], json["attestationFormats"]
+  end
+
   private
     def build_options(**overrides)
       ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(

--- a/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
@@ -146,4 +146,50 @@ class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSup
       { "type" => "public-key", "id" => "cred-1" }
     ], options.as_json["excludeCredentials"]
   end
+
+  test "as_json omits authenticatorAttachment by default" do
+    assert_nil @options.as_json["authenticatorSelection"]["authenticatorAttachment"]
+  end
+
+  test "as_json includes authenticatorAttachment when set" do
+    options = build_options(authenticator_attachment: "platform")
+
+    assert_equal "platform", options.as_json["authenticatorSelection"]["authenticatorAttachment"]
+  end
+
+  test "raises with invalid authenticatorAttachment" do
+    assert_raises(ActionPack::WebAuthn::InvalidOptionsError) do
+      build_options(authenticator_attachment: "invalid")
+    end
+  end
+
+  test "as_json renders timeout in milliseconds" do
+    assert_equal 600_000, @options.as_json["timeout"]
+  end
+
+  test "as_json renders a custom timeout in milliseconds" do
+    assert_equal 120_000, build_options(timeout: 2.minutes).as_json["timeout"]
+  end
+
+  test "as_json renders a sub-second timeout as integer milliseconds" do
+    json = build_options(timeout: 0.5).as_json
+
+    assert_equal 500, json["timeout"]
+    assert_kind_of Integer, json["timeout"]
+  end
+
+  test "as_json omits timeout when nil" do
+    assert_nil build_options(timeout: nil).as_json["timeout"]
+  end
+
+  private
+    def build_options(**overrides)
+      ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
+        id: "user-123",
+        name: "user@example.com",
+        display_name: "Test User",
+        relying_party: @relying_party,
+        **overrides
+      )
+    end
 end

--- a/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
@@ -182,6 +182,16 @@ class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSup
     assert_nil build_options(timeout: nil).as_json["timeout"]
   end
 
+  test "as_json omits extensions by default" do
+    assert_nil @options.as_json["extensions"]
+  end
+
+  test "as_json includes extensions when present" do
+    json = build_options(extensions: { "credProps" => true }).as_json
+
+    assert_equal({ "credProps" => true }, json["extensions"])
+  end
+
   private
     def build_options(**overrides)
       ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(

--- a/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/creation_options_test.rb
@@ -105,31 +105,14 @@ class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSup
     ], options.as_json["excludeCredentials"]
   end
 
-  test "as_json includes attestation none by default" do
+  test "as_json renders attestation, defaulting to none" do
     assert_equal "none", @options.as_json["attestation"]
-  end
-
-  test "as_json includes attestation when not none" do
-    options = ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
-      id: "user-123",
-      name: "user@example.com",
-      display_name: "Test User",
-      attestation: :direct,
-      relying_party: @relying_party
-    )
-
-    assert_equal "direct", options.as_json["attestation"]
+    assert_equal "direct", build_options(attestation: :direct).as_json["attestation"]
   end
 
   test "raises with invalid attestation preference" do
     assert_raises(ActionPack::WebAuthn::InvalidOptionsError) do
-      ActionPack::WebAuthn::PublicKeyCredential::CreationOptions.new(
-        id: "user-123",
-        name: "user@example.com",
-        display_name: "Test User",
-        attestation: :invalid,
-        relying_party: @relying_party
-      )
+      build_options(attestation: :invalid)
     end
   end
 
@@ -147,14 +130,9 @@ class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSup
     ], options.as_json["excludeCredentials"]
   end
 
-  test "as_json omits authenticatorAttachment by default" do
+  test "as_json renders authenticatorAttachment when set" do
     assert_nil @options.as_json["authenticatorSelection"]["authenticatorAttachment"]
-  end
-
-  test "as_json includes authenticatorAttachment when set" do
-    options = build_options(authenticator_attachment: "platform")
-
-    assert_equal "platform", options.as_json["authenticatorSelection"]["authenticatorAttachment"]
+    assert_equal "platform", build_options(authenticator_attachment: "platform").as_json["authenticatorSelection"]["authenticatorAttachment"]
   end
 
   test "raises with invalid authenticatorAttachment" do
@@ -163,45 +141,28 @@ class ActionPack::WebAuthn::PublicKeyCredential::CreationOptionsTest < ActiveSup
     end
   end
 
-  test "as_json renders timeout in milliseconds" do
+  test "as_json renders timeout as integer milliseconds, omitting when nil" do
     assert_equal 600_000, @options.as_json["timeout"]
-  end
-
-  test "as_json renders a custom timeout in milliseconds" do
     assert_equal 120_000, build_options(timeout: 2.minutes).as_json["timeout"]
-  end
 
-  test "as_json renders a sub-second timeout as integer milliseconds" do
-    json = build_options(timeout: 0.5).as_json
+    timeout = build_options(timeout: 0.5).as_json["timeout"]
+    assert_equal 500, timeout
+    assert_kind_of Integer, timeout
 
-    assert_equal 500, json["timeout"]
-    assert_kind_of Integer, json["timeout"]
-  end
-
-  test "as_json omits timeout when nil" do
     assert_nil build_options(timeout: nil).as_json["timeout"]
   end
 
-  test "as_json omits extensions by default" do
+  test "as_json renders extensions when present" do
     assert_nil @options.as_json["extensions"]
+    assert_equal({ "credProps" => true }, build_options(extensions: { "credProps" => true }).as_json["extensions"])
   end
 
-  test "as_json includes extensions when present" do
-    json = build_options(extensions: { "credProps" => true }).as_json
+  test "as_json renders hints and attestationFormats when present" do
+    default_json = @options.as_json
+    assert_nil default_json["hints"]
+    assert_nil default_json["attestationFormats"]
 
-    assert_equal({ "credProps" => true }, json["extensions"])
-  end
-
-  test "as_json omits hints and attestationFormats by default" do
-    json = @options.as_json
-
-    assert_nil json["hints"]
-    assert_nil json["attestationFormats"]
-  end
-
-  test "as_json includes hints and attestationFormats when present" do
     json = build_options(hints: [ "security-key" ], attestation_formats: [ "packed" ]).as_json
-
     assert_equal [ "security-key" ], json["hints"]
     assert_equal [ "packed" ], json["attestationFormats"]
   end

--- a/actionpack/test/web_authn/public_key_credential/request_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/request_options_test.rb
@@ -87,55 +87,27 @@ class ActionPack::WebAuthn::PublicKeyCredential::RequestOptionsTest < ActiveSupp
     ], options.as_json["allowCredentials"]
   end
 
-  test "as_json renders timeout in milliseconds" do
+  test "as_json renders timeout as integer milliseconds, omitting when nil" do
     assert_equal 300_000, @options.as_json["timeout"]
+
+    custom = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(relying_party: @relying_party, timeout: 2.minutes)
+    assert_equal 120_000, custom.as_json["timeout"]
+
+    without = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(relying_party: @relying_party, timeout: nil)
+    assert_nil without.as_json["timeout"]
   end
 
-  test "as_json renders a custom timeout in milliseconds" do
-    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
-      credentials: @credentials,
-      relying_party: @relying_party,
-      timeout: 2.minutes
-    )
-
-    assert_equal 120_000, options.as_json["timeout"]
-  end
-
-  test "as_json omits timeout when nil" do
-    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
-      credentials: @credentials,
-      relying_party: @relying_party,
-      timeout: nil
-    )
-
-    assert_nil options.as_json["timeout"]
-  end
-
-  test "as_json omits extensions by default" do
+  test "as_json renders extensions when present" do
     assert_nil @options.as_json["extensions"]
-  end
 
-  test "as_json includes extensions when present" do
-    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
-      credentials: @credentials,
-      relying_party: @relying_party,
-      extensions: { "appid" => "https://example.com" }
-    )
-
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(relying_party: @relying_party, extensions: { "appid" => "https://example.com" })
     assert_equal({ "appid" => "https://example.com" }, options.as_json["extensions"])
   end
 
-  test "as_json omits hints by default" do
+  test "as_json renders hints when present" do
     assert_nil @options.as_json["hints"]
-  end
 
-  test "as_json includes hints when present" do
-    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
-      credentials: @credentials,
-      relying_party: @relying_party,
-      hints: [ "client-device" ]
-    )
-
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(relying_party: @relying_party, hints: [ "client-device" ])
     assert_equal [ "client-device" ], options.as_json["hints"]
   end
 end

--- a/actionpack/test/web_authn/public_key_credential/request_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/request_options_test.rb
@@ -110,4 +110,18 @@ class ActionPack::WebAuthn::PublicKeyCredential::RequestOptionsTest < ActiveSupp
 
     assert_nil options.as_json["timeout"]
   end
+
+  test "as_json omits extensions by default" do
+    assert_nil @options.as_json["extensions"]
+  end
+
+  test "as_json includes extensions when present" do
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+      credentials: @credentials,
+      relying_party: @relying_party,
+      extensions: { "appid" => "https://example.com" }
+    )
+
+    assert_equal({ "appid" => "https://example.com" }, options.as_json["extensions"])
+  end
 end

--- a/actionpack/test/web_authn/public_key_credential/request_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/request_options_test.rb
@@ -124,4 +124,18 @@ class ActionPack::WebAuthn::PublicKeyCredential::RequestOptionsTest < ActiveSupp
 
     assert_equal({ "appid" => "https://example.com" }, options.as_json["extensions"])
   end
+
+  test "as_json omits hints by default" do
+    assert_nil @options.as_json["hints"]
+  end
+
+  test "as_json includes hints when present" do
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+      credentials: @credentials,
+      relying_party: @relying_party,
+      hints: [ "client-device" ]
+    )
+
+    assert_equal [ "client-device" ], options.as_json["hints"]
+  end
 end

--- a/actionpack/test/web_authn/public_key_credential/request_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/request_options_test.rb
@@ -86,4 +86,28 @@ class ActionPack::WebAuthn::PublicKeyCredential::RequestOptionsTest < ActiveSupp
       { "type" => "public-key", "id" => "cred-1" }
     ], options.as_json["allowCredentials"]
   end
+
+  test "as_json renders timeout in milliseconds" do
+    assert_equal 300_000, @options.as_json["timeout"]
+  end
+
+  test "as_json renders a custom timeout in milliseconds" do
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+      credentials: @credentials,
+      relying_party: @relying_party,
+      timeout: 2.minutes
+    )
+
+    assert_equal 120_000, options.as_json["timeout"]
+  end
+
+  test "as_json omits timeout when nil" do
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+      credentials: @credentials,
+      relying_party: @relying_party,
+      timeout: nil
+    )
+
+    assert_nil options.as_json["timeout"]
+  end
 end

--- a/actionpack/test/web_authn/public_key_credential/request_options_test.rb
+++ b/actionpack/test/web_authn/public_key_credential/request_options_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative "../../web_authn_test_helper"
+
+class ActionPack::WebAuthn::PublicKeyCredential::RequestOptionsTest < ActiveSupport::TestCase
+  include WebauthnTestHelper
+
+  setup do
+    @relying_party = ActionPack::WebAuthn::RelyingParty.new(id: "example.com", name: "Example App")
+    @credentials = [
+      build_credential(id: "credential-1"),
+      build_credential(id: "credential-2")
+    ]
+    @options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+      credentials: @credentials,
+      relying_party: @relying_party
+    )
+  end
+
+  test "initializes with required parameters" do
+    assert_equal @credentials, @options.credentials
+    assert_equal @relying_party, @options.relying_party
+  end
+
+  test "defaults challenge_purpose to authentication" do
+    assert_equal "authentication", @options.challenge_purpose
+  end
+
+  test "generates base64url encoded challenge" do
+    assert_match(/\A[A-Za-z0-9_-]+\z/, @options.challenge)
+  end
+
+  test "generates signed challenge containing nonce" do
+    signed_message = Base64.urlsafe_decode64(@options.challenge)
+    nonce = ActionPack::WebAuthn.challenge_verifier.verified(signed_message, purpose: "authentication")
+
+    assert_not_nil nonce
+    assert_equal 32, Base64.strict_decode64(nonce).bytesize
+  end
+
+  test "as_json" do
+    json = @options.as_json
+
+    assert_equal @options.challenge, json["challenge"]
+    assert_equal "example.com", json["rpId"]
+    assert_equal [
+      { "type" => "public-key", "id" => "credential-1" },
+      { "type" => "public-key", "id" => "credential-2" }
+    ], json["allowCredentials"]
+    assert_equal "preferred", json["userVerification"]
+  end
+
+  test "as_json supports except option" do
+    json = @options.as_json(except: :challenge)
+
+    assert_nil json["challenge"]
+    assert_not_nil json["rpId"]
+  end
+
+  test "as_json includes transports when present" do
+    credentials = [
+      build_credential(id: "cred-1", transports: [ "usb", "nfc" ]),
+      build_credential(id: "cred-2", transports: [ "internal" ])
+    ]
+
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+      credentials: credentials,
+      relying_party: @relying_party
+    )
+
+    assert_equal [
+      { "type" => "public-key", "id" => "cred-1", "transports" => [ "usb", "nfc" ] },
+      { "type" => "public-key", "id" => "cred-2", "transports" => [ "internal" ] }
+    ], options.as_json["allowCredentials"]
+  end
+
+  test "as_json omits transports when empty" do
+    credentials = [ build_credential(id: "cred-1") ]
+
+    options = ActionPack::WebAuthn::PublicKeyCredential::RequestOptions.new(
+      credentials: credentials,
+      relying_party: @relying_party
+    )
+
+    assert_equal [
+      { "type" => "public-key", "id" => "cred-1" }
+    ], options.as_json["allowCredentials"]
+  end
+end

--- a/actionpack/test/web_authn/relying_party_test.rb
+++ b/actionpack/test/web_authn/relying_party_test.rb
@@ -18,6 +18,28 @@ class ActionPack::WebAuthn::RelyingPartyTest < ActiveSupport::TestCase
     end
   end
 
+  test "initializes with default id from configured relying_party_id" do
+    ActionPack::WebAuthn.relying_party_id = "configured.example.com"
+
+    ActionPack::WebAuthn::Current.set(host: "request.example.com") do
+      relying_party = ActionPack::WebAuthn::RelyingParty.new(name: "Example App")
+
+      assert_equal "configured.example.com", relying_party.id
+    end
+  ensure
+    ActionPack::WebAuthn.relying_party_id = nil
+  end
+
+  test "explicit id takes precedence over configured relying_party_id" do
+    ActionPack::WebAuthn.relying_party_id = "configured.example.com"
+
+    relying_party = ActionPack::WebAuthn::RelyingParty.new(id: "explicit.example.com")
+
+    assert_equal "explicit.example.com", relying_party.id
+  ensure
+    ActionPack::WebAuthn.relying_party_id = nil
+  end
+
   test "initializes with default name from application_name" do
     relying_party = ActionPack::WebAuthn::RelyingParty.new(id: "example.com")
 

--- a/actionpack/test/web_authn/relying_party_test.rb
+++ b/actionpack/test/web_authn/relying_party_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../web_authn_test_helper"
+
+class ActionPack::WebAuthn::RelyingPartyTest < ActiveSupport::TestCase
+  test "initializes with explicit id and name" do
+    relying_party = ActionPack::WebAuthn::RelyingParty.new(id: "example.com", name: "Example App")
+
+    assert_equal "example.com", relying_party.id
+    assert_equal "Example App", relying_party.name
+  end
+
+  test "initializes with default id from Current.host" do
+    ActionPack::WebAuthn::Current.set(host: "default.example.com") do
+      relying_party = ActionPack::WebAuthn::RelyingParty.new(name: "Example App")
+
+      assert_equal "default.example.com", relying_party.id
+    end
+  end
+
+  test "initializes with default name from application_name" do
+    relying_party = ActionPack::WebAuthn::RelyingParty.new(id: "example.com")
+
+    assert_equal ActionPack::WebAuthn.application_name, relying_party.name
+  end
+
+  test "as_json returns id and name" do
+    relying_party = ActionPack::WebAuthn::RelyingParty.new(id: "example.com", name: "Example App")
+
+    assert_equal({ id: "example.com", name: "Example App" }, relying_party.as_json)
+  end
+end

--- a/actionpack/test/web_authn_test_helper.rb
+++ b/actionpack/test/web_authn_test_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_model"
+require "active_support/current_attributes"
+require "action_pack/web_authn"
+
+ActionPack::WebAuthn.challenge_verifier ||= ActiveSupport::MessageVerifier.new(SecureRandom.hex(64))
+ActionPack::WebAuthn.application_name ||= "TestApp"
+
+module WebauthnTestHelper
+  # Fixed EC P-256 key pair for WebAuthn tests.
+  WEBAUTHN_PRIVATE_KEY = OpenSSL::PKey::EC.new(
+    [ "307702010104201dd589de7210b3318620f32150e3012cce021519df1d6e9e01" \
+      "0471146d395cdca00a06082a8648ce3d030107a14403420004116847fe19e1ad" \
+      "4471ab9980d7ff9cc1e4c7cb7a3af00e082b64fcd84f5ae70114c2495eef16f" \
+      "542b5e57dd1b263661624e3cf28f581b57a441edbd756a41d0e" ].pack("H*")
+  )
+
+  private
+    def webauthn_challenge(purpose: nil)
+      ActionPack::WebAuthn::PublicKeyCredential::Options.new(challenge_purpose: purpose).challenge
+    end
+
+    def build_credential(id:, transports: [])
+      ActionPack::WebAuthn::PublicKeyCredential.new(
+        id: id,
+        public_key: WEBAUTHN_PRIVATE_KEY,
+        sign_count: 0,
+        transports: transports
+      )
+    end
+
+    def webauthn_sign(authenticator_data, client_data_json)
+      signed_data = authenticator_data + Digest::SHA256.digest(client_data_json)
+      WEBAUTHN_PRIVATE_KEY.sign("SHA256", signed_data)
+    end
+end

--- a/actionpack/test/well_known/webauthn_controller_test.rb
+++ b/actionpack/test/well_known/webauthn_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_pack/passkeys"
+require_relative "../../lib/passkeys/app/controllers/action_pack/well_known/webauthn_controller"
+
+class ActionPack::WellKnown::WebauthnControllerTest < ActionController::TestCase
+  tests ActionPack::WellKnown::WebauthnController
+
+  setup do
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw do
+      get "/.well-known/webauthn" => "action_pack/well_known/webauthn#show"
+    end
+
+    ActionPack::Passkeys.related_origins = [ "https://example.com", "https://example.co.uk" ]
+  end
+
+  teardown do
+    ActionPack::Passkeys.related_origins = []
+  end
+
+  test "show returns the configured related origins as JSON" do
+    get :show
+
+    assert_response :success
+    assert_equal "application/json", response.media_type
+
+    origins = response.parsed_body["origins"]
+    assert_kind_of Array, origins
+    assert_equal ActionPack::Passkeys.related_origins.sort, origins.sort
+  end
+end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `ActiveSupport::Base32::Crockford` for Crockford's Base32 encoding.
+
+    Generates and normalizes Crockford's Base32 strings, which are designed to
+    be unambiguous for humans. Useful for generating and normalizing short,
+    readable codes and tokens.
+
+    ```ruby
+    ActiveSupport::Base32::Crockford.generate(6)          # => "K5C9BM"
+    ActiveSupport::Base32::Crockford.normalize("OIL-123") # => "011123"
+    ```
+
+    *Stanko Krtalic Rusendic*
+
 *   Added `ActiveSupport::ProxyLogger`.
 
     The proxy logger, is a logger that forwards all received logs to another

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -64,6 +64,7 @@ module ActiveSupport
 
   eager_autoload do
     autoload :BacktraceCleaner
+    autoload :Base32
     autoload :Benchmark
     autoload :Benchmarkable
     autoload :Cache

--- a/activesupport/lib/active_support/base32.rb
+++ b/activesupport/lib/active_support/base32.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/securerandom"
+
+module ActiveSupport
+  # = Base32
+  #
+  # Namespace for Base32 encoding schemes.
+  #
+  # == Available schemes
+  #
+  # [ActiveSupport::Base32::Crockford]
+  #   Crockford's Base32 encoding, designed to be unambiguous for humans. Supports
+  #   generation and normalization of human-readable codes.
+  #
+  #     ActiveSupport::Base32::Crockford.generate(6)          # => "PAK1NG"
+  #     ActiveSupport::Base32::Crockford.normalize("OIL-123") # => "011123"
+  module Base32
+    autoload :Crockford, "active_support/base32/crockford"
+  end
+end

--- a/activesupport/lib/active_support/base32/crockford.rb
+++ b/activesupport/lib/active_support/base32/crockford.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/securerandom"
+
+module ActiveSupport
+  module Base32
+    # = Crockford
+    #
+    # Generates and normalizes Crockford's Base32 strings. This encoding is designed
+    # to be unambiguous for humans, excluding the characters I, L, O, and U from its
+    # alphabet.
+    #
+    # When normalizing user input, visually ambiguous characters are substituted
+    # (O → 0, I → 1, L → 1) and invalid characters are stripped, so that codes
+    # are forgiving to transcription errors.
+    #
+    #   ActiveSupport::Base32::Crockford.generate(6)          # => "PAK1NG"
+    #   ActiveSupport::Base32::Crockford.normalize("OIL-123") # => "011123"
+    module Crockford
+      SUBSTITUTIONS = { "O" => "0", "I" => "1", "L" => "1" }.freeze
+
+      class << self
+        # Generates a random Crockford Base32 string of the given +length+.
+        #
+        #   ActiveSupport::Base32::Crockford.generate(6) # => "PAK1NG"
+        def generate(length = 16)
+          SecureRandom.base32(length)
+        end
+
+        # Normalizes a human-entered code to valid Crockford Base32.
+        #
+        # Upcases the input, applies visual substitutions (O → 0, I → 1, L → 1),
+        # and strips any characters not in the Base32 alphabet. Returns +nil+ if the
+        # result is blank.
+        #
+        #   ActiveSupport::Base32::Crockford.normalize("OIL-123") # => "011123"
+        #   ActiveSupport::Base32::Crockford.normalize("abc 123") # => "ABC123"
+        #   ActiveSupport::Base32::Crockford.normalize(nil)       # => nil
+        #   ActiveSupport::Base32::Crockford.normalize("")        # => nil
+        def normalize(code)
+          if code.present?
+            code.to_s.upcase
+              .then { |c| apply_substitutions(c) }
+              .then { |c| c.gsub(/[^#{SecureRandom::BASE32_ALPHABET.join}]/, "") }
+              .presence
+          end
+        end
+
+        private
+          def apply_substitutions(code)
+            SUBSTITUTIONS.reduce(code) do |result, (from, to)|
+              result.gsub(from, to)
+            end
+          end
+      end
+    end
+  end
+end

--- a/activesupport/test/base32/crockford_test.rb
+++ b/activesupport/test/base32/crockford_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/base32"
+
+class ActiveSupport::Base32::CrockfordTest < ActiveSupport::TestCase
+  test "generate returns a string of the requested length" do
+    assert_equal 6, ActiveSupport::Base32::Crockford.generate(6).length
+  end
+
+  test "generate defaults to 16 characters" do
+    assert_equal 16, ActiveSupport::Base32::Crockford.generate.length
+  end
+
+  test "generate returns unique values" do
+    assert_not_equal ActiveSupport::Base32::Crockford.generate, ActiveSupport::Base32::Crockford.generate
+  end
+
+  test "generate only contains Crockford Base32 characters" do
+    code = ActiveSupport::Base32::Crockford.generate(100)
+    assert_match(/\A[0-9A-HJKMNP-TV-Z]+\z/, code)
+  end
+
+  test "normalize upcases input" do
+    assert_equal "ABC123", ActiveSupport::Base32::Crockford.normalize("abc 123")
+  end
+
+  test "normalize substitutes O to 0" do
+    assert_equal "0", ActiveSupport::Base32::Crockford.normalize("O")
+  end
+
+  test "normalize substitutes I to 1" do
+    assert_equal "1", ActiveSupport::Base32::Crockford.normalize("I")
+  end
+
+  test "normalize substitutes L to 1" do
+    assert_equal "1", ActiveSupport::Base32::Crockford.normalize("L")
+  end
+
+  test "normalize strips invalid characters" do
+    assert_equal "011123", ActiveSupport::Base32::Crockford.normalize("OIL-123")
+  end
+
+  test "normalize returns nil for nil" do
+    assert_nil ActiveSupport::Base32::Crockford.normalize(nil)
+  end
+
+  test "normalize returns nil for empty string" do
+    assert_nil ActiveSupport::Base32::Crockford.normalize("")
+  end
+
+  test "normalize returns nil for whitespace-only string" do
+    assert_nil ActiveSupport::Base32::Crockford.normalize("   ")
+  end
+
+  test "normalize returns nil for only invalid characters" do
+    assert_nil ActiveSupport::Base32::Crockford.normalize("---")
+  end
+end

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,4 +59,10 @@ export default [
       ],
     },
   },
+  {
+    files: ["actionpack/**"],
+    languageOptions: {
+      ecmaVersion: 2020,
+    },
+  },
 ];

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3775,13 +3775,17 @@ ceremony. Defaults to `{}`.
 A hash of default options merged into every passkey authentication
 ceremony. Defaults to `{}`.
 
-#### `config.action_pack.passkey.registration_challenge_expiration`
+#### `config.action_pack.passkey.registration_timeout`
 
-How long a registration challenge remains valid. Defaults to `10.minutes`.
+How long a registration ceremony may take. Sent to the browser as the WebAuthn
+`timeout` and used server-side as the challenge's validity window. Defaults to
+`10.minutes`.
 
-#### `config.action_pack.passkey.authentication_challenge_expiration`
+#### `config.action_pack.passkey.authentication_timeout`
 
-How long an authentication challenge remains valid. Defaults to `5.minutes`.
+How long an authentication ceremony may take. Sent to the browser as the WebAuthn
+`timeout` and used server-side as the challenge's validity window. Defaults to
+`5.minutes`.
 
 #### `config.action_pack.passkey.cbor_max_depth`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3742,6 +3742,57 @@ NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms
 
 See Ruby's documentation for [`Regexp.timeout=`](https://docs.ruby-lang.org/en/master/Regexp.html#method-c-timeout-3D).
 
+### Configuring Action Pack Passkeys
+
+#### `config.action_pack.passkey.parent_class_name`
+
+Specifies the parent class for the `ActionPack::Passkeys::Passkey` model.
+Defaults to `"ApplicationRecord"`.
+
+#### `config.action_pack.passkey.routes_prefix`
+
+Sets the URL prefix for the passkey challenge endpoint.
+Defaults to `"/rails/action_pack/passkey"`.
+
+#### `config.action_pack.passkey.draw_routes`
+
+Controls whether the passkey challenge route is automatically drawn.
+Set to `false` to define the route manually. Defaults to `true`.
+
+#### `config.action_pack.passkey.challenge_url`
+
+A proc that returns the challenge endpoint URL. When `nil`, the
+default route helper `passkey_challenge_path` is used.
+Defaults to `nil`.
+
+#### `config.action_pack.passkey.default_registration_options`
+
+A hash of default options merged into every passkey registration
+ceremony. Defaults to `{}`.
+
+#### `config.action_pack.passkey.default_authentication_options`
+
+A hash of default options merged into every passkey authentication
+ceremony. Defaults to `{}`.
+
+#### `config.action_pack.passkey.registration_challenge_expiration`
+
+How long a registration challenge remains valid. Defaults to `10.minutes`.
+
+#### `config.action_pack.passkey.authentication_challenge_expiration`
+
+How long an authentication challenge remains valid. Defaults to `5.minutes`.
+
+#### `config.action_pack.passkey.cbor_max_depth`
+
+Maximum nesting depth allowed when decoding CBOR data from
+authenticators. Defaults to `16`.
+
+#### `config.action_pack.passkey.cbor_max_size`
+
+Maximum byte size of CBOR input allowed from authenticators.
+Defaults to `10.megabytes`.
+
 ### Configuring a Database
 
 Just about every Rails application will interact with a database. You can connect to the database by setting an environment variable `ENV['DATABASE_URL']` or by using a configuration file called `config/database.yml`.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3767,25 +3767,15 @@ Defaults to `nil`.
 
 #### `config.action_pack.passkey.default_registration_options`
 
-A hash of default options merged into every passkey registration
-ceremony. Defaults to `{}`.
+A hash of default options merged into every passkey registration ceremony,
+e.g. `user_verification` or `timeout` (sent to the browser as the WebAuthn
+`timeout` and used server-side as the challenge's validity window). Defaults
+to `{}`.
 
 #### `config.action_pack.passkey.default_authentication_options`
 
-A hash of default options merged into every passkey authentication
-ceremony. Defaults to `{}`.
-
-#### `config.action_pack.passkey.registration_timeout`
-
-How long a registration ceremony may take. Sent to the browser as the WebAuthn
-`timeout` and used server-side as the challenge's validity window. Defaults to
-`10.minutes`.
-
-#### `config.action_pack.passkey.authentication_timeout`
-
-How long an authentication ceremony may take. Sent to the browser as the WebAuthn
-`timeout` and used server-side as the challenge's validity window. Defaults to
-`5.minutes`.
+A hash of default options merged into every passkey authentication ceremony,
+e.g. `user_verification` or `timeout`. Defaults to `{}`.
 
 #### `config.action_pack.passkey.cbor_max_depth`
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1602,18 +1602,26 @@ requiring a user to be authenticated to manage products.
 
 Rails comes with an authentication generator that we can use. It creates User
 and Session models and the controllers and views necessary to login to our
-application.
+application. For our store, we'll use password-based authentication to keep
+things simple.
 
 Head back to your terminal and run the following command:
 
 ```bash
-$ bin/rails generate authentication
+$ bin/rails generate authentication --password-based
 ```
 
 Then migrate the database to add the User and Session tables.
 
 ```bash
 $ bin/rails db:migrate
+```
+
+Restart your Rails server so it picks up the `bcrypt` gem added by the
+generator. BCrypt is used for securely hashing passwords for authentication.
+
+```bash
+$ bin/rails server
 ```
 
 Open the Rails console to create a User.
@@ -1629,13 +1637,6 @@ use your own email and password instead of the example.
 store(dev)> User.create! email_address: "you@example.org", password: "s3cr3t", password_confirmation: "s3cr3t"
 ```
 
-Restart your Rails server so it picks up the `bcrypt` gem added by the
-generator. BCrypt is used for securely hashing passwords for authentication.
-
-```bash
-$ bin/rails server
-```
-
 When you visit any page, Rails will prompt for a username and password. Enter
 the email and password you used when creating the User record.
 
@@ -1644,6 +1645,11 @@ Try it out by visiting http://localhost:3000/products/new
 If you enter the correct username and password, it will allow you through. Your
 browser will also store these credentials for future requests so you don't have
 to type it in every page view.
+
+NOTE: The default authentication generator (without `--password-based`) uses
+magic links and passkeys instead of passwords. See the
+[Security Guide](/security.html#authentication) for details on all available
+authentication methods.
 
 
 ### Adding Log Out

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -42,65 +42,82 @@ which provides a solid starting point for securing your application by only
 allowing access to verified users.
 
 The authentication generator adds all of the relevant models, controllers,
-views, routes, and migrations needed for basic authentication and password reset
-functionality.
+views, routes, and migrations needed for authentication. By default, it
+generates magic link and passkey authentication. You can pass
+`--password-based` to generate password-based authentication instead.
 
-To use this feature in your application, you can run `bin/rails generate
-authentication`. Here are all of the files the generator modifies and new files
-it adds:
+To use this feature in your application, run:
 
 ```bash
 $ bin/rails generate authentication
       invoke  erb
-      create    app/views/passwords/new.html.erb
-      create    app/views/passwords/edit.html.erb
       create    app/views/sessions/new.html.erb
+      create    app/views/sessions/magic_links/show.html.erb
+      create    app/views/my/passkeys/index.html.erb
+      create    app/views/my/passkeys/edit.html.erb
+      create    app/views/my/passkeys/_passkey.html.erb
       create  app/models/session.rb
       create  app/models/user.rb
       create  app/models/current.rb
       create  app/controllers/sessions_controller.rb
       create  app/controllers/concerns/authentication.rb
-      create  app/controllers/passwords_controller.rb
-      create  app/mailers/passwords_mailer.rb
-      create  app/views/passwords_mailer/reset.html.erb
-      create  app/views/passwords_mailer/reset.text.erb
-      create  test/mailers/previews/passwords_mailer_preview.rb
-        gsub  app/controllers/application_controller.rb
-       route  resources :passwords, param: :token
-       route  resource :session
-        gsub  Gemfile
-      bundle  install --quiet
-    generate  migration CreateUsers email_address:string!:uniq password_digest:string! --force
-       rails  generate migration CreateUsers email_address:string!:uniq password_digest:string! --force
+      create  app/controllers/sessions/passkeys_controller.rb
+      create  app/controllers/my/passkeys_controller.rb
+      create  app/models/magic_link.rb
+      create  app/controllers/sessions/magic_links_controller.rb
+      create  app/channels/application_cable/connection.rb
+      create  app/mailers/magic_link_mailer.rb
+      create  app/views/magic_link_mailer/sign_in.html.erb
+      create  app/views/magic_link_mailer/sign_in.text.erb
+      insert  app/controllers/application_controller.rb
+       route  namespace :my do
+                resources :passkeys, except: %i[ show new ]
+              end
+       route  resource :session, only: [:new, :create, :destroy] do
+                resource :magic_link, only: [:show, :create], module: :sessions
+                resource :passkey, only: :create, module: :sessions
+              end
+      append  app/javascript/application.js
+      append  config/importmap.rb
+         run  bundle add letter_opener --group development
+    generate  migration
+       rails  generate migration CreateUsers email_address:string!:uniq --force
       invoke  active_record
-      create    db/migrate/20241010215312_create_users.rb
-    generate  migration CreateSessions user:references ip_address:string user_agent:string --force
+      create    db/migrate/20260330094258_create_users.rb
+    generate  migration
+       rails  generate migration CreateMagicLinks user:references code:string!:uniq expires_at:datetime! --force
+      invoke  active_record
+      create    db/migrate/20260330094259_create_magic_links.rb
+    generate  migration
        rails  generate migration CreateSessions user:references ip_address:string user_agent:string --force
       invoke  active_record
-      create    db/migrate/20241010215314_create_sessions.rb
+      create    db/migrate/20260330094300_create_sessions.rb
+       rails  railties:install:migrations FROM=action_pack_passkey
+Copied migration 20260330094301_create_action_pack_passkeys.action_pack_passkey.rb from action_pack_passkey
+      invoke  test_unit
+      create    test/fixtures/users.yml
+      create    test/models/user_test.rb
+      create    test/controllers/sessions_controller_test.rb
+      create    test/controllers/sessions/passkeys_controller_test.rb
+      create    test/controllers/sessions/magic_links_controller_test.rb
+      create    test/mailers/previews/magic_link_mailer_preview.rb
+      create    test/test_helpers/session_test_helper.rb
+      create    test/test_helpers/webauthn_test_helper.rb
+      insert    test/test_helper.rb
 ```
 
-As shown above, the authentication generator modifies the `Gemfile` to add the
-[bcrypt](https://github.com/bcrypt-ruby/bcrypt-ruby/) gem. The generator uses
-the `bcrypt` gem to create a hash of the password, which is then stored in the
-database (instead of the plain-text password). As this process is not
-reversible, there's no way to go from the hash back to the password. The hashing
-algorithm is deterministic though, so the stored password is able to be compared
-with the hash of the user-inputted password during authentication.
-
-The generator adds two migration files for creating `user` and `session` tables.
-Next step is to run the migrations:
+As shown above, the generator adds migration files for creating
+`user`, `session`, `magic_link`, and `action_pack_passkey` tables.
+Run the migrations:
 
 ```bash
 $ bin/rails db:migrate
 ```
 
 Then, if you visit `/session/new` in your browser (you will see this route has
-been added in `routes.rb`), you'll see a form that accepts an email and a
-password with "sign in" button. This form routes to the `SessionsController`
-which was added by the generator. If you provide an email/password for a user
-that exists in the database, you will be able to successfully authenticate with
-those credentials and log in to the application.
+been added in `routes.rb`), you'll see a sign-in form. Users can authenticate
+by entering their email address to receive a magic link, or by using a passkey
+registered on their device.
 
 NOTE: After running the Authentication generator, you do need to implement your
 own *sign up flow* and add the necessary views, routes, and controller actions.
@@ -108,63 +125,86 @@ There is no code generated that creates new `user` records and allows users to
 "sign up" in the first place. This is something you'll need to wire up based on
 the requirements of your application.
 
-Here is a list of modified files:
+### Passkeys
 
-```bash
-On branch main
-Changes not staged for commit:
-  (use "git add <file>..." to update what will be committed)
-  (use "git restore <file>..." to discard changes in working directory)
-  modified:   Gemfile
-  modified:   Gemfile.lock
-  modified:   app/controllers/application_controller.rb
-  modified:   config/routes.rb
+Passkeys are a modern, phishing-resistant authentication method
+built on the WebAuthn standard. Instead of passwords, passkeys use
+public key cryptography — this means there is no shared secret that
+can be stolen or phished.
 
-Untracked files:
-  (use "git add <file>..." to include in what will be committed)
-  app/controllers/concerns/authentication.rb
-  app/controllers/passwords_controller.rb
-  app/controllers/sessions_controller.rb
-  app/mailers/passwords_mailer.rb
-  app/models/current.rb
-  app/models/session.rb
-  app/models/user.rb
-  app/views/passwords/
-  app/views/passwords_mailer/
-  app/views/sessions/
-  db/migrate/
-  db/schema.rb
-  test/mailers/previews/
+The authentication generator adds passkey support automatically. Users can
+register passkeys from the `/my/passkeys` page and sign in with them from the
+sign-in page.
+
+Rails provides the `has_passkeys` method to add passkey support to
+the user model. This method adds the necessary associations and
+methods to manage passkeys for users.
+
+#### `has_passkeys`
+
+The `has_passkeys` method is added to the `User` model by the authentication
+generator. It sets up a polymorphic `has_many :passkeys` association and defines
+the methods needed for the WebAuthn registration and authentication ceremonies:
+
+```ruby
+class User < ApplicationRecord
+  has_passkeys name: :email_address, display_name: :name
+  has_many :sessions, dependent: :destroy
+
+  normalizes :email_address, with: -> e { e.strip.downcase }
+end
 ```
 
-### Reset Password
+The `name` and `display_name` options tell the authenticator what to display
+when the user registers or selects a passkey. `name` is typically an email
+address or username, and `display_name` is typically the user's full name.
+Both accept a symbol for an attribute or method on the record or a proc.
 
-The authentication generator also adds reset password functionality. You can see
-a "forgot password?" link on the "sign in" page. Clicking that link navigates to
-the `/passwords/new` path and routes to the passwords controller. The `new`
-method of the `PasswordsController` class runs through the flow for sending a
-password reset email.
+For more advanced configuration, `has_passkeys` accepts a block:
+
+```ruby
+has_passkeys do |config|
+  config.registration_options { { name: email_address, display_name: name.split(" ").first } }
+  config.authentication_options { { user_verification: "required" } }
+end
+```
+
+### Magic Link-Based Authentication
+
+By default, the authentication generator uses magic links for email-based
+sign-in. When a user enters their email address, a one-time sign-in link is
+sent to their inbox. Clicking the link authenticates the user without a
+password.
+
+Magic links use a short-lived, single-use code stored in the database. The
+`MagicLink` model and `Sessions::MagicLinksController` are generated
+automatically.
+
+### Password-Based Authentication
+
+If you prefer traditional password-based authentication, pass the
+`--password-based` flag:
+
+```bash
+$ bin/rails generate authentication --password-based
+```
+
+This modifies the `Gemfile` to add the
+[bcrypt](https://github.com/bcrypt-ruby/bcrypt-ruby/) gem. The generator uses
+`bcrypt` to create a hash of the password, which is then stored in the database
+(instead of the plain-text password). As this process is not reversible, there's
+no way to go from the hash back to the password. The hashing algorithm is
+deterministic though, so the stored password can be compared with the hash of
+the user-inputted password during authentication.
+
+#### Reset Password
+
+The password-based generator also adds reset password functionality. You can
+see a "forgot password?" link on the sign-in page. Clicking that link navigates
+to the `/passwords/new` path and routes to the passwords controller.
 
 The link is valid for 15 minutes by default, but this can be configured with
 `has_secure_password`.
-
-The mailers for *reset password* are also set up by the generator at
-`app/mailers/password_mailer.rb` and render the following email to send to the
-user:
-
-```html+erb
-# app/views/passwords_mailer/reset.html.erb
-<p>
-  You can reset your password within the next 15 minutes on
-  <%= link_to "this password reset page", edit_password_url(@user.password_reset_token) %>.
-</p>
-```
-
-### Implementation Details
-
-This section covers some of the implementation details around the authentication
-flow added by the authentication generator: The `has_secure_password` method,
-the `authenticate_by` method, and the `Authentication` concern.
 
 #### `has_secure_password`
 
@@ -213,7 +253,7 @@ end
 
 If the credentials are valid, a new `Session` is created for that user.
 
-#### Session Management
+### Session Management
 
 The core functionality around session management is implemented in the
 `Authentication` controller concern, which is included by the
@@ -240,8 +280,7 @@ Rails source code. You are encouraged to explore the implementation details and
 not treat authentication as a black box.
 
 With the authentication generator configured as above, your application is ready
-for a more secure user authentication and password recovery process in just a
-few steps.
+for secure user authentication in just a few steps.
 
 Sessions
 --------

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -79,7 +79,7 @@ $ bin/rails generate authentication
               end
       append  app/javascript/application.js
       append  config/importmap.rb
-         run  bundle add letter_opener --group development
+         run  bundle add mailbin --group development
     generate  migration
        rails  generate migration CreateUsers email_address:string!:uniq --force
       invoke  active_record

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -169,6 +169,25 @@ has_passkeys do |config|
 end
 ```
 
+#### Passkeys Across Multiple Domains
+
+A passkey is scoped to a single relying party ID, so it only works on
+the domain it was registered on. Once the Passkey is registered, the
+relaying party ID can't be changed. To allow a passkey to work across several
+domains — for example after a domain change — use [Related Origin Requests](https://passkeys.dev/docs/advanced/related-origins/).
+
+Pin your current domain as the common relying party ID so every Passkey ceremony
+uses it, regardless of which domain the request came in on, and provide a list of related origins
+that may use those passkeys:
+
+```ruby
+# config/application.rb
+config.action_pack.passkey.relying_party_id = "example.com"
+config.action_pack.passkey.related_origins = [ "https://example.com", "https://example.co.uk" ]
+```
+
+Rails will serve that list of origins at `/.well-known/webauthn` for browsers to discover.
+
 ### Magic Link-Based Authentication
 
 By default, the authentication generator uses magic links for email-based

--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -35,11 +35,12 @@ Adding Sign Up
 
 We've already used the
 [Rails authentication generator in the Getting Started guide](/getting_started.html#adding-authentication)
-to allow users to login to their accounts. The generator created a `User` model
-with `email_address:string` and `password_digest:string` columns in the
-database. It also added `has_secure_password` to the `User` model which handles
-passwords and confirmations. This takes care of most of what we need to add sign
-up to our application.
+to allow users to login to their accounts. We used the `--password-based` flag,
+so the generator created a `User` model with `email_address:string` and
+`password_digest:string` columns in the database. It also added
+`has_secure_password` to the `User` model which handles passwords and
+confirmations. This takes care of most of what we need to add sign up to our
+application.
 
 ### Adding Names To Users
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "workspaces": [
     "actioncable",
+    "actionpack",
     "actiontext",
     "activestorage"
   ]

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add passkey support to the authentication generator and default to magic links.
+
+    Changes the default authentication generator to create passkey-based authentication with magic links
+    instead of password-based authentication.
+    This provides a more secure and user-friendly authentication method out of the box.
+    The old authentication generator is still available as `rails generate authentication --password-based`.
+
+    *Stanko Krtalic Rusendic*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/all.rb
+++ b/railties/lib/rails/all.rb
@@ -12,6 +12,7 @@ require "rails"
   action_cable/engine
   action_mailbox/engine
   action_text/engine
+  action_pack/passkeys/engine
   rails/test_unit/railtie
 ).each do |railtie|
   begin # rubocop:disable Style/RedundantBegin

--- a/railties/lib/rails/generators/erb/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/erb/authentication/authentication_generator.rb
@@ -7,10 +7,21 @@ module Erb # :nodoc:
     class AuthenticationGenerator < Rails::Generators::Base # :nodoc:
       hide!
 
+      class_option :password_based, type: :boolean, default: false
+
       def create_files
-        template "app/views/passwords/new.html.erb"
-        template "app/views/passwords/edit.html.erb"
         template "app/views/sessions/new.html.erb"
+
+        if options.password_based?
+          template "app/views/passwords/new.html.erb"
+          template "app/views/passwords/edit.html.erb"
+        else
+          template "app/views/sessions/magic_links/show.html.erb"
+        end
+
+        template "app/views/my/passkeys/index.html.erb"
+        template "app/views/my/passkeys/edit.html.erb"
+        template "app/views/my/passkeys/_passkey.html.erb"
       end
     end
   end

--- a/railties/lib/rails/generators/erb/authentication/templates/app/views/my/passkeys/_passkey.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/app/views/my/passkeys/_passkey.html.erb
@@ -1,0 +1,5 @@
+<li>
+  <%%= link_to edit_my_passkey_path(passkey) do %>
+    <strong><%%= passkey.name.presence || "Passkey" %></strong>
+  <%% end %>
+</li>

--- a/railties/lib/rails/generators/erb/authentication/templates/app/views/my/passkeys/edit.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/app/views/my/passkeys/edit.html.erb
@@ -1,0 +1,19 @@
+<h1>Edit Passkey</h1>
+
+<%% if params[:created] %>
+  <p>Your passkey has been registered. Give it a name so you can identify it later.</p>
+<%% end %>
+
+<%%= form_with model: @passkey, scope: :passkey, url: my_passkey_path(@passkey) do |form| %>
+  <div>
+    <%%= form.label :name, "Name your passkey" %><br>
+    <%%= form.text_field :name, autofocus: true, placeholder: "e.g. MacBook Pro, iPhone", autocomplete: "off" %>
+  </div>
+
+  <%%= form.submit "Save" %>
+<%% end %>
+
+<div>
+  <%%= button_to "Remove this passkey", my_passkey_path(@passkey), method: :delete,
+        data: { turbo_confirm: "Are you sure you want to remove this passkey?" } %>
+</div>

--- a/railties/lib/rails/generators/erb/authentication/templates/app/views/my/passkeys/index.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/app/views/my/passkeys/index.html.erb
@@ -1,0 +1,13 @@
+<h1>Passkeys</h1>
+
+<p>Passkeys let you sign in securely without a password or email code.</p>
+
+<%% if @passkeys.any? %>
+  <ul>
+    <%%= render partial: "my/passkeys/passkey", collection: @passkeys %>
+  </ul>
+<%% end %>
+
+<%%= passkey_registration_button "Register a passkey", my_passkeys_path, options: @registration_options %>
+
+<p><small>Your browser will prompt you to create a passkey using your device's biometrics, PIN, or security key.</small></p>

--- a/railties/lib/rails/generators/erb/authentication/templates/app/views/sessions/magic_links/show.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/app/views/sessions/magic_links/show.html.erb
@@ -1,0 +1,12 @@
+<h1>Check your email</h1>
+
+<%%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+
+<p>We sent a sign-in code to <strong><%%= email_address_pending_authentication %></strong>.</p>
+
+<%%= form_with url: session_magic_link_path do |form| %>
+  <%%= form.text_field :code, required: true, autofocus: true, autocomplete: "one-time-code", maxlength: 6, placeholder: "Enter code", value: params[:code] %><br>
+  <%%= form.submit "Verify" %>
+<%% end %>
+
+<p>The code will expire in <%%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.</p>

--- a/railties/lib/rails/generators/erb/authentication/templates/app/views/sessions/new.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/app/views/sessions/new.html.erb
@@ -2,10 +2,16 @@
 <%%= tag.div(flash[:notice], style: "color:green") if flash[:notice] %>
 
 <%%= form_with url: session_path do |form| %>
-  <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
+  <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username webauthn", placeholder: "Enter your email address", value: params[:email_address] %><br>
+<%- if options.password_based? -%>
   <%%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %><br>
+<%- end -%>
   <%%= form.submit "Sign in" %>
 <%% end %>
+<%- if options.password_based? -%>
 <br>
 
 <%%= link_to "Forgot password?", new_password_path %>
+<%- end -%>
+
+<%%= passkey_sign_in_button "Sign in with a passkey", session_passkey_path, options: @authentication_options, mediation: "conditional" %>

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -19,6 +19,12 @@ module Rails
         invoke template_engine unless options.api?
       end
 
+      def ensure_passkeys_engine_required
+        unless defined?(ActionPack::Passkeys::Engine)
+          insert_into_file "config/application.rb", %(require "action_pack/passkeys/engine"\n), after: %(require "rails"\n)
+        end
+      end
+
       def create_authentication_files
         @user_model_exists = File.exist?(File.expand_path("app/models/user.rb", destination_root))
 

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -110,8 +110,19 @@ module Rails
           else
             bundle_command("add bcrypt", {}, quiet: true)
           end
-        else
-          bundle_command("add letter_opener --group development", {}, quiet: true) if defined?(ActionMailer::Railtie)
+        end
+      end
+
+      def preview_emails_in_development
+        if !options.password_based? && defined?(ActionMailer::Railtie)
+          bundle_command("add mailbin --group development", {}, quiet: true)
+
+          environment <<~RUBY, env: "development"
+            config.action_mailer.delivery_method = :mailbin
+            config.action_mailer.perform_deliveries = true
+          RUBY
+
+          route "mount Mailbin::Engine => :mailbin if Rails.env.development?"
         end
       end
 

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 require "rails/generators/bundle_helper"
+require "rails/generators/js_package_manager"
 
 module Rails
   module Generators
     class AuthenticationGenerator < Base # :nodoc:
       include BundleHelper
+      include JsPackageManager
 
       class_option :api, type: :boolean,
         desc: "Generate API-only controllers and models, with no view templates"
+
+      class_option :password_based, type: :boolean, default: false,
+        desc: "Generate password-based authentication instead of magic links"
 
       hook_for :template_engine, as: :authentication do |template_engine|
         invoke template_engine unless options.api?
@@ -23,15 +28,30 @@ module Rails
 
         template "app/controllers/sessions_controller.rb"
         template "app/controllers/concerns/authentication.rb"
-        template "app/controllers/passwords_controller.rb"
+        template "app/controllers/sessions/passkeys_controller.rb"
+        template "app/controllers/my/passkeys_controller.rb"
+
+        if options.password_based?
+          template "app/controllers/passwords_controller.rb"
+        else
+          template "app/models/magic_link.rb"
+          template "app/controllers/sessions/magic_links_controller.rb"
+        end
 
         template "app/channels/application_cable/connection.rb" if defined?(ActionCable::Engine)
 
         if defined?(ActionMailer::Railtie)
-          template "app/mailers/passwords_mailer.rb"
+          if options.password_based?
+            template "app/mailers/passwords_mailer.rb"
 
-          template "app/views/passwords_mailer/reset.html.erb"
-          template "app/views/passwords_mailer/reset.text.erb"
+            template "app/views/passwords_mailer/reset.html.erb"
+            template "app/views/passwords_mailer/reset.text.erb"
+          else
+            template "app/mailers/magic_link_mailer.rb"
+
+            template "app/views/magic_link_mailer/sign_in.html.erb"
+            template "app/views/magic_link_mailer/sign_in.text.erb"
+          end
         end
       end
 
@@ -40,24 +60,77 @@ module Rails
       end
 
       def configure_authentication_routes
-        route "resources :passwords, param: :token, only: [:new, :create, :edit, :update]"
-        route "resource :session, only: [:new, :create, :destroy]"
+        route <<~RUBY.strip
+          namespace :my do
+            resources :passkeys, except: %i[ show new ]
+          end
+        RUBY
+
+        if options.password_based?
+          route "resources :passwords, param: :token, only: [:new, :create, :edit, :update]"
+          route <<~RUBY.strip
+            resource :session, only: [:new, :create, :destroy] do
+              resource :passkey, only: :create, module: :sessions
+            end
+          RUBY
+        else
+          route <<~RUBY.strip
+            resource :session, only: [:new, :create, :destroy] do
+              resource :magic_link, only: [:show, :create], module: :sessions
+              resource :passkey, only: :create, module: :sessions
+            end
+          RUBY
+        end
       end
 
-      def enable_bcrypt
-        if File.read(File.expand_path("Gemfile", destination_root)).include?('gem "bcrypt"')
-          uncomment_lines "Gemfile", /gem "bcrypt"/
-          bundle_command("install --quiet")
+      def add_passkey_javascript
+        return if options.api?
+
+        destination = Pathname(destination_root)
+
+        if using_js_runtime?
+          say "Installing JavaScript dependencies", :green
+          run package_add_command("@rails/actionpack-passkeys")
+        end
+
+        if (application_javascript_path = destination.join("app/javascript/application.js")).exist?
+          insert_into_file application_javascript_path.to_s, %(\nimport "@rails/actionpack-passkeys"\n)
+        end
+
+        if (importmap_path = destination.join("config/importmap.rb")).exist?
+          append_to_file importmap_path.to_s, %(pin "@rails/actionpack-passkeys", to: "actionpack-passkeys.esm.js"\n)
+        end
+      end
+
+      def add_gems
+        if options.password_based?
+          if File.read(File.expand_path("Gemfile", destination_root)).include?('gem "bcrypt"')
+            uncomment_lines "Gemfile", /gem "bcrypt"/
+            bundle_command("install --quiet")
+          else
+            bundle_command("add bcrypt", {}, quiet: true)
+          end
         else
-          bundle_command("add bcrypt", {}, quiet: true)
+          bundle_command("add letter_opener --group development", {}, quiet: true) if defined?(ActionMailer::Railtie)
         end
       end
 
       def add_migrations
-        unless @user_model_exists
-          generate "migration", "CreateUsers", "email_address:string!:uniq password_digest:string!", "--force"
+        if options.password_based?
+          unless @user_model_exists
+            generate "migration", "CreateUsers", "email_address:string!:uniq password_digest:string!", "--force"
+          end
+        else
+          unless @user_model_exists
+            generate "migration", "CreateUsers", "email_address:string!:uniq", "--force"
+          end
+
+          generate "migration", "CreateMagicLinks", "user:references code:string!:uniq expires_at:datetime!", "--force"
         end
+
         generate "migration", "CreateSessions", "user:references ip_address:string user_agent:string", "--force"
+
+        rails_command "railties:install:migrations FROM=action_pack_passkey", inline: true
       end
 
       hook_for :test_framework

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -4,6 +4,9 @@ module Authentication
   included do
     before_action :require_authentication
     helper_method :authenticated?
+<%- unless options.password_based? -%>
+    helper_method :email_address_pending_authentication
+<%- end -%>
   end
 
   class_methods do
@@ -49,4 +52,40 @@ module Authentication
       Current.session.destroy
       cookies.delete(:session_id)
     end
+<%- unless options.password_based? -%>
+
+    def redirect_to_session_magic_link(magic_link)
+      set_pending_authentication_token(magic_link)
+      redirect_to session_magic_link_path
+    end
+
+    def redirect_to_fake_session_magic_link(email_address)
+      redirect_to_session_magic_link MagicLink.new(
+        user: User.new(email_address: email_address),
+        code: ActiveSupport::Base32::Crockford.generate(6),
+        expires_at: MagicLink::EXPIRATION_TIME.from_now
+      )
+    end
+
+    def email_address_pending_authentication
+      pending_authentication_verifier.verified(cookies[:pending_authentication_token])
+    end
+
+    def set_pending_authentication_token(magic_link)
+      cookies[:pending_authentication_token] = {
+        value: pending_authentication_verifier.generate(magic_link.user.email_address, expires_at: magic_link.expires_at),
+        httponly: true,
+        same_site: :lax,
+        expires: magic_link.expires_at
+      }
+    end
+
+    def clear_pending_authentication_token
+      cookies.delete(:pending_authentication_token)
+    end
+
+    def pending_authentication_verifier
+      Rails.application.message_verifier(:pending_authentication)
+    end
+<%- end -%>
 end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/my/passkeys_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/my/passkeys_controller.rb.tt
@@ -9,9 +9,11 @@ class My::PasskeysController < ApplicationController
   end
 
   def create
-    passkey = Current.user.passkeys.register(passkey_registration_params)
-
-    redirect_to edit_my_passkey_path(passkey, created: true)
+    if passkey = Current.user.passkeys.register(passkey_registration_params)
+      redirect_to edit_my_passkey_path(passkey, created: true)
+    else
+      redirect_to my_passkeys_path, alert: "That passkey couldn't be registered. Try again."
+    end
   end
 
   def edit

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/my/passkeys_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/my/passkeys_controller.rb.tt
@@ -1,0 +1,34 @@
+class My::PasskeysController < ApplicationController
+  include ActionPack::Passkeys::Request
+
+  before_action :set_passkey, only: %i[ edit update destroy ]
+
+  def index
+    @passkeys = Current.user.passkeys.order(name: :asc, created_at: :desc)
+    @registration_options = passkey_registration_options(holder: Current.user)
+  end
+
+  def create
+    passkey = Current.user.passkeys.register(passkey_registration_params)
+
+    redirect_to edit_my_passkey_path(passkey, created: true)
+  end
+
+  def edit
+  end
+
+  def update
+    @passkey.update!(params.expect(passkey: [ :name ]))
+    redirect_to my_passkeys_path
+  end
+
+  def destroy
+    @passkey.destroy!
+    redirect_to my_passkeys_path
+  end
+
+  private
+    def set_passkey
+      @passkey = Current.user.passkeys.find(params[:id])
+    end
+end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions/magic_links_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions/magic_links_controller.rb.tt
@@ -1,0 +1,23 @@
+class Sessions::MagicLinksController < ApplicationController
+  allow_unauthenticated_access
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to session_magic_link_path, alert: "Try again later." }
+  before_action :ensure_pending_authentication
+
+  def show
+  end
+
+  def create
+    if magic_link = MagicLink.consume(params[:code])
+      clear_pending_authentication_token
+      start_new_session_for magic_link.user
+      redirect_to after_authentication_url
+    else
+      redirect_to session_magic_link_path, alert: "Invalid or expired code. Try again."
+    end
+  end
+
+  private
+    def ensure_pending_authentication
+      redirect_to new_session_path, alert: "Enter your email address to sign in." unless email_address_pending_authentication
+    end
+end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions/passkeys_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions/passkeys_controller.rb.tt
@@ -1,0 +1,15 @@
+class Sessions::PasskeysController < ApplicationController
+  include ActionPack::Passkeys::Request
+
+  allow_unauthenticated_access
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
+
+  def create
+    if credential = ActionPack::Passkeys::Passkey.authenticate(passkey_authentication_params)
+      start_new_session_for credential.holder
+      redirect_to after_authentication_url
+    else
+      redirect_to new_session_path, alert: "That passkey didn't work. Try again."
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -1,17 +1,32 @@
 class SessionsController < ApplicationController
+  include ActionPack::Passkeys::Request
+
   allow_unauthenticated_access only: %i[ new create ]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
 
   def new
+    @authentication_options = passkey_authentication_options
   end
 
   def create
+<%- if options.password_based? -%>
     if user = User.authenticate_by(params.permit(:email_address, :password))
       start_new_session_for user
       redirect_to after_authentication_url
     else
       redirect_to new_session_path, alert: "Try another email address or password."
     end
+<%- else -%>
+    if user = User.find_by(email_address: params[:email_address])
+      magic_link = user.magic_links.create!
+      <%- if defined?(ActionMailer::Railtie) -%>
+      MagicLinkMailer.sign_in(magic_link).deliver_later
+      <%- end -%>
+      redirect_to_session_magic_link magic_link
+    else
+      redirect_to_fake_session_magic_link params[:email_address]
+    end
+<%- end -%>
   end
 
   def destroy

--- a/railties/lib/rails/generators/rails/authentication/templates/app/mailers/magic_link_mailer.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/mailers/magic_link_mailer.rb.tt
@@ -1,0 +1,8 @@
+class MagicLinkMailer < ApplicationMailer
+  def sign_in(magic_link)
+    @magic_link = magic_link
+    @user = magic_link.user
+
+    mail to: @user.email_address, subject: "Your sign-in code is #{@magic_link.code}"
+  end
+end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/models/magic_link.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/models/magic_link.rb.tt
@@ -1,0 +1,30 @@
+class MagicLink < ApplicationRecord
+  EXPIRATION_TIME = 15.minutes
+
+  belongs_to :user
+
+  scope :active, -> { where(expires_at: Time.current...) }
+
+  before_validation :generate_code, on: :create
+  before_validation :set_expiration, on: :create
+
+  validates :code, uniqueness: true, presence: true
+
+  def self.consume(code)
+    active.find_by(code: ActiveSupport::Base32::Crockford.normalize(code))&.consume
+  end
+
+  def consume
+    destroy
+    self
+  end
+
+  private
+    def generate_code
+      self.code ||= ActiveSupport::Base32::Crockford.generate(6)
+    end
+
+    def set_expiration
+      self.expires_at ||= EXPIRATION_TIME.from_now
+    end
+end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/models/user.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/models/user.rb.tt
@@ -1,6 +1,13 @@
 class User < ApplicationRecord
+  has_passkeys name: :email_address, display_name: :email_address
+<%- if options.password_based? -%>
   has_secure_password
+<%- else -%>
+
+  has_many :magic_links, dependent: :destroy
+<%- end -%>
   has_many :sessions, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
+  validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/views/magic_link_mailer/sign_in.html.erb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/views/magic_link_mailer/sign_in.html.erb.tt
@@ -1,0 +1,3 @@
+<p><%%= link_to @magic_link.code, session_magic_link_url(code: @magic_link.code) %></p>
+
+<p>Click the code above to sign in. It will expire in <%%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.</p>

--- a/railties/lib/rails/generators/rails/authentication/templates/app/views/magic_link_mailer/sign_in.text.erb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/views/magic_link_mailer/sign_in.text.erb.tt
@@ -1,0 +1,5 @@
+Enter this code to sign in:
+
+<%%= @magic_link.code %>
+
+This code will expire in <%%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.

--- a/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
@@ -5,6 +5,8 @@ require "rails/generators/test_unit"
 module TestUnit # :nodoc:
   module Generators # :nodoc:
     class AuthenticationGenerator < Rails::Generators::Base # :nodoc:
+      class_option :password_based, type: :boolean, default: false
+
       def create_user_test_files
         template "test/fixtures/users.yml"
         template "test/models/user_test.rb"
@@ -12,15 +14,28 @@ module TestUnit # :nodoc:
 
       def create_controller_test_files
         template "test/controllers/sessions_controller_test.rb"
-        template "test/controllers/passwords_controller_test.rb"
+        template "test/controllers/sessions/passkeys_controller_test.rb"
+
+        if options.password_based?
+          template "test/controllers/passwords_controller_test.rb"
+        else
+          template "test/controllers/sessions/magic_links_controller_test.rb"
+        end
       end
 
       def create_mailer_preview_files
-        template "test/mailers/previews/passwords_mailer_preview.rb" if defined?(ActionMailer::Railtie)
+        if defined?(ActionMailer::Railtie)
+          if options.password_based?
+            template "test/mailers/previews/passwords_mailer_preview.rb"
+          else
+            template "test/mailers/previews/magic_link_mailer_preview.rb"
+          end
+        end
       end
 
       def create_test_helper_files
         template "test/test_helpers/session_test_helper.rb"
+        template "test/test_helpers/webauthn_test_helper.rb"
       end
 
       def configure_test_helper

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions/magic_links_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions/magic_links_controller_test.rb.tt
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Sessions::MagicLinksControllerTest < ActionDispatch::IntegrationTest
+  setup { @user = User.take }
+
+  test "show redirects without pending authentication" do
+    get session_magic_link_path
+
+    assert_redirected_to new_session_path
+  end
+
+  test "create with valid code signs in" do
+    post session_path, params: { email_address: @user.email_address }
+    assert_redirected_to session_magic_link_path
+
+    magic_link = @user.magic_links.last
+
+    post session_magic_link_path, params: { code: magic_link.code }
+
+    assert_redirected_to root_path
+    assert cookies[:session_id]
+  end
+
+  test "create with invalid code" do
+    post session_path, params: { email_address: @user.email_address }
+
+    post session_magic_link_path, params: { code: "WRONG1" }
+
+    assert_redirected_to session_magic_link_path
+  end
+end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions/passkeys_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions/passkeys_controller_test.rb.tt
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class Sessions::PasskeysControllerTest < ActionDispatch::IntegrationTest
+  test "create with invalid passkey" do
+    post session_passkey_path, params: { passkey: { id: "invalid", client_data_json: "{}", authenticator_data: "bad", signature: "bad" } }
+
+    assert_redirected_to new_session_path
+  end
+end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb.tt
@@ -7,6 +7,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     get new_session_path
     assert_response :success
   end
+<%- if options.password_based? -%>
 
   test "create with valid credentials" do
     post session_path, params: { email_address: @user.email_address, password: "password" }
@@ -21,6 +22,21 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
     assert_nil cookies[:session_id]
   end
+<%- else -%>
+
+  test "create sends magic link" do
+    post session_path, params: { email_address: @user.email_address }
+
+    assert_redirected_to session_magic_link_path
+    assert @user.magic_links.any?
+  end
+
+  test "create with unknown email" do
+    post session_path, params: { email_address: "unknown@example.com" }
+
+    assert_redirected_to new_session_path
+  end
+<%- end -%>
 
   test "destroy" do
     sign_in_as(@user)

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
@@ -1,3 +1,4 @@
+<%- if options.password_based? -%>
 <%% password_digest = BCrypt::Password.create("password") %>
 
 one:
@@ -7,3 +8,10 @@ one:
 two:
   email_address: two@example.com
   password_digest: <%%= password_digest %>
+<%- else -%>
+one:
+  email_address: one@example.com
+
+two:
+  email_address: two@example.com
+<%- end -%>

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/mailers/previews/magic_link_mailer_preview.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/mailers/previews/magic_link_mailer_preview.rb.tt
@@ -1,0 +1,8 @@
+# Preview all emails at http://localhost:3000/rails/mailers/magic_link_mailer
+class MagicLinkMailerPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/magic_link_mailer/sign_in
+  def sign_in
+    magic_link = User.take.magic_links.build
+    MagicLinkMailer.sign_in(magic_link)
+  end
+end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/test_helpers/webauthn_test_helper.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/test_helpers/webauthn_test_helper.rb.tt
@@ -1,0 +1,83 @@
+module WebauthnTestHelper
+  # Fixed EC P-256 key pair for WebAuthn tests.
+  WEBAUTHN_PRIVATE_KEY = OpenSSL::PKey::EC.new(
+    [ "307702010104201dd589de7210b3318620f32150e3012cce021519df1d6e9e01" \
+      "0471146d395cdca00a06082a8648ce3d030107a14403420004116847fe19e1ad" \
+      "4471ab9980d7ff9cc1e4c7cb7a3af00e082b64fcd84f5ae70114c2495eef16f" \
+      "542b5e57dd1b263661624e3cf28f581b57a441edbd756a41d0e" ].pack("H*")
+  )
+
+  # Pre-encoded COSE EC2/ES256 public key (CBOR) for the key above.
+  COSE_PUBLIC_KEY = [ "a5010203262001215820116847fe19e1ad4471ab9980d7ff9cc1" \
+    "e4c7cb7a3af00e082b64fcd84f5ae70122582014c2495eef16f542b5e57dd1b2" \
+    "63661624e3cf28f581b57a441edbd756a41d0e" ].pack("H*")
+
+  ATTESTATION_OBJECT_CBOR_PREFIX =
+    [ "a363666d74646e6f6e656761747453746d74a068617574684461746158a4" ].pack("H*")
+
+  private
+    def webauthn_challenge(purpose: nil)
+      ActionPack::WebAuthn::PublicKeyCredential::Options.new(challenge_purpose: purpose).challenge
+    end
+
+    def build_attestation_params(challenge:)
+      credential_id = SecureRandom.random_bytes(32)
+      auth_data = build_attestation_auth_data(credential_id: credential_id)
+
+      {
+        passkey: {
+          client_data_json: webauthn_client_data_json(challenge: challenge, type: "webauthn.create"),
+          attestation_object: Base64.urlsafe_encode64(ATTESTATION_OBJECT_CBOR_PREFIX + auth_data, padding: false),
+          transports: [ "internal" ]
+        }
+      }
+    end
+
+    def build_assertion_params(challenge:, credential:, sign_count: 1)
+      client_data_json = webauthn_client_data_json(challenge: challenge, type: "webauthn.get")
+      authenticator_data = build_assertion_auth_data(sign_count: sign_count)
+      signature = webauthn_sign(authenticator_data, client_data_json)
+
+      {
+        passkey: {
+          id: credential.credential_id,
+          client_data_json: client_data_json,
+          authenticator_data: Base64.urlsafe_encode64(authenticator_data, padding: false),
+          signature: Base64.urlsafe_encode64(signature, padding: false)
+        }
+      }
+    end
+
+    def webauthn_client_data_json(challenge:, type:)
+      { challenge: challenge, origin: "http://www.example.com", type: type }.to_json
+    end
+
+    def build_attestation_auth_data(credential_id:)
+      [
+        Digest::SHA256.digest("www.example.com"),
+        [ 0x45 ].pack("C"),
+        [ 0 ].pack("N"),
+        "\x00" * 16,
+        [ credential_id.bytesize ].pack("n"),
+        credential_id,
+        COSE_PUBLIC_KEY
+      ].join.b
+    end
+
+    def build_assertion_auth_data(sign_count:)
+      [
+        Digest::SHA256.digest("www.example.com"),
+        [ 0x05 ].pack("C"),
+        [ sign_count ].pack("N")
+      ].join.b
+    end
+
+    def webauthn_sign(authenticator_data, client_data_json)
+      signed_data = authenticator_data + Digest::SHA256.digest(client_data_json)
+      WEBAUTHN_PRIVATE_KEY.sign("SHA256", signed_data)
+    end
+end
+
+ActiveSupport.on_load(:action_dispatch_integration_test) do
+  include WebauthnTestHelper
+end

--- a/railties/test/application/help_test.rb
+++ b/railties/test/application/help_test.rb
@@ -18,7 +18,7 @@ class HelpTest < ActiveSupport::TestCase
     assert_match "You must specify a command. The most common commands are:", output
     assert_match "  generate     Generate new code (short-cut alias: \"g\")", output
     assert_match "In addition to those commands", output
-    assert_match(/^about(\s+)List versions of all Rails frameworks/, output)
+    assert_match(/^about(\s+)List versions of all Rails/, output)
     assert_match(/^test:models(\s+)Run tests in test\/models/, output)
     assert_match(/^routes(\s+)List all the defined routes/, output)
     assert_no_match(/^generate/, output)

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -64,6 +64,7 @@ rails_blob_representation_proxy GET  /rails/active_storage/representations/proxy
 
     assert_equal <<~MESSAGE, run_routes_command([ "-g", "POST" ])
                                      Prefix Verb URI Pattern                                                            Controller#Action
+                          passkey_challenge POST /rails/action_pack/passkey/challenge(.:format)                         action_pack/passkeys/challenges#create
                                             POST /cart(.:format)                                                        cart#create
               rails_postmark_inbound_emails POST /rails/action_mailbox/postmark/inbound_emails(.:format)                action_mailbox/ingresses/postmark/inbound_emails#create
                  rails_relay_inbound_emails POST /rails/action_mailbox/relay/inbound_emails(.:format)                   action_mailbox/ingresses/relay/inbound_emails#create
@@ -205,6 +206,7 @@ rails_blob_representation_proxy GET  /rails/active_storage/representations/proxy
 
     assert_equal <<~MESSAGE, run_routes_command
                                   Prefix Verb URI Pattern                                                                                       Controller#Action
+                       passkey_challenge POST /rails/action_pack/passkey/challenge(.:format)                                                    action_pack/passkeys/challenges#create
            rails_postmark_inbound_emails POST /rails/action_mailbox/postmark/inbound_emails(.:format)                                           action_mailbox/ingresses/postmark/inbound_emails#create
               rails_relay_inbound_emails POST /rails/action_mailbox/relay/inbound_emails(.:format)                                              action_mailbox/ingresses/relay/inbound_emails#create
            rails_sendgrid_inbound_emails POST /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                           action_mailbox/ingresses/sendgrid/inbound_emails#create
@@ -250,166 +252,173 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
 
     assert_equal <<~MESSAGE, output
       --[ Route 1 ]--------------
+      Prefix            | passkey_challenge
+      Verb              | POST
+      URI               | /rails/action_pack/passkey/challenge(.:format)
+      Controller#Action | action_pack/passkeys/challenges#create
+      Source Location   | #{rails_gem_root}/actionpack/lib/action_pack/passkeys/engine.rb:XX
+      Action Location   | #{rails_gem_root}/actionpack/lib/passkeys/app/controllers/action_pack/passkeys/challenges_controller.rb:XX
+      --[ Route 2 ]--------------
       Prefix            | cart
       Verb              | GET
       URI               | /cart(.:format)
       Controller#Action | cart#show
       Source Location   | #{app_path}/config/routes.rb:XX
-      --[ Route 2 ]--------------
+      --[ Route 3 ]--------------
       Prefix            | rails_postmark_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/postmark/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/postmark/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb:XX
-      --[ Route 3 ]--------------
+      --[ Route 4 ]--------------
       Prefix            | rails_relay_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/relay/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/relay/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/relay/inbound_emails_controller.rb:XX
-      --[ Route 4 ]--------------
+      --[ Route 5 ]--------------
       Prefix            | rails_sendgrid_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/sendgrid/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/sendgrid/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb:XX
-      --[ Route 5 ]--------------
+      --[ Route 6 ]--------------
       Prefix            | rails_mandrill_inbound_health_check
       Verb              | GET
       URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#health_check
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb:XX
-      --[ Route 6 ]--------------
+      --[ Route 7 ]--------------
       Prefix            | rails_mandrill_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb:XX
-      --[ Route 7 ]--------------
+      --[ Route 8 ]--------------
       Prefix            | rails_mailgun_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
       Controller#Action | action_mailbox/ingresses/mailgun/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb:XX
-      --[ Route 8 ]--------------
+      --[ Route 9 ]--------------
       Prefix            | rails_conductor_inbound_emails
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#index
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
-      --[ Route 9 ]--------------
+      --[ Route 10 ]-------------
       Prefix            |#{" "}
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
-      --[ Route 10 ]-------------
+      --[ Route 11 ]-------------
       Prefix            | new_rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#new
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
-      --[ Route 11 ]-------------
+      --[ Route 12 ]-------------
       Prefix            | rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#show
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:XX
-      --[ Route 12 ]-------------
+      --[ Route 13 ]-------------
       Prefix            | new_rails_conductor_inbound_email_source
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#new
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb:XX
-      --[ Route 13 ]-------------
+      --[ Route 14 ]-------------
       Prefix            | rails_conductor_inbound_email_sources
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb:XX
-      --[ Route 14 ]-------------
+      --[ Route 15 ]-------------
       Prefix            | rails_conductor_inbound_email_reroute
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)
       Controller#Action | rails/conductor/action_mailbox/reroutes#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/reroutes_controller.rb:XX
-      --[ Route 15 ]-------------
+      --[ Route 16 ]-------------
       Prefix            | rails_conductor_inbound_email_incinerate
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/incinerate(.:format)
       Controller#Action | rails/conductor/action_mailbox/incinerates#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/actionmailbox/app/controllers/rails/conductor/action_mailbox/incinerates_controller.rb:XX
-      --[ Route 16 ]-------------
+      --[ Route 17 ]-------------
       Prefix            | rails_service_blob
       Verb              | GET
       URI               | /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb:XX
-      --[ Route 17 ]-------------
+      --[ Route 18 ]-------------
       Prefix            | rails_service_blob_proxy
       Verb              | GET
       URI               | /rails/active_storage/blobs/proxy/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/proxy#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb:XX
-      --[ Route 18 ]-------------
+      --[ Route 19 ]-------------
       Prefix            |#{" "}
       Verb              | GET
       URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb:XX
-      --[ Route 19 ]-------------
+      --[ Route 20 ]-------------
       Prefix            | rails_blob_representation
       Verb              | GET
       URI               | /rails/active_storage/representations/redirect/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/representations/redirect_controller.rb:XX
-      --[ Route 20 ]-------------
+      --[ Route 21 ]-------------
       Prefix            | rails_blob_representation_proxy
       Verb              | GET
       URI               | /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/proxy#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/representations/proxy_controller.rb:XX
-      --[ Route 21 ]-------------
+      --[ Route 22 ]-------------
       Prefix            |#{" "}
       Verb              | GET
       URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/representations/redirect_controller.rb:XX
-      --[ Route 22 ]-------------
+      --[ Route 23 ]-------------
       Prefix            | rails_disk_service
       Verb              | GET
       URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
       Controller#Action | active_storage/disk#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/disk_controller.rb:XX
-      --[ Route 23 ]-------------
+      --[ Route 24 ]-------------
       Prefix            | update_rails_disk_service
       Verb              | PUT
       URI               | /rails/active_storage/disk/:encoded_token(.:format)
       Controller#Action | active_storage/disk#update
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:XX
       Action Location   | #{rails_gem_root}/activestorage/app/controllers/active_storage/disk_controller.rb:XX
-      --[ Route 24 ]-------------
+      --[ Route 25 ]-------------
       Prefix            | rails_direct_uploads
       Verb              | POST
       URI               | /rails/active_storage/direct_uploads(.:format)

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -27,18 +27,57 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     copy_routes
   end
 
+  # === Default (passkey + magic link) mode ===
+
   def test_authentication_generator
     generator([destination_root])
 
     run_generator_instance
 
-    assert_file "app/models/user.rb"
+    assert_file "app/models/user.rb" do |content|
+      assert_match(/has_passkeys/, content)
+      assert_match(/has_many :magic_links/, content)
+      assert_no_match(/has_secure_password/, content)
+    end
     assert_file "app/models/current.rb"
     assert_file "app/models/session.rb"
-    assert_file "app/controllers/sessions_controller.rb"
-    assert_file "app/controllers/concerns/authentication.rb"
-    assert_file "app/views/sessions/new.html.erb"
-    assert_file "app/channels/application_cable/connection.rb"
+    assert_file "app/models/magic_link.rb"
+
+    assert_file "app/controllers/sessions_controller.rb" do |content|
+      assert_match(/include ActionPack::Passkeys::Request/, content)
+      assert_match(/passkey_authentication_options/, content)
+      assert_match(/MagicLinkMailer/, content)
+    end
+    assert_file "app/controllers/sessions/passkeys_controller.rb" do |content|
+      assert_match(/ActionPack::Passkeys::Passkey.authenticate/, content)
+    end
+    assert_file "app/controllers/sessions/magic_links_controller.rb" do |content|
+      assert_match(/MagicLink.consume/, content)
+    end
+    assert_file "app/controllers/concerns/authentication.rb" do |content|
+      assert_match(/Session.find_by/, content)
+      assert_match(/session_id/, content)
+      assert_match(/pending_authentication/, content)
+    end
+
+    assert_no_file "app/controllers/passwords_controller.rb"
+    assert_no_file "app/mailers/passwords_mailer.rb"
+
+    assert_file "app/views/sessions/new.html.erb" do |content|
+      assert_match(/passkey_sign_in_button/, content)
+      assert_match(/authentication_options/, content)
+      assert_match(/username webauthn/, content)
+      assert_no_match(/password/, content)
+    end
+    assert_file "app/views/sessions/magic_links/show.html.erb"
+
+    assert_file "app/channels/application_cable/connection.rb" do |content|
+      assert_match(/Session.find_by/, content)
+    end
+
+    assert_file "app/mailers/magic_link_mailer.rb"
+    assert_file "app/views/magic_link_mailer/sign_in.html.erb"
+    assert_file "app/views/magic_link_mailer/sign_in.text.erb"
 
     assert_file "app/controllers/application_controller.rb" do |content|
       class_line, includes_line = content.lines.first(2)
@@ -47,24 +86,105 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
       assert_equal "  include Authentication\n", includes_line, "includes module on first line of class definition"
     end
 
+    assert_file "config/routes.rb" do |content|
+      assert_match(/resource :session/, content)
+      assert_match(/resource :magic_link/, content)
+      assert_match(/resource :passkey/, content)
+    end
+
+    assert_includes @bundle_commands, ["add letter_opener --group development", {}, { quiet: true }]
+
+    assert_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq --force"
+    assert_includes @rails_commands, "generate migration CreateSessions user:references ip_address:string user_agent:string --force"
+    assert_includes @rails_commands, "generate migration CreateMagicLinks user:references code:string!:uniq expires_at:datetime! --force"
+
+    assert_file "test/models/user_test.rb"
+    assert_file "test/fixtures/users.yml" do |content|
+      assert_no_match(/password_digest/, content)
+    end
+    assert_file "test/controllers/sessions_controller_test.rb"
+    assert_file "test/controllers/sessions/passkeys_controller_test.rb"
+    assert_file "test/controllers/sessions/magic_links_controller_test.rb"
+    assert_file "test/mailers/previews/magic_link_mailer_preview.rb"
+
+    assert_file "test/test_helpers/session_test_helper.rb" do |content|
+      assert_match(/session_id/, content)
+    end
+    assert_file "test/test_helpers/webauthn_test_helper.rb"
+
+    assert_file "test/test_helper.rb" do |content|
+      assert_match("require_relative \"test_helpers/session_test_helper\"", content)
+    end
+  end
+
+  # === Password-based mode ===
+
+  def test_authentication_generator_with_password_based_flag
+    generator([destination_root], password_based: true)
+
+    run_generator_instance
+
+    assert_file "app/models/user.rb" do |content|
+      assert_match(/has_passkeys/, content)
+      assert_match(/has_secure_password/, content)
+      assert_no_match(/magic_links/, content)
+    end
+    assert_file "app/models/current.rb"
+    assert_file "app/models/session.rb"
+    assert_no_file "app/models/magic_link.rb"
+
+    assert_file "app/controllers/sessions_controller.rb" do |content|
+      assert_match(/include ActionPack::Passkeys::Request/, content)
+      assert_match(/authenticate_by/, content)
+    end
+    assert_file "app/controllers/sessions/passkeys_controller.rb"
+    assert_file "app/controllers/passwords_controller.rb"
+    assert_no_file "app/controllers/sessions/magic_links_controller.rb"
+
+    assert_file "app/controllers/concerns/authentication.rb" do |content|
+      assert_match(/Session.find_by/, content)
+      assert_match(/session_id/, content)
+      assert_no_match(/pending_authentication/, content)
+    end
+
+    assert_file "app/views/sessions/new.html.erb" do |content|
+      assert_match(/passkey_sign_in_button/, content)
+      assert_match(/authentication_options/, content)
+      assert_match(/password/, content)
+      assert_match(/Forgot password/, content)
+    end
+    assert_file "app/views/passwords/new.html.erb"
+    assert_file "app/views/passwords/edit.html.erb"
+    assert_no_file "app/views/sessions/magic_links/show.html.erb"
+
+    assert_file "app/channels/application_cable/connection.rb"
+
     assert_file "Gemfile" do |content|
       assert_match(/\ngem "bcrypt"/, content)
     end
 
     assert_file "config/routes.rb" do |content|
       assert_match(/resource :session/, content)
+      assert_match(/resource :passkey/, content)
+      assert_match(/resources :passwords, param: :token, only: \[:new, :create, :edit, :update\]/, content)
     end
 
     assert_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq password_digest:string! --force"
     assert_includes @rails_commands, "generate migration CreateSessions user:references ip_address:string user_agent:string --force"
 
     assert_file "test/models/user_test.rb"
-    assert_file "test/fixtures/users.yml"
+    assert_file "test/fixtures/users.yml" do |content|
+      assert_match(/password_digest/, content)
+    end
     assert_file "test/controllers/sessions_controller_test.rb"
+    assert_file "test/controllers/sessions/passkeys_controller_test.rb"
     assert_file "test/controllers/passwords_controller_test.rb"
     assert_file "test/mailers/previews/passwords_mailer_preview.rb"
 
-    assert_file "test/test_helpers/session_test_helper.rb"
+    assert_file "test/test_helpers/session_test_helper.rb" do |content|
+      assert_match(/session_id/, content)
+    end
+    assert_file "test/test_helpers/webauthn_test_helper.rb"
 
     assert_file "test/test_helper.rb" do |content|
       assert_match("require_relative \"test_helpers/session_test_helper\"", content)
@@ -74,7 +194,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   def test_authentication_generator_without_bcrypt_in_gemfile
     File.write("#{destination_root}/Gemfile", File.read("#{destination_root}/Gemfile").sub(/# gem "bcrypt".*\n/, ""))
 
-    generator([destination_root])
+    generator([destination_root], password_based: true)
 
     run_generator_instance
 
@@ -89,38 +209,25 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/user.rb"
     assert_file "app/models/current.rb"
     assert_file "app/models/session.rb"
+    assert_file "app/models/magic_link.rb"
     assert_file "app/controllers/sessions_controller.rb"
+    assert_file "app/controllers/sessions/passkeys_controller.rb"
+    assert_file "app/controllers/sessions/magic_links_controller.rb"
     assert_file "app/controllers/concerns/authentication.rb"
     assert_no_file "app/views/sessions/new.html.erb"
+    assert_no_file "app/views/sessions/magic_links/show.html.erb"
+  end
 
-    assert_file "app/controllers/application_controller.rb" do |content|
-      class_line, includes_line = content.lines.first(2)
+  def test_authentication_generator_with_api_and_password_based_flags
+    generator([destination_root], api: true, password_based: true)
 
-      assert_equal "class ApplicationController < ActionController::Base\n", class_line, "does not affect class definition"
-      assert_equal "  include Authentication\n", includes_line, "includes module on first line of class definition"
-    end
+    run_generator_instance
 
-    assert_file "Gemfile" do |content|
-      assert_match(/\ngem "bcrypt"/, content)
-    end
-
-    assert_file "config/routes.rb" do |content|
-      assert_match(/resource :session, only: \[:new, :create, :destroy\]/, content)
-      assert_match(/resources :passwords, param: :token, only: \[:new, :create, :edit, :update\]/, content)
-    end
-
-    assert_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq password_digest:string! --force"
-    assert_includes @rails_commands, "generate migration CreateSessions user:references ip_address:string user_agent:string --force"
-
-    assert_file "test/models/user_test.rb"
-    assert_file "test/fixtures/users.yml"
-    assert_file "test/mailers/previews/passwords_mailer_preview.rb"
-
-    assert_file "test/test_helpers/session_test_helper.rb"
-
-    assert_file "test/test_helper.rb" do |content|
-      assert_match("require_relative \"test_helpers/session_test_helper\"", content)
-    end
+    assert_file "app/models/user.rb"
+    assert_file "app/controllers/sessions/passkeys_controller.rb"
+    assert_file "app/controllers/passwords_controller.rb"
+    assert_no_file "app/views/sessions/new.html.erb"
+    assert_no_file "app/views/passwords/new.html.erb"
   end
 
   def test_create_users_migration_is_skipped_when_user_model_already_exists
@@ -157,7 +264,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
     run_generator_instance
 
-    assert_no_file "test/mailers/previews/passwords_mailer_preview.rb"
+    assert_no_file "test/mailers/previews/magic_link_mailer_preview.rb"
   end
 
   def session_test_helper_is_skipped_if_test_framework_is_given
@@ -187,6 +294,24 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     old_value = ActionMailer.const_get(:Railtie)
     ActionMailer.send(:remove_const, :Railtie)
     generator([destination_root])
+    run_generator_instance
+
+    assert_no_file "app/mailers/magic_link_mailer.rb"
+    assert_no_file "app/views/magic_link_mailer/sign_in.html.erb"
+    assert_no_file "app/views/magic_link_mailer/sign_in.text.erb"
+    assert_no_file "test/mailers/previews/magic_link_mailer_preview.rb"
+
+    assert_file "app/controllers/sessions_controller.rb" do |content|
+      assert_no_match(/MagicLinkMailer/, content)
+    end
+  ensure
+    ActionMailer.const_set(:Railtie, old_value)
+  end
+
+  def test_password_based_generator_without_action_mailer
+    old_value = ActionMailer.const_get(:Railtie)
+    ActionMailer.send(:remove_const, :Railtie)
+    generator([destination_root], password_based: true)
     run_generator_instance
 
     assert_no_file "app/mailers/application_mailer.rb"

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -21,6 +21,11 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
         end
       end
     RUBY
+    FileUtils.mkdir_p("#{destination_root}/config/environments")
+    File.write("#{destination_root}/config/environments/development.rb", <<~RUBY)
+      Rails.application.configure do
+      end
+    RUBY
 
     copy_gemfile
 
@@ -90,9 +95,14 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
       assert_match(/resource :session/, content)
       assert_match(/resource :magic_link/, content)
       assert_match(/resource :passkey/, content)
+      assert_match(%r{mount Mailbin::Engine => :mailbin if Rails\.env\.development\?}, content)
     end
 
-    assert_includes @bundle_commands, ["add letter_opener --group development", {}, { quiet: true }]
+    assert_file "config/environments/development.rb" do |content|
+      assert_match(/config\.action_mailer\.delivery_method = :mailbin/, content)
+    end
+
+    assert_includes @bundle_commands, ["add mailbin --group development", {}, { quiet: true }]
 
     assert_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq --force"
     assert_includes @rails_commands, "generate migration CreateSessions user:references ip_address:string user_agent:string --force"

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -26,6 +26,14 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
       Rails.application.configure do
       end
     RUBY
+    File.write("#{destination_root}/config/application.rb", <<~RUBY)
+      require "rails"
+
+      module TestApp
+        class Application < Rails::Application
+        end
+      end
+    RUBY
 
     copy_gemfile
 
@@ -287,6 +295,29 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/session_test_helper/, test_helper_content)
       assert_no_match(/SessionTestHelper/, test_helper_content)
     end
+  end
+
+  def test_passkeys_engine_is_not_required_again_when_already_loaded
+    generator([destination_root])
+    run_generator_instance
+
+    assert_file "config/application.rb" do |content|
+      assert_no_match(/action_pack\/passkeys\/engine/, content)
+    end
+  end
+
+  def test_passkeys_engine_is_required_when_not_already_loaded
+    old_value = ActionPack::Passkeys.const_get(:Engine)
+    ActionPack::Passkeys.send(:remove_const, :Engine)
+
+    generator([destination_root])
+    run_generator_instance
+
+    assert_file "config/application.rb" do |content|
+      assert_match(/require "rails"\nrequire "action_pack\/passkeys\/engine"/, content)
+    end
+  ensure
+    ActionPack::Passkeys.const_set(:Engine, old_value)
   end
 
   def test_connection_class_skipped_without_action_cable

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1556,6 +1556,7 @@ en:
         ActionMailbox::Engine
         Trix::Engine
         ActionText::Engine
+        ActionPack::Passkeys::Engine
         Bukkits::Engine
         Importmap::Engine
         AppTemplate::Application


### PR DESCRIPTION
### Motivation / Background

Passkeys are a modern authentication method built on the WebAuthn standard that uses public-key cryptography instead of shared secrets — this makes them resistant to phishing and leaks. The standard has wide browser and platform support, and allows users to log in with their face, fingerprint, password manager, or authenticator.

https://github.com/user-attachments/assets/3b7352a6-09f5-4a93-b164-393a73fc1fef
 
This PR adds WebAuthn support to Action Pack along with a Passkey model and helpers for adding passkey-based authentication to any Rails app. It also updates the authentication generator to use magic links and passkeys as a more secure default to passwords. In case someone prefers passwords, they can still invoke the old generator by passing it `--password-based` as an option.


https://github.com/user-attachments/assets/05736520-8872-4d57-a5c0-f045bbaef98e

### Detail

Any record can add passkeys by calling `has_passkeys` and passing it `name` and `display_name` as arguments:

```ruby
class User < ApplicationRecord
  has_passkeys name: :email_address, display_name: :full_name
end
```

The `name` functions as the account identifier for the passkey — this is the name of the passkey. Typically this would be an email address or username. And the `display_name` is a friendly label that's shown by the browser during the passkey registration ceremony. These are the only required attributes. But any holder-specific part of the authentication and registration ceremony can be configured here:

```ruby
class User < ApplicationRecord
  has_passkeys do |config|
    config.registration_options do
      {
        name: email_address,
        display_name: name.split(" ").first
      }
    end

    config.authentication_options do
      { user_verification: "required" }
    end
  end
end
```

`has_passkeys` adds a `passkeys` association to the model calling it. Through that association new passkeys can be registered or existing passkeys authenticated:

```ruby
# Registration
class My::PasskeysController < ApplicationController
  include ActionPack::Passkeys::Request

  def new
    @registration_options = passkey_registration_options(holder: Current.user)
  end

  def create
    ActionPack::Passkey.register(passkey_registration_params, holder: Current.user)
    redirect_to my_passkeys_path
  end
end
```

```ruby
# Authentication
class Sessions::PasskeysController < ApplicationController
  include ActionPack::Passkeys::Request
  
  def new
    @authentication_options = passkey_authentication_options
  end

  def create
    if passkey = ActionPack::Passkey.authenticate(passkey_authentication_params)
      start_new_session_for passkey.holder
      redirect_to root_path
    else
      redirect_to new_session_path, alert: "Authentication failed"
    end
  end
end
```
The `ActionPack::Passkeys::Request` concern adds a few methods that makes it easier to work with passkey requests:
- `passkey_authentication_params` — strong parameters for the authentication ceremony
- `passkey_registration_params` — strong parameters for the registration ceremony
- `passkey_authentication_options` — generates `RequestOptions` for `navigator.credentials.get()`
- `passkey_registration_options(holder:)` — generates `CreationOptions` for `navigator.credentials.create()`

It also adds a before action that sets the current host and origin on `ActionPack::WebAuthn::Current`. These are needed in both ceremonies and this makes it easier to pass them around.

For the frontend side there are two new view helpers:
- `passkey_registration_button` — renders a web component with a form and button for registering a new passkey
- `passkey_sign_in_button` — renders a web component with a form and button for authenticating with a passkey

These have very similar semantics to `button_to` and can be used to render buttons for signing in with a passkey or for registering one:
```erb
<%= passkey_registration_button "Register a new passkey", my_passkeys_path,
      options: @registration_options %>

<%= passkey_sign_in_button "Sign in with a passkey", session_passkey_path,
      options: @authentication_options %>
```

The buttons are backed by web components that handle the browser's WebAuthn API. To use them, the Action Pack JavaScript must be imported:

```ruby
# config/importmap.rb
pin "@rails/actionpack", to: "actionpack.esm.js"
```

```js
// app/javascript/application.js
import "@rails/actionpack"
```

The authentication generator sets this up automatically.

#### ActionPack - WebAuthn & Passkeys

There are two additions to ActionPack: Passkeys and WebAuthn

WebAuthn is the protocol backing the passkeys implementation. This library closely follows the browsers' naming of ceremonies and objects to make it easier to reason about what the code does.

The `CborDecoder` and `CoseKey` are the main part of the implementation. They decode the payload that the browser passes to the server.

CBOR is a binary representation of a JSON object (with some extra features). The authenticator passes a CBOR blob to the browser, and the browser passes it on to the server. This binary format is used because WebAuthn supports different attestation schemes, some of which require cryptographic operations over the authenticator's response.

Attestation, in the context of WebAuthn, is the process of verifying that the authentication device (or program) used is genuine. There are a handful of different attestation schemes out there, but in this PR I added only the simplest — "none", which doesn't perform any verification.

But, as attestation is common in environments with high security requirements, the interface of the library allows users to plug-in their own attestation verifier:

```ruby
class PackedAttestationVerifier
  def verify!(attestation, client_data_json:)
    # Verify the attestation statement signature against the
    # authenticator's certificate chain
  end
end

ActionPack::WebAuthn.register_attestation_verifier("packed", PackedAttestationVerifier.new)
```

All authenticators should work with just "none". We tested a range of different devices from Apple Passwords (Face ID, Touch ID), Samsung Pass, Google Passwords, 1Password, Windows Hello, Yubikeys 4 & 5, and all worked.

The CBOR decoder is implemented as a recursive descent parser. It takes a CBOR blob and returns a Ruby Hash. It supports the full spec including indefinite types, various different float types, and tags (which are ignored) to provide broad device support. To test it I generated various CBOR values using Python's CBOR2 package and added them to the test suite. I also copied any examples from the spec into the test suite.

COSE is a format for encoding encryption keys (you can think of it as a DER file, but it's easier to parse). The decoder here is a simple parser that takes a CBOR blob and returns an OpenSSL PKey.

Passkey is an ActiveRecord record and a wrapper around WebAuthn that provides an easy-to-use interface around the various passkey ceremonies. It handles persistence, registration and authentication which includes controller and view helpers as well as some JavaScript.

To make this work I added a Passkeys engine. This makes it easy to include JavaScript and migrations. The rest of this namespace are concerns that get mixed into ActiveRecord, ActionView and ActionController.

There is also a controller that's used for generating passkey challenges. In all ceremonies, the authenticator uses its private key to sign a challenge generated by the application. The best practice is to have expiring challenges to prevent replay attacks, and that's how they are implemented in this PR (using a message verifier). But that causes a new problem where a user could experience an error authenticating or registering a passkey if they wait too long before triggering the ceremony. So this controller is used to fetch a new challenge for the ceremony when it begins.
#### Railtie

The authentication generator now has two modes:

- Default (no flags)
  Generates magic link + passkey authentication. Creates a `MagicLink` model, a `Sessions::MagicLinksController`, and the magic link mailer. 
  Also adds `letter_opener` for development.
- `--password-based`
  The previous behavior. Creates `has_secure_password`, a `PasswordsController`, the password reset mailer, and adds `bcrypt`.

Both modes generate passkey support (the `Sessions::PasskeysController`, `My::PasskeysController`, routes, JavaScript, and the passkey migration).
#### ActiveSupport

Added `ActiveSupport::Base32` for generating and normalizing Crockford's Base32 strings. 

This encoding is designed to be unambiguous for humans (it excludes I, L, O, and U), and the normalizer is forgiving of common transcription mistakes (e.g., `O` → `0`, `I` → `1`). It's used for the magic link codes.
#### Guides

- Security guide
  Rewrote the Authentication section to cover passkeys, magic links, and password-based authentication as three distinct paths. Added a `has_passkeys` section explaining the model setup and block configuration.
- Getting Started guide
  Updated to use `--password-based` and added a note pointing to the Security guide for the default (passkey + magic link) mode.
- Configuring guide
  Added all `config.action_pack.passkey.*` options.
- Sign Up and Settings guide
  Small update to mention the `--password-based` flag.

#### Callouts

##### Configurable parent class

Passkey allows you to configure it's parent class.
This allows for multi-database setups, but I don't know if that's a good way to go about this.
I saw other PRs that add multi-database support, to e.g. ActiveStorage, that take a more meta-programming approach to generating the models.

We have this in Fizzy, but this isn't necessary for passkeys to work, so if there are any issues with this approach I'd prefer to remove it.

##### `Passkey` vs `Passkeys`

`ActionPack::Passkey` and `ActionPack::Passkeys` are separate because Passkey is an ActiveRecord record which crashes if ActiveRecord isn't loaded. In Fizzy we worked around this by using a shim, but in Rails because I have an Engine it has to load before ActiveRecord is loaded and crashes. So I created a new namespace to make things easier.

The engine lives in a `passkeys` directory. To me this is the most logical place to put it, but it looks a bit off compared to the other directories there — any suggestions are welcome.

### Additional information

One of the goals of this passkey implementation was to have no external dependencies.

I've worked with @dhh on this. 

The bulk of the code was extracted from Fizzy:
- https://github.com/basecamp/fizzy/pull/2623
- https://github.com/basecamp/fizzy/pull/2748
- https://github.com/basecamp/fizzy/pull/2751
- https://github.com/basecamp/fizzy/pull/2758
- https://github.com/basecamp/fizzy/pull/1304

Official specifications:
- [Web Authentication (WebAuthn) Level 2](https://www.w3.org/TR/webauthn-2/)
- [RFC 8949 — Concise Binary Object Representation (CBOR)](https://tools.ietf.org/html/rfc8949)
- [RFC 9053 — CBOR Object Signing and Encryption (COSE)](https://datatracker.ietf.org/doc/html/rfc9053)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.