### PR TITLE
Remove caller supplied :object option in render_in ActiveModel helper

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -125,6 +125,7 @@ module ActiveModel
     #   render(person)              # => "<p>Ralph</p>
     #   render(renderable: person)  # => "<p>Ralph</p>
     def render_in(view_context, **options, &block)
+      options.delete(:object)
       view_context.render(partial: to_partial_path, object: self, **options, &block)
     end
 

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -77,6 +77,24 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal "block", rendered
   end
 
+  test "#render_in caller-supplied :object is silently dropped, not an error" do
+    contact = Contact.new
+    other   = Contact.new
+    view_context = Object.new
+    def view_context.render(**options)
+      options
+    end
+
+    options = nil
+    assert_nothing_raised do
+      options = contact.render_in(view_context, object: other, locals: { foo: "bar" })
+    end
+
+    assert_equal contact, options[:object]
+    assert_equal "bar", options.dig(:locals, :foo)
+    assert_equal contact.to_partial_path, options[:partial]
+  end
+
   test "#to_param_delimiter allows redefining the delimiter used in #to_param" do
     old_delimiter = Contact.param_delimiter
     Contact.param_delimiter = "_"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Follow-up to https://github.com/rails/rails/pull/57349

This Pull Request has been created to extract `object:` from `options` with a deliberate priority policy (`self` always wins for `object:`).

### Detail

If options contains an `object:` key (e.g. someone calls `render(renderable: person, locals: { object: other }))`, the keyword splat will raise an ArgumentError due to duplicate keyword. More subtly, if a caller passes `object:` directly in options, it silently overrides `self`. `object: self` is listed before the splat, if a caller passes `object:` inside `options` the Ruby keyword-argument splat raises `ArgumentError: duplicated keyword argument`. And if no explicit error is raised (e.g. if ActionView's render accepts a generic **options internally), the caller's `object:` silently wins — the opposite of what's intended. 

This PR always use `self` as the rendered object. This silently drop any caller-supplied `:object` to prevent unintended object substitution. All other options (:locals, :partial, :layout, etc.) are still forwarded as-is.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
