### PR TITLE
[ci skip] Add message for ActiveRecord::Rollback for nested transaction

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -445,6 +445,11 @@ module ActiveRecord
   #       redirect_to root_url
   #     end
   #   end
+  #
+  # In nested transaction blocks, raising ActiveRecord::Rollback in the inner block
+  # does not issue a ROLLBACK for the outer transaction.
+  # See {ActiveRecord::Transactions::ClassMethods}[rdoc-ref:Transactions::ClassMethods]
+  # for nested transactions.
   class Rollback < ActiveRecordError
   end
 


### PR DESCRIPTION
### Motivation / Background

This PR clarifies the `ActiveRecord::Rollback` API documentation for nested transactions.

`ActiveRecord::Rollback` has special behavior in nested transaction blocks: raising it in the inner block does not roll back the outer transaction, because the exception is captured by the nested transaction block and is not seen by the parent transaction. 
This can be surprising when reading the `ActiveRecord::Rollback` documentation on its own.

### Detail

This PR updates the documentation for `ActiveRecord::Rollback` to mention this nested-transaction behavior and points readers to the transaction documentation for more context.

This is a documentation-only change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
