### PR TITLE
fix(active_storage): preserve attachment_changes across record reload

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -318,7 +318,7 @@ module ActiveStorage
     end
 
     def reload(*) # :nodoc:
-      super.tap { @attachment_changes = nil }
+      super.tap { @active_storage_attached = nil }
     end
   end
 end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -430,6 +430,21 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_predicate @user.avatar, :attached?
   end
 
+  test "reload preserves pending attachment changes" do
+    @user.avatar = fixture_file_upload("racecar.jpg")
+    assert_includes @user.attachment_changes, "avatar"
+    @user.reload
+    assert_includes @user.attachment_changes, "avatar",
+      "reload must not discard unsaved attachment changes"
+  end
+
+  test "attachment assignment survives a reload before save" do
+    @user.avatar = fixture_file_upload("racecar.jpg")
+    @user.reload
+    @user.save!
+    assert_nothing_raised { @user.avatar.download }
+  end
+
   test "attaching an existing blob to a new record" do
     User.new(name: "Jason").tap do |user|
       user.avatar.attach create_blob(filename: "funky.jpg")


### PR DESCRIPTION
When a record with a pending attachment (set but not yet saved) is reloaded, `@attachment_changes` was unconditionally set to nil. Any attachment change that had already been written to the database via `after_save` but not yet uploaded to the storage service via `after_commit` would be silently dropped, leaving a dangling attachment record with no corresponding file on the service.

The typical trigger is an explicit outer transaction: save writes the attachment record, then the application calls reload (e.g. to refresh other columns), and the outer transaction commits — at which point `after_commit` finds an empty `attachment_changes` hash and skips the upload.

Fix: reset `@active_storage_attached` (the memoised proxy objects) on reload rather than `@attachment_changes` (the pending uploads). Resetting the proxy cache is still correct — it forces the next access to re-read the underlying association from the freshly reloaded record — but the upload queue is preserved so `after_commit` can finish the job.

Adds two regression tests:
- pending attachment_changes survive reload
- an assignment → reload → save round-trip still delivers a downloadable file

Fixes #57222

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
