### PR TITLE
fix: has_json accessors after requiring active_model

### DIFF
--- a/activemodel/lib/active_model/schematized_json.rb
+++ b/activemodel/lib/active_model/schematized_json.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/hash/reverse_merge"
+require "active_support/core_ext/string/filters"
 require "active_support/core_ext/symbol/starts_ends_with"
 
 module ActiveModel


### PR DESCRIPTION
### Motivation / Background

`ActiveModel::SchematizedJson` calls `String#remove`, which is defined by `active_support/core_ext/string/filters`.

That dependency is currently implicit. When `ActiveModel::SchematizedJson` is loaded without another file having already loaded that string extension, calling a `has_json` accessor can raise a `NoMethodError`.

### Detail

This Pull Request makes the dependency explicit by requiring `active_support/core_ext/string/filters` from `active_model/schematized_json`.

### Additional information

I verified the fix with a standalone Active Model script and the Active Model test suite.

No CHANGELOG entry was added because this is a minor bug fix.

### Reproduce steps

This reproduces on `main` by running:

```bash
bundle exec ruby -Iactivesupport/lib -Iactivemodel/lib -e 'require "active_model"; account = Class.new { include ActiveModel::Attributes; include ActiveModel::SchematizedJson; attribute :settings; has_json :settings, restricts_access: true }.new; p account.settings.restricts_access'
```


### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
