### PR TITLE
Fix `reset_counters` when using string ids

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -35,14 +35,16 @@ module ActiveRecord
       #   # attributes.
       #   Post.reset_counters(1, :comments, touch: true)
       def reset_counters(id, *counters, touch: nil)
-        ids = if composite_primary_key?
-          if id.first.is_a?(Array)
-            id
-          else
-            [id]
+        if composite_primary_key?
+          ids = id.first.is_a?(Array) ? id : [id]
+          types = primary_key.map { |column| type_for_attribute(column) }
+          ids = ids.map do |id_value|
+            id_value.map.with_index { |id, i| types[i].cast(id) }
           end
         else
-          Array(id)
+          ids = Array(id)
+          type = type_for_attribute(primary_key)
+          ids = ids.map { |id| type.cast(id) }
         end
 
         updates = Hash.new { |h, k| h[k] = {} }

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -127,6 +127,15 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "reset counters with string id" do
+    assert @topic.replies_count > 0, "Must have replies"
+    Topic.increment_counter("replies_count", @topic.id)
+
+    assert_difference "@topic.reload.replies_count", -1 do
+      Topic.reset_counters(@topic.id.to_s, :replies)
+    end
+  end
+
   test "reset counters with modularized and camelized classnames" do
     special = SpecialTopic.create!(title: "Special")
     SpecialTopic.increment_counter(:replies_count, special.id)
@@ -188,6 +197,19 @@ class CounterCacheTest < ActiveRecord::TestCase
     # check that it gets reset
     assert_difference -> { order.reload.books_count }, -1 do
       Cpk::Order.reset_counters(order.id, :books)
+    end
+  end
+
+  test "reset counters for cpk model with string ids" do
+    order = cpk_orders(:cpk_book_order_1)
+    assert order.books_count > 0, "Must have books"
+
+    Cpk::Order.increment_counter(:books_count, order.id)
+
+    # check that it gets reset
+    assert_difference -> { order.reload.books_count }, -1 do
+      string_id = order.id.map(&:to_s)
+      Cpk::Order.reset_counters(string_id, :books)
     end
   end
 

--- a/activerecord/test/fixtures/cpk_books.yml
+++ b/activerecord/test/fixtures/cpk_books.yml
@@ -14,6 +14,7 @@ cpk_great_author_second_book:
 cpk_famous_author_first_book:
   author: cpk_famous_author
   title: "Ruby on Rails"
+  order: cpk_book_order_1
   revision: 1
 
 cpk_book_with_generated_pk:

--- a/activerecord/test/fixtures/cpk_orders.yml
+++ b/activerecord/test/fixtures/cpk_orders.yml
@@ -9,3 +9,7 @@ cpk_groceries_order_2:
 
 cpk_coffee_order_1:
   status: "cancelled"
+
+cpk_book_order_1:
+  status: "paid"
+  books_count: 1


### PR DESCRIPTION
Fixes #56122.
Fixes #57185.
Closes #56123.