### PR TITLE
Remove framework_defaults if load_defaults matches

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove `new_framework_defaults` during `app:update` when `config.load_defaults`
+    already targets the current Rails version.
+
+    *Rune Philosof*
+
 *   Enable `config.asset_host` to read from environment by default
 
     This makes it so no code changes are needed in order to setup a CDN to

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -187,6 +187,11 @@ module Rails
           remove_file "config/initializers/content_security_policy.rb"
         end
       end
+
+      current_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
+      if remove_new_framework_defaults?(config_target_version, current_version)
+        remove_file "config/initializers/new_framework_defaults_#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR}.rb"
+      end
     end
 
     def master_key
@@ -609,6 +614,10 @@ module Rails
     # :startdoc:
 
     private
+      def remove_new_framework_defaults?(target_version, current_version)
+        Gem::Version.new(target_version.to_s) >= Gem::Version.new(current_version.to_s)
+      end
+
       # Define file as an alias to create_file for backwards compatibility.
       def file(*args, &block)
         create_file(*args, &block)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -176,7 +176,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     run_app_update
 
-    assert_file defaults_path
+    assert_no_file defaults_path
     assert_no_file "config/initializers/cors.rb"
   end
 
@@ -425,6 +425,27 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_app_update
 
     assert_file "config/application.rb", /\s+config\.load_defaults 5\.1/
+  end
+
+  def test_app_update_generates_new_framework_defaults_when_load_defaults_is_previous_version
+    run_generator
+
+    defaults_path = "config/initializers/new_framework_defaults_#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR}.rb"
+
+    FileUtils.cd(destination_root) do
+      config = "config/application.rb"
+      current_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
+      previous_version = "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR - 1}"
+      content = File.read(config)
+
+      File.write(config, content.gsub(/config\.load_defaults #{current_version}/, "config.load_defaults #{previous_version}"))
+    end
+
+    assert_no_file defaults_path
+
+    run_app_update
+
+    assert_file defaults_path
   end
 
   def test_app_update_does_not_change_app_name_when_app_name_is_hyphenated_name


### PR DESCRIPTION
### Motivation / Background

It is noisy to have a lot of unused new_framework_defaults.

### Detail

Previously the newest new_framework_defaults file would be deleted on `rails new`, but always created on `rails app:update`.

When you update `load_defaults`, you typically delete `new_framework_defaults`.
If you rerun `app:update` after updating `load_defaults`, you do not want `new_framework_defaults` recreated.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
