### PR TITLE
Raise ArgumentError when MemCacheStore is created with Dalli::Client

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -79,7 +79,7 @@ module ActiveSupport
         options[:max_key_size] ||= MAX_KEY_SIZE
         super(options)
 
-        unless [String, Dalli::Client, NilClass].include?(addresses.first.class)
+        unless [String, NilClass].include?(addresses.first.class)
           raise ArgumentError, "First argument must be an empty array, address, or array of addresses."
         end
 


### PR DESCRIPTION
Passing a Dalli::Client was deprecated in 78b74e9 and removed in c33e2d2e49d.
As this is no longer allowed an ArgumentError should be raised for
Dalli::Client as well.

This also is inline with the error message that states only "empty array,
address, or array of addresses" are allowed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
