### PR TITLE
[ci skip] Fix a typo in the ActionMailbox basics docs

### DIFF
--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -471,7 +471,7 @@ controller mounted at `/rails/conductor/action_mailbox/inbound_emails`, which
 gives you an index of all the InboundEmails in the system, their state of
 processing, and a form to create a new InboundEmail as well.
 
-Here is and example of testing an inbound email with Action Mailbox TestHelpers.
+Here is an example of testing an inbound email with Action Mailbox TestHelpers.
 
 ```ruby
 class ForwardsMailboxTest < ActionMailbox::TestCase


### PR DESCRIPTION
This PR fixes a simple typo in the ActionMailbox basics documentation page, replacing `and` with `an` to make the sentence read like:

> Here is an example of testing an inbound email with Action Mailbox TestHelpers