### PR TITLE
Reject malformed Mailgun ingress timestamps

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -85,7 +85,8 @@ module ActionMailbox
         attr_reader :key, :timestamp, :token, :signature
 
         def initialize(key:, timestamp:, token:, signature:)
-          @key, @timestamp, @token, @signature = key, Integer(timestamp), token, signature
+          @key, @timestamp, @token, @signature = key, timestamp.to_s, token, signature
+          @parsed_timestamp = Integer(timestamp, exception: false)
         end
 
         def authenticated?
@@ -99,7 +100,7 @@ module ActionMailbox
 
           # Allow for 2 minutes of drift between Mailgun time and local server time.
           def recent?
-            Time.at(timestamp) >= 2.minutes.ago
+            @parsed_timestamp && Time.at(@parsed_timestamp) >= 2.minutes.ago
           end
 
           def expected_signature

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -76,6 +76,24 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
     assert_response :unauthorized
   end
 
+  test "rejecting an inbound email from Mailgun with a malformed timestamp" do
+    timestamp = "not-a-number"
+    token = "7VwW7k6Ak7zcTwoSoNm7aTtbk1g67MKAnsYLfUB7PdszbgR5Xi"
+    signature = OpenSSL::HMAC.hexdigest OpenSSL::Digest::SHA256.new, ENV["MAILGUN_INGRESS_SIGNING_KEY"], "#{timestamp}#{token}"
+
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      travel_to "2018-10-09 15:15:00 EDT"
+      post rails_mailgun_inbound_emails_url, params: {
+        timestamp: timestamp,
+        token: token,
+        signature: signature,
+        "body-mime" => file_fixture("../files/welcome.eml").read
+      }
+    end
+
+    assert_response :unauthorized
+  end
+
   test "rejecting a forged inbound email from Mailgun" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       travel_to "2018-10-09 15:15:00 EDT"


### PR DESCRIPTION
### Motivation / Background

Fixes #57315.

The Mailgun Action Mailbox ingress parsed the request `timestamp` with `Integer(timestamp)` while constructing the authenticator. A malformed timestamp could raise `ArgumentError` before authentication returned `false`, so the ingress produced a server error instead of rejecting the request as unauthorized.

### Detail

This keeps the raw timestamp string for the Mailgun HMAC input, parses a separate timestamp value for the recency check with `exception: false`, and treats invalid timestamps as failed authentication.

### Additional information

Validated with:

```bash
cd actionmailbox && bin/test test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
cd actionmailbox && bin/test
bundle exec rubocop actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
git diff --check
```
