### PR TITLE
Handle missing Mandrill ingress signatures

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
@@ -66,7 +66,7 @@ module ActionMailbox
         end
 
         def authenticated?
-          ActiveSupport::SecurityUtils.secure_compare given_signature, expected_signature
+          given_signature.present? && ActiveSupport::SecurityUtils.secure_compare(given_signature, expected_signature)
         end
 
         private

--- a/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
@@ -38,6 +38,14 @@ class ActionMailbox::Ingresses::Mandrill::InboundEmailsControllerTest < ActionDi
     assert_response :unauthorized
   end
 
+  test "rejecting an inbound email from Mandrill without a signature" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_mandrill_inbound_emails_url, params: { mandrill_events: @events }
+    end
+
+    assert_response :unauthorized
+  end
+
   test "raising when Mandrill API key is nil" do
     switch_key_to nil do
       assert_raises ArgumentError do


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes #57329.

Action Mailbox's Mandrill ingress compares the `X-Mandrill-Signature` header directly with `ActiveSupport::SecurityUtils.secure_compare`. When the header is missing, the comparison receives `nil` and raises a `NoMethodError` before the ingress can reject the request.

### Detail

This Pull Request changes the Mandrill authenticator to require a present signature before comparing it with the expected HMAC. Missing signatures now fail authentication and return `401 Unauthorized`, matching the behavior for forged signatures.

A focused integration regression covers a Mandrill request without the signature header and asserts that no inbound email is created.

### Additional information

Before the fix, the new regression failed with:

```text
NoMethodError: undefined method `bytesize' for nil
    activesupport/lib/active_support/security_utils.rb:34:in `secure_compare'
```

Validation:

```bash
cd actionmailbox && bin/test test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb -i "/without a signature/"
cd actionmailbox && bin/test test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
bundle exec rubocop actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
git diff --check
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
