### PR TITLE
Fix renderable arity checks when method is overridden

### DIFF
--- a/actionview/lib/action_view/template/renderable.rb
+++ b/actionview/lib/action_view/template/renderable.rb
@@ -14,7 +14,9 @@ module ActionView
       end
 
       def render(context, locals)
-        if @renderable.method(:render_in).arity == 1
+        render_in_method = Kernel.instance_method(:method).bind_call(@renderable, :render_in)
+
+        if render_in_method.arity == 1
           ActionView.deprecator.warn <<~WARN
             Action View support for #render_in without options is deprecated.
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -429,6 +429,22 @@ module RenderTestCases
     end
   end
 
+  def test_render_renderable_object_with_method_reader
+    renderable = Class.new do
+      attr_reader :method
+
+      def initialize
+        @method = :get
+      end
+
+      def render_in(view_context, **options)
+        view_context.render plain: "Hello, #{options[:locals][:name]} with #{method}!"
+      end
+    end.new
+
+    assert_equal "Hello, Renderable with get!", @view.render(renderable, name: "Renderable")
+  end
+
   def test_render_renderable_render_in
     assert_equal "Hello, World!", @view.render(TestRenderable.new)
     assert_equal "Hello, World!", @view.render(renderable: TestRenderable.new)


### PR DESCRIPTION
Use `Kernel#method` explicitly when checking a renderable object's render_in arity, so objects that define their own method reader do not break rendering. Along with a regression test.

More context: https://github.com/rails/rails/pull/50623#discussion_r3230073756

cc @rafaelfranca / @seanpdoyle 


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
