### PR TITLE
Prevent development welcome route from duplicating on route reload

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Prevent the internal development welcome route from being duplicated on route reloads.
+
+    *Elliot Temple*
+
 *   Remove `new_framework_defaults` during `app:update` when `config.load_defaults`
     already targets the current Rails version.
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -147,9 +147,13 @@ module Rails
             get ".well-known/appspecific/com.chrome.devtools.json" => "rails/devtools#show",      internal: true
           end
 
+          welcome_route_appended = false
           routes_reloader.run_after_load_paths = -> do
-            app.routes.append do
-              get "/" => "rails/welcome#index", internal: true
+            unless welcome_route_appended
+              app.routes.append do
+                get "/" => "rails/welcome#index", internal: true
+              end
+              welcome_route_appended = true
             end
           end
         end

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -147,13 +147,9 @@ module Rails
             get ".well-known/appspecific/com.chrome.devtools.json" => "rails/devtools#show",      internal: true
           end
 
-          welcome_route_appended = false
-          routes_reloader.run_after_load_paths = -> do
-            unless welcome_route_appended
-              app.routes.append do
-                get "/" => "rails/welcome#index", internal: true
-              end
-              welcome_route_appended = true
+          routes_reloader.run_once_after_load_paths = -> do
+            app.routes.append do
+              get "/" => "rails/welcome#index", internal: true
             end
           end
         end

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -8,7 +8,7 @@ module Rails
 
       attr_reader :route_sets, :paths, :external_routes, :loaded
       attr_accessor :eager_load
-      attr_writer :run_after_load_paths, :loaded # :nodoc:
+      attr_writer :run_once_after_load_paths, :loaded # :nodoc:
       delegate :execute_if_updated, :updated?, to: :updater
 
       def initialize(file_watcher: ActiveSupport::FileUpdateChecker)
@@ -62,11 +62,14 @@ module Rails
 
       def load_paths
         paths.each { |path| load(path) }
-        run_after_load_paths.call
+        run_after_load_paths_callback
       end
 
-      def run_after_load_paths
-        @run_after_load_paths ||= -> { }
+      def run_after_load_paths_callback
+        if @run_once_after_load_paths
+          @run_once_after_load_paths.call
+          @run_once_after_load_paths = nil
+        end
       end
 
       def finalize!

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -22,6 +22,17 @@ module ApplicationTests
       assert_equal 200, last_response.status
     end
 
+    test "rails/welcome is not duplicated when routes reload in development" do
+      app("development")
+
+      3.times { Rails.application.reload_routes! }
+
+      welcome_routes = Rails.application.routes.routes.select do |route|
+        route.defaults[:controller] == "rails/welcome" && route.defaults[:action] == "index"
+      end
+      assert_equal 1, welcome_routes.size
+    end
+
     test "rails/info in development" do
       app("development")
       get "/rails/info"


### PR DESCRIPTION
### Motivation / Background

Rails registers its internal development welcome route from `routes_reloader.run_after_load_paths`.

That hook currently calls `app.routes.append` on each route reload. `RouteSet#append` stores append blocks persistently, while route reloads clear and finalize the realized routes. As a result, repeated `reload_routes!` calls in development add another internal `GET /` welcome route each time.

### Detail

Register the internal welcome route append block only once per application boot, while preserving the existing `append` behavior and route ordering. This keeps app-appended root routes taking precedence over the internal welcome route.

### Additional information

No existing issue found for this specific duplicate welcome-route behavior.

### Tests

- `ruby -c railties/lib/rails/application/finisher.rb`
- `ruby -c railties/test/application/routing_test.rb`
- `bundle exec rubocop railties/lib/rails/application/finisher.rb railties/test/application/routing_test.rb`
- `cd railties && bin/test test/application/routing_test.rb -i '/not duplicated|appended root/'`
- `cd railties && bin/test test/application/routing_test.rb`
