### PR TITLE
Prevent false leaked-connection reports during reaper maintenance

### DIFF
--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -60,15 +60,18 @@ module ActiveRecord
           end
         end
 
-        pool.reap
-        pool.connections.each do |conn|
-          if conn.in_use?
-            if conn.owner != Fiber.current && conn.owner != Thread.current
-              leaked_conn << [conn.owner, conn.owner.backtrace]
-              conn.owner&.kill
+        # Avoid racing the pool reaper while it is performing maintenance.
+        pool.reaper_lock do
+          pool.reap
+          pool.connections.each do |conn|
+            if conn.in_use?
+              if conn.owner != Fiber.current && conn.owner != Thread.current
+                leaked_conn << [conn.owner, conn.owner.backtrace]
+                conn.owner&.kill
+              end
+              conn.steal!
+              pool.checkin(conn)
             end
-            conn.steal!
-            pool.checkin(conn)
           end
         end
       end

--- a/activerecord/test/cases/test_case_test.rb
+++ b/activerecord/test/cases/test_case_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  class TestCaseLeakCheckTest < ActiveRecord::TestCase
+    include WaitForTestHelper
+
+    self.use_transactional_tests = false
+
+    def test_check_connection_leaks_does_not_report_connections_held_for_reaper_maintenance
+      pool = ActiveRecord::Base.connection_pool
+
+      conn = ActiveRecord::Base.lease_connection
+      conn.select_value("SELECT 1")
+      ActiveRecord::Base.connection_handler.clear_active_connections!
+
+      assert_not_nil conn
+
+      release_maintenance_latch = Concurrent::CountDownLatch.new(1)
+      leak_check_attempted_latch = Concurrent::CountDownLatch.new(1)
+
+      maintenance_thread = Thread.new do
+        Thread.current.name = "AR Pool Reaper"
+
+        pool.reaper_lock do
+          pool.send(:checkout_for_maintenance, conn)
+          release_maintenance_latch.wait
+          pool.send(:return_from_maintenance, conn)
+        end
+      end
+
+      wait_for(message: "connection was not checked out for maintenance", timeout: 1) do
+        conn.in_use?
+      end
+      assert_not_equal ActiveSupport::IsolatedExecutionState.context, conn.owner
+
+      original_reaper_lock_method = pool.method(:reaper_lock)
+      leak_check_thread = nil
+
+      pool.stub(:reaper_lock, ->(&block) do
+        leak_check_attempted_latch.count_down
+        original_reaper_lock_method.call(&block)
+      end) do
+        leak_check_thread = Thread.new do
+          check_connection_leaks
+        end
+
+        wait_for(message: "leak check did not reach the reaper lock", timeout: 1) do
+          !leak_check_thread.alive? || leak_check_attempted_latch.wait(0)
+        end
+
+        release_maintenance_latch.count_down
+        assert_nothing_raised do
+          leak_check_thread.value
+        end
+      end
+    ensure
+      release_maintenance_latch&.count_down
+      maintenance_thread&.join
+      leak_check_thread&.join
+
+      if conn&.in_use?
+        conn.steal!
+        pool.checkin(conn)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord::TestCase#check_connection_leaks` scans each pool during teardown to catch connections left owned by background threads.

`ConnectionPool::Reaper` can legitimately hold a connection under `reaper_lock` while it performs maintenance. The leak check currently inspects `pool.connections` without taking that lock, so teardown can race the reaper, report a leaked connection owned by `AR Pool Reaper`, and kill the maintenance thread even though no test leaked anything.

### Detail

Synchronize the leak scan with `pool.reaper_lock` so teardown waits for any in-flight maintenance to finish before classifying in-use connections as leaks.

Add a regression test that reproduces the false positive by holding a connection for maintenance from a thread named `AR Pool Reaper`. The new test fails against `origin/main` and passes with this patch.

### Additional information

This surfaced as an unrelated CI failure while validating #57367, where the reported leaked owner was the pool reaper thread.

### Tests

- `cd activerecord && ARCONN=postgresql bundle exec ruby -Itest test/cases/test_case_test.rb -v`
- `cd activerecord && ARCONN=postgresql bundle exec ruby -Itest test/cases/reaper_test.rb`
- `cd activerecord && ARCONN=postgresql bundle exec ruby -Itest test/cases/associations/has_and_belongs_to_many_associations_test.rb`
- `bundle exec rubocop activerecord/test/cases/test_case.rb activerecord/test/cases/test_case_test.rb`
