### PR TITLE
Fix io copy stream raises type error when writing

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -231,6 +231,8 @@ module ActionController
             raise ClientDisconnected, "client disconnected"
           end
         end
+
+        string.bytesize
       end
 
       # Same as `write` but automatically include a newline at the end of the string.

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -150,7 +150,8 @@ module ActionDispatch # :nodoc:
 
         @str_body = nil
         @response.commit!
-        @buf.push string
+        @buf.push string.frozen? ? string : string.dup
+        string.bytesize
       end
       alias_method :<<, :write
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -752,6 +752,28 @@ module ActionController
       buf = ActionController::Live::Buffer.new nil
       assert buf.call_on_error
     end
+
+    def test_write_returns_bytesize
+      response = ActionController::Live::Response.new
+      response.request = ActionDispatch::Request.empty
+      buf = ActionController::Live::Buffer.new response
+      result = buf.write "foo"
+      assert_equal 3, result
+    end
+
+    def test_write_dups_string_for_io_copy_stream_safety
+      response = ActionController::Live::Response.new
+      response.request = ActionDispatch::Request.empty
+      buf = response.stream
+      sio = StringIO.new("bar")
+      IO.copy_stream(sio, buf)
+      buf.write "baz"
+      buf.close
+
+      body = +""
+      response.each { |chunk| body << chunk }
+      assert_equal "barbaz", body
+    end
   end
 end
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -30,6 +30,20 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal "foo", @response.body
   end
 
+  def test_stream_write_returns_bytesize
+    result = @response.stream.write "foo"
+    @response.stream.close
+    assert_equal 3, result
+  end
+
+  def test_stream_write_dups_string_for_io_copy_stream_safety
+    sio = StringIO.new("Ho")
+    IO.copy_stream(sio, @response.stream)
+    @response.stream.write "me"
+    @response.stream.close
+    assert_equal "Home", @response.body
+  end
+
   def test_write_after_close
     @response.stream.close
 


### PR DESCRIPTION
### Motivation / Background

Fixes: https://github.com/rails/rails/issues/57186

`IO.copy_stream(src, response.stream)` raised a `TypeError: no implicit conversion of Array into Integer` when writing to Rails response stream buffers. This is because `Buffer#write` was returning the buffer array (result of `Array#push`) instead of an Integer representing bytes written, which is what `IO.copy_stream` expects from a destination `write` method.

A second, silent data-corruption bug was also present: `IO.copy_stream` reuses its internal string buffer after each call to `write` returns. Since `Buffer#write` stored the passed string by reference rather than duplicating it first, the buffered content could be mutated after being enqueued, silently corrupting the response body.

Both `ActionDispatch::Response::Buffer#write` and `ActionController::Live::Buffer#write` were affected.

### Detail

This Pull Request changes `Buffer#write` in two places:

**`ActionDispatch::Response::Buffer#write`** (`actionpack/lib/action_dispatch/http/response.rb`):
- Pushes `string.dup` onto the buffer instead of the original reference, preventing `IO.copy_stream`'s internal buffer reuse from corrupting already-enqueued chunks.
- Returns `string.bytesize` so that `IO.copy_stream` (and any other `IO`-compatible consumer) receives the expected Integer return value.

**`ActionController::Live::Buffer#write`** (`actionpack/lib/action_controller/metal/live.rb`):
- Returns `string.bytesize` for the same reason.

Tests are added for both classes to verify:
1. `#write` returns the correct byte count.
2. `IO.copy_stream` produces the correct response body without corruption.

### Additional information

`IO.copy_stream` documents that the destination's `write` method must return the number of bytes written (an Integer). The root cause was that `Array#push` returns the array itself, which propagated back as the return value of `Buffer#write`, causing `IO.copy_stream` to raise immediately.

Affects Rails 8.1.3 / Ruby 3.3.7 and likely all prior versions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.