### PR TITLE
Fallback to uncolorized SQL when SQL colorization times out

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -42,7 +42,13 @@ module ActiveRecord
       end
 
       name = colorize_payload_name(name, payload[:name])
-      sql  = color(sql, sql_color(sql), bold: true) if colorize_logging
+      if colorize_logging
+        begin
+          sql = color(sql, sql_color(sql), bold: true)
+        rescue Regexp::TimeoutError
+          # Leave sql uncolorized so the log line is still emitted.
+        end
+      end
 
       debug "  #{name}  #{sql}#{binds}"
     end

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -188,6 +188,17 @@ class LogSubscriberTest < ActiveRecord::TestCase
     assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.9ms\)#{REGEXP_CLEAR}  #{REGEXP_BOLD}#{SQL_COLORINGS[:LOCK]}.*LOCK TABLE.*#{REGEXP_CLEAR}/mi, logger.debugs.last)
   end
 
+  def test_sql_is_logged_uncolorized_when_sql_coloration_times_out
+    logger = TestDebugLogSubscriber.new
+    ActiveSupport.colorize_logging = true
+    def logger.sql_color(sql)
+      raise Regexp::TimeoutError
+    end
+    logger.sql({ payload: { sql: "SELECT * FROM users", duration_ms: 0.9 } })
+    assert_includes logger.debugs.last, "SELECT * FROM users"
+    assert_no_match(/#{REGEXP_BOLD}#{SQL_COLORINGS[:SELECT]}/i, logger.debugs.last)
+  end
+
   def test_exists_query_logging
     Developer.exists? 1
     assert_equal 1, @logger.logged(:debug).size


### PR DESCRIPTION
Fixes #57092 

When SQL colorization raises `Regexp::TimeoutError` in `ActiveRecord::LogSubscriber#sql`, the SQL log line is not emitted.
The solution is to rescue `Regexp::TimeoutError` during SQL colorization and fall back to logging the original uncolorized SQL string.
