### PR TITLE
Use hash lookup for exact-match regexp filters in ParameterFilter

### DIFF
--- a/activesupport/lib/active_support/parameter_filter.rb
+++ b/activesupport/lib/active_support/parameter_filter.rb
@@ -96,6 +96,18 @@ module ActiveSupport
     end
 
   private
+    # If the regexp is an anchored exact match like /^token$/ or /\Atoken\z/,
+    # returns the literal string.
+    def extract_exact_key(regexp) # :nodoc:
+      return if regexp.casefold?
+      source = regexp.source
+      return unless source.start_with?("^", "\\A") && source.end_with?("$", "\\z")
+
+      literal = source.delete_prefix("^").delete_prefix("\\A")
+                      .delete_suffix("$").delete_suffix("\\z")
+      literal if literal.match?(/\A[a-zA-Z0-9_]+\z/)
+    end
+
     def compile_filters!(filters)
       @no_filters = filters.empty?
       return if @no_filters
@@ -103,6 +115,7 @@ module ActiveSupport
       @regexps, strings = [], []
       @deep_regexps, deep_strings = nil, nil
       @blocks = nil
+      @exact_keys = nil
 
       filters.each do |item|
         case item
@@ -111,6 +124,8 @@ module ActiveSupport
         when Regexp
           if item.to_s.include?("\\.")
             (@deep_regexps ||= []) << item
+          elsif (literal = extract_exact_key(item))
+            (@exact_keys ||= {})[literal] = true
           else
             @regexps << item
           end
@@ -139,11 +154,15 @@ module ActiveSupport
     end
 
     def value_for_key(key, value, full_parent_key = nil, original_params = nil)
+      key_s = key.to_s
+
       if @deep_regexps
-        full_key = full_parent_key ? "#{full_parent_key}.#{key}" : key.to_s
+        full_key = full_parent_key ? "#{full_parent_key}.#{key_s}" : key_s
       end
 
-      if @regexps.any? { |r| r.match?(key.to_s) }
+      if @exact_keys && @exact_keys[key_s]
+        value = @mask
+      elsif @regexps.any? { |r| r.match?(key_s) }
         value = @mask
       elsif @deep_regexps&.any? { |r| r.match?(full_key) }
         value = @mask

--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -122,6 +122,12 @@ class ParameterFilterTest < ActiveSupport::TestCase
     end
   end
 
+  test "anchored exact-match regexp filters" do
+    parameter_filter = ActiveSupport::ParameterFilter.new([/^token$/, /\Astate\z/, /password/])
+    result = parameter_filter.filter("token" => "t0k3n", "state" => "abc", "password" => "pass", "user_password" => "pass", "not_secret" => "visible")
+    assert_equal({ "token" => "[FILTERED]", "state" => "[FILTERED]", "password" => "[FILTERED]", "user_password" => "[FILTERED]", "not_secret" => "visible" }, result)
+  end
+
   test "precompile_filters" do
     patterns = [/A.a/, /b.B/i, "ccC", :ddD]
     keys = ["Aaa", "Bbb", "Ccc", "Ddd"]


### PR DESCRIPTION
### Motivation / Background

I was looking at one of our applications at Shopify where a number of the ParameterFilter regexes are just exact matches -- e.g., `/^email$/`.

We can optimize ParameterFilter for cases like this and get a meaningful speedup in ParameterFilter. And because we call ParameterFilter so often, it can be meaningful.

### Detail

When ParameterFilter is initialized with anchored regexp filters like `/^code$/` or `/\Atoken\z/`, extract the literal string and store it in a Hash for O(1) lookup instead of iterating all regexps with `.any?`.

This is a common pattern in Rails apps that want to filter specific parameter names without matching substrings. I've included a benchmark script in the commit; if all filters are exact matches, it's 4.5x faster to use the hash to check for which parameters to exclude.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.