### PR TITLE
Disable freezing of NATIVE_DATABASE_TYPES for SQLite3 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -120,7 +120,7 @@ module ActiveRecord
       #
       class_attribute :strict_strings_by_default, default: false
 
-      NATIVE_DATABASE_TYPES = {
+      NATIVE_DATABASE_TYPES = { # rubocop:disable Style/MutableConstant
         primary_key:  "integer PRIMARY KEY AUTOINCREMENT NOT NULL",
         string:       { name: "varchar" },
         text:         { name: "text" },
@@ -133,7 +133,7 @@ module ActiveRecord
         binary:       { name: "blob" },
         boolean:      { name: "boolean" },
         json:         { name: "json" },
-      }.freeze
+      }
 
       DEFAULT_PRAGMAS = {
         "foreign_keys"        => true,

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -1131,6 +1131,22 @@ module ActiveRecord
         assert_not_equal stored_column, virtual_column
       end
 
+      def test_native_database_types_is_mutable
+        assert_not_predicate SQLite3Adapter::NATIVE_DATABASE_TYPES, :frozen?
+      end
+
+      def test_native_database_types_allows_custom_type
+        original = SQLite3Adapter::NATIVE_DATABASE_TYPES.dup
+
+        assert_nothing_raised do
+          SQLite3Adapter::NATIVE_DATABASE_TYPES[:vector] = { name: "F32_BLOB" }
+        end
+
+        assert_equal({ name: "F32_BLOB" }, SQLite3Adapter::NATIVE_DATABASE_TYPES[:vector])
+      ensure
+        SQLite3Adapter::NATIVE_DATABASE_TYPES.replace(original)
+      end
+
       def test_sqlite_extensions_are_constantized_for_the_client_constructor
         mock_adapter = Class.new(SQLite3Adapter) do
           class << self


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Follow up https://github.com/rails/rails/pull/57323

This Pull Request has been created because this mirrors what https://github.com/rails/rails/pull/57333 just did for the MySQL adapter.

### Detail


`NATIVE_DATABASE_TYPES` is a well-known extension point — gems like `neighbor` and `activerecord-enhancedsqlite3-adapter` mutate it to register custom types (e.g. `vector`) or similar gems try to extend the hash.
With `.freeze` in place those gems crash with `FrozenError: can't modify frozen Hash at load time`.
The one-line fix matches the pattern already approved for MySQL. 
The documentation ( for postgres though ) states that you can edit this constant to add you own custom types, here: https://github.com/rails/rails/blob/f9b888b3538f2987fef63ad120a8befbfc0c2370/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L118-L119

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
