### PR TITLE
Respect Ruby Time behavior when comparing against Numeric

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -330,6 +330,8 @@ class Time
       else
         compare_without_coercion(other.to_time)
       end
+    elsif other.is_a?(Numeric)
+      compare_without_coercion(other)
     else
       to_datetime <=> other
     end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -1145,6 +1145,13 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_nil Time.utc(2000) <=> "Invalid as Time"
   end
 
+  def test_compare_with_numeric_uses_time_native_behavior
+    time = Time.utc(2000)
+
+    assert_nil time <=> 1_700_000_000
+    assert_raise(ArgumentError) { time >= 1_700_000_000 }
+  end
+
   def test_at_with_datetime
     assert_equal Time.utc(2000, 1, 1, 0, 0, 0), Time.at(DateTime.civil(2000, 1, 1, 0, 0, 0))
 


### PR DESCRIPTION
## Summary
- avoid coercing `Time` to `DateTime` for Numeric comparisons in `compare_with_coercion`
- delegate Numeric comparisons to Ruby's native `Time#<=>` behavior
- add regression coverage ensuring `<=>` returns `nil` and `>=` raises `ArgumentError` for Numeric values

Fixes #50868
