### PR TITLE
ActiveSupport::Cache add a fast path for string keys

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -983,7 +983,7 @@ module ActiveSupport
         end
 
         def expand_and_namespace_key(key, options = nil)
-          str_key = expanded_key(key)
+          str_key = key.class == ::String ? key : expanded_key(key)
           raise(ArgumentError, "key cannot be blank") if !str_key || str_key.empty?
 
           namespace_key str_key, options

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -40,8 +40,6 @@ module ActiveSupport
 
       prepend Strategy::LocalCache
 
-      ESCAPE_KEY_CHARS = /[\x00-\x20%\x7F-\xFF]/n
-
       # Creates a new Dalli::Client instance with specified addresses and options.
       # If no addresses are provided, we give nil to Dalli::Client, so it uses its fallbacks:
       # - ENV["MEMCACHE_SERVERS"] (if defined)
@@ -259,10 +257,8 @@ module ActiveSupport
         # characters properly.
         def normalize_key(key, options)
           key = expand_and_namespace_key(key, options)
-          if key
-            key = key.dup.force_encoding(Encoding::ASCII_8BIT)
-            key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
-          end
+          key = key.b
+          key.gsub!(/[\x00-\x20%\x7F-\xFF]/n) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
           truncate_key(key)
         end
 


### PR DESCRIPTION
Since the overwhelming majority of keys are already strings, we can save a lot of busy work by skipping `#expanded_key`
