### PR TITLE
[ci skip] Fix typos in test descriptions

### DIFF
--- a/activestorage/test/models/named_variant_test.rb
+++ b/activestorage/test/models/named_variant_test.rb
@@ -9,17 +9,17 @@ class ActiveStorage::NamedVariantTest < ActiveSupport::TestCase
     @user = User.new(name: "joe")
   end
 
-  test "explicity sets the process to immediate" do
+  test "explicitly sets the process to immediate" do
     named_variant = @user.attachment_reflections["avatar_with_immediate_variants"].named_variants[:immediate_thumb]
     assert_equal :immediately, named_variant.process(@user)
   end
 
-  test "explicity sets the process to later" do
+  test "explicitly sets the process to later" do
     named_variant = @user.attachment_reflections["avatar_with_later_variants"].named_variants[:later_thumb]
     assert_equal :later, named_variant.process(@user)
   end
 
-  test "explicity sets the process to on_demand" do
+  test "explicitly sets the process to on_demand" do
     named_variant = @user.attachment_reflections["avatar_with_lazy_variants"].named_variants[:lazy_thumb]
     assert_equal :lazily, named_variant.process(@user)
   end

--- a/activesupport/test/env_configuration_test.rb
+++ b/activesupport/test/env_configuration_test.rb
@@ -20,13 +20,13 @@ class EnvConfigurationTest < ActiveSupport::TestCase
     end
   end
 
-  test "reqiure missing key raises key error" do
+  test "require missing key raises key error" do
     assert_raises(KeyError) do
       @config.require(:gone)
     end
   end
 
-  test "reqiure missing multiword key raises key error" do
+  test "require missing multiword key raises key error" do
     assert_raises(KeyError) do
       @config.require(:gone, :missing)
     end


### PR DESCRIPTION
### Summary

Fixes a few spelling mistakes in test description strings.

### Details

This updates:

- `reqiure` to `require` in `ActiveSupport::EnvConfigurationTest`
- `explicity` to `explicitly` in `ActiveStorage::NamedVariantTest`

These changes only rename the tests. They do not change what the tests do.

### Tests

Not run, because this only renames tests and does not change what they do.