### PR TITLE
Configure Action View render tracker before eager loading

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -79,6 +79,12 @@ module ActionView
       ActionView::Helpers::JavaScriptHelper.auto_include_nonce = app.config.content_security_policy_nonce_auto && app.config.content_security_policy_nonce_directives.intersect?(["script-src", "script-src-elem", "script-src-attr"]) && app.config.content_security_policy_nonce_generator.present?
     end
 
+    config.before_eager_load do |app|
+      if app.config.action_view.key?(:render_tracker)
+        ActionView.render_tracker = config.action_view.render_tracker
+      end
+    end
+
     config.after_initialize do |app|
       config.after_initialize do
         ActionView.render_tracker = config.action_view.render_tracker

--- a/railties/test/application/action_view_railtie_test.rb
+++ b/railties/test/application/action_view_railtie_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class ActionViewRailtieTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    test "render tracker is configured before eager loading" do
+      make_basic_app do |app|
+        app.config.load_defaults "8.1"
+        app.config.eager_load = true
+      end
+
+      trackers = ActionView::DependencyTracker.instance_variable_get(:@trackers)
+      erb_handler = ActionView::Template.handler_for_extension("erb")
+
+      assert_equal :ruby, ActionView.render_tracker
+      assert_equal ActionView::DependencyTracker::RubyTracker, trackers[erb_handler]
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Fixes #57265.

Applications using `config.load_defaults "8.1"` with `config.eager_load = true` can register `ActionView::DependencyTracker::ERBTracker` for ERB templates even though `config.action_view.render_tracker` is set to `:ruby`.

### Detail

This updates `ActionView.render_tracker` from `config.action_view.render_tracker` before eager loading runs, so `ActionView::DependencyTracker` sees the configured value when it is loaded.

A railtie test covers the `load_defaults "8.1"` and eager loading case.

### Additional information

Tested with:

```sh
RBENV_VERSION=3.4.9 BUNDLE_WITHOUT=db bundle exec ruby -I railties/test railties/test/application/action_view_railtie_test.rb
RBENV_VERSION=3.4.9 BUNDLE_WITHOUT=db bundle exec ruby -I actionview/test actionview/test/template/dependency_tracker_test.rb
```

I used `BUNDLE_WITHOUT=db` locally because the full bundle requires MySQL client libraries, and this change does not touch database code.

No CHANGELOG entry because this is a minor bug fix.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.