### PR TITLE
Prevent test_checkout_fairness_by_group from hanging indefinitely

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1915,7 +1915,7 @@ class BelongsToWithForeignKeyTest < ActiveRecord::TestCase
 end
 
 class AsyncBelongsToAssociationsTest < ActiveRecord::TestCase
-  include WaitForAsyncTestHelper
+  include WaitForTestHelper
 
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3254,7 +3254,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 end
 
 class AsyncHasManyAssociationsTest < ActiveRecord::TestCase
-  include WaitForAsyncTestHelper
+  include WaitForTestHelper
 
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -971,7 +971,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 end
 
 class AsyncHasOneAssociationsTest < ActiveRecord::TestCase
-  include WaitForAsyncTestHelper
+  include WaitForTestHelper
 
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -2,11 +2,12 @@
 
 require "cases/helper"
 require "concurrent/atomic/count_down_latch"
-require "timeout"
 
 module ActiveRecord
   module ConnectionAdapters
     module ConnectionPoolTests
+      include ActiveRecord::TestCase::WaitForTestHelper
+
       def self.included(test)
         super
         test.use_transactional_tests = false
@@ -907,11 +908,8 @@ module ActiveRecord
 
         checkin.call(group1.size)         # should wake up all group1
 
-        Timeout.timeout(5) do
-          loop do
-            sleep 0.1
-            break if mutex.synchronize { (successes.size + errors.size) == group1.size }
-          end
+        wait_for(message: "group1 threads did not finish", interval: 0.1) do
+          mutex.synchronize { (successes.size + errors.size) == group1.size }
         end
 
         winners = mutex.synchronize { successes.dup }

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "concurrent/atomic/count_down_latch"
+require "timeout"
 
 module ActiveRecord
   module ConnectionAdapters
@@ -906,9 +907,11 @@ module ActiveRecord
 
         checkin.call(group1.size)         # should wake up all group1
 
-        loop do
-          sleep 0.1
-          break if mutex.synchronize { (successes.size + errors.size) == group1.size }
+        Timeout.timeout(5) do
+          loop do
+            sleep 0.1
+            break if mutex.synchronize { (successes.size + errors.size) == group1.size }
+          end
         end
 
         winners = mutex.synchronize { successes.dup }

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -50,18 +50,26 @@ class ActiveRecord::TestCase
       end
   end
 
-  module WaitForAsyncTestHelper
+  module WaitForTestHelper
     private
+      def wait_for(message: "condition not met", timeout: 5, interval: 0.01)
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        loop do
+          return if yield
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+            raise Timeout::Error, "#{message} after #{timeout} seconds"
+          end
+          sleep interval
+        end
+      end
+
       def wait_for_async_query(connection = ActiveRecord::Base.lease_connection, timeout: 5)
         return unless connection.async_enabled?
 
         executor = connection.pool.async_executor
-        (timeout * 100).times do
-          return unless executor.scheduled_task_count > executor.completed_task_count
-          sleep 0.01
+        wait_for(message: "The async executor wasn't drained", timeout: timeout) do
+          executor.scheduled_task_count <= executor.completed_task_count
         end
-
-        raise Timeout::Error, "The async executor wasn't drained after #{timeout} seconds"
       end
   end
 end

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -9,7 +9,7 @@ require "concurrent/atomic/count_down_latch"
 
 module ActiveRecord
   class LoadAsyncTest < ActiveRecord::TestCase
-    include WaitForAsyncTestHelper
+    include WaitForTestHelper
 
     fixtures :posts, :comments, :categories, :categories_posts
 
@@ -411,7 +411,7 @@ module ActiveRecord
 
   class LoadAsyncMultiThreadPoolExecutorTest < ActiveRecord::TestCase
     unless in_memory_db?
-      include WaitForAsyncTestHelper
+      include WaitForTestHelper
 
       fixtures :posts, :comments
 
@@ -550,7 +550,7 @@ module ActiveRecord
 
   class LoadAsyncMixedThreadPoolExecutorTest < ActiveRecord::TestCase
     unless in_memory_db?
-      include WaitForAsyncTestHelper
+      include WaitForTestHelper
 
       fixtures :posts, :comments, :other_dogs
 


### PR DESCRIPTION
### Motivation / Background

`test_checkout_fairness_by_group` in `activerecord/test/cases/connection_pool_test.rb` can hang CI indefinitely. The test polls for thread completion with an unbounded `loop { sleep 0.1; break if ... }`; if a waiter never reaches the success or error path, the loop spins forever until the agent's job timeout kills the build.

Observed hanging build: https://buildkite.com/rails/rails/builds/128041

The same family of tests has been flaky before — see #53591.

### Detail

Wraps the poll loop in `Timeout.timeout(5)` so the failure surfaces as a normal test failure instead of a stuck CI job.

### Additional information

Test-only change. A follow-up could replace the poll with a `Concurrent::CountDownLatch` (already used elsewhere in this file) to drop the `sleep` entirely.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message describes what changed and why.
* [x] Tests are updated.
* [ ] CHANGELOG — n/a, test-only fix.