### PR TITLE
Fix belongs_to validation condition for composite foreign keys

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -140,8 +140,14 @@ module ActiveRecord::Associations::Builder # :nodoc:
             foreign_key = reflection.foreign_key
             foreign_type = reflection.foreign_type
 
-            record.read_attribute(foreign_key).nil? ||
-              record.attribute_changed?(foreign_key) ||
+            fk_missing_or_changed = if foreign_key.is_a?(Array)
+              foreign_key.any? { |fk| record.read_attribute(fk).nil? || record.attribute_changed?(fk) }
+            else
+              record.read_attribute(foreign_key).nil? ||
+                record.attribute_changed?(foreign_key)
+            end
+
+            fk_missing_or_changed ||
               (reflection.polymorphic? && (record.read_attribute(foreign_type).nil? || record.attribute_changed?(foreign_type)))
           }
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1820,6 +1820,32 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  test "skips parent presence check for composite foreign key if parent has not changed" do
+    order = Cpk::Order.create!(id: [1, 2])
+    book = Cpk::BookWithRequiredOrder.create!(id: [3, 4], order: order, title: "Book")
+    book.reload
+
+    assert_no_queries do
+      assert book.valid?
+    end
+  end
+
+  test "validates composite foreign key belongs_to when foreign key column is nil" do
+    book = Cpk::BookWithRequiredOrder.new(id: [1, 1], shop_id: nil, order_id: nil, title: "Book")
+    assert_not book.valid?
+    assert_includes book.errors.full_messages, "Order must exist"
+  end
+
+  test "validates composite foreign key belongs_to when foreign key column changes" do
+    order = Cpk::Order.create!(id: [1, 2])
+    book = Cpk::BookWithRequiredOrder.create!(id: [3, 4], order: order, title: "Book")
+    book.reload
+
+    book.order_id = 999999
+    assert_not book.valid?
+    assert_includes book.errors.full_messages, "Order must exist"
+  end
+
   test "runs parent presence check if parent has not changed and belongs_to_required_validates_foreign_key is set" do
     original_value = ActiveRecord.belongs_to_required_validates_foreign_key
     ActiveRecord.belongs_to_required_validates_foreign_key = true

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -47,4 +47,9 @@ module Cpk
     has_many :order_agreements, through: :order
     has_one :order_agreement, through: :order, source: :order_agreements
   end
+
+  class BookWithRequiredOrder < ActiveRecord::Base
+    self.table_name = :cpk_books
+    belongs_to :order, class_name: "Cpk::Order", foreign_key: [:shop_id, :order_id], primary_key: [:shop_id, :id], optional: false
+  end
 end


### PR DESCRIPTION
### Motivation / Background

When `belongs_to_required_validates_foreign_key` is `false` (the default since `load_defaults(7.1)`), Rails installs a conditional presence validator on required `belongs_to` associations. The condition lambda decides whether to actually run the validation by checking if the foreign key is `nil` or has changed:

```ruby
condition = lambda { |record|
  foreign_key = reflection.foreign_key

  record.read_attribute(foreign_key).nil? ||
    record.attribute_changed?(foreign_key) ||
    ...
}
```

This optimization avoids loading the parent record when the foreign key is present and hasn't changed. It works correctly for scalar foreign keys, but is broken for composite foreign keys.

`read_attribute` calls `.to_s` on its argument. When `foreign_key` is an array like `[:shop_id, :order_id]`, `.to_s` produces the string `'["shop_id", "order_id"]'`, which doesn't match any attribute so it always returns `nil`. This means the condition always evaluates to `true`, and the validation always fires, defeating the optimization entirely.

In practice, this causes the parent record to always be loaded through the default scope during validation. For models using soft-delete via `default_scope` (e.g. `where(is_not_deleted: true)`), a soft-deleted child record pointing to a soft-deleted parent will always fail validation, even though no foreign key columns have changed, because the parent can't be found through the default scope.

### Detail

This Pull Request fixes the condition lambda in `define_validations` to handle composite (array) foreign keys by checking each column individually, matching the existing behavior for scalar foreign keys.

With the fix:
- If all FK columns are present and none have changed → validation is skipped (same as scalar)
- If any FK column is `nil` → validation runs
- If any FK column has changed → validation runs

### Additional information

Self-contained reproduction script:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "activerecord", "~> 8.0"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord.belongs_to_required_validates_foreign_key = false

ActiveRecord::Schema.define do
  create_table :parents, force: true do |t|
    t.integer :shop_id, null: false
    t.boolean :is_not_deleted, default: true
  end
  create_table :children, force: true do |t|
    t.integer :shop_id, null: false
    t.integer :parent_id, null: false
  end
end

class Parent < ActiveRecord::Base
  default_scope { where(is_not_deleted: true) }
end

class ChildComposite < ActiveRecord::Base
  self.table_name = "children"
  belongs_to :parent,
    foreign_key: [:shop_id, :parent_id],
    primary_key: [:shop_id, :id],
    required: true
end

class BugTest < Minitest::Test
  def test_composite_fk_skips_validation_when_unchanged
    parent = Parent.create!(shop_id: 1)
    child = ChildComposite.create!(shop_id: 1, parent_id: parent.id)

    Parent.where(id: parent.id).update_all(is_not_deleted: false)
    record = ChildComposite.find(child.id)

    # Fails before fix: "Parent must exist"
    # Passes after fix: validation skipped because FK is present and unchanged
    assert record.valid?, "Expected valid but got: #{record.errors.full_messages}"
  end
end
```

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
