### PR TITLE
Add enums to query command output

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -23,6 +23,10 @@
 
     *Lewis Buckley*
 
+*   Update `bin/rails query` to include enum defintions in model and schema output.
+
+    *Geoff Harcourt*
+
 *   Avoid adding `Rack::Sendfile` to the middleware stack if `config.action_dispatch.x_sendfile_header` is `nil`.
 
     The middleware behave as a noop in such case so it's pointless to have it in the stack.

--- a/railties/lib/rails/commands/query/query_command.rb
+++ b/railties/lib/rails/commands/query/query_command.rb
@@ -83,8 +83,10 @@ module Rails
             {
               model: model.name,
               table_name: model.table_name,
+              fields: fields_for(model),
+              enums: model.defined_enums.presence,
               associations: format_associations(model)
-            }
+            }.compact
           end
 
           say JSON.generate(data)
@@ -216,15 +218,29 @@ module Rails
 
           JSON.generate({
             table: table,
-            columns: columns.map do |col|
-              { name: col.name, type: col.sql_type, null: col.null, default: col.default }
-            end,
+            columns: format_fields(model, columns),
             indexes: indexes.map do |idx|
               { name: idx.name, columns: idx.columns, unique: idx.unique }
             end,
             enums: model&.defined_enums.presence,
             associations: format_associations(model)
           }.compact)
+        end
+
+        def format_fields(model, columns)
+          enums = model&.defined_enums || {}
+
+          columns.map do |col|
+            field = { name: col.name, type: col.sql_type, null: col.null, default: col.default }
+            field[:enum] = enums[col.name] if enums.key?(col.name)
+            field
+          end
+        end
+
+        def fields_for(model)
+          format_fields(model, model.columns) if model.table_exists?
+        rescue ActiveRecord::ActiveRecordError
+          nil
         end
 
         def model_for_table(table)

--- a/railties/test/commands/query_test.rb
+++ b/railties/test/commands/query_test.rb
@@ -149,6 +149,43 @@ class Rails::Command::QueryTest < ActiveSupport::TestCase
     assert_equal "comments", post["associations"].first["name"]
   end
 
+  test "models lists fields for each model" do
+    data = query_json("models")
+    post = data.find { |m| m["model"] == "Post" }
+
+    field_names = post["fields"].map { |f| f["name"] }
+    assert_includes field_names, "id"
+    assert_includes field_names, "title"
+    assert_includes field_names, "status"
+
+    title = post["fields"].find { |f| f["name"] == "title" }
+    assert title.key?("type")
+    assert title.key?("null")
+    assert_not title.key?("enum")
+  end
+
+  test "models exposes enums at the model level" do
+    data = query_json("models")
+    post = data.find { |m| m["model"] == "Post" }
+
+    assert_equal({ "draft" => 0, "published" => 1 }, post.dig("enums", "status"))
+  end
+
+  test "models inlines enum mapping on enum-backed fields" do
+    data = query_json("models")
+    post = data.find { |m| m["model"] == "Post" }
+    status = post["fields"].find { |f| f["name"] == "status" }
+
+    assert_equal({ "draft" => 0, "published" => 1 }, status["enum"])
+  end
+
+  test "schema inlines enum mapping on enum-backed columns" do
+    data = query_json("schema", "posts")
+    status = data["columns"].find { |c| c["name"] == "status" }
+
+    assert_equal({ "draft" => 0, "published" => 1 }, status["enum"])
+  end
+
   test "schema shows associations" do
     data = query_json("schema", "comments")
 


### PR DESCRIPTION
### Motivation / Background

In #57156 a new feature was added to make it easier for external tools such as agents to query the application for the database schema. We've been using a similar tool on our own and we found that adding the enum defintions on a model enabled LLMs to get a better result to some questions with fewer (or sometimes zero) overall queries to the database. Having the enum definitions can remove the need to make a database query just to see the text value of the enums, etc.

### Detail

This change updates the `run_models` and `run_schema` methods invoked by the `rails query models` and `rails query schema` commands to return the enums on the models/tables along with the field definitions and associations.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
