### PR TITLE
Fix ActiveStorage::IntegrityError when mirroring variants without a checksum

### DIFF
--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -211,7 +211,7 @@ module ActiveStorage
         tempfile.flush
         tempfile.rewind
 
-        verify_integrity_of(tempfile, checksum: checksum) if verify
+        verify_integrity_of(tempfile, checksum: checksum) if verify && checksum
         if block_given?
           begin
             yield tempfile

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -79,6 +79,44 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     assert_equal "Surprise!", @service.mirrors.third.download(key)
   end
 
+  test "mirroring a file without a checksum does not raise IntegrityError" do
+    key  = SecureRandom.base58(24)
+    data = "Something else entirely!"
+
+    @service.primary.upload key, StringIO.new(data)
+
+    assert_nothing_raised do
+      @service.mirror key, checksum: nil
+    end
+
+    @service.mirrors.each do |mirror|
+      assert_equal data, mirror.download(key)
+    end
+  ensure
+    @service.delete key
+  end
+
+  test "uploading without a checksum mirrors to all services" do
+    old_service = ActiveStorage::Blob.service
+    ActiveStorage::Blob.service = @service
+
+    key  = SecureRandom.base58(24)
+    data = "Something else entirely!"
+    io   = StringIO.new(data)
+
+    assert_performed_jobs 1, only: ActiveStorage::MirrorJob do
+      @service.upload key, io.tap(&:read)
+    end
+
+    assert_equal data, @service.primary.download(key)
+    @service.mirrors.each do |mirror|
+      assert_equal data, mirror.download(key)
+    end
+  ensure
+    @service.delete key
+    ActiveStorage::Blob.service = old_service
+  end
+
   test "URL generation in primary service" do
     filename = ActiveStorage::Filename.new("test.txt")
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #57164

This PR has been created because `ActiveStorage::MirrorJob` raises an `ActiveStorage::IntegrityError` when mirroring variants uploaded without a checksum - which happens whenever `track_variants = false`.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Details

When `config.active_storage.track_variants = false`, variants are uploaded without a checksum, which means `MirrorJob` ends up calling `MirrorService#mirror` with `checksum: nil`. That `nil` eventually reaches `download_and_verify_tempfile`, which tries to verify integrity regardless - comparing the computed digest against `nil` always fails, so `IntegrityError` is raised every time. The fix is a one-line guard that mirrors what `DiskService#upload` already does.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
