### PR TITLE
Support multi-line strict locals for .ruby and .builder templates

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Support multi-line strict locals for templates using Ruby comment syntax
+    (e.g., `.ruby`, `.builder`, `.jbuilder`).
+
+    *Michael Oberegger*
+
 *   Skip blank attribute names in tag helpers to avoid generating invalid HTML.
 
     *Mike Dalessio*

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -361,12 +361,17 @@ module ActionView
     #
     #   <%# locals: (title: "Default title", comment_count: 0) %>
     #
+    # For .ruby or .builder templates, you can use Ruby comment syntax:
+    #
+    #   # locals: (title: "Default title", comment_count: 0)
+    #
     # Strict locals are useful for validating template arguments and for
     # specifying defaults.
     def strict_locals!
       if @strict_locals == NONE
         self.source.sub!(STRICT_LOCALS_REGEX, "")
-        @strict_locals = $1&.rstrip
+        # Strip leading `#` from continuation lines in Ruby comments
+        @strict_locals = $1&.gsub(/\n\s*#/, "\n")&.rstrip
 
         return if @strict_locals.nil? # Magic comment not found
 

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -485,3 +485,127 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 end
+
+class TestRubyTemplate < ActiveSupport::TestCase
+  RubyHandler = lambda { |_, source| source }
+
+  class LookupContext
+    def disable_cache
+      yield
+    end
+
+    def find_template(*args)
+    end
+
+    attr_accessor :formats
+  end
+
+  class Context < ActionView::Base
+    def lookup_context
+      @lookup_context ||= LookupContext.new
+    end
+  end
+
+  def new_template(body)
+    ActionView::Template.new(body.dup, "hello template", RubyHandler, virtual_path: "hello", format: :html, locals: [])
+  end
+
+  def render(**locals)
+    @template.render(@context, locals)
+  end
+
+  def setup
+    @context = Context.with_empty_template_cache.empty
+    super
+  end
+
+  def test_locals_can_be_specified
+    @template = new_template("# locals: (message:)\nmessage")
+    assert_equal "Hello", render(message: "Hello")
+  end
+
+  def test_locals_can_spread_to_multiple_lines
+    template = <<~RUBY.chomp
+      # locals: (arg_1:,
+      #          arg_2: nil,
+      #          arg_3: [])
+      [arg_1, arg_2, arg_3].compact.join
+    RUBY
+    @template = new_template(template)
+    assert_equal "First", render(arg_1: "First")
+  end
+
+  def test_locals_can_spread_to_multiple_lines_with_closing_parenthesis_on_diff_line
+    template = <<~RUBY.chomp
+      # locals: (
+      #   arg_1:,
+      #   arg_2: nil,
+      #   arg_3: []
+      # )
+      [arg_1, arg_2, arg_3].compact.join
+    RUBY
+    @template = new_template(template)
+    assert_equal "First", render(arg_1: "First")
+  end
+end
+
+class TestBuilderTemplate < ActiveSupport::TestCase
+  BuilderHandler = ActionView::Template::Handlers::Builder.new
+
+  class LookupContext
+    def disable_cache
+      yield
+    end
+
+    def find_template(*args)
+    end
+
+    attr_accessor :formats
+  end
+
+  class Context < ActionView::Base
+    def lookup_context
+      @lookup_context ||= LookupContext.new
+    end
+  end
+
+  def new_template(body)
+    ActionView::Template.new(body.dup, "hello template", BuilderHandler, virtual_path: "hello", format: :xml, locals: [])
+  end
+
+  def render(**locals)
+    @template.render(@context, locals)
+  end
+
+  def setup
+    @context = Context.with_empty_template_cache.empty
+    super
+  end
+
+  def test_locals_can_be_specified
+    @template = new_template("# locals: (message:)\nxml.p(message)")
+    assert_includes render(message: "Hello"), "Hello"
+  end
+
+  def test_locals_can_spread_to_multiple_lines
+    template = <<~RUBY.chomp
+      # locals: (message:,
+      #          show_title: true)
+      xml.p(message)
+    RUBY
+    @template = new_template(template)
+    assert_includes render(message: "Hello"), "Hello"
+  end
+
+  def test_locals_can_spread_to_multiple_lines_with_closing_parenthesis_on_diff_line
+    template = <<~RUBY.chomp
+      # locals: (
+      #   message:,
+      #   show_title: true
+      # )
+      xml.p(message)
+    RUBY
+    @template = new_template(template)
+    assert_includes render(message: "Hello"), "Hello"
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This builds on top of previous work done in #56270 and #56316 and adds multi-line support for strict locals done in regular Ruby comments.

I noticed this behaviour when using strict locals with `jbuilder`. Something like the following works

```ruby
# locals: (json:, title:, comment_count: 0)

json.title title
json.commentCount comment_count
```

But the following would not

```ruby
# locals: (
#   json:, 
#   title:, 
#   comment_count: 0
# )

json.title title
json.commentCount comment_count
```

At first I though it would be strange to have Rails-core support this quirk in `jbuilder` (even though that is technically a Rails gem), but Rails-core _does_ have `:ruby` and `:builder` handlers registered, which would also define strict locals with Ruby comments like this. I am unsure if this is officially/formally documented anywhere, but they _do_ support the single line variant of this.

This PR adjusts the strict locals parsing so that multi-line comments will work with `.builder`, `.ruby`, and `.jbuilder` templates (and I suppose any other handlers that use Ruby-style comments).

### Detail

The issue was that the `STRICT_LOCALS_REGEX` regular expression would capture the `#` characters on each line, so something like

```ruby
# locals: (arg_1:,
#          arg_2: nil,
#          arg_3: [])
```

would be captured as  `arg_1:,\n#          arg_2: nil,\n#          arg_3: []`. When the template compiles, those extra `#` character get in the way resulting in a `ActionView::SyntaxErrorInTemplate` error.

The fix is to simply substitute `\n#` with `\n`.

I have added some extra test cases for this. I was unsure where to put them. The existing strict locals tests were in `template_test.rb`, but the class was called `TestERBTemplate`. It didn't feel right to mix other handlers into this class, so I made new `TestRubyTemplate` and `TestBuilderTemplate` classes.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
