### PR TITLE
Reset `lock_version` after transaction rollback

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Reset the optimistic locking column when a transaction is rolled back.
+
+    Previously, when a record with optimistic locking was successfully saved
+    inside a transaction that later rolled back, the in-memory `lock_version`
+    was left at the incremented value while the database row was reverted to
+    the previous one. Saving the same instance again then raised
+    `ActiveRecord::StaleObjectError` because the WHERE clause used the
+    incremented value that no longer existed in the database.
+
+    The locking column is now restored from the snapshot taken at the start
+    of the transaction, so retrying a save on the same record after a
+    rollback works without an explicit `reload`.
+
+    *Kenta Ishizaki*
+
 *   Fix handling of expressions in array syntax for `add_index`.
 
     This change allows passing expressions in array syntax for `add_index` method.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -495,8 +495,21 @@ module ActiveRecord
           if force_restore_state || restore_state[:level] <= 1
             @new_record = restore_state[:new_record]
             @previously_new_record = restore_state[:previously_new_record]
-            @destroyed  = restore_state[:destroyed]
+            @destroyed = restore_state[:destroyed]
+            locking_column = self.class.locking_column if self.class.locking_enabled?
             @attributes = restore_state[:attributes].map do |attr|
+              if attr.name == locking_column
+                # The locking column is bumped by `_update_row` itself, not the caller, and
+                # `_update_row` writes the new value into the same `@attributes` object that
+                # the snapshot is holding a reference to (because the snapshot wraps the
+                # `AttributeSet` rather than deep-duping it). After a successful save,
+                # `forget_attribute_assignments` reassigns `@attributes`, so subsequent
+                # operations see a clean attribute, but the snapshot retains the dirty one.
+                # Forcibly rebuild the locking column attribute from its (still-correct)
+                # original value so the next save uses the pristine value in the WHERE
+                # clause and doesn't raise `StaleObjectError` after a rollback.
+                next attr.with_value_from_database(attr.original_value)
+              end
               value = @attributes.fetch_value(attr.name)
               attr = attr.with_value_from_user(value) if attr.value != value
               attr

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -981,3 +981,38 @@ class PessimisticLockingWhilePreventingWritesTest < ActiveRecord::TestCase
     end
   end
 end
+
+class OptimisticLockingRollbackTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def setup
+    @person = Person.create!(first_name: "Michael")
+  end
+
+  def teardown
+    @person.delete
+  end
+
+  def test_lock_version_restored_after_full_transaction_rollback
+    p = Person.find(@person.id)
+    assert_equal 0, p.lock_version
+
+    Person.transaction do
+      p.update!(first_name: "rollback-target")
+      assert_equal 1, p.lock_version
+      raise ActiveRecord::Rollback
+    end
+
+    # The transaction rolled back lock_version to 0 in the database. The in-memory
+    # record should match, not be left in a stale-but-dirty state that would
+    # trigger StaleObjectError on the next save without an explicit reload.
+    assert_equal 0, Person.find(@person.id).lock_version
+    assert_equal 0, p.lock_version
+    assert_not p.will_save_change_to_attribute?(:lock_version)
+    assert_nothing_raised do
+      p.update!(first_name: "after-rollback")
+    end
+    assert_equal 1, p.lock_version
+    assert_equal "after-rollback", Person.find(@person.id).first_name
+  end
+end


### PR DESCRIPTION
### Motivation / Background

When a record with optimistic locking is successfully saved inside a transaction that later rolls back, the in-memory `lock_version` is left at the incremented value while the database row is reverted to its previous one.
Saving the same instance again then raises `ActiveRecord::StaleObjectError` because the WHERE clause uses the incremented value that no longer exists in the database.

```ruby
widget = Widget.create!(name: "a")          # lock_version: 0

Widget.transaction do
  widget.update!(name: "b")                  # lock_version: 0 -> 1
  raise ActiveRecord::Rollback
end

widget.lock_version                          # => 1 (stale; DB has 0)
widget.update!(name: "c")                    # raises ActiveRecord::StaleObjectError
```

The documented workaround is to call `record.reload` after the rollback, but the failure is silent until the next save and the surrounding pattern (`transaction { update; rollback } + retry`) is common enough that the in-memory state should already match the database after rollback.

### Detail

The root cause is in `restore_transaction_record_state`. The snapshot taken at the start of a save (`remember_transaction_record_state`) stores `@attributes` **by reference** rather than deep-duping it:

```ruby
@_start_transaction_state ||= {
  ...
  attributes: @attributes,
  ...
}
```

`Locking::Optimistic#_update_row` then bumps the locking column in place via `self[locking_column] += 1`, which mutates that shared `AttributeSet`. After a successful save, `Dirty#forget_attribute_assignments` reassigns `@attributes` on the record to a fresh `AttributeSet`, but it does **not** touch the snapshot, so the snapshot retains the dirty `Attribute(value=N+1, original=N)`.

On rollback the existing restore loop short-circuits when `attr.value == current_value` (both `N+1` in this case) and keeps the dirty snapshot attribute. The next save then sees the locking column as dirty and `_lock_value_for_database` uses the incremented value in the WHERE clause, producing the `StaleObjectError`.

This PR special-cases the locking column inside `restore_transaction_record_state` and rebuilds it from the snapshot's `original_value` via `with_value_from_database`, yielding a clean `Attribute(value=N, original=N)`.
Both the WHERE clause and the dirty-tracking state then behave as if the increment never happened, which matches the database state after the rollback.

A regression test is added in a new `OptimisticLockingRollbackTest` class with `self.use_transactional_tests = false` so the outermost rollback actually fires `restore_transaction_record_state` with `force_restore_state: true` (a `requires_new: true` savepoint inside the test framework's transaction skips the restore branch because the snapshot level is greater than 1).

### Additional information

- **Scope.** This fixes the case in which the outermost transaction rolls back (`force_restore_state: true` or `restore_state[:level] <= 1`). Savepoint rollbacks at deeper levels currently bail out of `restore_transaction_record_state` entirely, so the same stale-`lock_version` symptom can still occur in `transaction { transaction(requires_new: true) { update!; raise Rollback } }` shapes. Fixing that path requires either restoring at every level or snapshotting per-level state, which felt out of scope for this PR. Happy to follow up if reviewers prefer a single broader change.

- **Repro & verification.**
  - Repro script: `/tmp/lock_rollback_deep.rb` (a self-contained SQLite script that fails with `StaleObjectError` before this patch and succeeds after).
  - Full Active Record suites that exercise this area pass locally on sqlite3: `locking_test.rb` (70), `transactions_test.rb` (109), `transaction_callbacks_test.rb` (57), `dirty_test.rb` (61), `autosave_association_test.rb` (217), `nested_attributes_test.rb` (167).
  - The new test fails on `main` without the patch (`Expected: 0, Actual: 1` at the first post-rollback assertion) and passes with it.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.