### PR TITLE
[ci skip] Fix getting started guide: remove autocomplete="off" from authenticity_token example

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1237,7 +1237,7 @@ will look like this:
 
 ```html
 <form action="/products" accept-charset="UTF-8" method="post">
-  <input type="hidden" name="authenticity_token" value="UHQSKXCaFqy_aoK760zpSMUPy6TMnsLNgbPMABwN1zpW-Jx6k-2mISiF0ulZOINmfxPdg5xMyZqdxSW1UK-H-Q" autocomplete="off">
+  <input type="hidden" name="authenticity_token" value="UHQSKXCaFqy_aoK760zpSMUPy6TMnsLNgbPMABwN1zpW-Jx6k-2mISiF0ulZOINmfxPdg5xMyZqdxSW1UK-H-Q">
 
   <div>
     <label for="product_name">Name</label>


### PR DESCRIPTION
The getting started guide shows an HTML form example with `autocomplete="off"` on the `authenticity_token` hidden input:

```html
    <input type="hidden" name="authenticity_token" value="..." autocomplete="off">
```
Since Rails 8.1.0, `autocomplete="off"` is no longer added to hidden inputs generated by `token_tag` (and others). This was removed in #53512 because the `autocomplete` attribute is not applicable to `hidden` input elements per the HTML spec.

This PR updates the example to reflect the current output.
