### PR TITLE
Correct action_dispatch.rescue_responses defaults in the v8.0 guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2074,8 +2074,8 @@ Use `ActionDispatch::ExceptionWrapper.rescue_responses` to observe the configura
   "ActionController::UnknownFormat" => :not_acceptable,
   "ActionDispatch::Http::MimeNegotiation::InvalidType" => :not_acceptable,
   "ActionController::MissingExactTemplate" => :not_acceptable,
-  "ActionController::InvalidAuthenticityToken" => :unprocessable_entity,
-  "ActionController::InvalidCrossOriginRequest" => :unprocessable_entity,
+  "ActionController::InvalidAuthenticityToken" => ActionDispatch::Constants::UNPROCESSABLE_CONTENT,
+  "ActionController::InvalidCrossOriginRequest" => ActionDispatch::Constants::UNPROCESSABLE_CONTENT,
   "ActionDispatch::Http::Parameters::ParseError" => :bad_request,
   "ActionController::BadRequest" => :bad_request,
   "ActionController::ParameterMissing" => :bad_request,
@@ -2083,10 +2083,13 @@ Use `ActionDispatch::ExceptionWrapper.rescue_responses` to observe the configura
   "Rack::QueryParser::InvalidParameterError" => :bad_request,
   "ActiveRecord::RecordNotFound" => :not_found,
   "ActiveRecord::StaleObjectError" => :conflict,
-  "ActiveRecord::RecordInvalid" => :unprocessable_entity,
-  "ActiveRecord::RecordNotSaved" => :unprocessable_entity
+  "ActiveRecord::RecordInvalid" => ActionDispatch::Constants::UNPROCESSABLE_CONTENT,
+  "ActiveRecord::RecordNotSaved" => ActionDispatch::Constants::UNPROCESSABLE_CONTENT
 }
 ```
+
+`ActionDispatch::Constants::UNPROCESSABLE_CONTENT` resolves to
+`:unprocessable_entity` on Rack < 3.1 and `:unprocessable_content` on Rack >= 3.1.
 
 Any exceptions that are not configured will be mapped to 500 Internal Server Error.
 


### PR DESCRIPTION
Fixes #57078.

The issue report references the v8.0 guide and Rails 8.0.4.1, so this targets `8-0-stable` instead of `main`.

This updates the guide example to match the 8.0 source of truth by using `ActionDispatch::Constants::UNPROCESSABLE_CONTENT` for the mappings whose concrete symbol depends on the Rack version, and adds a short note explaining how that constant resolves on Rack < 3.1 versus Rack >= 3.1.

Verification:
- compared the guide snippet against `actionpack/lib/action_dispatch/constants.rb`
- compared the guide snippet against `actionpack/lib/action_dispatch/middleware/exception_wrapper.rb`
- compared the Active Record additions against `activerecord/lib/active_record/railtie.rb`
- ran `git diff --check`