### PR TITLE
Add `ActiveJob::Attributes` to persist data between steps

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,41 @@
+*   Add `ActiveJob::Attributes` for declaring typed attributes that persist across
+    job serialization and deserialization. It is included by `ActiveJob::Continuable`
+    but can also be used standalone.
+
+    It uses the Active Model Attributes API to define typed, defaulted
+    attributes on jobs. Attribute values are automatically included in the
+    serialized job data and restored on deserialization, eliminating the need
+    to manually override `serialize` and `deserialize`.
+
+    This is especially useful with `ActiveJob::Continuable`, where a job may be
+    interrupted and resumed and attributes are preserved across resumptions.
+
+    ```ruby
+    class SubmitEnrollmentJob < ApplicationJob
+      include ActiveJob::Continuable
+
+      attribute :payment_token, :string
+      attribute :billing_profile_id, :integer
+
+      def perform(enrollment)
+        step(:tokenize_payment_instrument) do
+          self.payment_token = PaymentGateway.tokenize(enrollment.user.payment_instrument)
+        end
+
+        step(:create_billing_profile) do
+          self.billing_profile_id = BillingProfileApi.create(customer_id: enrollment.user_id)
+        end
+
+        step(:submit_enrollment) do
+          submission_id = EnrollmentApi.submit(enrollment, billing_profile_id)
+          enrollment.update!(status: 'processing', submission_id: submission_id)
+        end
+      end
+    end
+    ```
+
+    *Bart de Water*
+
 *   Deprecate built-in `queue_classic` Active Job adapter.
 
     *Harun Sabljaković, Wojciech Wnętrzak*

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -37,6 +37,7 @@ module ActiveJob
   autoload :Base
   autoload :QueueAdapters
   autoload :Arguments
+  autoload :Attributes
   autoload :DeserializationError, "active_job/arguments"
   autoload :SerializationError, "active_job/arguments"
   autoload :UnknownJobClassError, "active_job/core"

--- a/activejob/lib/active_job/attributes.rb
+++ b/activejob/lib/active_job/attributes.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "active_model"
+
+module ActiveJob
+  # = Active Job \Attributes
+  #
+  # The Attributes module provides typed attributes for jobs using the Active
+  # Model Attributes API. Declared attributes are automatically serialized with
+  # the job data and restored when the job is deserialized.
+  #
+  # This is especially useful with ActiveJob::Continuable, where a job may be
+  # interrupted and resumed multiple times and you need to persist attributes
+  # across steps until the job finishes.
+  #
+  #   class SubmitEnrollmentJob < ApplicationJob
+  #     include ActiveJob::Continuable
+  #
+  #     attribute :payment_token, :string
+  #     attribute :billing_profile_id, :integer
+  #
+  #     def perform(enrollment)
+  #       step(:tokenize_payment_instrument) do
+  #         self.payment_token = PaymentGateway.tokenize(enrollment.user.payment_instrument)
+  #       end
+  #
+  #       step(:create_billing_profile) do
+  #         self.billing_profile_id = BillingProfileApi.create(customer_id: enrollment.user_id)
+  #       end
+  #
+  #       step(:submit_enrollment) do
+  #         submission_id = EnrollmentApi.submit(enrollment, billing_profile_id)
+  #         enrollment.update!(status: 'processing', submission_id: submission_id)
+  #       end
+  #     end
+  #   end
+  #
+  # Attributes also work without Continuable, persisting across retries.
+  #
+  # Attributes support all built-in Active Model types, see +ActiveModel::Attribute+
+  # for details. For custom types attribute values must be serializable
+  # as Active Job arguments. See +ActiveJob::Arguments+ for the full list of
+  # supported types.
+  module Attributes
+    extend ActiveSupport::Concern
+    include ActiveModel::Attributes
+
+    def serialize # :nodoc:
+      super.merge("attributes" => serialize_attribute_values)
+    end
+
+    def deserialize(job_data) # :nodoc:
+      super
+      deserialize_attribute_values(job_data["attributes"]) if job_data["attributes"]
+    end
+
+    private
+      def serialize_attribute_values
+        values = {}
+        self.class.attribute_names.each do |name|
+          values[name] = @attributes.fetch_value(name)
+        end
+        Arguments.serialize([values]).first
+      end
+
+      def deserialize_attribute_values(serialized)
+        values = Arguments.deserialize([serialized]).first
+        values.each do |name, value|
+          name = name.to_s
+          @attributes.write_cast_value(name, value) if self.class.attribute_types.key?(name)
+        end
+      end
+  end
+end

--- a/activejob/lib/active_job/continuable.rb
+++ b/activejob/lib/active_job/continuable.rb
@@ -12,6 +12,7 @@ module ActiveJob
   #
   module Continuable
     extend ActiveSupport::Concern
+    include ActiveJob::Attributes
 
     included do
       class_attribute :max_resumptions, instance_writer: false

--- a/activejob/test/cases/attributes_test.rb
+++ b/activejob/test/cases/attributes_test.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require "helper"
+require "active_job/continuation/test_helper"
+require "active_support/core_ext/object/with"
+require "support/do_not_perform_enqueued_jobs"
+
+return unless adapter_is?(:test)
+
+class ActiveJob::AttributesTest < ActiveSupport::TestCase
+  include ActiveJob::Continuation::TestHelper
+  include DoNotPerformEnqueuedJobs
+
+  class AttributeJob < ActiveJob::Base
+    include ActiveJob::Attributes
+
+    attribute :name, :string
+    attribute :count, :integer, default: 0
+    attribute :active, :boolean, default: true
+  end
+
+  test "attributes have default values" do
+    job = AttributeJob.new
+    assert_nil job.name
+    assert_equal 0, job.count
+    assert_equal true, job.active
+  end
+
+  test "attributes can be set" do
+    job = AttributeJob.new
+    job.name = "test"
+    job.count = 5
+    job.active = false
+
+    assert_equal "test", job.name
+    assert_equal 5, job.count
+    assert_equal false, job.active
+  end
+
+  test "attributes are type cast" do
+    job = AttributeJob.new
+    job.count = "42"
+    assert_equal 42, job.count
+
+    job.active = "0"
+    assert_equal false, job.active
+  end
+
+  test "attributes round-trip through serialize and deserialize" do
+    job = AttributeJob.new
+    job.name = "test"
+    job.count = 5
+    job.active = false
+
+    data = job.serialize
+    assert data.key?("attributes")
+    restored = AttributeJob.new
+    restored.deserialize(data)
+
+    assert_equal "test", restored.name
+    assert_equal 5, restored.count
+    assert_equal false, restored.active
+  end
+
+  test "default values are preserved through serialization" do
+    job = AttributeJob.new
+    data = job.serialize
+    restored = AttributeJob.new
+    restored.deserialize(data)
+
+    assert_nil restored.name
+    assert_equal 0, restored.count
+    assert_equal true, restored.active
+  end
+
+  test "deserialize ignores unknown attributes" do
+    job = AttributeJob.new
+    job.name = "test"
+    data = job.serialize
+    data.fetch("attributes")["unknown_attr"] = "value"
+
+    restored = AttributeJob.new
+    assert_nothing_raised { restored.deserialize(data) }
+    assert_equal "test", restored.name
+  end
+
+  test "deserialize without attributes key uses defaults" do
+    job = AttributeJob.new
+    data = job.serialize
+    data.delete("attributes")
+
+    restored = AttributeJob.new
+    assert_nothing_raised { restored.deserialize(data) }
+    assert_equal 0, restored.count
+  end
+
+  class RetryJob < ActiveJob::Base
+    include ActiveJob::Attributes
+
+    attribute :attempt_number, :integer, default: 0
+
+    retry_on StandardError, wait: 0, attempts: 3
+
+    cattr_accessor :attempts, default: []
+
+    def perform
+      self.attempt_number += 1
+      attempts << attempt_number
+      raise StandardError, "boom" if attempt_number < 3
+    end
+  end
+
+  test "attributes persist across retries" do
+    RetryJob.attempts = []
+    perform_enqueued_jobs do
+      RetryJob.perform_later
+    end
+
+    assert_equal [1, 2, 3], RetryJob.attempts
+  end
+
+  class KeywordArgumentsJob < ActiveJob::Base
+    include ActiveJob::Attributes
+
+    cattr_accessor :performed_action
+
+    def perform(action:)
+      self.class.performed_action = action
+    end
+  end
+
+  test "attributes preserve keyword arguments" do
+    KeywordArgumentsJob.performed_action = nil
+
+    perform_enqueued_jobs do
+      KeywordArgumentsJob.perform_later(action: :test)
+    end
+
+    assert_equal :test, KeywordArgumentsJob.performed_action
+  end
+
+  class ContinuableAttributeJob < ActiveJob::Base
+    include ActiveJob::Continuable
+
+    attribute :processed_count, :integer, default: 0
+
+    cattr_accessor :final_count
+
+    IteratingRecord = Struct.new(:id) do
+      cattr_accessor :records
+
+      def self.find_each(start: nil)
+        records.sort_by(&:id).each do |record|
+          next if start && record.id < start
+          yield record
+        end
+      end
+    end
+
+    def perform
+      step :process do |step|
+        IteratingRecord.find_each(start: step.cursor) do |record|
+          self.processed_count += 1
+          step.advance! from: record.id
+        end
+      end
+
+      step :finalize do
+        self.final_count = processed_count
+      end
+    end
+  end
+
+  test "attributes persist when interrupted and resumed multiple times" do
+    ContinuableAttributeJob::IteratingRecord.records = (1..10).map { |i| ContinuableAttributeJob::IteratingRecord.new(i) }
+    ContinuableAttributeJob.final_count = nil
+
+    ContinuableAttributeJob.perform_later
+
+    interrupt_job_during_step ContinuableAttributeJob, :process, cursor: 4 do
+      assert_enqueued_jobs 1 do
+        perform_enqueued_jobs
+      end
+    end
+
+    interrupt_job_during_step ContinuableAttributeJob, :process, cursor: 8 do
+      assert_enqueued_jobs 1 do
+        perform_enqueued_jobs
+      end
+    end
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal 10, ContinuableAttributeJob.final_count
+  end
+end

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -107,7 +107,7 @@ module ActiveModel
         end
     end
 
-    def initialize(*) # :nodoc:
+    def initialize(...) # :nodoc:
       @attributes = self.class._default_attributes.deep_dup
       super
     end


### PR DESCRIPTION
### Motivation / Background

Discussion: https://discuss.rubyonrails.org/t/proposal-activejob-attributes-to-persist-data-between-steps/91051

At work we have multi-step jobs where we need to temporarily hold on to some intermediate data from one step that's required for a subsequent step, and we don't want/need to persist these long term on our Active Record models. We originally solved this problem with job-iteration and overriding the `serialize`/`deserialize` methods ([gist w/ prototype](https://gist.github.com/bdewater/3e6f04c7dc8144f5814b680ce3b7771a)). 

Rails 8.1 made multi-step jobs a first-class citizen with [Active Job Continuation](https://api.rubyonrails.org/classes/ActiveJob/Continuation.html). For our needs the `step` DSL is an ergonomic improvement but it still missing a way to persist data across interruptions and resumptions. This PR adds that capability with `ActiveJob::Attributes`, using [Active Model Attributes](https://api.rubyonrails.org/classes/ActiveModel/Attributes.html) under the hood. It is included by default in `ActiveJob::Continuable`, where IMO it is most useful, but could also be used standalone.

### Additional information

I also considered an API where `step` could optionally persist its return value, for example:
```rb
payment_token = step(:tokenize_payment_instrument, store: true) do
  PaymentGateway.tokenize(enrollment.user.payment_instrument)
end
```
That would store the value under a key derived from the step name. I decided against that approach:
- using attributes is simpler and more explicit, and
- it feels more consistent with the existing Continuable API, where the cursor is handled explicitly through `step.cursor` and `set!`/`advance!` rather than handled by the framework.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
