### PR TITLE
Fix BigDecimal rendering failure in Arel tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     beaneater (1.1.3)
-    bigdecimal (3.2.3)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -787,7 +787,7 @@ CHECKSUMS
   bcrypt (3.1.20) sha256=8410f8c7b3ed54a3c00cd2456bf13917d695117f033218e2483b2e40b0784099
   bcrypt_pbkdf (1.1.1) sha256=2f9077dde837d1f0dd2eb0f9e5327c6871c68ebc8eba88870fb6b7956e1e2b13
   beaneater (1.1.3) sha256=3dbe673d4df984d85a486bccdfa5d5ac61754b094e19bf0a8a30bb27ac2d8acb
-  bigdecimal (3.2.3) sha256=ffd11d1ac67a0d3b2f44aec0a6487210b3f813f363dd11f1fcccf5ba00da4e1b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.18.4) sha256=ac4c42af397f7ee15521820198daeff545e4c360d2772c601fbdc2c07d92af55
   brakeman (7.0.0) sha256=1a0122b0c70f17519a61548a53a332c0acc19e3aa10b445e15e025a4b13b8577

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -347,7 +347,7 @@ module Arel
         end
 
         it "should visit_BigDecimal" do
-          _(compile(Nodes.build_quoted(BigDecimal("2.14")))).must_equal "2.14"
+          _(compile(Nodes.build_quoted(BigDecimal("2.14")))).must_equal BigDecimal("2.14").to_s
         end
 
         it "should visit_Date" do


### PR DESCRIPTION
```
  1) Failure:
Arel::Visitors::ToSQLTest::the to_sql visitor#test_0032_should visit_BigDecimal [test/cases/arel/visitors/to_sql_test.rb:350]:
Expected: "2.14"
  Actual: "0.214e1"

```