### PR TITLE
Limit the size of strings we call `to_i` on in ActiveRecord

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Limit the size of strings `ActiveModel::Type::Integer` will coerce with `to_i`.
+
+    Calling `to_i` on very long strings can take a long time and could be used as
+    a DoS vector. Integer casting now only considers the first `_limit * 4` bytes
+    of a string (16 bytes for a default 4-byte integer, 32 bytes for an 8-byte
+    bigint), which is enough to hold the maximum representable value plus a sign
+    or a short slug suffix.
+
+    *Aaron Patterson*, *Jean Boussier*
+
 *   Support proc and symbol for `NumericalityValidator`s `:in` option
 
     ```ruby

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -110,7 +110,15 @@ module ActiveModel
         end
 
         def cast_value(value)
-          value.to_i rescue nil
+          case value
+          when ::Integer
+            value
+          when ::String
+            str = value.bytesize > _limit * 4 ? value.byteslice(0, _limit * 4) : value
+            str.to_i rescue nil
+          else
+            value.to_i rescue nil
+          end
         end
 
         def max_value

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -165,6 +165,20 @@ module ActiveModel
         end
       end
 
+      test "long strings are truncated before being cast" do
+        type = Type::Integer.new # default limit: 4, byte cap: 16
+        # Only the first _limit * 4 == 16 bytes should be considered
+        assert_equal ("1" * 16).to_i, type.cast("1" * 17)
+      end
+
+      test "strings within the byte cap are cast normally" do
+        type = Type::Integer.new # default limit: 4, byte cap: 16
+        # A 16-byte numeric string is at the cap and should not be truncated
+        assert_equal 1234567890123456, type.cast("1234567890123456")
+        # Shorter strings are unaffected
+        assert_equal 42, type.cast("42-some-slug")
+      end
+
       test "Marshal round-trip preserves behaviour" do
         type = Integer.new
         restored = Marshal.load(Marshal.dump(type))


### PR DESCRIPTION
Calling `to_i` on very long strings can take a very long time and could be used as a DoS vector.  Users should validate input lengths before calling `to_i`, but we can do it somewhat automatically in ActiveModel.

This commit limits auto-integer coercion to the first `_limit * 4` bytes of a string, where `_limit` is the column's storage size in bytes.  For a default 4-byte integer that is 16 bytes; for an 8-byte bigint it is 32 bytes.  That is comfortably larger than the maximum number of digits any value in range can have (10 digits for a 4-byte int, 19 for an 8-byte bigint), with room left over for a sign or a short slug suffix.

For example, if we have a model like this:

```ruby
ActiveRecord::Base.connection.create_table :users do |t|
  t.integer :age, limit: 1
  t.timestamps
end

class User < ActiveRecord::Base; end

User.create(age: '9' * 5_000_000)
```

Before this commit, casting `age` would walk the entire 5 MB string. After this commit, only the first `_limit * 4` bytes are considered, bounding the work `to_i` has to do.

At first, I based this change off the width of the column from the database, but that doesn't work because ActiveRecord supports "auto integerization" of slugs.  For example you might have a controller that looks like this:

```ruby
Post.where(id: params[:id]).first
```

We expect slugs to come in with values like "123-hello-world-etc", so limiting strictly to the column width would break that.  Multiplying by 4 leaves room for typical slug suffixes while still bounding how much work `to_i` does.