### PR TITLE
Optimize `Relation#blank?` to use `#empty?` instead of loading all records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Optimize `Relation#blank?` to use `#empty?` instead of loading all records.
+
+    Previously, calling `blank?` on a relation would load all records via
+    `records.blank?`. Now it delegates to `empty?`, which can use a COUNT
+    query or check the loaded state without forcing a full load.
+
+    *George Ogata*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1304,7 +1304,7 @@ module ActiveRecord
 
     # Returns true if relation is blank.
     def blank?
-      records.blank?
+      empty?
     end
 
     def readonly?

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1177,6 +1177,41 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_not_empty post.readers
   end
 
+  def test_collection_not_blank_after_building
+    company = companies(:first_firm)
+    assert_predicate company.contracts, :blank?
+    company.contracts.build
+    assert_not_predicate company.contracts, :blank?
+  end
+
+  def test_collection_blank_with_dirty_target
+    post = posts(:thinking)
+    assert_equal [], post.reader_ids
+    assert_predicate post.readers, :blank?
+    post.readers.reset
+    post.readers.build
+    assert_equal [nil], post.reader_ids
+    assert_not_predicate post.readers, :blank?
+  end
+
+  def test_blank_does_not_load_target
+    firm = companies(:first_firm)
+    assert_not_predicate firm.clients_of_firm, :loaded?
+    assert_queries_count(1) do
+      assert_not_predicate firm.clients_of_firm, :blank?
+    end
+    assert_not_predicate firm.clients_of_firm, :loaded?
+  end
+
+  def test_present_does_not_load_target
+    firm = companies(:first_firm)
+    assert_not_predicate firm.clients_of_firm, :loaded?
+    assert_queries_count(1) do
+      assert_predicate firm.clients_of_firm, :present?
+    end
+    assert_not_predicate firm.clients_of_firm, :loaded?
+  end
+
   def test_collection_size_twice_for_regressions
     post = posts(:thinking)
     assert_equal 0, post.readers.size
@@ -1476,6 +1511,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     post = posts(:welcome)
     assert_no_queries do
       assert_not_empty post.comments
+    end
+  end
+
+  def test_calling_blank_with_counter_cache
+    post = posts(:welcome)
+    assert_no_queries do
+      assert_not_predicate post.comments, :blank?
+    end
+  end
+
+  def test_calling_present_with_counter_cache
+    post = posts(:welcome)
+    assert_no_queries do
+      assert_predicate post.comments, :present?
     end
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1196,6 +1196,21 @@ class RelationTest < ActiveRecord::TestCase
     assert_not_predicate no_posts, :loaded?
   end
 
+  def test_blank
+    posts = Post.all
+
+    assert_queries_count(1) { assert_equal false, posts.blank? }
+    assert_not_predicate posts, :loaded?
+
+    no_posts = posts.where(title: "")
+    assert_queries_count(1) { assert_equal true, no_posts.blank? }
+    assert_not_predicate no_posts, :loaded?
+
+    best_posts = posts.where(comments_count: 0)
+    best_posts.load # force load
+    assert_no_queries { assert_equal false, best_posts.blank? }
+  end
+
   def test_any
     posts = Post.all
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2033,11 +2033,12 @@ class RelationTest < ActiveRecord::TestCase
   def test_presence
     topics = Topic.all
 
-    # the first query is triggered because there are no topics yet.
+    # Before loading, present?/blank? should run a count without loading records.
     assert_queries_count(1) { assert_predicate topics, :present? }
+    assert_not_predicate topics, :loaded?
 
-    # checking if there are topics is used before you actually display them,
-    # thus it shouldn't invoke an extra count query.
+    # After loading, it should use the loaded records & not require a query.
+    topics.load
     assert_no_queries { assert_predicate topics, :present? }
     assert_no_queries { assert_not topics.blank? }
 


### PR DESCRIPTION
Previously, calling `blank?` on a relation would load all records via `records.blank?`. Now it delegates to `empty?`, which can use a COUNT query or check the loaded state without forcing a full load.

An innocent looking `if user.comments.blank?` in a view can be a performance footgun if it loads all the records.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
