### PR TITLE
Preserve metadata when mirroring Active Storage blobs

### DIFF
--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -66,10 +66,12 @@ module ActiveStorage
     def mirror(key, checksum:)
       instrument :mirror, key: key, checksum: checksum do
         if (mirrors_in_need_of_mirroring = mirrors.select { |service| !service.exist?(key) }).any?
+          metadata = ActiveStorage::Blob.find_by(key: key)&.send(:service_metadata) || {}
+
           primary.open(key, checksum: checksum) do |io|
             mirrors_in_need_of_mirroring.each do |service|
               io.rewind
-              service.upload key, io, checksum: checksum
+              service.upload key, io, checksum: checksum, **metadata
             end
           end
         end

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -1,8 +1,35 @@
 # frozen_string_literal: true
 
 require "service/shared_service_tests"
+require "database/setup"
 
 class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
+  class RecordingService < ActiveStorage::Service
+    attr_reader :uploads
+
+    def initialize
+      @uploads = []
+      @bytes_by_key = {}
+    end
+
+    def upload(key, io, **options)
+      @uploads << { key: key, options: options }
+      @bytes_by_key[key] = io.read
+    end
+
+    def download(key)
+      @bytes_by_key.fetch(key)
+    end
+
+    def open(key, **)
+      yield StringIO.new(download(key))
+    end
+
+    def exist?(key)
+      @bytes_by_key.key?(key)
+    end
+  end
+
   mirror_config = (1..3).to_h do |i|
     [ "mirror_#{i}",
       service: "Disk",
@@ -77,6 +104,36 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     assert_equal data, @service.mirrors.first.download(key)
     assert_equal data, @service.mirrors.second.download(key)
     assert_equal "Surprise!", @service.mirrors.third.download(key)
+  end
+
+  test "mirroring forwards blob service metadata to secondary services" do
+    primary = RecordingService.new
+    mirror = RecordingService.new
+    service = ActiveStorage::Service::MirrorService.new(primary: primary, mirrors: [ mirror ])
+
+    data = "<!doctype html>"
+    checksum = OpenSSL::Digest::MD5.base64digest(data)
+    blob = ActiveStorage::Blob.create_before_direct_upload!(
+      key: SecureRandom.base58(24),
+      filename: "page.html",
+      byte_size: data.bytesize,
+      checksum: checksum,
+      content_type: "text/html",
+      metadata: { custom: { "tenant" => "rails" } }
+    )
+
+    primary.upload blob.key, StringIO.new(data), checksum: checksum
+
+    service.mirror blob.key, checksum: checksum
+
+    assert_equal data, mirror.download(blob.key)
+    assert_equal({
+      checksum: checksum,
+      content_type: ActiveStorage.binary_content_type,
+      disposition: :attachment,
+      filename: blob.filename,
+      custom_metadata: { "tenant" => "rails" }
+    }, mirror.uploads.last[:options])
   end
 
   test "URL generation in primary service" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because `ActiveStorage::Service::MirrorService#mirror` copies blobs from the primary service to mirror services with only the checksum. That drops upload metadata such as `content_type`, `disposition`, `filename`, and `custom_metadata`.

For services that persist those values as object headers, mirrored objects can fall back to backend defaults such as `application/octet-stream`. That breaks flows that serve mirrored objects directly from a bucket or CDN instead of through Rails-generated blob URLs.

Fixes #57270.

### Detail

This Pull Request changes `MirrorService#mirror` to look up the blob by key and forward the blob's existing `service_metadata` when uploading to mirror services. If no blob row exists for the key, mirroring still falls back to the previous metadata-less upload behavior.

The regression test uses a recording service to assert that mirror uploads receive the same service metadata shape that Active Storage passes to the primary upload path, including content type, disposition, filename, and custom
metadata.

### Additional information

Validated with:

```bash
bin/test test/service/mirror_service_test.rb
bin/test test/models/attachment_test.rb -n "/mirroring a directly-uploaded blob after attaching it/"
bin/test test/log_subscriber_test.rb -n "/service_mirror/"
bin/test test/structured_event_subscriber_test.rb -n "/service_mirror/"
bundle exec rubocop activestorage/lib/active_storage/service/mirror_service.rb activestorage/test/service/mirror_service_test.rb
git diff --check
```

No changelog entry is included because this is a minor bug fix.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
