### PR TITLE
Add charset=utf-8 to Content-Type for static CSS and HTML files

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Serve static CSS and HTML files with `charset=utf-8` in the Content-Type header.
+
+    Static CSS and HTML files served by `ActionDispatch::Static` now include
+    `; charset=utf-8` in their Content-Type response header, fixing browser
+    encoding issues with CSS files containing non-ASCII characters.
+
+    *Mike Dalessio*
+
 *   Add `query:` and `body:` kwargs to integration test request helpers.
 
     `params:` was ambiguous for GET requests with `as: :json` — unclear

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -109,8 +109,15 @@ module ActionDispatch
         end
       end
 
+      DEFAULT_UTF8_CONTENT_TYPES = [ Mime[:html], Mime[:css] ]
+      private_constant :DEFAULT_UTF8_CONTENT_TYPES
+
       def try_files(filepath, content_type, accept_encoding:)
         headers = { Rack::CONTENT_TYPE => content_type }
+
+        if DEFAULT_UTF8_CONTENT_TYPES.include?(content_type)
+          headers[Rack::CONTENT_TYPE] = "#{content_type}; charset=utf-8"
+        end
 
         if compressible? content_type
           try_precompressed_files filepath, headers, accept_encoding: accept_encoding

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -83,10 +83,15 @@ class StaticTest < ActiveSupport::TestCase
   def test_served_gzipped_static_file_with_non_english_filename
     response = get("/foo/%E3%81%95%E3%82%88%E3%81%86%E3%81%AA%E3%82%89.html", "HTTP_ACCEPT_ENCODING" => "gzip")
 
-    assert_gzip  "/foo/さようなら.html", response
-    assert_equal "text/html",          response.headers["content-type"]
-    assert_equal "accept-encoding",    response.headers["vary"]
-    assert_equal "gzip",               response.headers["content-encoding"]
+    assert_gzip  "/foo/さようなら.html",       response
+    assert_equal "text/html; charset=utf-8", response.headers["content-type"]
+    assert_equal "accept-encoding",          response.headers["vary"]
+    assert_equal "gzip",                     response.headers["content-encoding"]
+  end
+
+  def test_serves_static_css_with_charset
+    response = get("/foo/baz.css")
+    assert_equal "text/css; charset=utf-8", response.headers["content-type"]
   end
 
   def test_serves_static_file_with_exclamation_mark_in_filename
@@ -179,9 +184,9 @@ class StaticTest < ActiveSupport::TestCase
     file_name = "/gzip/logo-bcb6d75d927347158af5.svg"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip")
     assert_gzip  file_name, response
-    assert_equal "image/svg+xml", response.headers["Content-Type"]
-    assert_equal "accept-encoding",        response.headers["Vary"]
-    assert_equal "gzip",                   response.headers["Content-Encoding"]
+    assert_equal "image/svg+xml",   response.headers["Content-Type"]
+    assert_equal "accept-encoding", response.headers["Vary"]
+    assert_equal "gzip",            response.headers["Content-Encoding"]
   end
 
   def test_set_vary_when_origin_compressed_but_client_cant_accept
@@ -332,7 +337,7 @@ class StaticTest < ActiveSupport::TestCase
 
     def assert_html(body, response)
       assert_equal body, response.body
-      assert_equal "text/html", response.headers["content-type"]
+      assert_equal "text/html; charset=utf-8", response.headers["content-type"]
       assert_nil response.headers["vary"]
     end
 


### PR DESCRIPTION
### Motivation / Background

CSS files served by `ActionDispatch::Static` have `Content-Type: text/css` with no `charset=utf-8`. When Chrome discovers a stylesheet via `<link>` tag during HTML parsing (rather than via `Link: rel=preload` header), it may inherit the document's encoding or fall back to Windows-1252 instead of defaulting to UTF-8. This causes non-ASCII characters in CSS (e.g., en-dash U+2013 in `content` properties) to render as mojibake.

The same issue affects static HTML files in `public/` that lack a `<meta charset>` tag.

The CSS spec defaults to UTF-8, but Chrome has a [longstanding bug](https://issues.chromium.org/issues/41118088) where it doesn't reliably follow this default. Adding `charset=utf-8` to the Content-Type header is the highest-priority encoding signal in the spec's detection chain.

Companion Propshaft PR: https://github.com/rails/propshaft/pull/264

### Detail

`ActionDispatch::FileHandler#try_files` now appends `; charset=utf-8` to the Content-Type header for `text/css` and `text/html` static files. Only these two MIME types are affected — `text/javascript` is excluded per RFC 9239, `text/xml` could break encoding declarations, and `text/plain` has no demonstrated browser bug.

This is consistent with the rest of the Rails stack, which already assumes UTF-8 throughout: `Encoding.default_external`, `config.encoding`, `ActionDispatch::Response.default_charset`, and ActionView template transcoding all default to UTF-8.

### Additional information

`ActionDispatch::Response` already adds `charset=utf-8` unconditionally to all controller responses, including types like `application/json` and `image/png` where it's technically unnecessary. This fix is narrower and more spec-correct.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.