### PR TITLE
Add `strip_null_bytes` option to the PostgreSQL adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add `strip_null_bytes` option to the PostgreSQL adapter.
+
+    PostgreSQL does not support null bytes (`\0`) in text columns. When
+    `strip_null_bytes` is enabled, null bytes are automatically removed from
+    strings during quoting and type casting, preventing `ArgumentError`
+    exceptions from the `pg` gem.
+
+    ```ruby
+    # In config/initializers/active_record.rb or application.rb:
+    ActiveSupport.on_load(:active_record_postgresqladapter) do
+      self.strip_null_bytes = true
+    end
+
+    Book.create(name: "book1,book2\x00book3")        # saves as "book1,book2book3"
+    Book.where(name: "book1,book2\x00book3")         # queries for "book1,book2book3"
+    Book.where("name = ?", "book1,book2\x00book3")   # queries for "book1,book2book3"
+    ```
+
+    *Simon Isler*
+
 *   Treat `nil` values as `""` during multi-parameter attribute assignment
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -125,6 +125,7 @@ module ActiveRecord
 
         # Quotes strings for use in SQL input.
         def quote_string(s) # :nodoc:
+          s = s.delete("\0") if self.class.strip_null_bytes
           with_raw_connection(allow_retry: true, materialize_transactions: false) do |connection|
             connection.escape(s)
           end
@@ -181,6 +182,8 @@ module ActiveRecord
             encode_range(value)
           when Rational
             value.to_f
+          when String
+            self.class.strip_null_bytes ? value.delete("\0") : super
           else
             super
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -149,6 +149,21 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '\\x48656c6c6f'::bytea").encoding #=> Encoding::BINARY
       class_attribute :decode_bytea, default: false
 
+      ##
+      # :singleton-method:
+      # Toggles automatic stripping of null bytes (<tt>\\0</tt>) from string values.
+      #
+      # PostgreSQL does not support null bytes in text columns. By default, any
+      # string containing a null byte would raise an +ArgumentError+ from the +pg+ gem.
+      # When enabled, null bytes are silently removed from strings during quoting and
+      # type casting.
+      #
+      #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.strip_null_bytes = true
+      #   Book.create(name: "book1,book2\x00book3") # saves as "book1,book2book3"
+      #   Book.where(name: "book1,book2\x00book3")  # queries for "book1,book2book3"
+      #   Book.where("name = ?", "book1,book2\x00book3") # queries for "book1,book2book3"
+      class_attribute :strip_null_bytes, default: false
+
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigserial primary key",
         string:      { name: "character varying" },

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -208,11 +208,13 @@ To keep using the current cache store, you can turn off cache versioning entirel
         decode_bytea = config.active_record.postgresql_adapter_decode_bytea
         decode_dates = config.active_record.postgresql_adapter_decode_dates
         decode_money = config.active_record.postgresql_adapter_decode_money
+        strip_null_bytes = config.active_record.postgresql_adapter_strip_null_bytes
 
         ActiveSupport.on_load(:active_record_postgresqladapter) do
           self.decode_bytea = true if decode_bytea
           self.decode_dates = true if decode_dates
           self.decode_money = true if decode_money
+          self.strip_null_bytes = true if strip_null_bytes
         end
       end
     end
@@ -249,6 +251,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :postgresql_adapter_decode_dates,
           :postgresql_adapter_decode_money,
           :postgresql_adapter_decode_bytea,
+          :postgresql_adapter_strip_null_bytes,
           :use_legacy_signed_id_verifier,
         )
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -39,6 +39,37 @@ module ActiveRecord
       end
     end
 
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_null_bytes_stripped_with_strip_null_bytes_enabled
+        original = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.strip_null_bytes
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.strip_null_bytes = true
+
+        b = Book.create!(name: "book1,book2\x00book3")
+        b.reload
+        assert_equal "book1,book2book3", b.name
+
+        b.update!(name: "book3,book4\x00book5")
+        b.reload
+        assert_equal "book3,book4book5", b.name
+      ensure
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.strip_null_bytes = original
+      end
+
+      def test_null_bytes_in_where_with_strip_null_bytes_enabled
+        original = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.strip_null_bytes
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.strip_null_bytes = true
+
+        Book.create!(name: "findable")
+        assert_nil Book.find_by(name: "not\x00findable")
+        assert_equal "findable", Book.find_by(name: "findable").name
+
+        result = Book.where("name = ?", "not\x00findable")
+        assert_empty result
+      ensure
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.strip_null_bytes = original
+      end
+    end
+
     def test_create_record_with_pk_as_zero
       Book.create(id: 0)
       assert_equal 0, Book.find(0).id

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -33,6 +33,14 @@ module ActiveRecord
           assert_quoted_as "0/1", Rational(0)
         end
 
+        def test_where_with_null_byte_in_string_using_bind_parameters
+          original = PostgreSQLAdapter.strip_null_bytes
+          PostgreSQLAdapter.strip_null_bytes = true
+          assert_quoted_as "'book1,book2book3'", "book1,book2\x00book3"
+        ensure
+          PostgreSQLAdapter.strip_null_bytes = original
+        end
+
         private
           def assert_quoted_as(expected, value, match: 0)
             relation = Post.where("title = ?", value)

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -103,6 +103,41 @@ module ActiveRecord
           assert_equal "9223372036854775808", @conn.quote(value)
           ActiveRecord.raise_int_wider_than_64bit = @raise_int_wider_than_64bit
         end
+
+        def test_quote_string_strips_null_bytes_when_enabled
+          with_strip_null_bytes(true) do
+            assert_equal "book1,book2book3", @conn.quote_string("book1,book2\x00book3")
+          end
+        end
+
+        def test_quote_string_preserves_null_bytes_when_disabled
+          with_strip_null_bytes(false) do
+            assert_raises(ArgumentError) do
+              @conn.quote_string("book1,book2\x00book3")
+            end
+          end
+        end
+
+        def test_type_cast_strips_null_bytes_when_enabled
+          with_strip_null_bytes(true) do
+            assert_equal "book1,book2book3", @conn.type_cast("book1,book2\x00book3")
+          end
+        end
+
+        def test_type_cast_preserves_strings_without_null_bytes
+          with_strip_null_bytes(true) do
+            assert_equal "hello", @conn.type_cast("hello")
+          end
+        end
+
+        private
+          def with_strip_null_bytes(value)
+            original = PostgreSQLAdapter.strip_null_bytes
+            PostgreSQLAdapter.strip_null_bytes = value
+            yield
+          ensure
+            PostgreSQLAdapter.strip_null_bytes = original
+          end
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

PostgreSQL does not support null bytes in text columns. Any string containing a null byte raises an `ArgumentError` from the `pg` gem. In practice, null bytes can appear in user-submitted form data (e.g. search fields), causing unhandled 500 errors.

I started a discussion in https://discuss.rubyonrails.org/t/handling-null-bytes-in-postgres/89924 and explored multiple approaches to this problem. For now, I've decided to implement a `PostgreSQLAdapter` option `strip_null_bytes`.  The option defaults to false to preserve existing behavior. When `strip_null_bytes` is enabled, null bytes are being stripped from strings during quoting and type casting.

### Additional information

I spoke with @tenderlove about this topic at last year's Rails World. We still see this error coming up from time to time, so I thought I'd give it a try :)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
