### PR TITLE
Document Active Storage routes_prefix scope options

### DIFF
--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -360,6 +360,9 @@ module ActiveStorage
   mattr_accessor :touch_attachment_records, default: true
   mattr_accessor :urls_expire_in
 
+  # Configures the mount point for the default Active Storage routes. Accepts any
+  # value supported by `scope`, such as a string path prefix or a hash of routing
+  # options.
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
   mattr_accessor :draw_routes, default: true
   mattr_accessor :resolve_model_to_route, default: :rails_storage_redirect

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -840,6 +840,16 @@ config.active_storage.draw_routes = false
 
 to prevent files being accessed with the publicly accessible URLs.
 
+If you only need to mount the Active Storage routes at a different path or with
+additional routing options, configure `config.active_storage.routes_prefix`
+instead. It accepts any value supported by `scope`, so you can pass a string path
+prefix or a hash of routing options:
+
+```ruby
+config.active_storage.routes_prefix = "/files"
+config.active_storage.routes_prefix = { path: "/files", subdomain: "assets" }
+```
+
 [`ActiveStorage::Blobs::RedirectController`]: https://api.rubyonrails.org/classes/ActiveStorage/Blobs/RedirectController.html
 [`ActiveStorage::Blobs::ProxyController`]: https://api.rubyonrails.org/classes/ActiveStorage/Blobs/ProxyController.html
 [`ActiveStorage::Representations::RedirectController`]: https://api.rubyonrails.org/classes/ActiveStorage/Representations/RedirectController.html

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3554,10 +3554,18 @@ Directs ActiveStorage::Attachments to touch its corresponding record when update
 
 #### `config.active_storage.routes_prefix`
 
-Can be used to set the route prefix for the routes served by Active Storage. Accepts a string that will be prepended to the generated routes.
+Can be used to set the route prefix for the routes served by Active Storage.
+Accepts any value supported by `scope`, such as a string path prefix or a hash of
+routing options.
 
 ```ruby
 config.active_storage.routes_prefix = "/files"
+```
+
+For example, to serve the Active Storage routes from a specific subdomain:
+
+```ruby
+config.active_storage.routes_prefix = { path: "/files", subdomain: "assets" }
 ```
 
 The default is `/rails/active_storage`.


### PR DESCRIPTION
### Motivation / Background

This Pull Request documents that `config.active_storage.routes_prefix` can accept any value supported by `scope`, not only a string path prefix.

Closes #48915.

### Detail

The Active Storage routes are mounted with:

```ruby
scope ActiveStorage.routes_prefix do
```

so applications can pass either a string path prefix or a hash of routing options, such as a path plus subdomain constraint. This updates:

* the configuring guide
* the Active Storage overview guide
* the `ActiveStorage.routes_prefix` API comment

### Checklist

* [x] The documentation is updated.
