### PR TITLE
Fix MirrorService#mirror IntegrityError with nil checksum

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `MirrorService#mirror` raising `ActiveStorage::IntegrityError` when
+    mirroring without a checksum (e.g., `track_variants: false`).
+
+    *Denis Savchuk*
+
 *   Don't bump `lock_version` on attachment records' parents during blob analysis.
 
     `ActiveStorage::AnalyzeJob` writes only to `Blob#metadata`. The cascade

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -66,7 +66,7 @@ module ActiveStorage
     def mirror(key, checksum:)
       instrument :mirror, key: key, checksum: checksum do
         if (mirrors_in_need_of_mirroring = mirrors.select { |service| !service.exist?(key) }).any?
-          primary.open(key, checksum: checksum) do |io|
+          primary.open(key, checksum: checksum, verify: checksum.present?) do |io|
             mirrors_in_need_of_mirroring.each do |service|
               io.rewind
               service.upload key, io, checksum: checksum

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -79,6 +79,21 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     assert_equal "Surprise!", @service.mirrors.third.download(key)
   end
 
+  test "mirroring a file without a checksum does not raise" do
+    key  = SecureRandom.base58(24)
+    data = "Something else entirely!"
+
+    @service.primary.upload key, StringIO.new(data)
+
+    assert_nothing_raised { @service.mirror key, checksum: nil }
+
+    @service.mirrors.each do |mirror|
+      assert_equal data, mirror.download(key)
+    end
+  ensure
+    @service.delete key
+  end
+
   test "URL generation in primary service" do
     filename = ActiveStorage::Filename.new("test.txt")
 


### PR DESCRIPTION
### Motivation / Background

Fixes #57164.

`MirrorService#mirror` raises `ActiveStorage::IntegrityError` when `track_variants: false` causes `MirrorJob` to call `mirror(key, checksum: nil)`. `verify_integrity_of` compares the actual MD5 to `nil` — always fails.

### Detail

Pass `verify: checksum.present?` to `primary.open` so the integrity check is skipped when no checksum is provided, matching the documented behaviour: "integrity checks only occur when checksums exist."

```ruby
primary.open(key, checksum: checksum, verify: checksum.present?) do |io|
```

### Additional information

Related: #57171.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.