### PR TITLE
Fix #50258: avoid duplicate has_many inversing records during eager loading

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -283,13 +283,17 @@ module ActiveRecord
           unless model = model_cache[node][id]
             model = node.instantiate(row, aliases.column_aliases(node)) do |m|
               m.strict_loading! if strict_loading_value
-              other.set_inverse_instance(m)
+              other.set_inverse_instance_from_queries(m)
             end
             model_cache[node][id] = model if id
           end
 
           if node.reflection.collection?
-            other.target.push(model)
+            if node.reflection.klass.has_many_inversing
+              other.target = model
+            else
+              other.target.push(model)
+            end
           else
             other.target = model
           end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -190,7 +190,7 @@ module ActiveRecord
             # Processing only the first owner
             # because the record is modified but not an owner
             association = owners.first.association(reflection.name)
-            association.set_inverse_instance(record)
+            association.set_inverse_instance_from_queries(record)
           end
         end
 
@@ -228,7 +228,7 @@ module ActiveRecord
               association.target = record
 
               if i == 0 # Set inverse on first owner
-                association.set_inverse_instance(record)
+                association.set_inverse_instance_from_queries(record)
               end
             end
           end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -845,6 +845,18 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
+  def test_with_has_many_inversing_does_not_add_duplicate_records_when_same_model_is_eager_loaded_twice
+    with_has_many_inversing(Interest) do
+      interest = interests(:trainspotting)
+      loaded_interest = Interest.includes(human: :interests).find(interest.id)
+
+      loaded_interests = loaded_interest.human.interests
+      loaded_ids = loaded_interests.map(&:id)
+
+      assert_equal loaded_ids.uniq, loaded_ids
+    end
+  end
+
   def test_recursive_model_has_many_inversing
     with_has_many_inversing do
       main = Branch.create!


### PR DESCRIPTION
Fixes #50258

When eager loading associations where the same model appears in multiple paths (e.g. `User.eager_load(group: :users)`), `has_many_inversing` can end up with duplicate entries in the collection target.

This change keeps inverse assignment in query-loading paths conservative and routes collection assignment through dedupe-aware logic when `has_many_inversing` is enabled.

## What changed

- `activerecord/lib/active_record/associations/join_dependency.rb`
  - use `set_inverse_instance_from_queries` in eager-load instantiation path
  - for collection reflections with `has_many_inversing`, assign through `target=` instead of direct `push`
- `activerecord/lib/active_record/associations/preloader/association.rb`
  - use `set_inverse_instance_from_queries` in preload inverse assignment paths
- `activerecord/test/cases/associations/inverse_associations_test.rb`
  - add regression test:
    - `test_with_has_many_inversing_does_not_add_duplicate_records_when_same_model_is_eager_loaded_twice`

## Verification

Manual before/after reproduction using a minimal script in Docker (`ruby:3.3`):

- **Before (origin/main): FAIL** with duplicate users (`["John", "John", "Jane"]`)
- **After (this branch): PASS** (`0 failures`)

Evidence (bug-relevant output only):
- Before: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/rails/issue-50258/2026-04-03/before.png
- After: https://raw.githubusercontent.com/wwenrr/pr-evidence-images/main/rails/issue-50258/2026-04-03/after.png

## Thinking path

I considered limiting the fix only to `join_dependency`, but both eager-load join construction and preloader inverse assignment can set inverses during query materialization. To keep behavior consistent and reduce accidental inverse pollution, I used the existing query-safe API (`set_inverse_instance_from_queries`) in both paths, and for `has_many_inversing` collections I avoided direct array push in favor of association target assignment that already handles dedupe semantics.
