### PR TITLE
Add ActionController::Parameters#deep_transform_values

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Add `ActionController::Parameters#deep_transform_values` and `deep_transform_values!`.
+
+    Mirrors the existing `deep_transform_keys` / `deep_transform_keys!` pair,
+    and matches `Hash#deep_transform_values` from Active Support. The block is
+    yielded only for leaf values; nested hashes, arrays, and `Parameters`
+    instances are traversed automatically. The returned instance carries the
+    same `permitted?` status as the receiver.
+
+    Previously, transforming every nested value required dropping out of the
+    strong-parameters guardrails:
+
+    ```ruby
+    params.to_unsafe_h.deep_transform_values { |v| v.is_a?(String) ? v.strip : v }
+    ```
+
+    With this addition, the same transformation keeps the result inside
+    `ActionController::Parameters`, so it still has to be filtered through
+    `permit` / `expect` before mass assignment:
+
+    ```ruby
+    params = ActionController::Parameters.new(
+      user: { email: "  ALICE@EXAMPLE.COM  ", profile: { bio: "  Hello world  " } }
+    )
+    params.deep_transform_values { |v| v.is_a?(String) ? v.strip.downcase : v }
+    # => #<ActionController::Parameters {"user"=>#<ActionController::Parameters {"email"=>"alice@example.com", "profile"=>#<ActionController::Parameters {"bio"=>"hello world"} permitted: false>} permitted: false>} permitted: false>
+    ```
+
+    *Edil Talantbek uulu*
+
 *   `http_cache_forever` now accept an optional `last_modified:` keyword parameter.
 
     It still defaults to January 1st 2011, but you now can subtitute it for a relevant

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -3,6 +3,7 @@
 # :markup: markdown
 
 require "active_support/core_ext/hash/indifferent_access"
+require "active_support/core_ext/hash/deep_transform_values"
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/string/filters"
 require "active_support/core_ext/object/to_query"
@@ -961,6 +962,34 @@ module ActionController
       self
     end
 
+    # Returns a new `ActionController::Parameters` instance with the results of
+    # running `block` once for every value. This includes the values from the
+    # root hash and from all nested hashes and arrays. The keys are unchanged.
+    #
+    # The returned instance carries the same permitted status as the receiver,
+    # so the result still has to be filtered through `permit` / `expect` before
+    # being mass-assigned. Prefer this to `to_unsafe_h.deep_transform_values`,
+    # which discards the permitted/unpermitted distinction.
+    #
+    #     params = ActionController::Parameters.new(
+    #       user: { email: "  ALICE@EXAMPLE.COM  ", profile: { bio: "  Hello world  " } }
+    #     )
+    #     params.deep_transform_values { |v| v.is_a?(String) ? v.strip.downcase : v }
+    #     # => #<ActionController::Parameters {"user"=>#<ActionController::Parameters {"email"=>"alice@example.com", "profile"=>#<ActionController::Parameters {"bio"=>"hello world"} permitted: false>} permitted: false>} permitted: false>
+    def deep_transform_values(&block)
+      new_instance_with_inherited_permitted_status(
+        _deep_transform_values_in_object(@parameters, &block)
+      )
+    end
+
+    # Returns the same `ActionController::Parameters` instance with changed
+    # values. This includes the values from the root hash and from all nested
+    # hashes and arrays. The keys are unchanged.
+    def deep_transform_values!(&block)
+      @parameters = _deep_transform_values_in_object!(@parameters, &block)
+      self
+    end
+
     # Deletes a key-value pair from `Parameters` and returns the value. If `key` is
     # not found, returns `nil` (or, with optional code block, yields `key` and
     # returns the result). This method is similar to #extract!, which returns the
@@ -1252,6 +1281,40 @@ module ActionController
           object.map! { |e| _deep_transform_keys_in_object!(e, &block) }
         else
           object
+        end
+      end
+
+      def _deep_transform_values_in_object(object, &block)
+        case object
+        when Hash
+          object.transform_values { |value| _deep_transform_values_in_object(value, &block) }
+        when Parameters
+          if object.permitted?
+            object.to_h.deep_transform_values(&block)
+          else
+            object.to_unsafe_h.deep_transform_values(&block)
+          end
+        when Array
+          object.map { |e| _deep_transform_values_in_object(e, &block) }
+        else
+          yield(object)
+        end
+      end
+
+      def _deep_transform_values_in_object!(object, &block)
+        case object
+        when Hash
+          object.transform_values! { |value| _deep_transform_values_in_object!(value, &block) }
+        when Parameters
+          if object.permitted?
+            object.to_h.deep_transform_values!(&block)
+          else
+            object.to_unsafe_h.deep_transform_values!(&block)
+          end
+        when Array
+          object.map! { |e| _deep_transform_values_in_object!(e, &block) }
+        else
+          yield(object)
         end
       end
 

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -334,6 +334,34 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.deep_transform_keys { |k| k }, :permitted?
   end
 
+  test "deep_transform_values retains permitted status" do
+    @params.permit!
+    assert_predicate @params.deep_transform_values { |v| v }, :permitted?
+  end
+
+  test "deep_transform_values retains unpermitted status" do
+    assert_not_predicate @params.deep_transform_values { |v| v }, :permitted?
+  end
+
+  test "deep_transform_values yields only leaf values" do
+    yielded = []
+    @params.deep_transform_values { |v| yielded << v; v }
+
+    assert_includes yielded, "32"
+    assert_includes yielded, "David"
+    assert_includes yielded, "Heinemeier Hansson"
+    assert_includes yielded, "Chicago"
+    assert_includes yielded, "Illinois"
+    assert_not(yielded.any? { |v| v.is_a?(Hash) || v.is_a?(ActionController::Parameters) || v.is_a?(Array) })
+  end
+
+  test "deep_transform_values returns a new ActionController::Parameters" do
+    result = @params.deep_transform_values { |v| v }
+
+    assert_kind_of ActionController::Parameters, result
+    assert_not_same @params, result
+  end
+
   test "transform_values retains permitted status" do
     @params.permit!
     assert_predicate @params.transform_values { |v| v }, :permitted?

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -147,6 +147,43 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.deep_transform_keys! { |k| k }, :permitted?
   end
 
+  test "deep_transform_values! retains permitted status" do
+    @params.permit!
+    assert_predicate @params.deep_transform_values! { |v| v }, :permitted?
+  end
+
+  test "deep_transform_values! retains unpermitted status" do
+    assert_not_predicate @params.deep_transform_values! { |v| v }, :permitted?
+  end
+
+  test "deep_transform_values! transforms nested values" do
+    @params.permit!
+    @params.deep_transform_values! { |v| v.is_a?(String) ? v.upcase : v }
+
+    expected_hash = { "person" => { "age" => "32", "name" => { "first" => "DAVID", "last" => "HEINEMEIER HANSSON" }, "addresses" => [{ "city" => "CHICAGO", "state" => "ILLINOIS" }] } }
+    assert_equal expected_hash, @params.to_hash
+  end
+
+  test "deep_transform_values transforms nested values" do
+    original_hash = @params.to_unsafe_h
+    @params.permit!
+    new_params = @params.deep_transform_values { |v| v.is_a?(String) ? v.upcase : v }
+
+    assert_equal original_hash, @params.to_hash
+
+    expected_hash = { "person" => { "age" => "32", "name" => { "first" => "DAVID", "last" => "HEINEMEIER HANSSON" }, "addresses" => [{ "city" => "CHICAGO", "state" => "ILLINOIS" }] } }
+    assert_equal expected_hash, new_params.to_hash
+  end
+
+  test "deep_transform_values does not yield Hash, Array, or Parameters branches" do
+    @params.deep_transform_values do |v|
+      assert_not_kind_of Hash, v
+      assert_not_kind_of Array, v
+      assert_not_kind_of ActionController::Parameters, v
+      v
+    end
+  end
+
   test "compact retains permitted status" do
     @params.permit!
     assert_predicate @params.compact, :permitted?


### PR DESCRIPTION
## Motivation / Background

This PR has been created because I'd like a safer way of running a deep value transformation on `ActionController::Parameters`. Today, the only option is `params.to_unsafe_h.deep_transform_values { ... }`, which discards the permitted/unpermitted distinction and returns a plain `Hash`. This forces application code to bypass the strong-parameters guardrails for a routine normalization task (e.g., stripping whitespace from every nested string before validation).

`ActionController::Parameters` already exposes `deep_transform_keys` and `deep_transform_keys!`, and Active Support already extends `Hash` with `deep_transform_values`. This PR completes the symmetry by adding
`deep_transform_values` and `deep_transform_values!` to `Parameters`, matching `Hash#deep_transform_values` while keeping the result inside `ActionController::Parameters` with `permitted?` preserved.

## Details

```ruby
params = ActionController::Parameters.new(
  user: {
    email: "  ALICE@EXAMPLE.COM  ",
    profile: { bio: "  Hello world  " }
  }
)

params.deep_transform_values { |v| v.is_a?(String) ? v.strip.downcase : v }
# => #<ActionController::Parameters {"user"=>#<ActionController::Parameters {"email"=>"alice@example.com", "profile"=>#<ActionController::Parameters {"bio"=>"hello world"} permitted: false>} permitted: false>} permitted: false>

# The bang variant mutates in place
params.deep_transform_values! { |v| v.is_a?(String) ? v.strip : v }

# permitted? status is carried over
params.permit!
params.deep_transform_values { |v| v }.permitted? # => true