### PR TITLE
Accept Active Record Encryption credentials as ENV

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Accept encryption credentials as ENV
+
+    Taking advantage of Rails.apps.creds (#56455), the `primary_key`, `deterministic_key` and
+    `key_derivation_salt` required by ActiveRecord::Encryption can now also be provided through
+    environment variables named `ACTIVE_RECORD_ENCRYPTION__PRIMARY_KEY`,
+    `ACTIVE_RECORD_ENCRYPTION__DETERMINISTIC_KEY`, `ACTIVE_RECORD_ENCRYPTION__KEY_DERIVATION_SALT`.
+
+    *Claudio Baccigalupo*
+
 *   Treat `nil` values as `""` during multi-parameter attribute assignment
 
     ```ruby

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -373,9 +373,9 @@ To keep using the current cache store, you can turn off cache versioning entirel
     initializer "active_record_encryption.configuration" do |app|
       ActiveSupport.on_load(:active_record_encryption) do
         ActiveRecord::Encryption.configure(
-          primary_key: app.credentials.dig(:active_record_encryption, :primary_key),
-          deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
-          key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
+          primary_key: app.creds.option(:active_record_encryption, :primary_key),
+          deterministic_key: app.creds.option(:active_record_encryption, :deterministic_key),
+          key_derivation_salt: app.creds.option(:active_record_encryption, :key_derivation_salt),
           **app.config.active_record.encryption
         )
 

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -60,15 +60,9 @@ These values can be stored by copying and pasting the generated values into your
 existing [Rails credentials](/security.html#custom-credentials) file using
 `bin/rails credentials:edit`.
 
-Alternatively, the encryption keys can also be configured from other sources,
-such as environment variables:
-
-```ruby
-# config/application.rb
-config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
-config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
-config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
-```
+Alternatively, they can be stored in environment variables with these exact names (with a
+double underscore): `ACTIVE_RECORD_ENCRYPTION__PRIMARY_KEY`,
+`ACTIVE_RECORD_ENCRYPTION__DETERMINISTIC_KEY`, `ACTIVE_RECORD_ENCRYPTION__KEY_DERIVATION_SALT`.
 
 WARNING: It's recommended to use Rails built-in credentials support to store
 keys. If you set them manually via configuration properties, make sure you don't

--- a/railties/test/application/creds_test.rb
+++ b/railties/test/application/creds_test.rb
@@ -16,6 +16,7 @@ class Rails::CredsTest < ActiveSupport::TestCase
     app("production")
 
     ENV["MYSTERY"] = "hidden"
+    Rails.app.creds.reload
     assert_equal "hidden", Rails.app.creds.require(:mystery)
 
     ENV.delete("MYSTERY")
@@ -32,6 +33,7 @@ class Rails::CredsTest < ActiveSupport::TestCase
 
     ENV["MYSTERY"] = "hidden"
     Rails.app.creds = ActiveSupport::CombinedConfiguration.new(Rails.app.envs)
+    Rails.app.creds.reload
     assert_equal "hidden", Rails.app.creds.require(:mystery)
 
     ENV.delete("MYSTERY")

--- a/railties/test/application/envs_test.rb
+++ b/railties/test/application/envs_test.rb
@@ -13,6 +13,7 @@ class Rails::EnvsTest < ActiveSupport::TestCase
     app("production")
 
     ENV["MYSTERY"] = "hidden"
+    Rails.app.creds.reload
     assert_equal "hidden", Rails.app.envs.require(:mystery)
 
     ENV.delete("MYSTERY")


### PR DESCRIPTION
Taking advantage of `Rails.apps.creds` (#56455), the `primary_key`, `deterministic_key` and `key_derivation_salt` required by ActiveRecord::Encryption can now also be provided through environment variables named:

- `ACTIVE_RECORD_ENCRYPTION__PRIMARY_KEY`
- `ACTIVE_RECORD_ENCRYPTION__DETERMINISTIC_KEY`
- `ACTIVE_RECORD_ENCRYPTION__KEY_DERIVATION_SALT`
