### PR TITLE
[ci skip] Reference ActiveSupport::Cache::Store early in caching_with_rails.md

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -236,6 +236,9 @@ puts welcome_message # Output: Welcome to Rails!
 Rails.cache.delete("greeting")
 ```
 
+See [`ActiveSupport::Cache::Store` and its descendants](#activesupport-cache-store)
+for more details.
+
 #### Avoid Caching Instances of Active Record Objects
 
 Consider this example, which stores a list of Active Record objects representing superusers in the cache:


### PR DESCRIPTION
I was trying to find out where `Rails.cache.fetch` was implemented without knowing the name of the abstract class: `ActiveSupport::Cache::Store`. This change would have helped me to scroll down to the relevant section about cache stores.