### PR TITLE
Update Active Job Attributes documentation

### DIFF
--- a/activejob/lib/active_job/attributes.rb
+++ b/activejob/lib/active_job/attributes.rb
@@ -5,11 +5,12 @@ require "active_model"
 module ActiveJob
   # = Active Job \Attributes
   #
-  # The Attributes module provides typed attributes for jobs using the Active
-  # Model Attributes API. Declared attributes are automatically serialized with
-  # the job data and restored when the job is deserialized.
+  # The Attributes module provides typed attributes for jobs using the
+  # {Active Model Attributes API}[rdoc-ref:ActiveModel::Attributes]. Declared
+  # attributes are automatically serialized with the job data and restored when
+  # the job is deserialized.
   #
-  # This is especially useful with ActiveJob::Continuable, where a job may be
+  # This is especially useful with ActiveJob::Continuation, where a job may be
   # interrupted and resumed multiple times and you need to persist attributes
   # across steps until the job finishes.
   #
@@ -20,24 +21,24 @@ module ActiveJob
   #     attribute :billing_profile_id, :integer
   #
   #     def perform(enrollment)
-  #       step(:tokenize_payment_instrument) do
+  #       step :tokenize_payment_instrument do
   #         self.payment_token = PaymentGateway.tokenize(enrollment.user.payment_instrument)
   #       end
   #
-  #       step(:create_billing_profile) do
+  #       step :create_billing_profile do
   #         self.billing_profile_id = BillingProfileApi.create(customer_id: enrollment.user_id)
   #       end
   #
-  #       step(:submit_enrollment) do
-  #         submission_id = EnrollmentApi.submit(enrollment, billing_profile_id)
+  #       step :submit_enrollment do
+  #         submission_id = EnrollmentApi.submit(enrollment, payment_token, billing_profile_id)
   #         enrollment.update!(status: 'processing', submission_id: submission_id)
   #       end
   #     end
   #   end
   #
-  # Attributes also work without Continuable, persisting across retries.
+  # Attributes also work without Continuation, persisting across retries.
   #
-  # Attributes support all built-in Active Model types, see +ActiveModel::Attribute+
+  # Attributes support all built-in Active Model types, see +ActiveModel::Attributes+
   # for details. For custom types attribute values must be serializable
   # as Active Job arguments. See +ActiveJob::Arguments+ for the full list of
   # supported types.

--- a/activejob/lib/active_job/continuation.rb
+++ b/activejob/lib/active_job/continuation.rb
@@ -165,6 +165,13 @@ module ActiveJob
   #   step :quick_step2
   #   step :quick_step3
   #
+  # === Persisting State Across Steps with \Attributes
+  #
+  # Steps store serialized progress but they do not persist any other state. For multi-step jobs where you need to use
+  # the results of one step in a later step, you can use +ActiveJob::Attributes+ to persist this state. This module is
+  # already included in +ActiveJob::Continuable+, so you can declare attributes on your job and they will be
+  # automatically serialized when the job is interrupted, and restored when the job resumes.
+  #
   # === Errors
   #
   # If a job raises an error and is not retried via Active Job, it will be passed back to the underlying

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -12,6 +12,7 @@ After reading this guide, you will know:
 * How to configure and use Solid Queue.
 * How to run jobs in the background.
 * How to send emails from your application asynchronously.
+* How to write jobs that pause and resume progress during deploys.
 
 --------------------------------------------------------------------------------
 
@@ -720,6 +721,48 @@ step that uses a cursor, the job resumes from the last recorded position. This
 makes it easier to build long-running or multi-phase jobs that can safely pause
 and resume without losing progress.
 For more details, see [ActiveJob::Continuation](https://api.rubyonrails.org/classes/ActiveJob/Continuation.html).
+
+### Job Attributes
+
+Active Job attributes let jobs declare typed state using the
+[`Active Model Attributes API`][]. Attribute values are serialized when the job
+is interrupted or retried, and restored when the job resumes. This is
+especially useful where one step may compute a value needed by a later step.
+`ActiveJob::Continuable` includes [`ActiveJob::Attributes`][], so continuable
+jobs can declare attributes directly:
+
+```ruby
+class SubmitEnrollmentJob < ApplicationJob
+  include ActiveJob::Continuable
+
+  attribute :payment_token, :string
+  attribute :billing_profile_id, :integer
+
+  def perform(enrollment)
+    step :tokenize_payment_instrument do
+      self.payment_token = PaymentGateway.tokenize(enrollment.user.payment_instrument)
+    end
+
+    step :create_billing_profile do
+      self.billing_profile_id = BillingProfileApi.create(customer_id: enrollment.user_id)
+    end
+
+    step :submit_enrollment do
+      submission_id = EnrollmentApi.submit(enrollment, payment_token, billing_profile_id)
+      enrollment.update!(status: "processing", submission_id: submission_id)
+    end
+  end
+end
+```
+
+Attribute values must be serializable as
+[Active Job arguments](#supported-types-for-arguments). For more details, see
+[`ActiveJob::Attributes`][].
+
+[`Active Model Attributes API`]:
+    https://api.rubyonrails.org/classes/ActiveModel/Attributes.html
+[`ActiveJob::Attributes`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Attributes.html
 
 Callbacks
 ---------


### PR DESCRIPTION
### Motivation / Background

Follow-up to https://github.com/rails/rails/pull/57208 and making the intent of this addition more clear, after seeing the confusion on https://ruby.social/@getajobmike/116540627534276308

- Link to Active Job Attributes from the Rails guides and Continuation API documentation
- Fix the Attributes example to not just store, but actually use `payment_token` 😅 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
