### PR TITLE
Defer ViewReloader build when no view paths are registered

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Defer the View watcher build until view paths are actually registered.
+
+    *Hugo Vacher*
+
 *   Skip blank attribute names in tag helpers to avoid generating invalid HTML.
 
     *Mike Dalessio*

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -9,13 +9,11 @@ module ActionView
         @watched_dirs = nil
         @watcher = nil
         @previous_change = false
-
-        ActionView::PathRegistry.file_system_resolver_hooks << method(:rebuild_watcher)
       end
 
       def updated?
         build_watcher unless @watcher
-        @previous_change || @watcher.updated?
+        @previous_change || @watcher&.updated?
       end
 
       def execute
@@ -29,6 +27,11 @@ module ActionView
         watcher.execute
       end
 
+      def rebuild_watcher
+        return unless @watcher
+        build_watcher
+      end
+
       private
         def reload!
           ActionView::LookupContext::DetailsKey.clear
@@ -36,10 +39,15 @@ module ActionView
 
         def build_watcher
           @mutex.synchronize do
+            new_dirs = dirs_to_watch
+
+            # Skip the build entirely if there are no view paths to watch and we have not built a watcher yet.
+            return if new_dirs.empty? && @watcher.nil?
+
             old_watcher = @watcher
 
-            if @watched_dirs != dirs_to_watch
-              @watched_dirs = dirs_to_watch
+            if @watched_dirs != new_dirs
+              @watched_dirs = new_dirs
               new_watcher = @watcher_class.new([], @watched_dirs) do
                 reload!
               end
@@ -50,11 +58,6 @@ module ActionView
               @previous_change ||= old_watcher&.updated?
             end
           end
-        end
-
-        def rebuild_watcher
-          return unless @watcher
-          build_watcher
         end
 
         def dirs_to_watch

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -127,6 +127,7 @@ module ActionView
 
       unless enable_caching
         view_reloader = ActionView::CacheExpiry::ViewReloader.new(watcher: app.config.file_watcher)
+        ActionView::PathRegistry.file_system_resolver_hooks << view_reloader.method(:rebuild_watcher)
 
         app.reloaders << view_reloader
         app.reloader.to_run do

--- a/actionview/test/template/cache_expiry_test.rb
+++ b/actionview/test/template/cache_expiry_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class CacheExpiryViewReloaderTest < ActiveSupport::TestCase
+  # A no-op watcher class with the FileUpdateChecker API. Used instead of the
+  # real ActiveSupport::FileUpdateChecker so we can assert exactly when the
+  # watcher is materialized — its #initialize bumps a counter we can read.
+  class CountingWatcher
+    @@built = 0
+
+    class << self
+      def reset!
+        @@built = 0
+      end
+
+      def built
+        @@built
+      end
+    end
+
+    def initialize(_files, _dirs = {}, &block)
+      @block = block
+      @@built += 1
+    end
+
+    def updated?
+      false
+    end
+
+    def execute
+      @block&.call
+    end
+
+    def execute_if_updated
+      false
+    end
+  end
+
+  def setup
+    CountingWatcher.reset!
+    @reloader = ActionView::CacheExpiry::ViewReloader.new(watcher: CountingWatcher)
+  end
+
+  test "#updated? does not build a watcher when there are no view paths to watch" do
+    ActionView::PathRegistry.stub(:all_file_system_resolvers, []) do
+      assert_not @reloader.updated?
+    end
+
+    assert_equal 0, CountingWatcher.built
+  end
+
+  test "#rebuild_watcher is a no-op while @watcher has not been built" do
+    @reloader.rebuild_watcher
+
+    assert_equal 0, CountingWatcher.built
+  end
+
+  test "updated? builds a watcher once view paths are registered" do
+    paths = []
+    ActionView::PathRegistry.stub(:all_file_system_resolvers, paths) do
+      @reloader.updated?
+    end
+    assert_equal 0, CountingWatcher.built
+
+    paths << resolver_for_path("fixtures")
+    ActionView::PathRegistry.stub(:all_file_system_resolvers, paths) do
+      @reloader.updated?
+    end
+
+    assert_equal 1, CountingWatcher.built
+  end
+
+  test "#rebuild_watcher rebuilds the watcher after the first build" do
+    paths = [resolver_for_path("fixtures")]
+    ActionView::PathRegistry.stub(:all_file_system_resolvers, paths) do
+      @reloader.updated?
+    end
+
+    assert_equal 1, CountingWatcher.built
+
+    paths = paths << resolver_for_path("../fixtures/test")
+    ActionView::PathRegistry.stub(:all_file_system_resolvers, paths) do
+      @reloader.rebuild_watcher
+    end
+
+    assert_equal 2, CountingWatcher.built
+  end
+
+  private
+    def resolver_for_path(path)
+      ActionView::PathRegistry.cast_file_system_resolvers(path).first
+    end
+end


### PR DESCRIPTION
### Summary

Follow-up to #51308 ("Do not build View watcher until the first `updated?` check").

### Root cause

#51308's lazy guard relies on `@watcher` staying `nil` until view paths are registered. But it breaks when `updated?` is called while `dirs_to_watch` is still an empty array. [`#build_watcher`](https://github.com/rails/rails/blob/83423052fc899315fad91c20b5197a186fc8f0fd/actionview/lib/action_view/cache_expiry.rb#L37-L48) still constructs an empty `FileUpdateChecker` and assigns it to `@watcher`. From then on the [`return unless @watcher`](https://github.com/rails/rails/blob/83423052fc899315fad91c20b5197a186fc8f0fd/actionview/lib/action_view/cache_expiry.rb#L55-L58) guard in `#rebuild_watcher` is open, and every engine's subsequent `prepend_view_path` triggers a full `Dir[*globs] + File.mtime` rescan on the cumulative dir set.

Spring hits this when running a test with a warm cache, the preloader walks `Rails.application.reloaders` directly to decide whether to `reload!` before forking ([`spring/lib/spring/application.rb:197`](https://github.com/rails/spring/blob/main/lib/spring/application.rb#L197)) — bypassing `Reloader.check!`. Most engines' `prepend_view_path` calls live behind `ActiveSupport.on_load(:action_mailer)` / `:action_controller_base`, which haven't fired yet in Spring's preload phase, so the probe materializes an empty watcher and pins `@watcher` non-nil for every fork.

### Example

Assuming the (extreme) case where we would have 10 `prepend_view_path` calls:

**Pre-fix**:

 | Step | Real work? |
 |---|---|
 | Early-boot `updated?`  | no (cheap) |
 | `prepend_view_path` ×10 |  **10 real rebuilds** |
 | First request `updated?` |  no rebuild |

 **Post-fix**:

 | Step | Real work? |
 |---|---|
 | Early-boot `updated?` | no |
 | `prepend_view_path` ×10  | **0 rebuilds** |
 | First request `updated?`  | **1 build** |

### Impact

Measured on a Spring-warm test loop in Shopify's Rails monorepo, wall-time on a small workload drops from 5.16 s → 3.66 s (-29 %). Behavior is unchanged for production (`cache_classes = true` skips ViewReloader entirely) and for any app where view paths are registered before the first reloader probe.
