### PR TITLE
Fix `find_signed` for models with a composite primary key

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -70,7 +70,7 @@ module ActiveRecord
 
         options = { on_rotation: on_rotation }.compact
         if id = signed_id_verifier.verified(signed_id, purpose: combine_signed_id_purposes(purpose), **options)
-          find_by primary_key => id
+          find_by(primary_key => [id])
         end
       end
 

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -5,6 +5,7 @@ require "models/account"
 require "models/company"
 require "models/toy"
 require "models/matey"
+require "models/cpk"
 
 class SignedIdTest < ActiveRecord::TestCase
   class GetSignedIDInCallback < ActiveRecord::Base
@@ -18,7 +19,7 @@ class SignedIdTest < ActiveRecord::TestCase
       end
   end
 
-  fixtures :accounts, :toys, :companies
+  fixtures :accounts, :toys, :companies, :cpk_orders
 
   setup do
     @original_message_verifiers = ActiveRecord.message_verifiers
@@ -26,6 +27,7 @@ class SignedIdTest < ActiveRecord::TestCase
 
     @account = Account.first
     @toy = Toy.first
+    @cpk_order = Cpk::Order.first
   end
 
   teardown do
@@ -44,6 +46,16 @@ class SignedIdTest < ActiveRecord::TestCase
 
   test "find signed record with custom primary key" do
     assert_equal @toy, Toy.find_signed(@toy.signed_id)
+  end
+
+  test "find signed record with composite primary key" do
+    assert_equal @cpk_order, Cpk::Order.find_signed(@cpk_order.signed_id)
+  end
+
+  test "find signed record on relation with composite primary key" do
+    assert_equal @cpk_order, Cpk::Order.where("1=1").find_signed(@cpk_order.signed_id)
+
+    assert_nil Cpk::Order.where("1=0").find_signed(@cpk_order.signed_id)
   end
 
   test "find signed record for single table inheritance (STI Models)" do
@@ -71,6 +83,10 @@ class SignedIdTest < ActiveRecord::TestCase
 
   test "find signed record with a bang with custom primary key" do
     assert_equal @toy, Toy.find_signed!(@toy.signed_id)
+  end
+
+  test "find signed record with a bang with composite primary key" do
+    assert_equal @cpk_order, Cpk::Order.find_signed!(@cpk_order.signed_id)
   end
 
   test "find signed record with a bang for single table inheritance (STI Models)" do


### PR DESCRIPTION
## Summary

`ActiveRecord::SignedId::ClassMethods#find_signed` raises an `ArgumentError` for any model that declares a composite primary key (e.g. `self.primary_key = [:shop_id, :id]`). The bang variant `find_signed!` works correctly. This PR makes `find_signed` consistent with `find_signed!` and `find`.

## The bug

```ruby
class Cpk::Order < ActiveRecord::Base
  self.primary_key = [:shop_id, :id]
end

order = Cpk::Order.first
token = order.signed_id

Cpk::Order.find_signed!(token)
# => #<Cpk::Order id: 75294940, shop_id: 37647470, ...>

Cpk::Order.find_signed(token)
# => ArgumentError: Expected corresponding value for ["shop_id", "id"] to be an Array
```

Hits anyone using `find_signed` on a CPK model — for example, a magic sign-in link, password reset, or email confirmation that scopes its token to such a record.

## Root cause

`find_signed` calls

```ruby
find_by primary_key => id
```

at [`signed_id.rb`](https://github.com/rails/rails/blob/ff34428f313091cd579d7790b13cd7206c2efab9/activerecord/lib/active_record/signed_id.rb#L73). For composite primary keys, `primary_key` is an array (`["shop_id", "id"]`) and the verified `id` is also an array of values (`[37647470, 75294940]`). The predicate builder treats an array key as a request for multiple records and expects the value to be an array of arrays (`[[shop_id, id], [shop_id, id], ...]`). It iterates the inner values, finds non-arrays, and raises:

[predicate_builder.rb](https://github.com/rails/rails/blob/ff34428f313091cd579d7790b13cd7206c2efab9/activerecord/lib/active_record/relation/predicate_builder.rb#L95):
```
ArgumentError: Expected corresponding value for ["shop_id", "id"] to be an Array
```

`find_signed!` does not hit this because it uses `find(id)`, which dispatches to `find_one` and zips `primary_key` with `id` for CPK at [`finder_methods.rb`](https://github.com/rails/rails/blob/ff34428f313091cd579d7790b13cd7206c2efab9/activerecord/lib/active_record/relation/finder_methods.rb#L529-L533).

>[!NOTE]
>
> ### Prior art
> 
> The same class of bug was fixed for `find_by_token_for` in [`8617a7c`](https://github.com/rails/rails/commit/8617a7ce2ef4236f085e967b3fe3159e82bdb5d5) (September 2024, by @fatkodima), where `find_by(model.primary_key => id)` was changed to `find_by(model.primary_key => [id])` in `token_for.rb`. `signed_id.rb` has the identical pattern but was not updated at that time.

## Fix

Mirror the `find_one` pattern in `find_signed`:

```ruby
if id = signed_id_verifier.verified(...)
  if composite_primary_key?
    find_by(primary_key.zip(id).to_h)
  else
    find_by(primary_key => id)
  end
end
```

`find_by` (rather than `find`) is preserved so relation scoping via `SignedId::RelationMethods#find_signed` still works (e.g. `Cpk::Order.where(...).find_signed(token)`).

>[!NOTE]
>
> ### Why `zip` instead of wrapping in an array?
> 
> The `token_for.rb` fix wraps the value in an extra array (`find_by(primary_key => [id])`), which works because the predicate builder interprets it as "find one record matching this composite key tuple." This PR instead uses `primary_key.zip(id).to_h`, which produces a plain conditions hash (e.g. `{ shop_id: 37647470, id: 75294940 }`).
> 
> I chose the `zip` approach because:
> 
> 1. It mirrors the pattern already used in `find_one` ([`finder_methods.rb`](https://github.com/rails/rails/blob/ff34428f313091cd579d7790b13cd7206c2efab9/activerecord/lib/active_record/relation/finder_methods.rb#L529-L533)), keeping the CPK handling consistent across the codebase.
> 2. The intent is immediately clear — each key column is explicitly paired with its value — whereas `[id]` requires understanding how the predicate builder disambiguates single-tuple vs multi-record lookups.
> 
> Either approach produces the same query; this is purely a readability choice.

## Tests

Three new tests in `signed_id_test.rb` cover:

- `find_signed` round trip with CPK
- `find_signed` on a relation with CPK (positive + negative scope)
- `find_signed!` round trip with CPK (regression guard)

Added a CHANGELOG entry.

Without the fix, the first two fail with the `ArgumentError` shown above; with the fix, the full file (38 tests, 56 assertions) passes. CI will exercise MySQL and PostgreSQL as well.