### PR TITLE
Disable freezing of NATIVE_DATABASE_TYPES for MySQL adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -28,7 +28,7 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans = false
       class_attribute :emulate_booleans, default: true
 
-      NATIVE_DATABASE_TYPES = {
+      NATIVE_DATABASE_TYPES = { # rubocop:disable Style/MutableConstant
         primary_key: "bigint auto_increment PRIMARY KEY",
         string:      { name: "varchar", limit: 255 },
         text:        { name: "text" },
@@ -44,7 +44,7 @@ module ActiveRecord
         blob:        { name: "blob" },
         boolean:     { name: "boolean" },
         json:        { name: "json" },
-      }.freeze
+      }
 
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         private


### PR DESCRIPTION
Followup https://github.com/rails/rails/pull/57323

akin to https://github.com/rails/rails/blob/5700c17cb71aff5325f42ea1af32a019b6509cc7/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L152

and also this is used in the `neighbor` gem here: https://github.com/ankane/neighbor/blob/2978d482d48340ab16477f76406c7f1522427d68/lib/neighbor/mysql.rb#L9
which breaks my application like this:
```
/Users/chedli/.rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/neighbor-1.0.0/lib/neighbor/mysql.rb:9:in 'Neighbor::MySQL.initialize!': can't modify frozen Hash: {primary_key: "bigint auto_increment PRIMARY KEY", string: {name: "varchar", limit: 255}, text: {name: "text"}, integer: {name: "int", limit: 4}, bigint: {name: "bigint"}, float: {name: "float", limit: 24}, decimal: {name: "decimal"}, datetime: {name: "datetime"}, timestamp: {name: "timestamp"}, time: {name: "time"}, date: {name: "date"}, binary: {name: "blob"}, blob: {name: "blob"}, boolean: {name: "boolean"}, json: {name: "json"}} (FrozenError)
```

Please let me know if there is a better fix @paracycle @byroot 