### PR TITLE
[ci skip] Update sign_up_and_settings.md – fix User validation conditions

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -71,7 +71,7 @@ class User < ApplicationRecord
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
-  validates :first_name, :last_name, presence: true
+  validates :first_name, :last_name, presence: true, on: :create
 
   def full_name
     "#{first_name} #{last_name}"


### PR DESCRIPTION
The existing user was created before add_names_to_users ran, so their name columns are NULL. Without on: :create, the validation fires on every update call regardless of which attributes are changing. With this fix, names are still required at sign-up, and updating the password on an existing account won't fail due to unrelated blank columns.
