### PR TITLE
Deactivate ViewReloader hooks when reloaders are cleared

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ViewReloader#deactivate` removes the `file_system_resolver_hooks` callback
+    so forked processes that clear reloaders no longer trigger filesystem scans
+    on every `prepend_view_path`.
+
+    *Dave Ariens*
+
 *   Defer the View watcher build until view paths are actually registered.
 
     *Hugo Vacher*

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -3,12 +3,19 @@
 module ActionView
   module CacheExpiry # :nodoc: all
     class ViewReloader
+      def self.create(watcher:, &block)
+        reloader = new(watcher: watcher, &block)
+        ActionView::PathRegistry.file_system_resolver_hooks << reloader.hook
+        reloader
+      end
+
       def initialize(watcher:, &block)
         @mutex = Mutex.new
         @watcher_class = watcher
         @watched_dirs = nil
         @watcher = nil
         @previous_change = false
+        @hook = method(:rebuild_watcher)
       end
 
       def updated?
@@ -31,6 +38,17 @@ module ActionView
         return unless @watcher
         build_watcher
       end
+
+      # Remove this reloader's hook from PathRegistry so forked processes that
+      # clear reloaders stop triggering filesystem scans on prepend_view_path.
+      def deactivate
+        ActionView::PathRegistry.file_system_resolver_hooks.delete(@hook)
+        @watcher = nil
+        @watched_dirs = nil
+      end
+
+      # The bound method reference for rebuild_watcher.
+      attr_reader :hook
 
       private
         def reload!

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -126,8 +126,7 @@ module ActionView
       end
 
       unless enable_caching
-        view_reloader = ActionView::CacheExpiry::ViewReloader.new(watcher: app.config.file_watcher)
-        ActionView::PathRegistry.file_system_resolver_hooks << view_reloader.method(:rebuild_watcher)
+        view_reloader = ActionView::CacheExpiry::ViewReloader.create(watcher: app.config.file_watcher)
 
         app.reloaders << view_reloader
         app.reloader.to_run do

--- a/actionview/test/template/cache_expiry_test.rb
+++ b/actionview/test/template/cache_expiry_test.rb
@@ -42,6 +42,18 @@ class CacheExpiryViewReloaderTest < ActiveSupport::TestCase
     @reloader = ActionView::CacheExpiry::ViewReloader.new(watcher: CountingWatcher)
   end
 
+  test "create registers the hook on PathRegistry" do
+    hooks = ActionView::PathRegistry.file_system_resolver_hooks
+    initial_size = hooks.size
+
+    reloader = ActionView::CacheExpiry::ViewReloader.create(watcher: CountingWatcher)
+
+    assert_equal initial_size + 1, hooks.size
+    assert_includes hooks, reloader.hook
+  ensure
+    hooks.delete(reloader.hook)
+  end
+
   test "#updated? does not build a watcher when there are no view paths to watch" do
     ActionView::PathRegistry.stub(:all_file_system_resolvers, []) do
       assert_not @reloader.updated?
@@ -85,6 +97,39 @@ class CacheExpiryViewReloaderTest < ActiveSupport::TestCase
     end
 
     assert_equal 2, CountingWatcher.built
+  end
+
+  test "#hook returns the bound method used for PathRegistry registration" do
+    hooks = ActionView::PathRegistry.file_system_resolver_hooks
+    hooks << @reloader.hook
+
+    assert_includes hooks, @reloader.hook
+  ensure
+    hooks.delete(@reloader.hook)
+  end
+
+  test "#deactivate removes the hook from PathRegistry" do
+    hooks = ActionView::PathRegistry.file_system_resolver_hooks
+    hooks << @reloader.hook
+
+    @reloader.deactivate
+
+    assert_not_includes hooks, @reloader.hook
+  ensure
+    hooks.delete(@reloader.hook)
+  end
+
+  test "#deactivate is idempotent" do
+    hooks = ActionView::PathRegistry.file_system_resolver_hooks
+    initial_size = hooks.size
+    hooks << @reloader.hook
+
+    @reloader.deactivate
+    @reloader.deactivate
+
+    assert_equal initial_size, hooks.size
+  ensure
+    hooks.delete(@reloader.hook)
   end
 
   private

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `app.reloaders` is now a `ReloadersCollection` that calls `deactivate`
+    on each reloader when `clear` or `delete` is called, giving reloaders a
+    chance to clean up external state.
+
+    *Dave Ariens*
+
 *   Enable Ruby `frozen_string_literal` by default.
 
     New Rails apps now include a `config/bootsnap.rb` file that enables frozen string

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -66,6 +66,7 @@ module Rails
     autoload :DefaultMiddlewareStack, "rails/application/default_middleware_stack"
     autoload :Finisher,               "rails/application/finisher"
     autoload :Railties,               "rails/engine/railties"
+    autoload :ReloadersCollection,    "rails/application/reloaders_collection"
     autoload :RoutesReloader,         "rails/application/routes_reloader"
 
     class << self
@@ -110,7 +111,7 @@ module Rails
     def initialize(initial_variable_values = {}, &block)
       super()
       @initialized       = false
-      @reloaders         = []
+      @reloaders         = ReloadersCollection.new
       @routes_reloader   = nil
       @app_env_config    = nil
       @ordered_railties  = nil

--- a/railties/lib/rails/application/reloaders_collection.rb
+++ b/railties/lib/rails/application/reloaders_collection.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Rails
+  class Application < Engine
+    # Wraps the application's set of file reloaders. When a reloader is removed
+    # from the collection (via +clear+ or +delete+), its +deactivate+ method is
+    # called so it can clean up external state such as registered callbacks.
+    class ReloadersCollection # :nodoc:
+      include Enumerable
+
+      def initialize
+        @reloaders = []
+      end
+
+      def each(&block)
+        @reloaders.each(&block)
+      end
+
+      def <<(reloader)
+        @reloaders << reloader
+        self
+      end
+
+      def size
+        @reloaders.size
+      end
+
+      def empty?
+        @reloaders.empty?
+      end
+
+      def clear
+        @reloaders.each { |r| r.deactivate if r.respond_to?(:deactivate) }
+        @reloaders.clear
+      end
+
+      def delete(reloader)
+        reloader.deactivate if reloader.respond_to?(:deactivate)
+        @reloaders.delete(reloader)
+      end
+    end
+  end
+end

--- a/railties/test/application/reloaders_collection_test.rb
+++ b/railties/test/application/reloaders_collection_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "active_support/testing/autorun"
+require "rails/engine"
+require "rails/application"
+require "rails/application/reloaders_collection"
+
+class ReloadersCollectionTest < ActiveSupport::TestCase
+  class FakeReloader
+    attr_reader :deactivated
+
+    def initialize
+      @deactivated = false
+    end
+
+    def deactivate
+      @deactivated = true
+    end
+
+    def updated?
+      false
+    end
+  end
+
+  class PlainReloader
+    def updated?
+      false
+    end
+  end
+
+  test "clear deactivates each reloader" do
+    collection = Rails::Application::ReloadersCollection.new
+    r1 = FakeReloader.new
+    r2 = FakeReloader.new
+    collection << r1
+    collection << r2
+
+    collection.clear
+
+    assert r1.deactivated
+    assert r2.deactivated
+    assert collection.empty?
+  end
+
+  test "clear skips reloaders without deactivate" do
+    collection = Rails::Application::ReloadersCollection.new
+    collection << PlainReloader.new
+
+    assert_nothing_raised { collection.clear }
+    assert collection.empty?
+  end
+
+  test "delete deactivates the removed reloader" do
+    collection = Rails::Application::ReloadersCollection.new
+    r1 = FakeReloader.new
+    r2 = FakeReloader.new
+    collection << r1
+    collection << r2
+
+    collection.delete(r1)
+
+    assert r1.deactivated
+    assert_not r2.deactivated
+    assert_equal 1, collection.size
+  end
+
+  test "supports enumerable" do
+    collection = Rails::Application::ReloadersCollection.new
+    r1 = FakeReloader.new
+    r2 = FakeReloader.new
+    collection << r1
+    collection << r2
+
+    assert_equal [r1, r2], collection.to_a
+    assert collection.any? { |r| r == r1 }
+  end
+end


### PR DESCRIPTION
`ViewReloader` registers a `rebuild_watcher` hook on `PathRegistry.file_system_resolver_hooks` during railtie initialization (#57269). When a forked process (e.g. a Spring test worker) calls `app.reloaders.clear`, the reloader was removed from the array but the hook persisted — every subsequent `prepend_view_path` still triggered `Dir.[]` + `File.mtime` scans across all view directories for no purpose.

This adds `ViewReloader#deactivate` which removes the hook, and replaces the plain `Array` backing `app.reloaders` with a `ReloadersCollection` that calls `deactivate` on each member during `clear`/`delete`. Existing callers get the cleanup for free.

Builds on #57269 (now merged) which moved hook registration from `ViewReloader#initialize` to the railtie and defers watcher builds. That PR prevents unnecessary rebuilds at boot; this one ensures the hook is removed entirely in forked workers where file watching is not needed.

Also complementary to https://github.com/rails/spring/pull/754 (`Spring.after_environment_load`, also merged) which is for app-level preloading, not for cleaning Rails internals. The deactivation here happens automatically through the existing `app.reloaders.clear` call.