### PR TITLE
Enable models to connect/query different adapters.

### DIFF
--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -55,6 +55,16 @@ module ActiveModel
         end
       end
 
+      def apply_pending_attribute_modifications(attribute_set) # :nodoc:
+        if superclass.respond_to?(:apply_pending_attribute_modifications, true)
+          superclass.send(:apply_pending_attribute_modifications, attribute_set)
+        end
+
+        pending_attribute_modifications.each do |modification|
+          modification.apply_to(attribute_set)
+        end
+      end
+
       private
         PendingType = Struct.new(:name, :type) do # :nodoc:
           def apply_to(attribute_set)
@@ -81,16 +91,6 @@ module ActiveModel
 
         def pending_attribute_modifications
           @pending_attribute_modifications ||= []
-        end
-
-        def apply_pending_attribute_modifications(attribute_set)
-          if superclass.respond_to?(:apply_pending_attribute_modifications, true)
-            superclass.send(:apply_pending_attribute_modifications, attribute_set)
-          end
-
-          pending_attribute_modifications.each do |modification|
-            modification.apply_to(attribute_set)
-          end
         end
 
         def reset_default_attributes

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,37 @@
+*   Enable experimental support for models to connect to and query databases
+    with different adapters.
+
+    Previously, models cached many adapter specific values which would prevent
+    making queries against different database types. Now, those caches are per
+    `schema_context`, which can be configured in `database.yml`:
+
+    ```yaml
+    primary:
+      adapter: trilogy
+      database: myapp_development
+    primary_pg:
+      adapter: postgresql
+      database: myapp_development
+      schema_context: pg
+    ```
+
+    This enables models to connect to both MySQL and PostgreSQL databases in the
+    same application, and query them successfully:
+
+    ```ruby
+    class User < ApplicationRecord
+      connects_to shards: {
+        mysql: { writing: :primary, reading: :primary },
+        pg: { writing: :primary_pg, reading: :primary_pg },
+      }
+    end
+
+    User.connected_to(shard: :mysql) { User.first } # queries MySQL
+    User.connected_to(shard: :pg) { User.first } # queries PostgreSQL
+    ```
+
+    *Hartley McGuire*
+
 *   Fix inverse association matching for `has_many` and `has_one` associations
     with association-specific composite primary keys.
 

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -251,15 +251,15 @@ module ActiveRecord
       end
 
       def _default_attributes # :nodoc:
-        @default_attributes ||= begin
-          attributes_hash = columns_hash.transform_values do |column|
-            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
-          end
+        model_schema._default_attributes
+      end
 
-          attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
-          apply_pending_attribute_modifications(attribute_set)
-          attribute_set
-        end
+      def attribute_types # :nodoc:
+        model_schema.attribute_types
+      end
+
+      def type_for_column(column) # :nodoc:
+        hook_attribute_type(column.name, super)
       end
 
       ##
@@ -306,10 +306,6 @@ module ActiveRecord
 
         def resolve_type_name(name, **options)
           Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
-        end
-
-        def type_for_column(column)
-          hook_attribute_type(column.name, super)
         end
     end
   end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -265,7 +265,7 @@ module ActiveRecord
 
     module ClassMethods
       def initialize_find_by_cache # :nodoc:
-        @find_by_statement_cache = { true => Concurrent::Map.new, false => Concurrent::Map.new }
+        model_schemas.each_value(&:initialize_find_by_cache)
       end
 
       def find(*ids) # :nodoc:
@@ -414,8 +414,7 @@ module ActiveRecord
       end
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
-        cache = @find_by_statement_cache[connection.prepared_statements]
-        cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
+        model_schema.cached_find_by_statement(connection, key, &block)
       end
 
       private

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -213,6 +213,10 @@ module ActiveRecord
         configuration_hash.fetch(:use_metadata_table, true)
       end
 
+      def schema_context # :nodoc:
+        configuration_hash.fetch(:schema_context, "default").to_s
+      end
+
       private
         def schema_file_type(format)
           case format.to_sym

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "monitor"
+require "active_record/model_schema/schema"
 
 module ActiveRecord
   module ModelSchema
@@ -199,6 +200,21 @@ module ActiveRecord
     end
 
     module ClassMethods
+      def current_schema_context # :nodoc:
+        connection_db_config.schema_context
+      rescue ConnectionNotDefined
+        "default"
+      end
+
+      def model_schema # :nodoc:
+        context_key = current_schema_context
+        model_schemas[context_key] ||= Schema.new(self, context_key)
+      end
+
+      def model_schemas # :nodoc:
+        @model_schemas ||= {}
+      end
+
       # Guesses the table name (in forced lower-case) based on the name of the class in the
       # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
       # looks like: Reply < Message < ActiveRecord::Base, then Message is used
@@ -448,33 +464,23 @@ module ActiveRecord
       end
 
       def attributes_builder # :nodoc:
-        defaults = _default_attributes.except(*(column_names - Array(primary_key)))
-        ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
+        model_schema.attributes_builder
       end
 
       def columns_hash # :nodoc:
-        load_schema unless @columns_hash
-        @columns_hash
+        model_schema.columns_hash
       end
 
       def columns
-        @columns ||= columns_hash.values.freeze
+        model_schema.columns
       end
 
       def _returning_columns_for_insert(connection) # :nodoc:
-        @_returning_columns_for_insert ||= begin
-          auto_populated_columns = columns.filter_map do |c|
-            c.name if connection.return_value_after_insert?(c)
-          end
-
-          auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns
-        end
+        model_schema._returning_columns_for_insert(connection)
       end
 
-      def _returning_columns_for_update(connection)
-        @_returning_columns_for_update ||= columns.filter_map do |c|
-          c.name if connection.return_value_after_update?(c)
-        end
+      def _returning_columns_for_update(connection) # :nodoc:
+        model_schema._returning_columns_for_update(connection)
       end
 
       # Returns the column object for the named attribute.
@@ -500,28 +506,22 @@ module ActiveRecord
       # Returns a hash where the keys are column names and the values are
       # default values when instantiating the Active Record object for this table.
       def column_defaults
-        load_schema
-        @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
+        model_schema.column_defaults
       end
 
       # Returns an array of column names as strings.
       def column_names
-        columns.map(&:name).freeze
+        model_schema.column_names
       end
 
       def symbol_column_to_string(name_symbol) # :nodoc:
-        @symbol_column_to_string_name_hash ||= column_names.index_by(&:to_sym)
-        @symbol_column_to_string_name_hash[name_symbol]
+        model_schema.symbol_column_to_string(name_symbol)
       end
 
       # Returns an array of column objects where the primary id, all columns ending in "_id" or "_count",
       # and columns used for single table inheritance have been removed.
       def content_columns
-        @content_columns ||= columns.reject do |c|
-          Array(primary_key).include?(c.name) ||
-          c.name == inheritance_column ||
-          c.name.end_with?("_id", "_count")
-        end.freeze
+        model_schema.content_columns
       end
 
       # Resets all the cached information about columns, which will cause them
@@ -561,14 +561,25 @@ module ActiveRecord
 
       # Load the model's schema information either from the schema cache
       # or directly from the database.
+      #
+      # This separates two concerns:
+      # 1. Adapter-specific: populating the current Schema context's columns_hash
+      #    and default_attributes (runs per context, since different adapters may
+      #    return different column types).
+      # 2. Model-specific: the load_schema! super chain (counter_cache, encryption,
+      #    etc.) that mutates model-class-level state (runs once, since it's the
+      #    same regardless of adapter).
       def load_schema
         return if schema_loaded?
         @load_schema_monitor.synchronize do
           return if schema_loaded?
 
-          load_schema!
+          model_schema.load_schema!
 
-          @schema_loaded = true
+          unless @any_schema_loaded
+            load_schema!
+            @any_schema_loaded = true
+          end
         rescue
           reload_schema_from_cache # If the schema loading failed half way through, we must reset the state.
           raise
@@ -581,16 +592,13 @@ module ActiveRecord
         end
 
         def reload_schema_from_cache(recursive = true)
-          @_returning_columns_for_insert = nil
-          @_returning_columns_for_update = nil
+          @any_schema_loaded = false
           @arel_table = Arel::Table.new(klass: self)
-          @symbol_column_to_string_name_hash = nil
-          @content_columns = nil
-          @column_defaults = nil
-          @columns = nil
-          @columns_hash = nil
-          @schema_loaded = false
           @attribute_names = nil
+
+          # Reset all Schema instances
+          model_schemas.each_value(&:reload_schema_from_cache)
+
           if recursive
             subclasses.each do |descendant|
               descendant.send(:reload_schema_from_cache)
@@ -610,23 +618,17 @@ module ActiveRecord
         end
 
         def schema_loaded?
-          @schema_loaded
+          model_schema.schema_loaded?
         end
 
         def load_schema!
-          unless table_name
-            raise ActiveRecord::TableNotSpecified, "#{self} has no table configured. Set one with #{self}.table_name="
-          end
-
-          columns_hash = schema_cache.columns_hash(table_name)
-          if only_columns.present?
-            columns_hash = columns_hash.slice(*only_columns)
-          elsif ignored_columns.present?
-            columns_hash = columns_hash.except(*ignored_columns)
-          end
-          @columns_hash = columns_hash.freeze
-
-          _default_attributes # Precompute to cache DB-dependent attribute types
+          # Base implementation is a no-op. The adapter-specific schema loading
+          # (columns_hash, default_attributes) is handled by model_schema.load_schema!
+          # which is called directly from load_schema before this super chain.
+          #
+          # This method exists as the hook point for the super chain — overrides
+          # in CounterCache, EncryptableRecord, etc. call super and then do
+          # model-class-level setup that should only happen once.
         end
 
         # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/lib/active_record/model_schema/schema.rb
+++ b/activerecord/lib/active_record/model_schema/schema.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ModelSchema
+    # Encapsulates all schema-context-dependent state for a model.
+    # Each model class maintains a hash of Schema instances, keyed by schema context key.
+    #
+    # Schema context keys group connections sharing a schema shape - the same adapter,
+    # column types, SQL dialect, etc. Multiple pools (read replicas, shards) can share
+    # the same key, meaning they share cached schema information.
+    class Schema
+      attr_reader :model_class, :context_key
+
+      def initialize(model_class, context_key)
+        @model_class = model_class
+        @context_key = context_key
+        @schema_loaded = false
+
+        # Schema-context-dependent state
+        @columns_hash = nil
+        @columns = nil
+        @default_attributes = nil
+        @attribute_types = nil
+        @column_defaults = nil
+        @_returning_columns_for_insert = nil
+        @_returning_columns_for_update = nil
+        initialize_find_by_cache
+        @content_columns = nil
+        @symbol_column_to_string_name_hash = nil
+      end
+
+      # Returns the columns hash for this schema context
+      def columns_hash
+        model_class.load_schema unless @columns_hash
+        @columns_hash
+      end
+
+      # Returns array of column objects
+      def columns
+        @columns ||= columns_hash.values.freeze
+      end
+
+      # Returns array of column names as strings
+      def column_names
+        columns.map(&:name).freeze
+      end
+
+      # Returns the table name for this schema context
+      # For now, delegates to the model class
+      def table_name
+        model_class.table_name
+      end
+      # Returns the primary key column(s) for this schema context
+      # For now, delegates to the model class
+      # In a full implementation, this would be per-context
+      def primary_key
+        model_class.primary_key
+      end
+
+      # Returns the default attributes for this schema context
+      def _default_attributes
+        @default_attributes ||= begin
+          attributes_hash = columns_hash.transform_values do |column|
+            ActiveModel::Attribute.from_database(column.name, column.default, model_class.type_for_column(column))
+          end
+
+          attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
+          model_class.apply_pending_attribute_modifications(attribute_set)
+          attribute_set
+        end
+      end
+
+      # Returns the attributes builder for this schema context
+      def attributes_builder
+        defaults = _default_attributes.except(*(column_names - Array(primary_key)))
+        ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
+      end
+
+      # Returns column defaults hash
+      def column_defaults
+        model_class.load_schema
+        @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
+      end
+
+      # Returns columns for insert returning
+      def _returning_columns_for_insert(connection)
+        @_returning_columns_for_insert ||= begin
+          auto_populated_columns = columns.filter_map do |c|
+            c.name if connection.return_value_after_insert?(c)
+          end
+
+          auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns
+        end
+      end
+
+      def _returning_columns_for_update(connection)
+        @_returning_columns_for_update ||= columns.filter_map do |c|
+          c.name if connection.return_value_after_update?(c)
+        end
+      end
+
+      # Returns attribute types hash
+      def attribute_types
+        @attribute_types ||= _default_attributes.cast_types.tap do |hash|
+          hash.default = ActiveModel::Type.default_value
+        end
+      end
+
+      # Returns content columns (non-meta columns)
+      def content_columns
+        @content_columns ||= columns.reject do |c|
+          Array(primary_key).include?(c.name) ||
+          c.name == model_class.inheritance_column ||
+          c.name.end_with?("_id", "_count")
+        end.freeze
+      end
+
+      # Symbol to string column name mapping
+      def symbol_column_to_string(name_symbol)
+        @symbol_column_to_string_name_hash ||= column_names.index_by(&:to_sym)
+        @symbol_column_to_string_name_hash[name_symbol]
+      end
+
+      # Reset all cached schema state
+      def reload_schema_from_cache
+        @_returning_columns_for_insert = nil
+        @_returning_columns_for_update = nil
+        @symbol_column_to_string_name_hash = nil
+        @content_columns = nil
+        @column_defaults = nil
+        @columns = nil
+        @columns_hash = nil
+        @schema_loaded = false
+        @attribute_types = nil
+        @default_attributes = nil
+      end
+
+      def cached_find_by_statement(connection, key, &block)
+        cache = @find_by_statement_cache[connection.prepared_statements]
+        cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
+      end
+
+      def initialize_find_by_cache
+        @find_by_statement_cache = { true => Concurrent::Map.new, false => Concurrent::Map.new }
+      end
+
+      # Populate this schema context's columns and default attributes
+      # from the schema cache. Called by the model class's load_schema!.
+      def load_schema!
+        return if @schema_loaded
+
+        unless table_name
+          raise ActiveRecord::TableNotSpecified, "#{model_class} has no table configured. Set one with #{model_class}.table_name="
+        end
+
+        columns_hash = model_class.connection_pool.schema_cache.columns_hash(table_name)
+        if model_class.only_columns.present?
+          columns_hash = columns_hash.slice(*model_class.only_columns)
+        elsif model_class.ignored_columns.present?
+          columns_hash = columns_hash.except(*model_class.ignored_columns)
+        end
+        @columns_hash = columns_hash.freeze
+
+        # Precompute default attributes to cache DB-dependent attribute types
+        _default_attributes
+
+        @schema_loaded = true
+      end
+
+      def schema_loaded?
+        @schema_loaded
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -243,7 +243,7 @@ class CoreTest < ActiveRecord::TestCase
   def test_find_by_cache_does_not_duplicate_entries
     Topic.initialize_find_by_cache
     using_prepared_statements = Topic.lease_connection.prepared_statements
-    topic_find_by_cache = Topic.instance_variable_get("@find_by_statement_cache")[using_prepared_statements]
+    topic_find_by_cache = Topic.model_schema.instance_variable_get("@find_by_statement_cache")[using_prepared_statements]
 
     assert_difference -> { topic_find_by_cache.size }, +1 do
       Topic.find(1)

--- a/activerecord/test/cases/schema_context_test.rb
+++ b/activerecord/test/cases/schema_context_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class SchemaContextTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def teardown
+    # Clean up the connection handler to remove shards
+    clean_up_connection_handler
+
+    # Ensure we're back on the default connection
+    ActiveRecord::Base.establish_connection(:arunit)
+
+    # Drop our test table
+    ActiveRecord::Base.lease_connection.drop_table :schema_test_items, if_exists: true
+  end
+
+  def test_serialize_works_independently_per_schema_context
+    # Create an abstract model class for multi-shard configuration
+    # This isolates our test from ActiveRecord::Base
+    abstract_model = Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+
+      def self.name
+        "SchemaContextTestBase"
+      end
+    end
+
+    # Configure the abstract model with multiple shards, each with different schema contexts
+    # Force both adapters to use prepared_statements: false so they share the same cache bucket
+    arunit_config = ActiveRecord::Base.connection_db_config.configuration_hash.merge(
+      schema_context: "context_a",
+      prepared_statements: false
+    )
+
+    abstract_model.connects_to shards: {
+      default: { writing: arunit_config },
+      shard_b: { writing: { adapter: "sqlite3", database: ":memory:", schema_context: "context_b", prepared_statements: false } }
+    }
+
+    # Create schema_test_items table in default shard
+    abstract_model.connected_to(shard: :default) do
+      abstract_model.lease_connection.create_table :schema_test_items, force: true do |t|
+        t.string :name
+        t.text :metadata
+        t.timestamps
+      end
+    end
+
+    # Create schema_test_items table in shard_b
+    abstract_model.connected_to(shard: :shard_b) do
+      abstract_model.lease_connection.create_table :schema_test_items, force: true do |t|
+        t.string :name
+        t.text :metadata
+        t.timestamps
+      end
+    end
+
+    # Create a model class that inherits from the abstract model
+    test_model = Class.new(abstract_model) do
+      self.table_name = "schema_test_items"
+
+      serialize :metadata, coder: JSON
+
+      def self.name
+        "SchemaTestItem"
+      end
+    end
+
+    abstract_model.connected_to(shard: :default) do
+      record_a = test_model.create!(name: "Item A", metadata: { foo: "bar" })
+      assert_equal({ "foo" => "bar" }, record_a.reload.metadata)
+    end
+
+    abstract_model.connected_to(shard: :shard_b) do
+      record_b = test_model.create!(name: "Item B", metadata: { foo: "baz" })
+      assert_equal({ "foo" => "baz" }, record_b.reload.metadata)
+    end
+
+    # Do the SQLite find_by FIRST to cache its double-quoted SQL
+    abstract_model.connected_to(shard: :shard_b) do
+      record_b = test_model.find_by(name: "Item B")
+      record_b.metadata = { new: "data" }
+      record_b.save!
+      assert_equal({ "new" => "data" }, record_b.reload.metadata)
+    end
+
+    # Now try MySQL which will reuse the SQLite-quoted statement and fail
+    # because MySQL doesn't accept double-quoted identifiers
+    abstract_model.connected_to(shard: :default) do
+      record_a = test_model.find_by(name: "Item A")
+      record_a.metadata = { new: "data" }
+      record_a.save!
+      assert_equal({ "new" => "data" }, record_a.reload.metadata)
+    end
+  ensure
+    # Remove the connection handler for our abstract model
+    ActiveRecord::Base.connection_handler.instance_variable_get(:@connection_name_to_pool_manager).delete("SchemaContextTestBase")
+  end
+end


### PR DESCRIPTION
Previously, models cached many adapter specific values which would prevent making queries against different database types. Now, those caches are per `schema_context`, which can be configured in `database.yml`:

```yaml
primary:
  adapter: trilogy
  database: myapp_development
primary_pg:
  adapter: postgresql
  database: myapp_development
  schema_context: pg
```

This enables models to connect to both MySQL and PostgreSQL databases in the same application, and query them successfully:

```ruby
class User < ApplicationRecord
  connects_to shards: {
    mysql: { writing: :primary, reading: :primary },
    pg: { writing: :primary_pg, reading: :primary_pg },
  }
end

User.connected_to(shard: :mysql) { User.first } # queries MySQL
User.connected_to(shard: :pg) { User.first } # queries PostgreSQL
```