### PR TITLE
Fix NoMethodError in logger_tagged_by_active_job?

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `NoMethodError` in `logger_tagged_by_active_job?` when
+    `BroadcastLogger`'s first broadcast has a non-tagged formatter.
+
+    *Denis Savchuk*
+
 *   Deprecate built-in `queue_classic` Active Job adapter.
 
     *Harun Sabljaković, Wojciech Wnętrzak*

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -43,7 +43,8 @@ module ActiveJob
       end
 
       def logger_tagged_by_active_job?
-        logger.formatter.current_tags.include?("ActiveJob")
+        formatter = logger.formatter
+        formatter.respond_to?(:current_tags) && formatter.current_tags.include?("ActiveJob")
       end
   end
 end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -253,6 +253,18 @@ class LoggingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_tagged_logger_support_with_broadcast_logger_plain_formatter_first
+    plain_logger  = ::Logger.new(nil)
+    tagged_logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(nil))
+    broadcast     = ActiveSupport::BroadcastLogger.new(plain_logger, tagged_logger)
+
+    set_logger broadcast
+
+    assert_nothing_raised do
+      HelloJob.perform_now "Cristian"
+    end
+  end
+
   def test_job_error_logging
     perform_enqueued_jobs do
       RescueJob.perform_later "other"


### PR DESCRIPTION
### Motivation / Background

Fixes #57148

`logger_tagged_by_active_job?` calls `logger.formatter.current_tags` unconditionally. When `logger` is a `BroadcastLogger`, `formatter` dispatches to the first broadcast's formatter. If that broadcast is a plain `Logger` (e.g. added by Solid Queue in-process mode), `formatter` is `nil` and the call raises `NoMethodError`.

The outer guard in `tag_logger` checks `logger.respond_to?(:tagged)`, which returns `true` via `BroadcastLogger#method_missing` even when only a later broadcast responds — so the guard doesn't prevent the crash.

Reproduces without forking:

```ruby
plain  = Logger.new(STDOUT)
tagged = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
broadcast = ActiveSupport::BroadcastLogger.new(plain, tagged)

broadcast.respond_to?(:tagged)    # => true
broadcast.formatter               # => nil
broadcast.formatter.current_tags  # => NoMethodError
```

### Detail

Cache the formatter and guard with `respond_to?`. `respond_to?` is defined on `NilClass` (returns `false`), so it handles both nil and non-tagged formatters without `&.`.

```ruby
def logger_tagged_by_active_job?
  formatter = logger.formatter
  formatter.respond_to?(:current_tags) && formatter.current_tags.include?("ActiveJob")
end
```

Caching also avoids calling `logger.formatter` twice, which on `BroadcastLogger` dispatches through `method_missing` each time.

### Additional information

Isolated `logger_tagged_by_active_job?` (Ruby 4.0.1):

| Path | Before | After |
|---|---|---|
| Happy path (tagged first) | 2.132M i/s | 1.992M i/s (−7%) |
| Bug path (plain first, nil formatter) | 741k i/s (rescue) | 2.446M i/s (+3.3×) |

The −7% on the happy path is one `respond_to?` call + local variable. The +3.3× on the bug path is the guard avoiding exception machinery.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.