### PR TITLE
Fix retry_job to respect enqueue options when enqueue is deferred

### DIFF
--- a/activejob/lib/active_job/enqueue_after_transaction_commit.rb
+++ b/activejob/lib/active_job/enqueue_after_transaction_commit.rb
@@ -25,9 +25,20 @@ module ActiveJob
       def raw_enqueue
         if self.class.enqueue_after_transaction_commit
           self.successfully_enqueued = true
+          deferred_scheduled_at = scheduled_at
+          deferred_queue_name = queue_name
+          deferred_priority = priority
           ActiveRecord.after_all_transactions_commit do
+            previous_scheduled_at, previous_queue_name, previous_priority = scheduled_at, queue_name, priority
+            self.scheduled_at = deferred_scheduled_at
+            self.queue_name = deferred_queue_name
+            self.priority = deferred_priority
             self.successfully_enqueued = false
             super
+          ensure
+            self.scheduled_at = previous_scheduled_at
+            self.queue_name = previous_queue_name
+            self.priority = previous_priority
           end
           self
         else

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -125,6 +125,63 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
   end
 
+  class CapturingAdapter
+    attr_reader :enqueued, :scheduled
+
+    def initialize
+      @enqueued = []
+      @scheduled = []
+    end
+
+    def enqueue(job)
+      @enqueued << { job: job, queue_name: job.queue_name, priority: job.priority }
+    end
+
+    def enqueue_at(job, timestamp)
+      @scheduled << { job: job, timestamp: timestamp, queue_name: job.queue_name, priority: job.priority }
+    end
+  end
+
+  class CapturingJob < ActiveJob::Base
+    self.queue_adapter = CapturingAdapter.new
+
+    def perform
+      # noop
+    end
+  end
+
+  test "#retry_job preserves scheduled_at, queue_name, and priority when enqueue is deferred" do
+    fake_active_record = FakeActiveRecord.new(false)
+    stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
+      CapturingJob.enqueue_after_transaction_commit = true
+
+      job = CapturingJob.new
+      scheduled_time = Time.now.utc + 60
+      job.retry_job(wait_until: scheduled_time, queue: "retries", priority: 10)
+
+      # `retry_job` restores the original attributes on `self` after enqueue,
+      # but the deferred enqueue should still use the attributes passed to it.
+      assert_nil job.scheduled_at
+      assert_equal "default", job.queue_name
+      assert_nil job.priority
+
+      fake_active_record.run_after_commit_callbacks
+
+      scheduled = CapturingJob.queue_adapter.scheduled.last
+      assert_not_nil scheduled, "expected job to be scheduled via enqueue_at"
+      assert_same job, scheduled[:job]
+      assert_in_delta scheduled_time.to_f, scheduled[:timestamp], 0.001
+      assert_equal "retries", scheduled[:queue_name]
+      assert_equal 10, scheduled[:priority]
+
+      # After the deferred enqueue runs, the original attributes remain
+      # restored on `self` so callers don't observe mutated state.
+      assert_nil job.scheduled_at
+      assert_equal "default", job.queue_name
+      assert_nil job.priority
+    end
+  end
+
   test "#perform_later defers enqueue callbacks until after commit" do
     fake_active_record = FakeActiveRecord.new(false)
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/57197

When `enqueue_after_transaction_commit` is on and `retry_job` is called inside a transaction, the `wait`, `queue` and `priority` options are silently dropped - the retry gets enqueued immediately on the default queue.

#55141 changed `retry_job` to mutate `self` and reset it in an `ensure`. That's fine for synchronous enqueues, but `enqueue_after_transaction_commit` defers the real enqueue until after commit. By then the `ensure` has already reset `scheduled_at`, `queue_name` and `priority`, so the adapter sees the original values.

### Detail

Snapshot the enqueue attributes in `EnqueueAfterTransactionCommit#raw_enqueue` before registering the post-commit callback, then reapply them to `self` right before `super` and restore the previous state afterwards. This keeps `retry_job`'s no-mutation contract intact.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
