### PR TITLE
Bump Ruby version to 4.0.2 in devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 4.0, 3.4, 3.3, 3.2
-ARG VARIANT="4.0.1"
+ARG VARIANT="4.0.2"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Bumped Ruby Version to 4.0.2 in devcontainers 

https://www.ruby-lang.org/en/news/2026/03/16/ruby-4-0-2-released/

https://github.com/rails/devcontainer/pkgs/container/devcontainer%2Fimages%2Fruby/740481803?tag=4.0.2
