### PR TITLE
[ci skip] Update the debugging guide to link the actively maintained Exception Notifier repo

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -899,7 +899,7 @@ application. Here is a list of useful plugins for debugging:
 
 * [Query Trace](https://github.com/ruckus/active-record-query-trace/tree/master) Adds query
   origin tracing to your logs.
-* [Exception Notifier](https://github.com/smartinez87/exception_notification/tree/master)
+* [Exception Notifier](https://github.com/kmcphillips/exception_notification/tree/main)
   Provides a mailer object and a default set of templates for sending email
   notifications when errors occur in a Rails application.
 * [Better Errors](https://github.com/charliesome/better_errors) Replaces the


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the Exception Notifier repo linked in `guides/source/debugging_rails_applications.md` is no longer being actively maintained.

### Detail

This Pull Request changes the link to reference the actively maintained Exception Notifier repo.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
