### PR TITLE
railties: clarify production static file cache comment

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -17,7 +17,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
   <%- end -%>
 
-  # Cache assets for far-future expiry since they are all digest stamped.
+  # Cache static files served from /public, including assets under /public/assets.
+  # Be sure to use digest-stamped filenames for long-lived caching.
   config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -96,6 +96,8 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/environments/production.rb" do |content|
       assert_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
       assert_match(/config\.active_storage/, content)
+      assert_match(/# Cache static files served from \/public, including assets under \/public\/assets\./, content)
+      assert_match(/# Be sure to use digest-stamped filenames for long-lived caching\./, content)
     end
 
     assert_load_defaults


### PR DESCRIPTION
This updates the generated `config/environments/production.rb` comment for `config.public_file_server.headers`.

## Problem

The current comment says:

> Cache assets for far-future expiry since they are all digest stamped.

But `public_file_server.headers` applies to all static files served from `/public`, not only digest-stamped assets. This can be misleading for apps that also keep non-digest files in `/public`.

## Change

In the production environment template, replace the comment with:

- `Cache static files served from /public, including assets under /public/assets.`
- `Be sure to use digest-stamped filenames for long-lived caching.`

This keeps the behavior unchanged and clarifies the scope + caching expectation.

## Tests

Updated generator assertion in `railties/test/generators/shared_generator_tests.rb` to verify both new comment lines are present in generated `production.rb`.

## Verification

### Environment
- Docker image: `ruby:3.3`

### Command

```bash
docker run --rm -v "$PWD":/rails -w /rails ruby:3.3 bash -lc \
  'bundle config set without "db job cable storage ujs" >/dev/null 2>&1 || true; \
   bundle install -j4 >/tmp/bundle.log && \
   bundle exec ruby -Irailties/test -Itest railties/test/generators/app_generator_test.rb -n test_codebase_is_created'
```

### Result

- `1 runs, 119 assertions, 0 failures, 0 errors, 0 skips`
- Confirmed generated `config/environments/production.rb` includes the updated explanatory comment lines.

Closes #57019.
