### PR TITLE
Skip CreateUsers migration when User model already exists

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Skip `CreateUsers` migration when the User model already exists in the authentication generator.
+
+    *John Topley*
+
 *   `app.reloaders` is now a `ReloadersCollection` that calls `deactivate`
     on each reloader when `clear` or `delete` is called, giving reloaders a
     chance to clean up external state.

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -15,6 +15,8 @@ module Rails
       end
 
       def create_authentication_files
+        @user_model_exists = File.exist?(File.expand_path("app/models/user.rb", destination_root))
+
         template "app/models/session.rb"
         template "app/models/user.rb"
         template "app/models/current.rb"
@@ -52,7 +54,9 @@ module Rails
       end
 
       def add_migrations
-        generate "migration", "CreateUsers", "email_address:string!:uniq password_digest:string!", "--force"
+        unless @user_model_exists
+          generate "migration", "CreateUsers", "email_address:string!:uniq password_digest:string!", "--force"
+        end
         generate "migration", "CreateSessions", "user:references ip_address:string user_agent:string", "--force"
       end
 

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -123,6 +123,26 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_create_users_migration_is_skipped_when_user_model_already_exists
+    FileUtils.mkdir_p("#{destination_root}/app/models")
+    File.write("#{destination_root}/app/models/user.rb", <<~RUBY)
+      class User < ApplicationRecord
+      end
+    RUBY
+
+    generator([destination_root], force: true)
+
+    run_generator_instance
+
+    assert_not_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq password_digest:string! --force"
+    assert_includes @rails_commands, "generate migration CreateSessions user:references ip_address:string user_agent:string --force"
+
+    assert_file "app/models/session.rb"
+    assert_file "app/models/current.rb"
+    assert_file "app/controllers/sessions_controller.rb"
+    assert_file "app/controllers/concerns/authentication.rb"
+  end
+
   def test_model_test_is_skipped_if_test_framework_is_given
     generator([destination_root], ["-t", "rspec"])
 


### PR DESCRIPTION
The authentication generator creates a `CreateUsers` migration unconditionally, even when `app/models/user.rb` already exists. This causes `db:migrate` to fail with "table already exists" when adding authentication to an app with an existing User model.

This checks whether the User model file exists before the generator runs and skips the `CreateUsers` migration if it does.

Closes #57149.