### PR TITLE
Fix #57197: Preserve retry_job wait when enqueue is deferred

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `retry_job` to respect `:wait` when enqueue is deferred until after transaction commit.
+
+    *Maryam Fayyaz*
+
 *   Deprecate built-in `queue_classic` Active Job adapter.
 
     *Harun Sabljaković, Wojciech Wnętrzak*

--- a/activejob/lib/active_job/enqueue_after_transaction_commit.rb
+++ b/activejob/lib/active_job/enqueue_after_transaction_commit.rb
@@ -25,9 +25,16 @@ module ActiveJob
       def raw_enqueue
         if self.class.enqueue_after_transaction_commit
           self.successfully_enqueued = true
+          scheduled_at, queue_name, priority = self.scheduled_at, self.queue_name, self.priority
           ActiveRecord.after_all_transactions_commit do
             self.successfully_enqueued = false
-            super
+            previous_scheduled_at, previous_queue_name, previous_priority = self.scheduled_at, self.queue_name, self.priority
+            self.scheduled_at, self.queue_name, self.priority = scheduled_at, queue_name, priority
+            begin
+              super
+            ensure
+              self.scheduled_at, self.queue_name, self.priority = previous_scheduled_at, previous_queue_name, previous_priority
+            end
           end
           self
         else

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -73,6 +73,42 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
   end
 
+  test "#retry_job respects :wait when enqueue is deferred until after commit" do
+    fake_active_record = FakeActiveRecord.new(false)
+    stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do
+      job_class = Class.new(ActiveJob::Base) do
+        self.enqueue_after_transaction_commit = true
+
+        def perform
+          # noop
+        end
+      end
+
+      test_adapter = ActiveJob::QueueAdapters::TestAdapter.new
+      test_adapter.perform_enqueued_jobs = false
+      test_adapter.perform_enqueued_at_jobs = false
+
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = test_adapter
+
+      freeze_time do
+        job = job_class.new
+        job.retry_job wait: 5.seconds
+
+        assert_empty test_adapter.enqueued_jobs
+        assert_nil job.scheduled_at
+
+        fake_active_record.run_after_commit_callbacks
+
+        assert_equal 1, test_adapter.enqueued_jobs.size
+        assert_in_delta 5.seconds.from_now.to_f, test_adapter.enqueued_jobs.last[:at], 0.001
+        assert_nil job.scheduled_at
+      end
+    ensure
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+  end
+
   test "#perform_later wait for transactions to complete before enqueuing the job" do
     fake_active_record = FakeActiveRecord.new
     stub_const(Object, :ActiveRecord, fake_active_record, exists: false) do


### PR DESCRIPTION
**Problem**: When enqueue_after_transaction_commit defers enqueueing, [retry_job(wait: ...)](app://-/index.html?hostId=local#) can lose its delay and enqueue immediately (no scheduled_at / adapter :at).
**Cause**: The actual enqueue happens inside after_all_transactions_commit, after retry_job has restored/cleared transient state, so the deferred super enqueue doesn’t see the original schedule info.
**Fix**: In ActiveJob::EnqueueAfterTransactionCommit#raw_enqueue, capture scheduled_at/queue_name/priority at enqueue time and re-apply them only for the deferred super call.
**Tests**: Add regression test in [enqueue_after_transaction_commit_test.rb](app://-/index.html?hostId=local#) asserting the TestAdapter receives an :at timestamp ~5 seconds in the future.
**Changelog**: Update [CHANGELOG.md](app://-/index.html?hostId=local#).