### PR TITLE
Remove redundant libvips from Dockerfile build packages

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -631,9 +631,6 @@ module Rails
           packages << "python-is-python3"
         end
 
-        # ActiveStorage preview support
-        packages << "libvips" unless skip_active_storage?
-
         packages.compact.sort
       end
 


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because libvips is included in the build packages and the runtime (base) packages. Since the build stage inherits from base, including it in the build packages resulted in a duplicate installation entry in the generated Dockerfile.

Fixes [#57237](https://github.com/rails/rails/issues/57237)

### Detail

This Pull Request changes railties/lib/rails/generators/app_base.rb

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`