### PR TITLE
Fix GET+JSON+params in integration tests for API-only apps

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add `query:` and `body:` kwargs to integration test request helpers.
+
+    `params:` was ambiguous for GET requests with `as: :json` — unclear
+    whether params should go in the query string or request body. This
+    caused failures in API-only apps which exclude `Rack::MethodOverride`.
+
+    Use `query:` to explicitly send params in the URL query string (any
+    HTTP method), and `body:` to send an encoded request body. They can
+    be combined.
+
+    `params:` retains existing behavior: GET → query string,
+    other methods → request body.
+
+        get  "/search", query: { q: "rails" }, as: :json
+        post "/search", query: { page: 1 }, body: { filters: {} }, as: :json
+
+    Fixes #57131.
+
+    *Denis Savchuk*
+
 *   Add `ActionDispatch::Request#safe_method?` and `#unsafe_method?`.
 
     `safe_method?` returns true for HTTP methods that are defined as safe per

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -198,6 +198,9 @@ module ActionDispatch
       # *   `params`: The HTTP parameters that you want to pass. This may be `nil`, a
       #     Hash, or a String that is appropriately encoded
       #     (`application/x-www-form-urlencoded` or `multipart/form-data`).
+      #     For GET requests, params are sent as query string. For other methods,
+      #     params are sent as the request body. Use `query:` or `body:` for
+      #     explicit control.
       # *   `headers`: Additional headers to pass, as a Hash. The headers will be
       #     merged into the Rack env hash.
       # *   `env`: Additional env to pass, as a Hash. The headers will be merged into
@@ -208,6 +211,10 @@ module ActionDispatch
       # *   `as`: Used for encoding the request with different content type. Supports
       #     `:json` by default and will set the appropriate request headers. The
       #     headers will be merged into the Rack env hash.
+      # *   `query`: Parameters to always send as URL query string, regardless of
+      #     HTTP method. Accepts a Hash or pre-encoded String.
+      # *   `body`: Parameters to always send as the request body, encoded per `as:`.
+      #     Can be combined with `query:` to send both query string and body params.
       #
       #
       # This method is rarely used directly. Use RequestHelpers#get,
@@ -223,13 +230,15 @@ module ActionDispatch
       # Example:
       #
       #     process :get, '/author', params: { since: 201501011400 }
-      def process(method, path, params: nil, headers: nil, env: nil, xhr: false, as: nil)
+      #     process :get, '/author', query: { since: 201501011400 }, as: :json
+      #     process :post, '/search', query: { page: 1 }, body: { q: "rails" }, as: :json
+      def process(method, path, params: nil, headers: nil, env: nil, xhr: false, as: nil, query: nil, body: nil)
         request_encoder = RequestEncoder.encoder(as)
         headers ||= {}
 
-        if method == :get && as == :json && params
-          headers["X-Http-Method-Override"] = "GET"
-          method = :post
+        if query
+          query_string = query.is_a?(String) ? query : Rack::Utils.build_nested_query(query)
+          path = path.include?("?") ? "#{path}&#{query_string}" : "#{path}?#{query_string}"
         end
 
         if path.include?("://")
@@ -246,9 +255,12 @@ module ActionDispatch
 
         hostname, port = host.split(":")
 
+        body_params = body || (method != :get ? params : nil)
+        query_params = body ? nil : (method == :get ? params : nil)
+
         request_env = {
           :method => method,
-          :params => request_encoder.encode_params(params),
+          :params => body_params ? request_encoder.encode_params(body_params) : query_params,
 
           "SERVER_NAME"     => hostname,
           "SERVER_PORT"     => port || (https? ? "443" : "80"),
@@ -261,7 +273,7 @@ module ActionDispatch
           "HTTP_ACCEPT"    => request_encoder.accept_header || accept
         }
 
-        if request_encoder.content_type
+        if body_params && request_encoder.content_type
           request_env["CONTENT_TYPE"] = request_encoder.content_type
         end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1244,7 +1244,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_get_request_with_json_uses_method_override_and_sends_a_post_request
+  def test_get_with_json_and_params_sends_as_query_string
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
@@ -1254,8 +1254,8 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
 
       get "/foos_json", params: { foo: "heyo" }, as: :json
 
-      assert_equal "POST", request.method
-      assert_equal "GET", request.headers["X-Http-Method-Override"]
+      assert_equal "GET", request.method
+      assert_nil request.headers["X-Http-Method-Override"]
       assert_equal({ "foo" => "heyo" }, response.parsed_body)
     end
   end
@@ -1271,6 +1271,67 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
       get "/foos_json", as: :json
 
       assert_equal "http://www.example.com/foos_json", request.url
+    end
+  end
+
+  def test_get_with_explicit_query_kwarg
+    with_routing do |routes|
+      routes.draw do
+        ActionDispatch.deprecator.silence do
+          get ":action" => FooController
+        end
+      end
+
+      get "/foos_json", query: { foo: "heyo" }, as: :json
+
+      assert_equal "GET", request.method
+      assert_includes request.url, "foo=heyo"
+      assert_equal({ "foo" => "heyo" }, response.parsed_body)
+    end
+  end
+
+  def test_post_with_explicit_query_kwarg_appends_to_url
+    with_routing do |routes|
+      routes.draw do
+        ActionDispatch.deprecator.silence do
+          post ":action" => FooController
+        end
+      end
+
+      post "/foos_json", query: { foo: "heyo" }, as: :json
+
+      assert_includes request.url, "foo=heyo"
+      assert_equal({ "foo" => "heyo" }, response.parsed_body)
+    end
+  end
+
+  def test_post_with_explicit_body_kwarg
+    with_routing do |routes|
+      routes.draw do
+        ActionDispatch.deprecator.silence do
+          post ":action" => FooController
+        end
+      end
+
+      post "/foos_json", body: { foo: "fighters" }, as: :json
+
+      assert_equal "application/json", request.media_type
+      assert_equal({ "foo" => "fighters" }, response.parsed_body)
+    end
+  end
+
+  def test_post_with_query_and_body_kwargs
+    with_routing do |routes|
+      routes.draw do
+        ActionDispatch.deprecator.silence do
+          post ":action" => FooController
+        end
+      end
+
+      post "/foos_json", query: { foo: "heyo" }, body: { foo: "fighters" }, as: :json
+
+      assert_includes request.url, "foo=heyo"
+      assert_equal "application/json", request.media_type
     end
   end
 


### PR DESCRIPTION
### Summary

`params:` in integration test helpers was ambiguous — for GET requests with `as: :json` it was unclear whether params should go in the query string or request body. The original workaround converted GET to POST with `X-Http-Method-Override`, which broke API-only apps that exclude `Rack::MethodOverride`.

### Fix

Add `query:` and `body:` kwargs for explicit control. Remove the POST conversion hack.

- `query:` — always URL query string, any HTTP method
- `body:` — always encoded request body, any HTTP method
- `params:` — unchanged: GET → query string, other → body

```ruby
get  "/search", query: { q: "rails" }, as: :json
post "/search", query: { page: 1 }, body: { filters: {} }, as: :json
```

Fixes #57131

### Benchmark

Ruby 4.0.1, Rails 8.2.0.alpha

| Scenario | main (before) | PR (after) | Delta |
|---|---|---|---|
| `GET params` (no as:) | 27,428 i/s | 27,178 i/s | same-ish |
| `GET params + as: :json` | 25,946 i/s | 27,667 i/s | **+6.6% faster** |
| `POST params + as: :json` | 28,274 i/s | 27,916 i/s | same-ish |

New kwargs (baseline):

| Scenario | i/s |
|---|---|
| `GET query: + as: :json` | 26,239 |
| `POST body: + as: :json` | 28,126 |
| `POST query:+body: + as: :json` | 23,881 |