### PR TITLE
Avoid false dirty tracking for equivalent Action Text body HTML

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Avoid marking unchanged rich text bodies as dirty when stored HTML contains
+    equivalent entity representations.
+
+    Fixes #54812.
+
+    *Andrii Furmanets*
+
 *   Support block children in editor elements alongside value.
 
     Blocks were introduced in #55827, but only as an alternative to the value

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -39,7 +39,7 @@ module ActionText
     cattr_accessor :editors, instance_accessor: false, default: {}.freeze
     cattr_accessor :editor, instance_accessor: false
 
-    serialize :body, coder: ActionText::Content
+    serialize :body, coder: ActionText::Content, comparable: true
     delegate :to_s, :nil?, to: :body
 
     ##

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -81,6 +81,16 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_equal "Hello world", message.content.to_plain_text
   end
 
+  test "content stored with equivalent html entities is not dirty after load" do
+    message = Message.create!(subject: "Greetings", content: "Hello world")
+    html = "<div>Test with non-breaking space: \u00A0</div>"
+
+    # Bypass type serialization to reproduce rich text records written by older Rails versions.
+    ActionText::RichText.where(id: message.content.id).update_all(["body = ?", html])
+
+    assert_not_predicate Message.find(message.id).content, :body_changed?
+  end
+
   test "duplicating content" do
     message = Message.create!(subject: "Greetings", content: "<b>Hello!</b>")
     other_message = Message.create!(subject: "Greetings", content: message.content)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActionText::RichText#body` can be considered dirty after load even when the rich text content has not changed.

Fixes #54812.

The reported case involves older `action_text_rich_texts.body` rows that contain a literal non-breaking space character. Current Action Text serialization canonicalizes that value as `&nbsp;`, so Active Record's default serialized dirty check compares the raw stored HTML against the canonicalized serialized HTML and sees a change. Applications using `body_changed?` can then emit false update events for unchanged rich text content.

### Detail

This Pull Request changes `ActionText::RichText#body` serialization to use `comparable: true`.

That makes Active Record compare deserialized `ActionText::Content` values through their existing equality behavior instead of comparing raw serialized HTML strings. As a result, equivalent HTML entity representations no longer mark the rich text body as dirty.

A regression test was added for a legacy-style row containing a literal non-breaking space, bypassing type serialization to reproduce the stored database value from the issue report. The Action Text changelog was also updated.

### Additional information

Validated with:

* `cd actiontext && bin/test test/unit/model_test.rb -n '/content stored with equivalent html entities is not dirty after load/'`
* `cd actiontext && bin/test test/unit/model_test.rb`
* `cd actiontext && bin/test test/unit/content_test.rb`
* `cd actiontext && bin/test $(find test -name '*_test.rb' ! -path 'test/system/*' ! -name 'javascript_package_test.rb')`
* `bundle exec rubocop actiontext/app/models/action_text/rich_text.rb actiontext/test/unit/model_test.rb`

`cd actiontext && bin/test` could not complete in this checkout because `JavascriptPackageTest` requires `rollup`, which is not installed locally. A broader run excluding only that JavaScript packaging test then hit unrelated system-test instability in browser upload tests, so the final broad validation used non-system Action Text tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
