### PR TITLE
Support dynamic `store:` option in `rate_limit`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -9,7 +9,7 @@
       rate_limit to: 1000, within: 1.minute, store: :rate_store
 
       private
-      
+
       def rate_store
         current_user.premium? ? premium_cache : default_cache
       end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Support dynamic `store:` option in `rate_limit`.
+
+    The `store:` option now accepts callables (lambdas or procs) and method
+    names (as symbols), in addition to static values. This allows runtime
+    resolution of the cache store based on request context.
+
+    ```ruby
+    class APIController < ApplicationController
+      rate_limit to: 1000, within: 1.minute, store: :rate_store
+
+      private
+      
+      def rate_store
+        current_user.premium? ? premium_cache : default_cache
+      end
+    end
+    ```
+
+    *Charles Washington de Aquino dos Santos*
+
 *   Add a configuration for `ActionDispatch::ExceptionWrapper.silent_exceptions` at `config.action_dispatch.silent_exceptions`.
 
     Exceptions on this list do not fall back to framework-level backtraces when there is no application backtrace.

--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -36,7 +36,9 @@ module ActionController # :nodoc:
       # `config.action_controller.cache_store`, which itself defaults to the global
       # `config.cache_store`. If you don't want to store rate limits in the same
       # datastore as your general caches, you can pass a custom store in the `store`
-      # parameter.
+      # parameter. Like `to:` and `within:`, it can also be a method name (as a symbol)
+      # or a callable that will be evaluated in the context of the controller
+      # processing the request.
       #
       # If you want to use multiple rate limits per controller, you need to give each of
       # them an explicit name via the `name:` option.
@@ -62,6 +64,7 @@ module ActionController # :nodoc:
       #       rate_limit to: 10, within: 3.minutes, store: RATE_LIMIT_STORE
       #       rate_limit to: 100, within: 5.minutes, scope: :api_global
       #       rate_limit to: :max_requests, within: :time_window, by: -> { current_user.id }
+      #       rate_limit to: 1000, within: 1.minute, store: :rate_store
       #
       #       private
       #         def max_requests
@@ -70,6 +73,10 @@ module ActionController # :nodoc:
       #
       #         def time_window
       #           current_user.premium? ? 1.hour : 1.minute
+      #         end
+      #
+      #         def rate_store
+      #           current_user.premium? ? RATE_LIMIT_STORE : ActiveSupport::Cache::MemoryStore.new
       #         end
       #     end
       #
@@ -91,6 +98,7 @@ module ActionController # :nodoc:
         by = by.is_a?(Symbol) ? send(by) : instance_exec(&by)
         to = to.is_a?(Symbol) ? send(to) : (to.respond_to?(:call) ? instance_exec(&to) : to)
         within = within.is_a?(Symbol) ? send(within) : (within.respond_to?(:call) ? instance_exec(&within) : within)
+        store = store.is_a?(Symbol) ? send(store) : (store.respond_to?(:call) ? instance_exec(&store) : store)
 
         cache_key = ["rate-limit", scope, name, by].compact.join(":")
         count = store.increment(cache_key, 1, expires_in: within)

--- a/actionpack/test/controller/rate_limiting_test.rb
+++ b/actionpack/test/controller/rate_limiting_test.rb
@@ -86,7 +86,7 @@ class RateLimitedSharedFourController < RateLimitedSharedController
   end
 end
 
-class RateLimitedWithDynamicStoreController < ActionController::Base
+class RateLimitedWithStoreFromMethodController < ActionController::Base
   self.cache_store = ActiveSupport::Cache::MemoryStore.new
   rate_limit to: 2, within: 2.seconds, store: :store_for_request, only: :limited
 
@@ -102,7 +102,7 @@ class RateLimitedWithDynamicStoreController < ActionController::Base
     end
 end
 
-class RateLimitedWithCallableStoreController < ActionController::Base
+class RateLimitedWithStoreFromCallableController < ActionController::Base
   self.cache_store = ActiveSupport::Cache::MemoryStore.new
   rate_limit to: 2,
              within: 2.seconds,
@@ -304,8 +304,8 @@ class RateLimitingTest < ActionController::TestCase
   end
 
   test "dynamic store via method" do
-    @controller = RateLimitedWithDynamicStoreController.new
-    RateLimitedWithDynamicStoreController.cache_store.clear
+    @controller = RateLimitedWithStoreFromMethodController.new
+    RateLimitedWithStoreFromMethodController.cache_store.clear
 
     get :limited
     assert_response :ok
@@ -324,8 +324,8 @@ class RateLimitingTest < ActionController::TestCase
   end
 
   test "dynamic store via callable" do
-    @controller = RateLimitedWithCallableStoreController.new
-    RateLimitedWithCallableStoreController.cache_store.clear
+    @controller = RateLimitedWithStoreFromCallableController.new
+    RateLimitedWithStoreFromCallableController.cache_store.clear
 
     get :limited
     assert_response :ok

--- a/actionpack/test/controller/rate_limiting_test.rb
+++ b/actionpack/test/controller/rate_limiting_test.rb
@@ -95,12 +95,11 @@ class RateLimitedWithDynamicStoreController < ActionController::Base
   end
 
   private
-
-  def store_for_request
-    params[:use_alternate_store] ?
-      ActiveSupport::Cache::MemoryStore.new :
-      self.class.cache_store
-  end
+    def store_for_request
+      params[:use_alternate_store] ?
+        ActiveSupport::Cache::MemoryStore.new :
+        self.class.cache_store
+    end
 end
 
 class RateLimitedWithCallableStoreController < ActionController::Base

--- a/actionpack/test/controller/rate_limiting_test.rb
+++ b/actionpack/test/controller/rate_limiting_test.rb
@@ -86,6 +86,39 @@ class RateLimitedSharedFourController < RateLimitedSharedController
   end
 end
 
+class RateLimitedWithDynamicStoreController < ActionController::Base
+  self.cache_store = ActiveSupport::Cache::MemoryStore.new
+  rate_limit to: 2, within: 2.seconds, store: :store_for_request, only: :limited
+
+  def limited
+    head :ok
+  end
+
+  private
+
+  def store_for_request
+    params[:use_alternate_store] ?
+      ActiveSupport::Cache::MemoryStore.new :
+      self.class.cache_store
+  end
+end
+
+class RateLimitedWithCallableStoreController < ActionController::Base
+  self.cache_store = ActiveSupport::Cache::MemoryStore.new
+  rate_limit to: 2,
+             within: 2.seconds,
+             store: -> {
+               params[:use_alternate_store] ?
+                 ActiveSupport::Cache::MemoryStore.new :
+                 self.class.cache_store
+             },
+             only: :limited
+
+  def limited
+    head :ok
+  end
+end
+
 class RateLimitingTest < ActionController::TestCase
   tests RateLimitedController
 
@@ -269,5 +302,45 @@ class RateLimitingTest < ActionController::TestCase
     end
   ensure
     RateLimitedSharedController.cache_store.clear
+  end
+
+  test "dynamic store via method" do
+    @controller = RateLimitedWithDynamicStoreController.new
+    RateLimitedWithDynamicStoreController.cache_store.clear
+
+    get :limited
+    assert_response :ok
+    get :limited
+    assert_response :ok
+    assert_raises ActionController::TooManyRequests do
+      get :limited
+    end
+
+    get :limited, params: { use_alternate_store: "true" }
+    assert_response :ok
+    get :limited, params: { use_alternate_store: "true" }
+    assert_response :ok
+    get :limited, params: { use_alternate_store: "true" }
+    assert_response :ok
+  end
+
+  test "dynamic store via callable" do
+    @controller = RateLimitedWithCallableStoreController.new
+    RateLimitedWithCallableStoreController.cache_store.clear
+
+    get :limited
+    assert_response :ok
+    get :limited
+    assert_response :ok
+    assert_raises ActionController::TooManyRequests do
+      get :limited
+    end
+
+    get :limited, params: { use_alternate_store: "true" }
+    assert_response :ok
+    get :limited, params: { use_alternate_store: "true" }
+    assert_response :ok
+    get :limited, params: { use_alternate_store: "true" }
+    assert_response :ok
   end
 end


### PR DESCRIPTION
## Summary

Also support dynamic `store:` option in `rate_limit` like [we already do for some of the other params.](https://github.com/rails/rails/blob/18f0be3dda62235ea71ab8627322815d66dd6367/actionpack/lib/action_controller/metal/rate_limiting.rb#L91)

Proposed in https://discuss.rubyonrails.org/t/proposal-support-dynamic-store-option-in-rate-limit/91088.

## Motivation / Background

The `rate_limit` API supports method names and callables for some of the parameters. 
Extending this to `:store` allows applications to resolve the cache store at runtime (per-request, per-tenant, gradual cache migrations, etc.) without boilerplate conditionals in controllers. Static usages untouched.

## Detail

Changes `ActionController::RateLimiting` so that `store:` accepts:

- Static values (unchanged behavior), e.g. `store: RedisCacheStore.new(...)`.
- Instance method names (symbols), evaluated in the controller context via `send` (like we already do for [to](https://github.com/rails/rails/blob/18f0be3dda62235ea71ab8627322815d66dd6367/actionpack/lib/action_controller/metal/rate_limiting.rb#L92) and [within](https://github.com/rails/rails/blob/18f0be3dda62235ea71ab8627322815d66dd6367/actionpack/lib/action_controller/metal/rate_limiting.rb#L93)).
- Callables (lambdas/procs), evaluated in the controller context via `instance_exec` following the existing pattern.

Resolution logic:

- If value is a Symbol → `send(value)`
- Else if it responds to `call` → `instance_exec(&value)`
- Else → use as-is

## Additional information

- Aligns with earlier changes to allow method names for `:to`, `:within`, `:by`, and `:with`.
- Negligible overhead (a couple of conditional checks) on the rate-limited path.

## Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.