### PR TITLE
Allow attribute with symbol type without a DB connection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow `attribute` with a symbol type to be called without a database
+    connection. The type is resolved lazily when the schema is first loaded.
+
+    *Denis Savchuk*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -219,6 +219,25 @@ module ActiveRecord
       #--
       # Implemented by ActiveModel::AttributeRegistration#attribute.
 
+      def attribute(name, cast_type = nil, default: (no_default = true), **options) # :nodoc:
+        if cast_type.is_a?(Symbol)
+          begin
+            connection_db_config
+          rescue ActiveRecord::ConnectionNotDefined
+            name = resolve_attribute_name(name)
+            pending_attribute_modifications << PendingTypeName.new(name, cast_type, options, self)
+            pending_attribute_modifications << ActiveModel::AttributeRegistration::ClassMethods::PendingDefault.new(name, default) unless no_default
+            reset_default_attributes
+            return
+          end
+        end
+        if no_default
+          super(name, cast_type, **options)
+        else
+          super(name, cast_type, default: default, **options)
+        end
+      end
+
       # This API only accepts type objects, and will do its work immediately instead of
       # waiting for the schema to load. While this method
       # is provided so it can be used by plugin authors, application code
@@ -284,6 +303,17 @@ module ActiveRecord
         NO_DEFAULT_PROVIDED = Object.new # :nodoc:
         private_constant :NO_DEFAULT_PROVIDED
 
+        # Stored when attribute :foo, :bar is called without a connection.
+        # Resolved during apply_pending_attribute_modifications, where a
+        # connection is already guaranteed (columns_hash was just called).
+        PendingTypeName = Struct.new(:name, :type_name, :options, :model) do # :nodoc:
+          def apply_to(attribute_set)
+            type = model.send(:resolve_pending_type, name, type_name, options)
+            attribute = attribute_set[name]
+            attribute_set[name] = attribute.with_type(type)
+          end
+        end
+
         def define_default_attribute(name, value, type, from_user:)
           if value == NO_DEFAULT_PROVIDED
             default_attribute = _default_attributes[name].with_type(type)
@@ -306,6 +336,11 @@ module ActiveRecord
 
         def resolve_type_name(name, **options)
           Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
+        end
+
+        def resolve_pending_type(name, type_name, options)
+          type = Type.lookup(type_name, **options, adapter: Type.adapter_name_from(self))
+          hook_attribute_type(name, type)
         end
 
         def type_for_column(column)

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -364,6 +364,46 @@ module ActiveRecord
       end
     end
 
+    test "attribute with symbol type can be defined without a connection" do
+      klass = nil
+      ActiveRecord::Base.stub(:connection_db_config, -> { raise ActiveRecord::ConnectionNotDefined, "no connection" }) do
+        assert_nothing_raised do
+          klass = Class.new(ActiveRecord::Base) do
+            self.table_name = "overloaded_types"
+            attribute :virtual_string, :string
+          end
+        end
+      end
+      # Once connection is available, the attribute resolves and casts correctly
+      instance = klass.new(virtual_string: 42)
+      assert_equal "42", instance.virtual_string
+    end
+
+    test "attribute with symbol type and default can be defined without a connection" do
+      klass = nil
+      ActiveRecord::Base.stub(:connection_db_config, -> { raise ActiveRecord::ConnectionNotDefined, "no connection" }) do
+        assert_nothing_raised do
+          klass = Class.new(ActiveRecord::Base) do
+            self.table_name = "overloaded_types"
+            attribute :virtual_int, :integer, default: 7
+          end
+        end
+      end
+      assert_equal 7, klass.new.virtual_int
+    end
+
+    test "subclass inherits deferred attribute from parent" do
+      parent = nil
+      ActiveRecord::Base.stub(:connection_db_config, -> { raise ActiveRecord::ConnectionNotDefined, "no connection" }) do
+        parent = Class.new(ActiveRecord::Base) do
+          self.table_name = "overloaded_types"
+          attribute :virtual_string, :string
+        end
+      end
+      child = Class.new(parent)
+      assert_equal "42", child.new(virtual_string: 42).virtual_string
+    end
+
     test "unknown type error is raised" do
       assert_raise(ArgumentError) do
         OverloadedType.attribute :foo, :unknown


### PR DESCRIPTION
### Motivation / Background

Fixes #57099

`attribute :foo, :string` raises `ConnectionNotDefined` when no database
connection has been configured. This makes it impossible to define AR
models in gems without requiring a DB connection at load time.

### Detail

Override `attribute` in `Attributes::ClassMethods`. When a symbol type is
given and `connection_db_config` raises `ConnectionNotDefined`, store a
`PendingTypeName` modification instead of resolving the type immediately.

`PendingTypeName#apply_to` is called by `apply_pending_attribute_modifications`
inside `_default_attributes` — where a connection is guaranteed since
`columns_hash` was already called. Type resolution (including
`hook_attribute_type` for time zone conversion etc.) happens there.

### Additional information

**Benchmark** (Ruby 4.0.1, SQLite3):

| Scenario | Before | After | Δ |
|---|---|---|---|
| read string attr | 6.46M i/s | 6.41M i/s | ~0% |
| write string attr | 3.15M i/s | 3.05M i/s | ~0% |
| read integer attr | 6.14M i/s | 6.02M i/s | ~0% |
| write integer attr | 3.00M i/s | 2.96M i/s | ~0% |
| `attribute :foo, :string` w/ conn | 7.40k i/s | 7.72k i/s | ~0% |

Hot-path attribute access is unchanged. Class definition overhead is
negligible — `attribute` is called once at boot, not in hot loops.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.