### PR TITLE
Raise ArgumentError when content_security_policy_nonce_auto is misconfigured

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -74,6 +74,20 @@ module ActionView
     end
 
     config.after_initialize do |app|
+      if app.config.content_security_policy_nonce_auto
+        if app.config.content_security_policy_nonce_directives.nil?
+          raise ArgumentError, "Set config.content_security_policy_nonce_directives when " \
+            "using config.content_security_policy_nonce_auto. " \
+            "See config/initializers/content_security_policy.rb for more information."
+        end
+
+        if app.config.content_security_policy_nonce_generator.nil?
+          raise ArgumentError, "Set config.content_security_policy_nonce_generator when " \
+            "using config.content_security_policy_nonce_auto. " \
+            "See config/initializers/content_security_policy.rb for more information."
+        end
+      end
+
       ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_scripts = app.config.content_security_policy_nonce_auto && app.config.content_security_policy_nonce_directives.intersect?(["script-src", "script-src-elem", "script-src-attr"]) && app.config.content_security_policy_nonce_generator.present?
       ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles = app.config.content_security_policy_nonce_auto && app.config.content_security_policy_nonce_directives.intersect?(["style-src", "style-src-elem", "style-src-attr"]) && app.config.content_security_policy_nonce_generator.present?
       ActionView::Helpers::JavaScriptHelper.auto_include_nonce = app.config.content_security_policy_nonce_auto && app.config.content_security_policy_nonce_directives.intersect?(["script-src", "script-src-elem", "script-src-attr"]) && app.config.content_security_policy_nonce_generator.present?

--- a/railties/test/application/content_security_policy_test.rb
+++ b/railties/test/application/content_security_policy_test.rb
@@ -235,6 +235,26 @@ module ApplicationTests
       assert_policy "default-src 'self' https:"
     end
 
+    test "content_security_policy_nonce_auto raises when nonce_directives is not configured" do
+      app_file "config/initializers/content_security_policy.rb", <<-RUBY
+        Rails.application.config.content_security_policy_nonce_generator = proc { "iyhD0Yc0W+c=" }
+        Rails.application.config.content_security_policy_nonce_auto = true
+      RUBY
+
+      error = assert_raises(ArgumentError) { app("development") }
+      assert_match "content_security_policy_nonce_directives", error.message
+    end
+
+    test "content_security_policy_nonce_auto raises when nonce_generator is not configured" do
+      app_file "config/initializers/content_security_policy.rb", <<-RUBY
+        Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+        Rails.application.config.content_security_policy_nonce_auto = true
+      RUBY
+
+      error = assert_raises(ArgumentError) { app("development") }
+      assert_match "content_security_policy_nonce_generator", error.message
+    end
+
     private
       def assert_policy(expected, report_only: false)
         assert_equal 200, last_response.status


### PR DESCRIPTION
### Motivation / Background

Fixes #56480

When `config.content_security_policy_nonce_auto` is set to `true` without also configuring `content_security_policy_nonce_directives`, Rails crashes during initialization with `undefined method 'intersect?' for nil (NoMethodError)`. The default value of `content_security_policy_nonce_directives` is `nil`, and the auto-include assignments in ActionView's `after_initialize` block call `.intersect?` on it unconditionally.

The same problem exists if `content_security_policy_nonce_generator` is omitted — `nonce_auto` requires both to be configured, but neither absence is caught cleanly.

### Detail

This Pull Request changes `actionview/lib/action_view/railtie.rb` to add a validation block at the start of the `after_initialize` hook. When `content_security_policy_nonce_auto` is `true`, it now raises `ArgumentError` with a clear message if either `content_security_policy_nonce_directives` or `content_security_policy_nonce_generator` is `nil`, pointing the developer to `config/initializers/content_security_policy.rb`.

Two tests are added to `railties/test/application/content_security_policy_test.rb` covering each missing-config case.

### Additional information

Both new tests are intentionally minimal — no controller or route setup is needed since the error fires during `after_initialize` before any request is made.

Verified by running the full CSP integration test suite:
<img width="496" height="143" alt="Screenshot 2026-04-08 at 12 48 55 PM" src="https://github.com/user-attachments/assets/1fc16dcc-bfc4-4bb1-84d0-6d0e6c70fe2e" />

"confirm failure" test by running the CSP tests with the changes temporarily commented out:
<img width="834" height="494" alt="Screenshot 2026-04-08 at 12 50 10 PM" src="https://github.com/user-attachments/assets/e6b24cf4-2ea4-43d0-8de9-bcf870748480" />

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

☝️ intentionally skipping CHANGELOG as I don't believe it's necessary here (although I'm happy to add it if needed
