### PR TITLE
Define `as_json` on `ActiveStorage::Attached::One` and `Attached::Many`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Define `as_json` on `ActiveStorage::Attached::One` and `ActiveStorage::Attached::Many`.
+
+    The proxies hold a back-reference to the owning record in `@record`. Without an explicit
+    `as_json`, the default `Object#as_json` fall back serialized `instance_values`, which made
+    `record.to_json` recurse infinitely whenever the attached name collided with a model
+    attribute (e.g. an `ignored_columns` column brought back by `select('*')`).
+
+    `Attached::One#as_json` now returns the attachment record's JSON when attached and `nil`
+    otherwise. `Attached::Many#as_json` returns the attachment records' JSON as an array.
+
+    *Renxiang Cai*
+
 *   Configurable maximum streaming chunk size
 
     Makes sure that byte ranges for blobs don't exceed 100mb by default.

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -67,6 +67,10 @@ module ActiveStorage
       attachments.any?
     end
 
+    def as_json(options = nil)
+      attachments.as_json(options)
+    end
+
     private
       def purge_many
         Attached::Changes::PurgeMany.new(name, record, attachments)

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -45,6 +45,12 @@ module ActiveStorage
       !attached?
     end
 
+    # Returns the attachment record's JSON representation, or +nil+ when no
+    # attachment is present.
+    def as_json(options = nil)
+      attached? ? attachment.as_json(options) : nil
+    end
+
     # Attaches an +attachable+ to the record.
     #
     # If the record is persisted and unchanged, the attachment is saved to

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -932,4 +932,19 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal 1, @user.highlights.count
     assert_equal "racecar.jpg", @user.highlights.blobs.first.filename.to_s
   end
+
+  test "as_json returns an empty array when no attachments are present" do
+    assert_equal [], @user.highlights.as_json
+  end
+
+  test "as_json returns the attachment records when attached" do
+    @user.highlights.attach(create_blob(filename: "funky.jpg"))
+    assert_equal @user.highlights_attachments.as_json, @user.highlights.as_json
+  end
+
+  test "to_json on the record does not stack overflow when an attribute shadows the many-attached name" do
+    @user.highlights.attach(create_blob(filename: "funky.jpg"))
+    user = User.select("name AS highlights").find(@user.id)
+    assert_nothing_raised { user.to_json }
+  end
 end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -869,4 +869,19 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
     assert_match(/Cannot find variant :unknown for User#avatar_with_variants/, error.message)
   end
+
+  test "as_json returns nil when no attachment is present" do
+    assert_nil @user.avatar.as_json
+  end
+
+  test "as_json returns the attachment record when attached" do
+    @user.avatar.attach(create_blob(filename: "funky.jpg"))
+    assert_equal @user.avatar_attachment.as_json, @user.avatar.as_json
+  end
+
+  test "to_json on the record does not stack overflow when an attribute shadows the attached name" do
+    @user.avatar.attach(create_blob(filename: "funky.jpg"))
+    user = User.select("name AS avatar").find(@user.id)
+    assert_nothing_raised { user.to_json }
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #57287.

`record.to_json` raises `SystemStackError` whenever a `has_one_attached` / `has_many_attached` name shadows a model attribute. The most direct way to hit it is `ignored_columns` + a column brought back by an explicit `select('*')`:

```ruby
class Product < ApplicationRecord
  self.ignored_columns = [:photo]
  has_one_attached :photo
end

Product.select('*').first.to_json
# => SystemStackError: stack level too deep
```

`Attached::One` and `Attached::Many` hold a back-reference to the owning record in `@record`. Without an explicit `as_json`, the default `Object#as_json` fall back serialized `instance_values`, which made `record.to_json` recurse infinitely whenever the attached column shared a name with a model attribute.

The cycle from the stack trace:

```
1209 cycles of:
  ActiveModel::Serializers::JSON#as_json
  block in Hash#as_json
  Hash#each
  Hash#as_json
  Object#as_json                    # <-- Attached::One falls through here
  block in Hash#as_json
  Hash#each
  Hash#as_json
```

### Detail

This Pull Request changes `Attached::One` and `Attached::Many` to define `as_json` so they don't fall through to `Object#as_json`'s `instance_values` path:

- `Attached::One#as_json` now returns the attachment record's JSON when attached and `nil` otherwise.
- `Attached::Many#as_json` returns the attachment records' JSON as an array.

The `Attachment` records contain only scalar columns (`id`, `blob_id`, `name`, `record_id`, `record_type`, `created_at`), so there is no cycle.

### Additional information

Alternative considered: filtering `ignored_columns` out of the row hash in `ActiveRecord::Persistence#instantiate_instance_of` so `attribute_names` always honours `ignored_columns` regardless of how the SELECT was written. That's a broader behaviour change (silently drops user-requested SQL columns) and wouldn't help any other Object subclass that happens to back-reference its record. Defining `as_json` on the proxies is the narrower, more local fix.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.