### PR TITLE
Auto-add aria-current="page" to link_to on the current page

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Automatically add `aria-current="page"` to `link_to` when the link's URL
+    matches the current request.
+
+    Beyond the accessibility win, this lets you style the active link in a
+    navigation directly from CSS — no `.active` class to toggle, no
+    `link_to_unless_current` wrapper:
+
+        # On /articles
+        <%= link_to "Articles", articles_path %>
+        # => <a href="/articles" aria-current="page">Articles</a>
+
+        /* stylesheet */
+        nav a[aria-current="page"] { font-weight: bold; }
+
+    The new `:current` option overrides the auto behavior — pass `false` to
+    suppress the attribute, `true` to force it, or a String/Symbol (e.g.
+    `"step"`) for a custom ARIA value:
+
+        link_to "Step 2", step_path(2), current: "step"
+        # => <a href="/steps/2" aria-current="step">Step 2</a>
+
+    *Jeremy Bertrand*
+
 *   Pass render options and block to calls to `#render_in`
 
     ```ruby

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -92,6 +92,12 @@ module ActionView
       #
       # ==== Options
       # * <tt>:data</tt> - This option can be used to add custom data attributes.
+      # * <tt>:current</tt> - Controls the <tt>aria-current</tt> attribute. Pass
+      #   <tt>true</tt> to force <tt>aria-current="page"</tt>, <tt>false</tt> to
+      #   suppress the attribute, or a String/Symbol (e.g. <tt>"step"</tt>) to set
+      #   a custom value. When omitted, +link_to+ automatically adds
+      #   <tt>aria-current="page"</tt> if the link's URL matches the current
+      #   request (using +current_page?+).
       #
       # ==== Examples
       #
@@ -173,6 +179,42 @@ module ActionView
       #   link_to "External link", "http://www.rubyonrails.org/", target: "_blank", rel: "nofollow"
       #   # => <a href="http://www.rubyonrails.org/" target="_blank" rel="nofollow">External link</a>
       #
+      # ==== Styling the active link
+      #
+      # When a link's target matches the current request URL, +link_to+ adds
+      # <tt>aria-current="page"</tt> automatically. Beyond the accessibility win
+      # (screen readers announce the current page), this gives you a styling
+      # hook: highlight the active link in your navigation with one CSS rule,
+      # with no <tt>.active</tt> class to toggle and no conditional helpers
+      # like +link_to_unless_current+ to wrap each item.
+      #
+      #   # On /articles
+      #   <nav>
+      #     <%= link_to "Home", root_path %>
+      #     <%= link_to "Articles", articles_path %>
+      #   </nav>
+      #
+      #   # Renders:
+      #   <nav>
+      #     <a href="/">Home</a>
+      #     <a href="/articles" aria-current="page">Articles</a>
+      #   </nav>
+      #
+      #   /* In your stylesheet: */
+      #   nav a[aria-current="page"] { font-weight: bold; color: tomato; }
+      #
+      # Override the auto behavior with the <tt>:current</tt> option:
+      #
+      #   link_to "Articles", articles_path, current: false
+      #   # => <a href="/articles">Articles</a>
+      #
+      #   link_to "Step 2", step_path(2), current: "step"
+      #   # => <a href="/steps/2" aria-current="step">Step 2</a>
+      #
+      # +link_to+ never overwrites an <tt>aria-current</tt> attribute you set
+      # yourself, either as <tt>"aria-current"</tt> directly or under
+      # <tt>aria: { current: ... }</tt>.
+      #
       # ==== Turbo
       #
       # Rails 7 ships with Turbo enabled by default. Turbo provides the following +:data+ options:
@@ -203,6 +245,8 @@ module ActionView
 
         url = url_target(name, options)
         html_options["href"] ||= url
+
+        html_options = convert_options_to_aria_attributes(url, html_options)
 
         content_tag("a", name || url, html_options, &block)
       end
@@ -717,6 +761,33 @@ module ActionView
           else
             link_to_remote_options?(options) ? { "data-remote" => "true" } : {}
           end
+        end
+
+        def convert_options_to_aria_attributes(url, html_options)
+          return html_options if html_options.key?("aria-current")
+          return html_options if (aria = html_options["aria"]).is_a?(Hash) && (aria.key?(:current) || aria.key?("current"))
+
+          current = html_options.delete("current")
+
+          value =
+            case current
+            when false then return html_options
+            when true  then "page"
+            when nil
+              return html_options unless link_targets_current_page?(url)
+              "page"
+            else current.to_s
+            end
+
+          html_options["aria-current"] = value
+          html_options
+        end
+
+        def link_targets_current_page?(url)
+          return false unless respond_to?(:request) && request
+          current_page?(url)
+        rescue ArgumentError, URI::InvalidURIError
+          false
         end
 
         def url_target(name, options)

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -850,6 +850,86 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal "Fallback", link_to_unless(true, "Listing", url_hash) { "Fallback" }
   end
 
+  def test_link_to_adds_aria_current_when_target_matches_current_page
+    @request = request_for_url("/")
+
+    assert_dom_equal %{<a href="/" aria-current="page">Home</a>},
+      link_to("Home", url_hash)
+    assert_dom_equal %{<a href="http://www.example.com/" aria-current="page">Home</a>},
+      link_to("Home", "http://www.example.com/")
+  end
+
+  def test_link_to_does_not_add_aria_current_when_target_differs
+    @request = request_for_url("/other")
+
+    assert_dom_equal %{<a href="/">Home</a>},
+      link_to("Home", url_hash)
+  end
+
+  def test_link_to_with_current_false_suppresses_aria_current
+    @request = request_for_url("/")
+
+    assert_dom_equal %{<a href="/">Home</a>},
+      link_to("Home", url_hash, current: false)
+  end
+
+  def test_link_to_with_current_true_forces_aria_current
+    @request = request_for_url("/other")
+
+    assert_dom_equal %{<a href="/" aria-current="page">Home</a>},
+      link_to("Home", url_hash, current: true)
+  end
+
+  def test_link_to_with_current_string_uses_custom_value
+    @request = request_for_url("/")
+
+    assert_dom_equal %{<a href="/" aria-current="step">Step</a>},
+      link_to("Step", url_hash, current: "step")
+  end
+
+  def test_link_to_with_current_symbol_uses_custom_value
+    @request = request_for_url("/")
+
+    assert_dom_equal %{<a href="/" aria-current="location">Here</a>},
+      link_to("Here", url_hash, current: :location)
+  end
+
+  def test_link_to_without_request_does_not_raise
+    @request = nil
+
+    assert_dom_equal %{<a href="/foo">Foo</a>},
+      link_to("Foo", "/foo")
+  end
+
+  def test_link_to_preserves_explicit_aria_current
+    @request = request_for_url("/")
+
+    assert_dom_equal %{<a href="/" aria-current="step">Home</a>},
+      link_to("Home", url_hash, "aria-current" => "step")
+  end
+
+  def test_link_to_preserves_nested_aria_current
+    @request = request_for_url("/")
+
+    assert_dom_equal %{<a href="/" aria-current="step">Home</a>},
+      link_to("Home", url_hash, aria: { current: "step" })
+  end
+
+  def test_link_to_does_not_leak_current_option_as_attribute
+    @request = request_for_url("/other")
+
+    link = link_to("Home", url_hash, current: true)
+    assert_dom_equal %{<a href="/" aria-current="page">Home</a>}, link
+    assert_no_match(/\scurrent=/, link)
+  end
+
+  def test_link_to_with_string_url_matches_current_page
+    @request = request_for_url("/")
+
+    assert_dom_equal %{<a href="/" aria-current="page">Root</a>},
+      link_to("Root", "/")
+  end
+
   def test_mail_to
     assert_dom_equal %{<a href="mailto:david@loudthinking.com">david@loudthinking.com</a>}, mail_to("david@loudthinking.com")
     assert_dom_equal %{<a href="mailto:david@loudthinking.com">David Heinemeier Hansson</a>}, mail_to("david@loudthinking.com", "David Heinemeier Hansson")
@@ -1332,21 +1412,21 @@ class PolymorphicControllerTest < ActionController::TestCase
     @controller = WorkshopsController.new
 
     get :index
-    assert_equal %{/workshops\n<a href="/workshops">Workshop</a>}, @response.body
+    assert_equal %{/workshops\n<a href="/workshops" aria-current="page">Workshop</a>}, @response.body
   end
 
   def test_existing_resource
     @controller = WorkshopsController.new
 
     get :show, params: { id: 1 }
-    assert_equal %{/workshops/1\n<a href="/workshops/1">Workshop</a>}, @response.body
+    assert_equal %{/workshops/1\n<a href="/workshops/1" aria-current="page">Workshop</a>}, @response.body
   end
 
   def test_existing_cpk_resource
     @controller = WorkshopsController.new
 
     get :show, params: { id: "1-27" }
-    assert_equal %{/workshops/1-27\n<a href="/workshops/1-27">Workshop</a>}, @response.body
+    assert_equal %{/workshops/1-27\n<a href="/workshops/1-27" aria-current="page">Workshop</a>}, @response.body
   end
 
   def test_current_page_when_options_does_not_respond_to_to_hash
@@ -1367,14 +1447,14 @@ class PolymorphicSessionsControllerTest < ActionController::TestCase
     @controller = SessionsController.new
 
     get :index, params: { workshop_id: 1 }
-    assert_equal %{/workshops/1/sessions\n<a href="/workshops/1/sessions">Session</a>}, @response.body
+    assert_equal %{/workshops/1/sessions\n<a href="/workshops/1/sessions" aria-current="page">Session</a>}, @response.body
   end
 
   def test_existing_nested_resource
     @controller = SessionsController.new
 
     get :show, params: { workshop_id: 1, id: 1 }
-    assert_equal %{/workshops/1/sessions/1\n<a href="/workshops/1/sessions/1">Session</a>}, @response.body
+    assert_equal %{/workshops/1/sessions/1\n<a href="/workshops/1/sessions/1" aria-current="page">Session</a>}, @response.body
   end
 
   def test_existing_nested_resource_with_params


### PR DESCRIPTION
### Motivation / Background

  This Pull Request has been created because there is no built-in way to mark the link to the current page in link_to. Apps that build navigation menus today have two options, both unsatisfying:

  - Compute the active state per-link and toggle a .active class (boilerplate, easy to forget).
  - Use link_to_unless_current, which removes the link entirely on the current page — a regression for screen-reader users and a styling hassle (the markup changes shape).

  Adding aria-current="page" automatically when the link's target matches current_page? solves both problems at once:

  - Accessibility: screen readers announce the current page without any extra work from the developer.
  - Styling: apps can highlight the active nav item from CSS alone (nav a[aria-current="page"] { … }), with no class toggling and no conditional helpers.

  This is a small, focused addition; the per-call :current option keeps callers in full control when they need different semantics (step, location, …) or want to opt out.

Duplicate of #57343 that I closed by mistake

 ### Detail

  This Pull Request changes ActionView::Helpers::UrlHelper#link_to:

  - When the link's URL matches the current request (current_page?), link_to now emits aria-current="page" automatically.
  - A new :current option in html_options overrides the auto behavior:
    - current: false — suppress the attribute on the current page.
    - current: true — force aria-current="page".
    - current: "step" / current: :location — set a custom ARIA value (per WAI-ARIA: page, step, location, date, time).
  - An aria-current value supplied by the caller — either directly ("aria-current" => …) or nested (aria: { current: … }) — is never overwritten.
  - When no request is available (e.g. mailer views), auto-detection is silently skipped; link_to never raises.

  Implementation mirrors the existing convert_options_to_data_attributes pattern: a private convert_options_to_aria_attributes(url, html_options) helper that returns the updated hash, plus a small
  link_targets_current_page? guard that rescues no-request and URL-parsing failures.

  Example:
```
  <%# On /articles %>
  <nav>
    <%= link_to "Home", root_path %>
    <%= link_to "Articles", articles_path %>
  </nav>

  renders:

  <nav>
    <a href="/">Home</a>
    <a href="/articles" aria-current="page">Articles</a>
  </nav>

  nav a[aria-current="page"] { font-weight: bold; }
```

  ### Additional information

  - This is a behavior change: any link_to that points at the current page will now carry a new attribute. The change is opt-out (current: false) rather than opt-in to keep the API ergonomic; the accessibility improvement
  is a strict win for the common case. Five existing PolymorphicControllerTest cases were updated to reflect the new attribute — there were no other regressions in the Action View suite (1657 tests, 0 failures).
  - aria-current is a [WAI-ARIA 1.1 attribute](https://www.w3.org/TR/wai-aria-1.1/#aria-current); page is one of its defined values.
  - Related existing helper: link_to_unless_current. This change does not deprecate it, but for most navigation use cases the new behavior should be preferred since it keeps the link semantically present.

  ### Checklist

  Before submitting the PR make sure the following are checked:

  - [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
  - [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: [Fix #issue-number]
  - [x] Tests are added or updated if you fix a bug or add a feature.
  - [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
