### PR TITLE
Fix attachment uploads lost when reload is called inside a transaction

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix attachment uploads not completing when `reload` is called inside a transaction.
+
+    When a model with an attachment was saved inside a transaction and then
+    reloaded before the transaction committed, `@attachment_changes` was
+    cleared. This caused the `after_commit` callback to skip uploading the
+    blob to the storage service. Now, pending create changes with persisted
+    attachments are preserved across `reload`.
+
+    Fixes #57222.
+
+    *Hammad Khan*
+
 *   Configurable maximum streaming chunk size
 
     Makes sure that byte ranges for blobs don't exceed 100mb by default.

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -318,7 +318,19 @@ module ActiveStorage
     end
 
     def reload(*) # :nodoc:
-      super.tap { @attachment_changes = nil }
+      super.tap do
+        if @attachment_changes
+          @attachment_changes.select! do |_, change|
+            case change
+            when ActiveStorage::Attached::Changes::CreateOne
+              change.attachment.persisted?
+            when ActiveStorage::Attached::Changes::CreateMany
+              change.attachments.any?(&:persisted?)
+            end
+          end
+          @attachment_changes = nil if @attachment_changes.empty?
+        end
+      end
     end
   end
 end

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -319,17 +319,17 @@ module ActiveStorage
 
     def reload(*) # :nodoc:
       super.tap do
-        if @attachment_changes
-          @attachment_changes.select! do |_, change|
-            case change
-            when ActiveStorage::Attached::Changes::CreateOne
-              change.attachment.persisted?
-            when ActiveStorage::Attached::Changes::CreateMany
-              change.attachments.any?(&:persisted?)
-            end
+        next unless @attachment_changes
+
+        @attachment_changes.select! do |_, change|
+          case change
+          when ActiveStorage::Attached::Changes::CreateOne
+            change.attachment.persisted?
+          when ActiveStorage::Attached::Changes::CreateMany
+            change.attachments.any?(&:persisted?)
           end
-          @attachment_changes = nil if @attachment_changes.empty?
         end
+        @attachment_changes = nil if @attachment_changes.empty?
       end
     end
   end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -732,6 +732,22 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_not @user.highlights.attached?
   end
 
+  test "upload completes after reload inside a transaction" do
+    user = ActiveRecord::Base.transaction do
+      new_user = User.create!(name: "Jason",
+        highlights: [{
+          content_type: "text/plain",
+          filename: "dummy.txt",
+          io: StringIO.new("dummy"),
+        }]
+      )
+      new_user.reload
+    end
+
+    assert_predicate user.highlights, :attached?
+    assert_equal "dummy", user.highlights.first.download
+  end
+
   test "overriding attached reader" do
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
 

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -717,6 +717,22 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_not @user.avatar.attached?
   end
 
+  test "upload completes after reload inside a transaction" do
+    user = ActiveRecord::Base.transaction do
+      new_user = User.create!(name: "Jason",
+        avatar: {
+          content_type: "text/plain",
+          filename: "dummy.txt",
+          io: StringIO.new("dummy"),
+        }
+      )
+      new_user.reload
+    end
+
+    assert_predicate user.avatar, :attached?
+    assert_equal "dummy", user.avatar.download
+  end
+
   test "overriding attached reader" do
     @user.avatar.attach create_blob(filename: "funky.jpg")
 


### PR DESCRIPTION
### Motivation / Background

Fixes #57222.

When a model with an attachment is saved inside a transaction and then reloaded
before the transaction commits, the blob is never uploaded to the storage
service. This happens because `reload` clears `@attachment_changes`, so when
the `after_commit` callback fires, it finds nothing to upload.

### Detail

The callback chain for attachments is:

1. `after_save` — persists the attachment and blob records to the database
2. `after_commit` — uploads the file to the storage service via `attachment_changes.delete(name).try(:upload)`

When `reload` is called between steps 1 and 2 (which happens inside a
transaction since `after_commit` is deferred), `@attachment_changes = nil`
wipes the pending upload info.

This PR changes `reload` to preserve `CreateOne`/`CreateMany` changes whose
attachments have already been persisted (i.e. `after_save` already ran).
Unsaved attachment changes are still cleared on reload, matching existing
behavior — the "clearing change on reload" test continues to pass.

### Additional information

Reproduction script from the issue confirms the fix:

```ruby
user = ActiveRecord::Base.transaction do
  new_user = User.create!(
    profile: { content_type: "text/plain", filename: "dummy.txt", io: StringIO.new("dummy") }
  )
  new_user.reload
end

user.profile.download # => "dummy" (was raising ActiveStorage::FileNotFoundError)
```

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added for both `has_one_attached` and `has_many_attached`.
- [x] CHANGELOG entry added for ActiveStorage.
- [x] RuboCop passes with no offenses.