### PR TITLE
Fix `NoMethodError` for malformed multiparameter attribute keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Raise `ActiveRecord::MultiparameterAssignmentErrors` instead of `NoMethodError`
+    when assigning a malformed multiparameter attribute name.
+
+    A key routed to the multiparameter code path but missing a closing parenthesis
+    (e.g. `"written_on("`) used to crash with `NoMethodError: undefined method
+    'first' for nil` inside `find_parameter_position`. It now raises the same
+    `MultiparameterAssignmentErrors` already used for other invalid multiparameter
+    input, so callers can rescue a single documented error class.
+
+    *Kenta Ishizaki*
+
 *   Include the list of valid values in the `ArgumentError` raised when assigning
     an invalid value to an enum attribute.
 

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -2,6 +2,9 @@
 
 module ActiveRecord
   module AttributeAssignment
+    class InvalidParameterKey < StandardError # :nodoc:
+    end
+
     private
       def _assign_attributes(attributes)
         multi_parameter_attributes = nested_parameter_attributes = nil
@@ -59,6 +62,7 @@ module ActiveRecord
 
       def extract_callstack_for_multiparameter_attributes(pairs)
         attributes = {}
+        errors = []
 
         pairs.each do |(multiparameter_name, value)|
           attribute_name = multiparameter_name.split("(").first
@@ -66,6 +70,17 @@ module ActiveRecord
 
           parameter_value = value.blank? ? nil : type_cast_attribute_value(multiparameter_name, value)
           attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
+        rescue InvalidParameterKey => ex
+          errors << AttributeAssignmentError.new(
+            "invalid multiparameter attribute name #{multiparameter_name.inspect} (#{ex.message})",
+            ex,
+            multiparameter_name.split("(").first
+          )
+        end
+
+        unless errors.empty?
+          error_descriptions = errors.map(&:message).join(",")
+          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
         end
 
         attributes
@@ -76,7 +91,9 @@ module ActiveRecord
       end
 
       def find_parameter_position(multiparameter_name)
-        multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
+        match = multiparameter_name.match(/\(([0-9]*).*\)/)
+        raise InvalidParameterKey, "could not parse parameter position from #{multiparameter_name.inspect}" unless match
+        match[1].to_i
       end
   end
 end

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -400,4 +400,25 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     )
     assert_not_predicate topic, :written_on_came_from_user?
   end
+
+  def test_multiparameter_attributes_with_unclosed_parenthesis_raises_multiparameter_assignment_errors
+    ex = assert_raise(ActiveRecord::MultiparameterAssignmentErrors) do
+      Topic.new("written_on(" => "2024")
+    end
+    assert_equal 1, ex.errors.size
+    assert_equal "written_on", ex.errors[0].attribute
+  end
+
+  def test_multiparameter_attributes_with_malformed_name_reports_remaining_errors_alongside_valid_pairs
+    ex = assert_raise(ActiveRecord::MultiparameterAssignmentErrors) do
+      Topic.new(
+        "written_on(1i)" => "2024",
+        "written_on(2i)" => "6",
+        "written_on(3i)" => "24",
+        "broken(" => "x",
+      )
+    end
+    assert_equal 1, ex.errors.size
+    assert_equal "broken", ex.errors[0].attribute
+  end
 end


### PR DESCRIPTION
Malformed multiparameter attribute keys (e.g. `"written_on("`) crash with a raw `NoMethodError` instead of the expected `MultiparameterAssignmentErrors`.

### Problem

`_assign_attributes` routes attribute keys through the multiparameter codepath when the key contains `(`, regardless of whether it also has a closing `)`. However, `find_parameter_position` expects a closing `)` in its regex:

```ruby
multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
```

When the key has `(` but no `)`, `scan` returns `[]`, and `.first.first` raises:

```
NoMethodError: undefined method 'first' for nil
```

This bypasses the `MultiparameterAssignmentErrors` wrapper that `execute_callstack_for_multiparameter_attributes` uses for other invalid multiparameter input, so callers rescuing `ActiveRecord::MultiparameterAssignmentErrors` won't catch it.

### Fix

- `find_parameter_position` now raises `ArgumentError` when the regex does not match, instead of calling `.first.first` on `nil`.
- `extract_callstack_for_multiparameter_attributes` catches that `ArgumentError`, wraps it in an `AttributeAssignmentError`, and raises the same `MultiparameterAssignmentErrors` already used for other invalid multiparameter conditions. Valid keys are unaffected.

### Reproduction (before)

```ruby
Topic.new("written_on(" => "2024")
# => NoMethodError: undefined method 'first' for nil
#      activerecord/lib/active_record/attribute_assignment.rb:79:in 'find_parameter_position'
```

### After

```ruby
Topic.new("written_on(" => "2024")
# => ActiveRecord::MultiparameterAssignmentErrors:
#      1 error(s) on assignment of multiparameter attributes
#      [invalid multiparameter attribute name "written_on("
#       (could not parse parameter position from "written_on(")]
```

### Tests

Two new cases in `activerecord/test/cases/multiparameter_attributes_test.rb`:

1. A key with `(` but no `)` raises `MultiparameterAssignmentErrors`
2. A malformed key mixed with valid `written_on(1i)`/`(2i)`/`(3i)` pairs surfaces exactly one error against the malformed attribute, not the valid ones

Added a CHANGELOG entry.

Full suite result (sqlite3): 9419 runs, 32120 assertions, 0 failures, 0 errors, 46 skips.

### Design notes

I considered two alternative approaches:

- **Tightening the guard in `_assign_attributes`** to also check for `)` before routing to the multiparameter path. I went with fixing `find_parameter_position` instead, since that would change the existing behavior where `(` alone is sufficient to enter the multiparameter codepath — potentially affecting how keys are currently parsed in ways that are harder to reason about.
- **Silently coercing unmatched keys to position `0`**. I rejected this because it would hide genuinely malformed input and could conflate distinct attributes — surfacing the error felt more consistent with how other invalid multiparameter cases are already handled.

Open to changing direction if maintainers prefer leaving malformed keys as a raw error ("should never reach here" territory) — happy to adjust.