### PR TITLE
Update EnvConfiguration class doc examples and drop stale commented require

### DIFF
--- a/activesupport/lib/active_support/env_configuration.rb
+++ b/activesupport/lib/active_support/env_configuration.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# require "active_support/core_ext/module/delegation"
-
 module ActiveSupport
   # Provide a better interface for accessing configuration options stored in ENV.
   # Keys are accepted as symbols and turned into upcased strings. Nesting is provided by double underscores.
@@ -14,8 +12,8 @@ module ActiveSupport
   #   require(:db_host)                                   # => ENV.fetch("DB_HOST")
   #   require(:database, :host)                           # => ENV.fetch("DATABASE__HOST")
   #   option(:database, :host)                            # => ENV["DATABASE__HOST"]
-  #   option(:debug, default: "true")                     # => ENV.fetch("DB_HOST") { "true" }
-  #   option(:database, :host, default: -> { "missing" }) # => ENV.fetch("DATABASE__HOST") { default.call }
+  #   option(:debug, default: "true")                     # => ENV.fetch("DEBUG", "true")
+  #   option(:database, :host, default: -> { "missing" }) # => ENV.fetch("DATABASE__HOST") { "missing" }
   class EnvConfiguration
     def initialize
       reload


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Update `EnvConfiguration` class rdoc so the `option` examples use the right ENV keys and `fetch` shapes for `envify`, and delete the leftover commented `require`.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->