### PR TITLE
Add datalist to FormBuilder

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Add `f.datalist` to `FormBuilder`
+
+    Example:
+
+        <%= form_with model: @post do |f| %>
+           <%# Wire the input to the datalist using the same derived id: %>
+           <%= f.text_field :country, list: f.field_id(:country, :datalist) %>
+           <%= f.datalist  :country, ["Argentina", "Brazil", "Chile"] %>
+        <% end %>
+
+          Produces:
+          <input list="post_country_datalist" type="text"
+                 name="post[country]" id="post_country" />
+          <datalist id="post_country_datalist">
+            <option value="Argentina">Argentina</option>
+            <option value="Brazil">Brazil</option>
+            <option value="Chile">Chile</option>
+          </datalist>
+
+      *Tahsin Hasan*
+
 *   Add `datalist_tag` to create `datalist` form elements.
 
     Example:

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -924,6 +924,19 @@ module ActionView
       def collection_radio_buttons(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
         @template.collection_radio_buttons(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_html_options.merge(html_options), &block)
       end
+
+      # Wraps ActionView::Helpers::FormTagHelper#datalist_tag for form builders.
+      #
+      #   <%= form_with model: @post do |f| %>
+      #     <%# Wire the input to the datalist using the same derived id: %>
+      #     <%= f.text_field :country, list: f.field_id(:country, :datalist) %>
+      #     <%= f.datalist  :country, ["Argentina", "Brazil", "Chile"] %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def datalist(method, choices = nil, html_options = {})
+        @template.datalist_tag(field_id(method, "datalist"), choices, html_options)
+      end
     end
   end
 end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -33,6 +33,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     Country     = Struct.new("Country", :country_id, :country_name)
     Album       = Struct.new("Album", :id, :title, :genre)
     Digest      = Struct.new("Digest", :send_day)
+    Pic         = Struct.new("Pic", :country)
   end
 
   class Firm
@@ -1646,6 +1647,98 @@ class FormOptionsHelperTest < ActionView::TestCase
       "<select name=\"digest[send_day]\" id=\"digest_send_day\"><option selected=\"selected\" value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option></select>",
       output_buffer
     )
+  end
+
+  def test_datalist_with_plain_array
+    @post = Post.new
+
+    actual = fields_for(:post, @post) do |f|
+      f.datalist :country, %w[Argentina Brazil Chile]
+    end
+
+    expected = %(<datalist id="post_country_datalist">) +
+               %(<option value="Argentina">Argentina</option>) +
+               %(<option value="Brazil">Brazil</option>) +
+               %(<option value="Chile">Chile</option>) +
+               %(</datalist>)
+
+    assert_dom_equal expected, actual
+  end
+
+  def test_datalist_with_label_value_pairs
+    @post = Post.new
+
+    actual = fields_for(:post, @post) do |f|
+      f.datalist :country_code, [["Argentina", "AR"], ["Brazil", "BR"]]
+    end
+
+    expected = %(<datalist id="post_country_code_datalist">) +
+               %(<option value="AR">Argentina</option>) +
+               %(<option value="BR">Brazil</option>) +
+               %(</datalist>)
+
+    assert_dom_equal expected, actual
+  end
+
+  def test_datalist_id_matches_field_id_helper
+    @post = Post.new
+
+    datalist_html = fields_for(:post, @post) do |f|
+      f.datalist :country, %w[AR BR]
+    end
+
+    assert_match(/id="post_country_datalist"/, datalist_html)
+  end
+
+  def test_datalist_passes_html_options
+    @post = Post.new
+
+    actual = fields_for(:post, @post) do |f|
+      f.datalist :tag, %w[ruby rails], class: "suggestions", "data-remote" => "true"
+    end
+
+    assert_match(/class="suggestions"/, actual)
+    assert_match(/data-remote="true"/, actual)
+    assert_match(/id="post_tag_datalist"/, actual)
+  end
+
+  def test_datalist_with_collection_for_select
+    @post = Post.new
+    countries = [Country.new("AR", "Argentina"),
+                 Country.new("BR", "Brazil")]
+
+    actual = fields_for(:post, @post) do |f|
+      f.datalist :country,
+                 options_from_collection_for_select(countries, :country_id, :country_name)
+    end
+
+    assert_match(/id="post_country_datalist"/, actual)
+    assert_match(/<option value="AR">Argentina<\/option>/, actual)
+    assert_match(/<option value="BR">Brazil<\/option>/, actual)
+  end
+
+  def test_datalist_with_nil_choices
+    @post = Post.new
+
+    actual = fields_for(:post, @post) do |f|
+      f.datalist :country, nil
+    end
+
+    assert_dom_equal %(<datalist id="post_country_datalist"></datalist>), actual
+  end
+
+  def test_text_field_and_datalist_are_paired_correctly
+    @pic = Pic.new
+
+    output = fields_for(:pic, @pic) do |f|
+      safe_join([
+        f.text_field(:country, list: f.field_id(:country, :datalist)),
+        f.datalist(:country, %w[AR BR])
+      ])
+    end
+
+    assert_match(/list="pic_country_datalist"/, output)
+    assert_match(/id="pic_country_datalist"/, output)
   end
 
   private


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to add `datalist` to `FormBuilder`.

### Detail

This Pull Request changes to add `datalist` to `FormBuilder`.

Examples:
      
         <%= form_with model: @post do |f| %>
           <%# Wire the input to the datalist using the same derived id: %>
           <%= f.text_field :country, list: f.field_id(:country, :datalist) %>
           <%= f.datalist  :country, ["Argentina", "Brazil", "Chile"] %>
         <% end %>
      
     Produces:
      
      <input list="post_country_datalist" type="text"
              name="post[country]" id="post_country" />
       <datalist id="post_country_datalist">
         <option value="Argentina">Argentina</option>
         <option value="Brazil">Brazil</option>
         <option value="Chile">Chile</option>
       </datalist>
      
We create a `datalist` element whose `id` is automatically derived  from the builder's object name and the given method. e.g. A form builder for `post` with method `:country` produces `id="post_country_datalist"`. The companion `text_field`  must reference that id via its `list:` option to activate browser autocomplete.
      

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
