### PR TITLE
Gracefully handle `nil` during multi-parameter assignment

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Treat `nil` values as `""` during multi-parameter attribute assignment
+
+    ```ruby
+    topic = Topic.where.not(last_read: nil).first
+    topic.attributes = { "last_read(1i)" => nil, "last_read(2i)" => nil, "last_read(3i)" => nil }
+    topic.last_read # => nil
+    ```
+
+    *Sean Doyle*
+
 *   Bump the minimum PostgreSQL version to 10.0.
 
     As part of this change, `supports_pgcrypto_uuid?` is deprecated because

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -64,7 +64,7 @@ module ActiveRecord
           attribute_name = multiparameter_name.split("(").first
           attributes[attribute_name] ||= {}
 
-          parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
+          parameter_value = value.blank? ? nil : type_cast_attribute_value(multiparameter_name, value)
           attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
         end
 

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -65,6 +65,13 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     assert_nil topic.last_read
   end
 
+  def test_multiparameter_attributes_on_date_with_all_nil
+    attributes = { "last_read(1i)" => nil, "last_read(2i)" => nil, "last_read(3i)" => nil }
+    topic = Topic.find(1)
+    topic.attributes = attributes
+    assert_nil topic.last_read
+  end
+
   def test_multiparameter_attributes_on_time
     with_timezone_config default: :local do
       attributes = {


### PR DESCRIPTION
### Motivation / Background

When assigning to multi-parameter attributes (like `Date` columns), Active Record currently handles `""` values as empty values, resulting in the following:

```ruby
topic = Topic.where.not(last_read: nil).first
topic.attributes = { "last_read(1i)" => "", "last_read(2i)" => "", "last_read(3i)" => "" }
topic.last_read # => nil
```

However, if the `""` values are replaced with `nil`, the assignment raises a `NoMethodError`:

```
NoMethodError: undefined method 'empty?' for nil
```

### Detail

In this scenario, `""` and `nil` are semantically equivalent: the value is absent. However, the implementation invokes [String#empty?][], which is *not* implemented by [NilClass][].

This commit proposes that the implementation check for [String#blank?][] instead (which relies on [String#empty?][] under the hood), since there is also a [NilClass#blank?][] implementation.

```ruby
topic = Topic.where.not(last_read: nil).first
topic.attributes = { "last_read(1i)" => nil, "last_read(2i)" => nil, "last_read(3i)" => nil }
topic.last_read # => nil
```

[String#empty?]: https://ruby-doc.org/3.4.1/String.html#method-i-empty-3F
[NilClass]: https://edgeapi.rubyonrails.org/classes/NilClass.html
[String#blank?]: https://edgeapi.rubyonrails.org/classes/String.html#method-i-blank-3F
[NilClass#blank?]: https://edgeapi.rubyonrails.org/classes/NilClass.html#method-i-blank-3F

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
