### PR TITLE
railties: fix misleading production cache store comment

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -58,8 +58,8 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :mem_cache_store
+  # Replace the default file-based cache store with a more robust alternative.
+  # config.cache_store = :redis_cache_store, { url: ENV["REDIS_CACHE_URL"] }
 
   <%- unless options[:skip_active_job] -%>
   # Replace the default in-process and non-durable queuing backend for Active Job.


### PR DESCRIPTION
## Summary
Fixes a misleading comment in the generated `config/environments/production.rb` template.

The comment currently says the default cache store is an in-process memory store, but Rails defaults to a file-based cache store (`:file_store`) in `Rails::Application::Configuration`.

Closes #56089.

## Verification
### Before
- `railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt` comment said:
  - "Replace the default in-process memory cache store with a durable alternative."
- `railties/lib/rails/application/configuration.rb` default is:
  - `@cache_store = [ :file_store, "#{root}/tmp/cache/" ]`

### After
- Template comment now says:
  - "Replace the default file-based cache store with a more robust alternative."
- This now matches the actual default cache store configuration.

### Manual evidence (terminal)
- Verified with:
  - `grep -n "default file-based cache store" railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt`
  - `grep -n "@cache_store" railties/lib/rails/application/configuration.rb`
