### PR TITLE
Fix `ActionText::Editor::Tag#render_in` to accept kwargs

### DIFF
--- a/actiontext/lib/action_text/editor.rb
+++ b/actiontext/lib/action_text/editor.rb
@@ -68,7 +68,7 @@ module ActionText
       "#{editor_name}-editor"
     end
 
-    def render_in(view_context)
+    def render_in(view_context, ...)
       options[:class] ||= "#{editor_name}-content"
 
       view_context.content_tag(element_name, nil, options, &@block)

--- a/actiontext/test/unit/editor/tag_test.rb
+++ b/actiontext/test/unit/editor/tag_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ActionText
+  class Editor::TagTest < ActionView::TestCase
+    class TagSubclassCallingSuper < Editor::Tag
+      def render_in(view_context, ...)
+        super
+      end
+    end
+
+    test "subclasses can call super from #render_in" do
+      assert_nothing_raised do
+        render(TagSubclassCallingSuper.new("trix"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Since d24d0b71 (#50623), Action View renders objects responding to `#render_in` through `ActionView::Template::Renderable#render`, which calls:

```ruby
renderable.render_in(context, locals: locals, &@block)
```

when `render_in`'s arity is not 1.

`ActionText::Editor::Tag#render_in(view_context)` was not updated to match the new contract. Subclasses that follow the documented adapter pattern `render_in(view_context, ...)` and call `super` raise:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
```

The bundled `TrixEditor::Tag` doesn't hit this because it re-implements the body and never calls `super`. Out-of-tree adapters following the same pattern do.

### Detail

This Pull Request widens `ActionText::Editor::Tag#render_in` to `(view_context, ...)`, so subclasses can call `super` without caring about Action View's calling convention.

### Additional information

Discovered while running [Lexxy](https://github.com/basecamp/lexxy)'s CI against Rails `main`. Lexxy's adapter at [`lib/action_text/editor/lexxy_editor.rb`](https://github.com/basecamp/lexxy/blob/main/lib/action_text/editor/lexxy_editor.rb) is the real-world subclass that surfaced this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.