### PR TITLE
fix surprising behaviour during value lookup in datetime helpers

### DIFF
--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -6,7 +6,7 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = datetime_value(options.fetch("value", value))
+          options["value"] = datetime_value(options.fetch("value") { value })
           options["min"] = format_datetime(parse_datetime(options["min"]))
           options["max"] = format_datetime(parse_datetime(options["max"]))
           @options = options

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2003,6 +2003,13 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
+  def test_datetime_field_does_not_try_to_look_up_value_dynamically_when_explicitly_provided
+    @template_object = Post.new
+    expected = '<input value="2026-04-29T00:00:00" type="datetime-local" id="template_object_foo" name="template_object[foo]">'
+    actual = datetime_field("template_object", "foo", value: Date.parse("2026-04-29"))
+    assert_dom_equal expected, actual
+  end
+
   def test_form_for_with_nested_attributes_field_id
     post, comment, tag = Post.new, Comment.new, Tag.new
     comment.relevances = [tag]


### PR DESCRIPTION
`datetime_field("object", "field")` attempts to look up the input value by calling the method in the `field` variable on the object found in `"@#{object}"`

When the helper is called with the `value` keyword, eg:  `datetime_field("object", "field", value: "2024-04-30")`

this lookup should not happen as it leads to surprising behaviour including unexpected errors.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because we encountered some very confusing errors during a rails upgrade. The error occurred because our view contained `date_field("start_time", "date", value: @start_time)`. Even though the value was passed in explicitly, the code generated the following, rather confusing error: `NoMethodError: undefined method 'date' for an instance of Date` as a result of calling `@start_time.date`

### Detail

This Pull Request changes the datetime form helper and its subclasses in a way that the dynamic value lookup is now only executed when the input value is not found under the keyword argument. This change makes it behave the same way as `Tags::TextField`, which in inherits from.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
