### PR TITLE
Fix double-space typos in guides [ci skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -298,7 +298,7 @@ production:
 ```
 
 In the above example, workers will fetch jobs from queues starting with
-"active_storage", like  the `active_storage_analyse` queue and
+"active_storage", like the `active_storage_analyse` queue and
 `active_storage_transform` queue. Only when no jobs remain in the
 `active_storage`-prefixed queues will workers move on to the `mailers` queue.
 

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -1383,7 +1383,7 @@ Sometimes the callback methods that you'll write will be useful enough to be
 reused by other models. Active Record makes it possible to create classes that
 encapsulate the callback methods, so they can be reused.
 
-Here's an example of an `after_commit` callback  class to deal with the cleanup
+Here's an example of an `after_commit` callback class to deal with the cleanup
 of discarded files on the filesystem. This behavior may not be unique to our
 `PictureFile` model and we may want to share it, so it's a good idea to
 encapsulate this into a separate class. This will make testing that behavior and

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -413,7 +413,7 @@ end
 Without this setting, Rails would load fixture values as is. This wouldn't work
 for encrypted attributes and Active Record Encryption expects a JSON value in
 that column. However, when `encrypt_fixtures` is enabled, all the encryptable
-attributes will be automatically encrypted  and also seamlessly decrypted,
+attributes will be automatically encrypted and also seamlessly decrypted,
 according to the encryption settings defined in the model.
 
 #### Action Text Fixtures

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -199,7 +199,7 @@ As mentioned in the [Asset Organization section](#asset-organization), in
 Propshaft, all assets from the paths configured in `config.assets.paths` are
 available for serving and will be copied into the `public/assets` directory.
 
-When fingerprinted, an asset filename  like `styles.css` is renamed to
+When fingerprinted, an asset filename like `styles.css` is renamed to
 `styles-a1b2c3d4e5f6.css`. This ensures that if `styles.css` is updated, the
 filename changes as well, compelling the browser to download the latest version
 instead of using a potentially outdated cached copy.


### PR DESCRIPTION
Remove stray double spaces in four guide pages:

- `guides/source/active_job_basics.md`: `like  the` → `like the`
- `guides/source/active_record_callbacks.md`: `callback  class` → `callback class`
- `guides/source/active_record_encryption.md`: `encrypted  and` → `encrypted and`
- `guides/source/asset_pipeline.md`: `filename  like` → `filename like`

Each fix is a one-character diff. Confirmed these are not Markdown hard line breaks (all occur mid-line) and not inside code blocks.