### PR TITLE
Fix duplicate entries accumulating in `aliases_by_attribute_name`

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -204,7 +204,7 @@ module ActiveModel
         old_name = old_name.to_s
         new_name = new_name.to_s
         self.attribute_aliases = attribute_aliases.merge(new_name => old_name)
-        aliases_by_attribute_name[old_name] << new_name
+        aliases_by_attribute_name[old_name] |= [new_name]
         eagerly_generate_alias_attribute_methods(new_name, old_name)
       end
 

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -206,6 +206,18 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_equal({ "bar" => "foo" }, klass.attribute_aliases)
   end
 
+  test "#alias_attribute is idempotent when called multiple times with the same arguments" do
+    klass = Class.new(ModelWithAttributes) do
+      define_attribute_methods :foo
+      alias_attribute :bar, :foo
+      alias_attribute :bar, :foo
+      alias_attribute :bar, :foo
+    end
+
+    assert_equal({ "bar" => "foo" }, klass.attribute_aliases)
+    assert_equal ["bar"], klass.send(:aliases_by_attribute_name)["foo"]
+  end
+
   test "#define_attribute_methods generates attribute methods with spaces in their names" do
     ModelWithAttributesWithSpaces.define_attribute_methods(:'foo bar')
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -55,6 +55,21 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_includes new_topic_model.attribute_aliases, "id_value"
   end
 
+  test "#id_value alias does not accumulate duplicates when table_name is reassigned" do
+    klass = Class.new(ActiveRecord::Base)
+
+    klass.table_name = "topics"
+    klass.first
+
+    klass.table_name = "authors"
+    klass.first
+
+    klass.table_name = "topics"
+    klass.first
+
+    assert_equal ["id_value"], klass.send(:aliases_by_attribute_name)["id"]
+  end
+
   test "#id_value alias is not defined if id_value column exist" do
     new_book_identifier_model = Class.new(ActiveRecord::Base) do
       self.table_name = "book_identifiers"


### PR DESCRIPTION
Fixes #57235

### Motivation / Background

`ActiveModel::AttributeMethods#alias_attribute` appends to `aliases_by_attribute_name[old_name]` without checking for duplicates. When the same alias is registered more than once on the same class, the underlying storage accumulates duplicate entries, and `define_attribute_methods` later iterates every duplicate — generating the same aliased attribute methods once per duplicate.

This is a regression for any code that reassigns `self.table_name = ...` on a reusable AR class. Since Rails 7.1, `ActiveRecord::Base#load_schema!` auto-calls `alias_attribute :id_value, :id` for every `id` column on every schema load ([`activerecord/lib/active_record/model_schema.rb#L628`](https://github.com/rails/rails/blob/d39db5d1891f7509cde2efc425c9d69bbb77e670/activerecord/lib/active_record/model_schema.rb#L628), introduced in [rails/rails@e90b11e77e](https://github.com/rails/rails/commit/e90b11e77e)). Combined with the persistent `aliases_by_attribute_name` structure ([`activemodel/lib/active_model/attribute_methods.rb#L204-L209`](https://github.com/rails/rails/blob/d39db5d1891f7509cde2efc425c9d69bbb77e670/activemodel/lib/active_model/attribute_methods.rb#L204-L209), introduced in [rails/rails@0f5563bd40](https://github.com/rails/rails/commit/0f5563bd40)), repeatedly setting `table_name` appends a new `"id_value"` entry on every schema reload. After N reassignments, `aliases_by_attribute_name["id"]` contains N duplicate `"id_value"` strings, and each `define_attribute_methods` call re-generates aliased accessor methods N times per pattern per column.

Rails 7.0 and earlier did not have either the auto-alias or the persistent storage, so this pattern was effectively free before 7.1.

Compare 7.0 vs 7.1 `alias_attribute`:
- 7.0.10: [`activemodel/lib/active_model/attribute_methods.rb#L204-L235`](https://github.com/rails/rails/blob/f4321f78fe567fd29dd0a0fb5cb17af68efd36bb/activemodel/lib/active_model/attribute_methods.rb#L204-L235) — defines methods inline via `attribute_method_matchers.each`, no `aliases_by_attribute_name`.
- 7.1.0: [`activemodel/lib/active_model/attribute_methods.rb#L204-L209`](https://github.com/rails/rails/blob/d39db5d1891f7509cde2efc425c9d69bbb77e670/activemodel/lib/active_model/attribute_methods.rb#L204-L209) — appends to `aliases_by_attribute_name` (L208), delegates generation to `define_attribute_methods`.

In a representative reproduction, per-query cost grew monotonically from ~12 ms to ~90 ms over ~1000 `table_name=` swaps on a single class, with per-call allocations climbing from ~41 k to ~246 k objects — all attributable to repeated `define_attribute_method_pattern` work firing exponentially more times as duplicates accumulated.

### Detail

Dedupe the append in `alias_attribute`:

```ruby
aliases = aliases_by_attribute_name[old_name]
aliases << new_name unless aliases.include?(new_name)
```

The rest of the method is unchanged. `attribute_aliases.merge(new_name => old_name)` is already idempotent, and `eagerly_generate_alias_attribute_methods` is safe to re-call because `define_attribute_method_pattern` early-returns on `instance_method_already_implemented?`.

### Additional information

Two tests are added:

1. An ActiveModel unit test (`activemodel/test/cases/attribute_methods_test.rb`) calling `alias_attribute :bar, :foo` three times on the same class and asserting `aliases_by_attribute_name["foo"] == ["bar"]`.
2. An ActiveRecord integration test (`activerecord/test/cases/attribute_methods_test.rb`) that mirrors the real-world regression path — an anonymous `ActiveRecord::Base` subclass with `table_name` reassigned between `topics` and `posts`, asserting `aliases_by_attribute_name["id"] == ["id_value"]` after three `.first` queries.

Both tests fail on unpatched `main` (clean diffs: `["bar"] expected, ["bar", "bar", "bar"] actual` and `["id_value"]` expected, `["id_value", "id_value"]` actual) and pass with the patch applied. Full `activemodel` suite (1168 tests) and full `activerecord` sqlite3 suite (9418 tests) pass with zero new failures.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added for the bug fix.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
