### PR TITLE
Use Hash#each_key instead of Hash#keys.each

### DIFF
--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -57,7 +57,7 @@ module ActiveModel
       def has_delegated_json(attr, **schema)
         has_json attr, **schema
 
-        schema.keys.each do |schema_key|
+        schema.each_key do |schema_key|
           define_method(schema_key)       { public_send(attr).public_send(schema_key) }
           define_method("#{schema_key}?") { public_send(attr).public_send("#{schema_key}?") }
           define_method("#{schema_key}=") { |value| send(attr).public_send("#{schema_key}=", value) }

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -247,7 +247,7 @@ module ActiveRecord
           assert_instance_of String, db_config.env_name
           assert_instance_of String, db_config.name
 
-          db_config.configuration_hash.keys.each do |key|
+          db_config.configuration_hash.each_key do |key|
             assert_instance_of Symbol, key
           end
         end

--- a/activesupport/test/env_configuration_test.rb
+++ b/activesupport/test/env_configuration_test.rb
@@ -94,7 +94,7 @@ class EnvConfigurationTest < ActiveSupport::TestCase
       @config.reload
       yield
     ensure
-      attributes.keys.each do |key|
+      attributes.each_key do |key|
         ENV.delete(key)
       end
     end


### PR DESCRIPTION
### Motivation / Background

  `Hash#keys.each` allocates an intermediate array of all keys before iterating. `Hash#each_key` iterates directly over the
   hash's internal structure without the extra allocation.

  This follows the same cleanup done in #17099 

  ### Detail

  Replace `keys.each` with `each_key` in two locations where the hash is not mutated during iteration:

  - `activemodel/lib/active_model/schematized_json.rb`
  - `activerecord/lib/active_record/attribute_methods/dirty.rb`

  The remaining 3 `keys.each` calls in the codebase (`hash/keys.rb`, `strong_parameters.rb`, `routing/mapper.rb`) use
  `delete` inside the loop, so they need `keys` to snapshot before mutating.

  ### Additional information

  N/A

  ### Checklist

  - [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
  - [x] Commit message has a detailed description of what changed and why.
  - [ ] Tests are added or updated if you fix a bug or add a feature.
  - [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor
  bug fixes and documentation changes should not be included.