### PR TITLE
fix: unfreeze Date::DATE_FORMATS

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/date/zones"
 require "active_support/core_ext/module/redefine_method"
 
 class Date
-  DATE_FORMATS = {
+  DATE_FORMATS = { # rubocop:disable Style/MutableConstant
     short: "%d %b",
     long: "%B %d, %Y",
     db: "%Y-%m-%d",
@@ -19,7 +19,7 @@ class Date
     rfc822: "%d %b %Y",
     rfc2822: "%d %b %Y",
     iso8601: lambda { |date| date.iso8601 }
-  }.freeze
+  }
 
   # Convert to a formatted string. See DATE_FORMATS for predefined formats.
   #


### PR DESCRIPTION

### Motivation / Background

reverts the unintended `freeze` introduced by 34bce3f693b354f2172d8cf48648fe068605b2d5, following what was done in `activesupport/lib/active_support/core_ext/time/conversions.rb`


### Detail

Freezing DATE_FORMATS breaks adding new formats, as shown by the docs in the very same constant

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
