### PR TITLE
Accept callables as structured event subscribers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Accept callables as structured event subscribers.
+
+    Up to now, structured event subscribers had to respond to `emit`. Now, they
+    can also respond to the more neutral `call`, and in particular you can
+    subscribe lambdas.
+
+    If the subscriber responds both to `emit` and `call`, the former is called,
+    for backwards compatibility.
+
+    *Xavier Noria*
+
 *   Add `prepend: true` option to `ActiveSupport::Notifications.subscribe`.
 
       When `prepend: true` is passed, the subscriber is added to the front of

--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -120,7 +120,9 @@ module ActiveSupport
   #
   # === Subscribers
   #
-  # Subscribers must implement the +emit+ method, which will be called with the event hash.
+  # Subscribers are expected to respond to +call+, which will be called with the
+  # event hash. Alternatively, subscribers may also respond to +emit+. If both
+  # methods are present, +emit+ will be used for compatibility reasons.
   #
   # The event hash has the following keys:
   #
@@ -131,46 +133,14 @@ module ActiveSupport
   #   timestamp: Float (The timestamp of the event, in nanoseconds)
   #   source_location: Hash (The source location of the event, containing the filepath, lineno, and label)
   #
-  # Subscribers are responsible for encoding events to their desired format before emitting them to their
-  # target destination, such as a streaming platform, a log device, or an alerting service.
-  #
-  #   class JSONEventSubscriber
-  #     def emit(event)
-  #       json_data = JSON.generate(event)
-  #       LogExporter.export(json_data)
-  #     end
-  #   end
+  # Example:
   #
   #   class LogSubscriber
-  #     def emit(event)
+  #     def call(event)
   #       payload = event[:payload].map { |key, value| "#{key}=#{value}" }.join(" ")
   #       source_location = event[:source_location]
   #       log = "[#{event[:name]}] #{payload} at #{source_location[:filepath]}:#{source_location[:lineno]}"
   #       Rails.logger.info(log)
-  #     end
-  #   end
-  #
-  # Note that event objects are passed through to subscribers as-is, and may need to be serialized before being encoded:
-  #
-  #   class UserCreatedEvent
-  #     def initialize(id:, name:)
-  #       @id = id
-  #       @name = name
-  #     end
-  #
-  #     def serialize
-  #       {
-  #         id: @id,
-  #         name: @name
-  #       }
-  #     end
-  #   end
-  #
-  #   class LogSubscriber
-  #     def emit(event)
-  #       payload = event[:payload]
-  #       json_data = JSON.generate(payload.serialize)
-  #       LogExporter.export(json_data)
   #     end
   #   end
   #
@@ -298,7 +268,15 @@ module ActiveSupport
 
     # Registers a new event subscriber. The subscriber must respond to
     #
-    #   emit(event: Hash)
+    #   call(event)
+    #
+    # or
+    #
+    #   emit(event)
+    #
+    # where the argument is a hash, as documented above.
+    #
+    # If both methods are present, +emit+ is used for compatibility reasons.
     #
     # The event hash will have the following keys:
     #
@@ -315,8 +293,8 @@ module ActiveSupport
     #   Rails.event.subscribe(subscriber) { |event| event[:payload].is_a?(UserEvent) }
     #
     def subscribe(subscriber, &filter)
-      unless subscriber.respond_to?(:emit)
-        raise ArgumentError, "Event subscriber #{subscriber.class.name} must respond to #emit"
+      unless subscriber.respond_to?(:call) || subscriber.respond_to?(:emit)
+        raise ArgumentError, "Event subscriber #{subscriber.class.name} must respond to #call or #emit"
       end
       @subscribers << { subscriber: subscriber, filter: filter }
     end
@@ -403,7 +381,11 @@ module ActiveSupport
       end
 
       subscribers.each do |subscriber|
-        subscriber.emit(event)
+        if subscriber.respond_to?(:emit)
+          subscriber.emit(event)
+        else
+          subscriber.call(event)
+        end
       rescue => subscriber_error
         if raise_on_error?
           raise

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -52,6 +52,14 @@ module ActiveSupport
       end
     end
 
+    class DualMethodSubscriber
+      attr_reader :invoked
+
+      def initialize = @invoked = []
+      def call(_) = @invoked << __method__
+      def emit(_) = @invoked << __method__
+    end
+
     test "#subscribe" do
       reporter = ActiveSupport::EventReporter.new
       subscribers = reporter.subscribe(@subscriber)
@@ -67,14 +75,32 @@ module ActiveSupport
       assert_equal([{ subscriber: @subscriber, filter: filter }], subscribers)
     end
 
-    test "#subscribe raises ArgumentError when sink doesn't respond to emit" do
+    test "#subscribe raises ArgumentError when sink doesn't respond to emit or call" do
       invalid_subscriber = Object.new
 
       error = assert_raises(ArgumentError) do
         @reporter.subscribe(invalid_subscriber)
       end
 
-      assert_equal "Event subscriber Object must respond to #emit", error.message
+      assert_equal "Event subscriber Object must respond to #call or #emit", error.message
+    end
+
+    test "#subscribe accepts callables" do
+      events = []
+      @reporter.subscribe(->(event) { events << event })
+
+      @reporter.notify(:test_event, key: "value")
+
+      assert event_matcher(name: "test_event", payload: { key: "value" }).call(events.last)
+    end
+
+    test "#notify prefers emit over call when the subscriber implements both" do
+      subscriber = DualMethodSubscriber.new
+      @reporter.subscribe(subscriber)
+
+      @reporter.notify(:test_event)
+
+      assert_equal [:emit], subscriber.invoked
     end
 
     test "#unsubscribe" do


### PR DESCRIPTION
## Background

The events reporter was [originally](https://github.com/rails/rails/pull/56179#issuecomment-3633241964) extracted from a pub/sub system that collects stuff and forwards it to observability/analytics services.

However, what has been announced, the way things are worded, and what people are perceiving is that Rails has now an application-level message bus. Which makes sense, because that is what you  essentially have. I already noticed this in the hallway track in RailsConf Philadelphia. See also for example this [recent post](https://www.rorvswild.com/blog/2026/advanced-domain-modeling-global-message-bus-event-reporter) from [RoRvsWild](https://www.rorvswild.com/).

However, there are two things that in my view leak from the original use case:

1. Subscribers have to respond to `emit`.
2. There are examples warning that you get a hash and you should be transforming it to whatever your service expects.

Regarding (1), the event reporter _emits_, _broadcasts_, _publishes_ events. A subscriber _listens_, _receives_, _handles_ events. Subscribers do not need to _emit_ anything necessarily. For example, in tests they collect events in a stack.

Regarding (2) the docs of a pub/system should be more generic. People know what they get, the documented hash. Whether they have to transform that into something else to send to a service, or to escape for interpolation in SQL, ..., not something you have to underline in the pub/sub docs themselves, I think, that belongs to the docs of the other side, the analytics service API, or the ORM API. The pub/sub docs have to basically say: "This is your input, do whatever you want with it".

## Proposal

So, I propose to open the API to accept callables.

Why callables? I don't generally like `call`-based APIs, the name lacks intention generally for my taste. I was thinking about `handle`, for example. But I have experience configuring simple lambdas as subscribers in other pub/sub mechanisms when defining an actual class is unnecessary. So, my proposal is `call`.

## Additional remarks

This new system is designed for the use case in which all subscribers are interested in listening to all events, mostly, mod filters. There is no API to listen to just one type of event, and the reporter loops over all subscribers for all events. And that fits the original use case.

This is in contrast with a system where you subscribe to particular events or event patterns like AS notifications.

Indeed, I believe that there is a conflict with AS notifications that may be confusing from a framework perspective. We are providing systems that overlap. And perhaps that could be resolved that way: You use `Rails.event` when you broadcast something that potentially all subscribers are interested in. Otherwise, you use AS notifications.

In particular, in my view Active Record should not be emitting SQL statements. Too broad. Same with similar structured events that are forwarded by the Rails components from AS notifications unconditionally.

The existing ones are already in place, but at least I would personally resist adding new ones. It would the application responsibility to decide if they want to collect those AS notifications as structured events.