### PR TITLE
Allow to prepend AS::Notification subscribers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `prepend: true` option to `ActiveSupport::Notifications.subscribe`.
+
+      When `prepend: true` is passed, the subscriber is added to the front of
+      the subscriber list for the given event, ensuring it runs before any
+      previously registered subscribers. This allows mutating the event payload
+      before other subscribers process it.
+
+      ```ruby
+      ActiveSupport::Notifications.subscribe("sql.active_record", prepend: true) do |event|
+        event.payload[:name] = "[IDC] #{event.payload[:name]}"
+      end
+      ```
+
+      *Jean Boussier*, *Federico Carrocera*
+
 *   Deprecate `require_dependency`.
 
     `require_dependency` is deprecated without replacement and will be removed in Rails 9.

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -241,8 +241,8 @@ module ActiveSupport
       #   ActiveSupport::Notifications.subscribe(:render) {|event| ...}
       #   #=> ArgumentError (pattern must be specified as a String, Regexp or empty)
       #
-      def subscribe(pattern = nil, callback = nil, &block)
-        notifier.subscribe(pattern, callback, monotonic: false, &block)
+      def subscribe(pattern = nil, callback = nil, prepend: false, &block)
+        notifier.subscribe(pattern, callback, monotonic: false, prepend: prepend, &block)
       end
 
       # Performs the same functionality as #subscribe, but the +start+ and
@@ -251,8 +251,8 @@ module ActiveSupport
       # Daylights Savings). Use +monotonic_subscribe+ when accuracy of time
       # duration is important. For example, computing elapsed time between
       # two events.
-      def monotonic_subscribe(pattern = nil, callback = nil, &block)
-        notifier.subscribe(pattern, callback, monotonic: true, &block)
+      def monotonic_subscribe(pattern = nil, callback = nil, prepend: false, &block)
+        notifier.subscribe(pattern, callback, monotonic: true, prepend: prepend, &block)
       end
 
       def subscribed(callback, pattern = nil, monotonic: false, &block)

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -66,14 +66,21 @@ module ActiveSupport
         "#<#{self.class} (#{total_patterns} patterns)>"
       end
 
-      def subscribe(pattern = nil, callable = nil, monotonic: false, &block)
+      def subscribe(pattern = nil, callable = nil, monotonic: false, prepend: false, &block)
         subscriber = Subscribers.new(pattern, callable || block, monotonic)
         @mutex.synchronize do
           case pattern
           when String
-            @string_subscribers[pattern] << subscriber
+            if prepend
+              @string_subscribers[pattern].unshift(subscriber)
+            else
+              @string_subscribers[pattern] << subscriber
+            end
             clear_cache(pattern)
           when NilClass, Regexp
+            if prepend
+              raise ArgumentError, "Cannot prepend Regex subscribers"
+            end
             @other_subscribers << subscriber
             clear_cache
           else

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -51,6 +51,27 @@ module Notifications
       end
     end
 
+    def test_prepend_subscribe
+      calls = []
+      @notifier.subscribe("foo") do |event|
+        calls << :first
+      end
+
+      @notifier.subscribe("foo") do |event|
+        calls << :second
+      end
+
+      @notifier.subscribe("foo", prepend: true) do |event|
+        calls << :prepended
+      end
+
+      ActiveSupport::Notifications.instrument("foo") do |payload|
+        payload[:my_key] = "success!"
+      end
+
+      assert_equal([:prepended, :first, :second], calls)
+    end
+
     def test_subscribe_to_events_can_handle_nested_hashes_in_the_paylaod
       @notifier.subscribe do |event|
         assert_equal "success!", event.payload[:some_key][:key_one]


### PR DESCRIPTION
In our app, there is a few places where we wish to modify an event payload. Typically, for `sql.active_record` we want to augment the `name` in certain cases.

Right now there is no way other than monkey patch. However if we had the ability to ensure a particular event subscriber always run first, we could easily mutate the event payload.

```ruby
ActiveSupport::Notification.subscribe("sql.active_record", prepend: true) do |event|
  if IdentityCache.fetching?
    event.payload[:name] = "[IDC] #{event.payload[:name]}"
  end
end
```