### PR TITLE
Fix docs of Rails.{error,event}

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -82,8 +82,8 @@ module Rails
       @_env = ActiveSupport::EnvironmentInquirer.new(environment)
     end
 
-    # Returns the ActiveSupport::ErrorReporter of the current \Rails project,
-    # otherwise it returns +nil+ if there is no project.
+    # Returns the ActiveSupport::ErrorReporter instance used for reporting
+    # errors.
     #
     #   Rails.error.handle(IOError) do
     #     # ...
@@ -93,8 +93,8 @@ module Rails
       ActiveSupport.error_reporter
     end
 
-    # Returns the ActiveSupport::EventReporter of the current \Rails project,
-    # otherwise it returns +nil+ if there is no project.
+    # Returns the ActiveSupport::EventReporter instance used for broadcasting
+    # structured events.
     #
     #   Rails.event.notify("my_event", { message: "Hello, world!" })
     def event


### PR DESCRIPTION
The docs for `Rails.error` say:

> Returns the ActiveSupport::ErrorReporter of the current Rails project, otherwise it returns +nil+ if there is no project.

Similar for `Rails.event`.

However, those are just proxies to`ActiveSupport.{error,event}_reporter`, which are [unconditionally initialized](https://github.com/rails/rails/blob/af37013f126c529d3ee27ede1fcb13d8c42e2d88/activesupport/lib/active_support.rb):

```ruby
@error_reporter = ActiveSupport::ErrorReporter.new
singleton_class.attr_accessor :error_reporter # :nodoc:

@event_reporter = ActiveSupport::EventReporter.new
singleton_class.attr_accessor :event_reporter # :nodoc:
```

Therefore, these `Rails` methods do not depend on whether "there is no project", whatever that means. See, there is no project in this one-liner and we do not get `nil`:

```
~ % ruby -rrails -e 'pp Rails.event'
#<ActiveSupport::EventReporter:0x000000012a4a4018 @debug_mode=false, @raise_on_error=false, @subscribers=[]>
```

Furthermore, the accessors are not even public interface (they are nodoc'ed), so users are not even expected to be able to override these objects.

Let's update these docs.