### PR TITLE
Introduce `ActiveSupport::TimeFormats` and `ActiveSupport::DateFormats` for registering custom date formats

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       ##
       # :singleton-method:
       # Indicates the format used to generate the timestamp in the cache key, if
-      # versioning is off. Accepts any of the symbols in +Time::DATE_FORMATS+.
+      # versioning is off. Accepts any of the symbols in +ActiveSupport::TimeFormats+.
       #
       # This is +:usec+, by default.
       class_attribute :cache_timestamp_format, instance_writer: false, default: :usec

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -31,16 +31,13 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_inspect_instance_with_lambda_date_formatter
-    before = Time::DATE_FORMATS[:inspect]
-
     Topic.stub(:attributes_for_inspect, [:id, :last_read]) do
-      Time::DATE_FORMATS[:inspect] = ->(date) { "my_format" }
-      topic = topics(:first)
+      ActiveSupport::TimeFormats.stub(:lookup, ->(format) { { inspect: ->(date) { "my_format" } }[format] }) do
+        topic = topics(:first)
 
-      assert_equal %(#<Topic id: 1, last_read: "2004-04-15">), topic.inspect
+        assert_equal %(#<Topic id: 1, last_read: "2004-04-15">), topic.inspect
+      end
     end
-  ensure
-    Time::DATE_FORMATS[:inspect] = before
   end
 
   def test_inspect_new_instance

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Introduce `ActiveSupport::TimeFormats` and `ActiveSupport::DateFormats`
+    for registering custom date formats.
+
+    This allows adding custom date formats to `to_fs` without modifying the
+    global `Time::DATE_FORMATS` or `Date::DATE_FORMATS` hashes. Custom formats
+    are added via `ActiveSupport::TimeFormats.register` or
+    `ActiveSupport::DateFormats.register`, and will only be available to
+    `Time#to_fs`, and `Date#to_fs` respectively.
+
+    At the same time, the existing `Time::DATE_FORMATS` and `Date::DATE_FORMATS`
+    constants are still supported for backward compatibility, but they are now
+    deprecated and will be removed in the next version of Rails. This encourages
+    users to migrate to the new approach for better encapsulation and to avoid
+    potential conflicts with other libraries that may also modify the global
+    date formats.
+
+    ```ruby
+    ActiveSupport::TimeFormats.register(:month_and_year, '%B %Y')
+    ActiveSupport::DateFormats.register(
+      :short_ordinal,
+      ->(date) { date.strftime("%B #{date.day.ordinalize}") }
+    )
+
+    Time.now.to_fs(:month_and_year) # => "February 2024"
+    Date.today.to_fs(:short_ordinal)  # => "February 21st"
+    ```
+
+    *Ufuk Kayserilioglu*
+
 *   Add `start_day` argument to `this_week?` for consistency with `all_week`
 
     `this_week?` now accepts an optional `start_day` argument, matching the

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -42,6 +42,7 @@ module ActiveSupport
   autoload :ConfigurationFile
   autoload :ContinuousIntegration
   autoload :CurrentAttributes
+  autoload :DateFormats
   autoload :Dependencies
   autoload :DescendantsTracker
   autoload :Editor
@@ -58,6 +59,7 @@ module ActiveSupport
   autoload :Notifications
   autoload :Reloader
   autoload :SecureCompareRotator
+  autoload :TimeFormats
 
   eager_autoload do
     autoload :BacktraceCleaner

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -39,15 +39,15 @@ class Date
   #   date.to_fs(:iso8601)       # => "2007-11-10"
   #
   # == Adding your own date formats to to_fs
-  # You can add your own formats to the +Date::DATE_FORMATS+ hash.
-  # Use the format name as the hash key and either a strftime string
+  # You can add your own formats using the +ActiveSupport::DateFormats.register+ method.
+  # Use the format name as the name and either a strftime string
   # or Proc instance that takes a date argument as the value.
   #
   #   # config/initializers/date_formats.rb
-  #   Date::DATE_FORMATS[:month_and_year] = '%B %Y'
-  #   Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }
+  #   ActiveSupport::DateFormats.register(:month_and_year, '%B %Y')
+  #   ActiveSupport::DateFormats.register(:short_ordinal, ->(date) { date.strftime("%B #{date.day.ordinalize}") })
   def to_fs(format = :default)
-    if formatter = DATE_FORMATS[format]
+    if formatter = ActiveSupport::DateFormats.lookup(format)
       if formatter.respond_to?(:call)
         formatter.call(self).to_s
       else

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -26,16 +26,16 @@ class DateTime
   #
   # ==== Adding your own datetime formats to +to_fs+
   #
-  # DateTime formats are shared with Time. You can add your own to the
-  # +Time::DATE_FORMATS+ hash. Use the format name as the hash key and
+  # DateTime formats are shared with Time. You can add your own format using the
+  # +ActiveSupport::TimeFormats.register+ method. Use the format name as the key and
   # either a strftime string or Proc instance that takes a time or
   # datetime argument as the value.
   #
   #   # config/initializers/time_formats.rb
-  #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
-  #   Time::DATE_FORMATS[:short_ordinal] = lambda { |time| time.strftime("%B #{time.day.ordinalize}") }
+  #   ActiveSupport::TimeFormats.register(:month_and_year, '%B %Y')
+  #   ActiveSupport::TimeFormats.register(:short_ordinal, ->(date) { date.strftime("%B #{date.day.ordinalize}") })
   def to_fs(format = :default)
-    if formatter = ::Time::DATE_FORMATS[format]
+    if formatter = ::ActiveSupport::TimeFormats.lookup(format)
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     else
       to_s

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -45,15 +45,15 @@ class Time
   #   time.to_fs(:iso8601)      # => "2007-01-18T06:10:17-06:00"
   #
   # == Adding your own time formats to +to_fs+
-  # You can add your own formats to the +Time::DATE_FORMATS+ hash.
-  # Use the format name as the hash key and either a strftime string
+  # You can add your own formats using the +ActiveSupport::TimeFormats.register+ method.
+  # Use the format name as the name and either a strftime string
   # or Proc instance that takes a time argument as the value.
   #
   #   # config/initializers/time_formats.rb
-  #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
-  #   Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
+  #   ActiveSupport::TimeFormats.register(:month_and_year, '%B %Y')
+  #   ActiveSupport::TimeFormats.register(:short_ordinal, ->(time) { time.strftime("%B #{time.day.ordinalize}") })
   def to_fs(format = :default)
-    if formatter = DATE_FORMATS[format]
+    if formatter = ::ActiveSupport::TimeFormats.lookup(format)
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     else
       to_s

--- a/activesupport/lib/active_support/date_formats.rb
+++ b/activesupport/lib/active_support/date_formats.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/date/conversions"
+
+module ActiveSupport
+  module DateFormats
+    @list = Date::DATE_FORMATS.dup.freeze
+    @deprecated_list = Date::DATE_FORMATS
+    Date.deprecate_constant :DATE_FORMATS
+
+    # :nodoc:
+    def self.lookup(format)
+      @list[format] || @deprecated_list[format]
+    end
+
+    # Registers a new date format for formatting `Date` instances.
+    # See +Date::DATE_FORMATS+ for built-in formats.
+    # Use the format name as the name and either a strftime string or
+    # Proc instance that takes a date argument as the value.
+    def self.register(name, format)
+      @list = @list.merge(name => format).freeze
+    end
+  end
+end

--- a/activesupport/lib/active_support/time_formats.rb
+++ b/activesupport/lib/active_support/time_formats.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/time/conversions"
+
+module ActiveSupport
+  module TimeFormats
+    @list = Time::DATE_FORMATS.dup.freeze
+    @deprecated_list = Time::DATE_FORMATS
+    Time.deprecate_constant :DATE_FORMATS
+
+    # :nodoc:
+    def self.lookup(format)
+      @list[format] || @deprecated_list[format]
+    end
+
+    # Registers a new date format for formatting `Time` instances.
+    # See +Time::DATE_FORMATS+ for built-in formats.
+    # Use the format name as the name and either a strftime string or
+    # Proc instance that takes a date argument as the value.
+    def self.register(name, format)
+      @list = @list.merge(name => format).freeze
+    end
+  end
+end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -223,11 +223,11 @@ module ActiveSupport
     # Accepts an optional <tt>format</tt>:
     # * <tt>:default</tt> - default value, mimics Ruby Time#to_s format.
     # * <tt>:db</tt> - format outputs time in UTC :db time. See Time#to_fs(:db).
-    # * Any key in +Time::DATE_FORMATS+ can be used. See active_support/core_ext/time/conversions.rb.
+    # * Any key in +ActiveSupport::TimeFormats+ can be used. See active_support/core_ext/time/conversions.rb.
     def to_fs(format = :default)
       if format == :db
         utc.to_fs(format)
-      elsif formatter = ::Time::DATE_FORMATS[format]
+      elsif formatter = ::ActiveSupport::TimeFormats.lookup(format)
         formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
       else
         to_s

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -47,11 +47,9 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_date_formats_can_be_extended
-    Date::DATE_FORMATS[:custom_date_format] = "%B %Y"
-
-    assert_equal "February 2005", Date.new(2005, 2, 21).to_fs(:custom_date_format)
-  ensure
-    Date::DATE_FORMATS.delete(:custom_date_format)
+    ActiveSupport::DateFormats.stub(:lookup, ->(format) { { custom_date_format: "%B %Y" }[format] }) do
+      assert_equal "February 2005", Date.new(2005, 2, 21).to_fs(:custom_date_format)
+    end
   end
 
   def test_readable_inspect

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -42,10 +42,9 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_to_fs_with_custom_date_format
-    Time::DATE_FORMATS[:custom] = "%Y%m%d%H%M%S"
-    assert_equal "20050221143000", DateTime.new(2005, 2, 21, 14, 30, 0).to_fs(:custom)
-  ensure
-    Time::DATE_FORMATS.delete(:custom)
+    ActiveSupport::TimeFormats.stub(:lookup, ->(format) { { custom: "%Y%m%d%H%M%S" }[format] }) do
+      assert_equal "20050221143000", DateTime.new(2005, 2, 21, 14, 30, 0).to_fs(:custom)
+    end
   end
 
   def test_localtime

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -861,10 +861,9 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   end
 
   def test_to_fs_custom_date_format
-    Time::DATE_FORMATS[:custom] = "%Y%m%d%H%M%S"
-    assert_equal "20050221143000", Time.local(2005, 2, 21, 14, 30, 0).to_fs(:custom)
-  ensure
-    Time::DATE_FORMATS.delete(:custom)
+    ActiveSupport::TimeFormats.stub(:lookup, ->(format) { { custom: "%Y%m%d%H%M%S" }[format] }) do
+      assert_equal "20050221143000", Time.local(2005, 2, 21, 14, 30, 0).to_fs(:custom)
+    end
   end
 
   def test_rfc3339_with_fractional_seconds


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created in response to the comments by @byroot [here](https://github.com/rails/rails/pull/57332#issuecomment-4415097265) and [here](https://github.com/rails/rails/pull/57341#discussion_r3219396920).

### Detail

This Pull Request changes allows adding custom date formats to `to_fs` without modifying the global `Time::DATE_FORMATS` or `Date::DATE_FORMATS` hashes. Custom formats are added via `ActiveSupport::TimeFormats.register` or `ActiveSupport::DateFormats.register`, and will only be available to `Time#to_fs`, and `Date#to_fs` respectively.

At the same time, the existing `Time::DATE_FORMATS` and `Date::DATE_FORMATS` constants are still supported for backward compatibility, but they are now deprecated and will be removed in the next version of Rails. This encourages users to migrate to the new approach for better encapsulation and to avoid potential conflicts with other libraries that may also modify the global date formats.

```ruby
ActiveSupport::TimeFormats.register(:month_and_year, '%B %Y')
ActiveSupport::DateFormats.register(:short_ordinal, ->(date) { date.strftime("%B #{date.day.ordinalize}") })

Time.now.to_fs(:month_and_year) # => "February 2024"
Date.today.to_fs(:short_ordinal)  # => "February 21st"
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
The `ActiveSupport::TimeFormats.list` and `ActiveSupport::DateFormats.list` are initialized to `Time::DATE_FORMATS` and `Date::DATE_FORMATS` respectively, and **not** frozen, so that appending to the constants can still modify the lists until the constants are removed completely. This is important for backward compatibility.

However, as soon as a call to the respective `register` method is made, the `list` is modified and frozen considering that the user has opted in to the new API.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
