### PR TITLE
Ractor-safe class attribute implementation

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -944,7 +944,7 @@ module ActiveSupport
             # HACK: We're making assumption on how `class_attribute` is implemented
             # to save constantly duping the callback hash. If this desync with class_attribute
             # we'll lose the optimization, but won't cause an actual behavior bug.
-            unless singleton_class.private_method_defined?(:__class_attr__callbacks, false)
+            unless singleton_class.private_method_defined?(:__class_attr__callbacks_owner, false)
               self.__callbacks = __callbacks.dup
             end
             name = name.to_sym

--- a/activesupport/lib/active_support/class_attribute.rb
+++ b/activesupport/lib/active_support/class_attribute.rb
@@ -3,24 +3,24 @@
 module ActiveSupport
   module ClassAttribute # :nodoc:
     class << self
-      def redefine(owner, name, namespaced_name, value)
-        if owner.singleton_class?
-          if owner.attached_object.is_a?(Module)
-            redefine_method(owner, namespaced_name, private: true) { value }
+      def redefine(owner, name, owner_method, reader_method, value, instance_reader)
+        ivar_name = :"@#{reader_method}"
+        owner.instance_variable_set(ivar_name, value)
+
+        owner_proc =
+          if defined?(Ractor.shareable_proc)
+            Ractor.shareable_proc { owner }
           else
-            redefine_method(owner, name) { value }
+            -> { owner }
           end
+
+        # If redefining on a singleton class, and including instance_reader, we
+        # need to update it to use self.singleton_class instead of self.class
+        if owner.singleton_class? && !owner.attached_object.is_a?(Module) && instance_reader
+          owner.class_eval("def #{name}; self.singleton_class.#{reader_method}; end", __FILE__, __LINE__)
         end
 
-        redefine_method(owner.singleton_class, namespaced_name, private: true) { value }
-
-        redefine_method(owner.singleton_class, "#{namespaced_name}=", private: true) do |new_value|
-          if owner.equal?(self)
-            value = new_value
-          else
-            ::ActiveSupport::ClassAttribute.redefine(self, name, namespaced_name, new_value)
-          end
-        end
+        redefine_method(owner.singleton_class, owner_method, private: true, &owner_proc)
       end
 
       def redefine_method(owner, name, private: false, &block)

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -93,11 +93,22 @@ class Class
       end
 
       name = name.to_sym
-      namespaced_name = :"__class_attr_#{name}"
-      ::ActiveSupport::ClassAttribute.redefine(self, name, namespaced_name, default)
+      reader_method = :"__class_attr_#{name}"
+      owner_method = :"__class_attr_#{name}_owner"
+      ::ActiveSupport::ClassAttribute.redefine(self, name, owner_method, reader_method, default, instance_reader)
 
-      class_methods << "def #{name}; #{namespaced_name}; end"
-      class_methods << "def #{name}=(value); self.#{namespaced_name} = value; end"
+      singleton_class.attr_reader(reader_method)
+
+      class_methods << "def #{name}; #{owner_method}.#{reader_method}; end"
+      class_methods << <<~RUBY
+        def #{name}=(value)
+          if #{owner_method}.equal?(self)
+            @#{reader_method} = value
+          else
+            ::ActiveSupport::ClassAttribute.redefine(self, :#{name}, :#{owner_method}, :#{reader_method}, value, #{!!instance_reader})
+          end
+        end
+      RUBY
 
       if singleton_class?
         methods << <<~RUBY if instance_reader

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -83,6 +83,16 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_not_respond_to object, :setting?
   end
 
+  test "disabling instance reader is not bypassed by assigning on the singleton class" do
+    klass = Class.new { class_attribute :setting, instance_reader: false }
+    object = klass.new
+
+    object.singleton_class.setting = "foo"
+
+    assert_raise(NoMethodError) { object.setting }
+    assert_not_respond_to object, :setting
+  end
+
   test "disabling both instance writer and reader" do
     object = Class.new { class_attribute :setting, instance_accessor: false }.new
     assert_raise(NoMethodError) { object.setting }
@@ -221,8 +231,8 @@ class ClassAttributeTest < ActiveSupport::TestCase
   test "can check if value is set on a sub class" do
     # Note: this isn't a public API test and it's OK to break it.
     # However if it's broken make sure to update ActiveSupport::Callbacks::ClassMethods#set_callbacks
-    assert_equal false, @sub.singleton_class.private_method_defined?(:__class_attr_setting, false)
+    assert_equal false, @sub.singleton_class.private_method_defined?(:__class_attr_setting_owner, false)
     @sub.setting = true
-    assert_equal true, @sub.singleton_class.private_method_defined?(:__class_attr_setting, false)
+    assert_equal true, @sub.singleton_class.private_method_defined?(:__class_attr_setting_owner, false)
   end
 end


### PR DESCRIPTION
This modifies the class_attribute implementation to be Ractor-safe, with nearly the same performance (a tiny bit slower, but within 10%).

This is done by splitting the "namespaced_name" method, which was the block-method used with define_method to get the inheritance-based definition into two.

Previously we had a method named something like `__class_attr__name`, which would return the value, and we'd modify the value via closure and redefine it when the class changed. Under this commit instead we have `__class_attr__name_owner`, which returns just the class, rather than the value, and is redefined when the class changes. The value is read from an `attr_reader` named `__class_attr__name`, which does not need redefinition.

Because classes are Ractor-shareable, that allows us to make `__class_attr__name_owner` a shareable proc. And then we get Ractor ivar semantics from reading the value from the `attr_reader` (if the value is shareable all Ractors can read it, otherwise only the main Ractor can read it).

This also fixes a bug where instance_reader was defined unconditionally when setting on a singleton class.

**Benchmark**

``` ruby
require "bundler/setup"
require "active_support/core_ext/class/attribute"

class Base
  class_attribute :setting, default: :hello
  class_attribute :nums, default: [1, 2, 3].freeze
end

class Sub < Base
end

class SubSub < Sub
end

Sub.setting = :world

obj_base = Base.new
obj_sub = Sub.new

IPS.ips do |x|
  x.report("Base.setting (default)") { Base.setting }
  x.report("Sub.setting (overridden)") { Sub.setting }
  x.report("SubSub.setting (inherited 2 levels)") { SubSub.setting }
  x.report("Base.new.setting (instance)") { obj_base.setting }
  x.report("Sub.new.setting (instance, overridden class)") { obj_sub.setting }
end
```

**Before**

```
❯ ips --yjit bench_class_attr.rb
ruby 4.0.1 (2026-01-13 revision e04267a14b) +YJIT +PRISM [x86_64-linux]
                      Base.setting (default):    50.330M i/s (± 0.0%)
                    Sub.setting (overridden):    50.304M i/s (± 0.0%)
         SubSub.setting (inherited 2 levels):    50.130M i/s (± 0.0%)
                 Base.new.setting (instance):    42.409M i/s (± 0.3%)
Sub.new.setting (instance, overridden class):    42.130M i/s (± 0.1%)

Summary
  Base.setting (default) ran
    1.00 ± 0.00 times faster than Sub.setting (overridden)
    1.00 ± 0.00 times faster than SubSub.setting (inherited 2 levels)
    1.19 ± 0.00 times faster than Base.new.setting (instance)
    1.19 ± 0.00 times faster than Sub.new.setting (instance, overridden class)
```

**After**

```
❯ ips --yjit bench_class_attr.rb
ruby 4.0.1 (2026-01-13 revision e04267a14b) +YJIT +PRISM [x86_64-linux]
                      Base.setting (default):    49.119M i/s (± 0.1%)
                    Sub.setting (overridden):    48.812M i/s (± 0.0%)
         SubSub.setting (inherited 2 levels):    49.157M i/s (± 0.0%)
                 Base.new.setting (instance):    42.835M i/s (± 0.1%)
Sub.new.setting (instance, overridden class):    42.865M i/s (± 0.0%)

Summary
  SubSub.setting (inherited 2 levels) ran
    1.00 ± 0.00 times faster than Base.setting (default)
    1.01 ± 0.00 times faster than Sub.setting (overridden)
    1.15 ± 0.00 times faster than Sub.new.setting (instance, overridden class)
    1.15 ± 0.00 times faster than Base.new.setting (instance)
```