### PR TITLE
Fix config.credentials.key_path set in environment files being ignored

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix `config.credentials.key_path` set in environment files being ignored.
+
+    When `config.credentials.key_path` was set in an environment-specific
+    config file (e.g. `config/environments/development.rb`), the value could
+    be ignored if `Rails.application.credentials` was memoized before the
+    environment file was loaded. Now, memoized credentials are cleared after
+    environment config files load so the updated paths are picked up.
+
+    Fixes #57218.
+
+    *Hammad Khan*
+
 *   Add offline fallback page to the PWA scaffold.
 
     New Rails apps now include an `app/views/pwa/offline.html.erb` template and

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -583,6 +583,11 @@ module Rails
           require environment
         end
       end
+
+      # Reset memoized credentials so that config.credentials.key_path
+      # and config.credentials.content_path set in environment files
+      # are picked up by Rails.application.credentials.
+      self.credentials = nil if self.respond_to?(:credentials=)
     end
 
     initializer :set_load_path, before: :bootstrap_hook do |app|

--- a/railties/test/application/credentials_test.rb
+++ b/railties/test/application/credentials_test.rb
@@ -37,4 +37,14 @@ class Rails::CredentialsTest < ActiveSupport::TestCase
       assert_equal "revealed", Rails.application.credentials.mystery
     end
   end
+
+  test "picks up config.credentials.key_path set in environment file after credentials were already accessed" do
+    write_credentials_override(:staging)
+    add_to_env_config("production", "config.credentials.content_path = config.root.join('config/credentials/staging.yml.enc')")
+    add_to_env_config("production", "config.credentials.key_path = config.root.join('config/credentials/staging.key')")
+
+    app("production")
+
+    assert_equal "revealed", Rails.application.credentials.mystery
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #57218.

When `config.credentials.key_path` is set in an environment-specific config
file (e.g. `config/environments/development.rb`), it works for `bin/rails
server` but may be ignored by other processes like Solid Queue or Tailwind
watchers launched via `bin/dev`.

### Detail

`Rails.application.credentials` memoizes the `EncryptedConfiguration` instance
on first access (line 608 of `application.rb`):

```ruby
def credentials
  @credentials ||= encrypted(config.credentials.content_path, key_path: config.credentials.key_path)
end
```

If `credentials` is accessed before the environment config file is loaded
(e.g. via `secret_key_base` resolution which calls
`Rails.application.credentials.secret_key_base`), the memoized instance
captures the default `key_path`. Any override in `config/environments/*.rb`
is then silently ignored.

This PR clears the memoized `@credentials` after the `load_environment_config`
initializer loads environment files, so the next access will pick up the
overridden `config.credentials.key_path` and `config.credentials.content_path`.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added.
- [x] CHANGELOG entry added for Railties.
- [x] RuboCop passes with no offenses.