### PR TITLE
Fix preloader batch merging for parallel scoped through

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,8 +1,15 @@
-*   Fix preloads where multiple scoped `has_many :through` associations share the same query but must not share one batch loader (regression appeared as wrong STI/type rows when nesting `includes` with the same `:through`).
+*   Fix eager loading nested `includes` when several scoped parallel `has_many :through`
+    associations reuse the same through table/query.
+
+    Sibling loaders now concatenate `records_by_owner` hashes instead of using `Hash#merge`,
+    which last-winned overlapped owners. Inner through preloads additionally carry the outer
+    `has_many :through` reflection into batch partitioning so loaders that share identical SQL but
+    must not share one inverse/STI batch are split; outer reflections that are non-collection (e.g.
+    `has_one :through`) are excluded so unrelated sibling preloads stay merged into one query.
 
     Fixes #52061.
 
-    *Edilbek Talantbek uulu*
+    *Edil Talantbek uulu*
 
 *   Bump the minimum PostgreSQL version to 10.0.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix preloads where multiple scoped `has_many :through` associations share the same query but must not share one batch loader (regression appeared as wrong STI/type rows when nesting `includes` with the same `:through`).
+
+    Fixes #52061.
+
+    *Edilbek Talantbek uulu*
+
 *   Bump the minimum PostgreSQL version to 10.0.
 
     As part of this change, `supports_pgcrypto_uuid?` is deprecated because

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -96,7 +96,8 @@ module ActiveRecord
       # associations before querying the database. This can save database
       # queries by reusing in-memory objects. The optimization is only applied
       # to single associations (i.e. :belongs_to, :has_one) with no scopes.
-      def initialize(records:, associations:, scope: nil, available_records: [], associate_by_default: true)
+      def initialize(records:, associations:, scope: nil, available_records: [], associate_by_default: true,
+        through_parent_reflection: nil)
         @records = records
         @associations = associations
         @scope = scope
@@ -108,7 +109,8 @@ module ActiveRecord
           association: nil,
           children: @associations,
           associate_by_default: @associate_by_default,
-          scope: @scope
+          scope: @scope,
+          through_parent_reflection: through_parent_reflection
         )
         @tree.preloaded_records = @records
       end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -99,9 +99,10 @@ module ActiveRecord
             end
         end
 
-        attr_reader :klass
+        attr_reader :klass, :through_parent_reflection
 
-        def initialize(klass, owners, reflection, preload_scope, reflection_scope, associate_by_default)
+        def initialize(klass, owners, reflection, preload_scope, reflection_scope, associate_by_default,
+          through_parent_reflection: nil)
           @klass         = klass
           @owners        = owners.uniq(&:__id__)
           @reflection    = reflection
@@ -109,6 +110,7 @@ module ActiveRecord
           @reflection_scope = reflection_scope
           @associate     = associate_by_default || !preload_scope || preload_scope.empty_scope?
           @model         = owners.first && owners.first.class
+          @through_parent_reflection = through_parent_reflection
           @run = false
         end
 

--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -40,11 +40,14 @@ module ActiveRecord
           def group_and_load_similar(loaders)
             non_through = loaders.grep_v(ThroughAssociation)
 
+            # #52061: loaders can share the same LoaderQuery (SQL) but different
+            # Relation instances; merging their batches breaks set_inverse for
+            # parallel scoped has_many :through preloads.
             grouped = non_through.group_by do |loader|
-              [loader.loader_query, loader.klass]
+              [loader.loader_query, loader.klass, loader.scope.object_id]
             end
 
-            grouped.each do |(query, _klass), similar_loaders|
+            grouped.each do |(query, _klass, _scope_id), similar_loaders|
               query.load_records_in_batch(similar_loaders)
             end
           end

--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -40,14 +40,14 @@ module ActiveRecord
           def group_and_load_similar(loaders)
             non_through = loaders.grep_v(ThroughAssociation)
 
-            # #52061: loaders can share the same LoaderQuery (SQL) but different
-            # Relation instances; merging their batches breaks set_inverse for
-            # parallel scoped has_many :through preloads.
             grouped = non_through.group_by do |loader|
-              [loader.loader_query, loader.klass, loader.scope.object_id]
+              # Parallel scoped has_many :through preloads can share identical inner loaders
+              # (same through reflection + LoaderQuery); merging those batches mishandles callbacks
+              # and STI/source rows (#52061). Tagged only for has_many :through outer reflections.
+              [loader.loader_query, loader.klass, loader.through_parent_reflection]
             end
 
-            grouped.each do |(query, _klass, _scope_id), similar_loaders|
+            grouped.each do |(query, _klass), similar_loaders|
               query.load_records_in_batch(similar_loaders)
             end
           end

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         attr_reader :scope, :associate_by_default
         attr_writer :preloaded_records
 
-        def initialize(association:, children:, parent:, associate_by_default:, scope:)
+        def initialize(association:, children:, parent:, associate_by_default:, scope:, through_parent_reflection: nil)
           @association = if association
             begin
               @association = association.to_sym
@@ -19,6 +19,7 @@ module ActiveRecord
           @parent = parent
           @scope = scope
           @associate_by_default = associate_by_default
+          @through_parent_reflection = through_parent_reflection
 
           @children = build_children(children)
           @loaders = nil
@@ -101,7 +102,10 @@ module ActiveRecord
 
             [klass, reflection_scope]
           end.map do |(rhs_klass, reflection_scope), rs|
-            preloader_for(reflection).new(rhs_klass, rs, reflection, scope, reflection_scope, associate_by_default)
+            preloader_for(reflection).new(
+              rhs_klass, rs, reflection, scope, reflection_scope, associate_by_default,
+              through_parent_reflection: @through_parent_reflection
+            )
           end
         end
 
@@ -132,7 +136,8 @@ module ActiveRecord
                   association: parent,
                   children: child,
                   associate_by_default: associate_by_default,
-                  scope: scope
+                  scope: scope,
+                  through_parent_reflection: (root? ? @through_parent_reflection : nil)
                 )
               }
             }

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -76,7 +76,16 @@ module ActiveRecord
           end
 
           def through_preloaders
-            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(records: owners, associations: through_reflection.name, scope: through_scope, associate_by_default: false).loaders
+            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(
+              records: owners,
+              associations: through_reflection.name,
+              scope: through_scope,
+              associate_by_default: false,
+              # Only has_many :through can batch inner loaders with disjoint siblings (parallel
+              # scopes on shared join rows; #52061). has_one :through must merge with belongs_to:
+              # e.g. +has_one :author, through: :post+ vs +belongs_to :ordinary_post+ on Post.
+              through_parent_reflection: reflection.collection? ? reflection : nil
+            ).loaders
           end
 
           def through_reflection
@@ -88,11 +97,27 @@ module ActiveRecord
           end
 
           def source_records_by_owner
-            @source_records_by_owner ||= source_preloaders.map(&:records_by_owner).reduce(:merge)
+            @source_records_by_owner ||= merge_records_by_owner(source_preloaders.map(&:records_by_owner))
           end
 
           def through_records_by_owner
-            @through_records_by_owner ||= through_preloaders.map(&:records_by_owner).reduce(:merge)
+            @through_records_by_owner ||= merge_records_by_owner(through_preloaders.map(&:records_by_owner))
+          end
+
+          # Fixes #52061: Hash#merge last-wins when parallel loaders share owner keys.
+          #
+          # Do not use compare_by_identity on the accumulator: loaders can hold different
+          # Ruby instances for the same AR row (`Tagging.first` vs freshly loaded)—identity
+          # keys fragment the hash while #== / #eql? still match AR rows by id/class.
+          def merge_records_by_owner(hashes)
+            merged = {}
+            hashes.each do |h|
+              h.each do |owner, records|
+                (merged[owner] ||= []).concat(Array(records))
+              end
+            end
+            merged.each_value(&:uniq!)
+            merged
           end
 
           def preload_index

--- a/activerecord/test/cases/associations/includes_scoped_through_batch_test.rb
+++ b/activerecord/test/cases/associations/includes_scoped_through_batch_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+# Regression for https://github.com/rails/rails/issues/52061
+class IncludesScopedThroughBatchTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def setup
+    super
+    @connection = ActiveRecord::Base.lease_connection
+    @token = SecureRandom.hex(4)
+    @const_name = :"Issue52061#{@token}"
+    @mod = Object.const_set(@const_name, Module.new)
+    m = @mod
+
+    works_t = "works_#{@token}"
+    tags_t = "tags_#{@token}"
+    taggings_t = "taggings_#{@token}"
+
+    @connection.create_table works_t, force: true
+    @connection.create_table tags_t, force: true do |t|
+      t.string :type
+      t.integer :merger_id
+    end
+    @connection.create_table taggings_t, force: true do |t|
+      t.integer :tag_id
+      t.string :tag_type, limit: 100, default: ""
+      t.integer :work_id
+    end
+
+    m.const_set(:Tagging, Class.new(ActiveRecord::Base) do
+      self.table_name = taggings_t
+    end)
+
+    m.const_set(:Tag, Class.new(ActiveRecord::Base) do
+      self.table_name = tags_t
+      self.inheritance_column = "type"
+    end)
+
+    m.const_set(:Work, Class.new(ActiveRecord::Base) do
+      self.table_name = works_t
+    end)
+
+    m.const_set(:Fandom, Class.new(m::Tag))
+    m.const_set(:Relationship, Class.new(m::Tag))
+
+    m::Tag.const_set(:TYPES, ["Fandom", "Relationship"].freeze)
+
+    m::Tag.class_eval do
+      has_many :mergers, foreign_key: "merger_id", class_name: name
+      belongs_to :merger, class_name: name, optional: true
+
+      has_many :taggings, class_name: m::Tagging.name, inverse_of: :tag
+    end
+
+    m::Tagging.class_eval do
+      belongs_to :tag, polymorphic: true, inverse_of: :taggings
+      belongs_to :work, class_name: m::Work.name, inverse_of: :taggings
+    end
+
+    m::Work.class_eval do
+      has_many :taggings, class_name: m::Tagging.name, inverse_of: :work
+      has_many :tags, through: :taggings, source: :tag
+
+      # Qualified on Tag#arel_table: `where(tags: { ... })` would reference the
+      # logical name "tags", not Tag.table_name ("tags_<token>" in this test).
+      tags_table = m::Tag.arel_table
+      m::Tag::TYPES.each do |type_name|
+        type_model = m.const_get(type_name)
+        has_many type_name.underscore.pluralize.to_sym,
+          # STI discriminator matches #sti_name (full class name under default Rails settings).
+          -> { where(tags_table[:type].eq(type_model.sti_name)) },
+          through: :taggings,
+          source: :tag,
+          source_type: m::Tag.name # not "Tag": constantize resolves under this test module
+      end
+    end
+  end
+
+  def teardown
+    @connection.drop_table "taggings_#{@token}", if_exists: true
+    @connection.drop_table "tags_#{@token}", if_exists: true
+    @connection.drop_table "works_#{@token}", if_exists: true
+    Object.send(:remove_const, @const_name)
+    super
+  end
+
+  def test_parallel_scoped_through_includes_nested_self_association
+    m = @mod
+    f1 = m::Fandom.create!
+    rel1 = m::Relationship.create!
+    work = m::Work.create!
+    # Persist first; multiple scoped throughs on shared join must add rows sequentially
+    # (assigning both in one create! can leave only one side’s taggings depending on reflection merge).
+    work.fandoms << f1
+    work.relationships << rel1
+
+    bare = m::Work.first
+    assert_equal 1, bare.fandoms.count
+    assert_equal 1, bare.relationships.count
+    assert_instance_of m::Fandom, bare.fandoms.sole
+    assert_instance_of m::Relationship, bare.relationships.sole
+
+    loaded = m::Work.includes(fandoms: :merger, relationships: :merger).first
+    assert_equal 1, loaded.fandoms.count
+    assert_equal 1, loaded.relationships.count
+    assert_instance_of m::Fandom, loaded.fandoms.sole
+    assert_instance_of m::Relationship, loaded.relationships.sole
+  end
+end


### PR DESCRIPTION
# Fix #52061 — parallel scoped `has_many :through` eager loading

Partition preloader batches for inner through steps by the **outer** `has_many :through` reflection so parallel scoped throughs that share the same SQL do not corrupt inverse / STI rows when using nested `includes`. Also fix `records_by_owner` merging for sibling through loaders.

**Fixes #52061**

## Motivation / background

Two issues showed up for the same class of setup (parallel scoped `has_many :through` on a shared join, e.g. `includes(fandoms: :merger, relationships: :merger)`):

1. **`Preloader::Batch#group_and_load_similar`** grouped non-through loaders only by `[loader_query, klass]`. Parallel branches can produce **identical** `LoaderQuery` (same SQL) for the **same** inner through association (e.g. `:taggings`) while still representing different outer throughs (`:fandoms` vs `:relationships`). Merging those into one batch meant **`LoaderRecords`** ran **`set_inverse`** for every loader in the batch on each row, which mixed polymorphic / STI through rows.

2. **`ThroughAssociation`** combined `records_by_owner` from multiple through/source preloaders with **`Hash#merge`**, which **last-wins** on shared owner keys and could drop rows from the other branch.

Using **`loader.scope.object_id`** (or any blanket “split all same-SQL batches”) was too coarse: it broke query-count expectations and duplicate-preload merging for unrelated cases (e.g. **`PreloaderTest#test_preload_grouped_queries_of_middle_records`**).

## Detail

This pull request:

- **`activerecord/lib/active_record/associations/preloader/through_association.rb`**
  - Concatenate `records_by_owner` from sibling loaders instead of `Hash#merge` (with `uniq!` per owner), with a short comment on why `compare_by_identity` on the accumulator is unsafe.
  - When building inner **`through_preloaders`**, pass **`through_parent_reflection`** into **`Preloader`** only when the outer reflection is a **collection** through (**`has_many :through`**, i.e. **`reflection.collection?`**). That tags inner through batches so parallel **`has_many :through`** paths split correctly, while **`has_one :through`** does **not** tag—so it still merges with sibling **`belongs_to`** preloads that hit the same table (same SQL, one query).

- **`activerecord/lib/active_record/associations/preloader.rb`**, **`branch.rb`**, **`association.rb`**
  - Thread **`through_parent_reflection`** from the inner preloader root into branch loaders (only the **first** level under that inner tree, so nested `includes` like `:merger` are unchanged).

- **`activerecord/lib/active_record/associations/preloader/batch.rb`**
  - Extend the batch grouping key with **`loader.through_parent_reflection`** (typically `nil`; set only for inner steps of **`has_many :through`**).

- **`activerecord/test/cases/associations/includes_scoped_through_batch_test.rb`**
  - Isolated regression (temporary tables + namespaced STI models aligned with the issue).

- **`activerecord/CHANGELOG.md`**
  - Documents the behavior change and credits **Edil Talantbek uulu**.

## Additional information

### Tests run locally

```bash
bin/test activerecord/test/cases/associations/includes_scoped_through_batch_test.rb
bin/test activerecord/test/cases/associations_test.rb
bin/test activerecord
```

### Issue

[includes loads wrong data for scoped `has_many :through` when eager loading nested self join #52061](https://github.com/rails/rails/issues/52061)

## Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why, and references the issue (e.g. `[Fix #52061]`).
- [x] Tests are added or updated for the bug fix.
- [x] CHANGELOG is updated for the behavior change.
