### PR TITLE
Reduce number of queries during MariaDB column introspection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -1100,7 +1100,33 @@ module ActiveRecord
         end
 
         def column_definitions(table_name) # :nodoc:
-          query_all("SHOW FULL FIELDS FROM #{quote_table_name(table_name)}")
+          fields = query_all("SHOW FULL FIELDS FROM #{quote_table_name(table_name)}")
+
+          update_fields_for_mariadb(table_name, fields) if mariadb?
+
+          fields
+        end
+
+        def update_fields_for_mariadb(table_name, fields)
+          has_function_default_candidate = fields.any? do |field|
+            default = field["Default"]
+            default&.match?(/[a-zA-Z_]\w*\(/) && !/\ACURRENT_TIMESTAMP/i.match?(default)
+          end
+
+          if has_function_default_candidate
+            table_info = create_table_info(table_name)
+            fields.each do |field|
+              default = field["Default"]
+              next unless default&.match?(/[a-zA-Z_]\w*\(/)
+              next if /\ACURRENT_TIMESTAMP/i.match?(default)
+
+              field_name = field["Field"]
+              match = table_info&.match(/`#{field_name}` .+ DEFAULT ('|\d+|[A-z]+)/)
+              if match && match[1].match?(/\A[A-z]/)
+                field["Extra"] = "DEFAULT_GENERATED"
+              end
+            end
+          end
         end
 
         def create_table_info(table_name) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -194,21 +194,7 @@ module ActiveRecord
             MySQL::TableDefinition.new(self, name, **options)
           end
 
-          def default_type(table_name, field_name)
-            match = create_table_info(table_name)&.match(/`#{field_name}` (.+) DEFAULT ('|\d+|[A-z]+)/)
-            default_pre = match[2] if match
-
-            if default_pre == "'"
-              :string
-            elsif default_pre&.match?(/^\d+$/)
-              :integer
-            elsif default_pre&.match?(/^[A-z]+$/)
-              :function
-            end
-          end
-
           def new_column_from_field(table_name, field, _definitions)
-            field_name = field.fetch("Field")
             type_metadata = fetch_type_metadata(field["Type"], field["Extra"])
             default, default_function = field["Default"], nil
 
@@ -216,16 +202,18 @@ module ActiveRecord
               default = "#{default} ON UPDATE #{default}" if /on update CURRENT_TIMESTAMP/i.match?(field["Extra"])
               default, default_function = nil, default
             elsif type_metadata.extra == "DEFAULT_GENERATED"
-              default = +"(#{default})" unless default.start_with?("(")
-              default = default.gsub("\\'", "'")
-              default, default_function = nil, default
+              if mariadb?
+                default, default_function = nil, default
+              else
+                default = "(#{default})" unless default.start_with?("(")
+                default = default.gsub("\\'", "'")
+                default, default_function = nil, default
+              end
             elsif type_metadata.type == :text && default&.start_with?("'")
               # strip and unescape quotes
               default = default[1...-1].gsub("\\'", "'")
             elsif default&.match?(/\A\d/)
               # Its a number so we can skip the query to check if it is a function
-            elsif default && default_type(table_name, field_name) == :function
-              default, default_function = nil, default
             end
 
             MySQL::Column.new(

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1497,8 +1497,8 @@ if ActiveRecord::Base.lease_connection.supports_bulk_alter?
 
       classname = ActiveRecord::Base.lease_connection.class.name[/[^:]*$/]
       expected_query_count = {
-        "Mysql2Adapter"     => 7, # four queries to retrieve schema info, one for bulk change, one for UPDATE, one for NOT NULL
-        "TrilogyAdapter"    => 7, # four queries to retrieve schema info, one for bulk change, one for UPDATE, one for NOT NULL
+        "Mysql2Adapter"     => 6, # three queries to retrieve schema info, one for bulk change, one for UPDATE, one for NOT NULL
+        "TrilogyAdapter"    => 6, # three queries to retrieve schema info, one for bulk change, one for UPDATE, one for NOT NULL
         "PostgreSQLAdapter" => 5, # two queries for columns, one for bulk change, one for UPDATE, one for NOT NULL
       }.fetch(classname) {
         raise "need an expected query count for #{classname}"


### PR DESCRIPTION
### Motivation / Background
#44654 fixed MariaDB function default detection by adding a check in `new_column_from_field` which was running `SHOW CREATE TABLE` once per column, resulting in a lot of unnecessary queries for applications with large schemas even if these applications were not running MariaDB.

This PR moves the MariaDB function default detection out of `new_column_from_field` and up into `column_definitions`. This avoids the extra queries for non-MariaDB connections, and for MariaDB issues at most one `SHOW CREATE TABLE` per `columns` call only in cases when a field's default looks like a function. 

### Detail
After issuing `SHOW FULL FIELDS`, if we're on a MariaDB connection, we check whether any field's Default looks like a function call. If at least one does, we issue a single `SHOW CREATE TABLE` to confirm, then mark those fields as `DEFAULT_GENERATED` in the metadata. This routes the fields through the existing `new_column_from_field` branch that MySQL already uses.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
