### PR TITLE
Add offline fallback page to the PWA scaffold

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add offline fallback page to the PWA scaffold.
+
+    New Rails apps now include an `app/views/pwa/offline.html.erb` template and
+    a commented `get "offline"` route in `config/routes.rb`, alongside the existing
+    manifest and service worker. The service worker template also includes a
+    commented example for caching and serving the offline page.
+
+    *Juan Vasquez*
+
 *   Avoid adding `Rack::Sendfile` to the middleware stack if `config.action_dispatch.x_sendfile_header` is `nil`.
 
     The middleware behave as a noop in such case so it's pointless to have it in the stack.

--- a/railties/lib/rails/generators/rails/app/templates/app/views/pwa/offline.html.erb
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/pwa/offline.html.erb
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>You're offline</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f3f4f6;
+      color: #1f2937;
+      text-align: center;
+    }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    p { color: #6b7280; }
+    button {
+      margin-top: 1rem;
+      padding: 0.5rem 1.5rem;
+      background: #2563eb;
+      color: white;
+      border: none;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      font-size: 1rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #111827; color: #e5e7eb; }
+      p { color: #9ca3af; }
+      button { background: #3b82f6; }
+    }
+  </style>
+</head>
+<body>
+  <div>
+    <h1>You're offline</h1>
+    <p>Unable to connect to the server. Check your internet connection and try again.</p>
+    <button onclick="location.reload()">Retry</button>
+  </div>
+</body>
+</html>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/pwa/offline.html.erb
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/pwa/offline.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>You're offline</title>
   <meta charset="utf-8">
@@ -18,20 +18,20 @@
     }
     h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
     p { color: #6b7280; }
-    button {
+    a {
+      display: inline-block;
       margin-top: 1rem;
       padding: 0.5rem 1.5rem;
       background: #2563eb;
       color: white;
-      border: none;
       border-radius: 0.375rem;
-      cursor: pointer;
       font-size: 1rem;
+      text-decoration: none;
     }
     @media (prefers-color-scheme: dark) {
       body { background: #111827; color: #e5e7eb; }
       p { color: #9ca3af; }
-      button { background: #3b82f6; }
+      a { background: #3b82f6; }
     }
   </style>
 </head>
@@ -39,7 +39,7 @@
   <div>
     <h1>You're offline</h1>
     <p>Unable to connect to the server. Check your internet connection and try again.</p>
-    <button onclick="location.reload()">Retry</button>
+    <a href=".">Retry</a>
   </div>
 </body>
 </html>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/pwa/offline.html.erb
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/pwa/offline.html.erb
@@ -18,20 +18,20 @@
     }
     h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
     p { color: #6b7280; }
-    a {
-      display: inline-block;
+    button {
       margin-top: 1rem;
       padding: 0.5rem 1.5rem;
       background: #2563eb;
       color: white;
+      border: none;
       border-radius: 0.375rem;
+      cursor: pointer;
       font-size: 1rem;
-      text-decoration: none;
     }
     @media (prefers-color-scheme: dark) {
       body { background: #111827; color: #e5e7eb; }
       p { color: #9ca3af; }
-      a { background: #3b82f6; }
+      button { background: #3b82f6; }
     }
   </style>
 </head>
@@ -39,7 +39,9 @@
   <div>
     <h1>You're offline</h1>
     <p>Unable to connect to the server. Check your internet connection and try again.</p>
-    <a href=".">Retry</a>
+    <form action="." method="get" aria-label="Retry loading this page">
+      <button type="submit">Retry</button>
+    </form>
   </div>
 </body>
 </html>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/pwa/service-worker.js
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/pwa/service-worker.js
@@ -1,3 +1,22 @@
+// Cache the offline fallback page on install:
+//
+// self.addEventListener("install", (event) => {
+//   event.waitUntil(
+//     caches.open("offline").then((cache) => cache.add("/offline"))
+//   )
+//   self.skipWaiting()
+// })
+//
+// Serve the offline fallback page when a navigation request fails:
+//
+// self.addEventListener("fetch", (event) => {
+//   if (event.request.mode === "navigate") {
+//     event.respondWith(
+//       fetch(event.request).catch(() => caches.match("/offline"))
+//     )
+//   }
+// })
+
 // Add a service worker for processing Web Push notifications:
 //
 // self.addEventListener("push", async (event) => {

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  # get "offline" => "rails/pwa#offline", as: :pwa_offline
 
   <%- end -%>
   # Defines the root path route ("/")

--- a/railties/lib/rails/pwa_controller.rb
+++ b/railties/lib/rails/pwa_controller.rb
@@ -12,4 +12,8 @@ class Rails::PwaController < Rails::ApplicationController # :nodoc:
   def manifest
     render template: "pwa/manifest", layout: false
   end
+
+  def offline
+    render template: "pwa/offline", layout: false
+  end
 end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -31,6 +31,7 @@ DEFAULT_APP_FILES = %w(
   app/views/layouts/mailer.html.erb
   app/views/layouts/mailer.text.erb
   app/views/pwa/manifest.json.erb
+  app/views/pwa/offline.html.erb
   app/views/pwa/service-worker.js
   bin/brakeman
   bin/bundler-audit

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -38,6 +38,7 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/app/views/layouts/mailer.html.erb
   test/dummy/app/views/layouts/mailer.text.erb
   test/dummy/app/views/pwa/manifest.json.erb
+  test/dummy/app/views/pwa/offline.html.erb
   test/dummy/app/views/pwa/service-worker.js
   test/dummy/bin/ci
   test/dummy/bin/dev


### PR DESCRIPTION
### Motivation / Background

Every Progressive Web App needs an offline fallback page, yet Rails only scaffolds `manifest.json.erb` and `service-worker.js`. When a user loses connectivity, the browser has nothing to show unless the developer builds the offline page from scratch.

Adding an `offline` route and template to the PWA scaffold completes the pattern: manifest defines the app, the service worker intercepts failed navigations, and the offline page provides a graceful fallback. This is a standard PWA practice recommended by both [web.dev](https://web.dev/articles/offline-fallback-page) and the [MDN PWA guides](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation).

### Detail

This Pull Request adds an `offline` action to `Rails::PwaController` and includes it in the app scaffold alongside the existing `manifest` and `service_worker` actions:

- **`Rails::PwaController#offline`**: renders `pwa/offline` without a layout, matching the existing pattern for `manifest` and `service_worker`.
- **`app/views/pwa/offline.html.erb`**: a self-contained offline fallback page with dark mode support and a retry button. No external dependencies.
- **`config/routes.rb.tt`**: adds a commented `get "offline"` route next to the existing commented PWA routes.
- **`app/views/pwa/service-worker.js`**: adds a commented example showing how to cache the offline page on install and serve it when navigation requests fail.
- **`app_generator_test.rb`**: includes the new template in the expected generated files list.

Like the manifest and service worker routes, the offline route is commented out by default so developers opt in explicitly. The template is removed in API mode along with the rest of `app/views/pwa/`.

### Additional information

The offline fallback page uses inline styles and zero external assets so it works reliably without network access. The service worker example follows the standard Cache API pattern for offline fallback.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.