### PR TITLE
Update ActiveRecord::Associations::Preloader::Association.owners_by_key to handle composite keys

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -169,7 +169,7 @@ module ActiveRecord
         def owners_by_key
           @owners_by_key ||= owners.each_with_object({}) do |owner, result|
             key = derive_key(owner, owner_key_name)
-            (result[key] ||= []) << owner if key
+            (result[key] ||= []) << owner if key.is_a?(Array) ? key.all? : key
           end
         end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -54,7 +54,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
             :owners, :pets, :author_favorites, :jobs, :references, :subscribers, :subscriptions, :books,
             :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors,
             :pirates, :mateys, :sharded_blogs, :sharded_blog_posts, :sharded_comments, :sharded_blog_posts_tags,
-            :sharded_tags, :cpk_orders, :cpk_order_agreements
+            :sharded_tags, :cpk_authors, :cpk_orders, :cpk_books, :cpk_order_agreements
 
   def test_eager_with_has_one_through_join_model_with_conditions_on_the_through
     member = Member.all.merge!(includes: :favorite_club).find(members(:some_other_guy).id)
@@ -340,6 +340,15 @@ class EagerAssociationTest < ActiveRecord::TestCase
     # find the post, then find the author which is null so no query for the author or address
     assert_no_queries do
       assert_nil post.author_with_address
+    end
+  end
+
+  def test_finding_with_includes_on_null_composite_belongs_to_association_includes_only_once
+    book = cpk_books(:cpk_great_author_first_book)
+    book.update_columns(shop_id: nil, order_id: nil)
+    book = assert_queries_count(1) { Cpk::Book.all.merge!(includes: :order).find(book.id) }
+    assert_no_queries do
+      assert_nil book.order
     end
   end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -806,7 +806,7 @@ end
 class PreloaderTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :books, :authors, :tags, :taggings, :essays, :categories, :author_addresses,
            :sharded_blog_posts, :sharded_comments, :sharded_blog_posts_tags, :sharded_tags,
-           :members, :member_details, :organizations, :cpk_orders, :cpk_order_agreements,
+           :members, :member_details, :organizations, :cpk_authors, :cpk_orders, :cpk_books, :cpk_order_agreements,
            :dogs, :other_dogs
 
   def test_preload_with_scope
@@ -1429,6 +1429,20 @@ class PreloaderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_with_unpersisted_records_with_composite_foreign_key_no_ops
+    order = Cpk::Order.new
+    new_book_with_order = Cpk::Book.new(order: order)
+    new_book_without_order = Cpk::Book.new
+    books = [new_book_with_order, new_book_without_order]
+
+    assert_no_queries do
+      ActiveRecord::Associations::Preloader.new(records: books, associations: :order).call
+
+      assert_same order, new_book_with_order.order
+      assert_nil new_book_without_order.order
+    end
+  end
+
   def test_preload_wont_set_the_wrong_target
     post = posts(:welcome)
     post.update!(author_id: 54321)
@@ -1544,6 +1558,17 @@ class PreloaderTest < ActiveRecord::TestCase
       ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments).call
 
       assert_equal [comment], post.comments.to_a
+    end
+  end
+
+  def test_preload_keeps_built_has_many_records_with_composite_key_no_ops
+    order = Cpk::Order.new
+    book = order.books.build
+
+    assert_no_queries do
+      ActiveRecord::Associations::Preloader.new(records: [order], associations: :books).call
+
+      assert_equal [book], order.books.to_a
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because code that directly calls `ActiveRecord::Associations::Preloader` will have an extra unnecessary failed query when there is a composite key that is partially or all nil.

### Detail

This Pull Request changes `ActiveRecord::Associations::Preloader::Association.owners_by_key`

`owners_by_key` does not set a result when key is nil. However when key is composite it is an Array and passes the nil check even when the values are nil. This addes a check for Array and skips if any of the values in the array are nil. 

I am considering this a bug fix and not a change on the assumption that a query with a nil value for a composite key will always fail based on the pattern already set in ActiveRecord::Associations::BelongsToAssociation which uses: `Array(reflection.foreign_key).all?`

### Additional information

I chose to use the key.is_a?(Array) instead of casting all to an Array to preserve as close to the performance for the common path as possible.

Running a Benchmark to compare options gave the following results for 1000 iterations:
- No change:   0.177381   0.007517   0.184898 (  0.185270)
- This option (not composite):   0.177714   0.007319   0.185033 (  0.189884)
- This option (composite):   0.167168   0.009131   0.176299 (  0.181202)
- Array(key).all?:   0.262781   0.012571   0.275352 (  0.279990)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
