### PR TITLE
Fix touch_record for composite foreign keys

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -43,7 +43,16 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.touch_record(o, changes, foreign_key, name, touch) # :nodoc:
-      old_foreign_id = changes[foreign_key] && changes[foreign_key].first
+      old_foreign_id =
+        if foreign_key.is_a?(Array)
+          if foreign_key.any? { |fk| changes[fk] }
+            foreign_key.map do |fk|
+              changes[fk] ? changes[fk].first : o.read_attribute(fk)
+            end
+          end
+        elsif changes[foreign_key]
+          changes[foreign_key].first
+        end
 
       if old_foreign_id
         association = o.association(name)
@@ -56,7 +65,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
           klass = association.klass
         end
         primary_key = reflection.association_primary_key(klass)
-        old_record = klass.find_by(primary_key => old_foreign_id)
+        old_record = klass.find_by(primary_key => [old_foreign_id])
 
         if old_record
           if touch != true

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -9,6 +9,8 @@ require "models/pet"
 require "models/toy"
 require "models/car"
 require "models/task"
+require "models/cpk/book"
+require "models/cpk/order"
 
 class TimestampTest < ActiveRecord::TestCase
   fixtures :developers, :owners, :pets, :toys, :cars, :tasks
@@ -567,6 +569,68 @@ class TimestampTest < ActiveRecord::TestCase
   def test_all_timestamp_attributes_in_model
     toy = Toy.first
     assert_equal ["created_at", "updated_at"], toy.send(:all_timestamp_attributes_in_model)
+  end
+
+  def test_saving_cpk_record_with_touching_should_touch_parent
+    order = Cpk::Order.create!(id: [1, 2])
+    book = Cpk::Book.create!(id: [3, 4], order: order)
+
+    time = 3.days.ago.at_beginning_of_hour
+    order.update_columns(updated_at: time)
+
+    travel(1.second) do
+      book.update!(title: "Updated Title")
+    end
+
+    assert_not_equal time, order.reload.updated_at
+  end
+
+  def test_destroying_cpk_record_with_touching_should_touch_parent
+    order = Cpk::Order.create!(id: [1, 2])
+    book = Cpk::Book.create!(id: [3, 4], order: order)
+
+    time = 3.days.ago.at_beginning_of_hour
+    order.update_columns(updated_at: time)
+
+    travel(1.second) do
+      book.destroy
+    end
+
+    assert_not_equal time, order.reload.updated_at
+  end
+
+  def test_changing_cpk_parent_touches_both_new_and_old_parent_when_one_fk_component_changes
+    old_order = Cpk::Order.create!(id: [1, 2])
+    new_order = Cpk::Order.create!(id: [1, 3]) # same shop_id
+    book = Cpk::Book.create!(id: [3, 4], order: old_order)
+
+    time = 3.days.ago.at_beginning_of_hour
+    old_order.update_columns(updated_at: time)
+    new_order.update_columns(updated_at: time)
+
+    travel(1.second) do
+      book.update!(order: new_order)
+    end
+
+    assert_not_equal time, old_order.reload.updated_at
+    assert_not_equal time, new_order.reload.updated_at
+  end
+
+  def test_changing_cpk_parent_touches_both_new_and_old_parent_when_all_fk_components_change
+    old_order = Cpk::Order.create!(id: [1, 2])
+    new_order = Cpk::Order.create!(id: [3, 4]) # different shop_id
+    book = Cpk::Book.create!(id: [3, 4], order: old_order)
+
+    time = 3.days.ago.at_beginning_of_hour
+    old_order.update_columns(updated_at: time)
+    new_order.update_columns(updated_at: time)
+
+    travel(1.second) do
+      book.update!(order: new_order)
+    end
+
+    assert_not_equal time, old_order.reload.updated_at
+    assert_not_equal time, new_order.reload.updated_at
   end
 end
 

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -5,7 +5,7 @@ module Cpk
     attr_accessor :fail_destroy
 
     self.table_name = :cpk_books
-    belongs_to :order, autosave: true, foreign_key: [:shop_id, :order_id], counter_cache: true
+    belongs_to :order, autosave: true, foreign_key: [:shop_id, :order_id], counter_cache: true, touch: true
     belongs_to :order_explicit_fk_pk, class_name: "Cpk::Order", foreign_key: [:shop_id, :order_id], primary_key: [:shop_id, :id]
     belongs_to :author, class_name: "Cpk::Author"
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -300,6 +300,7 @@ ActiveRecord::Schema.define do
     t.integer :shop_id
     t.string :status
     t.integer :books_count, default: 0
+    t.timestamps
   end
 
   create_table :cpk_order_tags, primary_key: [:order_id, :tag_id], force: true do |t|


### PR DESCRIPTION
### Motivation / Background

  `belongs_to` associations with composite foreign keys and `touch: true` silently fail to touch the **old** associated record
  when the foreign key changes.

  For example, given:

  ```ruby
  class Book < ActiveRecord::Base
    belongs_to :order, foreign_key: [:shop_id, :order_number], touch: true
  end
```

  When a book moves from Order 1 to Order 2, only Order 2 gets its updated_at touched. Order 1 is silently skipped.

  Root cause: In touch_record, changes[foreign_key] performs a hash lookup using the entire array (e.g., ["shop_id",
  "order_number"]) as the key. But saved_changes uses individual column names as keys, so the lookup always returns nil for
  composite foreign keys.

###  Detail

  This Pull Request changes touch_record in ActiveRecord::Associations::Builder::BelongsTo to:

  - Normalize foreign_key with Array() so both scalar and composite foreign keys follow a single code path
  - Check each FK column individually in the changes hash
  - Build the old composite key using old values from changes for columns that changed, falling back to read_attribute for
  unchanged columns
  - Use Array(primary_key).zip(old_foreign_id).to_h for the find_by lookup so it works with both single and composite primary
  keys

###  Additional information

 Steps to reproduce:
```ruby
  class Order < ActiveRecord::Base
    self.primary_key = [:shop_id, :order_number]
  end

  class Book < ActiveRecord::Base
    belongs_to :order,
      foreign_key: [:shop_id, :order_number],
      primary_key: [:shop_id, :order_number],
      touch: true
  end

  order1 = Order.create!(shop_id: 1, order_number: 100, name: "Order 1")
  order2 = Order.create!(shop_id: 1, order_number: 200, name: "Order 2")
  book = Book.create!(title: "My Book", shop_id: 1, order_number: 100)

  sleep 1
  book.update!(order_number: 200)

  order1.reload
  # Before fix: order1.updated_at is unchanged (BUG)
  # After fix:  order1.updated_at is updated (CORRECT)
```