### PR TITLE
Enumerate columns in SELECT when only_columns is set

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1902,7 +1902,7 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values))
-        elsif model.ignored_columns.any? || model.enumerate_columns_in_select_statements
+        elsif model.ignored_columns.any? || model.enumerate_columns_in_select_statements || model.only_columns.any?
           arel.project(*model.column_names.map { |field| table[field] })
         else
           arel.project(table[Arel.star])

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1910,6 +1910,16 @@ class BasicsTest < ActiveRecord::TestCase
     assert query.include?("name")
   end
 
+  test "only columns are enumerated in SELECT" do
+    query = OnlyColumnsDeveloper.all.to_sql.downcase
+
+    # not in only_columns
+    assert_not query.include?("first_name")
+
+    # in only_columns
+    assert query.include?("name")
+  end
+
   test "column names are quoted when using #from clause and model has ignored columns" do
     assert_not_empty Developer.ignored_columns
     query = Developer.from("developers").to_sql


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `only_columns` (introduced in #55121) is documented as the counterpart to `ignored_columns`, but its SQL generation does not match that behavior. `columns_hash` is correctly restricted to the configured columns in `load_schema!`, yet queries are still emitted as `SELECT "table".*` because `build_select` only triggers explicit column enumeration when `ignored_columns` is set or `enumerate_columns_in_select_statements` is enabled. As a result, the database returns every column and they all end up populated on the loaded record, defeating the purpose of `only_columns`.

Reproduction:

```ruby
class User < ApplicationRecord
  self.only_columns = %w[id name]
end

User.all.to_sql
# Expected: SELECT "users"."id", "users"."name" FROM "users"
# Actual:   SELECT "users".* FROM "users"

User.first.attributes.keys
# Expected: ["id", "name"]
# Actual:   ["id", "name", "email", "created_at", "updated_at"]
```

### Detail

This Pull Request changes `ActiveRecord::QueryMethods#build_select` so that the explicit column enumeration branch is also taken when `only_columns` is set, mirroring the existing treatment of `ignored_columns`:

```ruby
elsif model.ignored_columns.any? || model.only_columns.any? || model.enumerate_columns_in_select_statements
  arel.project(*model.column_names.map { |field| table[field] })
```

`model.column_names` already reflects `only_columns` (it is derived from `columns_hash`, which is filtered in `load_schema!`), so no additional projection logic is required.

A test case (`BasicsTest#test_only_columns_are_enumerated_in_SELECT`) is added next to the existing `ignored_columns_not_included_in_SELECT` test, reusing the existing `OnlyColumnsDeveloper` fixture model.

### Additional information

- Verified against SQLite3 (in-memory), PostgreSQL, and MySQL — all pass with the fix and the new test fails without it.
- No public API or behavior change beyond making `only_columns` behave as its documentation states.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
