### PR TITLE
Use wait_for helper in reaper and async query tests

### DIFF
--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -4,6 +4,8 @@ require "cases/helper"
 require "models/post"
 
 module AsynchronousQueriesSharedTests
+  include ActiveRecord::TestCase::WaitForTestHelper
+
   def test_async_select_failure
     if in_memory_db?
       assert_raises ActiveRecord::StatementInvalid do
@@ -74,10 +76,7 @@ module AsynchronousQueriesSharedTests
 
   private
     def wait_for_future_result(result)
-      500.times do
-        break unless result.pending?
-        sleep 0.02
-      end
+      wait_for(message: "future result still pending", timeout: 10, interval: 0.02) { !result.pending? }
     end
 end
 

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -5,6 +5,8 @@ require "cases/helper"
 module ActiveRecord
   module ConnectionAdapters
     class ReaperTest < ActiveRecord::TestCase
+      include ActiveRecord::TestCase::WaitForTestHelper
+
       class FakePool
         attr_reader :reaped
         attr_reader :flushed
@@ -68,9 +70,7 @@ module ActiveRecord
 
         reaper = ConnectionPool::Reaper.new(fp, 0.0001)
         reaper.run
-        until fp.flushed
-          Thread.pass
-        end
+        wait_for(message: "fake pool was not flushed") { fp.flushed }
         assert fp.reaped
         assert fp.flushed
       ensure
@@ -192,9 +192,7 @@ module ActiveRecord
         ConnectionPool::Reaper.new(discarded_pool, frequency).run
         ConnectionPool::Reaper.new(pool, frequency).run
 
-        until pool.flushed
-          Thread.pass
-        end
+        wait_for(message: "pool was not flushed") { pool.flushed }
 
         assert_not discarded_pool.reaped
         assert pool.reaped
@@ -225,10 +223,7 @@ module ActiveRecord
         end
 
         def wait_for_conn_idle(conn, timeout = 5)
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          while conn.in_use? && Process.clock_gettime(Process::CLOCK_MONOTONIC) - start < timeout
-            Thread.pass
-          end
+          wait_for(message: "connection still in use", timeout: timeout) { !conn.in_use? }
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Follow-up to #57309. Three polling loops in activerecord tests still
use ad-hoc patterns: one is unbounded (hangs forever), two silently
fall through on timeout into misleading assertions.

### Detail

Replaces them with `wait_for` so hangs raise `Timeout::Error` at the
actual point of failure.

cc @rafaelfranca

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.