### PR TITLE
Let add_column raise if :null is true for PKs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Let `add_column` raise `ArgumentError` if `:null` is set to a true value
+    when defining a primary key.
+
+    Primary keys get a `NOT NULL` constraint unconditionally. In particular,
+    `null: true` was being ignored, thus not doing what the user specified.
+    We should rather raise to let the user know the call is invalid.
+
+    *Xavier Noria*
+
 *   Deprecate the `schema_order` option in PostgreSQL database configurations.
 
     Use `schema_search_path` instead. The `schema_order` alias will be

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -556,7 +556,14 @@ module ActiveRecord
         end
 
         options[:primary_key] ||= type == :primary_key
-        options[:null] = false if options[:primary_key]
+
+        if options[:primary_key]
+          if options[:null]
+            raise ArgumentError, "primary keys cannot be NULL"
+          end
+          options[:null] = false
+        end
+
         create_column_definition(name, type, options)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -598,7 +598,10 @@ module ActiveRecord
       #   and number of bytes for <tt>:text</tt>, <tt>:binary</tt>, <tt>:blob</tt>, and <tt>:integer</tt> columns.
       #   This option is ignored by some backends.
       # * <tt>:null</tt> -
-      #   Allows or disallows +NULL+ values in the column.
+      #   Whether the column allows +NULL+ values. If unset, or set to true, the column
+      #   allows +NULL+ values. If set to +false+, a <tt>NOT NULL</tt> constraint is added.
+      #   Primary keys always get a <tt>NOT NULL</tt> constraint regardless. Setting this
+      #   option to true for primary keys raises +ArgumentError+.
       # * <tt>:precision</tt> -
       #   Specifies the precision for the <tt>:decimal</tt>, <tt>:numeric</tt>,
       #   <tt>:datetime</tt>, and <tt>:time</tt> columns.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -670,10 +670,19 @@ module ActiveRecord
                 limit: column.limit,
                 precision: column.precision,
                 scale: column.scale,
-                null: column.null,
                 collation: column.collation,
                 primary_key: column_name == from_primary_key
               }
+
+              # column.null is true unless there is an explicit NOT NULL
+              # constraint:
+              #
+              #   // The PK gets rowids, but column.null is technically true.
+              #   CREATE TABLE foo (id INTEGER PRIMARY KEY)
+              #
+              # We always add a NOT NULL constraint for PKs, and `null: true` is
+              # invalid for them. That is why we skip in that case.
+              column_options[:null] = column.null unless column_name == from_primary_key
 
               if column.virtual?
                 column_options[:as] = column.default_function

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -96,6 +96,26 @@ module ActiveRecord
         connection.drop_table :my_table, if_exists: true
       end
 
+      def test_add_column_with_nullable_primary_key
+        exception = assert_raises(ArgumentError) do
+          add_column "test_models", "other_id", :primary_key, null: true
+        end
+
+        assert_equal(
+          "primary keys cannot be NULL",
+          exception.message
+        )
+
+        exception = assert_raises(ArgumentError) do
+          add_column "test_models", "another_id", :integer, primary_key: true, null: true
+        end
+
+        assert_equal(
+          "primary keys cannot be NULL",
+          exception.message
+        )
+      end
+
       def test_add_index_with_invalid_options
         exception = assert_raises(ArgumentError) do
           add_index "test_models", "first_name", nema: "my_index"


### PR DESCRIPTION
As the title says, this patch lets `add_column` raise if `:null` is true for PKs. See why in the `CHANGELOG` entry included in the patch.

Some tests uncovered the SQLite adapter could be actually setting `null: true` for PKs in `copy_table`! A code comment in the adapter explains the fine details.

As a curiosity, this started as a documentation patch that I thought was going to take five minutes, I wanted to make the docs of `:null` more clear. Then, I realized that the default is to allow nullables **except for PKs**, where `null: false` is forced unconditionally, and started to write something like "For PKs the option is ignored...". That sentence felt wrong.

This happens when you document: Sometimes, the docs you come with tell you something is actually not right, and you did not realize it until you dug into it and tried to verbalize behavior in detail.

