### PR TITLE
Fix TTOU hanging Rails when ffmpeg is spawned for video previews

### DIFF
--- a/activestorage/lib/active_storage/previewer.rb
+++ b/activestorage/lib/active_storage/previewer.rb
@@ -79,7 +79,7 @@ module ActiveStorage
         to.binmode
 
         open_tempfile do |err|
-          IO.popen(argv, err: err) { |out| IO.copy_stream(out, to) }
+          IO.popen(argv, in: IO::NULL, err: err) { |out| IO.copy_stream(out, to) }
           err.rewind
 
           unless $?.success?


### PR DESCRIPTION
### Motivation / Background

When generating video previews in ActiveStorage, Rails launches ffmpeg as a subprocess. ffmpeg watches for keypresses (eg q to quit), calling tcsetattr to configure the supervising terminal. 

If Rails is run with its own process group (eg using [overman](https://github.com/spinels/overman) that spawns processes with pgroup:true), this causes the Rails process to receive a TTOU signal, which results in Rails hanging indefinitely.

### Detail

We can avoid this by passing /dev/null to ffmpeg's stdin.

### Additional information

I can't see any benefit to providing stdin to any of the ActiveStorage::Previewers, so have just disabled it at the Previewer level rather than just for VideoPreviewer.

Another alternative would be to add `-nostdin` to ActiveStorage.video_preview_arguments

ActiveStorage has some other usage of, eg, `IO.popen("ffprobe"...)`, but from what I can tell ffprobe doesn't do anything funky with stdin, so I've left those as-is.

Tests for this might be tricky, let me know if you think they're really necessary.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
