### PR TITLE
Add pluck to ActionController::Parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -429,6 +429,25 @@ module ActionController
       to_enum(:each_value).to_a
     end
 
+    # Extract the given key from each value in the parameters.
+    #
+    # This is useful when parameters represent an array-like structure with
+    # numeric keys, such as form data like `items[0][name]=David&items[1][name]=Rafael`.
+    #
+    #     params = ActionController::Parameters.new(
+    #       "0" => { name: "David" },
+    #       "1" => { name: "Rafael" },
+    #       "2" => { name: "Aaron" }
+    #     )
+    #     params.pluck(:name)
+    #     # => ["David", "Rafael", "Aaron"]
+    #
+    #     params.pluck(:id, :name)
+    #     # => [[1, "David"], [2, "Rafael"], [3, "Aaron"]]
+    def pluck(*keys)
+      values.pluck(*keys)
+    end
+
     # Attribute that keeps track of converted arrays, if any, to avoid double
     # looping in the common use case permit + mass-assignment. Defined in a method
     # to instantiate it only if needed.

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -340,6 +340,36 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_equal ["Chicago", "Illinois", ActionController::Parameters.new(first_name: "David")], params.values
   end
 
+  test "pluck extracts values for a single key" do
+    params = ActionController::Parameters.new(
+      "0" => { name: "David", age: 32 },
+      "1" => { name: "Rafael", age: 28 },
+      "2" => { name: "Aaron", age: 35 }
+    )
+    assert_equal ["David", "Rafael", "Aaron"], params.pluck(:name)
+  end
+
+  test "pluck extracts values for multiple keys" do
+    params = ActionController::Parameters.new(
+      "0" => { name: "David", age: 32 },
+      "1" => { name: "Rafael", age: 28 }
+    )
+    assert_equal [["David", 32], ["Rafael", 28]], params.pluck(:name, :age)
+  end
+
+  test "pluck returns nil for missing keys" do
+    params = ActionController::Parameters.new(
+      "0" => { name: "David" },
+      "1" => { name: "Rafael" }
+    )
+    assert_equal [nil, nil], params.pluck(:missing)
+  end
+
+  test "pluck returns empty array for empty params" do
+    params = ActionController::Parameters.new
+    assert_equal [], params.pluck(:name)
+  end
+
   test "values_at retains permitted status" do
     @params.permit!
     assert_predicate @params.values_at(:person).first, :permitted?


### PR DESCRIPTION
## Summary

- Add `pluck` method to `ActionController::Parameters`
- Delegates to `values.pluck` for extracting keys from parameter values
- Useful when form data creates Parameters with numeric keys (e.g. `items[0][name]=David`)

## Motivation

When form data is submitted with array-like structure (`items[0][name]=David&items[1][name]=Rafael`), Rails parses this into a Parameters object with string numeric keys (`{"0" => {name: "David"}, "1" => {name: "Rafael"}}`), not an actual Array.

This leads to confusion when users try to call `pluck` on it:

```ruby
params[:items].pluck(:name)
# => undefined method 'pluck' for an instance of ActionController::Parameters
```

This PR adds `pluck` to Parameters so the above works as expected, returning `["David", "Rafael"]`.

## Test plan

- [x] Added tests for single key extraction
- [x] Added tests for multiple key extraction
- [x] Added tests for missing keys (returns nil)
- [x] Added tests for empty params (returns empty array)
- [x] All existing Parameters tests pass
