### PR TITLE
Fix formatting in Active Storage controller docs

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -4,7 +4,7 @@
 # The blob is streamed from storage directly to the response. This avoids having
 # a redirect and makes files easier to cache.
 #
-# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+# The <tt>signed_id</tt>s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
 # The response sets the HTTP cache to public and allows browsers and proxies to cache it indefinitely.
 #
 # The URLs created for this controller are set to never expire by default.

--- a/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -2,7 +2,7 @@
 
 # Finds a blob by a +signed_id+ and redirects to a blob's expiring service URL.
 #
-# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+# The <tt>signed_id</tt>s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
 #
 # The URLs created for this controller are set to never expire by default.
 # To make URLs expire, pass the +expires_in+ option when generating the URL:

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -4,7 +4,7 @@
 # The representation is streamed from storage directly to the response. This avoids having
 # a redirect and makes files easier to cache.
 #
-# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+# The <tt>signed_id</tt>s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
 # The response sets the HTTP cache to public and allows browsers and proxies to cache it indefinitely.
 #
 # The URLs created for this controller are set to never expire by default.

--- a/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
@@ -3,7 +3,7 @@
 # Finds a representation by a +signed_id+ and a +variation_key+, and redirects to a representation's expiring
 # service URL.
 #
-# The +signed_id+s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
+# The <tt>signed_id</tt>s make URLs hard to guess but permanent by design, allowing the URLs to be cached.
 #
 # The URLs created for this controller are set to never expire by default.
 # To make URLs expire, pass the +expires_in+ option when generating the URL:


### PR DESCRIPTION
Use `<tt>` for proper formatting. [ci-skip]

Before:
<img width="210" height="32" alt="image" src="https://github.com/user-attachments/assets/c554a0ef-4c99-439f-9568-dc47ee5b56a5" />
After:
<img width="217" height="24" alt="image" src="https://github.com/user-attachments/assets/96779897-d2b0-4549-ab96-401cfceaacb0" />


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
