### PR TITLE
Reject trailing dash in PostgreSQL adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module PostgreSQL
       module OID # :nodoc:
         class Uuid < Type::Value # :nodoc:
-          ACCEPTABLE_UUID = %r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}
+          ACCEPTABLE_UUID = %r{\A(\{)?[a-fA-F0-9]{4}(-?[a-fA-F0-9]{4}){7}(?(1)\}|)\z}
           CANONICAL_UUID = %r{\A[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\z}
 
           alias :serialize :deserialize

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -158,7 +158,8 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
      "a0ee-bc99------4ef8-bb6d-6bb9-bd38-0a11",
      "{a0eebc99-bb6d6bb9-bd380a11}",
      "{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11",
-     "a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}"].each do |invalid_uuid|
+     "a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}",
+     "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11-"].each do |invalid_uuid|
       uuid = UUIDType.new guid: invalid_uuid
       assert_nil uuid.guid
     end


### PR DESCRIPTION
PostgreSQL accepts UUIDs as documented:
https://www.postgresql.org/docs/18/datatype-uuid.html

However, the current regex in the PostgreSQL adapter allows a UUID with a single trailing dash. As a result, the following code does not raise `ActiveRecord::NotFound` error as expected:

    User.find('a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11-') # trailing dash

Rails automatically removes the trailing dash, masking invalid UUIDs.

This patch updates the regex to reject UUIDs with a trailing dash, ensuring only properly formatted UUIDs are considered valid.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because there is a bug when we fetch an object by UUID with a trailing dash and Postgres.

ActiveRecord returns a object because it silently removes the dash, it shouldn't.

### Detail

This Pull Request changes the way the UUID format are checked.

### Additional information

#49934 may have introduced this behavior change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
