### PR TITLE
Optimize merging `ActiveRecord::Relation` extensions

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -161,8 +161,10 @@ module ActiveRecord
             relation.order!(*other.order_values)
           end
 
-          extensions = other.extensions - relation.extensions
-          relation.extending!(*extensions) if extensions.any?
+          unless other.extensions.empty?
+            extensions = other.extensions - relation.extensions
+            relation.extending!(*extensions) if extensions.any?
+          end
         end
 
         def merge_single_values


### PR DESCRIPTION
From profiling our test suite, I got:
```
  Mode: wall(1000)
  Samples: 184070 (26.06% miss rate)
  GC: 6286 (3.42%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     19647  (10.7%)       19647  (10.7%)     PG::Connection#exec_params
     16969   (9.2%)       16969   (9.2%)     PG::Connection#exec_prepared
     10010   (5.4%)        9871   (5.4%)     Bootsnap::CompileCache::Native.fetch
      8948   (4.9%)        8747   (4.8%)     ActiveRecord::Relation::Merger#merge_multi_values   <========
      5012   (2.7%)        4750   (2.6%)     ActiveRecord::AttributeMethods#attributes_for_create
      4210   (2.3%)        4210   (2.3%)     (marking)
      3387   (1.8%)        3340   (1.8%)     FactoryBot::AttributeAssigner#attributes_to_set_on_instance
      3167   (1.7%)        3167   (1.7%)     Module#extend_object
```

```
                                  |   155  |         def merge_multi_values
   29    (0.0%) /    14   (0.0%)  |   156  |           if other.reordering_value
                                  |   157  |             # override any order specified in the original relation
                                  |   158  |             relation.reorder!(*other.order_values)
   34    (0.0%) /    16   (0.0%)  |   159  |           elsif other.order_values.any?
                                  |   160  |             # merge in order_values from relation
  140    (0.1%) /    12   (0.0%)  |   161  |             relation.order!(*other.order_values)
                                  |   162  |           end
                                  |   163  |
 8730    (4.7%) /  8693   (4.7%)  |   164  |           extensions = other.extensions - relation.extensions
    9    (0.0%) /     6   (0.0%)  |   165  |           relation.extending!(*extensions) if extensions.any?
    2    (0.0%) /     2   (0.0%)  |   166  |         end
                                  |   169  |
```

Almost always relations do not have any extensions, so we can do a quick check if there are any before merging them.

After applying this PR changes, that line disappeared from the profile and the test suite became constantly faster.

Simple benchmark mimicking before vs after:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
end

require "benchmark/ips"

a = []
b = []

Benchmark.ips do |x|
  x.report("original") do
    c = a - b
    c.any?
  end

  x.report("optimized") do
    unless a.empty?
      c = a - b
    end
  end

  x.compare!
end
```

```
Warming up --------------------------------------
            original   552.175k i/100ms
           optimized     1.470M i/100ms
Calculating -------------------------------------
            original      5.627M (± 4.6%) i/s  (177.73 ns/i) -     28.161M in   5.017172s
           optimized     13.578M (±14.7%) i/s   (73.65 ns/i) -     66.147M in   5.081352s

Comparison:
           optimized: 13578461.4 i/s
            original:  5626643.2 i/s - 2.41x  slower
```

If merging, since these are trivial changes, ok to backport to 8-1-stable, so we can start benefiting from this sooner?