### PR TITLE
Make becomes preserve marked_for_destruction

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -496,6 +496,7 @@ module ActiveRecord
         becoming.instance_variable_set(:@new_record, new_record?)
         becoming.instance_variable_set(:@previously_new_record, previously_new_record?)
         becoming.instance_variable_set(:@destroyed, destroyed?)
+        becoming.instance_variable_set(:@marked_for_destruction, marked_for_destruction?)
         becoming.errors.copy!(errors)
       end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -509,6 +509,15 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_predicate client, :previously_new_record?
   end
 
+  def test_becomes_preserve_mark_for_destruction
+    topic = topics(:first)
+    topic.mark_for_destruction
+    assert_predicate topic, :marked_for_destruction?
+
+    reply = topic.becomes(Reply)
+    assert_predicate reply, :marked_for_destruction?
+  end
+
   def test_becomes_initializes_missing_attributes
     company = Company.new(name: "GrowingCompany")
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix the behavior of `becomes` when working with mass-assignments:

- preserving marked_for_destruction
- preserving modifications on associations

### Detail

This Pull Request changes `ActiveRecord::Persistence#becomes` by adding a preservation of `marked_for_destruction` similar to what was already done for `previously_new_record`, and adding a preservation of loaded associations. It only iterates on cached associations to prevent instancing associations that may have been unused (and also prevent an error in tests since current test defines invalid associations).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
