### PR TITLE
Generate constants for enum values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Define class-level constants for enum values, mirroring the
+    `prefix`/`suffix` naming scheme used for the generated methods. The
+    constant value is the frozen label string.
+
+        class Conversation < ApplicationRecord
+          enum :status, [ :active, :archived ]
+        end
+
+        Conversation::ACTIVE   # => "active"
+        Conversation::ARCHIVED # => "archived"
+
+        Conversation.where(status: Conversation::ACTIVE)
+
+    With `prefix:` or `suffix:`, the constant name follows the same shape
+    as the generated method:
+
+        class Order < ApplicationRecord
+          enum :status, [ :placed, :shipped ], prefix: true
+        end
+
+        Order::STATUS_PLACED  # => "placed"
+        Order::STATUS_SHIPPED # => "shipped"
+
+    Constants already defined on the class are not overwritten.
+
+    *Jean Mendonça*
+
 *   Bump the minimum PostgreSQL version to 10.0.
 
     As part of this change, `supports_pgcrypto_uuid?` is deprecated because

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -118,6 +118,22 @@ module ActiveRecord
   #     enum :status, [ :active, :archived ], instance_methods: false
   #   end
   #
+  # A class-level constant is also defined for each value of the enum, named
+  # after the corresponding generated method (so +:prefix+ and +:suffix+ are
+  # honored as well). The constant's value is the frozen label string:
+  #
+  #   class Conversation < ActiveRecord::Base
+  #     enum :status, [ :active, :archived ]
+  #   end
+  #
+  #   Conversation::ACTIVE   # => "active"
+  #   Conversation::ARCHIVED # => "archived"
+  #
+  #   Conversation.where(status: Conversation::ACTIVE)
+  #
+  # Constants that are already defined on the class are not overwritten, so
+  # any value you have set manually takes precedence.
+  #
   # By default, an +ArgumentError+ will be raised when assigning an invalid value:
   #
   #   class Conversation < ActiveRecord::Base
@@ -266,6 +282,7 @@ module ActiveRecord
             value_method_name = "#{prefix}#{label}#{suffix}"
             value_method_names << value_method_name
             define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+            define_enum_constant(value_method_name, label)
 
             method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
             value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
@@ -273,6 +290,7 @@ module ActiveRecord
             if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
               value_method_names << value_method_alias
               define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
+              define_enum_constant(value_method_alias, label)
             end
           end
         end
@@ -319,6 +337,14 @@ module ActiveRecord
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
               klass.scope "not_#{value_method_name}", -> { where(predicate_builder[name, value, :is_distinct_from]) }
             end
+          end
+
+          # Conversation::ACTIVE = "active"
+          def define_enum_constant(value_method_name, label)
+            const_name = value_method_name.upcase
+            return unless const_name.match?(/\A[A-Z][A-Z0-9_]*\z/)
+            return if klass.const_defined?(const_name, false)
+            klass.const_set(const_name, -label)
           end
       end
       private_constant :EnumMethods

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1171,4 +1171,76 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { instance.proposed? }
     assert_raises(NoMethodError) { instance.proposed! }
   end
+
+  test "defines constants for enum values on the model class" do
+    assert_equal "proposed", Book::PROPOSED
+    assert_equal "written", Book::WRITTEN
+    assert_equal "published", Book::PUBLISHED
+  end
+
+  test "defined enum constants are frozen strings" do
+    assert_predicate Book::PROPOSED, :frozen?
+    assert_kind_of String, Book::PROPOSED
+  end
+
+  test "enum constants honor prefix: true" do
+    assert_equal "visible", Book::AUTHOR_VISIBILITY_VISIBLE
+    assert_equal "invisible", Book::AUTHOR_VISIBILITY_INVISIBLE
+  end
+
+  test "enum constants honor a custom prefix" do
+    assert_equal "english", Book::IN_ENGLISH
+    assert_equal "spanish", Book::IN_SPANISH
+    assert_equal "french", Book::IN_FRENCH
+  end
+
+  test "enum constants honor a custom suffix" do
+    assert_equal "easy", Book::EASY_TO_READ
+    assert_equal "medium", Book::MEDIUM_TO_READ
+    assert_equal "hard", Book::HARD_TO_READ
+  end
+
+  test "enum constants honor prefix and suffix together" do
+    assert_equal "small", Book::WITH_SMALL_FONT_SIZE
+    assert_equal "medium", Book::WITH_MEDIUM_FONT_SIZE
+    assert_equal "large", Book::WITH_LARGE_FONT_SIZE
+  end
+
+  test "enum constants for hash-form enums use the label, not the underlying value" do
+    assert_equal "hard", Book::HARD
+    assert_equal "soft", Book::SOFT
+    assert_equal "enabled", Book::ENABLED
+    assert_equal "disabled", Book::DISABLED
+  end
+
+  test "enum constants can be used in where clauses" do
+    book = Book.where(status: Book::PROPOSED).first
+    assert_predicate book, :proposed?
+  end
+
+  test "enum constants do not overwrite a constant already defined on the class" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      const_set(:PROPOSED, :keep_me)
+      enum :status, [:proposed, :written]
+    end
+
+    assert_equal :keep_me, klass::PROPOSED
+    assert_equal "written", klass::WRITTEN
+  end
+
+  test "enum constants are not generated for labels that produce invalid constant names" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, { "404": 0, "ok": 1 }
+    end
+
+    assert_not_includes klass.constants(false).map(&:to_s), "404"
+    assert_equal "ok", klass::OK
+  end
+
+  test "enum constants are inherited by subclasses" do
+    subclass = Class.new(Book)
+    assert_equal "proposed", subclass::PROPOSED
+  end
 end


### PR DESCRIPTION
### Motivation / Background

When you declare an `enum` on an Active Record model today, Rails generates predicate, bang, and scope methods, but it does not expose the values as constants. That means application code either hardcodes the underlying strings (`User.where(status: "active")`) or every project ends up reimplementing the same boilerplate (`ACTIVE = "active"`) on each model.

This PR makes Rails generate those constants automatically, using the same `prefix`/`suffix` rules already applied to method names — so the constants stay in sync with the methods you already get.

### Detail

For each enum value, a class-level constant is defined on the model. The constant name is `"#{prefix}#{label}#{suffix}".upcase` (matching the generated method name), and its value is the frozen label string.

```ruby
class Conversation < ApplicationRecord
  enum :status, [ :active, :archived ]
end

Conversation::ACTIVE   # => "active"
Conversation::ARCHIVED # => "archived"

Conversation.where(status: Conversation::ACTIVE)
```

`prefix` and `suffix` are honored:

```ruby
class Order < ApplicationRecord
  enum :status, [ :placed, :shipped ], prefix: true
end

Order::STATUS_PLACED  # => "placed"
Order::STATUS_SHIPPED # => "shipped"
```

```ruby
class Book < ApplicationRecord
  enum :font_size, [ :small, :medium, :large ], prefix: :with, suffix: true
end

Book::WITH_SMALL_FONT_SIZE  # => "small"
Book::WITH_MEDIUM_FONT_SIZE # => "medium"
Book::WITH_LARGE_FONT_SIZE  # => "large"
```

A few design choices worth flagging for review:

- **Pre-existing constants are not overwritten.** The implementation uses `const_defined?(name, false)` to skip when the class already defines a constant of the same name, so any manual declarations on the model take precedence and existing apps don't break on upgrade.
- **Invalid identifiers are skipped silently.** If the resulting name does not match `\A[A-Z][A-Z0-9_]*\z` (e.g. the label is `"404"` or contains non-ASCII characters), no constant is created, but the method is still generated as it is today. Consistent with the current behavior for similar labels.
- **No new option.** Rather than adding a `constants: false` opt-out, the silent skip on collision covers the only meaningful conflict case. Happy to add an explicit option if reviewers prefer.
- **Frozen string deduped via `-label`** instead of `label.freeze`, to take advantage of the frozen string pool.

### Additional information

- Documentation is updated in the module-level docstring for `ActiveRecord::Enum` (renders to api.rubyonrails.org).
- No dedicated guide for enums exists under `guides/source/`, so no guide change is required.
- `bin/rubocop activerecord/lib/active_record/enum.rb activerecord/test/cases/enum_test.rb` passes clean.
- `bundle exec rake test:sqlite3 TEST=test/cases/enum_test.rb` passes (111 runs, 503 assertions, 0 failures).
- Full `bundle exec rake test:sqlite3` shows 0 regressions versus `main`.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added.
* [x] CHANGELOG is updated.