### PR TITLE
Handle invalid SendGrid envelope input in Action Mailbox

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -5,6 +5,10 @@
 
     *Nesan Vettivel*
 
+*   Return `422 Unprocessable Content` for malformed SendGrid envelopes.
+
+    *Andrii Furmanets*
+
 *   Deprecate `Mail::Address.wrap` because it isn't used.
 
     *Gannon McGibbon*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
@@ -50,20 +50,32 @@ module ActionMailbox
 
     def create
       ActionMailbox::InboundEmail.create_and_extract_message_id! mail
-    rescue JSON::ParserError => error
+    rescue JSON::ParserError, MalformedEnvelopeError => error
       logger.error error.message
       head ActionDispatch::Constants::UNPROCESSABLE_CONTENT
     end
 
     private
-      def mail
-        params.require(:email).tap do |raw_email|
-          envelope["to"].each { |to| raw_email.prepend("X-Original-To: ", to, "\n") } if params.key?(:envelope)
+      class MalformedEnvelopeError < StandardError
+        def initialize(message = "Malformed SendGrid envelope")
+          super
         end
       end
 
-      def envelope
-        JSON.parse(params.require(:envelope))
+      def mail
+        params.require(:email).tap do |raw_email|
+          envelope_recipients.each { |to| raw_email.prepend("X-Original-To: ", to, "\n") } if params.key?(:envelope)
+        end
+      end
+
+      def envelope_recipients
+        envelope = JSON.parse(params.require(:envelope))
+        raise MalformedEnvelopeError unless envelope.is_a?(Hash)
+        raise MalformedEnvelopeError unless envelope.key?("to")
+
+        envelope["to"].tap do |recipients|
+          raise MalformedEnvelopeError unless recipients.is_a?(Array) && recipients.all?(String)
+        end
       end
   end
 end

--- a/actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb
@@ -47,6 +47,22 @@ class ActionMailbox::Ingresses::Sendgrid::InboundEmailsControllerTest < ActionDi
     assert_equal "replies@example.com", mail.header["X-Original-To"].decoded
   end
 
+  test "rejecting an inbound email from Sendgrid with envelope missing to recipients" do
+    assert_rejects_malformed_envelope "{\"from\":\"jason@37signals.com\"}"
+  end
+
+  test "rejecting an inbound email from Sendgrid with a non-object envelope" do
+    assert_rejects_malformed_envelope "[\"replies@example.com\"]"
+  end
+
+  test "rejecting an inbound email from Sendgrid with non-array to recipients" do
+    assert_rejects_malformed_envelope "{\"to\":\"replies@example.com\",\"from\":\"jason@37signals.com\"}"
+  end
+
+  test "rejecting an inbound email from Sendgrid with non-string to recipients" do
+    assert_rejects_malformed_envelope "{\"to\":[1],\"from\":\"jason@37signals.com\"}"
+  end
+
   test "rejecting an unauthorized inbound email from Sendgrid" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       post rails_sendgrid_inbound_emails_url, params: { email: file_fixture("../files/welcome.eml").read }
@@ -72,4 +88,17 @@ class ActionMailbox::Ingresses::Sendgrid::InboundEmailsControllerTest < ActionDi
       end
     end
   end
+
+  private
+    def assert_rejects_malformed_envelope(envelope)
+      assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+        post rails_sendgrid_inbound_emails_url,
+          headers: { authorization: credentials }, params: {
+            email: file_fixture("../files/welcome.eml").read,
+            envelope: envelope,
+          }
+      end
+
+      assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
+    end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #57334.

The SendGrid ingress already returns `422 Unprocessable Content` when the optional `envelope` parameter contains invalid JSON. This change applies the same response to an authenticated request whose `envelope` is valid JSON but does not match the expected shape.

This is a defensive consistency fix at the HTTP boundary, not a known SendGrid production payload.

### Detail

This Pull Request validates the parsed SendGrid envelope before using its `to` recipients. If the envelope is missing `to`, or `to` is not an array of strings, the request now follows the existing unprocessable response path and no inbound email is created.

### Additional information

Validation:

* `cd actionmailbox && bin/test test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb`
* `cd actionmailbox && bin/test`
* `bundle exec rubocop actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb`

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
