### PR TITLE
Fix #57231: Clear PostgreSQL schema search path cache on rollback

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -82,11 +82,21 @@ module ActiveRecord
         def exec_rollback_db_transaction # :nodoc:
           cancel_any_running_query
           query_command("ROLLBACK", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+        ensure
+          @schema_search_path = nil
         end
 
         def exec_restart_db_transaction # :nodoc:
           cancel_any_running_query
           query_command("ROLLBACK AND CHAIN", "TRANSACTION", allow_retry: false, materialize_transactions: true)
+        ensure
+          @schema_search_path = nil
+        end
+
+        def exec_rollback_to_savepoint(name = current_savepoint_name) # :nodoc:
+          query_command("ROLLBACK TO SAVEPOINT #{name}", "TRANSACTION")
+        ensure
+          @schema_search_path = nil
         end
 
         # From https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -320,6 +320,46 @@ module ActiveRecord
         connection&.disconnect!
       end
 
+      def test_schema_search_path_cache_is_cleared_after_rollback
+        old_search_path = @connection.schema_search_path
+        @connection.schema_search_path = "public"
+
+        @connection.transaction do
+          @connection.schema_search_path = "pg_catalog"
+          raise ActiveRecord::Rollback
+        end
+
+        assert_equal "public", @connection.select_value("SHOW search_path")
+
+        @connection.schema_search_path = "pg_catalog"
+        assert_equal "pg_catalog", @connection.select_value("SHOW search_path")
+      ensure
+        @connection.schema_search_path = old_search_path
+      end
+
+      def test_schema_search_path_cache_is_cleared_after_savepoint_rollback
+        old_search_path = @connection.schema_search_path
+        @connection.schema_search_path = "public"
+
+        @connection.transaction do
+          @connection.schema_search_path = "pg_catalog"
+
+          @connection.transaction(requires_new: true) do
+            @connection.schema_search_path = "public"
+            raise ActiveRecord::Rollback
+          end
+
+          assert_equal "pg_catalog", @connection.select_value("SHOW search_path")
+
+          @connection.schema_search_path = "public"
+          assert_equal "public", @connection.select_value("SHOW search_path")
+
+          raise ActiveRecord::Rollback
+        end
+      ensure
+        @connection.schema_search_path = old_search_path
+      end
+
       def test_queries_executed_on_fresh_connection_through_first_select
         reset_connection
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
This Pull Request has been created because PostgreSQL rolls back `SET search_path` changes when a transaction or savepoint rolls back, but Active Record kept the previously assigned `schema_search_path` cached on the adapter. That could make a later `schema_search_path = ...` call no-op against stale adapter state while PostgreSQL was still using a different search path, causing subsequent unqualified queries to run against the wrong schema.

Fixes #57231.

### Detail

This Pull Request changes the PostgreSQL adapter to clear its cached
`@schema_search_path` after:

* full transaction rollback
* transaction restart via `ROLLBACK AND CHAIN`
* savepoint rollback

With the cache cleared, the next `schema_search_path = ...` assignment compares
against the actual server state and reapplies `SET search_path` when needed.

Regression tests cover both top-level transaction rollback and nested
savepoint rollback.

### Additional information

Validated with:

```bash
ARCONN=postgresql bin/test test/cases/adapters/postgresql/postgresql_adapter_test.rb -i '/schema_search_path_cache_is_cleared_after_(rollback|savepoint_rollback)/'
ARCONN=postgresql bin/test test/cases/adapters/postgresql/postgresql_adapter_test.rb -i '/schema_search_path/'
ARCONN=postgresql bin/test test/cases/adapters/postgresql/postgresql_adapter_test.rb
ARCONN=postgresql bin/test test/cases/adapters/postgresql/transaction_test.rb test/cases/adapters/postgresql/transaction_nested_test.rb
bundle exec rubocop activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.