### PR TITLE
Fix incorrect indefinite article 'a' before vowel sounds

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -51,7 +51,7 @@ module ActionDispatch
     KEY = "action_dispatch.request.flash_hash"
 
     module RequestMethods
-      # Access the contents of the flash. Returns a ActionDispatch::Flash::FlashHash.
+      # Access the contents of the flash. Returns an ActionDispatch::Flash::FlashHash.
       #
       # See ActionDispatch::Flash for example usage.
       def flash

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -189,7 +189,7 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.compact_blank!, :permitted?
   end
 
-  test "to_h returns a ActiveSupport::HashWithIndifferentAccess" do
+  test "to_h returns an ActiveSupport::HashWithIndifferentAccess" do
     @params.permit!
     params_hash = @params.to_h
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, params_hash

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -626,7 +626,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal 3, log.lines.count
   end
 
-  test "doesn't log the framework backtrace when error type is a invalid mime type" do
+  test "doesn't log the framework backtrace when error type is an invalid mime type" do
     @app = ProductionApp
 
     output = StringIO.new

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -113,7 +113,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_arguments_roundtrip([a: 1, "b" => 2])
   end
 
-  test "serialize a ActionController::Parameters" do
+  test "serialize an ActionController::Parameters" do
     ActiveJob::Serializers.add_serializers ActiveJob::Serializers::ActionControllerParametersSerializer
 
     parameters = Parameters.new(a: 1)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -830,7 +830,7 @@ module ActiveRecord
       #
       #   CREATE INDEX index_suppliers_on_name ON suppliers(name)
       #
-      # ====== Creating a index which already exists
+      # ====== Creating an index which already exists
       #
       #   add_index(:suppliers, :name, if_not_exists: true)
       #

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -61,7 +61,7 @@ module ActiveRecord
           end
         end
 
-        # Given a attribute name, it returns the name of the source attribute when it's a preserved one.
+        # Given an attribute name, it returns the name of the source attribute when it's a preserved one.
         def source_attribute_from_preserved_attribute(attribute_name)
           attribute_name.to_s.sub(ORIGINAL_ATTRIBUTE_PREFIX, "") if attribute_name.start_with?(ORIGINAL_ATTRIBUTE_PREFIX)
         end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -82,7 +82,7 @@ module ActiveRecord
   #
   # In rare circumstances you might need to access the mapping directly.
   # The mappings are exposed through a class method with the pluralized attribute
-  # name, which return the mapping in a ActiveSupport::HashWithIndifferentAccess :
+  # name, which return the mapping in an ActiveSupport::HashWithIndifferentAccess :
   #
   #   Conversation.statuses[:active]    # => 0
   #   Conversation.statuses["archived"] # => 1

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -17,7 +17,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
     end
   end
 
-  test "raises when trying to open a transaction in a isolation level other than `read_uncommitted`" do
+  test "raises when trying to open a transaction in an isolation level other than `read_uncommitted`" do
     with_connection do |conn|
       assert_raises(ActiveRecord::TransactionIsolationError) do
         conn.transaction(requires_new: true, isolation: :something) do

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -310,7 +310,7 @@ module Arel
       end
 
       describe "#average" do
-        it "should create a AVG node" do
+        it "should create an AVG node" do
           relation = Table.new(:users)
           _(relation[:id].average).must_be_kind_of Nodes::Avg
         end

--- a/activerecord/test/cases/encryption/cipher_test.rb
+++ b/activerecord/test/cases/encryption/cipher_test.rb
@@ -8,7 +8,7 @@ class ActiveRecord::Encryption::CipherTest < ActiveRecord::EncryptionTestCase
     @key = ActiveRecord::Encryption.key_generator.generate_random_key
   end
 
-  test "encrypts returns a encrypted test that can be decrypted with the same key" do
+  test "encrypts returns an encrypted test that can be decrypted with the same key" do
     encrypted_text = @cipher.encrypt("clean text", key: @key)
     assert_equal "clean text", @cipher.decrypt(encrypted_text, key: @key)
   end

--- a/activerecord/test/cases/encryption/scheme_test.rb
+++ b/activerecord/test/cases/encryption/scheme_test.rb
@@ -15,7 +15,7 @@ class ActiveRecord::Encryption::SchemeTest < ActiveRecord::EncryptionTestCase
     assert_valid_declaration key_provider: ActiveRecord::Encryption::DerivedSecretKeyProvider.new("my secret")
   end
 
-  test "should create a encryptor well when compressor is given" do
+  test "should create an encryptor well when compressor is given" do
     MyCompressor = Class.new do
       def self.deflate(data)
         "deflated #{data}"
@@ -31,7 +31,7 @@ class ActiveRecord::Encryption::SchemeTest < ActiveRecord::EncryptionTestCase
     assert_equal MyCompressor, type.scheme.to_h[:encryptor].compressor
   end
 
-  test "should create a encryptor well when compress is false" do
+  test "should create an encryptor well when compress is false" do
     type = declare_encrypts_with compress: false
 
     assert_not type.scheme.to_h[:encryptor].compress?

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1152,7 +1152,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_match "Undeclared attribute type for enum 'typeless_genre' in Book", error.message
   end
 
-  test "supports attributes declared with a explicit type" do
+  test "supports attributes declared with an explicit type" do
     klass = Class.new(Book) do
       attribute :my_genre, :integer
       enum :my_genre, [:adventure, :comic]

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -145,7 +145,7 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
 
   test "uses a Live::Response" do
     # This tests for a regression of #45102. If the controller doesn't respond
-    # with a ActionController::Live::Response, it will serve corrupted files
+    # with an ActionController::Live::Response, it will serve corrupted files
     # over 5mb when using S3 services.
     request = ActionController::TestRequest.create({})
     assert_instance_of ActionController::Live::Response, ActiveStorage::Blobs::ProxyController.make_response!(request)

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -26,7 +26,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal 2736, blob.metadata[:height]
   end
 
-  test "attaching a un-analyzable blob" do
+  test "attaching an un-analyzable blob" do
     blob = create_blob(filename: "blank.txt")
 
     assert_not_predicate blob, :analyzed?
@@ -121,7 +121,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id, purpose: :custom_purpose)
   end
 
-  test "getting a signed blob ID from an attachment with a expires_in" do
+  test "getting a signed blob ID from an attachment with an expires_in" do
     blob = create_blob
     @user.avatar.attach(blob)
 
@@ -138,7 +138,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_nil ActiveStorage::Blob.find_signed(signed_id)
   end
 
-  test "getting a signed blob ID from an attachment with a expires_at" do
+  test "getting a signed blob ID from an attachment with an expires_at" do
     blob = create_blob
     @user.avatar.attach(blob)
 

--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -5,7 +5,7 @@ module ActiveSupport
   #
   # The Broadcast logger is a logger used to write messages to multiple IO. It is commonly used
   # in development to display messages on STDOUT and also write them to a file (development.log).
-  # With the Broadcast logger, you can broadcast your logs to a unlimited number of sinks.
+  # With the Broadcast logger, you can broadcast your logs to an unlimited number of sinks.
   #
   # The BroadcastLogger acts as a standard logger and all methods you are used to are available.
   # However, all the methods on this logger will propagate and be delegated to the other loggers

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2753,7 +2753,7 @@ module ApplicationTests
       end
     end
 
-    test "config_for returns a ActiveSupport::OrderedOptions" do
+    test "config_for returns an ActiveSupport::OrderedOptions" do
       app_file "config/custom.yml", <<~YAML
         shared:
           some_key: default


### PR DESCRIPTION
Replace `a` with `an` before words starting with vowel sounds in source comments, RDoc, and test descriptions across actionpack, activerecord, activejob, activestorage, activesupport, and railties.

### Source code (5 fixes)
- `flash.rb`: "Returns a ActionDispatch" → "an"
- `enum.rb`: "in a ActiveSupport" → "an"
- `encryptable_record.rb`: "a attribute name" → "an"
- `schema_statements.rb`: "Creating a index" → "an"
- `broadcast_logger.rb`: "to a unlimited" → "an"

### Test descriptions (14 fixes)
- `a encrypted` → `an encrypted`
- `a encryptor` → `an encryptor` (×2)
- `a explicit type` → `an explicit`
- `a expires_in` / `a expires_at` → `an`
- `a un-analyzable` → `an`
- `a invalid mime` → `an`
- `a isolation level` → `an`
- `a ActiveSupport` / `a ActionController` / `a AVG` → `an`

### Excluded
The error message template in `column_serializer.rb` uses `"supposed to be a #{object_class}"` — fixing this would require runtime article selection logic, so it is left for a separate discussion.