### PR TITLE
Document that days_in_month and days_in_year assume proleptic Gregorian calendar

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -21,6 +21,14 @@ class Time
 
     # Returns the number of days in the given month.
     # If no year is specified, it will use the current year.
+    #
+    # This method assumes the proleptic Gregorian calendar and does not
+    # account for the historical Gregorian Calendar Reform. During the
+    # reform, countries skipped several days (e.g., Italy skipped 10 days
+    # in October 1582, England skipped 11 days in September 1752). For
+    # such historical dates, use Ruby's +Date+ class directly instead:
+    #
+    #   (Date.new(1582, 10, 1)..Date.new(1582, 10, -1)).count  # => 21
     def days_in_month(month, year = current.year)
       if month == 2 && ::Date.gregorian_leap?(year)
         29
@@ -31,6 +39,9 @@ class Time
 
     # Returns the number of days in the given year.
     # If no year is specified, it will use the current year.
+    #
+    # Like +days_in_month+, this assumes the proleptic Gregorian calendar
+    # and does not account for the historical Gregorian Calendar Reform.
     def days_in_year(year = current.year)
       days_in_month(2, year) + 337
     end

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -23,10 +23,8 @@ class Time
     # If no year is specified, it will use the current year.
     #
     # This method assumes the proleptic Gregorian calendar and does not
-    # account for the historical Gregorian Calendar Reform. During the
-    # reform, countries skipped several days (e.g., Italy skipped 10 days
-    # in October 1582, England skipped 11 days in September 1752). For
-    # such historical dates, use Ruby's +Date+ class directly instead:
+    # account for the {Gregorian Calendar Reform}[https://en.wikipedia.org/wiki/Gregorian_calendar#Adoption_by_country].
+    # For such historical dates, use Ruby's +Date+ class directly instead:
     #
     #   (Date.new(1582, 10, 1)..Date.new(1582, 10, -1)).count  # => 21
     def days_in_month(month, year = current.year)


### PR DESCRIPTION
### Motivation / Background

Fixes #57109

`Time.days_in_month` and `Time.days_in_year` use a simple lookup table and do not account for the historical Gregorian Calendar Reform, during which countries skipped several days when transitioning from the Julian calendar (e.g., Italy skipped 10 days in October 1582, England skipped 11 days in September 1752).

Rather than adding region-specific calendar reform support — which would be disproportionately complex for an extremely niche historical use case — this PR documents the limitation and points users to Ruby's `Date` class for historical date calculations.

### Detail

Added RDoc documentation to both `Time.days_in_month` and `Time.days_in_year` noting that:
- These methods assume the proleptic Gregorian calendar
- They do not account for the historical Gregorian Calendar Reform
- Users should use Ruby's `Date` class directly for historical dates

### Additional information

```ruby
# Current behavior (unchanged):
Time.days_in_month(10, 1582) # => 31

# Ruby core Date accounts for the reform:
(Date.new(1582, 10, 1)..Date.new(1582, 10, -1)).count # => 21
```

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.