### PR TITLE
Add `ActiveSupport::Duration#in_quarters`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActiveSupport::Duration#in_quarters`
+
+    ```ruby
+    3.months.in_quarters # => 1.0
+    1.year.in_quarters # => 4.0
+    ```
+
+    *Sean Doyle*
+
 *   Add `#this_quarter?` to Date/Time.
 
     It returns true if the date/time falls within the current quarter.

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -110,12 +110,13 @@ module ActiveSupport
         end
     end
 
-    SECONDS_PER_MINUTE = 60
-    SECONDS_PER_HOUR   = 3600
-    SECONDS_PER_DAY    = 86400
-    SECONDS_PER_WEEK   = 604800
-    SECONDS_PER_MONTH  = 2629746  # 1/12 of a gregorian year
-    SECONDS_PER_YEAR   = 31556952 # length of a gregorian year (365.2425 days)
+    SECONDS_PER_MINUTE   = 60
+    SECONDS_PER_HOUR     = 3600
+    SECONDS_PER_DAY      = 86400
+    SECONDS_PER_WEEK     = 604800
+    SECONDS_PER_MONTH    = 2629746  # 1/12 of a gregorian year
+    SECONDS_PER_QUARTER  = 7889238  # 1/4 of a gregorian year
+    SECONDS_PER_YEAR     = 31556952 # length of a gregorian year (365.2425 days)
 
     PARTS_IN_SECONDS = {
       seconds: 1,
@@ -412,6 +413,14 @@ module ActiveSupport
     #   9.weeks.in_months # => 2.07
     def in_months
       value / SECONDS_PER_MONTH.to_f
+    end
+
+    # Returns the amount of quarters a duration covers as a float
+    #
+    #   3.months.in_quarters  # => 1.0
+    #   1.year.in_quarters    # => 4.0
+    def in_quarters
+      in_seconds / SECONDS_PER_QUARTER.to_f
     end
 
     # Returns the amount of years a duration covers as a float

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -76,6 +76,11 @@ class DurationTest < ActiveSupport::TestCase
     assert_in_delta 12.0, 1.year.in_months
   end
 
+  def test_in_quarters
+    assert_in_delta 1.0, 3.months.in_quarters
+    assert_in_delta 4.0, 1.year.in_quarters
+  end
+
   def test_in_years
     assert_in_delta 0.082, 30.days.in_years
     assert_in_delta 1.0, 365.days.in_years


### PR DESCRIPTION
### Motivation / Background

Extend `ActiveSupport::Duration` with quarter-wise arithmetic:

```ruby
3.months.in_quarters # => 1.0
1.year.in_quarters # => 4.0
```

[rails/rails#45009]: https://github.com/rails/rails/pull/45009

### Additional information

Related to [rails/rails#45009][]

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
