### PR TITLE
Add default `#render_in` implementation to `ActiveModel::Conversion`

### DIFF
--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -592,6 +592,10 @@ class TestController < ActionController::Base
     render partial: "hash_greeting", collection: [ { first_name: "Pratik" }, { first_name: "Amy" } ], locals: { greeting: "Hola" }
   end
 
+  def renderable_hash
+    render renderable: Quiz::Question.new(params[:name])
+  end
+
   def partial_with_implicit_local_assignment
     @customer = Customer.new("Marcel")
     render partial: "customer"
@@ -725,6 +729,7 @@ class RenderTest < ActionController::TestCase
     get :partial_with_nested_object_shorthand, to: "test#partial_with_nested_object_shorthand"
     get :partial_with_hashlike_locals, to: "test#partial_with_hashlike_locals"
     get :partials_list, to: "test#partials_list"
+    get :renderable_hash, to: "test#renderable_hash"
     get :render_action_hello_world, to: "test#render_action_hello_world"
     get :render_action_hello_world_as_string, to: "test#render_action_hello_world_as_string"
     get :render_action_hello_world_with_symbol, to: "test#render_action_hello_world_with_symbol"
@@ -1501,6 +1506,11 @@ class RenderTest < ActionController::TestCase
   def test_partial_hash_collection_with_locals
     get :partial_hash_collection_with_locals
     assert_equal "Hola: PratikHola: Amy", @response.body
+  end
+
+  def test_renderable_hash
+    get :renderable_hash, params: { name: "Why?" }
+    assert_equal "Why?", @response.body
   end
 
   def test_render_missing_partial_template

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -117,7 +117,8 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
       @view.render(Customer.new("david"), greeting: "hi")
 
-      assert_equal 1, @logger.logged(:debug).size
+      assert_equal 2, @logger.logged(:debug).size
+      assert_match(/Rendering Customer/, @logger.logged(:debug).first)
       assert_match(/Rendered customers\/_customer\.html\.erb/, @logger.logged(:debug).last)
     end
   end

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   Add default `#render_in` implementation to `ActiveModel::Conversion`
+
+    With the following view partial:
+
+    ```erb
+    <%# app/views/people/_person.html.erb %>
+    <% local_assigns.with_defaults(shout: false) => { shout: } %>
+
+    <%= shout ? person.name.upcase : person.name %>
+    ```
+
+    Callers can render an instance of `Person` as a positional argument or a
+    `:renderable` option:
+
+    ```ruby
+    person = Person.new(name: "Ralph")
+
+    render person                                       # => "Ralph"
+    render person, shout: true                          # => "RALPH"
+    render renderable: person                           # => "Ralph"
+    render renderable: person, locals: { shout: true }  # => "RALPH"
+    ```
+
+    *Sean Doyle*
+
 *   Combine `:if`, `:unless`, and `:on` options when specified at both the
     `validates` level and the per-validator level, instead of the per-validator
     options silently replacing the top-level ones.

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -104,6 +104,30 @@ module ActiveModel
       self.class._to_partial_path
     end
 
+    # Renders the object into an Action View context.
+    #
+    #   # app/models/person.rb
+    #   class Person
+    #     include ActiveModel::Conversion
+    #
+    #     attr_reader :name
+    #
+    #     def initialize(name)
+    #       @name = name
+    #     end
+    #   end
+    #
+    #   # app/views/people/_person.html.erb
+    #   <p><%= person.name %></p>
+    #
+    #   person = Person.new name: "Ralph"
+    #
+    #   render(person)              # => "<p>Ralph</p>
+    #   render(renderable: person)  # => "<p>Ralph</p>
+    def render_in(view_context, **options, &block)
+      view_context.render(partial: to_partial_path, object: self, **options, &block)
+    end
+
     module ClassMethods # :nodoc:
       # Provide a class level cache for #to_partial_path. This is an
       # internal method and should not be accessed directly.

--- a/activemodel/lib/active_model/lint.rb
+++ b/activemodel/lib/active_model/lint.rb
@@ -60,6 +60,20 @@ module ActiveModel
         assert_kind_of String, model.to_partial_path
       end
 
+      # Passes if the object's model responds to <tt>render_in</tt>
+      # calling this method returns a string. Fails otherwise.
+      #
+      # <tt>render_in</tt> is used for rendering an instance. For example,
+      # a BlogPost model might render itself into a "blog_posts/blog_post" partial.
+      def test_render_in
+        view_context = Object.new
+        def view_context.render(...)
+          ""
+        end
+        assert_respond_to model, :render_in
+        assert_kind_of String, model.render_in(view_context)
+      end
+
       # Passes if the object's model responds to <tt>persisted?</tt> and if
       # calling this method returns either +true+ or +false+. Fails otherwise.
       #

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -62,6 +62,21 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal "attack_helicopters/ah-64", Helicopter::Apache.new.to_partial_path
   end
 
+  test "#render_in defaults to rendering a partial with the object" do
+    contact = Contact.new
+    view_context = Object.new
+    def view_context.render(**options, &block)
+      [options, block.call]
+    end
+
+    options, rendered = contact.render_in(view_context, locals: { size: "small" }) { "block" }
+
+    assert_equal contact.to_partial_path, options[:partial]
+    assert_equal contact, options[:object]
+    assert_equal "small", options.dig(:locals, :size)
+    assert_equal "block", rendered
+  end
+
   test "#to_param_delimiter allows redefining the delimiter used in #to_param" do
     old_delimiter = Contact.param_delimiter
     Contact.param_delimiter = "_"

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -700,6 +700,25 @@ irb> person.to_partial_path
 => "people/person"
 ```
 
+The `ActiveModel::Conversion` module also defines a `render_in` method for
+integration with Action View. For example, consider a `people/person` partial:
+
+```erb
+<%# app/views/people/_person.html.erb %>
+<p>Persisted: <%= person.persisted? %></p>
+```
+
+By default, passing the object to `render` will invoke `to_partial_path` to
+determine the view partial to render:
+
+```ruby
+render person
+# => <p>Persisted: false</p>
+
+render renderable: person
+# => <p>Persisted: false</p>
+```
+
 ### Dirty
 
 [`ActiveModel::Dirty`](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html)


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#50623][]
Follow-up to [#46202][]

The `#render_in` method was introduced as an integration touch-point for views to intercept object rendering conventionally handled by Action View. 

This PR aims to provide Active Model-level (and therefore Active Record-level) flexibility to control how Action View transform models into HTML and JSON strings.

For example, users of the [view_component](https://github.com/ViewComponent/view_component) gem can "intercept" model rendering to directly an instance to a `ViewComponent::Base` instance.

### Detail

With the following view partial:

```erb
<%# app/views/people/_person.html.erb %>

<%= local_assigns[:shout] ? person.name.upcase : person.name %>
```

Callers can render an instance of `Person` as a positional argument or a `:renderable` option:

```ruby
person = Person.new(name: "Ralph")

render person                                       # => "Ralph"
render person, shout: true                          # => "RALPH"
render renderable: person                           # => "Ralph"
render renderable: person, locals: { shout: true }  # => "RALPH"
```

This change aims to preserve backward compatibility by providing a default `#render_in` method to relies on render the instance with a view partial inferred from combining `partial: to_partial_path` and `object: self`.

[#50623]: https://github.com/rails/rails/pull/50623
[#46202]: https://github.com/rails/rails/pull/46202#issuecomment-1281993332

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
