### PR TITLE
Fix: registers ERBTracker instead of RubyTracker when eager_load = true

### DIFF
--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -37,6 +37,7 @@ module ActionView
   eager_autoload do
     autoload :Base
     autoload :Context
+    autoload :DependencyTracker
     autoload :Digestor
     autoload :Helpers
     autoload :LookupContext
@@ -91,7 +92,19 @@ module ActionView
   autoload :CacheExpiry
   autoload :TestCase
 
-  singleton_class.attr_accessor :render_tracker
+  singleton_class.attr_reader :render_tracker
+
+  def self.render_tracker=(value)
+    @render_tracker = value
+    case value
+    when :ruby
+      DependencyTracker.register_tracker :erb, DependencyTracker::RubyTracker
+    else
+      DependencyTracker.register_tracker :erb, DependencyTracker::ERBTracker
+    end
+    value
+  end
+
   self.render_tracker = :regex
 
   def self.eager_load!

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -80,10 +80,6 @@ module ActionView
     end
 
     config.after_initialize do |app|
-      config.after_initialize do
-        ActionView.render_tracker = config.action_view.render_tracker
-      end
-
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
           next if k == :render_tracker
@@ -106,6 +102,10 @@ module ActionView
           ActionView::Resolver.caching = !app.config.reloading_enabled?
         end
       end
+    end
+
+    initializer "action_view.set_render_tracker" do |app|
+      ActionView.render_tracker = app.config.action_view.render_tracker
     end
 
     initializer "action_view.setup_action_pack" do |app|

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -48,6 +48,22 @@ class DependencyTrackerTest < ActionView::TestCase
     assert_equal ["foo/boo/hoo"], dependencies
   end
 
+  def test_changing_render_tracker_re_registers_erb_tracker
+    erb_handler = ActionView::Template.handler_for_extension("erb")
+    trackers = ActionView::DependencyTracker.instance_variable_get(:@trackers)
+    original = ActionView.render_tracker
+
+    ActionView.render_tracker = :ruby
+    assert_equal ActionView::DependencyTracker::RubyTracker, trackers[erb_handler],
+      "Expected RubyTracker after setting render_tracker to :ruby"
+
+    ActionView.render_tracker = :regex
+    assert_equal ActionView::DependencyTracker::ERBTracker, trackers[erb_handler],
+      "Expected ERBTracker after setting render_tracker to :regex"
+  ensure
+    ActionView.render_tracker = original
+  end
+
   def test_returns_empty_array_if_no_tracker_is_found
     template = FakeTemplate.new("boo/hoo", Bowtie)
     dependencies = tracker.find_dependencies("boo/hoo", template)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -529,6 +529,19 @@ module ApplicationTests
       assert_includes Rails.application.config.eager_load_namespaces, AppTemplate::Application
     end
 
+    test "load_defaults 8.1 registers RubyTracker for erb under eager_load" do
+      add_to_config <<~RUBY
+        config.enable_reloading = false
+        config.eager_load = true
+      RUBY
+
+      app "production"
+
+      erb_handler = ActionView::Template.handler_for_extension("erb")
+      trackers = ActionView::DependencyTracker.instance_variable_get(:@trackers)
+      assert_equal ActionView::DependencyTracker::RubyTracker, trackers[erb_handler]
+    end
+
     test "the application can be eager loaded even when there are no frameworks" do
       FileUtils.rm_rf("#{app_path}/app/jobs/application_job.rb")
       FileUtils.rm_rf("#{app_path}/app/models/application_record.rb")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes issue #57265 

Fix a bug where `ActionView.render_tracker` was being assigned inside a nested `config.after_initialize` block, which caused it to run too late (after the outer `after_initialize` callbacks had already completed). As a result, when `eager_load: true` was set, the ERB handler was never properly mapped to `RubyTracker` in `ActionView::DependencyTracker`, breaking dependency tracking for ERB templates.

### Detail

This Pull Request changes the assignment of `ActionView.render_tracker` from a nested `config.after_initialize` block to a dedicated `initializer "action_view.set_render_tracker"`, ensuring it runs at the correct point in the boot sequence, before `after_initialize` callbacks fire.

**Before:**
```ruby
config.after_initialize do |app|
  config.after_initialize do
    ActionView.render_tracker = config.action_view.render_tracker
  end
# ...
end
```

**After:**
```ruby
initializer "action_view.set_render_tracker" do |app|
  ActionView.render_tracker = app.config.action_view.render_tracker
end
```

A regression test was added to `railties/test/application/configuration_test.rb` verifying that with `load_defaults 8.1`, `eager_load: true`, and `enable_reloading: false`, the ERB handler is correctly mapped to `ActionView::DependencyTracker::RubyTracker`.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.