### PR TITLE
Add `use_dedicated_flash_cookie` to fix Flash race condition

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add `config.action_dispatch.use_dedicated_flash_cookie` to store flash in its own encrypted
+    cookie instead of the session.
+
+    When enabled, `flash` is read from and written to a dedicated `_flash` encrypted cookie rather
+    than `session["flash"]`. This fixes a race where a concurrent in-flight request (e.g. a lazy
+    `turbo_frame`, a prefetch, or another AJAX call) rewrites the session cookie without the flash
+    just after a form submission set one, clobbering the freshly-set flash.
+
+    Defaults to `false`; no behavior change for existing apps. To opt in:
+
+        # config/application.rb
+        config.action_dispatch.use_dedicated_flash_cookie = true
+
+    Caveats:
+
+    * Flashes that were sitting in a user's session cookie when the flag flips on will not render
+      (one-time, one lost flash per affected user).
+    * A `flash` key previously stored inside `session` is harmless but no longer read or written.
+      Apps that want to clean it up can do so with a short-lived `before_action`.
+    * A very large flash now raises `ActionDispatch::Cookies::CookieOverflow` for the `_flash`
+      cookie rather than the session cookie.
+
+    *Jordan Brough*
+
 *   Serve static CSS and HTML files with `charset=utf-8` in the Content-Type header.
 
     Static CSS and HTML files served by `ActionDispatch::Static` now include

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -50,6 +50,13 @@ module ActionDispatch
   class Flash
     KEY = "action_dispatch.request.flash_hash"
 
+    # Dedicated encrypted cookie for `use_dedicated_cookie`
+    FLASH_COOKIE_NAME = "_flash"
+
+    # When true, flash data is stored in a dedicated cookie rather than inside the session. Opt-in.
+    # See `use_dedicated_flash_cookie` in guides/source/configuring.md.
+    mattr_accessor :use_dedicated_cookie, default: false
+
     module RequestMethods
       # Access the contents of the flash. Returns an ActionDispatch::Flash::FlashHash.
       #
@@ -57,7 +64,14 @@ module ActionDispatch
       def flash
         flash = flash_hash
         return flash if flash
-        self.flash = Flash::FlashHash.from_session_value(session["flash"])
+
+        value = if Flash.use_dedicated_cookie
+          cookie_jar.encrypted[Flash::FLASH_COOKIE_NAME]
+        else
+          session["flash"]
+        end
+
+        self.flash = Flash::FlashHash.from_session_value(value)
       end
 
       def flash=(flash)
@@ -69,22 +83,58 @@ module ActionDispatch
       end
 
       def commit_flash # :nodoc:
-        return unless session.enabled?
-
-        if flash_hash && (flash_hash.present? || session.key?("flash"))
-          session["flash"] = flash_hash.to_session_value
-          self.flash = flash_hash.dup
-        end
-
-        if session.loaded? && session.key?("flash") && session["flash"].nil?
-          session.delete("flash")
+        if Flash.use_dedicated_cookie
+          commit_flash_to_cookie
+        else
+          commit_flash_to_session
         end
       end
 
       def reset_session # :nodoc:
         super
         self.flash = nil
+
+        # `super`'s session wipe doesn't reach the dedicated flash cookie; clear it so a pending
+        # unrendered flash doesn't survive sign-out in the browser.
+        if Flash.use_dedicated_cookie && cookies.key?(Flash::FLASH_COOKIE_NAME)
+          cookie_jar.delete(Flash::FLASH_COOKIE_NAME, path: "/")
+        end
       end
+
+      private
+        def commit_flash_to_session
+          return unless session.enabled?
+
+          if flash_hash && (flash_hash.present? || session.key?("flash"))
+            session["flash"] = flash_hash.to_session_value
+            self.flash = flash_hash.dup
+          end
+
+          if session.loaded? && session.key?("flash") && session["flash"].nil?
+            session.delete("flash")
+          end
+        end
+
+        def commit_flash_to_cookie
+          fh = flash_hash
+          return unless fh
+
+          # `cookies.key?` reads the incoming Cookie header, so this asks "did the browser send a
+          # flash cookie?" The `elsif had_incoming` guard below is required: without it, any response
+          # that reads flash but doesn't set one would emit a delete header, which would itself race
+          # and clobber a freshly-set flash from a parallel form POST — the exact bug this fixes.
+          had_incoming = cookies.key?(Flash::FLASH_COOKIE_NAME)
+
+          if fh.present? && (value = fh.to_session_value)
+            cookie_jar.encrypted[Flash::FLASH_COOKIE_NAME] = {
+              value: value,
+              httponly: true,
+            }
+            self.flash = fh.dup
+          elsif had_incoming
+            cookie_jar.delete(Flash::FLASH_COOKIE_NAME, path: "/")
+          end
+        end
     end
 
     class FlashNow # :nodoc:

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -27,6 +27,7 @@ module ActionDispatch
     config.action_dispatch.authenticated_encrypted_cookie_salt = "authenticated encrypted cookie"
     config.action_dispatch.use_authenticated_cookie_encryption = false
     config.action_dispatch.use_cookies_with_metadata = false
+    config.action_dispatch.use_dedicated_flash_cookie = false
     config.action_dispatch.perform_deep_munge = true
     config.action_dispatch.request_id_header = ActionDispatch::Constants::X_REQUEST_ID
     config.action_dispatch.log_rescued_responses = true
@@ -91,6 +92,8 @@ module ActionDispatch
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
+
+      ActionDispatch::Flash.use_dedicated_cookie = config.action_dispatch.use_dedicated_flash_cookie
 
       ActionDispatch::Routing::Mapper.route_source_locations = Rails.env.development?
 

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -421,3 +421,196 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       end
     end
 end
+
+class FlashDedicatedCookieTest < ActionDispatch::IntegrationTest
+  SessionKey = "_myapp_session"
+  SessionSecret = "b3c631c314c0bbca50c1b2843150fe33"
+  Generator = ActiveSupport::CachingKeyGenerator.new(
+    ActiveSupport::KeyGenerator.new(SessionSecret, iterations: 1000)
+  )
+  Rotations = ActiveSupport::Messages::RotationConfiguration.new
+  SIGNED_COOKIE_SALT = "signed cookie"
+  ENCRYPTED_COOKIE_SALT = "encrypted cookie"
+  ENCRYPTED_SIGNED_COOKIE_SALT = "signed encrypted cookie"
+  AUTHENTICATED_ENCRYPTED_COOKIE_SALT = "authenticated encrypted cookie"
+
+  class TestController < ActionController::Base
+    def set_flash
+      flash["that"] = "hello"
+      head :ok
+    end
+
+    def use_flash
+      render inline: "flash: #{flash["that"]}"
+    end
+
+    def set_flash_now
+      flash.now["that"] = "hello"
+      head :ok
+    end
+
+    def just_use_flash
+      flash["that"]
+      head :ok
+    end
+
+    def touch_nothing
+      head :ok
+    end
+
+    def reset_and_render
+      reset_session
+      render inline: "flash: #{flash["that"]}"
+    end
+
+    def set_flash_then_reset
+      flash["that"] = "hello"
+      reset_session
+      head :ok
+    end
+
+    def raise_data_overflow
+      flash["big"] = "x" * (5 * 1024)
+      head :ok
+    end
+  end
+
+  include CookieAssertions
+
+  def setup
+    super
+    ActionDispatch::Flash.use_dedicated_cookie = true
+  end
+
+  def teardown
+    ActionDispatch::Flash.use_dedicated_cookie = false
+    super
+  end
+
+  def test_flash_round_trips_via_dedicated_cookie
+    with_test_route_set do
+      get "/set_flash"
+      assert_response :success
+      assert_includes set_cookie_header.to_s, "_flash="
+      assert_not_includes set_cookie_header.to_s, "_myapp_session"
+
+      get "/use_flash"
+      assert_response :success
+      assert_equal "flash: hello", @response.body
+    end
+  end
+
+  def test_response_that_does_not_touch_flash_emits_no_flash_cookie
+    with_test_route_set do
+      get "/touch_nothing"
+      assert_response :success
+      assert_not_includes set_cookie_header.to_s, "_flash"
+    end
+  end
+
+  def test_response_that_reads_flash_without_incoming_cookie_emits_no_flash_cookie
+    # If this breaks, the race fix is gone. A concurrent response that happens to read flash but
+    # doesn't set one must NOT emit a delete header, or it will clobber a freshly-set _flash from a
+    # parallel form POST.
+    with_test_route_set do
+      get "/just_use_flash"
+      assert_response :success
+      assert_not_includes set_cookie_header.to_s, "_flash"
+    end
+  end
+
+  def test_flash_cookie_is_deleted_once_consumed
+    with_test_route_set do
+      get "/set_flash"
+      assert_response :success
+      assert_match(/_flash=[^;]+/, set_cookie_header.to_s)
+
+      get "/use_flash"
+      assert_response :success
+      # After consumption, the response should clear the cookie so the browser doesn't keep sending
+      # it forever.
+      assert_match(/_flash=;/, set_cookie_header.to_s)
+    end
+  end
+
+  def test_flash_now_does_not_set_cookie
+    with_test_route_set do
+      get "/set_flash_now"
+      assert_response :success
+      assert_not_includes set_cookie_header.to_s, "_flash"
+    end
+  end
+
+  def test_reset_session_clears_pending_flash_cookie
+    with_test_route_set do
+      get "/set_flash"
+      assert_match(/_flash=[^;]+/, set_cookie_header.to_s)
+
+      get "/reset_and_render"
+      assert_match(/_flash=;/, set_cookie_header.to_s)
+    end
+  end
+
+  def test_reset_session_without_incoming_flash_cookie_emits_no_flash_header
+    with_test_route_set do
+      get "/reset_and_render"
+      assert_not_includes set_cookie_header.to_s, "_flash"
+    end
+  end
+
+  def test_setting_flash_then_reset_session_in_same_request_does_not_persist
+    with_test_route_set do
+      get "/set_flash_then_reset"
+
+      get "/use_flash"
+      assert_equal "flash: ", @response.body
+    end
+  end
+
+  def test_overflow_raises_for_flash_cookie_not_session
+    with_test_route_set do
+      assert_raises(ActionDispatch::Cookies::CookieOverflow) do
+        get "/raise_data_overflow"
+      end
+    end
+  end
+
+  private
+    def set_cookie_header
+      @response.headers["Set-Cookie"]
+    end
+
+    def get(path, **options)
+      options[:env] ||= {}
+      options[:env]["action_dispatch.key_generator"] ||= Generator
+      options[:env]["action_dispatch.cookies_rotations"] = Rotations
+      options[:env]["action_dispatch.secret_key_base"] = SessionSecret
+      options[:env]["action_dispatch.use_authenticated_cookie_encryption"] = true
+      options[:env]["action_dispatch.signed_cookie_salt"] = SIGNED_COOKIE_SALT
+      options[:env]["action_dispatch.encrypted_cookie_salt"] = ENCRYPTED_COOKIE_SALT
+      options[:env]["action_dispatch.encrypted_signed_cookie_salt"] = ENCRYPTED_SIGNED_COOKIE_SALT
+      options[:env]["action_dispatch.authenticated_encrypted_cookie_salt"] = AUTHENTICATED_ENCRYPTED_COOKIE_SALT
+      options[:env]["action_dispatch.cookies_same_site_protection"] = proc { :lax }
+      super(path, **options)
+    end
+
+    def app
+      @app ||= self.class.build_app do |middleware|
+        middleware.use ActionDispatch::Session::CookieStore, key: SessionKey
+        middleware.use ActionDispatch::Flash
+        middleware.delete ActionDispatch::ShowExceptions
+      end
+    end
+
+    def with_test_route_set
+      with_routing do |set|
+        set.draw do
+          ActionDispatch.deprecator.silence do
+            get ":action", to: FlashDedicatedCookieTest::TestController
+          end
+        end
+
+        yield
+      end
+    end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2497,6 +2497,45 @@ This defaults to `true` in `development`, and `false` in all other environments.
 
 Specifies if source locations of redirects should be logged below relevant log lines. By default, the flag is `true` in development and `false` in all other environments.
 
+#### `config.action_dispatch.use_dedicated_flash_cookie`
+
+When `true`, flash data is stored in a dedicated encrypted cookie named `_flash` instead of inside
+`session["flash"]`. Defaults to `false`.
+
+Enabling this fixes a race that can silently drop flash messages after a form submission. The race
+requires a few things to line up: your app stores sessions in the cookie store (the default), a
+concurrent in-flight request is loading on the same page (a lazy `turbo_frame`, a prefetch, or
+another AJAX call, etc.), and the user submits a form that sets a flash and redirects. The
+concurrent response can arrive just after the form response and re-emit the session cookie without
+the flash, overwriting the freshly-set flash at the browser cookie layer — so the redirect renders
+without the toast.
+
+With the dedicated cookie, flash lives in its own encrypted cookie that is only written when flash
+is actually set, and only deleted when an incoming flash cookie has been consumed. Responses that
+don't touch flash never emit a `Set-Cookie: _flash` header, so there is nothing for concurrent
+responses to clobber.
+
+Caveats to be aware of when enabling:
+
+* **One-time flash loss at the flip.** Users whose session cookie contained a flash set just before
+  the deploy will not see that flash rendered. Impact is low and one-time.
+* **Legacy `session["flash"]` key lingers.** Rails does not proactively clean up any `flash` key
+  inside existing sessions; the new code simply stops reading or writing it. It's harmless, but if
+  you want to clean it up you can run this as a short-lived `before_action` and remove it after one
+  deploy:
+
+    ```ruby
+    before_action :drop_legacy_session_flash
+    def drop_legacy_session_flash
+      session.delete("flash") if session.loaded? && session.key?("flash")
+    end
+    ```
+
+* **Overflow failure mode changes.** A very large flash now raises
+  `ActionDispatch::Cookies::CookieOverflow` for the `_flash` cookie rather than for the session
+  cookie. Error signatures in your reporting tool will shift.
+* **No session required.** The dedicated-cookie path works even when the session backend is disabled.
+
 #### `ActionDispatch::Callbacks.before`
 
 Takes a block of code to run before the request.


### PR DESCRIPTION
### Motivation / Background

Turbo/Hotwire-heavy apps with concurrent requests can lose Flash messages due to a race condition.

This PR adds an opt-in `config.action_dispatch.use_dedicated_flash_cookie` to fix that by using a separate cookie for the flash instead of sharing one with the session.

### Example

1. Request A is a form POST that sets the flash and redirects. Its response carries a `Set-Cookie` for the session, including the flash message.
2. Request B (a lazy turbo frame, prefetch, or AJAX call) is concurrently loading something that reads the session. Just reading the session will trigger a session `Set-Cookie` in the response (with no flash message in it).
3. Response B comes back slightly later than Response A, with a `Set-Cookie` for the session that has no flash in it. The browser applies Response B's cookie last, which overwrites the one with the flash message.
4. The browser then follows the redirect, and no flash renders.

### Culprit

_Reading_ the session in a request causes a `Set-Cookie` in the response, because the session gets re-serialized with `Set-Cookie` if any session key was accessed.  This happens on most pages in many apps, e.g. for authentication. It's a reasonable way to handle a payload that might have changed, without having to track whether it changed, but it makes race conditions more likely because `Set-Cookie` happens a lot for the session.

Also, putting flash messages and the session in the same cookie increases the chance of collision.

### Fix

Move flash messages to their own cookie, separate from the session. Only send back a `Set-Cookie` for the flash when the flash has been modified or when it has been consumed.

The Flash seems different in purpose and behavior than the Session, so separation seems reasonable imo anyway.

Here's an example app I made to demonstrate the bug and the fix: https://github.com/jordan-brough/turbo-flash-cookie-loss

### Caveats

There are still other chances for Flash and Session collisions (two concurrent requests that both set the flash/session), but those should be rare compared to this scenario, which itself is fairly rare, but common enough to be frustrating in system tests, and to show up in the real world.

----------

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
