### PR TITLE
Fix MirrorService#mirror to forward blob metadata

### DIFF
--- a/activestorage/app/jobs/active_storage/mirror_job.rb
+++ b/activestorage/app/jobs/active_storage/mirror_job.rb
@@ -9,7 +9,7 @@ class ActiveStorage::MirrorJob < ActiveStorage::BaseJob
   discard_on ActiveStorage::FileNotFoundError
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
-  def perform(key, checksum:)
-    ActiveStorage::Blob.service.try(:mirror, key, checksum: checksum)
+  def perform(key, checksum:, **options)
+    ActiveStorage::Blob.service.try(:mirror, key, checksum: checksum, **options)
   end
 end

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -45,7 +45,7 @@ module ActiveStorage
     def upload(key, io, checksum: nil, **options)
       io.rewind
       primary.upload key, io, checksum: checksum, **options
-      mirror_later key, checksum: checksum
+      mirror_later key, checksum: checksum, **options
     end
 
     # Delete the file at the +key+ on all services.
@@ -58,18 +58,21 @@ module ActiveStorage
       perform_across_services :delete_prefixed, prefix
     end
 
-    def mirror_later(key, checksum:) # :nodoc:
-      ActiveStorage::MirrorJob.perform_later key, checksum: checksum
+    def mirror_later(key, checksum:, **options) # :nodoc:
+      options[:filename] = options[:filename].to_s if options[:filename]
+      ActiveStorage::MirrorJob.perform_later key, checksum: checksum, **options
     end
 
     # Copy the file at the +key+ from the primary service to each of the mirrors where it doesn't already exist.
-    def mirror(key, checksum:)
+    def mirror(key, checksum:, **options)
+      options[:filename] = ActiveStorage::Filename.wrap(options[:filename]) if options[:filename]
+
       instrument :mirror, key: key, checksum: checksum do
         if (mirrors_in_need_of_mirroring = mirrors.select { |service| !service.exist?(key) }).any?
           primary.open(key, checksum: checksum) do |io|
             mirrors_in_need_of_mirroring.each do |service|
               io.rewind
-              service.upload key, io, checksum: checksum
+              service.upload key, io, checksum: checksum, **options
             end
           end
         end

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -79,6 +79,31 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     assert_equal "Surprise!", @service.mirrors.third.download(key)
   end
 
+  test "mirror_later forwards blob metadata to MirrorJob" do
+    old_service = ActiveStorage::Blob.service
+    ActiveStorage::Blob.service = @service
+
+    key      = SecureRandom.base58(24)
+    data     = "Something else entirely!"
+    checksum = OpenSSL::Digest::MD5.base64digest(data)
+    metadata = {
+      content_type:    "image/jpeg",
+      filename:        "racecar.jpg",
+      disposition:     "inline",
+      custom_metadata: { "owner" => "alice" },
+    }
+
+    assert_enqueued_with(
+      job:  ActiveStorage::MirrorJob,
+      args: [ key, { checksum: checksum, **metadata } ]
+    ) do
+      @service.upload key, StringIO.new(data), checksum: checksum, **metadata
+    end
+  ensure
+    @service.delete key
+    ActiveStorage::Blob.service = old_service
+  end
+
   test "URL generation in primary service" do
     filename = ActiveStorage::Filename.new("test.txt")
 


### PR DESCRIPTION
  ### Motivation / Background                                                                                         
                                                                                                                      
  `ActiveStorage::Service::MirrorService#upload` already forwards `content_type`, `filename`, `disposition`, and      
  `custom_metadata` to the primary service, but the asynchronous mirror copy via `MirrorService#mirror_later`,      
  `ActiveStorage::MirrorJob`, and `MirrorService#mirror` discarded those keyword arguments before reaching each       
  mirror's `upload`. Mirrored objects on S3, R2, Azure, and GCS landed with the bucket's default content type       
  (`application/octet-stream` on S3 and Cloudflare R2), breaking flows that hit the bucket directly: public CDN custom
   domains, `<img>` tags pointed at canonical bucket URLs, and range requests for video. Signed `rails_blob_url` paths
   happen to mask the bug because the signed URL appends `response-content-type`.

  Fixes #57270.                                                                                                       
   
  ### Detail                                                                                                          
                                                                 
  This Pull Request threads the same `**options` already accepted by `MirrorService#upload` through `mirror_later` →  
  `MirrorJob#perform` → `mirror` → `service.upload`, so each mirror's upload receives the same metadata as the      
  primary's.                                                                                                          
                                                                 
  `ActiveStorage::Filename` has no `ActiveJob::Serializer`, so it is coerced to a String at the queue boundary in     
  `mirror_later` and rebuilt via `ActiveStorage::Filename.wrap` on the receiving side in `mirror`. The receiving    
  services (S3, GCS, Azure, Disk) see a `Filename` instance, matching the synchronous primary path.                   
                                                                 
  A new test in `mirror_service_test.rb` exercises the upload→`MirrorJob` enqueue path with `assert_enqueued_with`,   
  asserting the four metadata kwargs reach the queued job. The existing "mirroring a file from the primary service to
  secondary services where it doesn't exist" test continues to verify byte-level mirror correctness.                  
                                                                 
  ### Additional information         
                                                                                                                    
  `MirrorJob#perform` gains `**options` defaulting to empty, so jobs serialized before the upgrade (with only `[key,  
  {checksum:}]`) deserialize and run unchanged. Mid-deploy, new producers may briefly enqueue jobs with extra kwargs
  that old workers raise on, the standard `perform_later` rolling-deploy story for any ActiveJob signature change.    
                                                                 
  ### Checklist                      
                                                                                                                    
  Before submitting the PR make sure the following are checked:

  * [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.               
  * [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it
   in the commit message. Ex: `[Fix #issue-number]`                                                                   
  * [x] Tests are added or updated if you fix a bug or add a feature.
  * [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.    
  Minor bug fixes and documentation changes should not be included.                                                   
                                     
  Note on the last checkbox: per the contributing guide and the template itself ("Minor bug fixes and documentation   
  changes should not be included"), no CHANGELOG entry is added. The checkbox is checked as "complied with the rule"
  (rule applied: do not add for bug fixes), not as "added an entry."   