### PR TITLE
Avoid renaming database_tasks: false configs for parallel tests

### DIFF
--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -20,10 +20,11 @@ module ActiveRecord
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 
       ActiveRecord::Base.configurations.configs_for(env_name: env_name, include_hidden: true).each do |db_config|
-        db_config._database = "#{db_config.database}_#{i}"
-
         if db_config.database_tasks?
+          db_config._database = "#{db_config.database}_#{i}"
           ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, nil)
+        elsif db_config.replica?
+          db_config._database = "#{db_config.database}_#{i}"
         end
       end
     ensure

--- a/activerecord/test/cases/test_databases_test.rb
+++ b/activerecord/test/cases/test_databases_test.rb
@@ -131,5 +131,37 @@ class TestDatabasesTest < ActiveRecord::TestCase
       ActiveRecord::Base.establish_connection(:arunit)
       ENV["RAILS_ENV"] = previous_env
     end
+
+    def test_create_databases_after_fork_skips_configs_with_database_tasks_false
+      previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit"
+      prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {
+        "arunit" => {
+          "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+          "external" => { "adapter" => "sqlite3", "database" => "test/db/external.sqlite3", "database_tasks" => false }
+        }
+      }
+
+      idx = 42
+      primary_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      expected_primary_database = "#{primary_db_config.database}_#{idx}"
+      external_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "external", include_hidden: true)
+      expected_external_database = external_db_config.database
+      reconstruct_calls = 0
+
+      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _) {
+        reconstruct_calls += 1
+        assert_equal expected_primary_database, db_config.database
+      }) do
+        ActiveSupport::Testing::Parallelization.after_fork_hooks.each { |cb| cb.call(idx) }
+      end
+
+      assert_equal 1, reconstruct_calls
+      assert_equal expected_primary_database, ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").database
+      assert_equal expected_external_database, ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "external", include_hidden: true).database
+    ensure
+      ActiveRecord::Base.configurations = prev_configs
+      ActiveRecord::Base.establish_connection(:arunit)
+      ENV["RAILS_ENV"] = previous_env
+    end
   end
 end


### PR DESCRIPTION
Fixes #57068.

This keeps `ActiveRecord::TestDatabases.create_and_load_schema` from suffixing configs that explicitly set `database_tasks: false`, while preserving the hidden-replica renaming behavior added by #55769.

A plain `database_tasks?` guard is too broad here because replicas return false from `database_tasks?` but still need the worker suffix. This patch only skips configs with an explicit `database_tasks: false` setting, and adds a regression test for that case.

### Tests
- `cd activerecord && ARCONN=sqlite3 bin/test test/cases/test_databases_test.rb`
- `cd activerecord && ARCONN=sqlite3 bin/test test/cases/database_configurations/hash_config_test.rb -i /database_tasks/`