### PR TITLE
Fix `ConnectionPool#release_connection` to honor provided lease

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -430,7 +430,7 @@ module ActiveRecord
       def release_connection(existing_lease = nil)
         return if self.discarded?
 
-        if conn = connection_lease.release
+        if conn = (existing_lease || connection_lease).release
           checkin conn
           return true
         end

--- a/activerecord/test/cases/connection_handling_test.rb
+++ b/activerecord/test/cases/connection_handling_test.rb
@@ -77,6 +77,18 @@ module ActiveRecord
         ActiveRecord::Base.release_connection
       end
 
+      test "#release_connection releases the given lease" do
+        ActiveRecord::Base.release_connection
+        leased_connection = ActiveRecord::Base.lease_connection
+        empty_lease = ActiveRecord::ConnectionAdapters::ConnectionPool::Lease.new
+
+        assert_not ActiveRecord::Base.connection_pool.release_connection(empty_lease)
+        assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
+        assert_same leased_connection, ActiveRecord::Base.lease_connection
+      ensure
+        ActiveRecord::Base.release_connection
+      end
+
       test "#with_connection use the already leased connection if available" do
         leased_connection = ActiveRecord::Base.lease_connection
         assert_predicate ActiveRecord::Base.connection_pool, :active_connection?


### PR DESCRIPTION

### Motivation / Background
`ConnectionPool#release_connection` accepts an optional lease argument, but it was always releasing the current execution context’s lease instead.

### Changes
This changes it to release the provided lease when one is passed, falling back to the current context lease otherwise.

### Detail

- Use `existing_lease || connection_lease` in `release_connection`
- Add regression coverage to ensure passing an unrelated empty lease does not release the current active connection
- Add Active Record changelog entry
- 
### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
