### PR TITLE
When joining models across different SQLite databases, automatically ATTACH DATABASE to bring them into scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Automatically execute `ATTACH DATABASE` when joining across SQLite databases.
+
+    *Nick Pezza*
+
 *   Move the defaulting of `prevent_writes` to `true` when using the `reading` role into the parameters
     of the role switching methods, and raise an `ArgumentError` if `prevent_writes: false` is provided
     with the `reading` role.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -86,6 +86,12 @@ module ActiveRecord
           intent.finish
         end
 
+        def execute_intent(intent) # :nodoc:
+          super
+        ensure
+          deattach_databases(intent)
+        end
+
         private
           def internal_begin_transaction(mode, isolation)
             if isolation
@@ -107,6 +113,7 @@ module ActiveRecord
             if intent.batch
               raw_connection.execute_batch2(intent.processed_sql)
             else
+              attach_databases(intent)
               stmt = if intent.prepare
                 @statements[intent.processed_sql] ||= raw_connection.prepare(intent.processed_sql)
                 @statements[intent.processed_sql].reset!

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -153,6 +153,35 @@ module ActiveRecord
           end
       end
 
+      class AttachedDatabaseCollector # :nodoc:
+        attr_accessor :preparable, :retryable
+        attr_reader :databases
+
+        def initialize
+          @databases = Set.new
+        end
+
+        def <<(_)
+          self
+        end
+
+        def add_bind(*)
+          self
+        end
+
+        def add_binds(*)
+          self
+        end
+
+        def add_attached_database(config)
+          @databases << config
+        end
+
+        def value
+          databases
+        end
+      end
+
       def initialize(...)
         super
 
@@ -188,6 +217,7 @@ module ActiveRecord
           default_transaction_mode: :immediate,
           extensions: extensions
         )
+        reset_attached_databases
       end
 
       def database_exists?
@@ -279,8 +309,23 @@ module ActiveRecord
       def disconnect!
         super
 
+        reset_attached_databases
         @raw_connection&.close rescue nil
         @raw_connection = nil
+      end
+
+      def reset_attached_databases
+        @attached_databases = Set.new
+      end
+
+      def table_name_with_database(table, collector = nil)
+        if (config = attached_database_for(table))
+          collector.try(:add_attached_database, config)
+
+          "#{[config.env_name, config.name].compact.join("_")}.#{table.name}"
+        else
+          table.name
+        end
       end
 
       def supports_index_sort_order?
@@ -870,8 +915,55 @@ module ActiveRecord
 
         def connect
           @raw_connection = self.class.new_client(@connection_parameters)
+          reset_attached_databases
         rescue ConnectionNotEstablished => ex
           raise ex.set_pool(@pool)
+        end
+
+        def attach_database(config)
+          exec_query "ATTACH DATABASE '#{config.database}' AS #{[config.env_name, config.name].compact.join("_")}"
+        end
+
+        def deattach_database(config)
+          exec_query "DETACH DATABASE #{[config.env_name, config.name].compact.join("_")}"
+        end
+
+        def attach_databases(intent)
+          databases_needed_for_query(intent).each do |config|
+            next if @attached_databases.include?(config)
+
+            attach_database(config)
+            @attached_databases << config
+          end
+        end
+
+        def deattach_databases(intent)
+          databases_needed_for_query(intent).each do |config|
+            next unless @attached_databases.include?(config)
+
+            deattach_database(config)
+            @attached_databases.delete(config)
+          end
+        end
+
+        def databases_needed_for_query(intent)
+          arel = intent.arel
+          return {} unless arel
+
+          arel = arel.ast if arel.respond_to?(:ast)
+          return {} unless Arel.arel_node?(arel) && !(String === arel)
+
+          visitor.compile(arel, AttachedDatabaseCollector.new)
+        end
+
+        def attached_database_for(table)
+          config = table.klass&.connection_db_config
+
+          return unless config.present? && config.adapter == "sqlite3" &&
+            config.database != ":memory:" &&
+            pool.db_config != table.klass.connection_db_config
+
+          config
         end
 
         def reconnect

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -59,6 +59,28 @@ module Arel # :nodoc: all
           collector << quote_table_name(o.name)
         end
 
+        def visit_Arel_Table(o, collector)
+          if Arel::Nodes::Node === o.name
+            visit o.name, collector
+          else
+            collector << quote_table_name(@connection.try(:table_name_with_database, o, collector) || o.name)
+          end
+
+          if o.table_alias
+            collector << " " << quote_table_name(o.table_alias)
+          end
+
+          collector
+        end
+
+        def visit_Arel_Attributes_Attribute(o, collector)
+          join_name = o.relation.table_alias ||
+            @connection.try(:table_name_with_database, o.relation, collector) ||
+            o.relation.name
+
+          collector << quote_table_name(join_name) << "." << quote_column_name(o.name)
+        end
+
         # Locks are not supported in SQLite
         def visit_Arel_Nodes_Lock(o, collector)
           collector

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -108,6 +108,32 @@ class MultipleDbTest < ActiveRecord::TestCase
         College.first.courses.first
       end
     end
+
+    if current_adapter?(:SQLite3Adapter)
+      def test_sqlite_joins_from_primary_to_custom_connection_attach_the_custom_database
+        entrants = Entrant.joins(:course).where(courses: { name: "Ruby Development" }).order(:id).pluck(:name)
+
+        assert_equal ["Ruby Developer", "Ruby Guru"], entrants
+      end
+
+      def test_sqlite_joins_from_custom_connection_to_primary_attach_the_primary_database
+        assert_equal 3, Course.joins(:entrants).count
+      end
+
+      def test_sqlite_attached_databases_do_not_leak_between_queries
+        assert_equal 3, Course.joins(:entrants).count
+
+        assert_raises(ActiveRecord::StatementInvalid) do
+          Course.lease_connection.execute("SELECT * FROM entrants")
+        end
+      end
+
+      def test_sqlite_does_not_collect_attached_database_from_raw_sql_join
+        assert_raises(ActiveRecord::StatementInvalid) do
+          Entrant.joins("INNER JOIN courses ON courses.id = entrants.course_id").load
+        end
+      end
+    end
   end
 
   def test_exception_contains_connection_pool


### PR DESCRIPTION
### Motivation / Background

When using multiple databases you traditionally can't join across databases but SQLite has the unique ability to include different SQLite databases in the connection and treat them one big database. 

Take this setup for example:
```ruby
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true
end

class Course < ApplicationRecord
  has_many :entrants
end

class OtherRecord < ActiveRecord::Base
  self.abstract_class = true

  connects_to database: { writing: :other }
end

class Entrant < OtherRecord
  belongs_to :course
end
```

```yaml
default: &default
  adapter: sqlite3

development:
  primary:
    <<: *default
    database: storage/dev.sqlite3
  other:
    <<: *default
    migrations_paths: db/other_migrate
    database: storage/other_dev.sqlite3
```

Prior to this patch if you were to execute `Entrant.joins(:course).where(courses: { name: "Ruby Development" })`, a `StatementInvalid` error will be raised because `Entrant` and `Course` live in different databases. But if you execute `ATTACH DATABASE 'storage/other_dev.sqlite3' as other`, you bring `entrants` into scope and can join over to it. This patch prepends the database name to those external database table calls to avoid conflicts.

Given that we know where these models live, database wise, and SQLite offers us the an avenue to join across databases, we should automatically include those databases into scope and extract that away from the developer when executing a query. 

Since SQLite can be write constrained, if you have a particularly write heavy table, this would allow you to move the table to it's own database and free up the primary database for more writes while still allowing you to treat it as if it was in the primary database. 

### Additional information

[sqlite docs on attach](https://sqlite.org/lang_attach.html)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
