### PR TITLE
Optimize `ActiveRecord::Relation#extending!` to skip work when called with empty modules

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -161,10 +161,7 @@ module ActiveRecord
             relation.order!(*other.order_values)
           end
 
-          unless other.extensions.empty?
-            extensions = other.extensions - relation.extensions
-            relation.extending!(*extensions) if extensions.any?
-          end
+          relation.extending!(*other.extensions)
         end
 
         def merge_single_values

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1463,6 +1463,8 @@ module ActiveRecord
     end
 
     def extending!(*modules, &block) # :nodoc:
+      return self if modules.empty? && !block
+
       modules << Module.new(&block) if block
       modules.flatten!
 


### PR DESCRIPTION
Follow-up to #57199 by @fatkodima, applying the suggestion from the code review.

Instead of guarding at the call site in `merge_multi_values` only, move the early-return guard into `AR::Relation#extending!` itself so all callers benefit universally. The merger retains its own call-site guard since skipping the method call entirely is measurably faster on the hot path (empty extensions).

**Changes:**
- `extending!` returns `self` immediately if no modules and no block are given
- `merge_multi_values` simplified to `relation.extending!(*other.extensions) unless other.extensions.empty?`, removing the manual `a - b` set difference (dedup now handled by `|=` inside `extending!`)

Deduplication is already covered by https://github.com/rails/rails/blob/main/activerecord/test/cases/relation_test.rb#L45-L62

/cc @fatkodima @Hackerbee