### PR TITLE
Use ** in .dockerignore template for recursive directory exclusions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -15,23 +15,19 @@
 /config/credentials/*.key
 
 # Ignore all logfiles and tempfiles.
-/log/*
-/tmp/*
+/log/**
+/tmp/**
 <% if keeps? -%>
 !/log/.keep
 !/tmp/.keep
-
-# Ignore pidfiles, but keep the directory.
-/tmp/pids/*
 !/tmp/pids/.keep
 <% end -%>
 <% unless skip_storage? -%>
 
 # Ignore storage (uploaded files in development and any SQLite databases).
-/storage/*
+/storage/**
 <% if keeps? -%>
 !/storage/.keep
-/tmp/storage/*
 !/tmp/storage/.keep
 <% end -%>
 <% end -%>
@@ -39,7 +35,7 @@
 
 # Ignore assets.
 /node_modules/
-/app/assets/builds/*
+/app/assets/builds/**
 !/app/assets/builds/.keep
 /public/assets
 <% end -%>


### PR DESCRIPTION
## Summary

Replace single-level glob patterns (`*`) with recursive ones (`**`) in the generated `.dockerignore` to ensure nested subdirectories and their contents are excluded from the Docker build context.

Previously, patterns like `/log/*` and `/tmp/*` only matched files directly inside those directories, not files in subdirectories. Using `**` ensures full recursive exclusion. See [Docker docs on `.dockerignore` matching](https://docs.docker.com/build/concepts/context/#matching) for details.

## Changes

- `/log/*` → `/log/**`
- `/tmp/*` → `/tmp/**`
- `/storage/*` → `/storage/**`
- `/app/assets/builds/*` → `/app/assets/builds/**`
- Remove redundant `/tmp/pids/**` and `/tmp/storage/**` (already covered by `/tmp/**`)
- Group all `/tmp/**` negations (`!/tmp/.keep`, `!/tmp/pids/.keep`, `!/tmp/storage/.keep`) together for consistency

## Why it matters

With the old `*` pattern, the following files were **not** excluded from the build context:

- `tmp/cache/assets/sprockets/v4.0.0/ab/abcdef1234...` — Sprockets asset cache is deeply nested and would bloat the build context
- `tmp/pids/server.pid` — server PID file inside a subdirectory
- `storage/ab/cd/abcdefghijklmn` — Active Storage disk service stores files two levels deep by key prefix, meaning uploaded user files could be inadvertently included in the image