### PR TITLE
Add alias expected for ActionController::Parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `ActionController::Parameters#expected` and `#expected!` as
+    aliases of `#expect` and `#expect!`.
+
+    `expect` is one letter away from `except` and easy to misread at a glance.
+    `expected` reads as the same intent without the visual collision.
+
+        params.expected(person: [:name, :age])
+
+    *Josua Schmid*
+
 *   Serve static CSS and HTML files with `charset=utf-8` in the Content-Type header.
 
     Static CSS and HTML files served by `ActionDispatch::Static` now include

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `ActionController::Parameters#expected` and `#expected!` as
+    aliases of `#expect` and `#expect!`.
+
+    `expect` is one letter away from `except` and easy to misread at a glance.
+    `expected` reads as the same intent without the visual collision.
+
+        params.expected(person: [:name, :age])
+
+    *Josua Schmid*
+
 *   Split keyword arguments off `#args` on `Rails.application.middleware` entries.
 
     Middleware entries now expose keyword arguments through a new `#kwargs`

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -793,6 +793,9 @@ module ActionController
       raise ExpectedParameterMissing.new(e.param, e.keys)
     end
 
+    alias_method :expected, :expect
+    alias_method :expected!, :expect!
+
     # Returns a parameter for the given `key`. If not found, returns `nil`.
     #
     #     params = ActionController::Parameters.new(person: { name: "Francesco" })

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -796,6 +796,9 @@ module ActionController
       raise ExpectedParameterMissing.new(e.param, e.keys)
     end
 
+    alias_method :expected, :expect
+    alias_method :expected!, :expect!
+
     # Returns a parameter for the given `key`. If not found, returns `nil`.
     #
     #     params = ActionController::Parameters.new(person: { name: "Francesco" })

--- a/actionpack/test/controller/parameters/parameters_expect_test.rb
+++ b/actionpack/test/controller/parameters/parameters_expect_test.rb
@@ -264,4 +264,9 @@ class ParametersExpectTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "expected is an alias for expect" do
+    assert_equal @params.method(:expect), @params.method(:expected)
+    assert_equal @params.method(:expect!), @params.method(:expected!)
+  end
 end


### PR DESCRIPTION
[`expect`](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect) looks like [`except`](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-except).

After this PR I'm able to write it like this:

```rb
params = ActionController::Parameters.new(a: 1, b: 2, c: 3)

params.expect(:a, :b)
params.expected(:a, :b) # <-- new

params.except(:a, :b)
params.without(:a, :b)
```

The idea orginates from [my Rails Forum discussion](https://discuss.rubyonrails.org/t/expect-looks-like-except/90144). Since we already have the [alias `required` for `require`](https://github.com/rails/rails/blob/2d670320f7b02ae879545d5202f0633841b8f196/actionpack/lib/action_controller/metal/strong_parameters.rb#L533), I think this doesn't fall under bike-shedding as of: [PR#51674 issue comment](https://github.com/rails/rails/pull/51674#issuecomment-2341196891)