### PR TITLE
Fix nested `with_connection(prevent_permanent_checkout: true)` incorrectly clearing sticky lease set by `lease_connection`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -455,13 +455,13 @@ module ActiveRecord
           begin
             yield lease.connection
           ensure
-            lease.sticky = sticky_was if prevent_permanent_checkout && !sticky_was
+            lease.sticky = sticky_was if prevent_permanent_checkout
           end
         else
           begin
             yield lease.connection = checkout
           ensure
-            lease.sticky = sticky_was if prevent_permanent_checkout && !sticky_was
+            lease.sticky = sticky_was if prevent_permanent_checkout
             release_connection(lease) unless lease.sticky
           end
         end

--- a/activerecord/test/cases/connection_handling_test.rb
+++ b/activerecord/test/cases/connection_handling_test.rb
@@ -54,6 +54,29 @@ module ActiveRecord
         assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
       end
 
+      test "#with_connection(prevent_permanent_checkout: true) won't clear sticky lease set before by #lease_connection" do
+        ActiveRecord::Base.release_connection
+        assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
+
+        leased_connection = nil
+        ActiveRecord::Base.with_connection do |connection|
+          leased_connection = ActiveRecord::Base.lease_connection
+          assert_same connection, leased_connection
+
+          ActiveRecord::Base.with_connection(prevent_permanent_checkout: true) do |inner_connection|
+            assert_same leased_connection, inner_connection
+          end
+
+          assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
+          assert_same leased_connection, ActiveRecord::Base.lease_connection
+        end
+
+        assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
+        assert_same leased_connection, ActiveRecord::Base.lease_connection
+      ensure
+        ActiveRecord::Base.release_connection
+      end
+
       test "#with_connection use the already leased connection if available" do
         leased_connection = ActiveRecord::Base.lease_connection
         assert_predicate ActiveRecord::Base.connection_pool, :active_connection?


### PR DESCRIPTION
When `lease_connection` is called to permanently lease a connection within a `with_connection` block, a subsequent nested `with_connection(prevent_permanent_checkout: true)` would incorrectly clear the sticky flag due to a `&& !sticky_was` guard that prevented restoring `sticky_was` when it was `true`. This caused the outer `with_connection` block to release the connection on exit, even though it had been explicitly leased.

The fix removes the `&& !sticky_was` guard so the sticky state is always restored to its prior value when `prevent_permanent_checkout` is used.

### Example

This is the simple expected preexisting behavior:

```ruby
with_connection do
  lease_connection
end

# 🔒 lease is retained 
```

This PR fixes this behavior:

```ruby
with_connection do
  lease_connection
  with_connection(prevent_permanent_checkout: true) { true }
end

# 🔓 Currently, lease is released ❌
# 🔒 Fix is that lease should be retained ✅ 
```

I believe that I have fix is the correct behavior because I think `with_connection` should always be maintaining/restoring the outer context. 

### Why it matters

I have an advisory lock library that requires reusing the same connection. Not maintaining outer context makes it possible for application code to inadvertently break the library e.g. 

```ruby
library.take_advisory_lock_with_connection_lease do
  # application code
  with_connection(prevent_permanent_checkout: true) do
    lease_connection
    # do stuff
  end

  # library has no leased connection to finalize the block ❌ 
end 
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~ Seems like a minor bufgix.
