### PR TITLE
Fix #56853: Tolerate Bootsnap LoadError in generated boot.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -2,5 +2,9 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
 <% if depend_on_bootsnap? -%>
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+begin
+  require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+rescue LoadError => error
+  warn "Bootsnap disabled: #{error.message}" if ENV["BOOTSNAP_WARN"]
+end
 <%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1197,7 +1197,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     unless defined?(JRUBY_VERSION)
       assert_gem "bootsnap"
       assert_file "config/boot.rb" do |content|
+        assert_match(/^\s*begin$/, content)
         assert_match(/require "bootsnap\/setup"/, content)
+        assert_match(/rescue LoadError => error/, content)
+        assert_match(/warn "Bootsnap disabled: #\{error\.message\}" if ENV\["BOOTSNAP_WARN"\]/, content)
+        assert_match(/^\s*end$/, content)
       end
     else
       assert_no_gem "bootsnap"


### PR DESCRIPTION
**Problem**: New apps generated by rails new can fail CI “System Tests” when [boot.rb](app://-/index.html?hostId=local#) raises LoadError on require "bootsnap/setup".
**Change**: Wrap Bootsnap require in a begin … rescue LoadError block in the app template; optional warning behind ENV["BOOTSNAP_WARN"].
**Tests**: Updated [app_generator_test.rb](app://-/index.html?hostId=local#) expectations (run cd railties && bin/test test/generators/app_generator_test.rb -n "/test_bootsnap/").
**Notes**: Keeps Bootsnap enabled by default when available; falls back gracefully when not.