### PR TITLE
Make the warning about active storage redirect and proxy mode stronge…

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -1,10 +1,24 @@
 # frozen_string_literal: true
 
-# Proxy files through application. This avoids having a redirect and makes files easier to cache.
+# Finds a blob by a +signed_id+ and proxies the file through the application.
+# The blob is streamed from storage directly to the response. This avoids having
+# a redirect and makes files easier to cache.
 #
-# WARNING: All Active Storage controllers are publicly accessible by default. The
-# generated URLs are hard to guess, but permanent by design. If your files
-# require a higher level of protection consider implementing
+# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+# The response sets the HTTP cache to public and allows browsers and proxies to cache it indefinitely.
+#
+# The URLs created for this controller are set to never expire by default.
+# To make URLs expire, pass the +expires_in+ option when generating the URL:
+#
+#   rails_storage_proxy_url(blob, expires_in: 1.minute)
+#
+# Or set the default for all Active Storage URLs:
+#
+#   config.active_storage.urls_expire_in = 1.day
+#
+# WARNING: All Active Storage controllers are publicly accessible by default.
+# Anyone who knows the URL can access the file, even if the rest of your application requires
+# authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob

--- a/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -1,10 +1,26 @@
 # frozen_string_literal: true
 
-# Take a signed permanent reference for a blob and turn it into an expiring service URL for download.
+# Finds a blob by a +signed_id+ and redirects to a blob's expiring service URL.
 #
-# WARNING: All Active Storage controllers are publicly accessible by default. The
-# generated URLs are hard to guess, but permanent by design. If your files
-# require a higher level of protection consider implementing
+# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+#
+# The URLs created for this controller are set to never expire by default.
+# To make URLs expire, pass the +expires_in+ option when generating the URL:
+#
+#   rails_storage_redirect_url(blob, expires_in: 1.minute)
+#
+# Or set the default for all Active Storage URLs:
+#
+#   config.active_storage.urls_expire_in = 1.day
+#
+# The service URLs are set to expire in 5 minutes by default.
+# The default can be changed for all service URLs:
+#
+#   config.active_storage.service_urls_expire_in = 1.hour
+#
+# WARNING: All Active Storage controllers are publicly accessible by default.
+# Anyone who knows the URL can access the file, even if the rest of your application requires
+# authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -1,10 +1,24 @@
 # frozen_string_literal: true
 
-# Proxy files through application. This avoids having a redirect and makes files easier to cache.
+# Finds a representation by a +signed_id+ and a +variation_key+, and proxies the file through the application.
+# The representation is streamed from storage directly to the response. This avoids having
+# a redirect and makes files easier to cache.
 #
-# WARNING: All Active Storage controllers are publicly accessible by default. The
-# generated URLs are hard to guess, but permanent by design. If your files
-# require a higher level of protection consider implementing
+# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+# The response sets the HTTP cache to public and allows browsers and proxies to cache it indefinitely.
+#
+# The URLs created for this controller are set to never expire by default.
+# To make URLs expire, pass the +expires_in+ option when generating the URL:
+#
+#   rails_storage_proxy_url(representation, expires_in: 1.minute)
+#
+# Or set the default for all Active Storage URLs:
+#
+#   config.active_storage.urls_expire_in = 1.day
+#
+# WARNING: All Active Storage controllers are publicly accessible by default.
+# Anyone who knows the URL can access the file, even if the rest of your application requires
+# authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Representations::ProxyController < ActiveStorage::Representations::BaseController
   include ActiveStorage::Streaming

--- a/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
@@ -1,10 +1,27 @@
 # frozen_string_literal: true
 
-# Take a signed permanent reference for a blob representation and turn it into an expiring service URL for download.
+# Finds a representation by a +signed_id+ and a +variation_key+, and redirects to a representation's expiring
+# service URL.
 #
-# WARNING: All Active Storage controllers are publicly accessible by default. The
-# generated URLs are hard to guess, but permanent by design. If your files
-# require a higher level of protection consider implementing
+# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+#
+# The URLs created for this controller are set to never expire by default.
+# To make URLs expire, pass the +expires_in+ option when generating the URL:
+#
+#   rails_storage_redirect_url(representation, expires_in: 1.minute)
+#
+# Or set the default for all Active Storage URLs:
+#
+#   config.active_storage.urls_expire_in = 1.day
+#
+# The service URLs are set to expire in 5 minutes by default.
+# The default can be changed for all service URLs:
+#
+#   config.active_storage.service_urls_expire_in = 1.hour
+#
+# WARNING: All Active Storage controllers are publicly accessible by default.
+# Anyone who knows the URL can access the file, even if the rest of your application requires
+# authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Representations::RedirectController < ActiveStorage::Representations::BaseController
   def show

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -683,10 +683,10 @@ Serving Files
 
 Active Storage supports two ways to serve files: redirecting and proxying.
 
-WARNING: All Active Storage controllers are publicly accessible by default. The
-generated URLs are hard to guess, but permanent by design. If your files
-require a higher level of protection consider implementing
-[Authenticated Controllers](#authenticated-controllers).
+WARNING: All Active Storage controllers are publicly accessible by default.
+Anyone who knows the URL can access the file, even if the rest of your
+application requires authentication. If your files require access control
+consider implementing [Authenticated Controllers](#authenticated-controllers).
 
 ### Redirect Mode
 


### PR DESCRIPTION
…r (#55865) [ci-skip]

* Make the warning about active storage redirect and proxy mode stronger

The existing documentation implied that the "hard to guess" URLs active storage generates provides some sort of access control. This is not the case. Rather, as they rely on ActiveRecord::SignedId, they're tamper proof and don't expose the underlying id.

The security risk of using these URLs isn't that someone will guess them. Rather, it is if the URLs are ever leaked, the files will be exposed.

This happened to us via Cloudflare's crawler hints feature: https://www.tokyodev.com/articles/identifying-and-fixing-a-resume-visibility-mistake

But there is a myriad of other ways it could happen. E.g. anyone with access to the request log has access to them, they might be exposed via certain analytics tools, even if a user has access to the app revoked they'll still have access to any files, etc.

Because of this, whenever any access control is needed, proxy and redirect mode should not be used.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
