### PR TITLE
Skip image processing for identity format conversions in ActiveStorage

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -114,7 +114,7 @@ class ActiveStorage::Variant
   def process_from_io(io) # :nodoc:
     return if processed?
 
-    variation.transform(io) do |output|
+    variation.transform(io, content_type: blob.content_type) do |output|
       service.upload(key, output, content_type: content_type)
     end
   end
@@ -122,7 +122,7 @@ class ActiveStorage::Variant
   private
     def process
       blob.open do |input|
-        variation.transform(input) do |output|
+        variation.transform(input, content_type: blob.content_type) do |output|
           service.upload(key, output, content_type: content_type)
         end
       end

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -46,7 +46,7 @@ class ActiveStorage::VariantWithRecord
   def process_from_io(io) # :nodoc:
     return if processed?
 
-    variation.transform(io) do |output|
+    variation.transform(io, content_type: blob.content_type) do |output|
       create_or_find_record(image: {
         io: output,
         filename: "#{blob.filename.base}.#{variation.format.downcase}",
@@ -63,7 +63,7 @@ class ActiveStorage::VariantWithRecord
 
     def transform_blob
       blob.open do |input|
-        variation.transform(input) do |output|
+        variation.transform(input, content_type: blob.content_type) do |output|
           yield io: output, filename: "#{blob.filename.base}.#{variation.format.downcase}",
             content_type: variation.content_type, service_name: blob.service.name
         end

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -51,11 +51,21 @@ class ActiveStorage::Variation
     self.class.new transformations.reverse_merge(defaults)
   end
 
-  # Accepts a File object, performs the +transformations+ against it, and
-  # saves the transformed image into a temporary file.
-  def transform(file, &block)
-    ActiveSupport::Notifications.instrument("transform.active_storage") do
-      transformer.transform(file, format: format, &block)
+  # Accepts a File object and yields a transformed version of it. If the
+  # requested variation is an identity transformation for the supplied
+  # +content_type+, the original +file+ is yielded unchanged. Otherwise, the
+  # transformations are applied and the result is yielded as a temporary file.
+  #
+  # Callers should not assume that the yielded file is always a new temporary
+  # file, and should only clean it up if they own it.
+  def transform(file, content_type: nil, &block)
+    if content_type && identity_for?(content_type)
+      file.rewind if file.respond_to?(:rewind)
+      yield file
+    else
+      ActiveSupport::Notifications.instrument("transform.active_storage") do
+        transformer.transform(file, format: format, &block)
+      end
     end
   end
 
@@ -81,6 +91,11 @@ class ActiveStorage::Variation
   end
 
   private
+    def identity_for?(content_type)
+      transformations.except(:format).empty? &&
+        self.content_type == content_type
+    end
+
     def transformer
       ActiveStorage.variant_transformer.new(transformations.except(:format))
     end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -284,6 +284,38 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "variant with same format as blob skips processing" do
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    events = collect_transform_events do
+      variant = blob.variant(format: :jpeg).processed
+      assert_equal "image/jpeg", variant.content_type
+      assert_equal "racecar.jpeg", variant.filename.to_s
+    end
+
+    assert_empty events, "Expected no image transformation for identity format conversion, got: #{events.inspect}"
+  end
+
+  test "variant with different format from blob still processes" do
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    events = collect_transform_events do
+      blob.variant(format: :png).processed
+    end
+
+    assert_not_empty events, "Expected image transformation for format conversion"
+  end
+
+  test "variant with same format and other transformations still processes" do
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    events = collect_transform_events do
+      blob.variant(format: :jpeg, resize_to_limit: [100, 100]).processed
+    end
+
+    assert_not_empty events, "Expected image transformation when resize is requested"
+  end
+
   test "destroy deletes file from service" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant = blob.variant(resize_to_limit: [100, 100]).processed
@@ -294,6 +326,13 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   end
 
   private
+    def collect_transform_events(&block)
+      events = []
+      callback = ->(name, start, finish, id, payload) { events << { name: name, payload: payload } }
+      ActiveSupport::Notifications.subscribed(callback, "transform.active_storage", &block)
+      events
+    end
+
     def process_variants_with(processor)
       previous_transformer = ActiveStorage.variant_transformer
       ActiveStorage.variant_transformer =


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it has potential to save few cycles when variant transformation is not necessary.

### Detail

This Pull Request changes the behavior of #variant method. When asking for variant and only transformation that is requested is a format the same as original's format - the processing can be skipped (the variant blog is still downloaded, though)

### Additional information

For more aggresive optimization one can reach out to `#variant_or_self` method proposed in #57138 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* N/A CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
