### PR TITLE
[ci skip] Fix typo in Getting Started guide)

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -366,7 +366,7 @@ class Settings::PasswordsController < ApplicationController
 
   def update
     if Current.user.update(password_params)
-      redirect_to settings_profile_path, status: :see_other, notice: "Your password has been updated."
+      redirect_to settings_password_path, status: :see_other, notice: "Your password has been updated."
     else
       render :show, status: :unprocessable_entity
     end


### PR DESCRIPTION
settings_profile_path typo is referenced before being defined
(passwords_controller.rb:7): On success, the redirect pointed to settings_profile_path which doesn't exist — would have raised a routing error  even if the form worked.  