### PR TITLE
Query command for read-only database queries

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -741,6 +741,57 @@ primary database by default. You can specify which database to connect to using
 $ bin/rails dbconsole --database=animals
 ```
 
+### `bin/rails query`
+
+`query` runs read-only database queries and returns structured JSON output. It connects to the reading replica role by default and prevents database writes. The `--sql` flag restricts execution to SQL only. ActiveRecord expressions are evaluated as Ruby, with the same trust model as `bin/rails runner` and `bin/rails console`.
+
+```bash
+$ bin/rails query "Account.where(plan: 'premium').limit(10)"
+```
+
+You can run raw SQL with the `--sql` flag:
+
+```bash
+$ bin/rails query --sql "SELECT * FROM accounts LIMIT 10"
+```
+
+Results are paginated. Use `--page` and `--per` to navigate:
+
+```bash
+$ bin/rails query "Account.all" --page 2 --per 50
+```
+
+Pipe through `jq` for human-readable formatting:
+
+```bash
+$ bin/rails query "Account.first" | jq
+```
+
+The `schema` subcommand lists tables or shows detail for a specific table, including columns, indexes, enums, and associations:
+
+```bash
+$ bin/rails query schema
+$ bin/rails query schema accounts
+```
+
+The `models` subcommand lists all ActiveRecord models with their table names and associations:
+
+```bash
+$ bin/rails query models
+```
+
+The `explain` subcommand shows the query plan for an expression:
+
+```bash
+$ bin/rails query explain "Account.where(plan: 'premium')"
+```
+
+If you are using multiple databases, you can specify which database configuration to use with `--database` or `--db`:
+
+```bash
+$ bin/rails query "Account.count" --database primary_replica
+```
+
 ### `bin/rails runner`
 
 The `runner` command executes Ruby code in the context of the Rails application

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `bin/rails query` command for running read-only database queries.
+
+    Supports ActiveRecord expressions and raw SQL with JSON output.
+    Connects to the reading replica role by default and prevents writes.
+    Includes subcommands for schema introspection, model listing, and EXPLAIN.
+
+    ```bash
+    $ bin/rails query "Account.where(plan: 'premium').limit(10)"
+    $ bin/rails query --sql "SELECT COUNT(*) FROM accounts"
+    $ bin/rails query schema accounts
+    $ bin/rails query models
+    $ bin/rails query explain "Account.where(plan: 'premium')"
+    ```
+
+    *Lewis Buckley*
+
 *   Avoid adding `Rack::Sendfile` to the middleware stack if `config.action_dispatch.x_sendfile_header` is `nil`.
 
     The middleware behave as a noop in such case so it's pointless to have it in the stack.

--- a/railties/lib/rails/commands/query/USAGE
+++ b/railties/lib/rails/commands/query/USAGE
@@ -1,0 +1,51 @@
+Description:
+    Run read-only queries against your database. Connects to the
+    reading replica role by default and prevents database writes.
+
+    The --sql flag restricts execution to SQL only. ActiveRecord
+    expressions are evaluated as Ruby, with the same trust model
+    as rails runner and rails console.
+
+    Output is JSON. Pipe through jq for human-readable formatting.
+
+Subcommands:
+    <%= executable %> schema [TABLE]      Show tables or table detail with associations
+    <%= executable %> models              List ActiveRecord models with associations
+    <%= executable %> explain EXPRESSION  Show EXPLAIN output
+
+Examples:
+    Run an ActiveRecord query:
+
+        <%= executable %> "Account.where(plan: 'premium').limit(10)"
+
+    Pretty-print with jq:
+
+        <%= executable %> "Account.first" | jq
+
+    Extract just the rows:
+
+        <%= executable %> "Account.limit(5)" | jq -r '.rows[] | @csv'
+
+    Run raw SQL:
+
+        <%= executable %> --sql "SELECT * FROM accounts LIMIT 10"
+
+    Paginate results:
+
+        <%= executable %> "Account.all" --page 2 --per 50
+
+    Use a specific database config:
+
+        <%= executable %> "Account.count" --database primary_replica
+
+    Schema introspection:
+
+        <%= executable %> schema accounts
+
+    List models:
+
+        <%= executable %> models
+
+    Explain a query:
+
+        <%= executable %> explain "Account.where(plan: 'premium')"

--- a/railties/lib/rails/commands/query/query_command.rb
+++ b/railties/lib/rails/commands/query/query_command.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require "json"
+require "rails/command/environment_argument"
+
+module Rails
+  module Command
+    class QueryCommand < Base # :nodoc:
+      include EnvironmentArgument
+
+      class_option :sql, type: :boolean,
+        desc: "Treat input as raw SQL instead of an ActiveRecord expression"
+
+      class_option :database, aliases: "--db", type: :string,
+        desc: "Database configuration to use (e.g. primary_replica)"
+
+      class_option :page, type: :numeric, default: 1,
+        desc: "Page number for paginated results"
+
+      class_option :per, type: :numeric, default: 100,
+        desc: "Results per page (max 10000)"
+
+      desc "query [EXPRESSION]", "Run a read-only query against the database"
+      def perform(expression = nil, *args)
+        boot_application!
+        Rails.application.load_runner
+
+        ActiveSupport::Notifications.instrument("query.rails", expression: expression) do
+          case expression
+          when "schema"
+            run_schema(args.first)
+          when "models"
+            run_models
+          when "explain"
+            run_explain(args.first)
+          else
+            run_query(expression)
+          end
+        end
+      rescue StandardError, SyntaxError, NotImplementedError => e
+        output_error(e.message)
+        exit 1
+      end
+
+      private
+        def run_query(expression)
+          expression = resolve_expression(expression)
+          page = [ options[:page], 1 ].max
+          per = [ [ options[:per], 1 ].max, 10_000 ].min
+
+          start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result = if options[:sql]
+            with_readonly_connection do |connection|
+              execute_sql(connection: connection, sql: expression, page: page, per: per)
+            end
+          else
+            execute_ar(expression: expression, page: page, per: per)
+          end
+          elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(1)
+
+          say format_result(**result, elapsed_ms: elapsed_ms, page: page, per: per)
+        end
+
+        def run_schema(table = nil)
+          with_readonly_connection do |connection|
+            if table
+              say format_table_detail(connection, table)
+            else
+              say format_table_list(connection)
+            end
+          end
+        end
+
+        def run_models
+          Rails.application.eager_load!
+
+          models = ActiveRecord::Base.descendants
+            .reject(&:abstract_class?)
+            .select { |model| model.table_name.present? }
+            .sort_by(&:name)
+
+          data = models.map do |model|
+            {
+              model: model.name,
+              table_name: model.table_name,
+              associations: format_associations(model)
+            }
+          end
+
+          say JSON.generate(data)
+        end
+
+        def run_explain(expression = nil)
+          expression = resolve_expression(expression)
+
+          if options[:sql]
+            with_readonly_connection do |connection|
+              result = connection.select_all("EXPLAIN #{expression}")
+              say format_result(columns: result.columns, rows: result.rows, sql: "EXPLAIN #{expression}")
+            end
+          else
+            relation = eval(expression, TOPLEVEL_BINDING, "(query)", 1)
+            sql = relation.to_sql
+            with_readonly_connection_for(relation.model.connection_class_for_self) do |connection|
+              result = connection.select_all("EXPLAIN #{sql}")
+              say format_result(columns: result.columns, rows: result.rows, sql: "EXPLAIN #{sql}")
+            end
+          end
+        end
+
+        def with_readonly_connection(&block)
+          with_readonly_connection_for(ActiveRecord::Base, &block)
+        end
+
+        def with_readonly_connection_for(connection_class, &block)
+          if options[:database]
+            with_explicit_database(options[:database], &block)
+          elsif reading_role_available?(connection_class)
+            connection_class.connected_to(role: :reading) do
+              connection_class.with_connection(&block)
+            end
+          else
+            connection_class.while_preventing_writes do
+              connection_class.with_connection(&block)
+            end
+          end
+        end
+
+        def with_explicit_database(database)
+          original = ActiveRecord::Base.connection_db_config
+          begin
+            ActiveRecord::Base.establish_connection(database.to_sym)
+            ActiveRecord::Base.while_preventing_writes do
+              yield ActiveRecord::Base.lease_connection
+            end
+          ensure
+            ActiveRecord::Base.establish_connection(original)
+          end
+        end
+
+        def reading_role_available?(connection_class)
+          connection_class.connected_to(role: :reading) do
+            connection_class.lease_connection
+          end
+          true
+        rescue ActiveRecord::ConnectionNotEstablished
+          false
+        end
+
+        def execute_ar(expression:, page:, per:)
+          result = eval(expression, TOPLEVEL_BINDING, "(query)", 1)
+
+          case result
+          when ActiveRecord::Relation
+            relation = result.offset((page - 1) * per).limit(per + 1)
+            sql = relation.to_sql
+            with_readonly_connection_for(relation.model.connection_class_for_self) do |connection|
+              ar_result = connection.select_all(sql)
+              truncated = ar_result.rows.length > per
+              { columns: ar_result.columns, rows: ar_result.rows.first(per), sql: sql, truncated: truncated }
+            end
+          when ActiveRecord::Result
+            { columns: result.columns, rows: result.rows, sql: expression, truncated: false }
+          when Hash
+            rows = result.map { |key, val| [ key, val ] }
+            { columns: [ "key", "value" ], rows: rows, sql: expression, truncated: false }
+          when Array
+            rows = result.map { |val| Array(val) }
+            cols = Array.new(rows.first&.length.to_i) { |i| "column_#{i}" }
+            { columns: cols, rows: rows, sql: expression, truncated: false }
+          else
+            { columns: [ "result" ], rows: [ [ result ] ], sql: expression, truncated: false }
+          end
+        end
+
+        def execute_sql(connection:, sql:, page:, per:)
+          unless sql.gsub(/--.*$|\/\*.*?\*\//m, "").match?(/\bLIMIT\b/i)
+            offset = (page - 1) * per
+            sql = "#{sql.rstrip.chomp(';')} LIMIT #{per + 1}"
+            sql += " OFFSET #{offset}" if offset > 0
+          end
+
+          ar_result = connection.select_all(sql)
+          truncated = ar_result.rows.length > per
+          { columns: ar_result.columns, rows: ar_result.rows.first(per), sql: sql, truncated: truncated }
+        end
+
+        def format_result(columns:, rows:, sql:, elapsed_ms: 0, page: 1, per: rows.length, truncated: false)
+          JSON.generate({
+            columns: columns,
+            rows: rows,
+            meta: {
+              row_count: rows.length,
+              query_time_ms: elapsed_ms,
+              page: page,
+              per_page: per,
+              has_more: truncated,
+              sql: sql
+            }
+          })
+        end
+
+        def format_table_list(connection)
+          tables = connection.tables.sort
+          rows = tables.map { |table| [ table ] }
+
+          format_result(columns: [ "table_name" ], rows: rows, sql: "")
+        end
+
+        def format_table_detail(connection, table)
+          raise ArgumentError, "Table '#{table}' does not exist" unless connection.table_exists?(table)
+
+          columns = connection.columns(table)
+          indexes = connection.indexes(table)
+          model = model_for_table(table)
+
+          JSON.generate({
+            table: table,
+            columns: columns.map do |col|
+              { name: col.name, type: col.sql_type, null: col.null, default: col.default }
+            end,
+            indexes: indexes.map do |idx|
+              { name: idx.name, columns: idx.columns, unique: idx.unique }
+            end,
+            enums: model&.defined_enums.presence,
+            associations: format_associations(model)
+          }.compact)
+        end
+
+        def model_for_table(table)
+          Rails.application.eager_load!
+
+          ActiveRecord::Base.descendants.find do |klass|
+            !klass.abstract_class? && klass.table_name == table
+          end
+        end
+
+        def format_associations(model)
+          return unless model
+
+          model.reflect_on_all_associations.map do |assoc|
+            hash = {
+              type: assoc.macro,
+              name: assoc.name,
+              class_name: assoc.class_name
+            }
+            hash[:foreign_key] = assoc.foreign_key if assoc.respond_to?(:foreign_key)
+            hash[:through] = assoc.through_reflection.name if assoc.through_reflection?
+            hash
+          end
+        end
+
+        def resolve_expression(expression)
+          if expression == "-" || (expression.nil? && !$stdin.tty?)
+            $stdin.read.strip
+          elsif expression
+            expression
+          else
+            raise ArgumentError, "No query expression provided. Run '#{self.class.executable} -h' for help."
+          end
+        end
+
+        def output_error(message)
+          error JSON.generate({
+            error: message,
+            meta: { query_time_ms: 0 }
+          })
+        end
+    end
+  end
+end

--- a/railties/test/commands/query_test.rb
+++ b/railties/test/commands/query_test.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+
+class Rails::Command::QueryTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup :build_app
+  teardown :teardown_app
+
+  setup do
+    app_file "db/migrate/20250101000000_create_posts.rb", <<-RUBY
+      class CreatePosts < ActiveRecord::Migration::Current
+        def change
+          create_table :posts do |t|
+            t.string :title
+            t.text :body
+            t.integer :status, default: 0
+            t.timestamps
+          end
+        end
+      end
+    RUBY
+
+    app_file "db/migrate/20250101000001_create_comments.rb", <<-RUBY
+      class CreateComments < ActiveRecord::Migration::Current
+        def change
+          create_table :comments do |t|
+            t.references :post, null: false
+            t.text :body
+            t.timestamps
+          end
+        end
+      end
+    RUBY
+
+    app_file "app/models/post.rb", <<-RUBY
+      class Post < ApplicationRecord
+        enum :status, { draft: 0, published: 1 }
+        has_many :comments
+      end
+    RUBY
+
+    app_file "app/models/comment.rb", <<-RUBY
+      class Comment < ApplicationRecord
+        belongs_to :post
+      end
+    RUBY
+
+    rails "db:migrate"
+  end
+
+  test "executes raw SQL" do
+    data = query_json("--sql", "SELECT 1 AS num")
+
+    assert_equal [ "num" ], data["columns"]
+    assert_equal [ [ 1 ] ], data["rows"]
+  end
+
+  test "executes AR expression returning a relation" do
+    data = query_json("Post.all")
+
+    assert_includes data["columns"], "id"
+    assert_includes data["columns"], "title"
+  end
+
+  test "executes AR expression returning a scalar" do
+    data = query_json("Post.count")
+
+    assert_equal [ "result" ], data["columns"]
+    assert_kind_of Integer, data.dig("rows", 0, 0)
+  end
+
+  test "paginates SQL results" do
+    rails "runner", '3.times { |i| Post.create!(title: "Post #{i}") }'
+
+    data = query_json("--sql", "SELECT * FROM posts ORDER BY id", "--per", "2")
+
+    assert_equal 2, data.dig("meta", "row_count")
+    assert data.dig("meta", "has_more")
+  end
+
+  test "paginates to page 2 with different results" do
+    rails "runner", '4.times { |i| Post.create!(title: "Post #{i}") }'
+
+    page1 = query_json("--sql", "SELECT * FROM posts ORDER BY id", "--per", "2", "--page", "1")
+    page2 = query_json("--sql", "SELECT * FROM posts ORDER BY id", "--per", "2", "--page", "2")
+
+    assert_not_equal page1["rows"], page2["rows"]
+  end
+
+  test "does not double-eval on connection failure" do
+    app_file "app/models/counter.rb", <<-RUBY
+      class Counter
+        FILE = Rails.root.join("tmp/eval_count")
+        def self.track
+          count = FILE.exist? ? FILE.read.to_i : 0
+          FILE.write(count + 1)
+          count + 1
+        end
+      end
+    RUBY
+
+    query_error("Counter.track; raise ActiveRecord::ConnectionNotEstablished")
+
+    count = File.read(File.join(app_path, "tmp/eval_count")).to_i
+    assert_equal 1, count
+  end
+
+  test "prevents writes" do
+    output = query_error("--sql", "INSERT INTO posts (title) VALUES ('test')")
+
+    assert_match(/readonly|Write query/i, output)
+  end
+
+  test "json format handles nil values" do
+    data = query_json("--sql", "SELECT NULL AS val")
+
+    assert_nil data.dig("rows", 0, 0)
+  end
+
+  test "schema lists tables" do
+    data = query_json("schema")
+
+    assert_includes data["rows"].map(&:first), "posts"
+  end
+
+  test "schema shows table detail" do
+    data = query_json("schema", "posts")
+
+    assert_equal "posts", data["table"]
+    assert_includes data["columns"].map { |col| col["name"] }, "id"
+    assert_includes data["columns"].map { |col| col["name"] }, "title"
+  end
+
+  test "schema shows enums" do
+    data = query_json("schema", "posts")
+
+    assert_equal({ "draft" => 0, "published" => 1 }, data.dig("enums", "status"))
+  end
+
+  test "models lists AR models with associations" do
+    data = query_json("models")
+    post = data.find { |m| m["model"] == "Post" }
+
+    assert_equal "posts", post["table_name"]
+    assert_equal "has_many", post["associations"].first["type"]
+    assert_equal "comments", post["associations"].first["name"]
+  end
+
+  test "schema shows associations" do
+    data = query_json("schema", "comments")
+
+    belongs_to = data["associations"].find { |a| a["name"] == "post" }
+    assert_equal "belongs_to", belongs_to["type"]
+    assert_equal "Post", belongs_to["class_name"]
+    assert_equal "post_id", belongs_to["foreign_key"]
+  end
+
+  test "executes AR expression returning a hash" do
+    data = query_json("Post.column_names.index_with { |c| c.upcase }")
+
+    assert_equal [ "key", "value" ], data["columns"]
+    assert data["rows"].any?
+  end
+
+  test "executes AR expression returning an array" do
+    rails "runner", 'Post.create!(title: "Test")'
+    data = query_json("Post.pluck(:title)")
+
+    assert_includes data["columns"], "column_0"
+    assert_includes data["rows"].flatten, "Test"
+  end
+
+  test "explain with sql flag" do
+    data = query_json("explain", "--sql", "SELECT * FROM posts")
+
+    assert data["columns"].any?
+    assert data["rows"].any?
+  end
+
+  test "per option is clamped to bounds" do
+    rails "runner", '3.times { |i| Post.create!(title: "Post #{i}") }'
+
+    data = query_json("--sql", "SELECT * FROM posts ORDER BY id", "--per", "0")
+    assert_operator data.dig("meta", "row_count"), :>=, 1
+
+    data = query_json("--sql", "SELECT * FROM posts ORDER BY id", "--per", "99999")
+    assert_equal 3, data.dig("meta", "row_count")
+  end
+
+  test "explain shows query plan" do
+    data = query_json("explain", "Post.where(status: 0)")
+
+    assert data["columns"].any?
+    assert data["rows"].any?
+  end
+
+  test "handles NameError gracefully" do
+    output = query_error("NonexistentModel.all")
+
+    assert_match(/uninitialized constant/, output)
+  end
+
+  test "handles SyntaxError gracefully" do
+    output = query_error("Post.where(")
+    data = JSON.parse(output)
+
+    assert data["error"]
+  end
+
+  test "schema errors for nonexistent table" do
+    output = query_error("schema", "nonexistent_xyz")
+
+    assert_match(/does not exist/, output)
+  end
+
+  test "shows help with no arguments" do
+    output = run_query_command("-h")
+
+    assert_match(/query/, output)
+  end
+
+  private
+    def run_query_command(*args)
+      rails "query", *args, allow_failure: true
+    end
+
+    def query_json(*args)
+      output = run_query_command(*args)
+      JSON.parse(output)
+    end
+
+    def query_error(*args)
+      run_query_command(*args)
+    end
+end


### PR DESCRIPTION
### Motivation / Background

Agents and automated tooling increasingly need to query production databases to answer questions, investigate issues, and gather context. Today the closest option is `rails runner`, but it has real problems for this use case:

- **Unstructured output.** `rails runner "puts Account.count"` produces plain text. There's no consistent format an agent can parse reliably — you're at the mercy of whatever `inspect` or `puts` produces.
- **No read-only enforcement.** Nothing prevents `rails runner "Account.delete_all"` from executing.
- **No pagination.** Large result sets are dumped in full or require the caller to craft their own LIMIT/OFFSET logic.

With Kamal, running commands against production is straightforward (`kamal app exec`), but you need a command that returns structured, parseable output and enforces read-only access. That's what `rails query` provides.

### Detail

Adds `rails query` — a read-only database query command with structured JSON output.

**ActiveRecord expressions:**

```bash
$ rails query "Account.where(plan: 'premium').limit(2)"
```

```json
{
  "columns": ["id", "name", "plan", "created_at"],
  "rows": [
    [1, "Acme", "premium", "2025-01-15T10:30:00Z"],
    [2, "Widgets Co", "premium", "2025-03-22T14:00:00Z"]
  ],
  "meta": {
    "row_count": 2,
    "query_time_ms": 4.2,
    "page": 1,
    "per_page": 100,
    "has_more": false,
    "sql": "SELECT \"accounts\".* FROM \"accounts\" WHERE \"accounts\".\"plan\" = 'premium' LIMIT 2"
  }
}
```

**Raw SQL:**

```bash
$ rails query --sql "SELECT id, name FROM accounts LIMIT 2"
```

```json
{
  "columns": ["id", "name"],
  "rows": [[1, "Acme"], [2, "Widgets Co"]],
  "meta": {
    "row_count": 2,
    "query_time_ms": 1.8,
    "page": 1,
    "per_page": 100,
    "has_more": false,
    "sql": "SELECT id, name FROM accounts LIMIT 2"
  }
}
```

**Scalar results:**

```bash
$ rails query "Account.count"
```

```json
{
  "columns": ["result"],
  "rows": [[42]],
  "meta": {
    "row_count": 1,
    "query_time_ms": 2.1,
    "page": 1,
    "per_page": 100,
    "has_more": false,
    "sql": "Account.count"
  }
}
```

**Schema listing:**

```bash
$ rails query schema
```

```json
{
  "columns": ["table_name", "row_count"],
  "rows": [["accounts", "42"], ["posts", "1337"], ["users", "108"]],
  "meta": {
    "row_count": 3,
    "query_time_ms": 0,
    "page": 1,
    "per_page": 3,
    "has_more": false,
    "sql": ""
  }
}
```

**Table detail (with associations):**

```bash
$ rails query schema accounts
```

```json
{
  "table": "accounts",
  "columns": [
    {"name": "id", "type": "bigint", "null": false, "default": null},
    {"name": "name", "type": "varchar(255)", "null": false, "default": null},
    {"name": "plan", "type": "integer", "null": false, "default": "0"}
  ],
  "indexes": [
    {"name": "index_accounts_on_name", "columns": ["name"], "unique": true}
  ],
  "enums": {
    "plan": {"free": 0, "premium": 1, "enterprise": 2}
  },
  "associations": [
    {"type": "has_many", "name": "users", "class_name": "User", "foreign_key": "account_id"},
    {"type": "has_many", "name": "posts", "class_name": "Post", "foreign_key": "account_id"}
  ]
}
```

**Models (with associations):**

```bash
$ rails query models
```

```json
[
  {
    "model": "Account",
    "table_name": "accounts",
    "associations": [
      {"type": "has_many", "name": "users", "class_name": "User", "foreign_key": "account_id"}
    ]
  },
  {
    "model": "User",
    "table_name": "users",
    "associations": [
      {"type": "belongs_to", "name": "account", "class_name": "Account", "foreign_key": "account_id"}
    ]
  }
]
```

**Errors are always structured JSON:**

```bash
$ rails query --sql "INSERT INTO accounts (name) VALUES ('test')"
```

```json
{
  "error": "Write query attempted while in readonly mode",
  "meta": {"query_time_ms": 0}
}
```

**Subcommands:**
- `rails query schema [TABLE]` — list tables or show table detail with columns, indexes, enums, and associations
- `rails query models` — list ActiveRecord models with table names and associations
- `rails query explain EXPRESSION` — show EXPLAIN output

**Safety:** Connects to the reading replica role by default. Falls back to `while_preventing_writes` for single-database setups.

**Pagination:** `--page` and `--per` options with automatic LIMIT/OFFSET injection for SQL queries.

**Database selection:** `--database` / `--db` option for multi-database apps.

**Instrumentation:** Emits an `"query.rails"` ActiveSupport notification wrapping every query execution. This is a hook point for audit logging — applications that need to track who ran what against production (e.g. via [Console1984](https://github.com/basecamp/console1984)) can subscribe to this event without patching the command. The payload includes the expression that was evaluated.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.