### PR TITLE
[ci skip] Clarify API app ApplicationController guidance

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -271,7 +271,8 @@ config.debug_exception_response_format = :api
 
 By default, `config.debug_exception_response_format` is set to `:api`, when `config.api_only` is set to true.
 
-Finally, inside `app/controllers/application_controller.rb`, instead of:
+If the application was not created with `rails new --api`, inside
+`app/controllers/application_controller.rb`, instead of:
 
 ```ruby
 class ApplicationController < ActionController::Base


### PR DESCRIPTION
### Motivation / Background

  This Pull Request has been created because the API Applications guide can be confusing when read
  after creating a new application with `rails new --api`.

  The guide already says that new API applications inherit from `ActionController::API`, but the
  later section about changing an existing application can read like the same change is still
  required.

  ### Detail

  This Pull Request changes the existing application section to clarify that changing
  `ApplicationController` inheritance applies when the application was not created with `rails new
  --api`.

  ### Additional information

  This is a documentation-only change.

  I ran `bundle exec rake guides:generate:html ONLY=api_app` from the `guides` directory
  successfully. The command emitted existing Sass deprecation warnings.

  ### Checklist

  Before submitting the PR make sure the following are checked:

  * [x] This Pull Request is related to one change. Unrelated changes should be opened in separate
  PRs.
  * [x] Commit message has a detailed description of what changed and why. If this PR fixes a
  related issue include it in the commit message. Ex: `[Fix #issue-number]`
  * [x] Tests are added or updated if you fix a bug or add a feature.
  * [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or
  additional feature. Minor bug fixes and documentation changes should not be included.