### PR TITLE
Fix non-working time-only example in ActiveModel::Type::DateTime doc [ci skip]

### DIFF
--- a/activemodel/lib/active_model/type/date_time.rb
+++ b/activemodel/lib/active_model/type/date_time.rb
@@ -25,11 +25,8 @@ module ActiveModel
     #   event.start.sec   # => 0
     #   event.start.zone  # => "EAT"
     #
-    # String values are parsed using the ISO 8601 datetime format. Partial
-    # time-only formats are also accepted.
-    #
-    #   event.start = "06:07:08+09:00"
-    #   event.start.utc # => 1999-12-31 21:07:08 UTC
+    # String values are parsed using the ISO 8601 datetime format. Use the
+    # +:time+ type instead to parse partial time-only values.
     #
     # The degree of sub-second precision can be customized when declaring an
     # attribute:


### PR DESCRIPTION
### Motivation / Background

The `:datetime` type's RDoc claims partial time-only formats are accepted and shows an example (`event.start = "06:07:08+09:00"`) that returns a `Time`. In practice the `:datetime` type returns `nil` for time-only strings: `Date._parse` yields no `:year`, so `new_time` returns `nil`.

The sentence and example were copied from the `:time` type doc, where time-only parsing is genuinely supported.

### Detail

Drop the inaccurate claim and point readers to the `:time` type for time-only values instead.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature. — N/A; documentation-only change.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. — N/A; no behavior change.