### PR TITLE
Speedup ActiveRecord::LogSubscriber#sql_color

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -81,23 +81,35 @@ module ActiveRecord
       end
 
       def sql_color(sql)
-        case sql
-        when /\A\s*rollback/mi
-          RED
-        when /select .*for update/mi, /\A\s*lock/mi
-          WHITE
-        when /\A\s*select/i
-          BLUE
-        when /\A\s*insert/i
-          GREEN
-        when /\A\s*update/i
-          YELLOW
-        when /\A\s*delete/i
-          RED
-        when /transaction\s*\Z/i
-          CYAN
+        color = if (match = sql.match(/\A\s*(\w+)(?:\s|\Z)/))
+          case match[1].downcase
+          when "rollback"
+            RED
+          when "lock"
+            WHITE
+          when "select"
+            if sql.match?(/for update/mi)
+              WHITE
+            else
+              BLUE
+            end
+          when "insert"
+            GREEN
+          when "update"
+            YELLOW
+          when "delete"
+            RED
+          end
+        end
+
+        if color
+          color
         else
-          MAGENTA
+          if sql.match?(/transaction\s*\Z/i)
+            CYAN
+          else
+            MAGENTA
+          end
         end
       end
 

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -94,41 +94,35 @@ class LogSubscriberTest < ActiveRecord::TestCase
     assert_match(/SELECT .*?FROM .?developers.?/i, @logger.logged(:debug).last)
   end
 
-  def test_basic_query_logging_coloration
-    logger = TestDebugLogSubscriber.new
-    ActiveSupport.colorize_logging = true
-    SQL_COLORINGS.each do |verb, color_regex|
+  SQL_COLORINGS.each do |verb, color_regex|
+    test "basic_query_logging_coloration_#{verb}" do
+      logger = TestDebugLogSubscriber.new
+      ActiveSupport.colorize_logging = true
       logger.sql({ payload: { sql: verb.to_s, duration_ms: 0.9 } })
       assert_match(/#{REGEXP_BOLD}#{color_regex}#{verb}#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
-  end
 
-  def test_logging_sql_coloration_disabled
-    logger = TestDebugLogSubscriber.new
-    ActiveSupport.colorize_logging = false
+    test "logging_sql_coloration_disabled_#{verb}" do
+      logger = TestDebugLogSubscriber.new
+      ActiveSupport.colorize_logging = false
 
-    SQL_COLORINGS.each do |verb, color_regex|
       logger.sql({ payload: { sql: verb.to_s, duration_ms: 0.9 } })
       assert_no_match(/#{REGEXP_BOLD}#{color_regex}#{verb}#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
-  end
 
-  def test_basic_payload_name_logging_coloration_generic_sql
-    logger = TestDebugLogSubscriber.new
-    ActiveSupport.colorize_logging = true
-    SQL_COLORINGS.each do |verb, _|
+    test "basic_payload_name_logging_coloration_generic_sql_#{verb}" do
+      logger = TestDebugLogSubscriber.new
+      ActiveSupport.colorize_logging = true
       logger.sql({ payload: { sql: verb.to_s, duration_ms: 0.9 } })
       assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA} \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 
       logger.sql({ payload: { name: "SQL", sql: verb.to_s, duration_ms: 0.9 } })
       assert_match(/#{REGEXP_BOLD}#{REGEXP_MAGENTA}SQL \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
     end
-  end
 
-  def test_basic_payload_name_logging_coloration_named_sql
-    logger = TestDebugLogSubscriber.new
-    ActiveSupport.colorize_logging = true
-    SQL_COLORINGS.each do |verb, _|
+    test "basic_payload_name_logging_coloration_named_sql_#{verb}" do
+      logger = TestDebugLogSubscriber.new
+      ActiveSupport.colorize_logging = true
       logger.sql({ payload: { sql: verb.to_s, name: "Model Load", duration_ms: 0.9 } })
       assert_match(/#{REGEXP_BOLD}#{REGEXP_CYAN}Model Load \(0\.9ms\)#{REGEXP_CLEAR}/i, logger.debugs.last)
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/57092
Close: https://github.com/rails/rails/pull/57102

SQL queries can be very long, hence unanchored regexp, even if they have linear performance, may take longer than Regexp.timeout.
