### PR TITLE
Skip redundant File.exist? calls in Path#existent for glob paths

### DIFF
--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -218,14 +218,27 @@ module Rails
 
       # Returns all expanded paths but only if they exist in the filesystem.
       def existent
-        expanded.select do |f|
-          does_exist = File.exist?(f)
+        raise "You need to set a path root" unless @root.path
+        result = []
 
-          if !does_exist && File.symlink?(f)
-            raise "File #{f.inspect} is a symlink that does not point to a valid file"
+        each do |path|
+          path = File.expand_path(path, @root.path)
+
+          if @glob && File.directory?(path)
+            # Dir.glob only returns entries that exist, so there is no need
+            # to re-stat each one with File.exist?.
+            result.concat files_in(path)
+          else
+            if File.exist?(path)
+              result << path
+            elsif File.symlink?(path)
+              raise "File #{path.inspect} is a symlink that does not point to a valid file"
+            end
           end
-          does_exist
         end
+
+        result.uniq!
+        result
       end
 
       def existent_directories

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -315,4 +315,31 @@ class PathsIntegrationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "existent skips File.exist? for paths produced by Dir.glob" do
+    Dir.mktmpdir do |dir|
+      locales_dir = File.join(dir, "config", "locales")
+      FileUtils.mkdir_p(locales_dir)
+      File.write(File.join(locales_dir, "en.yml"), "en: {}")
+      File.write(File.join(locales_dir, "fr.yml"), "fr: {}")
+
+      root = Rails::Paths::Root.new(dir)
+      root.add "config/locales", glob: "**/*.{rb,yml}"
+
+      expected = root["config/locales"].expanded.sort
+      result = root["config/locales"].existent.sort
+
+      assert_equal expected, result
+    end
+  end
+
+  test "existent filters non-glob paths that do not exist" do
+    Dir.mktmpdir do |dir|
+      root = Rails::Paths::Root.new(dir)
+      root.add "config/locales", glob: "**/*.{rb,yml}"
+
+      # The directory does not exist, so existent should return nothing
+      assert_empty root["config/locales"].existent
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

`Path#existent` calls `expanded`, which uses `Dir.glob` to list files matching a glob pattern. It then filters every result through `File.exist?` — but this is redundant, since `Dir.glob` only returns entries that already exist on the filesystem.

In applications with many engines, this adds up to a large number of unnecessary stat syscalls during boot.

### Change

Instead of calling `expanded` and then filtering, `existent` now inlines the expansion logic:

- **Glob paths:** `Dir.glob` results are used directly — no `File.exist?` re-check.
- **Non-glob paths:** The existing `File.exist?` guard and broken-symlink detection are preserved.