### PR TITLE
Action Cable: explicitly require sibling deps in Redis adapter

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -7,6 +7,9 @@ require "redis"
 
 require "active_support/core_ext/hash/except"
 
+require "action_cable/subscription_adapter/base"
+require "action_cable/subscription_adapter/channel_prefix"
+
 module ActionCable
   module SubscriptionAdapter
     class Redis < Base # :nodoc:


### PR DESCRIPTION
### Motivation / Background

The Redis subscription adapter file references two sibling constants at file-load time:

```ruby
class Redis < Base
  prepend ChannelPrefix
```

Action Cable opts the `subscription_adapter/` directory out of eager_load via [`loader.do_not_eager_load(...)`](https://github.com/rails/rails/blob/main/actioncable/lib/action_cable.rb), so `Base` and `ChannelPrefix` are resolved through Zeitwerk's lazy autoload on first reference to the Redis adapter. Under concurrent first-references the autoload-management window is racy and produces:

```
NameError: uninitialized constant ActionCable::SubscriptionAdapter::Base
    class Redis < Base # :nodoc:
                  ^^^^
Did you mean? Base64
```

The race window itself is small, but the *failure state* persists for the lifetime of the affected process: once a process loses the race, the autoload pointer for `Base` has been consumed and `Redis` is never defined. Every subsequent broadcast in that process raises `NameError` until the process is recycled. We observed this in production on a Rails 7.2.3.1 app under Puma cluster mode — a single host accumulated ~500 events across 15 sister Sentry issues over ~80 minutes before being replaced.

### Detail

This patch makes the file's sibling dependencies explicit:

```ruby
require "action_cable/subscription_adapter/base"
require "action_cable/subscription_adapter/channel_prefix"
```

Two reasons this is the right shape:

1. **Matches the file's existing style.** `redis.rb` already explicitly requires `redis` and `active_support/core_ext/hash/except` at the top.
2. **Matches the stated intent in `actioncable.rb`.** The `do_not_eager_load` line is annotated with the comment "Adapters are required and loaded on demand" — meaning the adapter files are expected to load their own dependencies, not rely on Zeitwerk autoload at evaluation time.

### Scope

The same pattern affects `subscription_adapter/test.rb`, `async.rb`, `inline.rb`, and `postgresql.rb` — each references a sibling at file-load time without explicit require. I've kept this PR focused on the file where the bug was actually observed and reproduced. Happy to extend if preferred.

### Tests

The race is non-deterministic — it requires Zeitwerk's internal autoload-management transition to overlap with a constant lookup from another thread. A deterministic regression test would need to either manipulate `$LOADED_FEATURES` + `Module#remove_const` (which pollutes the test process) or run in a subshell. Happy to add one if maintainers prefer a particular shape.

### Related

- rails/rails#50802 (Zeitwerk deadlock)
- fxn/zeitwerk#52 (autoload thread-safety)
- fxn/zeitwerk#198 (sidekiq+bootsnap autoload race)

### Checklist

- [x] Patch is small and focused
- [x] Matches existing file style
- [x] Existing requires demonstrate the file already declares its dependencies explicitly
- [ ] Test added (skipped — see above; happy to add)
- [N/A] CHANGELOG entry (not required for bug fixes per CONTRIBUTING)
