### PR TITLE
Validate autosaved uniqueness before inserting collection records

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -443,7 +443,9 @@ module ActiveRecord
                 association.set_inverse_instance(record)
 
                 if autosave
-                  saved = association.insert_record(record, false)
+                  validate = autosave_uniqueness_validation?(reflection, record)
+                  saved = association.insert_record(record, validate)
+                  association_valid?(association, record) if validate && !saved
                 elsif !reflection.nested?
                   association_saved = association.insert_record(record)
 
@@ -460,6 +462,12 @@ module ActiveRecord
             end
           end
         end
+      end
+
+      def autosave_uniqueness_validation?(reflection, record)
+        reflection.validate? &&
+          !autosave_association_validations_skipped? &&
+          record.class.validators.any? { |validator| validator.kind == :uniqueness }
       end
 
       # Saves the associated record if it's new or <tt>:autosave</tt> is enabled

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -45,13 +45,17 @@ module ActiveRecord
     # The regular {ActiveRecord::Base#save}[rdoc-ref:Persistence#save] method is replaced
     # with this when the validations module is mixed in, which it is by default.
     def save(**options)
-      perform_validations(options) ? super : false
+      with_autosave_association_validation_context(options) do
+        perform_validations(options) ? super : false
+      end
     end
 
     # Attempts to save the record just like {ActiveRecord::Base#save}[rdoc-ref:Base#save] but
     # will raise an ActiveRecord::RecordInvalid exception instead of returning +false+ if the record is not valid.
     def save!(**options)
-      perform_validations(options) ? super : raise_validation_error
+      with_autosave_association_validation_context(options) do
+        perform_validations(options) ? super : raise_validation_error
+      end
     end
 
     # Runs all the validations within the specified context. Returns +true+ if
@@ -85,6 +89,19 @@ module ActiveRecord
 
     def raise_validation_error
       raise(RecordInvalid.new(self))
+    end
+
+    def autosave_association_validations_skipped?
+      @_skip_autosave_association_validations
+    end
+
+    def with_autosave_association_validation_context(options)
+      previous_validation_state = @_skip_autosave_association_validations
+      @_skip_autosave_association_validations = options[:validate] == false
+
+      yield
+    ensure
+      @_skip_autosave_association_validations = previous_validation_state
     end
 
     def perform_validations(options = {})

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -936,6 +936,85 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     end
   end
 
+  def test_autosaved_parent_should_not_get_saved_with_duplicate_children_records
+    topic_class, reply_class = nested_uniqueness_topic_and_reply_classes
+
+    assert_no_difference -> { topic_class.count } do
+      assert_no_difference -> { reply_class.count } do
+        topic = topic_class.new(title: "Nested uniqueness")
+        topic.nested_unique_replies.build([
+          { content: "Best content" },
+          { content: "Best content" }
+        ])
+
+        assert_not topic.save
+        assert_equal ["has already been taken"], topic.errors[:"nested_unique_replies.content"]
+        assert_empty topic.nested_unique_replies.first.errors[:content]
+        assert_equal ["has already been taken"], topic.nested_unique_replies.last.errors[:content]
+      end
+    end
+  end
+
+  def test_autosaved_existing_parent_should_not_get_saved_with_duplicate_new_children_records
+    topic_class, reply_class = nested_uniqueness_topic_and_reply_classes
+    topic = topic_class.create!(title: "Nested uniqueness")
+
+    assert_no_difference -> { reply_class.count } do
+      assert_not topic.update(nested_unique_replies_attributes: [
+        { content: "Best content" },
+        { content: "Best content" }
+      ])
+
+      assert_equal ["has already been taken"], topic.errors[:"nested_unique_replies.content"]
+      assert_empty topic.nested_unique_replies.first.errors[:content]
+      assert_equal ["has already been taken"], topic.nested_unique_replies.last.errors[:content]
+    end
+  end
+
+  def test_autosaved_duplicate_children_records_can_skip_uniqueness_validation
+    topic_class, reply_class = nested_uniqueness_topic_and_reply_classes
+
+    assert_difference -> { topic_class.count }, 1 do
+      assert_difference -> { reply_class.count }, 2 do
+        topic = topic_class.new(
+          title: "Nested uniqueness",
+          nested_unique_replies_attributes: [
+            { content: "Best content" },
+            { content: "Best content" }
+          ]
+        )
+
+        assert topic.save(validate: false)
+      end
+    end
+  end
+
+  def nested_uniqueness_topic_and_reply_classes
+    topic_class = Class.new(Topic) do
+      def self.name; "NestedUniquenessTopic"; end
+    end
+
+    reply_class = Class.new(Reply) do
+      def self.name; "NestedUniquenessReply"; end
+
+      validates :content, uniqueness: { scope: :parent_id }
+    end
+
+    reply_class.belongs_to :nested_uniqueness_topic,
+      anonymous_class: topic_class,
+      foreign_key: "parent_id",
+      inverse_of: :nested_unique_replies
+
+    topic_class.has_many :nested_unique_replies,
+      anonymous_class: reply_class,
+      foreign_key: "parent_id",
+      inverse_of: :nested_uniqueness_topic,
+      autosave: true
+    topic_class.accepts_nested_attributes_for :nested_unique_replies
+
+    [topic_class, reply_class]
+  end
+
   def test_invalid_build
     new_client = companies(:first_firm).clients_of_firm.build
     assert_not_predicate new_client, :persisted?


### PR DESCRIPTION
## Summary

- Revalidate autosaved collection records with uniqueness validators during insertion, after parent keys and prior siblings are available.
- Preserve `save(validate: false)` by skipping this late autosave uniqueness validation when validations are explicitly disabled.
- Add regression coverage for new and existing parents with duplicate nested children.

Fixes #20676.

## Validation

- `ARCONN=sqlite3 bin/test test/cases/autosave_association_test.rb`
- `ARCONN=sqlite3 bin/test test/cases/validations/uniqueness_validation_test.rb`
- `bundle exec rubocop activerecord/lib/active_record/autosave_association.rb activerecord/lib/active_record/validations.rb activerecord/test/cases/autosave_association_test.rb`
- `git diff --check`
