### PR TITLE
fix routing: mount inside constraints host: block no longer raises ArgumentError

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -643,11 +643,19 @@ module ActionDispatch
           via ||= :all
 
           # Merge scoped constraints and mount constraints
+          # @scope[:blocks] holds callables (lambda/proc from constraints block)
+          # @scope[:constraints] holds request-level constraints (Hash, e.g. host: "example.com")
+          # These serve different purposes — only add to merged if callable
           merged = []
 
           merged.concat(Array(@scope[:blocks])) if @scope[:blocks]
           merged.concat(Array(constraints)) if constraints
-          merged << @scope[:constraints] if @scope[:constraints].present?
+
+          # Merge @scope[:constraints] (Hash) into the constraints Hash, not into merged
+          if @scope[:constraints].present?
+            constraints = {} if constraints.nil? || !constraints.is_a?(Hash)
+            constraints = constraints.merge(@scope[:constraints])
+          end
 
           constraints = merged if merged.any?
 


### PR DESCRIPTION
Fixes rails/rails#57261.

**Regression introduced by:** #56718 (merged 2026-04-27)

**Problem:** When none on / type overlay (rw)
none on /dev type tmpfs (rw,nosuid,mode=0755)
none on /sys type sysfs (ro,noexec,nosuid,dentry_cache_limit=1000)
none on /proc type proc (rw,dentry_cache_limit=1000)
none on /dev/pts type devpts (rw,noexec,nosuid)
none on /dev/shm type tmpfs (rw,noexec,nosuid,mode=1777,size=4096M)
none on /mnt/pub type 9p (rw,nosuid,trans=fd,rfdno=12,wfdno=12,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=0,cache=remote_revalidating,disable_file_handle_sharing,disable_fifo_open,directfs)
none on /mnt/cloud type 9p (rw,nosuid,trans=fd,rfdno=11,wfdno=11,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=0,cache=remote_revalidating,disable_file_handle_sharing,disable_fifo_open,directfs)
none on /sys/fs/cgroup type tmpfs (ro,noexec,nosuid)
none on /sys/fs/cgroup/cpu type cgroup (rw,cpu)
none on /sys/fs/cgroup/cpuacct type cgroup (rw,cpuacct)
none on /sys/fs/cgroup/cpuset type cgroup (rw,cpuset)
none on /sys/fs/cgroup/devices type cgroup (rw,devices)
none on /sys/fs/cgroup/job type cgroup (rw,job)
none on /sys/fs/cgroup/memory type cgroup (rw,memory)
none on /sys/fs/cgroup/pids type cgroup (rw,pids)
none on /__modal/mounts type 9p (rw,nosuid,trans=fd,rfdno=6,wfdno=6,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=1000,cache=remote_revalidating,disable_fifo_open,directfs)
none on /etc/resolv.conf type 9p (ro,noexec,nosuid,trans=fd,rfdno=5,wfdno=5,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=1000,cache=remote_revalidating,disable_fifo_open,directfs)
none on /run/modal_daemon type 9p (rw,noexec,nosuid,trans=fd,rfdno=9,wfdno=9,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=1000,cache=remote_revalidating,disable_fifo_open,directfs)
none on /__modal/.debug_shell type 9p (ro,nosuid,trans=fd,rfdno=10,wfdno=10,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=1000,cache=remote_revalidating,disable_fifo_open,directfs)
none on /__modal/.task-startup type 9p (ro,nosuid,trans=fd,rfdno=7,wfdno=7,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=1000,cache=remote_revalidating,disable_fifo_open,directfs)
none on /sys/devices/virtual/dmi type tmpfs (ro,noexec,nosuid,size=1k)
none on /__modal/.container-arguments type 9p (ro,nosuid,trans=fd,rfdno=8,wfdno=8,aname=/,dfltuid=4294967294,dfltgid=4294967294,dcache=1000,cache=remote_revalidating,disable_fifo_open,directfs) is called inside a  block, the code was pushing  (a Hash like ) into the same array as callable block constraints. This array is later validated by  which requires all elements to respond to  or  — a Hash satisfies neither, hence .

**Fix:** Keep  as a Hash and merge it into the constraints Hash (same pattern used for ,  etc.), rather than pushing it into the merged callable array. This correctly separates request-level conditions (host, protocol) from route-level callables (custom constraint lambdas).