### PR TITLE
Infer PK for simple PSQL views from the underlying table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Infer primary key for simple PostgreSQL views from the underlying table.
+
+    Models backed by simple auto-updatable views (e.g.,
+    `CREATE VIEW old_name AS SELECT * FROM new_name`) now automatically
+    detect the primary key from the base table, removing the need to
+    declare `self.primary_key = "id"` on the model. This enables
+    zero-downtime table renames by creating a view alias with the old name.
+
+    *Phil Pirozhkov*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -587,15 +587,55 @@ module ActiveRecord
         end
 
         def primary_keys(table_name) # :nodoc:
-          query_values(<<~SQL)
+          quoted_regclass = quote(quote_table_name(table_name))
+
+          result = query_values(<<~SQL)
             SELECT a.attname
             FROM pg_index i
             JOIN pg_attribute a
               ON a.attrelid = i.indrelid
               AND a.attnum = ANY(i.indkey)
-            WHERE i.indrelid = #{quote(quote_table_name(table_name))}::regclass
+            WHERE i.indrelid = #{quoted_regclass}::regclass
               AND i.indisprimary
             ORDER BY array_position(i.indkey, a.attnum)
+          SQL
+
+          return result unless result.empty?
+
+          # For simple auto-updatable views, infer the primary key from the
+          # underlying table. Each candidate column must be a direct, updatable
+          # reference to a base-table primary-key column with the same name,
+          # and every base-table primary-key column must be present.
+          query_values(<<~SQL)
+            WITH view_pk_candidates AS (
+              SELECT ba.attname,
+                     ba.attnum AS base_attnum,
+                     i.indkey AS pk_indkey
+              FROM pg_class v
+              JOIN pg_rewrite rw ON rw.ev_class = v.oid
+                AND rw.rulename = '_RETURN'
+              JOIN pg_depend d ON d.objid = rw.oid
+                AND d.classid = 'pg_rewrite'::regclass
+                AND d.refclassid = 'pg_class'::regclass
+                AND d.deptype = 'n'
+                AND d.refobjsubid > 0
+              JOIN pg_class base ON base.oid = d.refobjid
+                AND base.relkind IN ('r', 'p')
+              JOIN pg_index i ON i.indrelid = base.oid
+                AND i.indisprimary
+              JOIN pg_attribute ba ON ba.attrelid = base.oid
+                AND ba.attnum = ANY(i.indkey)
+                AND ba.attnum = d.refobjsubid
+              JOIN pg_attribute va ON va.attrelid = v.oid
+                AND va.attname = ba.attname
+                AND NOT va.attisdropped
+                AND pg_column_is_updatable(v.oid, va.attnum, false)
+              WHERE v.oid = #{quoted_regclass}::regclass
+                AND v.relkind = 'v'
+            )
+            SELECT attname FROM view_pk_candidates
+            WHERE array_length(pk_indkey, 1) = (SELECT count(*) FROM view_pk_candidates)
+            ORDER BY array_position(pk_indkey, base_attnum)
           SQL
         end
 

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -68,10 +68,16 @@ module ViewBehavior
   end
 
   def test_does_not_assume_id_column_as_primary_key
+    view_name = "ebooks_computed_id"
+    create_view view_name, "SELECT 0 AS id, name FROM books"
+
     model = Class.new(ActiveRecord::Base) do
-      self.table_name = "ebooks'"
+      self.table_name = "ebooks_computed_id"
     end
+
     assert_nil model.primary_key
+  ensure
+    drop_view view_name
   end
 
   def test_does_not_dump_view_as_table
@@ -206,6 +212,85 @@ if ActiveRecord::Base.lease_connection.supports_views?
         end
       end
     end # end of `if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)`
+  end
+
+  class PostgreSQLViewPrimaryKeyInferenceTest < ActiveRecord::TestCase
+    if current_adapter?(:PostgreSQLAdapter)
+      self.use_transactional_tests = false
+      fixtures :books
+
+      setup do
+        @connection = ActiveRecord::Base.lease_connection
+      end
+
+      teardown do
+        @connection.execute "DROP VIEW IF EXISTS simple_books_view"
+        @connection.execute "DROP VIEW IF EXISTS no_pk_books_view"
+        @connection.execute "DROP VIEW IF EXISTS computed_id_books_view"
+        @connection.execute "DROP VIEW IF EXISTS cpk_posts_view"
+        @connection.execute "DROP VIEW IF EXISTS partial_cpk_posts_view"
+      end
+
+      def test_infers_primary_key_for_simple_view
+        @connection.execute <<~SQL
+          CREATE VIEW simple_books_view AS SELECT * FROM books
+        SQL
+
+        model = Class.new(ActiveRecord::Base) do
+          self.table_name = "simple_books_view"
+        end
+
+        assert_equal "id", model.primary_key
+      end
+
+      def test_no_primary_key_when_pk_column_missing_from_view
+        @connection.execute <<~SQL
+          CREATE VIEW no_pk_books_view AS SELECT name, status FROM books
+        SQL
+
+        model = Class.new(ActiveRecord::Base) do
+          self.table_name = "no_pk_books_view"
+        end
+
+        assert_nil model.primary_key
+      end
+
+      def test_no_primary_key_when_pk_column_is_computed
+        @connection.execute <<~SQL
+          CREATE VIEW computed_id_books_view AS SELECT 0 AS id, name FROM books
+        SQL
+
+        model = Class.new(ActiveRecord::Base) do
+          self.table_name = "computed_id_books_view"
+        end
+
+        assert_nil model.primary_key
+      end
+
+      def test_infers_composite_primary_key_from_view
+        @connection.execute <<~SQL
+          CREATE VIEW cpk_posts_view AS SELECT * FROM cpk_posts
+        SQL
+
+        model = Class.new(ActiveRecord::Base) do
+          self.table_name = "cpk_posts_view"
+        end
+
+        assert_equal ["title", "author"], model.primary_key
+      end
+
+      def test_no_primary_key_when_composite_pk_column_missing_from_view
+        @connection.execute <<~SQL
+          CREATE VIEW partial_cpk_posts_view AS SELECT title FROM cpk_posts
+        SQL
+
+        model = Class.new(ActiveRecord::Base) do
+          self.table_name = "partial_cpk_posts_view"
+        end
+
+        assert_nil model.primary_key
+      end
+    end
   end
 end # end of `if ActiveRecord::Base.lease_connection.supports_views?`
 


### PR DESCRIPTION
Models backed by simple auto-updatable views, e.g.:

    CREATE VIEW old_name AS SELECT * FROM new_name`

now automatically detect the primary key from the base table, removing the need to declare `self.primary_key = "id"` on the model. This enables zero-downtime table renames by creating a view alias with the old name.

### Motivation / Background

This Pull Request has been created to ease zero-time migration of table renames.

The [current approach suggested](https://github.com/ankane/strong_migrations/blob/736117d515b875c0a666ddb88819217a9155be3e/README.md?plain=1#L221) by `strong_migrations`:

1. Create a new table (deploy the code)
2. Write to both tables
3. Backfill data from the old table to the new table (deploy the code)
4. Move reads from the old table to the new table (deploy the code)
5. Stop writing to the old table (deploy the code)
6. Drop the old table (deploy the code)


5 deployments. With the change in this PR, two deployments are needed:

1. Rename the table. Create a view with the old table name. (deploy the code)
2. Drop the view. (deploy the code)

[Discussion](https://github.com/doctolib/safe-pg-migrations/pull/54#discussion_r724405651) in `safe-pg-migrations` (similar to [`strong_migrations`](https://github.com/ankane/strong_migrations))
[`online_migrations`'s workaround approach](https://github.com/fatkodima/online_migrations/blob/175dc298729f9d97854db8f6db5cb956d38b84f8/lib/online_migrations/schema_statements.rb#L229-L320).
[Suggestion to simplify the approach in `strong_migrations`](https://github.com/ankane/strong_migrations/issues/160).

### Detail

This Pull Request changes how PKs are inferred for models backed by PostgreSQL "simple views".

Despite the 7 JOINs, the query:
  - Short-circuits in <0.25ms for non-view relations (first index scan filters on relkind = 'v')
  - Only runs once per model (schema cache)
  - Each JOIN is necessary for correctness

The fallback query runs once per view name, per process lifetime. Here's the exact
  flow:

  App boots → Model class loads → reset_primary_key
    → get_primary_key → schema_cache.primary_keys("my_view")
      → cache miss → connection.primary_key("my_view")
        → primary_keys("my_view")
          → Query 1: pg_index (returns [], view has no indexes)
          → Query 2: the fallback (returns ["id"])
        → result cached in @primary_keys["my_view"]
      → all subsequent calls: hash lookup, no SQL

After that first call, schema_cache.primary_keys returns from a Ruby hash - zero SQL, zero overhead.

The 0.25ms is spent on Query 2 only, which happens that single time. What PostgreSQL does during it:

1. Index scan on pg_class_oid_index - finds the view's OID, checks relkind = 'v' (if it's a table, stops here - everything below is "never executed")
4. Index scan on pg_rewrite_rel_rulename_index - finds the _RETURN rule
8. Index scan on pg_depend_depender_index - finds column-level dependencies from the rule to the base table
9. Index scan on pg_attribute_relid_attnum_index - resolves base table column names
10. Index scan on pg_class_oid_index - confirms the base relation is a table (relkind IN ('r','p'))
11. Index scan on pg_index_indrelid_index - finds the base table's primary key index
12. Index scan on pg_attribute_relid_attnam_index - matches view column names to base PK column names
13. pg_column_is_updatable() - C function that checks the view's parsed query tree to confirm the column is a direct reference

All index scans. No sequential scans, no disk I/O on a warm system.

For a table (or join table without PK), Query 1 returns the result and Query 2 never runs. For a table without a PK, Query 1 returns [], Query 2 runs but short-circuits at step 1 (relkind = 'v' fails) in ~0.03ms.


### Additional information

One alternative approach I was considering is to propose a change to the PostgreSQL itself to return proper PK metadata for simple views. But it's a long-shot. I may still consider this in the future so other platforms/frameworks could benefit from simplified and zero-downtime table rename migrations.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
