### PR TITLE
Generate AGENTS.md for new Rails applications

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Generate an `AGENTS.md` file for new Rails applications.
+
+    `AGENTS.md` provides context for AI coding agents about the application's
+    stack: Rails version, JavaScript approach, CSS framework, asset pipeline,
+    database, and test framework. Pass `--skip-agent-file` to suppress generation.
+
+    *Andy Waite*
+
 *   Enable Ruby `frozen_string_literal` by default.
 
     New Rails apps now include a `config/bootsnap.rb` file that enables frozen string

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -111,6 +111,9 @@ module Rails
         class_option :skip_ci,             type: :boolean, default: nil,
                                            desc: "Skip GitHub CI files"
 
+        class_option :skip_agent_file,     type: :boolean, default: nil,
+                                           desc: "Skip AGENTS.md file"
+
         class_option :skip_kamal,          type: :boolean, default: nil,
                                            desc: "Skip Kamal setup"
 
@@ -408,6 +411,10 @@ module Rails
 
       def skip_ci?
         options[:skip_ci]
+      end
+
+      def skip_agent_file?
+        options[:skip_agent_file]
       end
 
       def skip_devcontainer?

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -111,7 +111,7 @@ module Rails
         class_option :skip_ci,             type: :boolean, default: nil,
                                            desc: "Skip GitHub CI files"
 
-        class_option :skip_agent_file,     type: :boolean, default: nil,
+        class_option :skip_agents_file,     type: :boolean, default: nil,
                                            desc: "Skip AGENTS.md file"
 
         class_option :skip_kamal,          type: :boolean, default: nil,
@@ -413,8 +413,8 @@ module Rails
         options[:skip_ci]
       end
 
-      def skip_agent_file?
-        options[:skip_agent_file]
+      def skip_agents_file?
+        options[:skip_agents_file]
       end
 
       def skip_devcontainer?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -421,7 +421,7 @@ module Rails
       end
 
       def create_agent_file
-        return if skip_agents_file?
+        return if skip_agents_file? || options[:dummy_app]
         build(:agent_file)
       end
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -93,6 +93,10 @@ module Rails
       template "rubocop.yml", ".rubocop.yml"
     end
 
+    def agent_file
+      template "AGENTS.md"
+    end
+
     def version_control
       if !options[:skip_git] && !options[:pretend]
         run git_init_command, capture: options[:quiet], abort_on_failure: false
@@ -414,6 +418,11 @@ module Rails
       def create_rubocop_file
         return if skip_rubocop?
         build(:rubocop)
+      end
+
+      def create_agent_file
+        return if skip_agent_file?
+        build(:agent_file)
       end
 
       def create_cifiles

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -421,7 +421,7 @@ module Rails
       end
 
       def create_agent_file
-        return if skip_agent_file?
+        return if skip_agents_file?
         build(:agent_file)
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/AGENTS.md.tt
+++ b/railties/lib/rails/generators/rails/app/templates/AGENTS.md.tt
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+This file provides context for AI coding agents working on this Rails application.
+
+## Rails Version
+
+Rails <%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %><% if options[:api] %> (API only)<% end %>
+
+## JavaScript
+<% if options[:skip_javascript] -%>
+None
+<% else -%>
+<%= options[:javascript].capitalize %><% unless options[:skip_hotwire] %> with Hotwire (Turbo + Stimulus)<% end %>
+<% end -%>
+
+## CSS
+<% if options[:css] -%>
+<%= options[:css].capitalize %>
+<% else -%>
+None
+<% end -%>
+
+## Asset Pipeline
+<% if options[:skip_asset_pipeline] -%>
+None
+<% else -%>
+propshaft
+<% end -%>
+
+## Database
+<% if options[:skip_active_record] -%>
+None
+<% else -%>
+<%= options[:database] %>
+<% end -%>
+
+## Test Framework
+<% if options[:skip_test] -%>
+None
+<% else -%>
+minitest
+<% end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -745,7 +745,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file ".github/dependabot.yml"
   end
 
-  def test_agent_file_is_generated_by_default
+  def test_agents_file_is_generated_by_default
     run_generator
 
     assert_file "AGENTS.md" do |content|
@@ -753,7 +753,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_indicates_api_mode
+  def test_agents_file_indicates_api_mode
     run_generator [destination_root, "--api"]
 
     assert_file "AGENTS.md" do |content|
@@ -761,13 +761,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_is_skipped_if_required
-    run_generator [destination_root, "--skip-agent-file"]
+  def test_agents_file_is_skipped_if_required
+    run_generator [destination_root, "--skip-agents-file"]
 
     assert_no_file "AGENTS.md"
   end
 
-  def test_agent_file_includes_css_framework
+  def test_agents_file_includes_css_framework
     run_generator [destination_root, "--css=tailwind"]
 
     assert_file "AGENTS.md" do |content|
@@ -775,7 +775,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_includes_javascript_approach
+  def test_agents_file_includes_javascript_approach
     run_generator [destination_root, "--javascript=esbuild"]
 
     assert_file "AGENTS.md" do |content|
@@ -783,7 +783,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_includes_asset_pipeline_by_default
+  def test_agents_file_includes_asset_pipeline_by_default
     run_generator
 
     assert_file "AGENTS.md" do |content|
@@ -791,7 +791,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_shows_no_asset_pipeline_when_skipped
+  def test_agents_file_shows_no_asset_pipeline_when_skipped
     run_generator [destination_root, "--skip-asset-pipeline"]
 
     assert_file "AGENTS.md" do |content|
@@ -799,7 +799,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_includes_database
+  def test_agents_file_includes_database
     run_generator [destination_root, "--database=postgresql"]
 
     assert_file "AGENTS.md" do |content|
@@ -807,7 +807,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_shows_no_database_when_active_record_skipped
+  def test_agents_file_shows_no_database_when_active_record_skipped
     run_generator [destination_root, "--skip-active-record"]
 
     assert_file "AGENTS.md" do |content|
@@ -815,7 +815,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_includes_minitest_by_default
+  def test_agents_file_includes_minitest_by_default
     run_generator
 
     assert_file "AGENTS.md" do |content|
@@ -823,7 +823,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_agent_file_shows_no_test_framework_when_skipped
+  def test_agents_file_shows_no_test_framework_when_skipped
     run_generator [destination_root, "--skip-test"]
 
     assert_file "AGENTS.md" do |content|

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -745,6 +745,92 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file ".github/dependabot.yml"
   end
 
+  def test_agent_file_is_generated_by_default
+    run_generator
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/Rails #{Rails::VERSION::MAJOR}\.#{Rails::VERSION::MINOR}$/, content)
+    end
+  end
+
+  def test_agent_file_indicates_api_mode
+    run_generator [destination_root, "--api"]
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/Rails #{Rails::VERSION::MAJOR}\.#{Rails::VERSION::MINOR} \(API only\)/, content)
+    end
+  end
+
+  def test_agent_file_is_skipped_if_required
+    run_generator [destination_root, "--skip-agent-file"]
+
+    assert_no_file "AGENTS.md"
+  end
+
+  def test_agent_file_includes_css_framework
+    run_generator [destination_root, "--css=tailwind"]
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/Tailwind/, content)
+    end
+  end
+
+  def test_agent_file_includes_javascript_approach
+    run_generator [destination_root, "--javascript=esbuild"]
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/Esbuild/, content)
+    end
+  end
+
+  def test_agent_file_includes_asset_pipeline_by_default
+    run_generator
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/propshaft/, content)
+    end
+  end
+
+  def test_agent_file_shows_no_asset_pipeline_when_skipped
+    run_generator [destination_root, "--skip-asset-pipeline"]
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/Asset Pipeline\nNone/, content)
+    end
+  end
+
+  def test_agent_file_includes_database
+    run_generator [destination_root, "--database=postgresql"]
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/postgresql/, content)
+    end
+  end
+
+  def test_agent_file_shows_no_database_when_active_record_skipped
+    run_generator [destination_root, "--skip-active-record"]
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/Database\nNone/, content)
+    end
+  end
+
+  def test_agent_file_includes_minitest_by_default
+    run_generator
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/minitest/, content)
+    end
+  end
+
+  def test_agent_file_shows_no_test_framework_when_skipped
+    run_generator [destination_root, "--skip-test"]
+
+    assert_file "AGENTS.md" do |content|
+      assert_match(/Test Framework\nNone/, content)
+    end
+  end
+
   def test_configuration_of_solid
     generator [destination_root]
     run_generator_instance


### PR DESCRIPTION
### Motivation / Background

AI coding agents benefit from a brief description of an application's tech stack. Without it, agents have to infer the setup by reading multiple files, consuming unnecessary tokens.

The `AGENTS.md` convention is supported by a growing number of AI coding tools as a tool-agnostic way to provide context to agents.

### Detail

Generates an `AGENTS.md` file by default when running `rails new`, containing:

- Rails version (with API mode noted if applicable)
- JavaScript approach (with Hotwire status)
- CSS framework
- Asset pipeline
- Database (omitted if `--skip-active-record`)
- Test framework

Pass `--skip-agents-file` to suppress generation.

### Additional information

**On opt-out by default**: this is consistent with Rails' omakase philosophy. The file is small and easily deleted, similar to how `.github/ci.yml` is generated by default.

**On staleness**: the file reflects the stack at generation time and is intended to be a living document, updated as the application evolves — not just for framework changes, but to capture architectural decisions and conventions that help agents understand the application more deeply.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.