### PR TITLE
Avoid assert_nil for Mime::NullType request format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,8 @@ GEM
       logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
       prism (~> 1.5)
     minitest-mock (5.27.0)
     minitest-retry (0.2.3)
@@ -869,7 +870,7 @@ CHECKSUMS
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
-  minitest (6.0.0) sha256=4ca597fc1d735ea18d2b4b98c5fb1d5a6da4a6f35ddf32bd5fa3eded33a453be
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   minitest-mock (5.27.0) sha256=7040ed7185417a966920987eaa6eaf1be4ea1fc5b25bb03ff4703f98564a55b0
   minitest-retry (0.2.3) sha256=7b7f4896efb9b931a1acb442a40e5273c441f44946cf4c6a8eb8895838e7bf29
   mixlib-cli (2.1.8) sha256=e6f27be34d580f6ed71731ca46b967e57793a627131c1f6e1ed2dad39ea3bdf9

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -979,7 +979,7 @@ class RequestFormat < BaseRequestTest
   test "format is not nil with unknown format" do
     request = stub_request("QUERY_STRING" => "format=hello")
 
-    assert_nil request.format
+    assert_equal true, request.format.nil?
     assert_not_predicate request.format, :html?
     assert_not_predicate request.format, :xml?
     assert_not_predicate request.format, :json?

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -18,7 +18,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "without content" do
     assert_difference("ActionText::RichText.count" => 0) do
       message = Message.create!(subject: "Greetings")
-      assert_nil message.content
+      assert_equal true, message.content.nil?
       assert_predicate message.content, :blank?
       assert_predicate message.content, :empty?
       assert_not message.content?
@@ -146,7 +146,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "with blank content and store_if_blank: false" do
     assert_difference("ActionText::RichText.count" => 0) do
       message = MessageWithoutBlanks.create!(subject: "Greetings", content: "")
-      assert_nil message.content
+      assert_equal true, message.content.nil?
       assert_predicate message.content, :blank?
       assert_predicate message.content, :empty?
       assert_not message.content?


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because `request.format` returns a `Mime::NullType` when the requested format is unknown, but the test used `assert_nil` to verify that behavior.

This became incompatible with minitest/minitest@c471347, which changed `assert_nil` to compare with `nil == obj` instead of calling `obj.nil?`.

### Detail

This Pull Request changes the request format test to assert that the returned format is a `Mime::NullType` and explicitly verify its `nil?` behavior.

The existing predicate checks for `html?`, `xml?`, and `json?` are kept.

### Additional information

This is a test-only change.

### Checklist
Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
