### PR TITLE
Fix cookies.delete for scoped cookies absent from the request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `cookies.delete` for scoped cookies that are not part of the current request.
+
+    Explicit cookie scope like `path:` or `domain:` now still emits a deletion
+    header even when the cookie was not sent with the current request.
+
+    *afurm*
+
 *   Add `content_type` option to HTTP authentication methods.
 
     `request_http_basic_authentication`, `request_http_digest_authentication`,

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -402,9 +402,9 @@ module ActionDispatch
       #
       # Returns the value of the cookie, or `nil` if the cookie does not exist.
       def delete(name, options = {})
-        return unless @cookies.has_key? name.to_s
-
         options.symbolize_keys!
+        return unless @cookies.has_key?(name.to_s) || options.present?
+
         handle_options(options)
 
         value = @cookies.delete(name.to_s)

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -559,6 +559,11 @@ class CookiesTest < ActionController::TestCase
     assert_set_cookie_header "user_name=; path=/beaten; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
+  def test_delete_cookie_with_path_when_cookie_is_not_in_request
+    get :delete_cookie_with_path
+    assert_set_cookie_header "user_name=; path=/beaten; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+  end
+
   def test_delete_cookie_return_value
     request.cookies[:user_name] = "Joe"
     return_value = request.cookies.delete(:user_name)


### PR DESCRIPTION
### Motivation / Background

Fixes #49746.

`cookies.delete(name, path: ...)` currently returns early unless the cookie is present in the current request jar. That breaks deletion for scoped cookies, because a path-scoped cookie is not sent on requests to other paths even though Rails can still expire it by sending the correct `Set-Cookie` header.

This means a cookie created with a custom `path:` can remain undeleted when `cookies.delete` is called from a different path.

### Detail

This Pull Request changes `ActionDispatch::Cookies::CookieJar#delete` to allow deletions with explicit scope options even when the cookie is not present in the current request.

In particular, if `cookies.delete` is called with options such as `path:` or `domain:`, Rails now still emits the deletion header instead of returning early.

This PR also adds a regression test covering deletion of a path-scoped cookie that is not included in the current request.

### Additional information

Verified with:

`cd actionpack && bin/test test/dispatch/cookies_test.rb`

The full cookie test file passes after this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
