### PR TITLE
Don't bump lock_version on records during blob analysis

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -52,8 +52,34 @@ module ActiveRecord
     module Optimistic
       extend ActiveSupport::Concern
 
+      # Captures the +preserve_lock_version_on_touch+ intent on the record at
+      # +touch_later+ time, since the actual touch is deferred until the
+      # transaction commits — by which point the surrounding block has already
+      # exited.
+      module DeferredTouch # :nodoc:
+        def touch_later(*)
+          if Optimistic.preserving_lock_version_on_touch?
+            @_skip_locking_column_on_touch = true
+          end
+          super
+        end
+      end
+
       included do
         class_attribute :lock_optimistically, instance_writer: false, default: true
+        prepend DeferredTouch
+      end
+
+      def self.preserve_lock_version_on_touch # :nodoc:
+        prior = ActiveSupport::IsolatedExecutionState[:active_record_preserve_lock_version_on_touch]
+        ActiveSupport::IsolatedExecutionState[:active_record_preserve_lock_version_on_touch] = true
+        yield
+      ensure
+        ActiveSupport::IsolatedExecutionState[:active_record_preserve_lock_version_on_touch] = prior
+      end
+
+      def self.preserving_lock_version_on_touch? # :nodoc:
+        ActiveSupport::IsolatedExecutionState[:active_record_preserve_lock_version_on_touch]
       end
 
       def locking_enabled? # :nodoc:
@@ -85,12 +111,17 @@ module ActiveRecord
         end
 
         def _touch_row(attribute_names, time)
-          @_touch_attr_names << self.class.locking_column if locking_enabled?
+          if locking_enabled? && !_skip_locking_column_on_touch?
+            @_touch_attr_names << self.class.locking_column
+          end
           super
+        ensure
+          @_skip_locking_column_on_touch = nil
         end
 
         def _update_row(attribute_names, attempted_action = "update")
           return super unless locking_enabled?
+          return super if attempted_action == "touch" && _skip_locking_column_on_touch?
 
           begin
             locking_column = self.class.locking_column
@@ -126,6 +157,10 @@ module ActiveRecord
             @attributes[locking_column] = lock_attribute_was
             raise
           end
+        end
+
+        def _skip_locking_column_on_touch?
+          @_skip_locking_column_on_touch || Optimistic.preserving_lock_version_on_touch?
         end
 
         def destroy_row

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -199,6 +199,41 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_not_predicate stale_person, :saved_changes?
   end
 
+  def test_preserve_lock_version_on_touch_skips_lock_version_bump
+    p1 = Person.find(1)
+    original_lock_version = p1.lock_version
+
+    travel 1.second do
+      ActiveRecord::Locking::Optimistic.preserve_lock_version_on_touch do
+        p1.touch
+      end
+    end
+
+    assert_equal original_lock_version, p1.lock_version
+    assert_equal original_lock_version, Person.find(1).lock_version
+    assert_equal ["updated_at"], p1.saved_changes.keys
+  end
+
+  def test_preserve_lock_version_on_touch_does_not_raise_on_stale_object
+    person = Person.create!(first_name: "Mehmet Emin")
+    stale_person = Person.find(person.id)
+    person.update!(gender: "M")
+
+    assert_nothing_raised do
+      ActiveRecord::Locking::Optimistic.preserve_lock_version_on_touch do
+        stale_person.touch
+      end
+    end
+  end
+
+  def test_preserve_lock_version_on_touch_only_affects_block_scope
+    p1 = Person.find(1)
+    ActiveRecord::Locking::Optimistic.preserve_lock_version_on_touch { p1.touch }
+    p1.touch
+
+    assert_equal 1, p1.lock_version
+  end
+
   def test_update_with_dirty_primary_key
     assert_raises(ActiveRecord::RecordNotUnique) do
       person = Person.find(1)

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Don't bump `lock_version` on attachment records' parents during blob analysis.
+
+    `ActiveStorage::AnalyzeJob` writes only to `Blob#metadata`. The cascade
+    that touches attached records (and their parents) exists for cache-key
+    invalidation; when those records use optimistic locking, the previous
+    behavior bumped `lock_version`, causing concurrent form edits to raise
+    spurious `ActiveRecord::StaleObjectError`s. The `updated_at` cascade is
+    preserved; the `lock_version` bump on this code path is now suppressed.
+
+    Fixes #55764.
+
+    *Greg Pavlik*
+
 *   Accept Tempfile as ActiveStorage attachable.
 
     ```ruby

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -422,14 +422,19 @@ class ActiveStorage::Blob < ActiveStorage::Record
     end
 
     def touch_attachments
-      attachments.then do |relation|
-        if ActiveStorage.touch_attachment_records
-          relation.includes(:record)
-        else
-          relation
+      # The cascade exists to invalidate cache keys; it must not bump
+      # +lock_version+ on parents, since blob analysis does not modify any
+      # field of theirs and would otherwise race with concurrent edits.
+      ActiveRecord::Locking::Optimistic.preserve_lock_version_on_touch do
+        attachments.then do |relation|
+          if ActiveStorage.touch_attachment_records
+            relation.includes(:record)
+          else
+            relation
+          end
+        end.each do |attachment|
+          attachment.touch
         end
-      end.each do |attachment|
-        attachment.touch
       end
     end
 

--- a/activestorage/test/database/create_users_migration.rb
+++ b/activestorage/test/database/create_users_migration.rb
@@ -5,6 +5,7 @@ class ActiveStorageCreateUsers < ActiveRecord::Migration[5.2]
     create_table :users do |t|
       t.string :name
       t.integer :group_id
+      t.integer :lock_version, null: false, default: 0
       t.string :type
       t.timestamps
     end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -122,6 +122,42 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "analyze does not bump lock_version on the attachment record" do
+    user = User.create!(
+      name: "Nate",
+      avatar: {
+        content_type: "image/jpeg",
+        filename: "racecar.jpg",
+        io: file_fixture("racecar.jpg").open,
+      }
+    )
+    original_lock_version = user.reload.lock_version
+
+    assert_changes -> { user.reload.updated_at } do
+      user.avatar.blob.analyze
+    end
+
+    assert_equal original_lock_version, user.reload.lock_version
+  end
+
+  test "saving a stale-but-lock-valid record after analyze does not raise StaleObjectError" do
+    user = User.create!(
+      name: "Nate",
+      avatar: {
+        content_type: "image/jpeg",
+        filename: "racecar.jpg",
+        io: file_fixture("racecar.jpg").open,
+      }
+    )
+    stale_user = User.find(user.id)
+
+    user.avatar.blob.analyze
+
+    assert_nothing_raised do
+      stale_user.update!(name: "Nathan")
+    end
+  end
+
   test "build_after_unfurling generates a 28-character base36 key" do
     assert_match(/^[a-z0-9]{28}$/, build_blob_after_unfurling.key)
   end


### PR DESCRIPTION
### Motivation / Background

  Fixes #55764.

  ActiveStorage::AnalyzeJob writes only to Blob#metadata, but it cascades a touch to attached records and their parents. And on records using optimistic locking, that touch bumps lock_version. A user editing a form during the brief window between attach and analyze submits with the now-stale lock_version and gets ActiveRecord::StaleObjectError, even though no real conflict exists.

  The window is small in well-orchestrated systems but reliably hit by apps that auto-save while jobs are still in flight.

  The cascade itself is intentional: it was added in 294c271062 / #45567 to invalidate caches on parent records after async analysis (without it, a request that built a cache between attach and analyze would keep serving unanalyzed views indefinitely). The lock_version bump, by contrast, is incidental: it just falls out of record.touch going through Locking::Optimistic#_update_row, and no prior PR has discussed it.

  The existing config.active_storage.touch_attachment_records = false knob (#49723) is too coarse to use as a workaround: it disables the entire cascade, reintroducing the cache bug from #45567.

###  Detail

  Adds ActiveRecord::Locking::Optimistic.preserve_lock_version_on_touch, a block helper that suppresses the lock_version bump (and the WHERE lock_version = X constraint) on touches fired inside it. `updated_at` still updates, so cache keys keep invalidating.

  Implementation:

  - _touch_row skips adding locking_column to @_touch_attr_names when the flag is set (so dirty tracking doesn't claim lock_version was touched).
  - _update_row returns super early for attempted_action == "touch" when the flag is set, falling through to Persistence#_update_row (no bump, no constraint). The attempted_action == "touch" guard ensures regular saves still go through the locking path even if the
  flag happens to be set.
  - A prepended DeferredTouch module captures intent at touch_later time onto the record instance, since belongs_to ..., touch: true defers the parent touch to before_committed! — by which point the surrounding block has already exited. The instance flag is consumed
  when the deferred touch fires.

  ActiveStorage::Blob#touch_attachments wraps its cascade with the helper, since blob analysis is exactly the case where bumping the parents' lock_version is unjustified – analysis doesn't modify any parent field.

 ### Additional information

  Related:

  - #55764 issue this PR fixes.
  - #55799  documents the edge case as-is. Not a replacement; if both merge, the doc note can be dropped.
  - #45567 / 294c271062 original motivation for the cascade (cache invalidation).
  - #49723 touch_attachment_records config; insufficient as a workaround.

  Alternatives considered:

  1. analyze_blobs_async: false per attachment. Sidesteps the race at the cost of synchronous analysis on every upload. Discussed in #55764.
  2. Disabling the cascade entirely (touch_attachment_records = false). Reintroduces #45567.
  3. Doc-only (#55799). Leaves the bug in place.

###  Checklist

  Before submitting the PR make sure the following are checked:

  - [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
  - [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: [Fix #issue-number]
  - [x] Tests are added or updated if you fix a bug or add a feature.
  - [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.