### PR TITLE
Fix ActionCable Overview JS example: localStorage.get → getItem

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -302,7 +302,7 @@ createConsumer('https://ws.example.com/cable')
 createConsumer(getWebSocketURL)
 
 function getWebSocketURL() {
-  const token = localStorage.get('auth-token')
+  const token = localStorage.getItem('auth-token')
   return `wss://example.com/cable?token=${token}`
 }
 ```


### PR DESCRIPTION
# Pull request description (paste into GitHub)

Use `localStorage.getItem` in the Action Cable Overview JavaScript snippet so the documented dynamic WebSocket URL example works in browsers.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are available
[here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The Action Cable guide showed `localStorage.get('auth-token')`, which is not part of the Web Storage API in browsers (`Storage` uses `getItem`). Copy-pasting the example can raise `TypeError: localStorage.get is not a function`. This PR corrects the snippet to `localStorage.getItem('auth-token')`.

Fixes #[ISSUE_NUMBER]

### Detail

This Pull Request updates `guides/source/action_cable_overview.md` in the `getWebSocketURL` example under **Connect Consumer**: replace `localStorage.get` with `localStorage.getItem`.

### Additional information

No runtime Rails behavior change. Documentation only; no new tests. Per the checklist below, a CHANGELOG entry is not needed for this minor documentation fix.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. _(Documentation-only; no test changes.)_
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
