### PR TITLE
Document `_came_from_user?` and `_for_database` attribute method suffixes [ci skip]

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -25,6 +25,21 @@ module ActiveRecord
     #
     #   task.id_before_type_cast           # => "1"
     #   task.completed_on_before_type_cast # => "2012-10-21"
+    #
+    # It also declares a method for all attributes with the <tt>*_for_database</tt>
+    # suffix, returning the serialized value used when writing to the database, and
+    # a method with the <tt>*_came_from_user?</tt> suffix, returning whether the
+    # attribute was assigned from user input (as opposed to loaded from the database
+    # or left at its default).
+    #
+    #   class Book < ActiveRecord::Base
+    #     enum :status, { draft: 1, published: 2 }
+    #   end
+    #
+    #   book = Book.new(status: "published")
+    #   book.status_for_database     # => 2
+    #   book.status_came_from_user?  # => true
+    #   book.id_came_from_user?      # => false
     module BeforeTypeCast
       extend ActiveSupport::Concern
 
@@ -94,10 +109,12 @@ module ActiveRecord
           @attributes[attr_name].value_before_type_cast
         end
 
+        # Dispatch target for <tt>*_for_database</tt> attribute methods.
         def attribute_for_database(attr_name)
           @attributes[attr_name].value_for_database
         end
 
+        # Dispatch target for <tt>*_came_from_user?</tt> attribute methods.
         def attribute_came_from_user?(attr_name)
           @attributes[attr_name].came_from_user?
         end


### PR DESCRIPTION
### Summary

`ActiveRecord::AttributeMethods::BeforeTypeCast` registers three attribute method suffixes:

```ruby
attribute_method_suffix "_before_type_cast", "_for_database", parameters: false
attribute_method_suffix "_came_from_user?", parameters: false
```

…but only `_before_type_cast` is described in the module-level rdoc, and the private dispatch target for `_came_from_user?` had no comment. `_for_database` is reachable via the documented `read_attribute_for_database` / `attributes_for_database` methods, but the suffix form (e.g. `book.status_for_database`) wasn't mentioned anywhere.

### Changes

* Extend the module-level rdoc with a short `Book` / enum example covering `*_for_database` and `*_came_from_user?`.
* Add `# Dispatch target for *_for_database attribute methods.` to `attribute_for_database`.
* Add `# Dispatch target for *_came_from_user?  attribute methods.` to `attribute_came_from_user?`, matching the existing comment on `attribute_before_type_cast`.

Documentation-only; no behavior change.