### PR TITLE
Fix double space in action_controller_overview comment example [ci skip]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -133,7 +133,7 @@ class ClientsController < ApplicationController
     end
   end
 
-  # This action receives parameters from a POST request to "/clients" URL with  form data in the request body.
+  # This action receives parameters from a POST request to "/clients" URL with form data in the request body.
   def create
     @client = Client.new(params[:client])
     if @client.save


### PR DESCRIPTION
### Motivation / Background

Fixes #57241

### Detail

This Pull Request removes a double space in a code comment in the `ClientsController` example in the Parameters section of the Action Controller Overview guide.

### Additional information

N/A

### Checklist
* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. [Fix #57241]
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.