### PR TITLE
Normalize validation context to symbol for type-agnostic comparison

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Normalize validation context to symbol so that `on:` and the argument to
+    `valid?` can be used interchangeably as strings or symbols.
+
+    Previously, `on: :my_context` with `valid?("my_context")` (or vice versa)
+    would silently skip the validation due to a type mismatch. Now both sides
+    are normalized to symbols before comparison.
+
+    ```ruby
+    class Person
+      include ActiveModel::Validations
+      validates :name, presence: true, on: :custom
+    end
+
+    person = Person.new
+    person.valid?("custom")  # => false (was true before, validation was skipped)
+    ```
+
+    *Dmitry Gusev*
+
 *   Combine `:if`, `:unless`, and `:on` options when specified at both the
     `validates` level and the per-validator level, instead of the per-validator
     options silently replacing the top-level ones.

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -190,9 +190,9 @@ module ActiveModel
 
         if options.key?(:except_on)
           options = options.dup
-          options[:except_on] = Array(options[:except_on])
+          options[:except_on] = Array(options[:except_on]).map(&:to_sym)
           options[:unless] = [
-            ->(o) { options[:except_on].intersect?(Array(o.validation_context)) },
+            ->(o) { options[:except_on].intersect?(Array(o.validation_context).map(&:to_sym)) },
             *options[:unless]
           ]
         end
@@ -310,7 +310,7 @@ module ActiveModel
         @@predicates_for_validation_contexts = {}
 
         def predicate_for_validation_context(context)
-          context = context.is_a?(Array) ? context.sort : Array(context)
+          context = context.is_a?(Array) ? context.map(&:to_sym).sort : Array(context&.to_sym)
 
           @@predicates_for_validation_contexts[context] ||= -> (model) do
             if model.validation_context.is_a?(Array)
@@ -376,6 +376,7 @@ module ActiveModel
     #   person.valid?(:new) # => false
     def valid?(context = nil)
       current_context = validation_context
+      context = context.is_a?(Array) ? context.map(&:to_sym) : context&.to_sym
       context_for_validation.context = context
       errors.clear
       run_validations!

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -98,20 +98,20 @@ module ActiveModel
         private
           def set_options_for_callback(options)
             if options.key?(:on)
-              options[:on] = Array(options[:on])
+              options[:on] = Array(options[:on]).map(&:to_sym)
               options[:if] = [
                 ->(o) {
-                  options[:on].intersect?(Array(o.validation_context))
+                  options[:on].intersect?(Array(o.validation_context).map(&:to_sym))
                 },
                 *options[:if]
               ]
             end
 
             if options.key?(:except_on)
-              options[:except_on] = Array(options[:except_on])
+              options[:except_on] = Array(options[:except_on]).map(&:to_sym)
               options[:unless] = [
                 ->(o) {
-                  options[:except_on].intersect?(Array(o.validation_context))
+                  options[:except_on].intersect?(Array(o.validation_context).map(&:to_sym))
                 },
                 *options[:unless]
               ]

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -67,4 +67,61 @@ class ValidationsContextTest < ActiveModel::TestCase
     assert_includes topic.errors[:base], ERROR_MESSAGE
     assert_includes topic.errors[:base], ANOTHER_ERROR_MESSAGE
   end
+
+  test "with a context defined as symbol and valid? called with a string" do
+    Topic.validates_with(ValidatorThatAddsErrors, on: :context1)
+
+    topic = Topic.new
+    assert topic.invalid?("context1"), "Validation did not run when 'on' is a symbol and valid? is called with a matching string"
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+  end
+
+  test "with a context defined as string and valid? called with a symbol" do
+    Topic.validates_with(ValidatorThatAddsErrors, on: "context1")
+
+    topic = Topic.new
+    assert topic.invalid?(:context1), "Validation did not run when 'on' is a string and valid? is called with a matching symbol"
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+  end
+
+  test "with a context defined as string and valid? called with a string" do
+    Topic.validates_with(ValidatorThatAddsErrors, on: "context1")
+
+    topic = Topic.new
+    assert topic.invalid?("context1"), "Validation did not run when 'on' is a string and valid? is called with a matching string"
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+  end
+
+  test "with a mixed array context defined as on option and valid? called with a string" do
+    Topic.validates_with(ValidatorThatAddsErrors, on: ["context1", :context2])
+
+    topic = Topic.new
+    assert topic.invalid?(:context1), "Validation did not run when 'on' includes a string and valid? is called with a matching symbol"
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+
+    assert topic.invalid?("context2"), "Validation did not run when 'on' includes a symbol and valid? is called with a matching string"
+    assert_includes topic.errors[:base], ERROR_MESSAGE
+  end
+
+  test "with an except_on defined as string and valid? called with a matching string" do
+    Topic.validates_with(ValidatorThatAddsErrors, except_on: "context1")
+
+    topic = Topic.new
+    assert topic.valid?("context1"), "Validation ran when 'except_on' is a string and valid? is called with a matching string context"
+
+    topic2 = Topic.new
+    assert topic2.invalid?("context2"), "Validation did not run on a non-excluded string context"
+    assert_includes topic2.errors[:base], ERROR_MESSAGE
+  end
+
+  test "with an except_on defined as symbol and valid? called with a matching string" do
+    Topic.validates_with(ValidatorThatAddsErrors, except_on: :context1)
+
+    topic = Topic.new
+    assert topic.valid?("context1"), "Validation ran when 'except_on' is a symbol and valid? is called with a matching string context"
+
+    topic2 = Topic.new
+    assert topic2.invalid?("context2"), "Validation did not run on a non-excluded string context"
+    assert_includes topic2.errors[:base], ERROR_MESSAGE
+  end
 end


### PR DESCRIPTION
### Motivation / Background

When defining a validation with `on:` using a symbol and calling `valid?` with a string (or vice versa), the validation is silently skipped due to a strict type comparison. Users may not expect the type of the context value to matter here. This is especially easy to run into when the context comes from an external source such as params or a service, where values are naturally strings:

```ruby
class Person
  include ActiveModel::Validations
  validates :name, presence: true, on: :custom
end

# context derived from params or an external service
context = params[:validation_context]  # => "custom" (a string)

person = Person.new
person.valid?(context)   # => true (validation silently skipped!)
person.valid?(:custom)   # => false (works as expected)
```

Both of these should behave identically.

### Detail

Validation contexts are now normalized to symbols, so `on:` and the argument to `valid?` can be used interchangeably as strings or symbols. This means all four of these now behave identically:

```ruby
person.valid?("custom")   # on: :custom
person.valid?(:custom)    # on: :custom
person.valid?("custom")   # on: "custom"
person.valid?(:custom)    # on: "custom"
```
