### PR TITLE
[RF-DOCS] Rewrite the Layouts and Rendering guide

### DIFF
--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -31,13 +31,12 @@ is a type of malicious attack where unauthorized requests are submitted by
 impersonating a user that the web application trusts.
 
 The first step to avoid this type of attack is to ensure that all "destructive"
-actions (create, update, and destroy) in your application use non-GET requests (like POST, PUT and DELETE).
+actions (create, update, and destroy) in your application use non-`GET` requests (like `POST`, `PUT` and `DELETE`).
 
-However, a malicious site can still send a non-GET request to your site, so
-Rails builds in request forgery protection into controllers by default. Safe
-methods — GET, HEAD, and the HTTP QUERY method
-([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) — are exempt from this
-verification, since they must not change state.
+Rails builds in request forgery protection into controllers by default for all non-`GET` requests.
+
+NOTE: The `GET`, `HEAD`, and `QUERY` methods are excluded from forgery
+protection since they must only read data, and not write any changes.
 
 This is done by adding a token using the
 [protect_from_forgery](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery)

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -3,1018 +3,362 @@
 Action Controller Overview
 ==========================
 
-In this guide, you will learn how controllers work and how they fit into the request cycle in your application.
+In this guide, you will learn how controllers work and how they fit into the
+request cycle in your application.
 
 After reading this guide, you will know how to:
 
-* Follow the flow of a request through a controller.
-* Access parameters passed to your controller.
-* Use Strong Parameters and permit values.
-* Store data in the cookie, the session, and the flash.
-* Work with action callbacks to execute code during request processing.
-* Use the Request and Response Objects.
+- Follow the flow of a request through a controller.
+- Render HTTP responses as well as redirect responses.
+- Work with action callbacks to execute code during request processing.
+- Access and securely filter parameters passed to your controller.
+- Store data in the cookie, the session, and the flash.
+- Use the Request and Response Objects.
 
 --------------------------------------------------------------------------------
 
-Introduction
-------------
+Action Controller Basics
+------------------------
 
-Action Controller is the C in the Model View Controller
+Action Controller is the **C** in the Model View Controller
 ([MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller))
-pattern. After the [router](routing.html) has matched a controller to an
-incoming request, the controller is responsible for processing the request and
-generating the appropriate output.
+pattern. The [router](routing.html) matches a controller to an incoming request,
+which is responsible for processing the request and generating the response.
 
 For most conventional
 [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer)
 applications, the controller will receive the request, fetch or save data from a
-model, and use a view to create HTML output.
+model, and render a view to create HTML output.
 
-You can imagine that a controller sits between models and views. The controller
-makes model data available to the view, so that the view can display that data
-to the user. The controller also receives user input from the view and saves or
-updates model data accordingly.
+A controller sits between models and views. The controller makes model data
+available to the view, so that the view can display that data to the user. The
+controller also receives user input from the view and saves or updates model
+data accordingly.
 
-Creating a Controller
----------------------
+### Structure of a Controller
 
 A controller is a Ruby class which inherits from `ApplicationController` and has
-methods just like any other class. Once an incoming request is matched to a
-controller by the router, Rails creates an instance of that controller class and
-calls the method with the same name as the action.
+methods just like any other class. Public methods in a controller are also known
+as _actions_, as they are responsible for rendering responses.
 
 ```ruby
-class ClientsController < ApplicationController
-  def new
+# app/controllers/products_controller.rb
+
+class ProductsController < ApplicationController
+  def index
   end
 end
 ```
 
-Given the above `ClientsController`, if a user goes to `/clients/new` in your
-application to add a new client, Rails will create an instance of
-`ClientsController` and call its `new` method. If the `new` method is empty, Rails
-will automatically render the `new.html.erb` view by default.
-
-NOTE: The `new` method is an instance method here, called on an instance of `ClientsController`. This should not be confused with the `new` class method (i.e., `ClientsController.new`).
-
-In the `new` method, the controller would typically create an instance of the
-`Client` model, and make it available as an instance variable called `@client`
-in the view:
+As per Rails conventions, controllers should define up to 7 conventional CRUD
+actions as demonstrated below. This convention is used by the
+[Router DSL](routing.html#crud-verbs-and-actions) to configure resourceful
+routes to the controller. Other actions may be defined and routed to, but these
+are outside Rails conventions. Further details are available in the
+[Routing guide](routing.html).
 
 ```ruby
-def new
-  @client = Client.new
+# config/routes.rb
+
+Rails.application.routes.draw do
+  # A resourceful route to the `ProductsController`
+  resources :products
+end
+```
+
+```ruby
+# app/controllers/products_controller.rb
+
+class ProductsController < ApplicationController
+  # GET /products
+  def index
+    # Display all products
+  end
+
+  # GET /products/new
+  def new
+    # Render a form to create a new product
+  end
+
+  # POST /products
+  def create
+    # Handle the submission form rendered in `new`
+    # and create the product in the database
+  end
+
+  # GET /products/:id
+  def show
+    # Show the product
+  end
+
+  # GET /products/:id/edit
+  def edit
+    # Render a form to edit the product
+  end
+
+  # PATCH /products/:id
+  def update
+    # Handle the submission form rendered in `edit`
+    # and update the product in the database
+  end
+
+  # DELETE /product/:id
+  def destroy
+    # Delete the product
+  end
+end
+```
+
+Once the [router matches](routing.html) an incoming request to a controller and
+action, Rails creates an instance of that controller class and calls the method
+with the same name as the action.
+
+NOTE: The `new` method in the above controller is an instance method, called on
+an instance of `ProductsController`. This should not be confused with the `new`
+class method used to instantiate objects (`ProductsController.new`).
+
+### Naming Conventions
+
+Rails favors pluralizing the resource in the controller's name. For example,
+`ProductsController` is preferred over `ProductController` and
+`SiteAdminsController` over `SiteAdminController` or `SitesAdminsController`.
+However, the plural names are not strictly required — for example,
+`ApplicationController`.
+
+Following this naming convention will allow you to use
+[resourceful routes](routing.html#crud-verbs-and-actions) without needing to
+qualify each with
+[additional options](routing.html#specifying-a-controller-to-use). The
+convention also makes named route helpers consistent throughout your
+application.
+
+The controller naming convention is different from models. While plural names
+are preferred for controller names, the singular form is preferred for
+[model names](active_record_basics.html#naming-conventions) (e.g. `Account` vs.
+`Accounts`).
+
+Controller actions should be _public_, as only _public_ methods are callable as
+actions. Helper methods within controllers which are _not_ intended to be
+actions should be declared `private` or `protected`.
+
+WARNING: Ensure that you do not override methods defined by
+`ActionController::Base` when creating actions. Accidentally redefining them
+could result in `SystemStackError`. If you limit your controllers to the 7 CRUD
+actions, this won't be an issue.
+
+NOTE: If you must use a reserved method as an action name, one workaround is to
+use a custom route to map the reserved method name to your non-reserved action
+method.
+
+### Rendering Responses
+
+Consider the below route and controller.
+
+```ruby
+# config/routes.rb
+
+Rails.application.routes.draw do
+  # A resourceful route to the `ProductsController`
+  resources :products
+end
+```
+
+```ruby
+class ProductsController < ApplicationController
+  def index
+  end
+end
+```
+
+When a user navigates to `/products`, Rails will create an instance of
+`ProductsController` and call its `index` method. If the `index` method is
+empty, Rails will automatically render `app/views/products/index.html.erb`.
+
+You can explicity define the template to render using the `render` method:
+
+```ruby
+class ProductsController < ApplicationController
+  def index
+    # Renders `app/views/products/feed.html.erb`
+    render "feed"
+  end
+end
+```
+
+WARNING: Calling `render` does not `return` from the current scope. Statements
+after the method call will still be executed. Ensure you do not call `render`
+more than once in any given action, as it will raise an
+`AbstractController::DoubleRenderError`.
+
+To enable rendering of additional formats, not just HTML, use a `respond_to`
+block. This will choose the correct template based on the `Accept` header in the
+HTTP request:
+
+```ruby
+class ProductsController < ApplicationController
+  def index
+    respond_to do |format|
+      format.html   # renders `app/views/products/index.html.erb`
+      format.xml    # renders `app/views/products/index.xml.erb`
+    end
+  end
+end
+```
+
+See the
+[Layouts and Rendering guide](layouts_and_rendering.html#rendering-responses)
+for futher details on rendering responses.
+
+In the `index` method, the controller would typically create an array of the
+`Product` model instances, and make it available as an instance variable called
+`@products` in the view:
+
+```ruby
+def index
+  @products = Product.all
 end
 ```
 
 NOTE: All controllers inherit from `ApplicationController`, which in turn
 inherits from
 [`ActionController::Base`](https://api.rubyonrails.org/classes/ActionController/Base.html).
-For [API only](https://guides.rubyonrails.org/api_app.html) applications `ApplicationController` inherits from
+For [API only](https://guides.rubyonrails.org/api_app.html) applications
+`ApplicationController` inherits from
 [`ActionController::API`](https://edgeapi.rubyonrails.org/classes/ActionController/API.html).
 
-### Controller Naming Convention
+### Redirecting Requests
 
-Rails favors making the resource in the controller's name plural. For example,
-`ClientsController` is preferred over `ClientController` and
-`SiteAdminsController` over `SiteAdminController` or `SitesAdminsController`.
-However, the plural names are not strictly required (e.g.
-`ApplicationController`).
-
-Following this naming convention will allow you to use the [default route
-generators](routing.html#crud-verbs-and-actions) (e.g. `resources`) without
-needing to qualify each with options such as
-[`:controller`](routing.html#specifying-a-controller-to-use). The convention
-also makes named route helpers consistent throughout your application.
-
-The controller naming convention is different from models. While plural names
-are preferred for controller names, the singular form is preferred for [model
-names](active_record_basics.html#naming-conventions) (e.g. `Account` vs.
-`Accounts`).
-
-Controller actions should be `public`, as only `public` methods are callable as
-actions. It is also best practice to lower the visibility of helper methods
-(with `private` or `protected`) which are _not_ intended to be actions.
-
-WARNING: Some method names are reserved by Action Controller. Accidentally
-redefining them could result in `SystemStackError`. If you limit your
-controllers to only RESTful [Resource Routing][] actions you should not need to
-worry about this.
-
-NOTE: If you must use a reserved method as an action name, one workaround is to
-use a custom route to map the reserved method name to your non-reserved action
-method.
-
-[Resource Routing]: routing.html#resource-routing-the-rails-default
-
-Parameters
-----------
-
-Data sent by the incoming request is available in your controller in the
-[`params`][] hash. There are two types of parameter data:
-
-- Query string parameters which are sent as part of the URL (for example, after
-  the `?` in `http://example.com/accounts?filter=free`).
-- POST parameters which are submitted from an HTML form.
-
-Rails does not make a distinction between query string parameters and POST
-parameters; both are available in the `params` hash in your controller. For
-example:
+Instead of rendering a fully-formed response, such as an HTML document, you
+might want to redirect the user to a different path. An
+[HTTP redirection status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#redirection_messages)
+can be used for this. Rails' [`redirect_to`][] method uses `302 Found` by
+default.
 
 ```ruby
-class ClientsController < ApplicationController
-  # This action receives query string parameters from an HTTP GET request
-  # at the URL "/clients?status=activated"
-  def index
-    if params[:status] == "activated"
-      @clients = Client.activated
-    else
-      @clients = Client.inactivated
-    end
-  end
-
-  # This action receives parameters from a POST request to "/clients" URL with  form data in the request body.
-  def create
-    @client = Client.new(params[:client])
-    if @client.save
-      redirect_to @client
-    else
-      render "new"
-    end
-  end
-end
+redirect_to photos_url
 ```
 
-NOTE: The `params` hash is not a plain old Ruby Hash; instead, it is an
-[`ActionController::Parameters`][] object. It does not inherit from Hash, but it behaves mostly like Hash.
-It provides methods for filtering `params` and, unlike a Hash, keys `:foo` and `"foo"` are considered to be the same.
+This will send a `302` HTTP response to the browser with `photos_url` in the
+`Location` header. The browser will then make a new `GET` request to the
+`photos_url`.
 
-[`params`]:
-    https://api.rubyonrails.org/classes/ActionController/StrongParameters.html#method-i-params
-[`ActionController::Parameters`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html
-
-### Hash and Array Parameters
-
-The `params` hash is not limited to one-dimensional keys and values. It can
-contain nested arrays and hashes. To send an array of values, append an empty
-pair of square brackets `[]` to the key name:
-
-```
-GET /users?ids[]=1&ids[]=2&ids[]=3
+```http
+HTTP/1.1 302 Found
+referrer-policy: strict-origin-when-cross-origin
+location: http://localhost:3000/photos
+content-type: text/html; charset=utf-8
+cache-control: no-cache
+connection: close
+content-length: 0
 ```
 
-NOTE: The actual URL in this example will be encoded as
-`/users?ids%5b%5d=1&ids%5b%5d=2&ids%5b%5d=3` as the `[` and `]` characters are
-not allowed in URLs. Most of the time you don't have to worry about this because
-the browser will encode it for you, and Rails will decode it automatically, but
-if you ever find yourself having to send those requests to the server manually
-you should keep this in mind.
+NOTE: It's worth being aware that `redirect_to` doesn't move execution to a
+different method within the same request. It sends an HTTP response and then the
+browser makes a new request to the redirected location which won't have any
+context from the previous request.
 
-The value of `params[:ids]` will be the array `["1", "2", "3"]`. Note that
-parameter values are always strings; Rails does not attempt to guess or cast the
-type.
-
-NOTE: Values such as `[nil]` or `[nil, nil, ...]` in `params` are replaced with
-`[]` for security reasons by default. See [Security
-Guide](security.html#unsafe-query-generation) for more information.
-
-To send a hash, you include the key name inside the brackets:
-
-```html
-<form accept-charset="UTF-8" action="/users" method="post">
-  <input type="text" name="user[name]" value="Acme" />
-  <input type="text" name="user[phone]" value="12345" />
-  <input type="text" name="user[address][postcode]" value="12345" />
-  <input type="text" name="user[address][city]" value="Carrot City" />
-</form>
-```
-
-When this form is submitted, the value of `params[:user]` will be `{ "name" =>
-"Acme", "phone" => "12345", "address" => { "postcode" => "12345", "city" =>
-"Carrot City" } }`. Note the nested hash in `params[:user][:address]`.
-
-The `params` object acts like a Hash, but lets you use symbols and strings
-interchangeably as keys.
-
-### Composite Key Parameters
-
-[Composite key parameters](active_record_composite_primary_keys.html) contain
-multiple values in one parameter separated by a delimiter (e.g., an underscore).
-Therefore, you will need to extract each value so that you can pass them to
-Active Record. You can use the `extract_value` method to do that.
-
-For example, given the following controller:
+Alternatively, you can use [`redirect_back`][] to return the user to the page
+they just came from. The location is pulled from the `HTTP_REFERER` header which
+is not guaranteed to be set by the browser, so you must provide a
+`fallback_location`.
 
 ```ruby
-class BooksController < ApplicationController
-  def show
-    # Extract the composite ID value from URL parameters.
-    id = params.extract_value(:id)
-    @book = Book.find(id)
-  end
-end
+redirect_back(fallback_location: root_path)
+# or
+redirect_back_or_to root_path
 ```
 
-And this route:
+WARNING: Similar to `render`, `redirect_to` and `redirect_back` do not
+automatically `return` from the current scope, instead they simply set the HTTP
+response. Statements occurring after them will still be executed.
+
+[`redirect_to`]:
+  https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
+[`redirect_back`]:
+  https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back
+
+Use the [`status:`](layouts_and_rendering.html#status) option to use a different
+HTTP response code. Both numeric and symbolic values are valid.
 
 ```ruby
-get "/books/:id", to: "books#show"
+redirect_to photos_path, status: :see_other
 ```
 
-When a user requests the URL `/books/4_2`, the controller will extract the
-composite key value `["4", "2"]` and pass it to `Book.find`. The `extract_value`
-method may be used to extract arrays out of any delimited parameters.
-
-### JSON Parameters
-
-If your application exposes an API, you will likely accept parameters in JSON
-format. If the `content-type` header of your request is set to
-`application/json`, Rails will automatically load your parameters into the
-`params` hash, which you can access as you would normally.
-
-So for example, if you are sending this JSON content:
-
-```json
-{ "user": { "name": "acme", "address": "123 Carrot Street" } }
-```
-
-Your controller will receive:
-
-```ruby
-{ "user" => { "name" => "acme", "address" => "123 Carrot Street" } }
-```
-
-#### Configuring Wrap Parameters
-
-You can use [Wrap Parameters][], which automatically add the controller name to
-JSON parameters. For example, you can send the below JSON without a root `:user`
-key prefix:
-
-```json
-{ "name": "acme", "address": "123 Carrot Street" }
-```
-
-Assuming that you're sending the above data to the `UsersController`, the JSON
-will be wrapped within the `:user` key like this:
-
-```ruby
-{ name: "acme", address: "123 Carrot Street", user: { name: "acme", address: "123 Carrot Street" } }
-```
-
-NOTE: Wrap Parameters adds a clone of the parameters to the hash within a key
-that is the same as the controller name. As a result, both the original version
-of the parameters and the "wrapped" version of the parameters will exist in the
-params hash.
-
-This feature clones and wraps parameters with a key chosen based on your
-controller's name. It is configured to `true` by default. If you do not want to
-wrap parameters you can
-[configure](configuring.html#config-action-controller-wrap-parameters-by-default)
-it to `false`.
-
-```ruby
-config.action_controller.wrap_parameters_by_default = false
-```
-
-You can also customize the name of the key or specific parameters you want to
-wrap, see the [API
-documentation](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html)
-for more.
-
-[Wrap Parameters]:
-    https://api.rubyonrails.org/classes/ActionController/ParamsWrapper/Options/ClassMethods.html#method-i-wrap_parameters
-
-### Routing Parameters
-
-Parameters specified as part of a route declaration in the `routes.rb` file are
-also made available in the `params` hash. For example, we can add a route that
-captures the `:status` parameter for a client:
-
-```ruby
-get "/clients/:status", to: "clients#index", foo: "bar"
-```
-
-When a user navigates to `/clients/active` URL, `params[:status]` will be set to
-"active". When this route is used, `params[:foo]` will also be set to "bar", as
-if it were passed in the query string.
-
-Any other parameters defined by the route declaration, such as `:id`, will also
-be available.
-
-NOTE: In the above example, your controller will also receive `params[:action]`
-as "index" and `params[:controller]` as "clients". The `params` hash will always
-contain the `:controller` and `:action` keys, but it's recommended to use the
-methods [`controller_name`][] and [`action_name`][] instead to access these
-values.
-
-[`controller_name`]:
-    https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-controller_name
-[`action_name`]:
-    https://api.rubyonrails.org/classes/AbstractController/Base.html#method-i-action_name
-
-### The `default_url_options` Method
-
-You can set global default parameters for [`url_for`](
-https://api.rubyonrails.org/classes/ActionView/RoutingUrlFor.html#method-i-url_for)
-by defining a method called `default_url_options` in your controller. For
-example:
-
-```ruby
-class ApplicationController < ActionController::Base
-  def default_url_options
-    { locale: I18n.locale }
-  end
-end
-```
-
-The specified defaults will be used as a starting point when generating URLs.
-They can be overridden by the options passed to `url_for` or any path helper
-such as `posts_path`. For example, by setting `locale: I18n.locale`, Rails will
-automatically add the locale to every URL:
-
-```ruby
-posts_path # => "/posts?locale=en"
-```
-
-You can still override this default if needed:
-
-```ruby
-posts_path(locale: :fr) # => "/posts?locale=fr"
-```
-
-NOTE: Under the hood, `posts_path` is a shorthand for calling `url_for` with the
-appropriate parameters.
-
-If you define `default_url_options` in `ApplicationController`, as in the
-example above, these defaults will be used for all URL generation. The method
-can also be defined in a specific controller, in which case it only applies to
-URLs generated for that controller.
-
-In a given request, the method is not actually called for every single generated
-URL. For performance reasons the returned hash is cached per request.
-
-Strong Parameters
------------------
-
-With Action Controller [Strong
-Parameters](https://api.rubyonrails.org/classes/ActionController/StrongParameters.html),
-parameters cannot be used in Active Model mass assignments until they have been
-explicitly permitted. This means you will need to decide which attributes to
-permit for mass update and declare them in the controller. This is a security
-practice to prevent users from accidentally updating sensitive model attributes.
-
-In addition, parameters can be marked as required and the request will result in
-a 400 Bad Request being returned if not all required parameters are passed in.
-
-```ruby
-class PeopleController < ActionController::Base
-  # This will raise an ActiveModel::ForbiddenAttributesError
-  # because it's using mass assignment without an explicit permit.
-  def create
-    Person.create(params[:person])
-  end
-
-  # This will work as we are using `person_params` helper method, which has the
-  # call to `expect` to allow mass assignment.
-  def update
-    person = Person.find(params[:id])
-    person.update!(person_params)
-    redirect_to person
-  end
-
-  private
-    # Using a private method to encapsulate the permitted parameters is a good
-    # pattern. You can use the same list for both create and update.
-    def person_params
-      params.expect(person: [:name, :age])
-    end
-end
-```
-
-### Permitting Values
-
-#### `expect`
-
-The [`expect`][] method provides a concise and safe way to require and permit
-parameters.
-
-```ruby
-id = params.expect(:id)
-```
-
-The above `expect` will always return a scalar value and not an array or hash.
-Another example is form params, you can use `expect` to ensure that the root key
-is present and the attributes are permitted.
-
-```ruby
-user_params = params.expect(user: [:username, :password])
-user_params.has_key?(:username) # => true
-```
-
-In the above example, if the `:user` key is not a nested hash with the specified
-keys, `expect` will raise an error and return a 400 Bad Request response.
-
-To require and permit an entire hash of parameters, [`expect`][] can be used in
-this way.
-
-```ruby
-params.expect(log_entry: {})
-```
-
-This marks the `:log_entry` parameters hash and any sub-hash of it as permitted
-and does not check for permitted scalars, anything is accepted.
-
-WARNING: Extreme care should be taken when calling `expect` with an empty
-hash, as it will allow all current and future model attributes to be
-mass-assigned.
-
-#### `permit`
-
-Calling [`permit`][] allows the specified key in `params` (`:id` or `:admin`
-below) for inclusion in mass assignment (e.g. via `create` or `update`):
-
-```irb
-params = ActionController::Parameters.new(id: 1, admin: "true")
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: false>
-params.permit(:id)
-=> #<ActionController::Parameters {"id"=>1} permitted: true>
-params.permit(:id, :admin)
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: true>
-```
-
-For the permitted key `:id`, its value also needs to be one of these permitted
-scalar values: `String`, `Symbol`, `NilClass`, `Numeric`, `TrueClass`,
-`FalseClass`, `Date`, `Time`, `DateTime`, `StringIO`, `IO`,
-`ActionDispatch::Http::UploadedFile`, and `Rack::Test::UploadedFile`.
-
-If you have not called `permit` on the key, it will be filtered out. Arrays,
-hashes, or any other objects are not injected by default.
-
-To include a value in `params` that's an array of one of the permitted scalar
-values, you can map the key to an empty array like this:
-
-```irb
-params = ActionController::Parameters.new(tags: ["rails", "parameters"])
-=> #<ActionController::Parameters {"tags"=>["rails", "parameters"]} permitted: false>
-params.permit(tags: [])
-=> #<ActionController::Parameters {"tags"=>["rails", "parameters"]} permitted: true>
-```
-
-To include hash values, you can map to an empty hash:
-
-```irb
-params = ActionController::Parameters.new(options: { darkmode: true })
-=> #<ActionController::Parameters {"options"=>{"darkmode"=>true}} permitted: false>
-params.permit(options: {})
-=> #<ActionController::Parameters {"options"=>#<ActionController::Parameters {"darkmode"=>true} permitted: true>} permitted: true>
-```
-
-The above `permit` call ensures that values in `options` are permitted scalars
-and filters out anything else.
-
-WARNING: The `permit` with an empty hash is convenient since sometimes it is not
-possible or convenient to declare each valid key of a hash parameter or its
-internal structure. But note that the above `permit` with an empty hash opens
-the door to arbitrary input.
-
-#### `permit!`
-
-There is also [`permit!`][] (with an `!`) which permits an entire hash of
-parameters without checking the values.
-
-```irb
-params = ActionController::Parameters.new(id: 1, admin: "true")
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: false>
-params.permit!
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: true>
-```
-
-WARNING: Extreme care should be taken when using `permit!`, as it will allow all
-current and *future* model attributes to be mass-assigned.
-
-[`permit`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit
-[`permit!`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit-21
-[`expect`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect
-
-### Nested Parameters
-
-You can also use `expect` (or `permit`) on nested parameters, like:
-
-```ruby
-# Given the example expected params:
-params = ActionController::Parameters.new(
-  name: "Martin",
-  emails: ["me@example.com"],
-  friends: [
-    { name: "André", family: { name: "RubyGems" }, hobbies: ["keyboards", "card games"] },
-    { name: "Kewe", family: { name: "Baroness" }, hobbies: ["video games"] },
-  ]
-)
-# the following expect will ensure the params are permitted
-name, emails, friends = params.expect(
-  :name,                 # permitted scalar
-  emails: [],            # array of permitted scalars
-  friends: [[            # array of permitted Parameter hashes
-    :name,               # permitted scalar
-    family: [:name],     # family: { name: "permitted scalar" }
-    hobbies: []          # array of permitted scalars
-  ]]
-)
-```
-
-This declaration permits the `name`, `emails`, and `friends` attributes and
-returns them each. It is expected that `emails` will be an array of permitted
-scalar values, and that `friends` will be an array of resources (note the new
-double array syntax to explicitly require an array) with specific attributes.
-These attributes should have a `name` attribute (any permitted scalar values allowed), a
-`hobbies` attribute as an array of permitted scalar values, and a `family`
-attribute which is restricted to a hash with only a `name` key and any permitted
-scalar value.
-
-### Examples
-
-Here are some examples of how to use `permit` for different use cases.
-
-**Example 1**: You may want to use the permitted attributes in your `new` action.
-This raises the problem that you can't use [`require`][] on the root key
-because, normally, it does not exist when calling `new`:
-
-```ruby
-# using `fetch` you can supply a default and use
-# the Strong Parameters API from there.
-params.fetch(:blog, {}).permit(:title, :author)
-```
-
-**Example 2**: The model class method `accepts_nested_attributes_for` allows you to
-update and destroy associated records. This is based on the `id` and `_destroy`
-parameters:
-
-```ruby
-# permit :id and :_destroy
-params.expect(author: [ :name, books_attributes: [[ :title, :id, :_destroy ]] ])
-```
-
-**Example 3**: Hashes with integer keys are treated differently, and you can declare
-the attributes as if they were direct children. You get these kinds of
-parameters when you use `accepts_nested_attributes_for` in combination with a
-`has_many` association:
-
-```ruby
-# To permit the following data:
-# {"book" => {"title" => "Some Book",
-#             "chapters_attributes" => { "1" => {"title" => "First Chapter"},
-#                                        "2" => {"title" => "Second Chapter"}}}}
-
-params.expect(book: [ :title, chapters_attributes: [[ :title ]] ])
-```
-
-**Example 4**: Imagine a scenario where you have parameters representing a product
-name, and a hash of arbitrary data associated with that product, and you want to
-permit the product name attribute and also the whole data hash:
-
-```ruby
-def product_params
-  params.expect(product: [ :name, data: {} ])
-end
-```
-
-[`require`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-require
-
-Cookies
--------
-
-The concept of a cookie is not specific to Rails. A
-[cookie](https://en.wikipedia.org/wiki/HTTP_cookie) (also known as an HTTP
-cookie or a web cookie) is a small piece of data from the server that is saved
-in the user's browser. The browser may store cookies, create new cookies, modify
-existing ones, and send them back to the server with later requests. Cookies
-persist data across web requests and therefore enable web applications to
-remember user preferences.
-
-Rails provides an easy way to access cookies via the [`cookies`][] method, which
-works like a hash:
-
-```ruby
-class CommentsController < ApplicationController
-  def new
-    # Auto-fill the commenter's name if it has been stored in a cookie
-    @comment = Comment.new(author: cookies[:commenter_name])
-  end
-
-  def create
-    @comment = Comment.new(comment_params)
-    if @comment.save
-      if params[:remember_name]
-        # Save the commenter's name in a cookie.
-        cookies[:commenter_name] = @comment.author
-      else
-        # Delete cookie for the commenter's name, if any.
-        cookies.delete(:commenter_name)
-      end
-      redirect_to @comment.article
-    else
-      render action: "new"
-    end
-  end
-end
-```
-
-NOTE: To delete a cookie, you need to use `cookies.delete(:key)`. Setting the
-`key` to a `nil` value does not delete the cookie.
-
-When passed a scalar value, the cookie will be deleted when the user closes their browser.
-If you want the cookie to expire at a specific time, pass a hash with the `:expires` option when setting the cookie.
-For example, to set a cookie that expires in 1 hour:
-
-```ruby
-cookies[:login] = { value: "XJ-122", expires: 1.hour }
-```
-
-If you want to create cookies that never expire use the permanent cookie jar.
-This sets the assigned cookies to have an expiration date 20 years from now.
-
-```ruby
-cookies.permanent[:locale] = "fr"
-```
-
-### Encrypted and Signed Cookies
-
-Since cookies are stored on the client browser, they can be susceptible to
-tampering and are not considered secure for storing sensitive data. Rails
-provides a signed cookie jar and an encrypted cookie jar for storing sensitive
-data. The signed cookie jar appends a cryptographic signature on the cookie
-values to protect their integrity. The encrypted cookie jar encrypts the values
-in addition to signing them, so that they cannot be read by the user.
-
-Refer to the [API
-documentation](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html)
-for more details.
-
-```ruby
-class CookiesController < ApplicationController
-  def set_cookie
-    cookies.signed[:user_id] = current_user.id
-    cookies.encrypted[:expiration_date] = Date.tomorrow # => Thu, 20 Mar 2024
-    redirect_to action: "read_cookie"
-  end
-
-  def read_cookie
-    cookies.encrypted[:expiration_date] # => "2024-03-20"
-  end
-end
-```
-
-These special cookie jars use a serializer to serialize the cookie values into
-strings and deserialize them into Ruby objects when read back. You can specify
-which serializer to use via [`config.action_dispatch.cookies_serializer`][]. The
-default serializer for new applications is `:json`.
-
-NOTE: Be aware that JSON has limited support serializing Ruby objects such as
-`Date`, `Time`, and `Symbol`. These will be serialized and deserialized into
-`String`s.
-
-If you need to store these or more complex objects, you may need to manually
-convert their values when reading them in subsequent requests.
-
-If you use the cookie session store, the above applies to the `session` and
-`flash` hash as well.
-
-[`config.action_dispatch.cookies_serializer`]:
-    configuring.html#config-action-dispatch-cookies-serializer
-[`cookies`]:
-    https://api.rubyonrails.org/classes/ActionController/Cookies.html#method-i-cookies
-
-Session
--------
-
-While cookies are stored client-side, session data is stored server-side (in
-memory, a database, or a cache), and the duration is usually temporary and tied
-to the user's session (e.g. until they close the browser). An example use case
-for session is storing sensitive data like user authentication.
-
-In a Rails application, the session is available in the controller and the view.
-
-### Working with the Session
-
-You can use the `session` instance method to access the session in your
-controllers. Session values are stored as key/value pairs like a hash:
-
-```ruby
-class ApplicationController < ActionController::Base
-  private
-    # Look up the key `:current_user_id` in the session and use it to
-    # find the current `User`. This is a common way to handle user login in
-    # a Rails application; logging in sets the session value and
-    # logging out removes it.
-    def current_user
-      @current_user ||= User.find_by(id: session[:current_user_id]) if session[:current_user_id]
-    end
-end
-```
-
-To store something in the session, you can assign it to a key similar to adding
-a value to a hash. After a user is authenticated, its `id` is saved in the
-session to be used for subsequent requests:
-
-```ruby
-class SessionsController < ApplicationController
-  def create
-    if user = User.authenticate_by(email: params[:email], password: params[:password])
-      # Save the user ID in the session so it can be used in
-      # subsequent requests
-      session[:current_user_id] = user.id
-      redirect_to root_url
-    end
-  end
-end
-```
-
-To remove something from the session, delete the key/value pair. Deleting the
-`current_user_id` key from the session is a typical way to log the user out:
-
-```ruby
-class SessionsController < ApplicationController
-  def destroy
-    session.delete(:current_user_id)
-    # Clear the current user as well.
-    @current_user = nil
-    redirect_to root_url, status: :see_other
-  end
-end
-```
-
-It is possible to reset the entire session with [`reset_session`][]. It is
-recommended to use `reset_session` after logging in to avoid session fixation
-attacks. Please refer to the [Security
-Guide](https://edgeguides.rubyonrails.org/security.html#session-fixation-countermeasures)
-for details.
-
-NOTE: Sessions are lazily loaded. If you don't access sessions in your action's
-code, they will not be loaded. Hence, you will never need to disable sessions -
-not accessing them will do the job.
-
-[`reset_session`]:
-    https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-reset_session
-
-### The Flash
-
-The [flash](https://api.rubyonrails.org/classes/ActionDispatch/Flash.html)
-provides a way to pass temporary data between controller actions. Anything you
-place in the flash will be available to the very next action and then cleared.
-The flash is typically used for setting messages (e.g. notices and alerts) in a
-controller action before redirecting to an action that displays the message to
-the user.
-
-The flash is accessed via the [`flash`][] method. Similar to the session, the
-flash values are stored as key/value pairs.
-
-For example, in the controller action for logging out a user, the controller can
-set a flash message which can be displayed to the user on the next request:
-
-```ruby
-class SessionsController < ApplicationController
-  def destroy
-    session.delete(:current_user_id)
-    flash[:notice] = "You have successfully logged out."
-    redirect_to root_url, status: :see_other
-  end
-end
-```
-
-Displaying a message after a user performs some interactive action in your
-application is a good practice to give the user feedback that their action was
-successful (or that there were errors).
-
-In addition to `:notice`, you can also use `:alert`. These are typically styled
-(using CSS) with different colors to indicate their meaning (e.g. green for
-notices and orange/red for alerts).
-
-You can also assign a flash message directly within the `redirect_to` method by
-including it as a parameter to `redirect_to`:
-
-```ruby
-redirect_to root_url, notice: "You have successfully logged out."
-redirect_to root_url, alert: "There was an issue."
-```
-
-You're not limited to `notice` and `alert`.
-You can set any key in a flash (similar to sessions), by assigning it to the `:flash` argument.
-For example, assigning `:just_signed_up`:
-
-```ruby
-redirect_to root_url, flash: { just_signed_up: true }
-```
-
-This will allow you to have the below in the view:
-
-```erb
-<% if flash[:just_signed_up] %>
-  <p class="welcome">Welcome to our site!</p>
-<% end %>
-```
-
-In the above logout example, the `destroy` action redirects to the application's
-`root_url`, where the message is available to be displayed. However, it's not
-displayed automatically. It's up to the next action to decide what, if anything,
-it will do with what the previous action put in the flash.
-
-#### Displaying flash messages
-
-If a previous action _has_ set a flash message, it's a good idea to display that
-to the user. We can accomplish this consistently by adding the HTML for
-displaying any flash messages in the application's default layout. Here's an
-example from `app/views/layouts/application.html.erb`:
-
-```erb
-<html>
-  <!-- <head/> -->
-  <body>
-    <% flash.each do |name, msg| -%>
-      <%= content_tag :div, msg, class: name %>
-    <% end -%>
-
-    <!-- more content -->
-    <%= yield %>
-  </body>
-</html>
-```
-
-The `name` above indicates the type of flash message, such as `notice` or
-`alert`. This information is normally used to style how the message is displayed
-to the user.
-
-TIP: You can filter by `name` if you want to limit to displaying only `notice`
-and `alert` in layout. Otherwise, all keys set in the `flash` will be displayed.
-
-Including the reading and displaying of flash messages in the layout ensures
-that your application will display these automatically, without each view having
-to include logic to read the flash.
-
-#### `flash.keep` and `flash.now`
-
-[`flash.keep`][] is used to carry over the flash value through to an additional
-request. This is useful when there are multiple redirects.
-
-For example, assume that the `index` action in the controller below corresponds
-to the `root_url`. And you want all requests here to be redirected to
-`UsersController#index`. If an action sets the flash and redirects to
-`MainController#index`, those flash values will be lost when another redirect
-happens, unless you use `flash.keep` to make the values persist for another
+NOTE: When redirecting using `302 Found`, the client may not always make a `GET`
+request to the `Location`. JavaScript's `fetch` method will make a `GET` request
+after redirection from a `GET` or `POST` request. But, if the initial request is
+another method, for example `PUT`, it will use the same method when requesting
+the redirected location. This is not a problem in Rails because all
+[form submissions use `POST`](https://guides.rubyonrails.org/form_helpers.html#forms-with-patch-put-or-delete-methods),
+even when using [Turbo](http://turbo.hotwired.dev). <br><br> When making
+requests in custom JavaScript, redirect using
+[`303 See Other`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/303)
+to ensure a `GET` request to the redirected location, or
+[`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/307)
+to preserve the original HTTP verb.
+
+### Header-Only Responses
+
+The [`head`][] method can be used to send responses with only headers to the
+browser. This is usually in response to an
+[HTTP `HEAD`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/HEAD)
 request.
 
-```ruby
-class MainController < ApplicationController
-  def index
-    # Will persist all flash values.
-    flash.keep
-
-    # You can also use a key to keep only some kind of value.
-    # flash.keep(:notice)
-    redirect_to users_url
-  end
-end
-```
-
-[`flash.now`][] is used to make the flash values available in the same request.
-By default, adding values to the flash will make them available to the next
-request. For example, if the `create` action fails to save a resource, and you
-render the `new` template directly, that's not going to result in a new request,
-but you may still want to display a message using the flash. To do this, you can
-use [`flash.now`][] in the same way you use the normal `flash`:
+The `head` method accepts a number or symbol representing an HTTP status code.
 
 ```ruby
-class ClientsController < ApplicationController
-  def create
-    @client = Client.new(client_params)
-    if @client.save
-      # ...
-    else
-      flash.now[:error] = "Could not save client"
-      render action: "new"
-    end
-  end
-end
+head :bad_request
+# or
+head 400
 ```
 
-[`flash`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Flash/RequestMethods.html#method-i-flash
-[`flash.keep`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-keep
-[`flash.now`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-now
+This would produce the following HTTP response:
 
-### Session Stores
+```http
+HTTP/1.1 400 Bad Request
+connection: close
+transfer-encoding: chunked
+content-type: text/html; charset=utf-8
+set-cookie: _blog_session=...snip...; path=/; HttpOnly
+cache-control: no-cache
+```
 
-All sessions have a unique ID that represents the session object; these session
-IDs are stored in a cookie. The actual session objects use one of the following
-storage mechanisms:
-
-* [`ActionDispatch::Session::CookieStore`][] - Stores everything on the client.
-* [`ActionDispatch::Session::CacheStore`][] - Stores the data in the Rails
-  cache.
-* [`ActionDispatch::Session::ActiveRecordStore`][activerecord-session_store] -
-  Stores the data in a database using Active Record (requires the
-  [`activerecord-session_store`][activerecord-session_store] gem).
-* A custom store or a store provided by a third party gem.
-
-For most session stores, the unique session ID in the cookie is used to look up
-session data on the server (e.g. a database table). Rails does not allow you to
-pass the session ID in the URL as this is less secure.
-
-#### `CookieStore`
-
-The `CookieStore` is the default and recommended session store. It stores all
-session data in the cookie itself (the session ID is still available to you if
-you need it). The `CookieStore` is lightweight and does not require any
-configuration to use in a new application.
-
-The `CookieStore` can store 4 kB of data - much less than the other storage
-options - but this is usually enough. Storing large amounts of data in the
-session is discouraged. You should especially avoid storing complex objects
-(such as model instances) in the session.
-
-#### `CacheStore`
-
-You can use the `CacheStore` if your sessions don't store critical data or don't
-need to be around for long periods (for instance if you just use the flash for
-messaging). This will store sessions using the cache implementation you have
-configured for your application. The advantage is that you can use your existing
-cache infrastructure for storing sessions without requiring any additional setup
-or administration. The downside is that the session storage will be temporary
-and they could disappear at any time.
-
-Read more about session storage in the [Security Guide](security.html#sessions).
-
-### Session Storage Options
-
-There are a few configuration options related to session storage. You can
-configure the type of storage in an initializer:
+You can add additional HTTP headers if you wish.
 
 ```ruby
-Rails.application.config.session_store :cache_store
+head :created, location: photo_path(@photo)
 ```
 
-Rails sets up a session key (the name of the cookie) when signing the session
-data. These can also be changed in an initializer:
+Which would produce:
 
-```ruby
-Rails.application.config.session_store :cookie_store, key: "_your_app_session"
+```http
+HTTP/1.1 201 Created
+connection: close
+transfer-encoding: chunked
+location: /photos/1
+content-type: text/html; charset=utf-8
+set-cookie: _blog_session=...snip...; path=/; HttpOnly
+cache-control: no-cache
 ```
 
-NOTE: Be sure to restart your server when you modify an initializer file.
-
-You can also pass a `:domain` key and specify the domain name for the cookie:
-
-```ruby
-Rails.application.config.session_store :cookie_store, key: "_your_app_session", domain: ".example.com"
-```
-
-TIP: See [`config.session_store`](configuring.html#config-session-store) in the
-configuration guide for more information.
-
-Rails sets up a secret key for `CookieStore` used for signing the session data
-in `config/credentials.yml.enc`. The credentials can be updated with `bin/rails
-credentials:edit`.
-
-```yaml
-# aws:
-#   access_key_id: 123
-#   secret_access_key: 345
-
-# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
-secret_key_base: 492f...
-```
-
-WARNING: Changing the `secret_key_base` when using the `CookieStore` will
-invalidate all existing sessions. You'll need to configure a [cookie rotator](https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-cookies-rotations)
-to rotate existing sessions.
-
-[`ActionDispatch::Session::CookieStore`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
-[`ActionDispatch::Session::CacheStore`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Session/CacheStore.html
-[activerecord-session_store]:
-    https://github.com/rails/activerecord-session_store
+[`head`]:
+  https://api.rubyonrails.org/classes/ActionController/Head.html#method-i-head
 
 Controller Callbacks
 --------------------
 
-Controller callbacks are methods that are defined to automatically run before
-and/or after a controller action. A controller callback method can be defined in
-a given controller or in the `ApplicationController`. Since all controllers
-inherit from `ApplicationController`, callbacks defined here will run on every
-controller in your application.
+Controller callbacks are methods that are defined to automatically run before or
+after a controller action. Callbacks may be defined in the
+`ApplicationController` if they need to be run across the application, or within
+specific controllers only.
 
 ### `before_action`
 
 Callback methods registered via [`before_action`][] run _before_ a controller
-action. They may halt the request cycle. A common use case for `before_action`
-is ensuring that a user is logged in:
+action. They may halt the request cycle meaning the controller action itself is
+never called.
+
+A common use case for `before_action` is to ensure that a user is logged in:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -1022,47 +366,45 @@ class ApplicationController < ActionController::Base
 
   private
     def require_login
-      unless logged_in?
-        flash[:error] = "You must be logged in to access this section"
+      unless Current.user.present?
         redirect_to new_login_url # halts request cycle
       end
     end
 end
 ```
 
-The method stores an error message in the flash and redirects to the login form
-if the user is not already logged in. When a `before_action` callback renders or
-redirects (like in the example above), the original controller action is not
-run. If there are additional callbacks registered to run, they are also
-cancelled and not run.
+When a `before_action` callback renders or redirects (like in the example
+above), the controller action is not run. If there are additional callbacks
+registered to run, they will be cancelled.
 
-In this example, the `before_action` is defined in `ApplicationController` so
-all controllers in the application inherit it. That implies that all requests in
-the application will require the user to be logged in. This is fine except for
-the "login" page. The "login" action should succeed even when the user is not
-logged in (to allow the user to log in) otherwise the user will never be able to
-log in. You can use [`skip_before_action`][] to allow specified controller
+In this example, the `before_action` is defined in `ApplicationController`
+meaning it will be run before all actions across the applications. This also
+means the user will need to be logged into access the login page, which doesn't
+make sense.
+
+In such cases, use [`skip_before_action`][] to allow specified controller
 actions to skip a given `before_action`:
 
 ```ruby
-class LoginsController < ApplicationController
+class SessionsController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
 end
 ```
 
-Now, the `LoginsController`'s `new` and `create` actions will work without
+Now, the `SessionsController`'s `new` and `create` actions will work without
 requiring the user to be logged in.
 
-The `:only` option skips the callback only for the listed actions; there is also
+The `:only` option skips the callback only for the listed actions. There is also
 an `:except` option which works the other way. These options can be used when
-registering action callbacks too, to add callbacks which only run for selected
-actions.
+registering action callbacks to run them only for specific actions.
 
 NOTE: If you register the same action callback multiple times with different
 options, the last action callback definition will overwrite the previous ones.
 
-[`before_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_action
-[`skip_before_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-skip_before_action
+[`before_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_action
+[`skip_before_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-skip_before_action
 
 ### `after_action` and `around_action`
 
@@ -1080,7 +422,7 @@ action, and not if an exception is raised in the request cycle.
 The `around_action` callbacks are useful when you want to execute code before
 and after a controller action, allowing you to encapsulate functionality that
 affects the action's execution. They are responsible for running their
-associated actions by yielding.
+associated actions by `yield`ing.
 
 For example, imagine you want to monitor the performance of specific actions.
 You could use an `around_action` to measure how long each action takes to
@@ -1108,37 +450,36 @@ you can use, as shown in the example above.
 The `around_action` callback also wraps rendering. In the example above, view
 rendering will be included in the `duration`. The code after the `yield` in an
 `around_action` is run even when there is an exception in the associated action
-and there is an `ensure` block in the callback. (This is different from
-`after_action` callbacks where an exception in the action cancels the
-`after_action` code.)
+and there is an `ensure` block in the callback.
 
-[`after_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-after_action
-[`around_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-around_action
+This is different from `after_action` callbacks where an exception in the action
+cancels any `after_action` callbacks.
 
-### Other Ways to Use Callbacks
+[`after_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-after_action
+[`around_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-around_action
 
-In addition to `before_action`, `after_action`, or `around_action`, there are
-two less common ways to register callbacks.
+### Advanced Techniques to Register Callbacks
 
-The first is to use a block directly with the `*_action` methods. The block
-receives the controller as an argument. For example, the `require_login` action
-callback from above could be rewritten to use a block:
+In addition to registering a method name using `before_action`, `after_action`,
+or `around_action`, there are two other ways to register callbacks.
+
+#### Using a Block
+
+A block can be supplied to the `*_action` methods. It receives the controller as
+an argument. The `require_login` action callback from above could be rewritten
+to use a block:
 
 ```ruby
 class ApplicationController < ActionController::Base
   before_action do |controller|
-    unless controller.send(:logged_in?)
-      flash[:error] = "You must be logged in to access this section"
+    unless Current.user.present?
       redirect_to new_login_url
     end
   end
 end
 ```
-
-Note that the action callback, in this case, uses `send` because the
-`logged_in?` method is private, and the action callback does not run in the
-scope of the controller. This is not the recommended way to implement this
-particular action callback, but in simpler cases, it might be useful.
 
 Specifically for `around_action`, the block also yields in the `action`:
 
@@ -1146,10 +487,16 @@ Specifically for `around_action`, the block also yields in the `action`:
 around_action { |_controller, action| time(&action) }
 ```
 
-The second way is to specify a class (or any object that responds to the
-expected methods) for the callback action. This can be useful in cases that are
-more complex. As an example, you could rewrite the `around_action` callback to
-measure execution time with a class:
+#### Using an Object
+
+An object, usually a class, can be used to register callbacks. The object must
+implement a method with the same name as the action callback.
+
+For the `before_action` callback, the class must implement a `before` method,
+and so on. Also, the `around` method must `yield` to execute the action.
+
+This can be useful in cases that are more complex. As an example, you could
+rewrite the `around_action` callback to measure execution time with a class:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -1168,29 +515,912 @@ class ActionDurationCallback
 end
 ```
 
-In the above example, the `ActionDurationCallback`'s method is not run in the scope
-of the controller but gets `controller` as an argument.
+In the above example, the `ActionDurationCallback`'s method is not run in the
+scope of the controller but gets `controller` as an argument.
 
-In general, the class being used for a `*_action` callback must implement a
-method with the same name as the action callback. So for the `before_action`
-callback, the class must implement a `before` method, and so on. Also,
-the `around` method must `yield` to execute the action.
+Request Parameters
+------------------
+
+Data sent by the incoming request is available in your controller using the
+[`params`][] method which returns an [`ActionController::Parameters`][] object.
+
+There are two types of parameter data:
+
+- Query string parameters which are sent as part of the URL (for example, after
+  the `?` in `http://example.com/accounts?filter=free`).
+- Request body parameters in non-`GET` requests, usually from an HTML form.
+
+Rails does not make a distinction between query string parameters and request
+body parameters — both are available in the `params` object in your controller.
+For example:
+
+```ruby
+class ProductsController < ApplicationController
+  # This action receives query string parameters from an HTTP GET request
+  # at the URL "/products?filter=books"
+  def index
+    if params[:filter] == "books"
+      @products = Product.books
+    else
+      @products = Product.all
+    end
+  end
+
+  # This action receives parameters from a POST request to "/products" URL with
+  # form data in the request body.
+  def create
+    @product = Product.new(params[:product])
+    if @product.save
+      redirect_to @product
+    else
+      render "new", status: :unprocessable_content
+    end
+  end
+end
+```
+
+NOTE: [`ActionController::Parameters`][] does not inherit from Hash, but it is
+mostly similar in behavior. Unlike a Hash, symbolic and string keys, such as
+`:foo` and `"foo"`, are considered to be the same.
+
+[`params`]:
+  https://api.rubyonrails.org/classes/ActionController/StrongParameters.html#method-i-params
+[`ActionController::Parameters`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html
+
+### Parameter Value Types
+
+Values in an [`ActionController::Parameters`][] object must be a permitted
+scalar value defined in `ActionController::Parameters::PERMITTED_SCALAR_TYPES`.
+
+```ruby
+ActionController::Parameters::PERMITTED_SCALAR_TYPES
+# => [String, Symbol, NilClass, Numeric, TrueClass, FalseClass, Date, Time, StringIO, IO, ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile]
+```
+
+The object can contain nested hashes and arrays, but values within those must
+also contain a permitted scalar.
+
+To send an array of values, append an empty pair of square brackets `[]` to the
+key name:
+
+```
+GET /users?ids[]=1&ids[]=2&ids[]=3
+```
+
+NOTE: The actual URL in this example will be encoded as
+`/users?ids%5b%5d=1&ids%5b%5d=2&ids%5b%5d=3` as the `[` and `]` characters are
+not allowed in URLs. Most of the time you don't have to worry about this because
+the browser will encode it for you, and Rails will decode it automatically, but
+if you ever find yourself having to send those requests to the server manually
+you should keep this in mind.
+
+The value of `params[:ids]` will be the array `["1", "2", "3"]`. Parameter
+values are always strings, Rails does not attempt to guess or cast the type.
+
+NOTE: Values such as `[nil]` or `[nil, nil, ...]` in `params` are replaced with
+`[]` for security reasons by default. See
+[Security Guide](security.html#unsafe-query-generation) for more information.
+
+To send a hash, you include the key name inside the brackets:
+
+```html
+<form accept-charset="UTF-8" action="/users" method="post">
+  <input type="text" name="user[name]" value="Acme" />
+  <input type="text" name="user[phone]" value="12345" />
+  <input type="text" name="user[address][postcode]" value="12345" />
+  <input type="text" name="user[address][city]" value="Carrot City" />
+</form>
+```
+
+When this form is submitted, the value of `params[:user]` will be:
+
+```ruby
+{
+  "name" => "Acme",
+  "phone" => "12345",
+  "address" => {
+    "postcode" => "12345",
+    "city" => "Carrot City"
+  }
+}
+```
+
+Note the nested hash in `params[:user][:address]`.
+
+Rails provides helpers to construct HTML forms that adhere to Rails conventions.
+Refer to the [Form Helpers guide](form_helpers.html) for further information.
+
+### Composite Key Parameters
+
+[Composite key parameters](active_record_composite_primary_keys.html) contain
+multiple values in one parameter separated by a delimiter (such as an
+underscore). Therefore, you will need to extract each value so that you can pass
+them to Active Record. You can use the [`extract_value`][] method to do that.
+
+Consider the below controller and route:
+
+```ruby#4
+class ProductsController < ApplicationController
+  def show
+    # Extract the composite ID value from URL parameters.
+    id = params.extract_value(:id)
+    @product = Product.find(id)
+  end
+end
+```
+
+```ruby
+get "/products/:id", to: "products#show"
+```
+
+When a user requests the URL `/products/4_2`, the controller will extract the
+composite key value `["4", "2"]` and pass it to `Product.find`. The
+[`extract_value`][] method may be used to extract arrays out of any delimited
+parameters.
+
+[`extract_value`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-extract_value
+
+### JSON Parameters
+
+If your application exposes an API, you will likely accept parameters in JSON
+format. If the `content-type` header of your request is set to
+`application/json`, Rails will automatically load your parameters into the
+`params` hash, which you can access as you would normally.
+
+So for example, if you are sending this JSON content:
+
+```json
+{ "user": { "name": "acme", "address": "123 Carrot Street" } }
+```
+
+Your controller will receive:
+
+```ruby
+{ "user" => { "name" => "acme", "address" => "123 Carrot Street" } }
+```
+
+#### Parameter Wrapping
+
+Rails will automatically wrap parameters within a key denoting the corresponding
+resource, and also add the controller name to JSON parameters.
+
+For example, consider the below JSON object:
+
+```json
+{ "name": "acme", "address": "123 Carrot Street" }
+```
+
+If we send the above data to `create` action of the `UsersController`, the JSON
+data will be wrapped within the `:user` key as:
+
+```ruby
+{
+  controller: "users",
+  action: "create",
+  name: "acme",
+  address: "123 Carrot Street",
+  user: {
+    name: "acme", address: "123 Carrot Street"
+  }
+}
+```
+
+NOTE: Rails adds a clone of the parameters to the hash within the key
+corresponding to the resource's name. As a result, both the original version of
+the parameters and the "wrapped" version of the parameters will exist in the
+params object.
+
+NOTE: While the action and controller names are available in the params object,
+it is recommended to use the methods [`controller_name`][] and [`action_name`][]
+instead to access these values.
+
+Parameter wrapping is enabled by default, but can be disabled using a
+configuration option:
+
+```ruby
+# config/application.rb
+
+config.action_controller.wrap_parameters_by_default = false
+```
+
+You can also customize the name of the key or specific parameters you want to
+wrap, see the
+[API documentation](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html)
+for more.
+
+[`controller_name`]:
+  https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-controller_name
+[`action_name`]:
+  https://api.rubyonrails.org/classes/AbstractController/Base.html#method-i-action_name
+
+### Routing Parameters
+
+Parameters specified as part of a route declaration in the `routes.rb` file are
+also made available in the `params` hash. For example, we can add a route that
+captures the `:category` parameter for a product:
+
+```ruby
+get "/products/:category", to: "products#index", foo: "bar"
+```
+
+When a user navigates to `/products/electronics` URL, `params[:category]` will
+be set to "electronics". When this route is used, `params[:foo]` will also be
+set to "bar", as if it were passed in the query string.
+
+Any other parameters defined by the route declaration, such as `:id`, will also
+be available.
+
+### Global Default Parameters
+
+You can set global default parameters when generating URLs by defining a
+`default_url_options` method in your controller.
+
+```ruby
+class ApplicationController < ActionController::Base
+  def default_url_options
+    { locale: I18n.locale }
+  end
+end
+```
+
+The specified defaults will be used as a starting point when generating URLs.
+They can be overridden by the options passed to [`url_for`][] or any path helper
+such as `products_path`. The above example will automatically add the locale to
+every URL.
+
+```ruby
+products_path # => "/products?locale=en"
+```
+
+You can still override this default if needed:
+
+```ruby
+products_path(locale: :fr) # => "/products?locale=fr"
+```
+
+NOTE: All Rails path helpers call `url_for` under the hood.
+
+If you define `default_url_options` in `ApplicationController`, as in the
+example above, these defaults will be used for all URL generation. The method
+can also be defined in a specific controller, in which case it only applies to
+URLs generated for that controller.
+
+In a given request, the method is not actually called for every single generated
+URL. For performance reasons the returned hash is cached per request.
+
+[`url_for`]:
+  https://api.rubyonrails.org/classes/ActionView/RoutingUrlFor.html#method-i-url_for
+
+### Securing Submitted Parameters
+
+[Action Controller Strong Parameters](https://api.rubyonrails.org/classes/ActionController/StrongParameters.html)
+ensures parameters cannot be used in Active Model mass assignments until they
+have been explicitly permitted.
+
+This requires you to specify the allowed attributes for any given model and
+declare them in the controller. This is a security practice to prevent users
+from accidentally or maliciously updating sensitive model attributes.
+
+Consider the below controller and action:
+
+```ruby
+class PeopleController < ActionController::Base
+  def create
+    @person = Person.create(params[:person])
+    # ...
+  end
+end
+```
+
+We create a `Person` record using the parameters passed in the `:person` key,
+without explicitly defining which parameters are permitted. A `Person` may have
+a boolean attribute which specifies whether or not they're an _admin_. A
+malicious user could modify the HTML form to send this value and make themselves
+an admin without permission. As such, all parameters used in mass assignment
+must be explicitly allowed, and the above example will raise a
+`ActiveModel::ForbiddenAttributesError`.
+
+#### Permitting Parameter Attributes
+
+Each attribute must be manually permitted using its key. Nested hashes and
+arrays within attributes are allowed, and depending on the method used, nested
+keys may also need to be specified.
+
+The [`expect`][], [`permit`][], and [`require`][] methods are commonly used to
+specify permitted attributes.
+
+##### `expect`
+
+The [`expect`][] method is the safest and most explicit way to permit
+parameters. If the request doesn't contain all expected parameters,
+`ActionController::ParameterMissing` will be raised and a `400 Bad Request` HTTP
+response will be returned.
+
+```ruby#5
+class UsersController < ApplicationController
+  # ...
+
+  def update
+    id = params.expect(:id)
+  end
+
+  # ...
+end
+```
+
+When handling Rails forms, use [`expect`][] to ensure that the root key is
+present and define the permitted attributes.
+
+```ruby#5
+class UsersController < ApplicationController
+  # ...
+  private
+    def user_params
+      params.expect(user: [:username, :password])
+    end
+end
+```
+
+[`expect`][] is strict with types. Supplying a single key will return a scalar,
+and multiple keys will return an array of those values.
+
+```ruby
+params = ActionController::Parameters.new(name: "John Doe")
+params.expect(:name)
+# => "John Doe"
+
+params = ActionController::Parameters.new(name: "John Doe", title: "Mr")
+params.expect(:name, :title)
+# => ["John Doe", "Mr"]
+```
+
+Nested hashes and arrays must be specified, including any nested keys, or they
+will be filtered out.
+
+```ruby
+params = ActionController::Parameters.new(user: { name: "John Doe" })
+params.expect(:user)
+# => param is missing or the value is empty or invalid: user (ActionController::ParameterMissing)
+params.expect(user: [:name])
+# => #<ActionController::Parameters {"name" => "John Doe"} permitted: true>
+
+params = ActionController::Parameters.new(ids: ["1", "2", "3"])
+params.expect(:ids)
+# => param is missing or the value is empty or invalid: ids (ActionController::ParameterMissing)
+params.expect(ids: [])
+# => ["1", "2", "3"]
+
+params = ActionController::Parameters.new(
+  users: [{ name: "John Doe" }, { name: "Jane Doe" }]
+)
+params.expect(users: [])
+# => param is missing or the value is empty or invalid: users (ActionController::ParameterMissing)
+params.expect(users: [:name])
+# => param is missing or the value is empty or invalid: users (ActionController::ParameterMissing)
+params.expect(users: [[:name]])
+# => [#<ActionController::Parameters {"name" => "John Doe"} permitted: true>, #<ActionController::Parameters {"name" => "Jane Doe"} permitted: true>]
+```
+
+Permit all attributes under a key using:
+
+```ruby
+params.expect(user: {})
+```
+
+This does not check for types or any nested types. All contained attributes are
+permitted, which somewhat bypasses the security aspects of strong parameters.
+
+WARNING: Extreme care should be taken when calling `expect` with an empty hash,
+as it will allow all current and future model attributes to be mass-assigned.
+
+[`expect`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect
+
+##### `permit` and `require`
+
+[`permit`][] returns a new `ActionController::Parameters` object containing only
+the permitted attributes. Disallowed attributes are filtered out, and no error
+is raised.
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.permit(:user)
+# => #<ActionController::Parameters {} permitted: true>
+params.permit(user: [:id])
+# => #<ActionController::Parameters {"user" => #<ActionController::Parameters {"id" => 1} permitted: true>} permitted: true>
+params.permit(user: [:id, :admin])
+# => #<ActionController::Parameters {"user" => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: true>} permitted: true>
+```
+
+All values under a key can be permitted using `{}`:
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.permit(user: {})
+# => #<ActionController::Parameters {"user" => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: true>} permitted: true>
+```
+
+WARNING: Exercise caution when calling `permit` with an empty hash, as it will
+allow all current and future model attributes to be mass-assigned.
+
+[`permit`][] is commonly chained with [`require`][] to permit a set of
+attributes keyed by a resource name. [`require`][] accepts a single key or an
+array of keys. It returns the associated values if found, or raises
+`ActionController::ParameterMissing` if any supplied keys are missing.
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.require(:user)
+# => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: false>
+```
+
+As demonstrated above, the object returned by `require(:user)` has not yet been
+`permitted`. As such, [`require`][] is often chained with [`permit`][] to return
+a set of permitted attributes:
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.require(:user).permit(:id, :admin)
+# => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: true>
+```
+
+Note that [`expect`][] is the recommended technique to permit attributes,
+especially when working with nested objects, as it is more explicit about value
+types, and hence provides additional safety.
+
+[`permit`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit
+[`require`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-require
+
+##### `permit!`
+
+The [`permit!`][] method sets the `permitted` attribute on an
+`ActionController::Parameters` object to `true`. It does no filtering or value
+checking whatsoever.
+
+```ruby
+params = ActionController::Parameters.new(id: 1, admin: "true")
+# => #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: false>
+params.permit!
+# => #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: true>
+```
+
+WARNING: Since `permit!` does not check any values, it bypasses all security
+benefits provided by strong parameters. Use with extreme caution.
+
+[`permit!`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit-21
+
+Further details on advanced parameter filtering are available in the
+[API docs](https://api.rubyonrails.org/classes/ActionController/Parameters.html).
+
+Cookies
+-------
+
+A [cookie](https://en.wikipedia.org/wiki/HTTP_cookie) (also known as an HTTP
+cookie or a web cookie) is a small piece of data from the server that is saved
+in the user's browser. The browser may store cookies, create new cookies, modify
+existing ones, and send them back to the server with later requests. Cookies
+persist data across web requests and therefore enable web applications to
+remember user preferences.
+
+Rails provides access to cookies in a controller via the [`cookies`][] method,
+which returns an instance of [`ActionDispatch::Cookies`][].
+[`ActionDispatch::Cookies`][] is a key-value store and is similar to a Ruby
+Hash.
+
+```ruby
+class PreferencesController < ApplicationController
+  def new
+    # Read data from a cookie
+    @preferences = cookies[:preferences]
+  end
+
+  def create
+    # Write data to a cookie
+    cookies[:preferences] = params.expect(preferences: {})
+  end
+
+  def destroy
+    # Delete a key from a cookie
+    cookies.delete(:preferences)
+  end
+end
+```
+
+NOTE: Setting a key to `nil` will not delete the cookie. You need to use
+`cookies.delete(:key)`.
+
+Cookies have a
+[default lifetime](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#removal_defining_the_lifetime_of_a_cookie)
+of `Session`, so they will be deleted when the user closes their browser.
+
+Create a _permanent cookie_ that expires at a specific time by passing a hash
+with the `:expires` option:
+
+```ruby
+cookies[:remember_me] = { value: "true", expires: 1.month }
+```
+
+Rails also provides a _permanent cookie jar_ that automatically sets the
+expiration date to 20 years from the time of creation:
+
+```ruby
+cookies.permanent[:locale] = "fr"
+```
+
+### Encrypted and Signed Cookies
+
+Since cookies are stored on the client browser, they can be susceptible to
+tampering and are not considered secure for storing sensitive data. Rails
+provides signed and encrypted cookie jars for storing sensitive data.
+
+The signed cookie jar appends a cryptographic signature on the cookie data to
+protect its integrity. The data can be read by a user, but cannot be tampered
+with as it is cryptographically signed.
+
+```ruby
+cookes.signed[:preferences] = @user.preferences.to_h
+```
+
+The encrypted cookie jar encrypts the data in addition to signing it, so that it
+cannot be read by the user nor tampered with.
+
+```ruby
+cookes.encrypted[:remember_token] = @user.remember_token
+```
+
+Refer to the
+[API documentation](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html)
+for more details.
+
+These special cookie jars use a serializer to serialize the cookie values into
+strings and deserialize them into Ruby objects when read back. The default
+serializer for new applications is `:json`.
+
+You can specify the serializer via
+[`config.action_dispatch.cookies_serializer`][].
+
+NOTE: Be aware that JSON has limited support serializing Ruby objects such as
+`Date`, `Time`, and `Symbol`. These will be serialized and deserialized into
+`String`s.
+
+If you need to store these or more complex objects, you may need to manually
+convert their values when reading them in subsequent requests.
+
+[`config.action_dispatch.cookies_serializer`]:
+  configuring.html#config-action-dispatch-cookies-serializer
+[`ActionDispatch::Cookies`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html
+[`cookies`]:
+  https://api.rubyonrails.org/classes/ActionController/Cookies.html#method-i-cookies
+
+Session
+-------
+
+Rails provides a _session_ object which is used to store data relevant to the
+current user session. For example, data related to user authentication may be
+stored in the session object.
+
+Session data is stored in an encrypted cookie by default, but other stores
+[may be configured](#session-stores).
+
+### Working with the Session
+
+The session is available in the controller and the view via the `session` method
+which returns an instance of `ActionDispatch::Http::Session`. This object is a
+key-value store and values can be accessed and set in the same way as a Ruby
+Hash.
+
+```ruby
+class SessionsController < ActionController::Base
+  # Read the session to redirect the user back to their initial location
+  # after a log in, or redirect them to the root path if no location is set.
+  def create
+    # ...
+
+    redirect_to session[:initial_location] || root_path
+  end
+end
+```
+
+To store data the session, assign a value to a key as you would in a Ruby Hash.
+
+```ruby
+class ProductsController < ApplicationController
+  def create
+    # ...
+
+    # Handle logged out user
+    session[:initial_location] = request.referer
+    redirect_to login_path
+  end
+end
+```
+
+To remove something from the session, delete the key:
+
+```ruby
+class ProductsController < ApplicationController
+  def new
+    session.delete(:initial_location)
+  end
+end
+```
+
+Delete all data and create a new session object using [`reset_session`][]. It is
+recommended to use `reset_session` before logging in to avoid
+[session fixation attacks](security.html#session-fixation).
+
+NOTE: Sessions are lazily loaded. If you don't access sessions in your action's
+code, they will not be loaded. Hence, you will never need to disable sessions -
+not accessing them will do the job.
+
+[`reset_session`]:
+  https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-reset_session
+
+### Session Stores
+
+The storage mechanism for session data can be configured. By default, data is
+stored in an encrypted cookie, but other stores are available.
+
+All sessions have a unique ID representing the session object. Regardless of the
+chosen store, this session ID is always stored in a cookie. The session data can
+be stored using one of the following storage mechanisms:
+
+- [`ActionDispatch::Session::CookieStore`][] - Stores the data in an encrypted
+  cookie.
+- [`ActionDispatch::Session::CacheStore`][] - Stores the data in the Rails
+  cache.
+- [`ActionDispatch::Session::ActiveRecordStore`][activerecord-session_store] -
+  Stores the data in a database using Active Record (requires the
+  [`activerecord-session_store`][activerecord-session_store] gem).
+- A custom store or a store provided by a third party gem.
+
+For most session stores, Rails uses the unique session ID in the cookie to read
+session data from your chosen store. Rails does not allow you to pass the
+session ID in the URL as this is less secure.
+
+#### `CookieStore`
+
+The `CookieStore` is the default and recommended session store. It stores all
+session data, including the session ID, in an encrypted cookie. The
+`CookieStore` is lightweight and does not require any configuration to use in a
+new application.
+
+Cookies are limited 4 kB of data, and the cookie store is bound by this limit.
+While this is lesser than the other storage options, it is usually enough.
+Storing large amounts of data in the session is discouraged. You should
+especially avoid storing complex objects (such as model instances) in the
+session.
+
+#### `CacheStore`
+
+You can use the `CacheStore` if your sessions don't store critical data or don't
+need to be around for long periods. This will store sessions using the cache
+implementation you have configured for your application. The advantage is that
+you can use your existing cache infrastructure for storing sessions without
+requiring any additional setup or administration. The downside is that the
+session storage will be temporary and data could disappear at any time.
+
+Read more about session storage in the [Security Guide](security.html#sessions).
+
+### Configuring the Session
+
+Some aspects of the session can be configured.
+
+Set the session store using:
+
+```ruby
+# config/initializers/sessions.rb
+
+Rails.application.config.session_store :cache_store
+```
+
+When using the cookie store, Rails automatically sets the name of the cookie.
+However, this can also be configured:
+
+```ruby
+# config/initializers/sessions.rb
+
+Rails.application.config.session_store :cookie_store, key: "_your_app_session"
+```
+
+NOTE: Be sure to restart your server when you modify an initializer file.
+
+You can also pass a `:domain` key and specify the domain name for the cookie:
+
+```ruby
+Rails.application.config.session_store :cookie_store, key: "_your_app_session", domain: ".example.com"
+```
+
+See [`config.session_store`](configuring.html#config-session-store) in the
+configuration guide for more information.
+
+NOTE: Signed and encrypted cookies, including the session when using the cookie
+store, are signed using the `secret_key_base` generated for all new Rails
+applications. It is usually stored in the encrypted credentials file:
+`config/credentials.yml.enc`. Changing the `secret_key_base` will render all
+signed and encrypted cookies unreadable. Refer to the
+[security guide](security.html#custom-credentials) for further information.
+
+[`ActionDispatch::Session::CookieStore`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
+[`ActionDispatch::Session::CacheStore`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Session/CacheStore.html
+[activerecord-session_store]:
+  https://github.com/rails/activerecord-session_store
+
+### The Flash
+
+The [flash](https://api.rubyonrails.org/classes/ActionDispatch/Flash.html)
+provides a way to pass temporary data between controller actions invoked in
+successive HTTP requests.
+
+Anything you place in the flash will be available in the very next request, and
+then cleared.
+
+The flash is typically used for setting messages such as notices and alerts in a
+controller action, before redirecting to an action that displays the message.
+
+The flash is accessed via the [`flash`][] method which returns an instance of
+[`ActionDispatch::Flash::FlashHash`][]. Similar to the session, the flash values
+are stored as key-value pairs exactly like a Ruby Hash.
+
+Consider the below example where the controller sets a flash message after a
+product is created, which will be available to display during the next request
+after the user is redirected.
+
+```ruby
+class ProductsController < ApplicationController
+  def create
+    # ...
+
+    flash[:notice] = "Your product was created!"
+    redirect_to products_path, status: :see_other
+  end
+end
+```
+
+You may use different keys to assign different message types:
+
+```ruby
+flash[:notice]  = "Your product was created!"
+flash[:alert]   = "Sorry, something when wrong while creating your product."
+flash[:warning] = "Your product was created, but there were some problems."
+```
+
+Set a flash message when calling `redirect_to` by including it as a parameter:
+
+```ruby
+# Equivalent to setting flash[:notice]
+redirect_to root_url, notice: "Your product was created!"
+
+# Equivalent to setting flash[:alert]
+redirect_to root_url, alert: "Sorry, something when wrong when creating your product."
+```
+
+Only `notice:` and `alert:` options may be used at the top-level. Storing
+messages under other keys needs the `flash:` option:
+
+```ruby
+# Equivalent to setting flash[:warning]
+redirect_to root_url, flash: { warning: "Your product was created, but there were some problems." }
+```
+
+The flash does not render anything in the UI — it is a short-term data storage
+mechanism. Reading flash data and rendering the appropriate HTML is left up the
+the developer.
+
+[`ActionDispatch::Flash::FlashHash`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html
+
+#### Displaying Flash Messages
+
+It is recommend to add code to render flash messages in your application layout,
+so messages are automatically rendered on every page without additional steps.
+
+Iterate through all the keys and values to render all set messages, and then you
+can use CSS to style the different types of messages based on their type:
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+
+<html>
+  <%# ... %>
+  <body>
+    <% flash.each do |type, message| -%>
+      <%= tag.div class: class_names("flash", type) do %>
+        <p><%= message %></p>
+      <% end %>
+    <% end -%>
+
+    <%# ... %>
+    <%= yield %>
+  </body>
+</html>
+```
+
+#### `flash.keep` and `flash.now`
+
+[`flash.keep`][] is used to carry over the flash value through to an additional
+request. This is useful when there are multiple redirects.
+
+For example, assume that the `root_url` routes to the `index` action in the
+controller below, and all requests here are redirected to
+`UsersController#index`.
+
+If an action sets the flash and redirects to `MainController#index`, those flash
+values will be lost during the next redirect.
+
+Use `flash.keep` to persist the values in the flash for one more request.
+
+```ruby#4,7
+class MainController < ApplicationController
+  def index
+    # Persists all flash values.
+    flash.keep
+
+    # Persists only the `:notice` value.
+    flash.keep(:notice)
+
+    # ...
+  end
+end
+```
+
+By default, setting flash value will make them available to the next request.
+[`flash.now`][] is used to make the flash values available in the same request.
+
+In the below example, when the `create` action fails to save a resource, the
+`new` template is rendered.
+
+Since there is no redirection, the response will not immediately trigger another
+HTTP request. Use `flash.now` to display a message using the flash in this case.
+This will make the message available in only the current request.
+
+```ruby
+class ProductsController < ApplicationController
+  def create
+    @product = Product.new(product_params)
+    if @product.save
+      # ...
+    else
+      flash.now[:error] = "The product could not be saved"
+      render "new", status: :unprocessable_content
+    end
+  end
+end
+```
+
+[`flash`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/RequestMethods.html#method-i-flash
+[`flash.keep`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-keep
+[`flash.now`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-now
 
 The Request and Response Objects
 --------------------------------
 
 Every controller has two methods, [`request`][] and [`response`][], which can be
-used to access the request and response objects associated with the
-current request cycle. The `request` method returns an instance of
-[`ActionDispatch::Request`][]. The [`response`][] method returns an instance
-of [`ActionDispatch::Response`][], an object representing what is going to be
-sent back to the client browser (e.g. from `render` or `redirect` in the
-controller action).
+used to access the request and response objects associated with the current
+request cycle.
 
-[`ActionDispatch::Request`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html
-[`request`]: https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-request
-[`response`]: https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-response
-[`ActionDispatch::Response`]: https://api.rubyonrails.org/classes/ActionDispatch/Response.html
+The `request` method returns an instance of [`ActionDispatch::Request`][]. The
+[`response`][] method returns an instance of [`ActionDispatch::Response`][].
+
+[`ActionDispatch::Request`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Request.html
+[`request`]:
+  https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-request
+[`response`]:
+  https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-response
+[`ActionDispatch::Response`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Response.html
 
 ### The `request` Object
 
@@ -1198,24 +1428,23 @@ The request object contains useful information about the request coming in from
 the client. This section describes the purpose of some of the properties of the
 `request` object.
 
-To get a full list of the available methods, refer to the [Rails API
-documentation](https://api.rubyonrails.org/classes/ActionDispatch/Request.html)
-and [Rack](https://rack.github.io/rack/main/Rack/Request.html)
-documentation.
+The full list of the available methods can be viewed in the
+[Rails API documentation](https://api.rubyonrails.org/classes/ActionDispatch/Request.html)
+and [Rack](https://rack.github.io/rack/main/Rack/Request.html) documentation.
 
-| Property of `request`                     | Purpose                                                                          |
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| `host`                                    | The hostname used for this request.                                              |
-| `domain(n=2)`                             | The hostname's first `n` segments, starting from the right (the TLD).            |
-| `format`                                  | The content type requested by the client.                                        |
-| `method`                                  | The HTTP method used for the request.                                            |
-| `get?`, `post?`, `patch?`, `put?`, `delete?`, `head?` | Returns true if the HTTP method is GET/POST/PATCH/PUT/DELETE/HEAD.   |
-| `headers`                                 | Returns a hash containing the headers associated with the request.               |
-| `port`                                    | The port number (integer) used for the request.                                  |
-| `protocol`                                | Returns a string containing the protocol used plus "://", for example "http://". |
-| `query_string`                            | The query string part of the URL, i.e., everything after "?".                    |
-| `remote_ip`                               | The IP address of the client.                                                    |
-| `url`                                     | The entire URL used for the request.                                             |
+| Property of `request`                                 | Purpose                                                                          |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `host`                                                | The hostname used for this request.                                              |
+| `domain(n=2)`                                         | The hostname's first `n` segments, starting from the right (the TLD).            |
+| `format`                                              | The content type requested by the client.                                        |
+| `method`                                              | The HTTP method used for the request.                                            |
+| `get?`, `post?`, `patch?`, `put?`, `delete?`, `head?` | Returns true if the HTTP method is GET/POST/PATCH/PUT/DELETE/HEAD.               |
+| `headers`                                             | Returns a hash containing the headers associated with the request.               |
+| `port`                                                | The port number (integer) used for the request.                                  |
+| `protocol`                                            | Returns a string containing the protocol used plus "://", for example "http://". |
+| `query_string`                                        | The query string part of the URL, i.e., everything after "?".                    |
+| `remote_ip`                                           | The IP address of the client.                                                    |
+| `url`                                                 | The entire URL used for the request.                                             |
 
 #### `query_parameters`, `request_parameters`, and `path_parameters`
 
@@ -1224,70 +1453,26 @@ including the ones set in the URL as query string parameters, and those sent as
 the body of a `POST` request. The request object has three methods that give you
 access to the various parameters.
 
-* [`query_parameters`][] - contains parameters that were sent as part of the
+- [`query_parameters`][] - contains parameters that were sent as part of the
   query string.
-* [`request_parameters`][] - contains parameters sent as part of the post body.
-* [`path_parameters`][] - contains parameters parsed by the router as being part
+- [`request_parameters`][] - contains parameters sent as part of the post body.
+- [`path_parameters`][] - contains parameters parsed by the router as being part
   of the path leading to this particular controller and action.
 
-[`path_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html#method-i-path_parameters
-[`query_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-query_parameters
-[`request_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters
-
-#### `request.variant`
-
-Controllers might need to tailor a response based on context-specific
-information in a request. For example, controllers responding to requests from a
-mobile platform might need to render different content than requests from a
-desktop browser. One strategy to accomplish this is by customizing a request's
-variant. Variant names are arbitrary, and can communicate anything from the
-request's platform (`:android`, `:ios`, `:linux`, `:macos`, `:windows`) to its
-browser (`:chrome`, `:edge`, `:firefox`, `:safari`), to the type of user
-(`:admin`, `:guest`, `:user`).
-
-You can set the [`request.variant`](https://api.rubyonrails.org/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-variant-3D) in a `before_action`:
-
-```ruby
-request.variant = :tablet if request.user_agent.include?("iPad")
-```
-
-Responding with a variant in a controller action is like responding with a format:
-
-```ruby
-# app/controllers/projects_controller.rb
-
-def show
-  # ...
-  respond_to do |format|
-    format.html do |html|
-      html.tablet                         # renders app/views/projects/show.html+tablet.erb
-      html.phone { extra_setup; render }  # renders app/views/projects/show.html+phone.erb
-    end
-  end
-end
-```
-
-A separate template should be created for each format and variant:
-
-* `app/views/projects/show.html.erb`
-* `app/views/projects/show.html+tablet.erb`
-* `app/views/projects/show.html+phone.erb`
-
-You can also simplify the variants definition using the inline syntax:
-
-```ruby
-respond_to do |format|
-  format.html.tablet
-  format.html.phone  { extra_setup; render }
-end
-```
+[`path_parameters`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html#method-i-path_parameters
+[`query_parameters`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-query_parameters
+[`request_parameters`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters
 
 ### The `response` Object
 
 The response object is built up during the execution of the action from
 rendering data to be sent back to the client browser. It's not usually used
 directly but sometimes, in an `after_action` callback for example, it can be
-useful to access the response directly. One use case is for setting the content type header:
+useful to access the response directly. One use case is for setting the content
+type header:
 
 ```ruby
 response.content_type = "application/pdf"
@@ -1316,7 +1501,6 @@ Here are some of the properties of the `response` object:
 | `charset`              | The character set being used for the response. Default is "utf-8".                                  |
 | `headers`              | Headers used for the response.                                                                      |
 
-To get a full list of the available methods, refer to the [Rails API
-documentation](https://api.rubyonrails.org/classes/ActionDispatch/Response.html)
-and [Rack
-Documentation](https://rack.github.io/rack/main/Rack/Response.html).
+To get a full list of the available methods, refer to the
+[Rails API documentation](https://api.rubyonrails.org/classes/ActionDispatch/Response.html)
+and [Rack Documentation](https://rack.github.io/rack/main/Rack/Response.html).

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -3,1021 +3,362 @@
 Action Controller Overview
 ==========================
 
-In this guide, you will learn how controllers work and how they fit into the request cycle in your application.
+In this guide, you will learn how controllers work and how they fit into the
+request cycle in your application.
 
 After reading this guide, you will know how to:
 
-* Follow the flow of a request through a controller.
-* Access parameters passed to your controller.
-* Use Strong Parameters and permit values.
-* Store data in the cookie, the session, and the flash.
-* Work with action callbacks to execute code during request processing.
-* Use the Request and Response Objects.
+- Follow the flow of a request through a controller.
+- Render HTTP responses as well as redirect responses.
+- Work with action callbacks to execute code during request processing.
+- Access and securely filter parameters passed to your controller.
+- Store data in the cookie, the session, and the flash.
+- Use the Request and Response Objects.
 
 --------------------------------------------------------------------------------
 
-Introduction
-------------
+Action Controller Basics
+------------------------
 
-Action Controller is the C in the Model View Controller
+Action Controller is the **C** in the Model View Controller
 ([MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller))
-pattern. After the [router](routing.html) has matched a controller to an
-incoming request, the controller is responsible for processing the request and
-generating the appropriate output.
+pattern. The [router](routing.html) matches a controller to an incoming request,
+which is responsible for processing the request and generating the response.
 
 For most conventional
 [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer)
 applications, the controller will receive the request, fetch or save data from a
-model, and use a view to create HTML output.
+model, and render a view to create HTML output.
 
-You can imagine that a controller sits between models and views. The controller
-makes model data available to the view, so that the view can display that data
-to the user. The controller also receives user input from the view and saves or
-updates model data accordingly.
+A controller sits between models and views. The controller makes model data
+available to the view, so that the view can display that data to the user. The
+controller also receives user input from the view and saves or updates model
+data accordingly.
 
-Creating a Controller
----------------------
+### Structure of a Controller
 
 A controller is a Ruby class which inherits from `ApplicationController` and has
-methods just like any other class. Once an incoming request is matched to a
-controller by the router, Rails creates an instance of that controller class and
-calls the method with the same name as the action.
+methods just like any other class. Public methods in a controller are also known
+as _actions_, as they are responsible for rendering responses.
 
 ```ruby
-class ClientsController < ApplicationController
-  def new
+# app/controllers/products_controller.rb
+
+class ProductsController < ApplicationController
+  def index
   end
 end
 ```
 
-Given the above `ClientsController`, if a user goes to `/clients/new` in your
-application to add a new client, Rails will create an instance of
-`ClientsController` and call its `new` method. If the `new` method is empty, Rails
-will automatically render the `new.html.erb` view by default.
-
-NOTE: The `new` method is an instance method here, called on an instance of `ClientsController`. This should not be confused with the `new` class method (i.e., `ClientsController.new`).
-
-In the `new` method, the controller would typically create an instance of the
-`Client` model, and make it available as an instance variable called `@client`
-in the view:
+As per Rails conventions, controllers should define up to 7 conventional CRUD
+actions as demonstrated below. This convention is used by the
+[Router DSL](routing.html#crud-verbs-and-actions) to configure resourceful
+routes to the controller. Other actions may be defined and routed to, but these
+are outside Rails conventions. Further details are available in the
+[Routing guide](routing.html).
 
 ```ruby
-def new
-  @client = Client.new
+# config/routes.rb
+
+Rails.application.routes.draw do
+  # A resourceful route to the `ProductsController`
+  resources :products
+end
+```
+
+```ruby
+# app/controllers/products_controller.rb
+
+class ProductsController < ApplicationController
+  # GET /products
+  def index
+    # Display all products
+  end
+
+  # GET /products/new
+  def new
+    # Render a form to create a new product
+  end
+
+  # POST /products
+  def create
+    # Handle the submission form rendered in `new`
+    # and create the product in the database
+  end
+
+  # GET /products/:id
+  def show
+    # Show the product
+  end
+
+  # GET /products/:id/edit
+  def edit
+    # Render a form to edit the product
+  end
+
+  # PATCH /products/:id
+  def update
+    # Handle the submission form rendered in `edit`
+    # and update the product in the database
+  end
+
+  # DELETE /product/:id
+  def destroy
+    # Delete the product
+  end
+end
+```
+
+Once the [router matches](routing.html) an incoming request to a controller and
+action, Rails creates an instance of that controller class and calls the method
+with the same name as the action.
+
+NOTE: The `new` method in the above controller is an instance method, called on
+an instance of `ProductsController`. This should not be confused with the `new`
+class method used to instantiate objects (`ProductsController.new`).
+
+### Naming Conventions
+
+Rails favors pluralizing the resource in the controller's name. For example,
+`ProductsController` is preferred over `ProductController` and
+`SiteAdminsController` over `SiteAdminController` or `SitesAdminsController`.
+However, the plural names are not strictly required — for example,
+`ApplicationController`.
+
+Following this naming convention will allow you to use
+[resourceful routes](routing.html#crud-verbs-and-actions) without needing to
+qualify each with
+[additional options](routing.html#specifying-a-controller-to-use). The
+convention also makes named route helpers consistent throughout your
+application.
+
+The controller naming convention is different from models. While plural names
+are preferred for controller names, the singular form is preferred for
+[model names](active_record_basics.html#naming-conventions) (e.g. `Account` vs.
+`Accounts`).
+
+Controller actions should be _public_, as only _public_ methods are callable as
+actions. Helper methods within controllers which are _not_ intended to be
+actions should be declared `private` or `protected`.
+
+WARNING: Ensure that you do not override methods defined by
+`ActionController::Base` when creating actions. Accidentally redefining them
+could result in `SystemStackError`. If you limit your controllers to the 7 CRUD
+actions, this won't be an issue.
+
+NOTE: If you must use a reserved method as an action name, one workaround is to
+use a custom route to map the reserved method name to your non-reserved action
+method.
+
+### Rendering Responses
+
+Consider the below route and controller.
+
+```ruby
+# config/routes.rb
+
+Rails.application.routes.draw do
+  # A resourceful route to the `ProductsController`
+  resources :products
+end
+```
+
+```ruby
+class ProductsController < ApplicationController
+  def index
+  end
+end
+```
+
+When a user navigates to `/products`, Rails will create an instance of
+`ProductsController` and call its `index` method. If the `index` method is
+empty, Rails will automatically render `app/views/products/index.html.erb`.
+
+You can explicity define the template to render using the `render` method:
+
+```ruby
+class ProductsController < ApplicationController
+  def index
+    # Renders `app/views/products/feed.html.erb`
+    render "feed"
+  end
+end
+```
+
+WARNING: Calling `render` does not `return` from the current scope. Statements
+after the method call will still be executed. Ensure you do not call `render`
+more than once in any given action, as it will raise an
+`AbstractController::DoubleRenderError`.
+
+To enable rendering of additional formats, not just HTML, use a `respond_to`
+block. This will choose the correct template based on the `Accept` header in the
+HTTP request:
+
+```ruby
+class ProductsController < ApplicationController
+  def index
+    respond_to do |format|
+      format.html   # renders `app/views/products/index.html.erb`
+      format.xml    # renders `app/views/products/index.xml.erb`
+    end
+  end
+end
+```
+
+See the
+[Layouts and Rendering guide](layouts_and_rendering.html#rendering-responses)
+for futher details on rendering responses.
+
+In the `index` method, the controller would typically create an array of the
+`Product` model instances, and make it available as an instance variable called
+`@products` in the view:
+
+```ruby
+def index
+  @products = Product.all
 end
 ```
 
 NOTE: All controllers inherit from `ApplicationController`, which in turn
 inherits from
 [`ActionController::Base`](https://api.rubyonrails.org/classes/ActionController/Base.html).
-For [API only](https://guides.rubyonrails.org/api_app.html) applications `ApplicationController` inherits from
+For [API only](https://guides.rubyonrails.org/api_app.html) applications
+`ApplicationController` inherits from
 [`ActionController::API`](https://edgeapi.rubyonrails.org/classes/ActionController/API.html).
 
-### Controller Naming Convention
+### Redirecting Requests
 
-Rails favors making the resource in the controller's name plural. For example,
-`ClientsController` is preferred over `ClientController` and
-`SiteAdminsController` over `SiteAdminController` or `SitesAdminsController`.
-However, the plural names are not strictly required (e.g.
-`ApplicationController`).
-
-Following this naming convention will allow you to use the [default route
-generators](routing.html#crud-verbs-and-actions) (e.g. `resources`) without
-needing to qualify each with options such as
-[`:controller`](routing.html#specifying-a-controller-to-use). The convention
-also makes named route helpers consistent throughout your application.
-
-The controller naming convention is different from models. While plural names
-are preferred for controller names, the singular form is preferred for [model
-names](active_record_basics.html#naming-conventions) (e.g. `Account` vs.
-`Accounts`).
-
-Controller actions should be `public`, as only `public` methods are callable as
-actions. It is also best practice to lower the visibility of helper methods
-(with `private` or `protected`) which are _not_ intended to be actions.
-
-WARNING: Some method names are reserved by Action Controller. Accidentally
-redefining them could result in `SystemStackError`. If you limit your
-controllers to only RESTful [Resource Routing][] actions you should not need to
-worry about this.
-
-NOTE: If you must use a reserved method as an action name, one workaround is to
-use a custom route to map the reserved method name to your non-reserved action
-method.
-
-[Resource Routing]: routing.html#resource-routing-the-rails-default
-
-Parameters
-----------
-
-Data sent by the incoming request is available in your controller in the
-[`params`][] hash. There are two types of parameter data:
-
-- Query string parameters which are sent as part of the URL (for example, after
-  the `?` in `http://example.com/accounts?filter=free`).
-- Body parameters which are submitted in the request content — from an HTML
-  form POST, or from an HTTP QUERY request
-  ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)), which carries its
-  query in the request body rather than the URL.
-
-Rails does not make a distinction between query string parameters and body
-parameters; both are available in the `params` hash in your controller. For
-example:
+Instead of rendering a fully-formed response, such as an HTML document, you
+might want to redirect the user to a different path. An
+[HTTP redirection status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#redirection_messages)
+can be used for this. Rails' [`redirect_to`][] method uses `302 Found` by
+default.
 
 ```ruby
-class ClientsController < ApplicationController
-  # This action receives query string parameters from an HTTP GET request
-  # at the URL "/clients?status=activated"
-  def index
-    if params[:status] == "activated"
-      @clients = Client.activated
-    else
-      @clients = Client.inactivated
-    end
-  end
-
-  # This action receives parameters from a POST request to "/clients" URL with  form data in the request body.
-  def create
-    @client = Client.new(params[:client])
-    if @client.save
-      redirect_to @client
-    else
-      render "new"
-    end
-  end
-end
+redirect_to photos_url
 ```
 
-NOTE: The `params` hash is not a plain old Ruby Hash; instead, it is an
-[`ActionController::Parameters`][] object. It does not inherit from Hash, but it behaves mostly like Hash.
-It provides methods for filtering `params` and, unlike a Hash, keys `:foo` and `"foo"` are considered to be the same.
+This will send a `302` HTTP response to the browser with `photos_url` in the
+`Location` header. The browser will then make a new `GET` request to the
+`photos_url`.
 
-[`params`]:
-    https://api.rubyonrails.org/classes/ActionController/StrongParameters.html#method-i-params
-[`ActionController::Parameters`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html
-
-### Hash and Array Parameters
-
-The `params` hash is not limited to one-dimensional keys and values. It can
-contain nested arrays and hashes. To send an array of values, append an empty
-pair of square brackets `[]` to the key name:
-
-```
-GET /users?ids[]=1&ids[]=2&ids[]=3
+```http
+HTTP/1.1 302 Found
+referrer-policy: strict-origin-when-cross-origin
+location: http://localhost:3000/photos
+content-type: text/html; charset=utf-8
+cache-control: no-cache
+connection: close
+content-length: 0
 ```
 
-NOTE: The actual URL in this example will be encoded as
-`/users?ids%5b%5d=1&ids%5b%5d=2&ids%5b%5d=3` as the `[` and `]` characters are
-not allowed in URLs. Most of the time you don't have to worry about this because
-the browser will encode it for you, and Rails will decode it automatically, but
-if you ever find yourself having to send those requests to the server manually
-you should keep this in mind.
+NOTE: It's worth being aware that `redirect_to` doesn't move execution to a
+different method within the same request. It sends an HTTP response and then the
+browser makes a new request to the redirected location which won't have any
+context from the previous request.
 
-The value of `params[:ids]` will be the array `["1", "2", "3"]`. Note that
-parameter values are always strings; Rails does not attempt to guess or cast the
-type.
-
-NOTE: Values such as `[nil]` or `[nil, nil, ...]` in `params` are replaced with
-`[]` for security reasons by default. See [Security
-Guide](security.html#unsafe-query-generation) for more information.
-
-To send a hash, you include the key name inside the brackets:
-
-```html
-<form accept-charset="UTF-8" action="/users" method="post">
-  <input type="text" name="user[name]" value="Acme" />
-  <input type="text" name="user[phone]" value="12345" />
-  <input type="text" name="user[address][postcode]" value="12345" />
-  <input type="text" name="user[address][city]" value="Carrot City" />
-</form>
-```
-
-When this form is submitted, the value of `params[:user]` will be `{ "name" =>
-"Acme", "phone" => "12345", "address" => { "postcode" => "12345", "city" =>
-"Carrot City" } }`. Note the nested hash in `params[:user][:address]`.
-
-The `params` object acts like a Hash, but lets you use symbols and strings
-interchangeably as keys.
-
-### Composite Key Parameters
-
-[Composite key parameters](active_record_composite_primary_keys.html) contain
-multiple values in one parameter separated by a delimiter (e.g., an underscore).
-Therefore, you will need to extract each value so that you can pass them to
-Active Record. You can use the `extract_value` method to do that.
-
-For example, given the following controller:
+Alternatively, you can use [`redirect_back`][] to return the user to the page
+they just came from. The location is pulled from the `HTTP_REFERER` header which
+is not guaranteed to be set by the browser, so you must provide a
+`fallback_location`.
 
 ```ruby
-class BooksController < ApplicationController
-  def show
-    # Extract the composite ID value from URL parameters.
-    id = params.extract_value(:id)
-    @book = Book.find(id)
-  end
-end
+redirect_back(fallback_location: root_path)
+# or
+redirect_back_or_to root_path
 ```
 
-And this route:
+WARNING: Similar to `render`, `redirect_to` and `redirect_back` do not
+automatically `return` from the current scope, instead they simply set the HTTP
+response. Statements occurring after them will still be executed.
+
+[`redirect_to`]:
+  https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
+[`redirect_back`]:
+  https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back
+
+Use the [`status:`](layouts_and_rendering.html#status) option to use a different
+HTTP response code. Both numeric and symbolic values are valid.
 
 ```ruby
-get "/books/:id", to: "books#show"
+redirect_to photos_path, status: :see_other
 ```
 
-When a user requests the URL `/books/4_2`, the controller will extract the
-composite key value `["4", "2"]` and pass it to `Book.find`. The `extract_value`
-method may be used to extract arrays out of any delimited parameters.
-
-### JSON Parameters
-
-If your application exposes an API, you will likely accept parameters in JSON
-format. If the `content-type` header of your request is set to
-`application/json`, Rails will automatically load your parameters into the
-`params` hash, which you can access as you would normally.
-
-So for example, if you are sending this JSON content:
-
-```json
-{ "user": { "name": "acme", "address": "123 Carrot Street" } }
-```
-
-Your controller will receive:
-
-```ruby
-{ "user" => { "name" => "acme", "address" => "123 Carrot Street" } }
-```
-
-#### Configuring Wrap Parameters
-
-You can use [Wrap Parameters][], which automatically add the controller name to
-JSON parameters. For example, you can send the below JSON without a root `:user`
-key prefix:
-
-```json
-{ "name": "acme", "address": "123 Carrot Street" }
-```
-
-Assuming that you're sending the above data to the `UsersController`, the JSON
-will be wrapped within the `:user` key like this:
-
-```ruby
-{ name: "acme", address: "123 Carrot Street", user: { name: "acme", address: "123 Carrot Street" } }
-```
-
-NOTE: Wrap Parameters adds a clone of the parameters to the hash within a key
-that is the same as the controller name. As a result, both the original version
-of the parameters and the "wrapped" version of the parameters will exist in the
-params hash.
-
-This feature clones and wraps parameters with a key chosen based on your
-controller's name. It is configured to `true` by default. If you do not want to
-wrap parameters you can
-[configure](configuring.html#config-action-controller-wrap-parameters-by-default)
-it to `false`.
-
-```ruby
-config.action_controller.wrap_parameters_by_default = false
-```
-
-You can also customize the name of the key or specific parameters you want to
-wrap, see the [API
-documentation](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html)
-for more.
-
-[Wrap Parameters]:
-    https://api.rubyonrails.org/classes/ActionController/ParamsWrapper/Options/ClassMethods.html#method-i-wrap_parameters
-
-### Routing Parameters
-
-Parameters specified as part of a route declaration in the `routes.rb` file are
-also made available in the `params` hash. For example, we can add a route that
-captures the `:status` parameter for a client:
-
-```ruby
-get "/clients/:status", to: "clients#index", foo: "bar"
-```
-
-When a user navigates to `/clients/active` URL, `params[:status]` will be set to
-"active". When this route is used, `params[:foo]` will also be set to "bar", as
-if it were passed in the query string.
-
-Any other parameters defined by the route declaration, such as `:id`, will also
-be available.
-
-NOTE: In the above example, your controller will also receive `params[:action]`
-as "index" and `params[:controller]` as "clients". The `params` hash will always
-contain the `:controller` and `:action` keys, but it's recommended to use the
-methods [`controller_name`][] and [`action_name`][] instead to access these
-values.
-
-[`controller_name`]:
-    https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-controller_name
-[`action_name`]:
-    https://api.rubyonrails.org/classes/AbstractController/Base.html#method-i-action_name
-
-### The `default_url_options` Method
-
-You can set global default parameters for [`url_for`](
-https://api.rubyonrails.org/classes/ActionView/RoutingUrlFor.html#method-i-url_for)
-by defining a method called `default_url_options` in your controller. For
-example:
-
-```ruby
-class ApplicationController < ActionController::Base
-  def default_url_options
-    { locale: I18n.locale }
-  end
-end
-```
-
-The specified defaults will be used as a starting point when generating URLs.
-They can be overridden by the options passed to `url_for` or any path helper
-such as `posts_path`. For example, by setting `locale: I18n.locale`, Rails will
-automatically add the locale to every URL:
-
-```ruby
-posts_path # => "/posts?locale=en"
-```
-
-You can still override this default if needed:
-
-```ruby
-posts_path(locale: :fr) # => "/posts?locale=fr"
-```
-
-NOTE: Under the hood, `posts_path` is a shorthand for calling `url_for` with the
-appropriate parameters.
-
-If you define `default_url_options` in `ApplicationController`, as in the
-example above, these defaults will be used for all URL generation. The method
-can also be defined in a specific controller, in which case it only applies to
-URLs generated for that controller.
-
-In a given request, the method is not actually called for every single generated
-URL. For performance reasons the returned hash is cached per request.
-
-Strong Parameters
------------------
-
-With Action Controller [Strong
-Parameters](https://api.rubyonrails.org/classes/ActionController/StrongParameters.html),
-parameters cannot be used in Active Model mass assignments until they have been
-explicitly permitted. This means you will need to decide which attributes to
-permit for mass update and declare them in the controller. This is a security
-practice to prevent users from accidentally updating sensitive model attributes.
-
-In addition, parameters can be marked as required and the request will result in
-a 400 Bad Request being returned if not all required parameters are passed in.
-
-```ruby
-class PeopleController < ActionController::Base
-  # This will raise an ActiveModel::ForbiddenAttributesError
-  # because it's using mass assignment without an explicit permit.
-  def create
-    Person.create(params[:person])
-  end
-
-  # This will work as we are using `person_params` helper method, which has the
-  # call to `expect` to allow mass assignment.
-  def update
-    person = Person.find(params[:id])
-    person.update!(person_params)
-    redirect_to person
-  end
-
-  private
-    # Using a private method to encapsulate the permitted parameters is a good
-    # pattern. You can use the same list for both create and update.
-    def person_params
-      params.expect(person: [:name, :age])
-    end
-end
-```
-
-### Permitting Values
-
-#### `expect`
-
-The [`expect`][] method provides a concise and safe way to require and permit
-parameters.
-
-```ruby
-id = params.expect(:id)
-```
-
-The above `expect` will always return a scalar value and not an array or hash.
-Another example is form params, you can use `expect` to ensure that the root key
-is present and the attributes are permitted.
-
-```ruby
-user_params = params.expect(user: [:username, :password])
-user_params.has_key?(:username) # => true
-```
-
-In the above example, if the `:user` key is not a nested hash with the specified
-keys, `expect` will raise an error and return a 400 Bad Request response.
-
-To require and permit an entire hash of parameters, [`expect`][] can be used in
-this way.
-
-```ruby
-params.expect(log_entry: {})
-```
-
-This marks the `:log_entry` parameters hash and any sub-hash of it as permitted
-and does not check for permitted scalars, anything is accepted.
-
-WARNING: Extreme care should be taken when calling `expect` with an empty
-hash, as it will allow all current and future model attributes to be
-mass-assigned.
-
-#### `permit`
-
-Calling [`permit`][] allows the specified key in `params` (`:id` or `:admin`
-below) for inclusion in mass assignment (e.g. via `create` or `update`):
-
-```irb
-params = ActionController::Parameters.new(id: 1, admin: "true")
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: false>
-params.permit(:id)
-=> #<ActionController::Parameters {"id"=>1} permitted: true>
-params.permit(:id, :admin)
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: true>
-```
-
-For the permitted key `:id`, its value also needs to be one of these permitted
-scalar values: `String`, `Symbol`, `NilClass`, `Numeric`, `TrueClass`,
-`FalseClass`, `Date`, `Time`, `DateTime`, `StringIO`, `IO`,
-`ActionDispatch::Http::UploadedFile`, and `Rack::Test::UploadedFile`.
-
-If you have not called `permit` on the key, it will be filtered out. Arrays,
-hashes, or any other objects are not injected by default.
-
-To include a value in `params` that's an array of one of the permitted scalar
-values, you can map the key to an empty array like this:
-
-```irb
-params = ActionController::Parameters.new(tags: ["rails", "parameters"])
-=> #<ActionController::Parameters {"tags"=>["rails", "parameters"]} permitted: false>
-params.permit(tags: [])
-=> #<ActionController::Parameters {"tags"=>["rails", "parameters"]} permitted: true>
-```
-
-To include hash values, you can map to an empty hash:
-
-```irb
-params = ActionController::Parameters.new(options: { darkmode: true })
-=> #<ActionController::Parameters {"options"=>{"darkmode"=>true}} permitted: false>
-params.permit(options: {})
-=> #<ActionController::Parameters {"options"=>#<ActionController::Parameters {"darkmode"=>true} permitted: true>} permitted: true>
-```
-
-The above `permit` call ensures that values in `options` are permitted scalars
-and filters out anything else.
-
-WARNING: The `permit` with an empty hash is convenient since sometimes it is not
-possible or convenient to declare each valid key of a hash parameter or its
-internal structure. But note that the above `permit` with an empty hash opens
-the door to arbitrary input.
-
-#### `permit!`
-
-There is also [`permit!`][] (with an `!`) which permits an entire hash of
-parameters without checking the values.
-
-```irb
-params = ActionController::Parameters.new(id: 1, admin: "true")
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: false>
-params.permit!
-=> #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: true>
-```
-
-WARNING: Extreme care should be taken when using `permit!`, as it will allow all
-current and *future* model attributes to be mass-assigned.
-
-[`permit`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit
-[`permit!`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit-21
-[`expect`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect
-
-### Nested Parameters
-
-You can also use `expect` (or `permit`) on nested parameters, like:
-
-```ruby
-# Given the example expected params:
-params = ActionController::Parameters.new(
-  name: "Martin",
-  emails: ["me@example.com"],
-  friends: [
-    { name: "André", family: { name: "RubyGems" }, hobbies: ["keyboards", "card games"] },
-    { name: "Kewe", family: { name: "Baroness" }, hobbies: ["video games"] },
-  ]
-)
-# the following expect will ensure the params are permitted
-name, emails, friends = params.expect(
-  :name,                 # permitted scalar
-  emails: [],            # array of permitted scalars
-  friends: [[            # array of permitted Parameter hashes
-    :name,               # permitted scalar
-    family: [:name],     # family: { name: "permitted scalar" }
-    hobbies: []          # array of permitted scalars
-  ]]
-)
-```
-
-This declaration permits the `name`, `emails`, and `friends` attributes and
-returns them each. It is expected that `emails` will be an array of permitted
-scalar values, and that `friends` will be an array of resources (note the new
-double array syntax to explicitly require an array) with specific attributes.
-These attributes should have a `name` attribute (any permitted scalar values allowed), a
-`hobbies` attribute as an array of permitted scalar values, and a `family`
-attribute which is restricted to a hash with only a `name` key and any permitted
-scalar value.
-
-### Examples
-
-Here are some examples of how to use `permit` for different use cases.
-
-**Example 1**: You may want to use the permitted attributes in your `new` action.
-This raises the problem that you can't use [`require`][] on the root key
-because, normally, it does not exist when calling `new`:
-
-```ruby
-# using `fetch` you can supply a default and use
-# the Strong Parameters API from there.
-params.fetch(:blog, {}).permit(:title, :author)
-```
-
-**Example 2**: The model class method `accepts_nested_attributes_for` allows you to
-update and destroy associated records. This is based on the `id` and `_destroy`
-parameters:
-
-```ruby
-# permit :id and :_destroy
-params.expect(author: [ :name, books_attributes: [[ :title, :id, :_destroy ]] ])
-```
-
-**Example 3**: Hashes with integer keys are treated differently, and you can declare
-the attributes as if they were direct children. You get these kinds of
-parameters when you use `accepts_nested_attributes_for` in combination with a
-`has_many` association:
-
-```ruby
-# To permit the following data:
-# {"book" => {"title" => "Some Book",
-#             "chapters_attributes" => { "1" => {"title" => "First Chapter"},
-#                                        "2" => {"title" => "Second Chapter"}}}}
-
-params.expect(book: [ :title, chapters_attributes: [[ :title ]] ])
-```
-
-**Example 4**: Imagine a scenario where you have parameters representing a product
-name, and a hash of arbitrary data associated with that product, and you want to
-permit the product name attribute and also the whole data hash:
-
-```ruby
-def product_params
-  params.expect(product: [ :name, data: {} ])
-end
-```
-
-[`require`]:
-    https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-require
-
-Cookies
--------
-
-The concept of a cookie is not specific to Rails. A
-[cookie](https://en.wikipedia.org/wiki/HTTP_cookie) (also known as an HTTP
-cookie or a web cookie) is a small piece of data from the server that is saved
-in the user's browser. The browser may store cookies, create new cookies, modify
-existing ones, and send them back to the server with later requests. Cookies
-persist data across web requests and therefore enable web applications to
-remember user preferences.
-
-Rails provides an easy way to access cookies via the [`cookies`][] method, which
-works like a hash:
-
-```ruby
-class CommentsController < ApplicationController
-  def new
-    # Auto-fill the commenter's name if it has been stored in a cookie
-    @comment = Comment.new(author: cookies[:commenter_name])
-  end
-
-  def create
-    @comment = Comment.new(comment_params)
-    if @comment.save
-      if params[:remember_name]
-        # Save the commenter's name in a cookie.
-        cookies[:commenter_name] = @comment.author
-      else
-        # Delete cookie for the commenter's name, if any.
-        cookies.delete(:commenter_name)
-      end
-      redirect_to @comment.article
-    else
-      render action: "new"
-    end
-  end
-end
-```
-
-NOTE: To delete a cookie, you need to use `cookies.delete(:key)`. Setting the
-`key` to a `nil` value does not delete the cookie.
-
-When passed a scalar value, the cookie will be deleted when the user closes their browser.
-If you want the cookie to expire at a specific time, pass a hash with the `:expires` option when setting the cookie.
-For example, to set a cookie that expires in 1 hour:
-
-```ruby
-cookies[:login] = { value: "XJ-122", expires: 1.hour }
-```
-
-If you want to create cookies that never expire use the permanent cookie jar.
-This sets the assigned cookies to have an expiration date 20 years from now.
-
-```ruby
-cookies.permanent[:locale] = "fr"
-```
-
-### Encrypted and Signed Cookies
-
-Since cookies are stored on the client browser, they can be susceptible to
-tampering and are not considered secure for storing sensitive data. Rails
-provides a signed cookie jar and an encrypted cookie jar for storing sensitive
-data. The signed cookie jar appends a cryptographic signature on the cookie
-values to protect their integrity. The encrypted cookie jar encrypts the values
-in addition to signing them, so that they cannot be read by the user.
-
-Refer to the [API
-documentation](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html)
-for more details.
-
-```ruby
-class CookiesController < ApplicationController
-  def set_cookie
-    cookies.signed[:user_id] = current_user.id
-    cookies.encrypted[:expiration_date] = Date.tomorrow # => Thu, 20 Mar 2024
-    redirect_to action: "read_cookie"
-  end
-
-  def read_cookie
-    cookies.encrypted[:expiration_date] # => "2024-03-20"
-  end
-end
-```
-
-These special cookie jars use a serializer to serialize the cookie values into
-strings and deserialize them into Ruby objects when read back. You can specify
-which serializer to use via [`config.action_dispatch.cookies_serializer`][]. The
-default serializer for new applications is `:json`.
-
-NOTE: Be aware that JSON has limited support serializing Ruby objects such as
-`Date`, `Time`, and `Symbol`. These will be serialized and deserialized into
-`String`s.
-
-If you need to store these or more complex objects, you may need to manually
-convert their values when reading them in subsequent requests.
-
-If you use the cookie session store, the above applies to the `session` and
-`flash` hash as well.
-
-[`config.action_dispatch.cookies_serializer`]:
-    configuring.html#config-action-dispatch-cookies-serializer
-[`cookies`]:
-    https://api.rubyonrails.org/classes/ActionController/Cookies.html#method-i-cookies
-
-Session
--------
-
-While cookies are stored client-side, session data is stored server-side (in
-memory, a database, or a cache), and the duration is usually temporary and tied
-to the user's session (e.g. until they close the browser). An example use case
-for session is storing sensitive data like user authentication.
-
-In a Rails application, the session is available in the controller and the view.
-
-### Working with the Session
-
-You can use the `session` instance method to access the session in your
-controllers. Session values are stored as key/value pairs like a hash:
-
-```ruby
-class ApplicationController < ActionController::Base
-  private
-    # Look up the key `:current_user_id` in the session and use it to
-    # find the current `User`. This is a common way to handle user login in
-    # a Rails application; logging in sets the session value and
-    # logging out removes it.
-    def current_user
-      @current_user ||= User.find_by(id: session[:current_user_id]) if session[:current_user_id]
-    end
-end
-```
-
-To store something in the session, you can assign it to a key similar to adding
-a value to a hash. After a user is authenticated, its `id` is saved in the
-session to be used for subsequent requests:
-
-```ruby
-class SessionsController < ApplicationController
-  def create
-    if user = User.authenticate_by(email: params[:email], password: params[:password])
-      # Save the user ID in the session so it can be used in
-      # subsequent requests
-      session[:current_user_id] = user.id
-      redirect_to root_url
-    end
-  end
-end
-```
-
-To remove something from the session, delete the key/value pair. Deleting the
-`current_user_id` key from the session is a typical way to log the user out:
-
-```ruby
-class SessionsController < ApplicationController
-  def destroy
-    session.delete(:current_user_id)
-    # Clear the current user as well.
-    @current_user = nil
-    redirect_to root_url, status: :see_other
-  end
-end
-```
-
-It is possible to reset the entire session with [`reset_session`][]. It is
-recommended to use `reset_session` after logging in to avoid session fixation
-attacks. Please refer to the [Security
-Guide](https://edgeguides.rubyonrails.org/security.html#session-fixation-countermeasures)
-for details.
-
-NOTE: Sessions are lazily loaded. If you don't access sessions in your action's
-code, they will not be loaded. Hence, you will never need to disable sessions -
-not accessing them will do the job.
-
-[`reset_session`]:
-    https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-reset_session
-
-### The Flash
-
-The [flash](https://api.rubyonrails.org/classes/ActionDispatch/Flash.html)
-provides a way to pass temporary data between controller actions. Anything you
-place in the flash will be available to the very next action and then cleared.
-The flash is typically used for setting messages (e.g. notices and alerts) in a
-controller action before redirecting to an action that displays the message to
-the user.
-
-The flash is accessed via the [`flash`][] method. Similar to the session, the
-flash values are stored as key/value pairs.
-
-For example, in the controller action for logging out a user, the controller can
-set a flash message which can be displayed to the user on the next request:
-
-```ruby
-class SessionsController < ApplicationController
-  def destroy
-    session.delete(:current_user_id)
-    flash[:notice] = "You have successfully logged out."
-    redirect_to root_url, status: :see_other
-  end
-end
-```
-
-Displaying a message after a user performs some interactive action in your
-application is a good practice to give the user feedback that their action was
-successful (or that there were errors).
-
-In addition to `:notice`, you can also use `:alert`. These are typically styled
-(using CSS) with different colors to indicate their meaning (e.g. green for
-notices and orange/red for alerts).
-
-You can also assign a flash message directly within the `redirect_to` method by
-including it as a parameter to `redirect_to`:
-
-```ruby
-redirect_to root_url, notice: "You have successfully logged out."
-redirect_to root_url, alert: "There was an issue."
-```
-
-You're not limited to `notice` and `alert`.
-You can set any key in a flash (similar to sessions), by assigning it to the `:flash` argument.
-For example, assigning `:just_signed_up`:
-
-```ruby
-redirect_to root_url, flash: { just_signed_up: true }
-```
-
-This will allow you to have the below in the view:
-
-```erb
-<% if flash[:just_signed_up] %>
-  <p class="welcome">Welcome to our site!</p>
-<% end %>
-```
-
-In the above logout example, the `destroy` action redirects to the application's
-`root_url`, where the message is available to be displayed. However, it's not
-displayed automatically. It's up to the next action to decide what, if anything,
-it will do with what the previous action put in the flash.
-
-#### Displaying flash messages
-
-If a previous action _has_ set a flash message, it's a good idea to display that
-to the user. We can accomplish this consistently by adding the HTML for
-displaying any flash messages in the application's default layout. Here's an
-example from `app/views/layouts/application.html.erb`:
-
-```erb
-<html>
-  <!-- <head/> -->
-  <body>
-    <% flash.each do |name, msg| -%>
-      <%= content_tag :div, msg, class: name %>
-    <% end -%>
-
-    <!-- more content -->
-    <%= yield %>
-  </body>
-</html>
-```
-
-The `name` above indicates the type of flash message, such as `notice` or
-`alert`. This information is normally used to style how the message is displayed
-to the user.
-
-TIP: You can filter by `name` if you want to limit to displaying only `notice`
-and `alert` in layout. Otherwise, all keys set in the `flash` will be displayed.
-
-Including the reading and displaying of flash messages in the layout ensures
-that your application will display these automatically, without each view having
-to include logic to read the flash.
-
-#### `flash.keep` and `flash.now`
-
-[`flash.keep`][] is used to carry over the flash value through to an additional
-request. This is useful when there are multiple redirects.
-
-For example, assume that the `index` action in the controller below corresponds
-to the `root_url`. And you want all requests here to be redirected to
-`UsersController#index`. If an action sets the flash and redirects to
-`MainController#index`, those flash values will be lost when another redirect
-happens, unless you use `flash.keep` to make the values persist for another
+NOTE: When redirecting using `302 Found`, the client may not always make a `GET`
+request to the `Location`. JavaScript's `fetch` method will make a `GET` request
+after redirection from a `GET` or `POST` request. But, if the initial request is
+another method, for example `PUT`, it will use the same method when requesting
+the redirected location. This is not a problem in Rails because all
+[form submissions use `POST`](https://guides.rubyonrails.org/form_helpers.html#forms-with-patch-put-or-delete-methods),
+even when using [Turbo](http://turbo.hotwired.dev). <br><br> When making
+requests in custom JavaScript, redirect using
+[`303 See Other`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/303)
+to ensure a `GET` request to the redirected location, or
+[`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/307)
+to preserve the original HTTP verb.
+
+### Header-Only Responses
+
+The [`head`][] method can be used to send responses with only headers to the
+browser. This is usually in response to an
+[HTTP `HEAD`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/HEAD)
 request.
 
-```ruby
-class MainController < ApplicationController
-  def index
-    # Will persist all flash values.
-    flash.keep
-
-    # You can also use a key to keep only some kind of value.
-    # flash.keep(:notice)
-    redirect_to users_url
-  end
-end
-```
-
-[`flash.now`][] is used to make the flash values available in the same request.
-By default, adding values to the flash will make them available to the next
-request. For example, if the `create` action fails to save a resource, and you
-render the `new` template directly, that's not going to result in a new request,
-but you may still want to display a message using the flash. To do this, you can
-use [`flash.now`][] in the same way you use the normal `flash`:
+The `head` method accepts a number or symbol representing an HTTP status code.
 
 ```ruby
-class ClientsController < ApplicationController
-  def create
-    @client = Client.new(client_params)
-    if @client.save
-      # ...
-    else
-      flash.now[:error] = "Could not save client"
-      render action: "new"
-    end
-  end
-end
+head :bad_request
+# or
+head 400
 ```
 
-[`flash`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Flash/RequestMethods.html#method-i-flash
-[`flash.keep`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-keep
-[`flash.now`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-now
+This would produce the following HTTP response:
 
-### Session Stores
+```http
+HTTP/1.1 400 Bad Request
+connection: close
+transfer-encoding: chunked
+content-type: text/html; charset=utf-8
+set-cookie: _blog_session=...snip...; path=/; HttpOnly
+cache-control: no-cache
+```
 
-All sessions have a unique ID that represents the session object; these session
-IDs are stored in a cookie. The actual session objects use one of the following
-storage mechanisms:
-
-* [`ActionDispatch::Session::CookieStore`][] - Stores everything on the client.
-* [`ActionDispatch::Session::CacheStore`][] - Stores the data in the Rails
-  cache.
-* [`ActionDispatch::Session::ActiveRecordStore`][activerecord-session_store] -
-  Stores the data in a database using Active Record (requires the
-  [`activerecord-session_store`][activerecord-session_store] gem).
-* A custom store or a store provided by a third party gem.
-
-For most session stores, the unique session ID in the cookie is used to look up
-session data on the server (e.g. a database table). Rails does not allow you to
-pass the session ID in the URL as this is less secure.
-
-#### `CookieStore`
-
-The `CookieStore` is the default and recommended session store. It stores all
-session data in the cookie itself (the session ID is still available to you if
-you need it). The `CookieStore` is lightweight and does not require any
-configuration to use in a new application.
-
-The `CookieStore` can store 4 kB of data - much less than the other storage
-options - but this is usually enough. Storing large amounts of data in the
-session is discouraged. You should especially avoid storing complex objects
-(such as model instances) in the session.
-
-#### `CacheStore`
-
-You can use the `CacheStore` if your sessions don't store critical data or don't
-need to be around for long periods (for instance if you just use the flash for
-messaging). This will store sessions using the cache implementation you have
-configured for your application. The advantage is that you can use your existing
-cache infrastructure for storing sessions without requiring any additional setup
-or administration. The downside is that the session storage will be temporary
-and they could disappear at any time.
-
-Read more about session storage in the [Security Guide](security.html#sessions).
-
-### Session Storage Options
-
-There are a few configuration options related to session storage. You can
-configure the type of storage in an initializer:
+You can add additional HTTP headers if you wish.
 
 ```ruby
-Rails.application.config.session_store :cache_store
+head :created, location: photo_path(@photo)
 ```
 
-Rails sets up a session key (the name of the cookie) when signing the session
-data. These can also be changed in an initializer:
+Which would produce:
 
-```ruby
-Rails.application.config.session_store :cookie_store, key: "_your_app_session"
+```http
+HTTP/1.1 201 Created
+connection: close
+transfer-encoding: chunked
+location: /photos/1
+content-type: text/html; charset=utf-8
+set-cookie: _blog_session=...snip...; path=/; HttpOnly
+cache-control: no-cache
 ```
 
-NOTE: Be sure to restart your server when you modify an initializer file.
-
-You can also pass a `:domain` key and specify the domain name for the cookie:
-
-```ruby
-Rails.application.config.session_store :cookie_store, key: "_your_app_session", domain: ".example.com"
-```
-
-TIP: See [`config.session_store`](configuring.html#config-session-store) in the
-configuration guide for more information.
-
-Rails sets up a secret key for `CookieStore` used for signing the session data
-in `config/credentials.yml.enc`. The credentials can be updated with `bin/rails
-credentials:edit`.
-
-```yaml
-# aws:
-#   access_key_id: 123
-#   secret_access_key: 345
-
-# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
-secret_key_base: 492f...
-```
-
-WARNING: Changing the `secret_key_base` when using the `CookieStore` will
-invalidate all existing sessions. You'll need to configure a [cookie rotator](https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-cookies-rotations)
-to rotate existing sessions.
-
-[`ActionDispatch::Session::CookieStore`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
-[`ActionDispatch::Session::CacheStore`]:
-    https://api.rubyonrails.org/classes/ActionDispatch/Session/CacheStore.html
-[activerecord-session_store]:
-    https://github.com/rails/activerecord-session_store
+[`head`]:
+  https://api.rubyonrails.org/classes/ActionController/Head.html#method-i-head
 
 Controller Callbacks
 --------------------
 
-Controller callbacks are methods that are defined to automatically run before
-and/or after a controller action. A controller callback method can be defined in
-a given controller or in the `ApplicationController`. Since all controllers
-inherit from `ApplicationController`, callbacks defined here will run on every
-controller in your application.
+Controller callbacks are methods that are defined to automatically run before or
+after a controller action. Callbacks may be defined in the
+`ApplicationController` if they need to be run across the application, or within
+specific controllers only.
 
 ### `before_action`
 
 Callback methods registered via [`before_action`][] run _before_ a controller
-action. They may halt the request cycle. A common use case for `before_action`
-is ensuring that a user is logged in:
+action. They may halt the request cycle meaning the controller action itself is
+never called.
+
+A common use case for `before_action` is to ensure that a user is logged in:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -1025,47 +366,45 @@ class ApplicationController < ActionController::Base
 
   private
     def require_login
-      unless logged_in?
-        flash[:error] = "You must be logged in to access this section"
+      unless Current.user.present?
         redirect_to new_login_url # halts request cycle
       end
     end
 end
 ```
 
-The method stores an error message in the flash and redirects to the login form
-if the user is not already logged in. When a `before_action` callback renders or
-redirects (like in the example above), the original controller action is not
-run. If there are additional callbacks registered to run, they are also
-cancelled and not run.
+When a `before_action` callback renders or redirects (like in the example
+above), the controller action is not run. If there are additional callbacks
+registered to run, they will be cancelled.
 
-In this example, the `before_action` is defined in `ApplicationController` so
-all controllers in the application inherit it. That implies that all requests in
-the application will require the user to be logged in. This is fine except for
-the "login" page. The "login" action should succeed even when the user is not
-logged in (to allow the user to log in) otherwise the user will never be able to
-log in. You can use [`skip_before_action`][] to allow specified controller
+In this example, the `before_action` is defined in `ApplicationController`
+meaning it will be run before all actions across the applications. This also
+means the user will need to be logged into access the login page, which doesn't
+make sense.
+
+In such cases, use [`skip_before_action`][] to allow specified controller
 actions to skip a given `before_action`:
 
 ```ruby
-class LoginsController < ApplicationController
+class SessionsController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
 end
 ```
 
-Now, the `LoginsController`'s `new` and `create` actions will work without
+Now, the `SessionsController`'s `new` and `create` actions will work without
 requiring the user to be logged in.
 
-The `:only` option skips the callback only for the listed actions; there is also
+The `:only` option skips the callback only for the listed actions. There is also
 an `:except` option which works the other way. These options can be used when
-registering action callbacks too, to add callbacks which only run for selected
-actions.
+registering action callbacks to run them only for specific actions.
 
 NOTE: If you register the same action callback multiple times with different
 options, the last action callback definition will overwrite the previous ones.
 
-[`before_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_action
-[`skip_before_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-skip_before_action
+[`before_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_action
+[`skip_before_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-skip_before_action
 
 ### `after_action` and `around_action`
 
@@ -1083,7 +422,7 @@ action, and not if an exception is raised in the request cycle.
 The `around_action` callbacks are useful when you want to execute code before
 and after a controller action, allowing you to encapsulate functionality that
 affects the action's execution. They are responsible for running their
-associated actions by yielding.
+associated actions by `yield`ing.
 
 For example, imagine you want to monitor the performance of specific actions.
 You could use an `around_action` to measure how long each action takes to
@@ -1111,49 +450,53 @@ you can use, as shown in the example above.
 The `around_action` callback also wraps rendering. In the example above, view
 rendering will be included in the `duration`. The code after the `yield` in an
 `around_action` is run even when there is an exception in the associated action
-and there is an `ensure` block in the callback. (This is different from
-`after_action` callbacks where an exception in the action cancels the
-`after_action` code.)
+and there is an `ensure` block in the callback.
 
-[`after_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-after_action
-[`around_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-around_action
+This is different from `after_action` callbacks where an exception in the action
+cancels any `after_action` callbacks.
 
-### Other Ways to Use Callbacks
+[`after_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-after_action
+[`around_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-around_action
 
-In addition to `before_action`, `after_action`, or `around_action`, there are
-two less common ways to register callbacks.
+### Advanced Techniques to Register Callbacks
 
-The first way is to use a block directly with the `*_action` methods. The block runs
-in the scope of the controller instance. For example, the `require_login` action
-callback from above could be rewritten to use a block:
+In addition to registering a method name using `before_action`, `after_action`,
+or `around_action`, there are two other ways to register callbacks.
+
+#### Using a Block
+
+A block can be supplied to the `*_action` methods. It receives the controller as
+an argument. The `require_login` action callback from above could be rewritten
+to use a block:
 
 ```ruby
 class ApplicationController < ActionController::Base
-  before_action do
-    unless logged_in?
-      flash[:error] = "You must be logged in to access this section"
+  before_action do |controller|
+    unless Current.user.present?
       redirect_to new_login_url
     end
   end
 end
 ```
 
-This is not the recommended way to implement this particular action callback,
-but in simpler cases, it might be useful.
-
-Specifically for `around_action`, the block also yields the `action`:
+Specifically for `around_action`, the block also yields in the `action`:
 
 ```ruby
 around_action { |_controller, action| time(&action) }
 ```
 
-Note that the `controller` is also passed to the block, but it can often
-be ignored because the block is already executed in that controller's scope.
+#### Using an Object
 
-The second way is to specify a class (or any object that responds to the
-expected methods) for the callback action. This can be useful in cases that are
-more complex. As an example, you could rewrite the `around_action` callback to
-measure execution time with a class:
+An object, usually a class, can be used to register callbacks. The object must
+implement a method with the same name as the action callback.
+
+For the `before_action` callback, the class must implement a `before` method,
+and so on. Also, the `around` method must `yield` to execute the action.
+
+This can be useful in cases that are more complex. As an example, you could
+rewrite the `around_action` callback to measure execution time with a class:
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -1172,29 +515,912 @@ class ActionDurationCallback
 end
 ```
 
-In the above example, the `ActionDurationCallback`'s method is not run in the scope
-of the controller but gets `controller` as an argument.
+In the above example, the `ActionDurationCallback`'s method is not run in the
+scope of the controller but gets `controller` as an argument.
 
-In general, the class being used for a `*_action` callback must implement a
-method with the same name as the action callback. So for the `before_action`
-callback, the class must implement a `before` method, and so on. Also,
-the `around` method must `yield` to execute the action.
+Request Parameters
+------------------
+
+Data sent by the incoming request is available in your controller using the
+[`params`][] method which returns an [`ActionController::Parameters`][] object.
+
+There are two types of parameter data:
+
+- Query string parameters which are sent as part of the URL (for example, after
+  the `?` in `http://example.com/accounts?filter=free`).
+- Request body parameters in non-`GET` requests, usually from an HTML form.
+
+Rails does not make a distinction between query string parameters and request
+body parameters — both are available in the `params` object in your controller.
+For example:
+
+```ruby
+class ProductsController < ApplicationController
+  # This action receives query string parameters from an HTTP GET request
+  # at the URL "/products?filter=books"
+  def index
+    if params[:filter] == "books"
+      @products = Product.books
+    else
+      @products = Product.all
+    end
+  end
+
+  # This action receives parameters from a POST request to "/products" URL with
+  # form data in the request body.
+  def create
+    @product = Product.new(params[:product])
+    if @product.save
+      redirect_to @product
+    else
+      render "new", status: :unprocessable_content
+    end
+  end
+end
+```
+
+NOTE: [`ActionController::Parameters`][] does not inherit from Hash, but it is
+mostly similar in behavior. Unlike a Hash, symbolic and string keys, such as
+`:foo` and `"foo"`, are considered to be the same.
+
+[`params`]:
+  https://api.rubyonrails.org/classes/ActionController/StrongParameters.html#method-i-params
+[`ActionController::Parameters`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html
+
+### Parameter Value Types
+
+Values in an [`ActionController::Parameters`][] object must be a permitted
+scalar value defined in `ActionController::Parameters::PERMITTED_SCALAR_TYPES`.
+
+```ruby
+ActionController::Parameters::PERMITTED_SCALAR_TYPES
+# => [String, Symbol, NilClass, Numeric, TrueClass, FalseClass, Date, Time, StringIO, IO, ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile]
+```
+
+The object can contain nested hashes and arrays, but values within those must
+also contain a permitted scalar.
+
+To send an array of values, append an empty pair of square brackets `[]` to the
+key name:
+
+```
+GET /users?ids[]=1&ids[]=2&ids[]=3
+```
+
+NOTE: The actual URL in this example will be encoded as
+`/users?ids%5b%5d=1&ids%5b%5d=2&ids%5b%5d=3` as the `[` and `]` characters are
+not allowed in URLs. Most of the time you don't have to worry about this because
+the browser will encode it for you, and Rails will decode it automatically, but
+if you ever find yourself having to send those requests to the server manually
+you should keep this in mind.
+
+The value of `params[:ids]` will be the array `["1", "2", "3"]`. Parameter
+values are always strings, Rails does not attempt to guess or cast the type.
+
+NOTE: Values such as `[nil]` or `[nil, nil, ...]` in `params` are replaced with
+`[]` for security reasons by default. See
+[Security Guide](security.html#unsafe-query-generation) for more information.
+
+To send a hash, you include the key name inside the brackets:
+
+```html
+<form accept-charset="UTF-8" action="/users" method="post">
+  <input type="text" name="user[name]" value="Acme" />
+  <input type="text" name="user[phone]" value="12345" />
+  <input type="text" name="user[address][postcode]" value="12345" />
+  <input type="text" name="user[address][city]" value="Carrot City" />
+</form>
+```
+
+When this form is submitted, the value of `params[:user]` will be:
+
+```ruby
+{
+  "name" => "Acme",
+  "phone" => "12345",
+  "address" => {
+    "postcode" => "12345",
+    "city" => "Carrot City"
+  }
+}
+```
+
+Note the nested hash in `params[:user][:address]`.
+
+Rails provides helpers to construct HTML forms that adhere to Rails conventions.
+Refer to the [Form Helpers guide](form_helpers.html) for further information.
+
+### Composite Key Parameters
+
+[Composite key parameters](active_record_composite_primary_keys.html) contain
+multiple values in one parameter separated by a delimiter (such as an
+underscore). Therefore, you will need to extract each value so that you can pass
+them to Active Record. You can use the [`extract_value`][] method to do that.
+
+Consider the below controller and route:
+
+```ruby#4
+class ProductsController < ApplicationController
+  def show
+    # Extract the composite ID value from URL parameters.
+    id = params.extract_value(:id)
+    @product = Product.find(id)
+  end
+end
+```
+
+```ruby
+get "/products/:id", to: "products#show"
+```
+
+When a user requests the URL `/products/4_2`, the controller will extract the
+composite key value `["4", "2"]` and pass it to `Product.find`. The
+[`extract_value`][] method may be used to extract arrays out of any delimited
+parameters.
+
+[`extract_value`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-extract_value
+
+### JSON Parameters
+
+If your application exposes an API, you will likely accept parameters in JSON
+format. If the `content-type` header of your request is set to
+`application/json`, Rails will automatically load your parameters into the
+`params` hash, which you can access as you would normally.
+
+So for example, if you are sending this JSON content:
+
+```json
+{ "user": { "name": "acme", "address": "123 Carrot Street" } }
+```
+
+Your controller will receive:
+
+```ruby
+{ "user" => { "name" => "acme", "address" => "123 Carrot Street" } }
+```
+
+#### Parameter Wrapping
+
+Rails will automatically wrap parameters within a key denoting the corresponding
+resource, and also add the controller name to JSON parameters.
+
+For example, consider the below JSON object:
+
+```json
+{ "name": "acme", "address": "123 Carrot Street" }
+```
+
+If we send the above data to `create` action of the `UsersController`, the JSON
+data will be wrapped within the `:user` key as:
+
+```ruby
+{
+  controller: "users",
+  action: "create",
+  name: "acme",
+  address: "123 Carrot Street",
+  user: {
+    name: "acme", address: "123 Carrot Street"
+  }
+}
+```
+
+NOTE: Rails adds a clone of the parameters to the hash within the key
+corresponding to the resource's name. As a result, both the original version of
+the parameters and the "wrapped" version of the parameters will exist in the
+params object.
+
+NOTE: While the action and controller names are available in the params object,
+it is recommended to use the methods [`controller_name`][] and [`action_name`][]
+instead to access these values.
+
+Parameter wrapping is enabled by default, but can be disabled using a
+configuration option:
+
+```ruby
+# config/application.rb
+
+config.action_controller.wrap_parameters_by_default = false
+```
+
+You can also customize the name of the key or specific parameters you want to
+wrap, see the
+[API documentation](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html)
+for more.
+
+[`controller_name`]:
+  https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-controller_name
+[`action_name`]:
+  https://api.rubyonrails.org/classes/AbstractController/Base.html#method-i-action_name
+
+### Routing Parameters
+
+Parameters specified as part of a route declaration in the `routes.rb` file are
+also made available in the `params` hash. For example, we can add a route that
+captures the `:category` parameter for a product:
+
+```ruby
+get "/products/:category", to: "products#index", foo: "bar"
+```
+
+When a user navigates to `/products/electronics` URL, `params[:category]` will
+be set to "electronics". When this route is used, `params[:foo]` will also be
+set to "bar", as if it were passed in the query string.
+
+Any other parameters defined by the route declaration, such as `:id`, will also
+be available.
+
+### Global Default Parameters
+
+You can set global default parameters when generating URLs by defining a
+`default_url_options` method in your controller.
+
+```ruby
+class ApplicationController < ActionController::Base
+  def default_url_options
+    { locale: I18n.locale }
+  end
+end
+```
+
+The specified defaults will be used as a starting point when generating URLs.
+They can be overridden by the options passed to [`url_for`][] or any path helper
+such as `products_path`. The above example will automatically add the locale to
+every URL.
+
+```ruby
+products_path # => "/products?locale=en"
+```
+
+You can still override this default if needed:
+
+```ruby
+products_path(locale: :fr) # => "/products?locale=fr"
+```
+
+NOTE: All Rails path helpers call `url_for` under the hood.
+
+If you define `default_url_options` in `ApplicationController`, as in the
+example above, these defaults will be used for all URL generation. The method
+can also be defined in a specific controller, in which case it only applies to
+URLs generated for that controller.
+
+In a given request, the method is not actually called for every single generated
+URL. For performance reasons the returned hash is cached per request.
+
+[`url_for`]:
+  https://api.rubyonrails.org/classes/ActionView/RoutingUrlFor.html#method-i-url_for
+
+### Securing Submitted Parameters
+
+[Action Controller Strong Parameters](https://api.rubyonrails.org/classes/ActionController/StrongParameters.html)
+ensures parameters cannot be used in Active Model mass assignments until they
+have been explicitly permitted.
+
+This requires you to specify the allowed attributes for any given model and
+declare them in the controller. This is a security practice to prevent users
+from accidentally or maliciously updating sensitive model attributes.
+
+Consider the below controller and action:
+
+```ruby
+class PeopleController < ActionController::Base
+  def create
+    @person = Person.create(params[:person])
+    # ...
+  end
+end
+```
+
+We create a `Person` record using the parameters passed in the `:person` key,
+without explicitly defining which parameters are permitted. A `Person` may have
+a boolean attribute which specifies whether or not they're an _admin_. A
+malicious user could modify the HTML form to send this value and make themselves
+an admin without permission. As such, all parameters used in mass assignment
+must be explicitly allowed, and the above example will raise a
+`ActiveModel::ForbiddenAttributesError`.
+
+#### Permitting Parameter Attributes
+
+Each attribute must be manually permitted using its key. Nested hashes and
+arrays within attributes are allowed, and depending on the method used, nested
+keys may also need to be specified.
+
+The [`expect`][], [`permit`][], and [`require`][] methods are commonly used to
+specify permitted attributes.
+
+##### `expect`
+
+The [`expect`][] method is the safest and most explicit way to permit
+parameters. If the request doesn't contain all expected parameters,
+`ActionController::ParameterMissing` will be raised and a `400 Bad Request` HTTP
+response will be returned.
+
+```ruby#5
+class UsersController < ApplicationController
+  # ...
+
+  def update
+    id = params.expect(:id)
+  end
+
+  # ...
+end
+```
+
+When handling Rails forms, use [`expect`][] to ensure that the root key is
+present and define the permitted attributes.
+
+```ruby#5
+class UsersController < ApplicationController
+  # ...
+  private
+    def user_params
+      params.expect(user: [:username, :password])
+    end
+end
+```
+
+[`expect`][] is strict with types. Supplying a single key will return a scalar,
+and multiple keys will return an array of those values.
+
+```ruby
+params = ActionController::Parameters.new(name: "John Doe")
+params.expect(:name)
+# => "John Doe"
+
+params = ActionController::Parameters.new(name: "John Doe", title: "Mr")
+params.expect(:name, :title)
+# => ["John Doe", "Mr"]
+```
+
+Nested hashes and arrays must be specified, including any nested keys, or they
+will be filtered out.
+
+```ruby
+params = ActionController::Parameters.new(user: { name: "John Doe" })
+params.expect(:user)
+# => param is missing or the value is empty or invalid: user (ActionController::ParameterMissing)
+params.expect(user: [:name])
+# => #<ActionController::Parameters {"name" => "John Doe"} permitted: true>
+
+params = ActionController::Parameters.new(ids: ["1", "2", "3"])
+params.expect(:ids)
+# => param is missing or the value is empty or invalid: ids (ActionController::ParameterMissing)
+params.expect(ids: [])
+# => ["1", "2", "3"]
+
+params = ActionController::Parameters.new(
+  users: [{ name: "John Doe" }, { name: "Jane Doe" }]
+)
+params.expect(users: [])
+# => param is missing or the value is empty or invalid: users (ActionController::ParameterMissing)
+params.expect(users: [:name])
+# => param is missing or the value is empty or invalid: users (ActionController::ParameterMissing)
+params.expect(users: [[:name]])
+# => [#<ActionController::Parameters {"name" => "John Doe"} permitted: true>, #<ActionController::Parameters {"name" => "Jane Doe"} permitted: true>]
+```
+
+Permit all attributes under a key using:
+
+```ruby
+params.expect(user: {})
+```
+
+This does not check for types or any nested types. All contained attributes are
+permitted, which somewhat bypasses the security aspects of strong parameters.
+
+WARNING: Extreme care should be taken when calling `expect` with an empty hash,
+as it will allow all current and future model attributes to be mass-assigned.
+
+[`expect`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect
+
+##### `permit` and `require`
+
+[`permit`][] returns a new `ActionController::Parameters` object containing only
+the permitted attributes. Disallowed attributes are filtered out, and no error
+is raised.
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.permit(:user)
+# => #<ActionController::Parameters {} permitted: true>
+params.permit(user: [:id])
+# => #<ActionController::Parameters {"user" => #<ActionController::Parameters {"id" => 1} permitted: true>} permitted: true>
+params.permit(user: [:id, :admin])
+# => #<ActionController::Parameters {"user" => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: true>} permitted: true>
+```
+
+All values under a key can be permitted using `{}`:
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.permit(user: {})
+# => #<ActionController::Parameters {"user" => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: true>} permitted: true>
+```
+
+WARNING: Exercise caution when calling `permit` with an empty hash, as it will
+allow all current and future model attributes to be mass-assigned.
+
+[`permit`][] is commonly chained with [`require`][] to permit a set of
+attributes keyed by a resource name. [`require`][] accepts a single key or an
+array of keys. It returns the associated values if found, or raises
+`ActionController::ParameterMissing` if any supplied keys are missing.
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.require(:user)
+# => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: false>
+```
+
+As demonstrated above, the object returned by `require(:user)` has not yet been
+`permitted`. As such, [`require`][] is often chained with [`permit`][] to return
+a set of permitted attributes:
+
+```ruby
+params = ActionController::Parameters.new(user: { id: 1, admin: "true" })
+params.require(:user).permit(:id, :admin)
+# => #<ActionController::Parameters {"id" => 1, "admin" => "true"} permitted: true>
+```
+
+Note that [`expect`][] is the recommended technique to permit attributes,
+especially when working with nested objects, as it is more explicit about value
+types, and hence provides additional safety.
+
+[`permit`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit
+[`require`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-require
+
+##### `permit!`
+
+The [`permit!`][] method sets the `permitted` attribute on an
+`ActionController::Parameters` object to `true`. It does no filtering or value
+checking whatsoever.
+
+```ruby
+params = ActionController::Parameters.new(id: 1, admin: "true")
+# => #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: false>
+params.permit!
+# => #<ActionController::Parameters {"id"=>1, "admin"=>"true"} permitted: true>
+```
+
+WARNING: Since `permit!` does not check any values, it bypasses all security
+benefits provided by strong parameters. Use with extreme caution.
+
+[`permit!`]:
+  https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-permit-21
+
+Further details on advanced parameter filtering are available in the
+[API docs](https://api.rubyonrails.org/classes/ActionController/Parameters.html).
+
+Cookies
+-------
+
+A [cookie](https://en.wikipedia.org/wiki/HTTP_cookie) (also known as an HTTP
+cookie or a web cookie) is a small piece of data from the server that is saved
+in the user's browser. The browser may store cookies, create new cookies, modify
+existing ones, and send them back to the server with later requests. Cookies
+persist data across web requests and therefore enable web applications to
+remember user preferences.
+
+Rails provides access to cookies in a controller via the [`cookies`][] method,
+which returns an instance of [`ActionDispatch::Cookies`][].
+[`ActionDispatch::Cookies`][] is a key-value store and is similar to a Ruby
+Hash.
+
+```ruby
+class PreferencesController < ApplicationController
+  def new
+    # Read data from a cookie
+    @preferences = cookies[:preferences]
+  end
+
+  def create
+    # Write data to a cookie
+    cookies[:preferences] = params.expect(preferences: {})
+  end
+
+  def destroy
+    # Delete a key from a cookie
+    cookies.delete(:preferences)
+  end
+end
+```
+
+NOTE: Setting a key to `nil` will not delete the cookie. You need to use
+`cookies.delete(:key)`.
+
+Cookies have a
+[default lifetime](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#removal_defining_the_lifetime_of_a_cookie)
+of `Session`, so they will be deleted when the user closes their browser.
+
+Create a _permanent cookie_ that expires at a specific time by passing a hash
+with the `:expires` option:
+
+```ruby
+cookies[:remember_me] = { value: "true", expires: 1.month }
+```
+
+Rails also provides a _permanent cookie jar_ that automatically sets the
+expiration date to 20 years from the time of creation:
+
+```ruby
+cookies.permanent[:locale] = "fr"
+```
+
+### Encrypted and Signed Cookies
+
+Since cookies are stored on the client browser, they can be susceptible to
+tampering and are not considered secure for storing sensitive data. Rails
+provides signed and encrypted cookie jars for storing sensitive data.
+
+The signed cookie jar appends a cryptographic signature on the cookie data to
+protect its integrity. The data can be read by a user, but cannot be tampered
+with as it is cryptographically signed.
+
+```ruby
+cookes.signed[:preferences] = @user.preferences.to_h
+```
+
+The encrypted cookie jar encrypts the data in addition to signing it, so that it
+cannot be read by the user nor tampered with.
+
+```ruby
+cookes.encrypted[:remember_token] = @user.remember_token
+```
+
+Refer to the
+[API documentation](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html)
+for more details.
+
+These special cookie jars use a serializer to serialize the cookie values into
+strings and deserialize them into Ruby objects when read back. The default
+serializer for new applications is `:json`.
+
+You can specify the serializer via
+[`config.action_dispatch.cookies_serializer`][].
+
+NOTE: Be aware that JSON has limited support serializing Ruby objects such as
+`Date`, `Time`, and `Symbol`. These will be serialized and deserialized into
+`String`s.
+
+If you need to store these or more complex objects, you may need to manually
+convert their values when reading them in subsequent requests.
+
+[`config.action_dispatch.cookies_serializer`]:
+  configuring.html#config-action-dispatch-cookies-serializer
+[`ActionDispatch::Cookies`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html
+[`cookies`]:
+  https://api.rubyonrails.org/classes/ActionController/Cookies.html#method-i-cookies
+
+Session
+-------
+
+Rails provides a _session_ object which is used to store data relevant to the
+current user session. For example, data related to user authentication may be
+stored in the session object.
+
+Session data is stored in an encrypted cookie by default, but other stores
+[may be configured](#session-stores).
+
+### Working with the Session
+
+The session is available in the controller and the view via the `session` method
+which returns an instance of `ActionDispatch::Http::Session`. This object is a
+key-value store and values can be accessed and set in the same way as a Ruby
+Hash.
+
+```ruby
+class SessionsController < ActionController::Base
+  # Read the session to redirect the user back to their initial location
+  # after a log in, or redirect them to the root path if no location is set.
+  def create
+    # ...
+
+    redirect_to session[:initial_location] || root_path
+  end
+end
+```
+
+To store data the session, assign a value to a key as you would in a Ruby Hash.
+
+```ruby
+class ProductsController < ApplicationController
+  def create
+    # ...
+
+    # Handle logged out user
+    session[:initial_location] = request.referer
+    redirect_to login_path
+  end
+end
+```
+
+To remove something from the session, delete the key:
+
+```ruby
+class ProductsController < ApplicationController
+  def new
+    session.delete(:initial_location)
+  end
+end
+```
+
+Delete all data and create a new session object using [`reset_session`][]. It is
+recommended to use `reset_session` before logging in to avoid
+[session fixation attacks](security.html#session-fixation).
+
+NOTE: Sessions are lazily loaded. If you don't access sessions in your action's
+code, they will not be loaded. Hence, you will never need to disable sessions -
+not accessing them will do the job.
+
+[`reset_session`]:
+  https://api.rubyonrails.org/classes/ActionController/Metal.html#method-i-reset_session
+
+### Session Stores
+
+The storage mechanism for session data can be configured. By default, data is
+stored in an encrypted cookie, but other stores are available.
+
+All sessions have a unique ID representing the session object. Regardless of the
+chosen store, this session ID is always stored in a cookie. The session data can
+be stored using one of the following storage mechanisms:
+
+- [`ActionDispatch::Session::CookieStore`][] - Stores the data in an encrypted
+  cookie.
+- [`ActionDispatch::Session::CacheStore`][] - Stores the data in the Rails
+  cache.
+- [`ActionDispatch::Session::ActiveRecordStore`][activerecord-session_store] -
+  Stores the data in a database using Active Record (requires the
+  [`activerecord-session_store`][activerecord-session_store] gem).
+- A custom store or a store provided by a third party gem.
+
+For most session stores, Rails uses the unique session ID in the cookie to read
+session data from your chosen store. Rails does not allow you to pass the
+session ID in the URL as this is less secure.
+
+#### `CookieStore`
+
+The `CookieStore` is the default and recommended session store. It stores all
+session data, including the session ID, in an encrypted cookie. The
+`CookieStore` is lightweight and does not require any configuration to use in a
+new application.
+
+Cookies are limited 4 kB of data, and the cookie store is bound by this limit.
+While this is lesser than the other storage options, it is usually enough.
+Storing large amounts of data in the session is discouraged. You should
+especially avoid storing complex objects (such as model instances) in the
+session.
+
+#### `CacheStore`
+
+You can use the `CacheStore` if your sessions don't store critical data or don't
+need to be around for long periods. This will store sessions using the cache
+implementation you have configured for your application. The advantage is that
+you can use your existing cache infrastructure for storing sessions without
+requiring any additional setup or administration. The downside is that the
+session storage will be temporary and data could disappear at any time.
+
+Read more about session storage in the [Security Guide](security.html#sessions).
+
+### Configuring the Session
+
+Some aspects of the session can be configured.
+
+Set the session store using:
+
+```ruby
+# config/initializers/sessions.rb
+
+Rails.application.config.session_store :cache_store
+```
+
+When using the cookie store, Rails automatically sets the name of the cookie.
+However, this can also be configured:
+
+```ruby
+# config/initializers/sessions.rb
+
+Rails.application.config.session_store :cookie_store, key: "_your_app_session"
+```
+
+NOTE: Be sure to restart your server when you modify an initializer file.
+
+You can also pass a `:domain` key and specify the domain name for the cookie:
+
+```ruby
+Rails.application.config.session_store :cookie_store, key: "_your_app_session", domain: ".example.com"
+```
+
+See [`config.session_store`](configuring.html#config-session-store) in the
+configuration guide for more information.
+
+NOTE: Signed and encrypted cookies, including the session when using the cookie
+store, are signed using the `secret_key_base` generated for all new Rails
+applications. It is usually stored in the encrypted credentials file:
+`config/credentials.yml.enc`. Changing the `secret_key_base` will render all
+signed and encrypted cookies unreadable. Refer to the
+[security guide](security.html#custom-credentials) for further information.
+
+[`ActionDispatch::Session::CookieStore`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
+[`ActionDispatch::Session::CacheStore`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Session/CacheStore.html
+[activerecord-session_store]:
+  https://github.com/rails/activerecord-session_store
+
+### The Flash
+
+The [flash](https://api.rubyonrails.org/classes/ActionDispatch/Flash.html)
+provides a way to pass temporary data between controller actions invoked in
+successive HTTP requests.
+
+Anything you place in the flash will be available in the very next request, and
+then cleared.
+
+The flash is typically used for setting messages such as notices and alerts in a
+controller action, before redirecting to an action that displays the message.
+
+The flash is accessed via the [`flash`][] method which returns an instance of
+[`ActionDispatch::Flash::FlashHash`][]. Similar to the session, the flash values
+are stored as key-value pairs exactly like a Ruby Hash.
+
+Consider the below example where the controller sets a flash message after a
+product is created, which will be available to display during the next request
+after the user is redirected.
+
+```ruby
+class ProductsController < ApplicationController
+  def create
+    # ...
+
+    flash[:notice] = "Your product was created!"
+    redirect_to products_path, status: :see_other
+  end
+end
+```
+
+You may use different keys to assign different message types:
+
+```ruby
+flash[:notice]  = "Your product was created!"
+flash[:alert]   = "Sorry, something when wrong while creating your product."
+flash[:warning] = "Your product was created, but there were some problems."
+```
+
+Set a flash message when calling `redirect_to` by including it as a parameter:
+
+```ruby
+# Equivalent to setting flash[:notice]
+redirect_to root_url, notice: "Your product was created!"
+
+# Equivalent to setting flash[:alert]
+redirect_to root_url, alert: "Sorry, something when wrong when creating your product."
+```
+
+Only `notice:` and `alert:` options may be used at the top-level. Storing
+messages under other keys needs the `flash:` option:
+
+```ruby
+# Equivalent to setting flash[:warning]
+redirect_to root_url, flash: { warning: "Your product was created, but there were some problems." }
+```
+
+The flash does not render anything in the UI — it is a short-term data storage
+mechanism. Reading flash data and rendering the appropriate HTML is left up the
+the developer.
+
+[`ActionDispatch::Flash::FlashHash`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html
+
+#### Displaying Flash Messages
+
+It is recommend to add code to render flash messages in your application layout,
+so messages are automatically rendered on every page without additional steps.
+
+Iterate through all the keys and values to render all set messages, and then you
+can use CSS to style the different types of messages based on their type:
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+
+<html>
+  <%# ... %>
+  <body>
+    <% flash.each do |type, message| -%>
+      <%= tag.div class: class_names("flash", type) do %>
+        <p><%= message %></p>
+      <% end %>
+    <% end -%>
+
+    <%# ... %>
+    <%= yield %>
+  </body>
+</html>
+```
+
+#### `flash.keep` and `flash.now`
+
+[`flash.keep`][] is used to carry over the flash value through to an additional
+request. This is useful when there are multiple redirects.
+
+For example, assume that the `root_url` routes to the `index` action in the
+controller below, and all requests here are redirected to
+`UsersController#index`.
+
+If an action sets the flash and redirects to `MainController#index`, those flash
+values will be lost during the next redirect.
+
+Use `flash.keep` to persist the values in the flash for one more request.
+
+```ruby#4,7
+class MainController < ApplicationController
+  def index
+    # Persists all flash values.
+    flash.keep
+
+    # Persists only the `:notice` value.
+    flash.keep(:notice)
+
+    # ...
+  end
+end
+```
+
+By default, setting flash value will make them available to the next request.
+[`flash.now`][] is used to make the flash values available in the same request.
+
+In the below example, when the `create` action fails to save a resource, the
+`new` template is rendered.
+
+Since there is no redirection, the response will not immediately trigger another
+HTTP request. Use `flash.now` to display a message using the flash in this case.
+This will make the message available in only the current request.
+
+```ruby
+class ProductsController < ApplicationController
+  def create
+    @product = Product.new(product_params)
+    if @product.save
+      # ...
+    else
+      flash.now[:error] = "The product could not be saved"
+      render "new", status: :unprocessable_content
+    end
+  end
+end
+```
+
+[`flash`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/RequestMethods.html#method-i-flash
+[`flash.keep`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-keep
+[`flash.now`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-now
 
 The Request and Response Objects
 --------------------------------
 
 Every controller has two methods, [`request`][] and [`response`][], which can be
-used to access the request and response objects associated with the
-current request cycle. The `request` method returns an instance of
-[`ActionDispatch::Request`][]. The [`response`][] method returns an instance
-of [`ActionDispatch::Response`][], an object representing what is going to be
-sent back to the client browser (e.g. from `render` or `redirect` in the
-controller action).
+used to access the request and response objects associated with the current
+request cycle.
 
-[`ActionDispatch::Request`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html
-[`request`]: https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-request
-[`response`]: https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-response
-[`ActionDispatch::Response`]: https://api.rubyonrails.org/classes/ActionDispatch/Response.html
+The `request` method returns an instance of [`ActionDispatch::Request`][]. The
+[`response`][] method returns an instance of [`ActionDispatch::Response`][].
+
+[`ActionDispatch::Request`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Request.html
+[`request`]:
+  https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-request
+[`response`]:
+  https://api.rubyonrails.org/classes/ActionController/Base.html#method-i-response
+[`ActionDispatch::Response`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Response.html
 
 ### The `request` Object
 
@@ -1202,10 +1428,9 @@ The request object contains useful information about the request coming in from
 the client. This section describes the purpose of some of the properties of the
 `request` object.
 
-To get a full list of the available methods, refer to the [Rails API
-documentation](https://api.rubyonrails.org/classes/ActionDispatch/Request.html)
-and [Rack](https://rack.github.io/rack/main/Rack/Request.html)
-documentation.
+The full list of the available methods can be viewed in the
+[Rails API documentation](https://api.rubyonrails.org/classes/ActionDispatch/Request.html)
+and [Rack](https://rack.github.io/rack/main/Rack/Request.html) documentation.
 
 | Property of `request`                     | Purpose                                                                          |
 | ----------------------------------------- | -------------------------------------------------------------------------------- |
@@ -1229,70 +1454,26 @@ including the ones set in the URL as query string parameters, and those sent as
 the body of a `POST` request. The request object has three methods that give you
 access to the various parameters.
 
-* [`query_parameters`][] - contains parameters that were sent as part of the
+- [`query_parameters`][] - contains parameters that were sent as part of the
   query string.
-* [`request_parameters`][] - contains parameters sent as part of the post body.
-* [`path_parameters`][] - contains parameters parsed by the router as being part
+- [`request_parameters`][] - contains parameters sent as part of the post body.
+- [`path_parameters`][] - contains parameters parsed by the router as being part
   of the path leading to this particular controller and action.
 
-[`path_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html#method-i-path_parameters
-[`query_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-query_parameters
-[`request_parameters`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters
-
-#### `request.variant`
-
-Controllers might need to tailor a response based on context-specific
-information in a request. For example, controllers responding to requests from a
-mobile platform might need to render different content than requests from a
-desktop browser. One strategy to accomplish this is by customizing a request's
-variant. Variant names are arbitrary, and can communicate anything from the
-request's platform (`:android`, `:ios`, `:linux`, `:macos`, `:windows`) to its
-browser (`:chrome`, `:edge`, `:firefox`, `:safari`), to the type of user
-(`:admin`, `:guest`, `:user`).
-
-You can set the [`request.variant`](https://api.rubyonrails.org/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-variant-3D) in a `before_action`:
-
-```ruby
-request.variant = :tablet if request.user_agent.include?("iPad")
-```
-
-Responding with a variant in a controller action is like responding with a format:
-
-```ruby
-# app/controllers/projects_controller.rb
-
-def show
-  # ...
-  respond_to do |format|
-    format.html do |html|
-      html.tablet                         # renders app/views/projects/show.html+tablet.erb
-      html.phone { extra_setup; render }  # renders app/views/projects/show.html+phone.erb
-    end
-  end
-end
-```
-
-A separate template should be created for each format and variant:
-
-* `app/views/projects/show.html.erb`
-* `app/views/projects/show.html+tablet.erb`
-* `app/views/projects/show.html+phone.erb`
-
-You can also simplify the variants definition using the inline syntax:
-
-```ruby
-respond_to do |format|
-  format.html.tablet
-  format.html.phone  { extra_setup; render }
-end
-```
+[`path_parameters`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html#method-i-path_parameters
+[`query_parameters`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-query_parameters
+[`request_parameters`]:
+  https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-request_parameters
 
 ### The `response` Object
 
 The response object is built up during the execution of the action from
 rendering data to be sent back to the client browser. It's not usually used
 directly but sometimes, in an `after_action` callback for example, it can be
-useful to access the response directly. One use case is for setting the content type header:
+useful to access the response directly. One use case is for setting the content
+type header:
 
 ```ruby
 response.content_type = "application/pdf"
@@ -1321,23 +1502,6 @@ Here are some of the properties of the `response` object:
 | `charset`              | The character set being used for the response. Default is "utf-8".                                  |
 | `headers`              | Headers used for the response.                                                                      |
 
-To get a full list of the available methods, refer to the [Rails API
-documentation](https://api.rubyonrails.org/classes/ActionDispatch/Response.html)
-and [Rack
-Documentation](https://rack.github.io/rack/main/Rack/Response.html).
-
-Handling HTTP QUERY Requests
-----------------------------
-
-The HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) is
-a safe, idempotent, cacheable method that carries its query in the request body
-instead of the URL — "GET with a body". It's useful when a query is too large,
-too structured, or too sensitive to encode in a URL's query string.
-
-Rails routes QUERY requests with the [`query`](routing.html#http-verb-constraints)
-routing helper, parses the request body into `params` based on its
-`Content-Type` (form-encoded and JSON bodies work out of the box), exempts
-QUERY from CSRF verification like GET and HEAD, and answers conditional
-requests (`fresh_when`/`stale?`) with `304 Not Modified` just as it does for
-GET. You can check for a QUERY request with `request.query?`.
-
+To get a full list of the available methods, refer to the
+[Rails API documentation](https://api.rubyonrails.org/classes/ActionDispatch/Response.html)
+and [Rack Documentation](https://rack.github.io/rack/main/Rack/Response.html).

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -81,19 +81,16 @@ details about each of the three components: `Templates`, `Partials`, `Layouts`.
 Templates
 ---------
 
-Action View templates can be written in different formats. If the template file
-has a `.erb` extension, it uses embedded Ruby to build an HTML response. If the
-template has a `.jbuilder` extension, it uses the
-[Jbuilder](https://github.com/rails/jbuilder) gem to build a JSON response. And
-a template with a `.builder` extension uses the
-[`Builder::XmlMarkup`](https://github.com/rails/builder) library to build an XML
-response.
+Action View templates can be written in different formats. Rails uses the file
+extension to determine the view's format and templating system.
 
-Rails uses the file extension to distinguish among multiple template systems.
-For example, an HTML file using the ERB template system will have `.html.erb` as
-a file extension, and a JSON file using the Jbuilder template system will have
-the `.json.jbuilder` file extension. Other libraries may add other template
-types and file extensions as well.
+For example, a file with a `.html.erb` extension uses ERB to build an
+HTML response. [Jbuilder](https://github.com/rails/jbuilder) templates
+that generate JSON will have the extension `.json.jbuilder`. And an XML
+template using [`Builder`](https://github.com/rails/builder) would
+use `.xml.builder`.
+
+Other libraries may add more templating engines and formats.
 
 ### ERB
 
@@ -247,17 +244,28 @@ method within the view:
 ```
 
 This will look for a file named `_product.html.erb` in the same folder to render
-within that view. Partial file names start with leading underscore character by
+within that view. If no such file exists, Rails will look for it under the
+`app/view/application/` folder. This makes `app/views/application/` a great
+place for your shared partials.
+
+NOTE: Rails doesn't automatically create `app/views/application/`. You'll
+need to create this folder yourself.
+
+NOTE: Refer to the
+[Layouts and Rendering guide](layouts_and_rendering.html#template_lookup_hierarchy)
+for further information on the lookup hierarchy of partials and template.
+
+Partial file names start with leading underscore character by
 convention. The file name distinguishes partials from regular views. However, no
 underscore is used when referring to partials for rendering within a view. This
 is true even when you reference a partial from another directory:
 
 ```erb
-<%= render "application/product" %>
+<%= render "admin/control_panel" %>
 ```
 
-That code will look for and display a partial file named `_product.html.erb` in
-`app/views/application/`.
+That code will look for and render a partial named `_control_panel.html.erb` in
+`app/views/admin/`.
 
 ### Using Partials to Simplify Views
 
@@ -399,6 +407,9 @@ You can also use this shorthand based on conventions:
 This will look for a partial named `_product.html.erb` in `app/views/products/`,
 as well as pass a local named `product` set to the value `@product`.
 
+NOTE: Under the hood, Rails calls `to_partial_path` on the model to determine
+which partial to render. You can override this method to customize the
+partial if required.
 
 ### The `as` and `object` Options
 
@@ -476,19 +487,43 @@ variable named after the partial. In this case, since the partial is
 `_product.html.erb`, you can use `product` to refer to the collection member
 that is being rendered.
 
-You can also use the following conventions based shorthand syntax for rendering
-collections.
+When the collection you wish to render contains objects that respond
+to `to_partial_path`, such as Active Record and Active Model instances,
+you can use the following shorthand:
 
-```erb
+```html+erb
 <%= render @products %>
 ```
 
-The above assumes that `@products` is a collection of `Product` instances. Rails
-uses naming conventions to determine the name of the partial to use by looking
-at the model name in the collection, `Product` in this case. In fact, you can
-even render a collection made up of instances of different models using this
-shorthand, and Rails will choose the proper partial for each member of the
-collection.
+Rails determines the partial for each object by calling `to_partial_path` on it.
+Conventionally, for Active Record objects, this is the name of the model:
+`products/_product.html.erb` for `Product`.
+
+A collection can be composed of different types of objects and Rails will render
+the corresponding partial for each one.
+
+```html+erb
+<%# customers/_customer.html.erb -%>
+<p>Customer: <%= customer.name %></p>
+
+<%# employees/_employee.html.erb -%>
+<p>Employee: <%= employee.name %></p>
+```
+
+```
+<%# index.html.erb -%>
+<h1>Contacts</h1>
+
+<%# Rails will render the matching partial for customer and employee objects -%>
+<%= render [customer1, employee1, customer2, employee2] %>
+```
+
+If the collection is empty, `render` will return nil so you can define a fallback.
+
+```html+erb
+<h1>Products</h1>
+<%= render(@products) || "There are no products available." %>
+```
 
 ### Spacer Templates
 
@@ -502,31 +537,33 @@ main partial by using the `:spacer_template` option:
 Rails will render the `_product_ruler.html.erb` partial (with no data passed to
 it) between each pair of `_product.html.erb` partials.
 
-### Counter Variables
+### Iteration Variables
 
-Rails also makes a counter variable available within a partial called by the
-collection. The variable is named after the title of the partial followed by
-`_counter`. For example, when rendering a collection `@products` the partial
-`_product.html.erb` can access the variable `product_counter`. The variable
-indexes the number of times the partial has been rendered within the enclosing
-view, starting with a value of `0` on the first render.
+Rails injects two additional variables into each partial when rendering
+a collection: `<object>_counter` and `<object>_iteration`.
 
-```erb
-<%# index.html.erb %>
-<%= render partial: "product", collection: @products %>
+```html+erb
+<%# app/views/products/index.html.erb -%>
+<%= render @products %>
+
+<%# app/views/products/_product.html.erb -%>
+<ul>
+  <li>Counter: <%= product_counter %></li>
+  <li>Iteration: <%= product_iteration %></li>
+</ul>
 ```
 
-```erb
-<%# _product.html.erb %>
-<%= product_counter %> # 0 for the first product, 1 for the second product...
-```
+The `product_counter` is the index of the element being rendered within the collection.
+The `product_iteration` is an instance of
+[`ActionView::PartialIteration`](https://api.rubyonrails.org/classes/ActionView/PartialIteration.html)
+which can be used to determine if it's the first or last element in
+the collection.
 
-This also works when the local variable name is changed using the `as:` option.
-So if you did `as: :item`, the counter variable would be `item_counter`.
+When using the `as:` option, these variable names will also change.
+For example, using `as: :item` will create variables
+called `item_counter` and `item_iteration`.
 
-NOTE: When rendering collections with instances of different models, the counter variable increments for each partial, regardless of the class of the model being rendered.
-
-Note: The following two sections, [Strict Locals](#strict-locals) and [Local
+NOTE: The following two sections, [Strict Locals](#strict-locals) and [Local
 Assigns with Pattern Matching](#local-assigns-with-pattern-matching) are more
 advanced features of using partials, included here for completeness.
 
@@ -607,11 +644,13 @@ enables compact partial-local default variable assignments:
 ### Strict Locals
 
 Action View partials are compiled into regular Ruby methods under the hood.
-Because it is impossible in Ruby to dynamically create local variables, every single combination of `locals` passed to
-a partial requires compiling another version:
+Because it is impossible in Ruby to dynamically create local variables,
+every single combination of `locals` passed to a partial requires
+compiling another version:
 
 ```html+erb
 <%# app/views/articles/show.html.erb %>
+
 <%= render partial: "article", layout: "box", locals: { article: @article } %>
 <%= render partial: "article", layout: "box", locals: { article: @article, theme: "dark" } %>
 ```
@@ -686,7 +725,6 @@ You can allow optional local variable arguments with the double splat `**`
 operator:
 
 ```erb
-
 <%# app/views/messages/_message.html.erb %>
 
 <%# locals: (message: "Hello, world!", **attributes) -%>
@@ -708,6 +746,13 @@ exception:
 render "messages/message", unknown_local: "will raise"
 # => ActionView::Template::Error: no locals accepted for app/views/messages/_message.html.erb
 ```
+
+WARNING: When using strict locals with collection rendering, you need to
+explicity allow the `<object>_counter` and `<object>_iteration` variables or
+they will not be set: `<%# locals: (product_counter: nil, product_iteration: nil)`.
+The `nil` default values are needed so the partial doesn't break
+when rendered outside of collections, where these two variables will
+not be set.
 
 Action View will process the `locals:` signature in any templating engine
 that supports `#`-prefixed comments, and will read the signature from any
@@ -747,7 +792,7 @@ example, rendering actions from the `ProductsController` class will use
 
 Rails will use `app/views/layouts/application.html.erb` if a controller-specific layout does not exist.
 
-Here is an example of a simple layout in `application.html.erb` file:
+Here is an example of a basic layout in `application.html.erb` file:
 
 ```html+erb
 <!DOCTYPE html>
@@ -765,7 +810,7 @@ Here is an example of a simple layout in `application.html.erb` file:
   <ul>
     <li><%= link_to "Home", root_path %></li>
     <li><%= link_to "Products", products_path %></li>
-    <!-- Additional navigation links here -->
+    <%# Additional navigation links here %>
   </ul>
 </nav>
 
@@ -779,9 +824,177 @@ Here is an example of a simple layout in `application.html.erb` file:
 In the above example layout, view content will be rendered in place of `<%=
 yield %>`, and surrounded by the same `<head>`, `<nav>`, and `<footer>` content.
 
-Rails provides more ways to assign specific layouts to individual controllers
-and actions. You can learn more about layouts in general in the [Layouts and
-Rendering in Rails](layouts_and_rendering.html) guide.
+To learn more about controller-specific layouts, see the [Layouts and
+Rendering in Rails](layouts_and_rendering.html#setting_layouts_in_controllers)
+guide.
+
+### Structuring Layouts
+
+Layouts can provide one or more slots into which views can render content.
+They can also incorporate partials just like regular views to offer
+better structure.
+
+Slots can be defined using `yield` and [`content_for`][].
+
+[`content_for`]: https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-content_for
+
+#### Understanding `yield`
+
+Within a layout, `yield` provides the slot where content from the view
+should be inserted.
+
+```html+erb
+<html>
+  <head>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>
+```
+
+You can also create a layout with multiple yielding regions:
+
+```html+erb
+<html>
+  <head>
+    <%= yield :head %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>
+```
+
+The main body of the view will always render into the unnamed `yield`. To
+render content into a named `yield`, call `content_for` with the same
+argument as the named `yield`.
+
+#### Slotting Content with `content_for`
+
+The [`content_for`][] method allows you to insert content into a named
+`yield` block in your layout. For example, consider the following layout
+and view:
+
+```html+erb
+<html>
+  <head>
+    <title>The page title</title>
+  </head>
+  <body>
+    <header>
+      <%= yield :header %>
+    </header>
+
+    <main>
+      <%= yield %>
+    </main>
+  </body>
+</html>
+```
+
+```html+erb
+<% content_for :header do %>
+  <h1>A simple page</h1>
+<% end %>
+
+<p>Hello, Rails!</p>
+```
+
+This will render out:
+
+```html
+<html>
+  <head>
+    <title>The page title</title>
+  </head>
+  <body>
+    <header>
+      <h1>A simple page</h1>
+    </header>
+    <main>
+      <p>Hello, Rails!</p>
+    </main>
+  </body>
+</html>
+```
+
+You can also use `content_for` in the layout instead of `yield`, along
+with an optional check to inquire whether content for that particular
+slot was provided:
+
+```html+erb
+<html>
+  <head>
+    <title>The page title</title>
+  </head>
+  <body>
+    <header>
+      <%= content_for :header if content_for?(:header) %>
+    </header>
+
+    <main>
+      <%= yield %>
+    </main>
+  </body>
+</html>
+```
+
+This example is functionally equivalent to the previous one where we
+used `yield :head`.
+
+TIP: The `content_for` method is very helpful when your layout contains
+distinct regions such as sidebars and footers that should get their own
+blocks of content inserted. It's also useful for inserting page-specific
+JavaScript and CSS, context-specific `<meta>` elements, or any other elements
+into an otherwise generic layout.
+
+#### Nested Layouts
+
+Layouts can inherit from other layouts when you need to make minor changes
+for certain controllers. Let's say your application has an _admin_ area
+which displays an extra _admin panel_ but the rest of the layout is
+the same.
+
+Instead of duplicating your `application.html.erb` layout with the
+addition of the admin panel, you can create an `admin.html.erb` layout
+which inherits from `application.html.erb`.
+
+```html+erb
+<%# app/views/layouts/application.html.erb -%>
+
+<html>
+  <%# ... -%>
+  <body>
+    <header>
+      <nav>Navigation menu items here</nav>
+    </header>
+
+    <main>
+      <% if content_for(:main) -%>
+        <%= yield :content %>
+      <% else %>
+        <%= yield %>
+      <% end %>
+    </main>
+  </body>
+</html>
+```
+
+```html+erb
+<%# app/views/layouts/admin.html.erb -%>
+
+<% content_for :main do %>
+  <aside>Admin panel goes here</aside>
+
+  <%= yield %>
+<% end %>
+
+<%= render template: "layouts/application" %>
+```
+
+You can then set all the controllers serving the _admin area_ of the
+application to layout using `admin.html.erb`, and your view code remains DRY.
 
 ### Partial Layouts
 

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -3,82 +3,120 @@
 Layouts and Rendering in Rails
 ==============================
 
-This guide covers the basic layout features of Action Controller and Action View.
+This guide covers the rendering features of Action Controller and its
+relationship with Action View.
 
 After reading this guide, you will know:
 
-* How to use the various rendering methods built into Rails.
-* How to create layouts with multiple content sections.
-* How to use partials to DRY up your views.
-* How to use nested layouts (sub-templates).
+- How to use the various rendering methods built into Rails.
+- How to render views in multiple formats and variants.
+- How to register custom MIME types and render responses using them.
+- How to set the layout in Rails controllers.
 
 --------------------------------------------------------------------------------
 
-Overview: How the Pieces Fit Together
--------------------------------------
+Introduction
+------------
 
-This guide focuses on the interaction between Controller and View in the Model-View-Controller triangle. As you know, the Controller is responsible for orchestrating the whole process of handling a request in Rails, though it normally hands off any heavy code to the Model. But then, when it's time to send a response back to the user, the Controller hands things off to the View. It's that handoff that is the subject of this guide.
+In this guide, we'll focus on the relationship between the **Controller** and
+the **View**, and the process of rendering a response to send back to the
+client. You'll need a basic understanding of
+[HTTP requests and responses](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Overview),
+[Action View](action_view_overview.html),
+[Rails controller conventions](action_controller_overview.html), and
+[Rails routing](routing.html).
 
-In broad strokes, this involves deciding what should be sent as the response and calling an appropriate method to create that response. If the response is a full-blown view, Rails also does some extra work to wrap the view in a layout and possibly to pull in partial views. You'll see all of those paths later in this guide.
+The controller is responsible for orchestrating how an HTTP request is handled
+in Rails. It reads the parameters from an incoming request, then hands off to
+the model layer for any complex business logic. Finally, it hands off to the
+view to send a response back to the user.
 
-Creating Responses
-------------------
+There are four ways to create an HTTP response in a Rails controller:
 
-From the controller's point of view, there are three ways to create an HTTP response:
+- [`render`][controller.render] to create a full response with a body, usually
+  with a `2xx` status code.
+- [`respond_to`][] to enable rendering of multiple formats based on the HTTP
+  request's `Accept` header.
+- [`redirect_to`][] to redirect the user to another path using an HTTP redirect
+  status code.
+- [`head`][] to create a response consisting solely of HTTP headers without a
+  body.
 
-* Call [`render`][controller.render] to create a full response to send back to the browser
-* Call [`redirect_to`][] to send an HTTP redirect status code to the browser
-* Call [`head`][] to create a response consisting solely of HTTP headers to send back to the browser
+[controller.render]:
+  https://api.rubyonrails.org/classes/ActionController/Rendering.html#method-i-render
+[`redirect_to`]:
+  https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
+[`head`]:
+  https://api.rubyonrails.org/classes/ActionController/Head.html#method-i-head
+[`respond_to`]:
+  https://api.rubyonrails.org/classes/ActionController/MimeResponds.html#method-i-respond_to
 
-[controller.render]: https://api.rubyonrails.org/classes/ActionController/Rendering.html#method-i-render
-[`redirect_to`]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to
-[`head`]: https://api.rubyonrails.org/classes/ActionController/Head.html#method-i-head
+In this guide, we will focus on the `render` and `respond_to` methods. Consult
+the [Action Controller guide](action_controller_overview.html) for details on
+`redirect_to` and `head`.
 
-### Rendering by Default: Convention Over Configuration in Action
+Rendering Responses
+-------------------
 
-You've heard that Rails promotes "convention over configuration". Default rendering is an excellent example of this. By default, controllers in Rails automatically render views with names that correspond to valid routes. For example, if you have this code in your `BooksController` class:
+The [`render`][controller.render] method is the primary workhorse to create HTTP
+responses in Rails. It's used to create a fully-formed response with a body
+which usually contains an HTML document.
+
+### The Basics
+
+Consider the below controller class and the route pointing to it. We also have a
+view for the `index` action.
 
 ```ruby
+# app/controllers/books_controller.rb
+
 class BooksController < ApplicationController
+  def index
+    render "index"
+  end
 end
 ```
 
-And the following in your routes file:
-
 ```ruby
-resources :books
+# config/routes.rb
+
+Rails.application.routes.draw do
+  resources :books
+end
 ```
 
-And you have a view file `app/views/books/index.html.erb`:
-
 ```html+erb
+<%# app/views/books/index.html.erb -%>
+
 <h1>Books are coming soon!</h1>
 ```
 
-Rails will automatically render `app/views/books/index.html.erb` when you navigate to `/books` and you will see "Books are coming soon!" on your screen.
+Rails will automatically look for the specified view in the corresponding view
+folder for the controller. Navigating to `/books` will render the heading "Books
+are coming soon!".
 
-However, a coming soon screen is only minimally useful, so you will soon create your `Book` model and add the index action to `BooksController`:
+Next, we enhance the action by loading all `Book` records from our database to
+render in the view.
 
 ```ruby
 class BooksController < ApplicationController
   def index
     @books = Book.all
+    render "index"
   end
 end
 ```
 
-Note that we don't have explicit render at the end of the index action in accordance with "convention over configuration" principle. The rule is that if you do not explicitly render something at the end of a controller action, Rails will automatically look for the `action_name.html.erb` template in the controller's view path and render it. So in this case, Rails will render the `app/views/books/index.html.erb` file.
-
-If we want to display the properties of all the books in our view, we can do so with an ERB template like this:
+The view to display all the books might look like:
 
 ```html+erb
-<h1>Listing Books</h1>
+<h1>Books</h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Content</th>
+      <th>Name</th>
+      <th>Synopsis</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -86,8 +124,8 @@ If we want to display the properties of all the books in our view, we can do so 
   <tbody>
     <% @books.each do |book| %>
       <tr>
-        <td><%= book.title %></td>
-        <td><%= book.content %></td>
+        <td><%= book.name %></td>
+        <td><%= book.synopsis %></td>
         <td><%= link_to "Show", book %></td>
         <td><%= link_to "Edit", edit_book_path(book) %></td>
         <td><%= link_to "Destroy", book, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %></td>
@@ -101,434 +139,957 @@ If we want to display the properties of all the books in our view, we can do so 
 <%= link_to "New book", new_book_path %>
 ```
 
-NOTE: The actual rendering is done by nested classes of the module [`ActionView::Template::Handlers`](https://api.rubyonrails.org/classes/ActionView/Template/Handlers.html). This guide does not dig into that process, but it's important to know that the file extension on your view controls the choice of template handler.
+We'll now see this table at `/books`.
 
-### Using `render`
+#### Conventional Rendering
 
-In most cases, the controller's [`render`][controller.render] method does the heavy lifting of rendering your application's content for use by a browser. There are a variety of ways to customize the behavior of `render`. You can render the default view for a Rails template, or a specific template, or a file, or inline code, or nothing at all. You can render text, JSON, or XML. You can specify the content type or HTTP status of the rendered response as well.
-
-TIP: If you want to see the exact results of a call to `render` without needing to inspect it in a browser, you can call `render_to_string`. This method takes exactly the same options as `render`, but it returns a string instead of sending a response back to the browser.
-
-#### Rendering an Action's View
-
-If you want to render the view that corresponds to a different template within the same controller, you can use `render` with the name of the view:
+Rails will conventionally render the view with the same name as the action —
+`render` doesn't need to be called manually.
 
 ```ruby
-def update
-  @book = Book.find(params[:id])
-  if @book.update(book_params)
-    redirect_to(@book)
-  else
-    render "edit"
+# app/controllers/books_controller.rb
+
+class BooksController < ApplicationController
+  # Automatically renders `app/views/books/index.html.erb`
+  def index
+    @books = Book.all
   end
 end
 ```
 
-If the call to `update` fails, calling the `update` action in this controller will render the `edit.html.erb` template belonging to the same controller.
+You only need to explicitly call `render` in the action to customize responses
+as described in the next section.
 
-If you prefer, you can use a symbol instead of a string to specify the action to render:
+### Rendering Templates
 
-```ruby
+`render` accepts options to to render a different template within a controller
+action, or set the HTTP response code.
+
+```ruby#6
 def update
   @book = Book.find(params[:id])
   if @book.update(book_params)
-    redirect_to(@book)
+    redirect_to @book
   else
-    render :edit, status: :unprocessable_entity
+    render "edit", status: :unprocessable_content
   end
 end
 ```
 
-#### Rendering an Action's Template from Another Controller
+You can also use a symbol instead of a string to specify the name of the
+template:
 
-What if you want to render a template from an entirely different controller from the one that contains the action code? You can also do that with `render`, which accepts the full path (relative to `app/views`) of the template to render. For example, if you're running code in an `AdminProductsController` that lives in `app/controllers/admin`, you can render the results of an action to a template in `app/views/products` this way:
+```ruby
+render :edit, status: :unprocessable_content
+```
+
+You can use the `action:` option to be more explicit:
+
+```ruby
+render action: :edit, status: :unprocessable_content
+```
+
+NOTE: We render with the HTTP status
+[`303 Unprocessable Content`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/303)
+in the above example because it's the idiomatically correct HTTP response code
+for a form submission error. It's also required by the
+[Turbo](https://turbo.hotwired.dev) JavaScript library which Rails includes by
+default.
+
+To render a template which belongs to a different controller, you can use its
+relative path from the `app/views/` directory. For example, render
+`app/views/products/show.html.erb` from the `BooksController` using:
 
 ```ruby
 render "products/show"
 ```
 
-Rails knows that this view belongs to a different controller because of the embedded slash character in the string. If you want to be explicit, you can use the `:template` option (which was required on Rails 2.2 and earlier):
+Optionally, you can include the `template:` keyword argument:
 
 ```ruby
 render template: "products/show"
 ```
 
-#### Wrapping it up
+NOTE: `render :edit`, `render action: :edit`, and `render template: :edit` are
+all functionally equivalent. Rails normalizes all 3 method signatures under the
+hood meaning they follow the same code path.
 
-The above two ways of rendering (rendering the template of another action in the same controller, and rendering the template of another action in a different controller) are actually variants of the same operation.
-
-In fact, in the `BooksController` class, inside of the update action where we want to render the edit template if the book does not update successfully, all of the following render calls would all render the `edit.html.erb` template in the `views/books` directory:
-
-```ruby
-render :edit
-render action: :edit
-render "edit"
-render action: "edit"
-render "books/edit"
-render template: "books/edit"
-```
-
-Which one you use is really a matter of style and convention, but the rule of thumb is to use the simplest one that makes sense for the code you are writing.
-
-#### Using `render` with `:inline`
-
-The `render` method can do without a view completely, if you're willing to use the `:inline` option to supply ERB as part of the method call. This is perfectly valid:
+Rendering a template for a different controller action does not call the method
+corresponding to that controller action. Consider the below example:
 
 ```ruby
-render inline: "<% products.each do |p| %><p><%= p.name %></p><% end %>"
+def edit
+  @book = Book.find(params[:id])
+end
+
+def update
+  render "edit", status: :unprocessable_content
+end
 ```
 
-WARNING: There is seldom any good reason to use this option. Mixing ERB into your controllers defeats the MVC orientation of Rails and will make it harder for other developers to follow the logic of your project. Use a separate erb view instead.
+`render "edit"` **will not** call the `edit` method. It will render the
+`edit.html.erb` template from the context of the `update` action, meaning
+`@book` will not be set when the `update` action is rendered.
 
-By default, inline rendering uses ERB. You can force it to use Builder instead with the `:type` option:
+### Template Lookup Hierarcy
+
+When there isn't an explicit call to `render`, Rails follows the controller's
+inheritance chain to find the appropriate template. Consider the below
+controllers:
 
 ```ruby
-render inline: "xml.p {'Horrid coding practice!'}", type: :builder
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+end
+
+# app/controllers/admin_controller.rb
+class AdminController < ApplicationController
+end
+
+# app/controllers/admin/products_controller.rb
+class Admin::ProductsController < AdminController
+  def index
+  end
+end
 ```
 
-#### Rendering Text
+The lookup order for an `admin/products#index` action will be:
 
-You can send plain text - with no markup at all - back to the browser by using
-the `:plain` option to `render`:
+1. `app/views/admin/products/index.html.erb`
+2. `app/views/admin/index.html.erb`
+3. `app/views/application/index.html.erb`
 
-```ruby
-render plain: "OK"
-```
+If the template is missing from all these locations, an
+`ActionView::MissingTemplate` error will be raised.
 
-TIP: Rendering pure text is most useful when you're responding to Ajax or web
-service requests that are expecting something other than proper HTML.
+### Inline `render`ing
 
-NOTE: By default, if you use the `:plain` option, the text is rendered without
-using the current layout. If you want Rails to put the text into the current
-layout, you need to add the `layout: true` option and use the `.text.erb`
-extension for the layout file.
+The `render` method can be used to define the response body within the
+controller itself. This technique can be used to render reponses in a variety of
+formats such as _plain text_, _JSON_, _XML_ etc.
 
-#### Rendering HTML
+A key difference when rendering inline is that the response is rendered without
+a [layout](action_view_overview.html#layouts) by default. For HTML and plain
+text responses, you can use the `layout:` option to explicity define a layout
+template; but, all other formats have
+[custom renderers](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/renderers.rb#L169)
+which don't incorporate a layout.
 
-You can send an HTML string back to the browser by using the `:html` option to
-`render`:
+Let's look at some examples to understand what this means.
+
+#### HTML
+
+Use the `html:` option to render an HTML string inline.
 
 ```ruby
 render html: helpers.tag.strong("Not Found")
 ```
 
-TIP: This is useful when you're rendering a small snippet of HTML code.
-However, you might want to consider moving it to a template file if the markup
-is complex.
+The response will be rendered without a layout by default. Use the `layout:`
+option to render within a layout template:
 
-NOTE: When using `html:` option, HTML entities will be escaped if the string is not composed with `html_safe`-aware APIs.
+```ruby
+# Renders within the default layout for the controller,
+# usually: `app/views/layouts/application.html.erb`.
+render html: helpers.tag.strong("Not Found"), layout: true
 
-#### Rendering JSON
+# Explitly define rendering within the `app/views/layouts/admin.html.erb`
+# layout template.
+render html: helpers.tag.strong("Not Found"), layout: "admin"
+```
 
-JSON is a JavaScript data format used by many Ajax libraries. Rails has built-in support for converting objects to JSON and rendering that JSON back to the browser:
+NOTE: There's rarely a good reason to do this in practice. Use a template file
+to render HTML responses.
+
+WARNING: When using the `html:` option, HTML entities will be escaped if the
+string is not composed with `html_safe`-aware APIs.
+
+#### Plain Text
+
+You can send plain text, without markup, back to the browser:
+
+```ruby
+render plain: "OK"
+```
+
+To wrap this response in a layout, you'll need a `.text.erb` layout file and
+then use the `layout:` option:
+
+```ruby
+# Inserts the text "OK" into the controller's default layout, usually:
+# `app/views/layouts/application.text.erb`
+render plain: "OK", layout: true
+
+# Inserts the text "OK" into `app/views/layouts/plain_text_wrapper.text.erb`
+render plain: "OK", layout: "plain_text_wrapper"
+```
+
+#### JSON
+
+Use the `json:` option to format JSON reponses. The supplied object will be
+converted to JSON using `to_json`:
 
 ```ruby
 render json: @product
 ```
 
-TIP: You don't need to call `to_json` on the object that you want to render. If you use the `:json` option, `render` will automatically call `to_json` for you.
+#### XML
 
-#### Rendering XML
-
-Rails also has built-in support for converting objects to XML and rendering that XML back to the caller:
+XML can be rendered with the `xml:` option. The supplied object will be
+converted to XML using `to_xml`:
 
 ```ruby
 render xml: @product
 ```
 
-TIP: You don't need to call `to_xml` on the object that you want to render. If you use the `:xml` option, `render` will automatically call `to_xml` for you.
+#### Raw Body
 
-#### Rendering Vanilla JavaScript
-
-Rails can render vanilla JavaScript:
-
-```ruby
-render js: "alert('Hello Rails');"
-```
-
-This will send the supplied string to the browser with a MIME type of `text/javascript`.
-
-#### Rendering Raw Body
-
-You can send a raw content back to the browser, without setting any content
-type, by using the `:body` option to `render`:
+You can create a response using a raw string using the `body:` option:
 
 ```ruby
 render body: "raw"
 ```
 
-TIP: This option should be used only if you don't care about the content type of
-the response. Using `:plain` or `:html` might be more appropriate most of the
-time.
+WARNING: There's unlikely to be a practical scenario where this option fits the
+bill. Use one of the alternate rendering options such as JSON or XML to create
+stucturally sound reponses and all the security benefits that come with it.
 
-NOTE: Unless overridden, your response returned from this render option will be
-`text/plain`, as that is the default content type of Action Dispatch response.
+#### Files
 
-#### Rendering Raw File
+Rails can render a file from an absolute path. This is useful for rendering
+static files like error pages. ERB and other templating engines are not
+supported in files passed to this option.
 
-Rails can render a raw file from an absolute path. This is useful for
-conditionally rendering static files like error pages.
+```ruby
+render file: "#{Rails.root}/public/404.html"
+```
+
+If a layout file matching the file's format exists, it will be rendered within
+that layout by default. For example, the above example will render the
+`404.html` page within the `app/views/layouts/application.html.erb` layout. This
+can be disabled using `layout: false`:
 
 ```ruby
 render file: "#{Rails.root}/public/404.html", layout: false
 ```
 
-This renders the raw file (it doesn't support ERB or other handlers). By
-default it is rendered within the current layout.
+NOTE: The layout that a static file is inserted into can written using a
+templating language like ERB. However, the file supplied to the `file:` option
+must be static. It will not be processed through a templating engine.
 
-WARNING: Using the `:file` option in combination with users input can lead to security problems
-since an attacker could use this action to access security sensitive files in your file system.
+WARNING: Using the `:file` option in combination with users input can lead to
+security problems since an attacker could use this action to access security
+sensitive files on your file system.
 
-TIP: `send_file` is often a faster and better option if a layout isn't required.
+TIP: [`send_file`](action_controller_advanced_topics.html#sending-files) is
+often a faster and better option if a layout isn't required.
 
 #### Rendering Objects
 
-Rails can render objects that respond to `#render_in`. You can provide the object as the first positional argument or provide it as the `:renderable` option to `render`. The object must also define a `#format` method that returns a valid [Mime#[]](https://api.rubyonrails.org/classes/Mime.html#method-c-5B-5D) key:
+Rails can render objects responding to `render_in`. The `render_in` method
+signature must accept the `view_context` (usually an instance of
+`ActionView::Base`), and arbitrary keyword arguments which can be defined to set
+local variables.
 
+The object must also define a `format` method that returns a valid
+[Mime key](https://api.rubyonrails.org/classes/Mime.html#method-c-5B-5D).
+
+NOTE: See the [Custom MIME types](#custom-mime-types) section below for further
+details on Mime keys.
 
 ```ruby
 class Greeting
-  def render_in(view_context, **)
-    if block_given?
-      view_context.render(html: yield)
-    else
-      view_context.render(inline: <<~ERB.strip, **)
-        Hello <%= local_assigns[:name] || "World" %>!
-      ERB
-    end
+  include ActionView::Helpers::TagHelper
+
+  def render_in(view_context, **options)
+    name = options[:locals][:name] || "world"
+    view_context.render html: tag.h1("Hello, #{name}")
   end
 
   def format
     :html
   end
 end
-
-render Greeting.new
-# => "Hello World!"
-
-render renderable: Greeting.new
-# => "Hello World!"
-
-render Greeting.new, name: "Rails"
-# => "Hello Rails!"
-
-render renderable: Greeting.new, locals: { name: "Rails" }
-# => "Hello Rails!"
-
-render(Greeting.new) { "Hello Block!" }
-# => "Hello Block!"
-
-render(renderable: Greeting.new) { "Hello Block!" }
-# => "Hello Block!"
 ```
 
-#### Options for `render`
+Render the above object in a controller action using:
 
-Calls to the [`render`][controller.render] method generally accept six options:
+```ruby
+render Greeting.new
+# => <h1>Hello, world</h1>
+```
 
-* `:content_type`
-* `:layout`
-* `:location`
-* `:status`
-* `:formats`
-* `:variants`
+Pass a local variable to the object as:
 
-##### The `:content_type` Option
+```ruby
+render Greeting.new, name: "Rails"
+# => <h1>Hello, Rails</h1>
+```
 
-By default, Rails will serve the results of a rendering operation with the MIME content-type of `text/html` (or `application/json` if you use the `:json` option, or `application/xml` for the `:xml` option.). There are times when you might like to change this, and you can do so by setting the `:content_type` option:
+This calls `render_in` on the provided object with the current [view context][].
+You can specify the `renderable:` option to be more explicit:
+
+```ruby
+render renderable: Greeting.new, name: "Rails"
+# => <h1>Hello, Rails</h1>
+```
+
+Render an ERB template from within your renderable object as:
+
+```ruby
+class Greeting
+  def render_in(view_context, **)
+    view_context.render(inline: <<~ERB.strip, **)
+      <h1>Hello, <%= local_assigns[:name] || "world" %></h1>
+    ERB
+  end
+
+  def format
+    :html
+  end
+end
+```
+
+```ruby
+render Greeting.new
+# => <h1>Hello, world</h1>
+
+render Greeting.new, name: "Rails"
+# => <h1>Hello, Rails</h1>
+```
+
+[view context]: https://api.rubyonrails.org/classes/ActionView/Base.html
+
+#### Inline Templating
+
+ERB or a similar templating string can be rendered inline using the `inline:`
+option:
+
+```ruby
+render inline: "<% products.each do |p| %><p><%= p.name %></p><% end %>"
+```
+
+Other templating engines can be used with the `type:` option:
+
+```ruby
+render inline: "xml.p 'This is a bad idea...'", type: :builder
+```
+
+```ruby
+render inline: "json.content 'This is a bad idea...'", type: :jbuilder
+```
+
+WARNING: There is seldom any good reason to use this technique. Mixing
+templating logic into your controllers defeats the MVC orientation of Rails and
+will make it harder for other developers to follow the logic of your project.
+Use a separate view instead.
+
+### Customizing Responses
+
+HTTP responses can be customized by passing additional options to
+[`render`][controller.render].
+
+#### `content_type:`
+
+The `content_type:` option sets the
+[`content-type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type)
+HTTP header for the response. It needs to be set to a valid
+[MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types)
+so the browser understands how the response is formatted.
+
+Rails automatically sets this in most cases. For example, rendering an HTML ERB
+template will set the content type to `text/html`, and rendering a JSON object
+will set it to `application/json`.
+
+It can be explicity set if needed:
 
 ```ruby
 render template: "feed", content_type: "application/rss"
 ```
 
-##### The `:layout` Option
+#### `location:`
 
-With most of the options to `render`, the rendered content is displayed as part of the current layout. You'll learn more about layouts and how to use them later in this guide.
-
-You can use the `:layout` option to tell Rails to use a specific file as the layout for the current action:
-
-```ruby
-render layout: "special_layout"
-```
-
-You can also tell Rails to render with no layout at all:
+Use the `location` option to set the HTTP
+[`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Location)
+header:
 
 ```ruby
-render layout: false
+render plain: "Redirecting...", location: root_path, status: :see_other
 ```
 
-##### The `:location` Option
+WARNING: While this is valid code, using [`redirect_to`](#redirecting-requests)
+is the canonical way to send redirect responses in Rails.
 
-You can use the `:location` option to set the HTTP `Location` header:
+#### `status:`
 
-```ruby
-render xml: photo, location: photo_url(photo)
-```
-
-##### The `:status` Option
-
-Rails will automatically generate a response with the correct HTTP status code (in most cases, this is `200 OK`). You can use the `:status` option to change this:
+Rails automatically sets the HTTP status code — in most cases, this is `200 OK`.
+Change it by supplying a `status:`:
 
 ```ruby
 render status: 500
 render status: :forbidden
 ```
 
-Rails understands both numeric status codes and the corresponding symbols shown below.
+Rails understands both numeric status codes and the corresponding symbols shown
+below.
 
-| Response Class      | HTTP Status Code | Symbol                           |
-| ------------------- | ---------------- | -------------------------------- |
-| **Informational**   | 100              | :continue                        |
-|                     | 101              | :switching_protocols             |
-|                     | 102              | :processing                      |
-| **Success**         | 200              | :ok                              |
-|                     | 201              | :created                         |
-|                     | 202              | :accepted                        |
-|                     | 203              | :non_authoritative_information   |
-|                     | 204              | :no_content                      |
-|                     | 205              | :reset_content                   |
-|                     | 206              | :partial_content                 |
-|                     | 207              | :multi_status                    |
-|                     | 208              | :already_reported                |
-|                     | 226              | :im_used                         |
-| **Redirection**     | 300              | :multiple_choices                |
-|                     | 301              | :moved_permanently               |
-|                     | 302              | :found                           |
-|                     | 303              | :see_other                       |
-|                     | 304              | :not_modified                    |
-|                     | 305              | :use_proxy                       |
-|                     | 307              | :temporary_redirect              |
-|                     | 308              | :permanent_redirect              |
-| **Client Error**    | 400              | :bad_request                     |
-|                     | 401              | :unauthorized                    |
-|                     | 402              | :payment_required                |
-|                     | 403              | :forbidden                       |
-|                     | 404              | :not_found                       |
-|                     | 405              | :method_not_allowed              |
-|                     | 406              | :not_acceptable                  |
-|                     | 407              | :proxy_authentication_required   |
-|                     | 408              | :request_timeout                 |
-|                     | 409              | :conflict                        |
-|                     | 410              | :gone                            |
-|                     | 411              | :length_required                 |
-|                     | 412              | :precondition_failed             |
-|                     | 413              | :payload_too_large               |
-|                     | 414              | :uri_too_long                    |
-|                     | 415              | :unsupported_media_type          |
-|                     | 416              | :range_not_satisfiable           |
-|                     | 417              | :expectation_failed              |
-|                     | 421              | :misdirected_request             |
-|                     | 422              | :unprocessable_entity            |
-|                     | 423              | :locked                          |
-|                     | 424              | :failed_dependency               |
-|                     | 426              | :upgrade_required                |
-|                     | 428              | :precondition_required           |
-|                     | 429              | :too_many_requests               |
-|                     | 431              | :request_header_fields_too_large |
-|                     | 451              | :unavailable_for_legal_reasons   |
-| **Server Error**    | 500              | :internal_server_error           |
-|                     | 501              | :not_implemented                 |
-|                     | 502              | :bad_gateway                     |
-|                     | 503              | :service_unavailable             |
-|                     | 504              | :gateway_timeout                 |
-|                     | 505              | :http_version_not_supported      |
-|                     | 506              | :variant_also_negotiates         |
-|                     | 507              | :insufficient_storage            |
-|                     | 508              | :loop_detected                   |
-|                     | 510              | :not_extended                    |
-|                     | 511              | :network_authentication_required |
+| Response Class    | HTTP Status Code | Symbol                           |
+| ----------------- | ---------------- | -------------------------------- |
+| **Informational** | 100              | :continue                        |
+|                   | 101              | :switching_protocols             |
+|                   | 102              | :processing                      |
+|                   | 103              | :early_hints                     |
+| **Success**       | 200              | :ok                              |
+|                   | 201              | :created                         |
+|                   | 202              | :accepted                        |
+|                   | 203              | :non_authoritative_information   |
+|                   | 204              | :no_content                      |
+|                   | 205              | :reset_content                   |
+|                   | 206              | :partial_content                 |
+|                   | 207              | :multi_status                    |
+|                   | 208              | :already_reported                |
+|                   | 226              | :im_used                         |
+| **Redirection**   | 300              | :multiple_choices                |
+|                   | 301              | :moved_permanently               |
+|                   | 302              | :found                           |
+|                   | 303              | :see_other                       |
+|                   | 304              | :not_modified                    |
+|                   | 305              | :use_proxy                       |
+|                   | 307              | :temporary_redirect              |
+|                   | 308              | :permanent_redirect              |
+| **Client Error**  | 400              | :bad_request                     |
+|                   | 401              | :unauthorized                    |
+|                   | 402              | :payment_required                |
+|                   | 403              | :forbidden                       |
+|                   | 404              | :not_found                       |
+|                   | 405              | :method_not_allowed              |
+|                   | 406              | :not_acceptable                  |
+|                   | 407              | :proxy_authentication_required   |
+|                   | 408              | :request_timeout                 |
+|                   | 409              | :conflict                        |
+|                   | 410              | :gone                            |
+|                   | 411              | :length_required                 |
+|                   | 412              | :precondition_failed             |
+|                   | 413              | :content_too_large               |
+|                   | 414              | :uri_too_long                    |
+|                   | 415              | :unsupported_media_type          |
+|                   | 416              | :range_not_satisfiable           |
+|                   | 417              | :expectation_failed              |
+|                   | 421              | :misdirected_request             |
+|                   | 422              | :unprocessable_content           |
+|                   | 423              | :locked                          |
+|                   | 424              | :failed_dependency               |
+|                   | 426              | :upgrade_required                |
+|                   | 428              | :precondition_required           |
+|                   | 429              | :too_many_requests               |
+|                   | 431              | :request_header_fields_too_large |
+|                   | 451              | :unavailable_for_legal_reasons   |
+| **Server Error**  | 500              | :internal_server_error           |
+|                   | 501              | :not_implemented                 |
+|                   | 502              | :bad_gateway                     |
+|                   | 503              | :service_unavailable             |
+|                   | 504              | :gateway_timeout                 |
+|                   | 505              | :http_version_not_supported      |
+|                   | 506              | :variant_also_negotiates         |
+|                   | 507              | :insufficient_storage            |
+|                   | 508              | :loop_detected                   |
+|                   | 510              | :not_extended                    |
+|                   | 511              | :network_authentication_required |
 
-NOTE:  If you try to render content along with a non-content status code
-(100-199, 204, 205, or 304), it will be dropped from the response.
+NOTE: The mapping between the codes and symbols is
+[defined within Rack](https://github.com/rack/rack/blob/main/lib/rack/utils.rb#L590).
+If you try to render content along with a non-content status code (100-199, 204,
+205, or 304), it will be dropped from the response.
 
-##### The `:formats` Option
+### Inspecting Responses
 
-Rails uses the format specified in the request (or `:html` by default). You can
-change this passing the `:formats` option with a symbol or an array:
-
-```ruby
-render formats: :xml
-render formats: [:json, :xml]
-```
-
-If a template with the specified format does not exist an `ActionView::MissingTemplate` error is raised.
-
-##### The `:variants` Option
-
-This tells Rails to look for template variations of the same format.
-You can specify a list of variants by passing the `:variants` option with a symbol or an array.
-
-An example of use would be this.
+A response body can be inspected using `render_to_string`. This method takes the
+same options as `render`, but instead of setting the response, it returns a
+string containing the response body.
 
 ```ruby
-# called in HomeController#index
-render variants: [:mobile, :desktop]
+json_response = render_to_string formats: :json
 ```
 
-With this set of variants Rails will look for the following set of templates and use the first that exists.
-
-- `app/views/home/index.html+mobile.erb`
-- `app/views/home/index.html+desktop.erb`
-- `app/views/home/index.html.erb`
-
-If a template with the specified format does not exist an `ActionView::MissingTemplate` error is raised.
-
-Instead of setting the variant on the render call you may also set
-[`request.variant`](https://api.rubyonrails.org/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-variant-3D)
-in your controller action. Learn more about variants in the [Action Controller
-Overview](./action_controller_overview.html#request-variant) guides.
+This method doesn't affect the actual rendering of the response. The below
+action will still implicitly render the `index` view:
 
 ```ruby
 def index
-  request.variant = determine_variant
+  @books = Book.all
+  json_response = render_to_string formats: :json
 end
-
-private
-  def determine_variant
-    variant = nil
-    # some code to determine the variant(s) to use
-    variant = :mobile if session[:use_mobile]
-
-    variant
-  end
 ```
 
-NOTE: Adding many new variant templates with similarities to existing template
-files can make maintaining your view code more difficult.
+`render_to_string` doesn't return any headers, just the response body. Hence,
+options such as `status:` are ignored.
 
-#### Finding Layouts
+### Avoiding Double Render Errors
 
-To find the current layout, Rails first looks for a file in `app/views/layouts` with the same base name as the controller. For example, rendering actions from the `PhotosController` class will use `app/views/layouts/photos.html.erb` (or `app/views/layouts/photos.builder`). If there is no such controller-specific layout, Rails will use `app/views/layouts/application.html.erb` or `app/views/layouts/application.builder`. If there is no `.erb` layout, Rails will use a `.builder` layout if one exists. Rails also provides several ways to more precisely assign specific layouts to individual controllers and actions.
+The `render` method **does not** `return` from the current scope. Lines after a
+`render` call will still be executed. Calling `render` multiple times in the
+same controller action is not allowed and will raise a
+`AbstractController::DoubleRenderError`.
 
-##### Specifying Layouts for Controllers
+For example, this action could trigger a double render error:
 
-You can override the default layout conventions in your controllers by using the [`layout`][] declaration. For example:
+```ruby
+def index
+  @books = Book.all
+  if Current.user.admin?
+    render "admin/books/index"
+  end
+
+  render "index"
+end
+```
+
+If the user is an admin, the `render` within the `if` statement will be called,
+but so will `render "index"`.
+
+You can fix this by adding an explicit `return`:
+
+```ruby
+def index
+  @books = Book.all
+  if Current.user.admin?
+    return render "admin/books/index"
+  end
+
+  render "index"
+end
+```
+
+Or by using an `else` branch:
+
+```ruby
+def index
+  @books = Book.all
+  if Current.user.admin?
+    render "admin/books/index"
+  else
+    render "index"
+  end
+end
+```
+
+Implicit rendering is unaffected by this. The controller action will only render
+the conventional template if `render` wasn't called when the action executed.
+The below example will not raise a double render error and is functionally
+equivalent to the previous example.
+
+```ruby
+def index
+  @books = Book.all
+  if Current.user.admin?
+    render "admin/books/index"
+  end
+end
+```
+
+Multi-Format Responses
+----------------------
+
+Rails templates
+[can be written in a variety of formats](action_view_overview.html#templates),
+not just HTML. For example, consider the below JSON and XML templates:
+
+```ruby
+# app/views/books/index.json.jbuilder
+
+json.array! @books do |book|
+  json.name(book.name)
+  json.synopsis(book.synopsis)
+end
+```
+
+```erb
+<%# app/views/books/index.xml.erb -%>
+
+<books>
+  <% @books.each do |book| %>
+  <book>
+    <name><%= book.name %></name>
+    <synopsis><%= book.synopsis %></synopsis>
+  </book>
+  <% end %>
+</books>
+```
+
+NOTE: In these examples, we're building the JSON template using
+[`jbuilder`](action_view_overview.html#jbuilder) for security and convenience,
+but still using ERB for the XML template. Rails also includes
+[`builder`](action_view_overview.html#builder), which provides a DSL to create
+XML templates if you wish to use it.
+
+These templates can co-exist alongside an HTML ERB template:
+
+```html+erb
+<%# app/views/books/index.html.erb -%>
+
+<h1>Books</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Synopsis</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @books.each do |book| %>
+    <tr>
+      <td><%= book.name %></td>
+      <td><%= book.synopsis %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+```
+
+This means there are 3 template formats available for the `index` action on the
+`BooksController`. Without an explicit `render`, Rails will automatically choose
+the correct format based on the request.
+
+The request can control the response format by specifying an `Accept` HTTP
+header with the appropriate
+[MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types):
+
+```
+GET /books.json HTTP/1.1
+Accept: application/json
+```
+
+or it can set an extension on the path:
+
+```
+/books.json
+/books.xml
+```
+
+The default format is HTML. For more fine-grained control over formats, Rails
+controllers offer two methods:
+
+- Supplying `formats:` when calling `render`.
+- Using [`respond_to`][].
+
+### The `formats:` option
+
+The `formats:` option on `render` overrides any definitions in the request and
+forces the controller to render the specified format:
+
+```ruby
+render formats: :json
+```
+
+An array can be passed to define fallbacks if the template for a given format
+doesn't exist. The below example will attempt to render the JSON template, but
+fallback to XML if it doesn't exist.
+
+```ruby
+render formats: [:json, :xml]
+```
+
+An `ActionView::MissingTemplate` error is raised when a template with the
+required format doesn't exist.
+
+### Advanced Format Handling Using `respond_to`
+
+[`respond_to`][] explicitly defines the formats available to the controller.
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to :html, :xml, :json
+  end
+end
+```
+
+The above is functionally equivalent to an implicit render when templates for
+all 3 formats exist:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+  end
+end
+```
+
+It can also be expressed using a block:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html
+      format.json
+      format.xml
+    end
+  end
+end
+```
+
+The above 3 code snippets are functionally equivalent. However, within this
+block structure, you can define custom handling for each format. For example,
+you might want to render a different template for HTML requests:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { render "carousel" }
+      format.json
+      format.xml
+    end
+  end
+end
+```
+
+HTML requests will render `carousel.html.erb`, whereas JSON and XML requests
+will render `index.json.jbuilder` and `index.xml.erb` respectively.
+
+You can even
+[redirect requests](action_controller_overview.html#redirecting-requests) based
+on the format:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { redirect_to books_grid_path }
+      format.json
+      format.xml
+    end
+  end
+end
+```
+
+Now requests for HTML pages will be redirected, but JSON and XML requests will
+be rendered.
+
+You can create a handler for multiple formats using `format.any`:
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { redirect_to books_grid_path }
+      format.any(:xml, :json)
+    end
+  end
+end
+```
+
+Omit the format definitions passed to `format.any` to create a catch-all
+handler. The below example will redirect HTML requests and render the
+appropriate `index` template for all other request types, where available.
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    respond_to do |format|
+      format.html { redirect_to books_grid_path }
+      format.any
+    end
+  end
+end
+```
+
+If the requested format isn't available when using `respond_to`, Rails will
+respond with the HTTP status `406 Not Acceptable`.
+
+### Template Variants
+
+Rails allows you to create multiple variants of the same template. Controllers
+responding to requests from a mobile platform might need to render different
+content than requests from a desktop browser. One strategy to accomplish this is
+to set a request variant.
+
+Variant names are arbitrary, and can communicate anything from the request's
+platform (`:android`, `:ios`, `:linux`, `:macos`, `:windows`) to its device
+(`:mobile`, `:desktop`), to the type of user (`:admin`, `:guest`, `:user`).
+
+The variant name is included in the file's extension.
+
+- `app/views/books/index.html+mobile.erb`
+- `app/views/books/index.html+desktop.erb`
+- `app/views/books/index.html.erb`
+
+Render a variant using the `variants:` option.
+
+```ruby
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+
+    # `variants:` accepts a single symbol or an array of symbols
+    render variants: [:mobile, :desktop]
+  end
+end
+```
+
+Rails will render the first available template variant from the array supplied,
+falling back to the default `.html.erb` if no matching variant is found.
+
+Rails automatically renders the appropriate variant when
+[`request.variant`](https://api.rubyonrails.org/classes/ActionDispatch/Http/MimeNegotiation.html#method-i-variant-3D)
+is set. It's a good idea to add the logic to set the variant to your
+`ApplicationController` so all your controllers get this functionality. Rails
+will always render the default template so variants can be added only where
+necessary.
+
+```ruby
+# app/controllers/concerns/set_request_variant.rb
+module SetRequestVariant
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_request_variant
+  end
+
+  private
+
+    def set_request_variant
+      # App-specific logic to determine which variant is requested
+      request.variant = # ...
+    end
+end
+
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  include SetRequestVariant
+end
+
+# app/controllers/books_controller.rb
+class BooksController < ApplicationController
+  def index
+    @books = Book.all
+  end
+end
+```
+
+An explicit `render variants:` call isn't required when using `request.variant`.
+
+You can add custom handling for variants within a `respond_to` block:
+
+```ruby
+respond_to do |format|
+  format.html do |html|
+    html.desktop { render "dashboard" }
+    html.mobile
+  end
+  format.json
+  format.xml
+end
+```
+
+```ruby
+respond_to do |format|
+  format.html.desktop { render "dashboard" }
+  format.html
+  format.json
+  format.xml
+end
+```
+
+Both the above examples are functionally equivalent. Choose the syntax that is
+appropriate for your use case.
+
+### Custom MIME types
+
+Rails registers several common
+[MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types)
+[by default](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/http/mime_types.rb).
+All these types can be used within `respond_to`. Your application can
+additionally define custom MIME types.
+
+```ruby
+# config/initializers/mime_types.rb
+
+Mime::Type.register "text/vnd.my-mime-type", :my_mime_type
+```
+
+The above definition follows the convention for naming custom MIME types. This
+can now be used to render responses:
+
+```ruby
+respond_to do |format|
+  format.my_mime_type { render plain: "This is a custom MIME type" }
+  format.any
+end
+```
+
+Even though we're using `render plain:`, the `content-type` HTTP header in the
+response will be set to `text/vnd.my-mime-type` since it's a format-specific
+handler.
+
+NOTE: This is exactly how
+[Rails' integration](https://github.com/hotwired/turbo-rails) with
+[Turbo](https://turbo.hotwired.dev) creates Turbo Stream responses. It registers
+the `text/vnd.turbo-stream.html` MIME type which allows us to create
+`.turbo_stream.html` templates and use `format.turbo_stream` in `respond_to`
+blocks.
+
+Setting Layouts In Controllers
+-------------------------------
+
+Layouts provide a common structure into which responses are rendered. If a
+layout isn't explicitly defined, Rails will automatically select it.
+
+### Automatic Layout Selection
+
+All layout files must be placed within `app/views/layouts`. Rails will first
+look for a layout file with the same base name as the controller — for example,
+`photos.html.erb` for a `PhotosController`. If such a file doesn't exist, it
+will fall back to the default `application.html.erb`.
+
+### Specifying Layouts for Controllers
+
+Explicity define a layout for a controller with the [`layout`][] declaration.
 
 ```ruby
 class ProductsController < ApplicationController
   layout "inventory"
-  #...
+
+  # ...
 end
 ```
 
-With this declaration, all of the views rendered by the `ProductsController` will use `app/views/layouts/inventory.html.erb` as their layout.
+With this declaration, all views rendered by the `ProductsController` will be
+inserted into `app/views/layouts/inventory.html.erb`.
 
-To assign a specific layout for the entire application, use a `layout` declaration in your `ApplicationController` class:
+Use a `layout` declaration in your `ApplicationController` to change the default
+layout for your entire application:
 
 ```ruby
 class ApplicationController < ActionController::Base
   layout "main"
-  #...
+
+  # ...
 end
 ```
 
-With this declaration, all of the views in the entire application will use `app/views/layouts/main.html.erb` for their layout.
+[`layout`]:
+  https://api.rubyonrails.org/classes/ActionView/Layouts/ClassMethods.html#method-i-layout
 
-[`layout`]: https://api.rubyonrails.org/classes/ActionView/Layouts/ClassMethods.html#method-i-layout
+### Setting Layouts Dynamically
 
-##### Choosing Layouts at Runtime
-
-You can use a symbol to defer the choice of layout until a request is processed:
+Call the `layout` method with a symbol denoting a method name to select a layout
+dynamically at runtime.
 
 ```ruby
 class ProductsController < ApplicationController
@@ -540,915 +1101,87 @@ class ProductsController < ApplicationController
 
   private
     def products_layout
-      @current_user.special? ? "special" : "products"
+      Current.user.admin? ? "admin" : "products"
     end
 end
 ```
 
-Now, if the current user is a special user, they'll get a special layout when viewing a product.
+Now, if the current user is a administrator, they'll get the admin-specific
+layout when viewing a product.
 
-You can even use an inline method, such as a Proc, to determine the layout. For example, if you pass a Proc object, the block you give the Proc will be given the `controller` instance, so the layout can be determined based on the current request:
+You can also invoke `layout` with a
+[`Proc`](https://docs.ruby-lang.org/en/master/Proc.html) or
+[`lambda`](https://docs.ruby-lang.org/en/master/Kernel.html#method-i-lambda).
+The controller instance will be passed into it.
 
 ```ruby
 class ProductsController < ApplicationController
-  layout Proc.new { |controller| controller.request.xhr? ? "popup" : "application" }
+  layout ->(controller) { controller.request.xhr? ? "popup" : "application" }
 end
 ```
 
-##### Conditional Layouts
+### Conditional Layouts
 
-Layouts specified at the controller level support the `:only` and `:except` options. These options take either a method name, or an array of method names, corresponding to method names within the controller:
+Layouts defined at the controller level support the `:only` and `:except`
+options. You can use these options to specify layouts for a subset of the
+controller's actions.
 
 ```ruby
 class ProductsController < ApplicationController
+  # The `product` layout is used for all actions except `index` and `rss`.
   layout "product", except: [:index, :rss]
 end
 ```
 
-With this declaration, the `product` layout would be used for everything but the `rss` and `index` methods.
+```ruby
+class ProductsController < ApplicationController
+  # The `product` layout is used only for the `show` and `edit` actions.
+  layout "product", only: [:show, :edit]
+end
+```
 
-##### Layout Inheritance
+### Layout Hierarchy
 
-Layout declarations cascade downward in the hierarchy, and more specific layout declarations always override more general ones. For example:
-
-* `application_controller.rb`
-
-    ```ruby
-    class ApplicationController < ActionController::Base
-      layout "main"
-    end
-    ```
-
-* `articles_controller.rb`
-
-    ```ruby
-    class ArticlesController < ApplicationController
-    end
-    ```
-
-* `special_articles_controller.rb`
-
-    ```ruby
-    class SpecialArticlesController < ArticlesController
-      layout "special"
-    end
-    ```
-
-* `old_articles_controller.rb`
-
-    ```ruby
-    class OldArticlesController < SpecialArticlesController
-      layout false
-
-      def show
-        @article = Article.find(params[:id])
-      end
-
-      def index
-        @old_articles = Article.older
-        render layout: "old"
-      end
-      # ...
-    end
-    ```
-
-In this application:
-
-* In general, views will be rendered in the `main` layout
-* `ArticlesController#index` will use the `main` layout
-* `SpecialArticlesController#index` will use the `special` layout
-* `OldArticlesController#show` will use no layout at all
-* `OldArticlesController#index` will use the `old` layout
-
-##### Template Inheritance
-
-Similar to the Layout Inheritance logic, if a template or partial is not found in the conventional path, the controller will look for a template or partial to render in its inheritance chain. For example:
+Layout declarations cascade downward in the hierarchy, and more specific layout
+declarations always override more general ones. For example:
 
 ```ruby
 # app/controllers/application_controller.rb
 class ApplicationController < ActionController::Base
+  layout "main"
 end
-```
 
-```ruby
-# app/controllers/admin_controller.rb
-class AdminController < ApplicationController
+# app/controllers/articles_controller.rb
+class ArticlesController < ApplicationController
 end
-```
 
-```ruby
-# app/controllers/admin/products_controller.rb
-class Admin::ProductsController < AdminController
+# app/controllers/products_controller.rb
+class ProductsController < ArticlesController
+  layout "product"
+end
+
+# app/controllers/profiles_controller.rb
+class ProfilesController < ApplicationController
+  layout false
+
+  def show
+    @profile = Profile.find(params[:id])
+    render layout: "profile"
+  end
+
   def index
+    @profiles = Profile.all
   end
+
+  # ...
 end
 ```
 
-The lookup order for an `admin/products#index` action will be:
-
-* `app/views/admin/products/`
-* `app/views/admin/`
-* `app/views/application/`
-
-This makes `app/views/application/` a great place for your shared partials, which can then be rendered in your ERB as such:
-
-```erb
-<%# app/views/admin/products/index.html.erb %>
-<%= render @products || "empty_list" %>
-
-<%# app/views/application/_empty_list.html.erb %>
-There are no items in this list <em>yet</em>.
-```
-
-#### Avoiding Double Render Errors
-
-Sooner or later, most Rails developers will see the error message "Can only render or redirect once per action". While this is annoying, it's relatively easy to fix. Usually it happens because of a fundamental misunderstanding of the way that `render` works.
-
-For example, here's some code that will trigger this error:
-
-```ruby
-def show
-  @book = Book.find(params[:id])
-  if @book.special?
-    render action: "special_show"
-  end
-  render action: "regular_show"
-end
-```
-
-If `@book.special?` evaluates to `true`, Rails will start the rendering process to dump the `@book` variable into the `special_show` view. But this will _not_ stop the rest of the code in the `show` action from running, and when Rails hits the end of the action, it will start to render the `regular_show` view - and throw an error. The solution is simple: make sure that you have only one call to `render` or `redirect` in a single code path. One thing that can help is `return`. Here's a patched version of the method:
-
-```ruby
-def show
-  @book = Book.find(params[:id])
-  if @book.special?
-    render action: "special_show"
-    return
-  end
-  render action: "regular_show"
-end
-```
-
-Note that the implicit render done by ActionController detects if `render` has been called, so the following will work without errors:
-
-```ruby
-def show
-  @book = Book.find(params[:id])
-  if @book.special?
-    render action: "special_show"
-  end
-end
-```
-
-This will render a book with `special?` set with the `special_show` template, while other books will render with the default `show` template.
-
-### Using `redirect_to`
-
-Another way to handle returning responses to an HTTP request is with [`redirect_to`][]. As you've seen, `render` tells Rails which view (or other asset) to use in constructing a response. The `redirect_to` method does something completely different: it tells the browser to send a new request for a different URL. For example, you could redirect from wherever you are in your code to the index of photos in your application with this call:
-
-```ruby
-redirect_to photos_url
-```
-
-You can use [`redirect_back`][] to return the user to the page they just came from.
-This location is pulled from the `HTTP_REFERER` header which is not guaranteed
-to be set by the browser, so you must provide the `fallback_location`
-to use in this case.
-
-```ruby
-redirect_back(fallback_location: root_path)
-```
-
-NOTE: `redirect_to` and `redirect_back` do not halt and return immediately from method execution, but simply set HTTP responses. Statements occurring after them in a method will be executed. You can halt by an explicit `return` or some other halting mechanism, if needed.
-
-[`redirect_back`]: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back
-
-#### Getting a Different Redirect Status Code
-
-Rails uses HTTP status code 302, a temporary redirect, when you call `redirect_to`. If you'd like to use a different status code, perhaps 301, a permanent redirect, you can use the `:status` option:
-
-```ruby
-redirect_to photos_path, status: 301
-```
-
-Just like the `:status` option for `render`, `:status` for `redirect_to` accepts both numeric and symbolic header designations.
-
-#### The Difference Between `render` and `redirect_to`
-
-Sometimes inexperienced developers think of `redirect_to` as a sort of `goto`
-command, moving execution from one place to another in your Rails code. This is
-_not_ correct.
-
-The current action will complete, returning a response to the browser. After
-this your code stops running and waits for a new request, it just happens that
-you've told the browser what request it should make next by sending back an
-HTTP 302 status code.
-
-Consider these actions to see the difference:
-
-```ruby
-def index
-  @books = Book.all
-end
-
-def show
-  @book = Book.find_by(id: params[:id])
-  if @book.nil?
-    render action: "index"
-  end
-end
-```
-
-With the code in this form, there will likely be a problem if the `@book` variable is `nil`. Remember, a `render :action` doesn't run any code in the target action, so nothing will set up the `@books` variable that the `index` view will probably require. One way to fix this is to redirect instead of rendering:
-
-```ruby
-def index
-  @books = Book.all
-end
-
-def show
-  @book = Book.find_by(id: params[:id])
-  if @book.nil?
-    redirect_to action: :index
-  end
-end
-```
-
-With this code, the browser will make a fresh request for the index page, the code in the `index` method will run, and all will be well.
-
-The only downside to this code is that it requires a round trip to the browser: the browser requested the show action with `/books/1` and the controller finds that there are no books, so the controller sends out a 302 redirect response to the browser telling it to go to `/books/`, the browser complies and sends a new request back to the controller asking now for the `index` action, the controller then gets all the books in the database and renders the index template, sending it back down to the browser which then shows it on your screen.
-
-While in a small application, this added latency might not be a problem, it is something to think about if response time is a concern. We can demonstrate one way to handle this with a contrived example:
-
-```ruby
-def index
-  @books = Book.all
-end
-
-def show
-  @book = Book.find_by(id: params[:id])
-  if @book.nil?
-    @books = Book.all
-    flash.now[:alert] = "Your book was not found"
-    render "index"
-  end
-end
-```
-
-This would detect that there are no books with the specified ID, populate the `@books` instance variable with all the books in the model, and then directly render the `index.html.erb` template, returning it to the browser with a flash alert message to tell the user what happened.
-
-### Using `head` to Build Header-Only Responses
-
-The [`head`][] method can be used to send responses with only headers to the browser. The `head` method accepts a number or symbol (see [reference table](#the-status-option)) representing an HTTP status code. The options argument is interpreted as a hash of header names and values. For example, you can return only an error header:
-
-```ruby
-head :bad_request
-```
-
-This would produce the following header:
-
-```http
-HTTP/1.1 400 Bad Request
-Connection: close
-Date: Sun, 24 Jan 2010 12:15:53 GMT
-Transfer-Encoding: chunked
-Content-Type: text/html; charset=utf-8
-X-Runtime: 0.013483
-Set-Cookie: _blog_session=...snip...; path=/; HttpOnly
-Cache-Control: no-cache
-```
-
-Or you can use other HTTP headers to convey other information:
-
-```ruby
-head :created, location: photo_path(@photo)
-```
-
-Which would produce:
-
-```http
-HTTP/1.1 201 Created
-Connection: close
-Date: Sun, 24 Jan 2010 12:16:44 GMT
-Transfer-Encoding: chunked
-Location: /photos/1
-Content-Type: text/html; charset=utf-8
-X-Runtime: 0.083496
-Set-Cookie: _blog_session=...snip...; path=/; HttpOnly
-Cache-Control: no-cache
-```
-
-Structuring Layouts
--------------------
-
-When Rails renders a view as a response, it does so by combining the view with the current layout, using the rules for finding the current layout that were covered earlier in this guide. Within a layout, you have access to three tools for combining different bits of output to form the overall response:
-
-* Asset tags
-* `yield` and [`content_for`][]
-* Partials
-
-[`content_for`]: https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-content_for
-
-### Asset Tag Helpers
-
-Asset tag helpers provide methods for generating HTML that link views to feeds, JavaScript, stylesheets, images, videos, and audios. There are six asset tag helpers available in Rails:
-
-* [`auto_discovery_link_tag`][]
-* [`javascript_include_tag`][]
-* [`stylesheet_link_tag`][]
-* [`image_tag`][]
-* [`video_tag`][]
-* [`audio_tag`][]
-
-You can use these tags in layouts or other views, although the `auto_discovery_link_tag`, `javascript_include_tag`, and `stylesheet_link_tag`, are most commonly used in the `<head>` section of a layout.
-
-WARNING: The asset tag helpers do _not_ verify the existence of the assets at the specified locations; they simply assume that you know what you're doing and generate the link.
-
-[`auto_discovery_link_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-auto_discovery_link_tag
-[`javascript_include_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-javascript_include_tag
-[`stylesheet_link_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-stylesheet_link_tag
-[`image_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-image_tag
-[`video_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-video_tag
-[`audio_tag`]: https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-audio_tag
-
-#### Linking to Feeds with the `auto_discovery_link_tag`
-
-The [`auto_discovery_link_tag`][] helper builds HTML that most browsers and feed readers can use to detect the presence of RSS, Atom, or JSON feeds. It takes the type of the link (`:rss`, `:atom`, or `:json`), a hash of options that are passed through to url_for, and a hash of options for the tag:
-
-```erb
-<%= auto_discovery_link_tag(:rss, {action: "feed"},
-  {title: "RSS Feed"}) %>
-```
-
-There are three tag options available for the `auto_discovery_link_tag`:
-
-* `:rel` specifies the `rel` value in the link. The default value is "alternate".
-* `:type` specifies an explicit MIME type. Rails will generate an appropriate MIME type automatically.
-* `:title` specifies the title of the link. The default value is the uppercase `:type` value, for example, "ATOM" or "RSS".
-
-#### Linking to JavaScript Files with the `javascript_include_tag`
-
-The [`javascript_include_tag`][] helper returns an HTML `script` tag for each source provided.
-
-If you are using Rails with the [Asset Pipeline](asset_pipeline.html) enabled, this helper will generate a link to `/assets/javascripts/` rather than `public/javascripts` which was used in earlier versions of Rails. This link is then served by the asset pipeline.
-
-A JavaScript file within a Rails application or Rails engine goes in one of three locations: `app/assets`, `lib/assets` or `vendor/assets`. These locations are explained in detail in the [Asset Organization section in the Asset Pipeline Guide](asset_pipeline.html#asset-organization).
-
-You can specify a full path relative to the document root, or a URL, if you prefer. For example, to link to a JavaScript file `main.js` that is inside one of `app/assets/javascripts`, `lib/assets/javascripts` or `vendor/assets/javascripts`, you would do this:
-
-```erb
-<%= javascript_include_tag "main" %>
-```
-
-Rails will then output a `script` tag such as this:
-
-```html
-<script src='/assets/main.js'></script>
-```
-
-The request to this asset is then served by the Sprockets gem.
-
-To include multiple files such as `app/assets/javascripts/main.js` and `app/assets/javascripts/columns.js` at the same time:
-
-```erb
-<%= javascript_include_tag "main", "columns" %>
-```
-
-To include `app/assets/javascripts/main.js` and `app/assets/javascripts/photos/columns.js`:
-
-```erb
-<%= javascript_include_tag "main", "/photos/columns" %>
-```
-
-To include `http://example.com/main.js`:
-
-```erb
-<%= javascript_include_tag "http://example.com/main.js" %>
-```
-
-#### Linking to CSS Files with the `stylesheet_link_tag`
-
-The [`stylesheet_link_tag`][] helper returns an HTML `<link>` tag for each source provided.
-
-If you are using Rails with the "Asset Pipeline" enabled, this helper will generate a link to `/assets/stylesheets/`. This link is then processed by the Sprockets gem. A stylesheet file can be stored in one of three locations: `app/assets`, `lib/assets`, or `vendor/assets`.
-
-You can specify a full path relative to the document root, or a URL. For example, to link to a stylesheet file that is inside a directory called `stylesheets` inside of one of `app/assets`, `lib/assets`, or `vendor/assets`, you would do this:
-
-```erb
-<%= stylesheet_link_tag "main" %>
-```
-
-To include `app/assets/stylesheets/main.css` and `app/assets/stylesheets/columns.css`:
-
-```erb
-<%= stylesheet_link_tag "main", "columns" %>
-```
-
-To include `app/assets/stylesheets/main.css` and `app/assets/stylesheets/photos/columns.css`:
-
-```erb
-<%= stylesheet_link_tag "main", "photos/columns" %>
-```
-
-To include `http://example.com/main.css`:
-
-```erb
-<%= stylesheet_link_tag "http://example.com/main.css" %>
-```
-
-By default, the `stylesheet_link_tag` creates links with `rel="stylesheet"`. You can override this default by specifying an appropriate option (`:rel`):
-
-```erb
-<%= stylesheet_link_tag "main_print", media: "print" %>
-```
-
-#### Linking to Images with the `image_tag`
-
-The [`image_tag`][] helper builds an HTML `<img />` tag to the specified file. By default, files are loaded from `public/images`.
-
-WARNING: Note that you must specify the extension of the image.
-
-```erb
-<%= image_tag "header.png" %>
-```
-
-You can supply a path to the image if you like:
-
-```erb
-<%= image_tag "icons/delete.gif" %>
-```
-
-You can supply a hash of additional HTML options:
-
-```erb
-<%= image_tag "icons/delete.gif", {height: 45} %>
-```
-
-You can supply alternate text for the image which will be used if the user has images turned off in their browser. If you do not specify an alt text explicitly, it defaults to the file name of the file, capitalized and with no extension. For example, these two image tags would return the same code:
-
-```erb
-<%= image_tag "home.gif" %>
-<%= image_tag "home.gif", alt: "Home" %>
-```
-
-You can also specify a special size tag, in the format "{width}x{height}":
-
-```erb
-<%= image_tag "home.gif", size: "50x20" %>
-```
-
-In addition to the above special tags, you can supply a final hash of standard HTML options, such as `:class`, `:id`, or `:name`:
-
-```erb
-<%= image_tag "home.gif", alt: "Go Home",
-                          id: "HomeImage",
-                          class: "nav_bar" %>
-```
-
-#### Linking to Videos with the `video_tag`
-
-The [`video_tag`][] helper builds an HTML5 `<video>` tag to the specified file. By default, files are loaded from `public/videos`.
-
-```erb
-<%= video_tag "movie.ogg" %>
-```
-
-Produces
-
-```erb
-<video src="/videos/movie.ogg" />
-```
-
-Like an `image_tag` you can supply a path, either absolute, or relative to the `public/videos` directory. Additionally you can specify the `size: "#{width}x#{height}"` option just like an `image_tag`. Video tags can also have any of the HTML options specified at the end (`id`, `class` et al).
-
-The video tag also supports all of the `<video>` HTML options through the HTML options hash, including:
-
-* `poster: "image_name.png"`, provides an image to put in place of the video before it starts playing.
-* `autoplay: true`, starts playing the video on page load.
-* `loop: true`, loops the video once it gets to the end.
-* `controls: true`, provides browser supplied controls for the user to interact with the video.
-* `autobuffer: true`, the video will pre load the file for the user on page load.
-
-You can also specify multiple videos to play by passing an array of videos to the `video_tag`:
-
-```erb
-<%= video_tag ["trailer.ogg", "movie.ogg"] %>
-```
-
-This will produce:
-
-```erb
-<video>
-  <source src="/videos/trailer.ogg">
-  <source src="/videos/movie.ogg">
-</video>
-```
-
-#### Linking to Audio Files with the `audio_tag`
-
-The [`audio_tag`][] helper builds an HTML5 `<audio>` tag to the specified file. By default, files are loaded from `public/audios`.
-
-```erb
-<%= audio_tag "music.mp3" %>
-```
-
-You can supply a path to the audio file if you like:
-
-```erb
-<%= audio_tag "music/first_song.mp3" %>
-```
-
-You can also supply a hash of additional options, such as `:id`, `:class`, etc.
-
-Like the `video_tag`, the `audio_tag` has special options:
-
-* `autoplay: true`, starts playing the audio on page load
-* `controls: true`, provides browser supplied controls for the user to interact with the audio.
-* `autobuffer: true`, the audio will pre load the file for the user on page load.
-
-### Understanding `yield`
-
-Within the context of a layout, `yield` identifies a section where content from the view should be inserted. The simplest way to use this is to have a single `yield`, into which the entire contents of the view currently being rendered is inserted:
-
-```html+erb
-<html>
-  <head>
-  </head>
-  <body>
-    <%= yield %>
-  </body>
-</html>
-```
-
-You can also create a layout with multiple yielding regions:
-
-```html+erb
-<html>
-  <head>
-    <%= yield :head %>
-  </head>
-  <body>
-    <%= yield %>
-  </body>
-</html>
-```
-
-The main body of the view will always render into the unnamed `yield`. To render content into a named `yield`, call the `content_for` method with the same argument as the named `yield`.
-
-NOTE: Newly generated applications will include `<%= yield :head %>` within the `<head>` element of its `app/views/layouts/application.html.erb` template.
-
-### Using the `content_for` Method
-
-The [`content_for`][] method allows you to insert content into a named `yield` block in your layout. For example, this view would work with the layout that you just saw:
-
-```html+erb
-<% content_for :head do %>
-  <title>A simple page</title>
-<% end %>
-
-<p>Hello, Rails!</p>
-```
-
-The result of rendering this page into the supplied layout would be this HTML:
-
-```html+erb
-<html>
-  <head>
-    <title>A simple page</title>
-  </head>
-  <body>
-    <p>Hello, Rails!</p>
-  </body>
-</html>
-```
-
-The `content_for` method is very helpful when your layout contains distinct regions such as sidebars and footers that should get their own blocks of content inserted. It's also useful for inserting page-specific JavaScript `<script>` elements, CSS `<link>` elements, context-specific `<meta>` elements, or any other elements into the `<head>` of an otherwise generic layout.
-
-### Using Partials
-
-Partial templates - usually just called "partials" - are another device for breaking the rendering process into more manageable chunks. With a partial, you can move the code for rendering a particular piece of a response to its own file.
-
-#### Naming Partials
-
-To render a partial as part of a view, you use the [`render`][view.render] method within the view:
-
-```html+erb
-<%= render "menu" %>
-```
-
-This will render a file named `_menu.html.erb` at that point within the view being rendered. Note the leading underscore character: partials are named with a leading underscore to distinguish them from regular views, even though they are referred to without the underscore. This holds true even when you're pulling in a partial from another folder:
-
-```html+erb
-<%= render "application/menu" %>
-```
-
-Since view partials rely on the same [Template Inheritance](#template-inheritance)
-as templates and layouts, that code will pull in the partial from `app/views/application/_menu.html.erb`.
-
-[view.render]: https://api.rubyonrails.org/classes/ActionView/Helpers/RenderingHelper.html#method-i-render
-
-#### Using Partials to Simplify Views
-
-One way to use partials is to treat them as the equivalent of subroutines: as a way to move details out of a view so that you can grasp what's going on more easily. For example, you might have a view that looked like this:
-
-```erb
-<%= render "application/ad_banner" %>
-
-<h1>Products</h1>
-
-<p>Here are a few of our fine products:</p>
-<%# ... %>
-
-<%= render "application/footer" %>
-```
-
-Here, the `_ad_banner.html.erb` and `_footer.html.erb` partials could contain
-content that is shared by many pages in your application. You don't need to see
-the details of these sections when you're concentrating on a particular page.
-
-As seen in the previous sections of this guide, `yield` is a very powerful tool
-for cleaning up your layouts. Keep in mind that it's pure Ruby, so you can use
-it almost everywhere. For example, we can use it to DRY up form layout
-definitions for several similar resources:
-
-* `users/index.html.erb`
-
-    ```html+erb
-    <%= render "application/search_filters", search: @q do |form| %>
-      <p>
-        Name contains: <%= form.text_field :name_contains %>
-      </p>
-    <% end %>
-    ```
-
-* `roles/index.html.erb`
-
-    ```html+erb
-    <%= render "application/search_filters", search: @q do |form| %>
-      <p>
-        Title contains: <%= form.text_field :title_contains %>
-      </p>
-    <% end %>
-    ```
-
-* `application/_search_filters.html.erb`
-
-    ```html+erb
-    <%= form_with model: search do |form| %>
-      <h1>Search form:</h1>
-      <fieldset>
-        <%= yield form %>
-      </fieldset>
-      <p>
-        <%= form.submit "Search" %>
-      </p>
-    <% end %>
-    ```
-
-TIP: For content that is shared among all pages in your application, you can use partials directly from layouts.
-
-#### Partial Layouts
-
-A partial can use its own layout file, just as a view can use a layout. For example, you might call a partial like this:
-
-```erb
-<%= render partial: "link_area", layout: "graybar" %>
-```
-
-This would look for a partial named `_link_area.html.erb` and render it using the layout `_graybar.html.erb`. Note that layouts for partials follow the same leading-underscore naming as regular partials, and are placed in the same folder with the partial that they belong to (not in the master `layouts` folder).
-
-Also note that explicitly specifying `:partial` is required when passing additional options such as `:layout`.
-
-#### Passing Local Variables
-
-You can also pass local variables into partials, making them even more powerful and flexible. For example, you can use this technique to reduce duplication between new and edit pages, while still keeping a bit of distinct content:
-
-* `new.html.erb`
-
-    ```html+erb
-    <h1>New zone</h1>
-    <%= render partial: "form", locals: {zone: @zone} %>
-    ```
-
-* `edit.html.erb`
-
-    ```html+erb
-    <h1>Editing zone</h1>
-    <%= render partial: "form", locals: {zone: @zone} %>
-    ```
-
-* `_form.html.erb`
-
-    ```html+erb
-    <%= form_with model: zone do |form| %>
-      <p>
-        <b>Zone name</b><br>
-        <%= form.text_field :name %>
-      </p>
-      <p>
-        <%= form.submit %>
-      </p>
-    <% end %>
-    ```
-
-Although the same partial will be rendered into both views, Action View's submit helper will return "Create Zone" for the new action and "Update Zone" for the edit action.
-
-To pass a local variable to a partial in only specific cases use the `local_assigns`.
-
-* `index.html.erb`
-
-    ```erb
-    <%= render user.articles %>
-    ```
-
-* `show.html.erb`
-
-    ```erb
-    <%= render article, full: true %>
-    ```
-
-* `_article.html.erb`
-
-    ```erb
-    <h2><%= article.title %></h2>
-
-    <% if local_assigns[:full] %>
-      <%= simple_format article.body %>
-    <% else %>
-      <%= truncate article.body %>
-    <% end %>
-    ```
-
-This way it is possible to use the partial without the need to declare all local variables.
-
-Every partial also has a local variable with the same name as the partial (minus the leading underscore). You can pass an object in to this local variable via the `:object` option:
-
-```erb
-<%= render partial: "customer", object: @new_customer %>
-```
-
-Within the `customer` partial, the `customer` variable will refer to `@new_customer` from the parent view.
-
-If you have an instance of a model to render into a partial, you can use a shorthand syntax:
-
-```erb
-<%= render @customer %>
-```
-
-Assuming that the `@customer` instance variable contains an instance of the `Customer` model, this will use `_customer.html.erb` to render it and will pass the local variable `customer` into the partial which will refer to the `@customer` instance variable in the parent view.
-
-#### Rendering Collections
-
-Partials are very useful in rendering collections. When you pass a collection to a partial via the `:collection` option, the partial will be inserted once for each member in the collection:
-
-* `index.html.erb`
-
-    ```html+erb
-    <h1>Products</h1>
-    <%= render partial: "product", collection: @products %>
-    ```
-
-* `_product.html.erb`
-
-    ```html+erb
-    <p>Product Name: <%= product.name %></p>
-    ```
-
-When a partial is called with a pluralized collection, then the individual instances of the partial have access to the member of the collection being rendered via a variable named after the partial. In this case, the partial is `_product`, and within the `_product` partial, you can refer to `product` to get the instance that is being rendered.
-
-There is also a shorthand for this. Assuming `@products` is a collection of `Product` instances, you can simply write this in the `index.html.erb` to produce the same result:
-
-```html+erb
-<h1>Products</h1>
-<%= render @products %>
-```
-
-Rails determines the name of the partial to use by looking at the model name in the collection. In fact, you can even create a heterogeneous collection and render it this way, and Rails will choose the proper partial for each member of the collection:
-
-* `index.html.erb`
-
-    ```html+erb
-    <h1>Contacts</h1>
-    <%= render [customer1, employee1, customer2, employee2] %>
-    ```
-
-* `customers/_customer.html.erb`
-
-    ```html+erb
-    <p>Customer: <%= customer.name %></p>
-    ```
-
-* `employees/_employee.html.erb`
-
-    ```html+erb
-    <p>Employee: <%= employee.name %></p>
-    ```
-
-In this case, Rails will use the customer or employee partials as appropriate for each member of the collection.
-
-In the event that the collection is empty, `render` will return nil, so it should be fairly simple to provide alternative content.
-
-```html+erb
-<h1>Products</h1>
-<%= render(@products) || "There are no products available." %>
-```
-
-#### Local Variables
-
-To use a custom local variable name within the partial, specify the `:as` option in the call to the partial:
-
-```erb
-<%= render partial: "product", collection: @products, as: :item %>
-```
-
-With this change, you can access an instance of the `@products` collection as the `item` local variable within the partial.
-
-You can also pass in arbitrary local variables to any partial you are rendering with the `locals: {}` option:
-
-```erb
-<%= render partial: "product", collection: @products,
-           as: :item, locals: {title: "Products Page"} %>
-```
-
-In this case, the partial will have access to a local variable `title` with the value "Products Page".
-
-#### Counter Variables
-
-Rails also makes a counter variable available within a partial called by the collection. The variable is named after the title of the partial followed by `_counter`. For example, when rendering a collection `@products` the partial `_product.html.erb` can access the variable `product_counter`. The variable indexes the number of times the partial has been rendered within the enclosing view, starting with a value of `0` on the first render.
-
-```erb
-# index.html.erb
-<%= render partial: "product", collection: @products %>
-```
-
-```erb
-# _product.html.erb
-<%= product_counter %> # 0 for the first product, 1 for the second product...
-```
-
-This also works when the local variable name is changed using the `as:` option. So if you did `as: :item`, the counter variable would be `item_counter`.
-
-#### Spacer Templates
-
-You can also specify a second partial to be rendered between instances of the main partial by using the `:spacer_template` option:
-
-```erb
-<%= render partial: @products, spacer_template: "product_ruler" %>
-```
-
-Rails will render the `_product_ruler` partial (with no data passed in to it) between each pair of `_product` partials.
-
-#### Collection Partial Layouts
-
-When rendering collections it is also possible to use the `:layout` option:
-
-```erb
-<%= render partial: "product", collection: @products, layout: "special_layout" %>
-```
-
-The layout will be rendered together with the partial for each item in the collection. The current object and object_counter variables will be available in the layout as well, the same way they are within the partial.
-
-### Using Nested Layouts
-
-You may find that your application requires a layout that differs slightly from your regular application layout to support one particular controller. Rather than repeating the main layout and editing it, you can accomplish this by using nested layouts (sometimes called sub-templates). Here's an example:
-
-Suppose you have the following `ApplicationController` layout:
-
-* `app/views/layouts/application.html.erb`
-
-    ```html+erb
-    <html>
-    <head>
-      <title><%= @page_title or "Page Title" %></title>
-      <%= stylesheet_link_tag "layout" %>
-      <%= yield :head %>
-    </head>
-    <body>
-      <div id="top_menu">Top menu items here</div>
-      <div id="menu">Menu items here</div>
-      <div id="content"><%= content_for?(:content) ? yield(:content) : yield %></div>
-    </body>
-    </html>
-    ```
-
-On pages generated by `NewsController`, you want to hide the top menu and add a right menu:
-
-* `app/views/layouts/news.html.erb`
-
-    ```html+erb
-    <% content_for :head do %>
-      <style>
-        #top_menu {display: none}
-        #right_menu {float: right; background-color: yellow; color: black}
-      </style>
-    <% end %>
-    <% content_for :content do %>
-      <div id="right_menu">Right menu items here</div>
-      <%= content_for?(:news_content) ? yield(:news_content) : yield %>
-    <% end %>
-    <%= render template: "layouts/application" %>
-    ```
-
-That's it. The News views will use the new layout, hiding the top menu and adding a new right menu inside the "content" div.
-
-There are several ways of getting similar results with different sub-templating schemes using this technique. Note that there is no limit in nesting levels. One can use the `ActionView::render` method via `render template: 'layouts/news'` to base a new layout on the News layout. If you are sure you will not subtemplate the `News` layout, you can replace the `content_for?(:news_content) ? yield(:news_content) : yield` with simply `yield`.
+In this application:
+
+- All `ArticlesController` actions will use the `main` layout.
+- All `ProductsController` actions will use the `product` layout.
+- `ProfilesController#show` will use the `profile` layout.
+- `ProfilesController#index` and all other actions in that controller will not
+  use a layout.
+- All other actions across the application will default to the `main` layout.


### PR DESCRIPTION
### Motivation / Background

A complete rewrite of the Layouts and Rendering guide. It covered a lot of topics already covered in other guides, and the narrative flow went off on numerous tangents. I've moved content to other guides and removed information as I saw fit.

### Detail

I've rewritten the guide to focus heavily on the _relationship_ between the controller and the view. 

A lot of detail about rendering partials was already covered in the Action View Overview guide, so I've removed it. I moved the information about structuring layouts and similar view related detail into the Action View Overview with it fits a lot better with the narrative.

I've moved the section on request variants out of the Action Controller Overview and added it to this guide where I feel it fits a lot better. I also took the opportunity to add a brief intro about rendering to the Action Controller Overview and signpost this guide since they are very closely related.

### Internal Audit

Section 1: "though it normally hands off any heavy code to the Model" - 'heavy code' is possibly a bit unhelpful for beginners. How about 'it normally hands off more complex logic to methods on the model' or something like that?
Section 2: Creating responses. I almost want to go one step even further back and be sure to cover what we mean by HTTP responses, for those just starting out. Not in massive depth, because it isn't the right place for that, but just a little bit more clarification. Something like: "there are three ways to create an HTTP response in order to display information to the user on the page".

"Call [render](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Rendering.html#method-i-render) to create a full response to send back to the browser". Perhaps we could just add one more sentence here to break down what a 'full response' really is in terms of what a new developer/user would experience.

"Call [head](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Head.html#method-i-head) to create a response consisting solely of HTTP headers to send back to the browser" - maybe we could add examples of why we might do this?
[New boost](https://3.basecamp.com/3076981/buckets/35498807/boosts/new?boost%5Bboostable_gid%5D=Z2lkOi8vYmMzL1JlY29yZGluZy83Njk3MzY5MTA4)Section 1: "though it normally hands off any heavy code to the Model" - 'heavy code' is possibly a bit unhelpful for beginners. How about 'it normally hands off more complex logic to methods on the model' or something like that?

Section 2: Creating responses. I almost want to go one step even further back and be sure to cover what we mean by HTTP responses, for those just starting out. Not in massive depth, because it isn't the right place for that, but just a little bit more clarification. Something like: "there are three ways to create an HTTP response in order to display information to the user on the page".

"Call [render](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Rendering.html#method-i-render) to create a full response to send back to the browser". Perhaps we could just add one more sentence here to break down what a 'full response' really is in terms of what a new developer/user would experience.

"Call [head](https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Head.html#method-i-head) to create a response consisting solely of HTTP headers to send back to the browser" - maybe we could add examples of why we might do this?
[New boost](https://3.basecamp.com/3076981/buckets/35498807/boosts/new?boost%5Bboostable_gid%5D=Z2lkOi8vYmMzL1JlY29yZGluZy83Njk3MzY5MTA4)

End of section 2.1.1 we mention `status: :unprocessable_entity`. Worth expanding out this slightly to point out that we can render a template with a specific status code etc., and briefly why we might want to do this. We've got more info on this in section 2.2.13.4, so maybe just worth linking to this.

2.2.4 - I feel like this section is slightly confusing. We are told that it's valid to use `render inline:`, but the warning box tells us that there is seldom any reason to use this. Maybe it would be better to find a reason why we would need this, but if not, make it short and clear - more like 'this is here but probably won't be needed'.

2.2.7 and 2.2.8 feel repetitive. Can we combine these into one section and say that it's applicable to both XML and JSON?
2.2.13.1 MIME content type - worth a link to the MDN web docs or similar for explanation.

2.2.14 Finding Layouts - this is mostly a repeat of information at the beginning of the guide - the only difference is the addition of the builder information. We can probably re-organise this to make both sections more DRY.

At the start of Section 3, it mentions 'the rules for finding layouts that were mentioned earlier in this guide'. It would be more user-friendly to also link to them at this point.

3.1.1 - let's provide links to more information about RSS/Atom if possible?
Likewise, would be good to provide a link to the Sprockets gem repo when we mention it, for context.

- I think the "Using `render`" section could be it's own top section. This probably applies to all sections ("Rendering by Default", "Using `redirect_to`" and "Using `head`"). All these sections have interesting sub section that currently don't show up in the sidebar and this guide doesn't have that much sub sections as of yet.

- "Rendering an Action's View" shows an example of explicitly rendering a view (the "edit" view in the "update" action). Maybe rename this section to: "Explicitly Rendering an Action's View"? Maybe the example could be simpler as well with a "show" action that renders for example a "details" view?
- "Ajax libraries" is probably an outdated term? Maybe replace with something about an API end-point?

- The "Finding Layouts" section should probably be a top section in a "Layout and Rendering" guide?
- Some examples here could benefit from having the filename as a comment in the example code.

- The whole "Asset Tag Helpers" section can probably be removed as these are already described the in the "Action View Helpers" guide. I'm not sure it adds anything here.
- Maybe move the "Understanding yield" section to the "Action View Overview" guide under "Layouts" which also handles `yield`?
- The above also applies to "Using the content_for method".
- The "Using Partials" section can probably be removed as this is already described in the "Action View Overview" guide. Partials don't really know anything about Controllers, so it makes more sense to have it in a Action View guide.
- I'm not sure if the "Nested Layouts" adds anything or if that is a commonly used pattern.