### PR TITLE
Guides: remove outdated link to Action Cable examples

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -713,11 +713,6 @@ callback. The data passed as an argument is the hash sent as the second paramete
 to the server-side broadcast call, JSON encoded for the trip across the wire
 and unpacked for the data argument arriving as `received`.
 
-### More Complete Examples
-
-See the [rails/actioncable-examples](https://github.com/rails/actioncable-examples)
-repository for a full example of how to set up Action Cable in a Rails app and adding channels.
-
 ## Configuration
 
 Action Cable has two required configurations: a subscription adapter and allowed request origins.


### PR DESCRIPTION
Here's a link to this section in the current guides: https://guides.rubyonrails.org/action_cable_overview.html#more-complete-examples

It links to [a repo](https://github.com/rails/actioncable-examples) that hasn't been updated in 9 years and has since been archived.  Probably not worth linking to anymore.