### PR TITLE
Optimize `ActionView::LookupContext#normalize_name` with cache

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Cache `ActionView::LookupContext#normalize_name` to reduce memory allocations during template lookups.
+
+    *Michael Oberegger*
+
 *   Skip blank attribute names in tag helpers to avoid generating invalid HTML.
 
     *Mike Dalessio*

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -125,6 +125,9 @@ module ActionView
     module ViewPaths
       attr_reader :view_paths, :html_fallback_for_js
 
+      NORMALIZE_NAME_CACHE = Concurrent::Map.new
+      private_constant :NORMALIZE_NAME_CACHE
+
       def find(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
         details, details_key = detail_args_for(options)
@@ -211,17 +214,31 @@ module ActionView
         idx = name.rindex("/")
         return name, prefixes.presence || [""] unless idx
 
-        path_prefix = name[0, idx]
-        path_prefix = path_prefix.from(1) if path_prefix.start_with?("/")
-        name = name.from(idx + 1)
+        NORMALIZE_NAME_CACHE[normalize_name_cache_key(name, prefixes)] ||= begin
+          path_prefix = name[0, idx]
+          path_prefix = path_prefix.from(1) if path_prefix.start_with?("/")
+          name = name.from(idx + 1)
 
-        if !prefixes || prefixes.empty?
-          prefixes = [path_prefix]
-        else
-          prefixes = prefixes.map { |p| "#{p}/#{path_prefix}" }
+          if prefixes.present?
+            prefixes = prefixes.map { |p| "#{p}/#{path_prefix}" }
+          else
+            prefixes = [path_prefix]
+          end
+
+          [name.freeze, prefixes.freeze]
         end
+      end
 
-        return name, prefixes
+      def normalize_name_cache_key(name, prefixes)
+        if prefixes.present?
+          if prefixes.length == 1
+            "#{name}:#{prefixes[0]}"
+          else
+            prefixes.join(",").prepend(name, ":")
+          end
+        else
+          name
+        end
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

I noticed `normalize_name` as a hotspot for memory allocations in our production profiles. I looked at some previous (#42194) work to optimize this, and that PR mentions that this method runs on every template lookup under render, which would explain why it's such a hot spot. The method is "pure" in the sense that the same output would be expected for the same input, so I thought it would make sense to cache the results. 

Note that this did _not_ come up as a hotspot for CPU or wall time, so the method is pretty fast. My intention here is to save on memory allocation without affecting latency.

### Detail

I have only cached the results for when `name` doesn't have a `"/"` in it. The current logic will return earlier in this situation, and I don't believe there is any additional memory allocation happening here - at least none that we would save on with caching. I suppose the default `[""]` could be saved in an `EMPTY_PREFIXES` constant, though.

For `name`s with a `"/"`, results will be cached. I did my best to make the computation of the cache key as quick and memory efficient as possible. If `prefixes` is empty, the `name` will be used as the key. If `prefixes` contains a single item - which I believe is a common case - a faster string interpolation path is used for the key. In all other situations, it will join the `prefixes` and prepend it with name. This is to keep the cache key to a single string allocation.

I explored using `[name, prefixes]` as the cache key, but that didn't perform very well and introduced an extra array allocation, pretty much negating any memory savings, and it also caused the method to run a bit slower.

I used a `Concurrent::Map` to keep it aligned with `ActionView::LookupContext::DetailsKey`. I also mimicked how caching was done in `ActionView::AbstractRenderer::ObjectRendering`, which is largely what influenced me to put the cache in a constant.

### Additional information

I did some benchmarking against the `normalize_name` method directly for a various set of inputs. Results look positive!

Source 

```ruby
# frozen_string_literal: true
require "benchmark/ips"
require "benchmark/memory"

ENV["RAILS_ENV"] = "test"

$:.unshift File.expand_path("../actionview/lib", __dir__)
$:.unshift File.expand_path("../actionview/test", __dir__)
$:.unshift File.expand_path("../activesupport/lib", __dir__)
$:.unshift File.expand_path("../actionpack/lib", __dir__)
$:.unshift File.expand_path("../activemodel/lib", __dir__)
$:.unshift File.expand_path("../activejob/lib", __dir__)
$:.unshift File.expand_path("../activerecord/lib", __dir__)
$:.unshift File.expand_path("../railties/lib", __dir__)

require "abstract_unit"

lookup_context = ActionView::LookupContext.new([])

cases = {
  "slash, no prefixes" => ["shared/sidebar", []],
  "slash, with prefix" => ["admin/dashboard", ["users"]],
  "leading slash"      => ["/shared/sidebar", []],
}

puts "=== IPS Benchmark ==="
cases.each do |label, (name, prefixes)|
  Benchmark.ips do |x|
    x.report("#{label} - original") { lookup_context.send(:normalize_name, name, prefixes) }
    x.report("#{label} - cached") { lookup_context.send(:normalize_name, name, prefixes) }

    x.hold! "benchmark_normalize_name_ips_#{label.tr(" ,", "_")}"
    x.compare!(order: :baseline)
  end
end

puts "\n=== Memory Benchmark ==="
cases.each do |label, (name, prefixes)|
  Benchmark.memory do |x|
    x.report("#{label} - original") { lookup_context.send(:normalize_name, name, prefixes) }
    x.report("#{label} - cached") { lookup_context.send(:normalize_name, name, prefixes) }

    x.hold! "benchmark_normalize_name_memory_#{label.tr(" ,", "_")}.json"
    x.compare!
  end
end
```

```
name = "shared/sidebar"
prefixes =  []

=== IPS ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
slash, no prefixes - original
                       449.615k i/100ms
slash, no prefixes - cached
                         1.078M i/100ms
Calculating -------------------------------------
slash, no prefixes - original
                          4.884M (± 2.6%) i/s  (204.73 ns/i) -     24.729M in   5.066313s
slash, no prefixes - cached
                         13.307M (± 1.7%) i/s   (75.15 ns/i) -     66.856M in   5.025757s

Comparison:
slash, no prefixes - original:  4884496.8 i/s
slash, no prefixes - cached: 13306510.6 i/s - 2.72x  faster

=== Memory ===
Calculating -------------------------------------
slash, no prefixes - original
                       160.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
slash, no prefixes - cached
                         0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
slash, no prefixes - cached:          0 allocated
slash, no prefixes - original:        160 allocated - Infx more
```

```
name = "admin/dashboard"
prefixes = ["users"]

=== IPS ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
slash, with prefix - original
                       337.616k i/100ms
slash, with prefix - cached
                       545.546k i/100ms
Calculating -------------------------------------
slash, with prefix - original
                          3.531M (± 3.1%) i/s  (283.22 ns/i) -     17.894M in   5.073191s
slash, with prefix - cached
                          6.351M (± 1.5%) i/s  (157.46 ns/i) -     32.187M in   5.069400s

Comparison:
slash, with prefix - original:  3530784.8 i/s
slash, with prefix - cached:  6350802.0 i/s - 1.80x  faster

=== Memory ===
Calculating -------------------------------------
slash, with prefix - original
                       200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)
slash, with prefix - cached
                        80.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
slash, with prefix - cached:         80 allocated
slash, with prefix - original:        200 allocated - 2.50x more
```

```
name = "/shared/sidebar"
prefixes = []

=== IPS ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
leading slash - original
                       365.432k i/100ms
leading slash - cached
                         1.069M i/100ms
Calculating -------------------------------------
leading slash - original
                          4.004M (± 2.5%) i/s  (249.75 ns/i) -     20.099M in   5.022761s
leading slash - cached
                         13.058M (± 5.0%) i/s   (76.58 ns/i) -     65.238M in   5.012474s

Comparison:
leading slash - original:  4004049.8 i/s
leading slash - cached: 13057728.1 i/s - 3.26x  faster

=== Memory ===
Calculating -------------------------------------
leading slash - original
                       200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)
leading slash - cached
                         0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
leading slash - cached:          0 allocated
leading slash - original:        200 allocated - Infx more
```

I also did some benchmarking against an entire render. The optimization does get diluted here, but you do still see savings in memory for a single render - I would expect those to add up over multiple renders. IPS stayed consistent, so there appears to be no reduction in performance with the new change.

Source:
```ruby
# frozen_string_literal: true
require "benchmark/ips"
require "benchmark/memory"

ENV["RAILS_ENV"] = "test"

$:.unshift File.expand_path("../actionview/lib", __dir__)
$:.unshift File.expand_path("../actionview/test", __dir__)
$:.unshift File.expand_path("../activesupport/lib", __dir__)
$:.unshift File.expand_path("../actionpack/lib", __dir__)
$:.unshift File.expand_path("../activemodel/lib", __dir__)
$:.unshift File.expand_path("../activejob/lib", __dir__)
$:.unshift File.expand_path("../activerecord/lib", __dir__)
$:.unshift File.expand_path("../railties/lib", __dir__)

require "abstract_unit"

class BenchmarkController < ActionController::Base
end

def setup_view
  paths = [File.expand_path("../actionview/test/fixtures", __dir__)]

  view = Class.new(ActionView::Base.with_empty_template_cache) {
    def view_cache_dependencies; []; end
    def combined_fragment_cache_key(key) = [:views, key]
  }.with_view_paths(paths)

  controller = BenchmarkController.new
  view.controller = controller
  view
end

view = setup_view

# Warm up
view.render(template: "test/hello_world")
view.render(template: "test/hello_world_with_partial")
view.render(template: "test/one")

templates = {
  "simple template"       => "test/hello_world",
  "template with partial" => "test/hello_world_with_partial",
  "nested partials"       => "test/one",
}

puts "=== IPS Benchmark ==="
templates.each do |label, template|
  Benchmark.ips do |x|
    x.report("#{label} - original") { view.render(template: template) }
    x.report("#{label} - cached") { view.render(template: template) }

    x.hold! "benchmark_render_ips_#{label}"
    x.compare!(order: :baseline)
  end
end

puts "\n=== Memory Benchmark ==="
templates.each do |label, template|
  Benchmark.memory do |x|
    x.report("#{label} - original") { view.render(template: template) }
    x.report("#{label} - cached") { view.render(template: template) }

    x.hold! "benchmark_render_mem_#{label}"
    x.compare!
  end
end
```

```
Against "test/hello_world.erb":

Hello world!

=== IPS ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
simple template - original
                         8.813k i/100ms
simple template - cached
                         9.165k i/100ms
Calculating -------------------------------------
simple template - original
                         90.020k (± 2.3%) i/s   (11.11 μs/i) -    458.276k in   5.093502s
simple template - cached
                         89.899k (± 2.5%) i/s   (11.12 μs/i) -    458.250k in   5.100749s

Comparison:
simple template - original:    90020.0 i/s
simple template - cached:    89899.3 i/s - same-ish: difference falls within error

=== Memory ===
Calculating -------------------------------------
simple template - original
                         7.048k memsize (    80.000  retained)
                        72.000  objects (     2.000  retained)
                        11.000  strings (     0.000  retained)
simple template - cached
                         6.888k memsize (    80.000  retained)
                        68.000  objects (     2.000  retained)
                         9.000  strings (     0.000  retained)

Comparison:
simple template - cached:       6888 allocated
simple template - original:       7048 allocated - 1.02x more
```

```
Against "test/hello_world_with_partial.erb":

Hello world!
<%= render '/test/partial' %>

=== IPS ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
template with partial - original
                         3.874k i/100ms
template with partial - cached
                         3.828k i/100ms
Calculating -------------------------------------
template with partial - original
                         38.855k (± 2.9%) i/s   (25.74 μs/i) -    197.574k in   5.089263s
template with partial - cached
                         39.186k (± 3.3%) i/s   (25.52 μs/i) -    199.056k in   5.085663s

Comparison:
template with partial - original:    38854.9 i/s
template with partial - cached:    39186.4 i/s - same-ish: difference falls within error

=== Memory ===
Calculating -------------------------------------
template with partial - original
                        12.710k memsize (   160.000  retained)
                       131.000  objects (     3.000  retained)
                        20.000  strings (     1.000  retained)
template with partial - cached
                        12.350k memsize (   160.000  retained)
                       122.000  objects (     3.000  retained)
                        16.000  strings (     1.000  retained)

Comparison:
template with partial - cached:      12350 allocated
template with partial - original:      12710 allocated - 1.03x more
```

```
Against "test/one.erb":

<%= render partial: "test/two" %> world

=== IPS ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
nested partials - original
                         4.127k i/100ms
nested partials - cached
                         4.296k i/100ms
Calculating -------------------------------------
nested partials - original
                         42.833k (± 2.4%) i/s   (23.35 μs/i) -    214.604k in   5.013190s
nested partials - cached
                         41.980k (± 4.9%) i/s   (23.82 μs/i) -    210.504k in   5.028147s

Comparison:
nested partials - original:    42833.3 i/s
nested partials - cached:    41980.2 i/s - same-ish: difference falls within error

=== Memory ===
Calculating -------------------------------------
nested partials - original
                        12.272k memsize (    80.000  retained)
                       126.000  objects (     2.000  retained)
                        19.000  strings (     0.000  retained)
nested partials - cached
                        11.952k memsize (    80.000  retained)
                       118.000  objects (     2.000  retained)
                        16.000  strings (     0.000  retained)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
