### PR TITLE
Avoid re-unescaping decoded PostgreSQL bytea values

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -27,6 +27,13 @@ module ActiveRecord
               elsif value.encoding == Encoding::BINARY &&
                   !value.instance_variable_defined?(:@ar_pg_bytea_decoded)
 
+                # When bytea decoding is enabled, values from the database are
+                # already unescaped. Serialization boundaries can strip the
+                # decoded marker, so preserve the Rails 8.3 behavior here.
+                if ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_bytea
+                  return value.dup
+                end
+
                 ActiveRecord.deprecator.warn(<<~MSG.squish)
                   bytea column received a binary string for unescaping. In Rails 8.3, binary strings
                   will be treated as already unescaped.

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1370,6 +1370,29 @@ module ActiveRecord
         end
       end
 
+      def test_bytea_preserves_decoded_value_when_marker_is_stripped_under_decode_bytea
+        type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+
+        PostgreSQLAdapter.with(decode_bytea: true) do
+          decoded = "Hello\0world".b
+          decoded.instance_variable_set(:@ar_pg_bytea_decoded, true)
+
+          # Simulate a serialization boundary that preserves the bytes and
+          # encoding but drops Active Record's per-string instance variable
+          # (e.g. msgpack, a JSON binary encoder, or any String rebuild such
+          # as String#b, String.new(s), or interpolation).
+          unmarked = String.new(decoded)
+          assert_equal Encoding::BINARY, unmarked.encoding
+          assert_not unmarked.instance_variable_defined?(:@ar_pg_bytea_decoded)
+
+          result = type.deserialize(unmarked)
+
+          assert_equal decoded, result
+          assert_equal Encoding::BINARY, result.encoding
+          assert_not result.instance_variable_defined?(:@ar_pg_bytea_decoded)
+        end
+      end
+
       def test_bytea_marked_true_skips_decode
         type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
 


### PR DESCRIPTION
### Motivation / Background

When `config.active_record.postgresql_adapter_decode_bytea` is enabled, Active Record installs a `bytea` decoder on the PG result type map so values are unescaped as the result set is parsed rather than later in `Bytea#deserialize`. Decoded strings are tagged with a `@ar_pg_bytea_decoded` instance variable so `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea#deserialize` knows to skip a second call to `PG::Connection.unescape_bytea`.

That marker is a per-string Ruby instance variable, so it does not survive serialization boundaries that rebuild the String — for example MessagePack or a job payload encoder that round-trips through raw bytes, or any `String#b` / `String.new(s)` / interpolation. When such a value reaches `Bytea#deserialize` again it has lost the marker, the deserializer treats it as an escaped bytea literal, and `PG::Connection.unescape_bytea` is called a second time. That:

- raises `ArgumentError: string contains null byte` for any decoded value that contains a null byte, and
- silently corrupts other values whose bytes happen to look like backslash escapes (e.g. `\042` decodes to `"`).

### Detail

This change treats unmarked binary strings as already decoded only when `PostgreSQLAdapter.decode_bytea` is enabled.

For applications that have not enabled PG-level bytea decoding, behavior is unchanged: unmarked binary strings still follow the current deprecation path and are passed to `PG::Connection.unescape_bytea`.

For applications that have enabled PG-level bytea decoding, the existing deprecation warning is no longer emitted for unmarked binary strings — those strings now take the post-deprecation path early. This aligns with the contract the deprecation message already announces:

> In Rails 8.3, binary strings will be treated as already unescaped.

### Backport

Targets `main` only — `decode_bytea` itself is on `main`.
