### PR TITLE
Move generated kamal gem into development group

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -29,11 +29,6 @@ gem "solid_cable"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 <% end -%>
-<% unless options.skip_kamal? -%>
-
-# Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
-gem "kamal", require: false
-<% end -%>
 <% unless options.skip_thruster? -%>
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
@@ -71,13 +66,22 @@ group :development, :test do
 <%- end -%>
 end
 <% end -%>
-<%- unless options.api? || options.skip_dev_gems? -%>
+<% unless options.skip_dev_gems? -%>
+<% if !options.skip_kamal? || !options.api? -%>
 
 group :development do
+<% unless options.skip_kamal? -%>
+  # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
+  gem "kamal", require: false
+<% end -%>
+<%- unless options.api? -%>
+
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-end
 <%- end -%>
+end
+<% end -%>
+<% end -%>
 <%- if depends_on_system_test? -%>
 
 group :test do

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -49,6 +49,8 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/gem "selenium-webdriver"/, content)
       assert_match(/# gem "jbuilder"/, content)
       assert_match(/# gem "rack-cors"/, content)
+      assert_match(/group :development do\n  # Deploy this application anywhere as a Docker container \[https:\/\/kamal-deploy\.org\]\n  gem "kamal", require: false\nend/, content)
+      assert_equal 1, content.scan(/^group :development do$/).size
     end
 
     assert_file "config/application.rb", /config\.api_only = true/

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1189,6 +1189,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_skip_dev_gems
     run_generator [destination_root, "--skip-dev-gems"]
     assert_no_gem "web-console"
+    assert_no_gem "kamal"
+  end
+
+  def test_kamal_is_in_development_group
+    run_generator
+
+    assert_file "Gemfile" do |content|
+      assert_match(/group :development do\n  # Deploy this application anywhere as a Docker container \[https:\/\/kamal-deploy\.org\]\n  gem "kamal", require: false/, content)
+      assert_no_match(/^gem "kamal", require: false$/, content)
+      assert_equal 1, content.scan(/^group :development do$/).size
+    end
   end
 
   def test_bootsnap


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `rails new` currently generates `gem "kamal", require: false` as a top-level dependency in the app `Gemfile`, which includes Kamal in production bundles by default even though it is deploy tooling.

Fixes #57205.

### Detail

This Pull Request changes the app Gemfile template so generated `kamal` is placed under `group :development` instead of top-level.

It also updates generator tests to verify the new behavior and guard existing option behavior:

- regular app generation includes Kamal in `group :development`
- API app generation still has expected Gemfile output with Kamal grouped in development
- `--skip-dev-gems` omits Kamal
- `--skip-kamal` still omits Kamal

Changed files:

- `railties/lib/rails/generators/rails/app/templates/Gemfile.tt`
- `railties/test/generators/app_generator_test.rb`
- `railties/test/generators/api_app_generator_test.rb`

### Additional information

Verified with focused generator test runs:

- `bundle exec ruby -Irailties/test railties/test/generators/app_generator_test.rb -n "/kamal|skip_dev_gems/"`
- `bundle exec ruby -Irailties/test railties/test/generators/api_app_generator_test.rb -n "/test_api_modified_files|test_kamal_deploy_yml_excludes_asset_path_for_api_apps/"`

Both passed.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.