### PR TITLE
Empty SQL query `;` in PostgreSQL is a read query

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         end
 
         READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
-          :close, :declare, :fetch, :move, :set, :show, :reset
+          :close, :declare, :fetch, :move, :set, :show, :reset, ";"
         ) # :nodoc:
         private_constant :READ_QUERY
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
@@ -48,6 +48,12 @@ module ActiveRecord
         end
       end
 
+      def test_doesnt_error_when_an_empty_query_is_called_while_preventing_writes
+        ActiveRecord::Base.while_preventing_writes do
+          assert_queries_count(1) { @connection.execute(";") }
+        end
+      end
+
       def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
         with_example_table do
           @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")


### PR DESCRIPTION
Currently, an empty (`;`) SQL query is considered as a write query:

```ruby
User.connection.execute(';')
# => ActiveRecord::ReadOnlyError: Write query attempted while in readonly mode: ;
```

These queries are often used as a faster alternative to `SELECT 1` (or something like that), which is a read query. Was surprised to find out that `;` is considered a write query.