### PR TITLE
Enable frozen string literal by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Enable Ruby `frozen_string_literal` by default.
+
+    New Rails apps now include a `config/bootsnap.rb` file that enables frozen string
+    literals. This only impact the application code, not the dependencies.
+
+    It is also possible to enable it for dependencies for reduce allocations, but
+    some older gems may not yet be compatible. If you do attempt this an run into
+    incompatibilites please do report it on the gem bug tracker.
+
+    Additionally, `.rubocop.yml` is configured to assume frozen string literals
+    are enabled, if you decide not to enable frozen string literals for your application,
+    make sureto update the rubocop configuration accordingly.
+
+    *Jean Boussier*
+
 *   Add offline fallback page to the PWA scaffold.
 
     New Rails apps now include an `app/views/pwa/offline.html.erb` template and

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -128,6 +128,7 @@ module Rails
         template "application.rb"
         template "environment.rb"
         template "bundler-audit.yml" unless skip_bundler_audit?
+        template "bootsnap.rb" if depend_on_bootsnap?
         template "cable.yml" unless options[:update] || skip_action_cable?
         template "ci.rb"
         template "puma.rb"

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -27,7 +27,7 @@ gem "solid_cable"
 <% if depend_on_bootsnap? -%>
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", require: false
+gem "bootsnap", ">= 1.24", require: false
 <% end -%>
 <% unless options.skip_kamal? -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/config/bootsnap.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/bootsnap.rb.tt
@@ -1,0 +1,4 @@
+# Enable frozen string literal across the app, but not dependencies.
+# This configuration should be kept in sync with
+# `AllCops/StringLiteralsFrozenByDefault` in `.rubocop.yml`
+Bootsnap.enable_frozen_string_literal(app_only: true)

--- a/railties/lib/rails/generators/rails/app/templates/rubocop.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/rubocop.yml.tt
@@ -1,6 +1,12 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+<% if depend_on_bootsnap? -%>
+AllCops:
+    # This configuration should be kept in sync with `config/bootsnap.rb`
+    StringLiteralsFrozenByDefault: true
+
+<% end -%>
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -768,6 +768,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file ".kamal/secrets"
   end
 
+  def test_inclusion_of_bootsnap_files
+    generator [destination_root]
+    run_generator_instance
+
+    assert_file "config/bootsnap.rb"
+  end
+
   def test_kamal_files_are_skipped_if_required
     generator [destination_root], ["--skip-kamal"]
     run_generator_instance


### PR DESCRIPTION
Ref: https://github.com/rails/bootsnap/pull/535

This only impact the app own code, and not dependencies. It is also possible to enable it for gems, but some old ones may still not be ready.
