### PR TITLE
Add `enforced:` option for foreign keys on PostgreSQL 18.4+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Add `enforced:` option to `add_foreign_key` and `change_foreign_key` for PostgreSQL 18.4+.
+
+    `NOT ENFORCED` foreign keys are available since PostgreSQL 18.0, but `DEFERRABLE`
+    was lost on them until 18.4 ("Fix loss of deferrability of foreign-key triggers",
+    https://www.postgresql.org/docs/release/18.4/). Rails therefore requires PostgreSQL
+    18.4 or later for this feature.
+
+    When `enforced: false` is passed to `add_foreign_key`, the constraint is created as `NOT ENFORCED`,
+    meaning PostgreSQL skips referential integrity checks during DML.
+    PostgreSQL marks `NOT ENFORCED` constraints as `NOT VALID` internally (and `VALIDATE CONSTRAINT`
+    does not apply to them), so the schema dumper outputs both
+    `enforced: false` and `validate: false`.
+
+    `change_foreign_key` toggles the enforced status of an existing foreign key. Without
+    this method, users would need to issue raw `ALTER TABLE ... ALTER CONSTRAINT` SQL
+    to disable enforcement temporarily (e.g., for bulk DML that loads the referenced
+    and referencing tables in arbitrary order) and then re-enable it.
+
+    ```ruby
+    add_foreign_key :articles, :authors, enforced: false
+    # => ALTER TABLE "articles" ADD CONSTRAINT ... FOREIGN KEY ("author_id") REFERENCES "authors" ("id") NOT ENFORCED
+
+    change_foreign_key :articles, :authors, enforced: true
+    # => ALTER TABLE "articles" ALTER CONSTRAINT "fk_rails_..." ENFORCED
+
+    change_foreign_key :articles, :authors, enforced: false
+    # => ALTER TABLE "articles" ALTER CONSTRAINT "fk_rails_..." NOT ENFORCED
+    ```
+
+    *Yasuo Honda*
+
 *   Expose `cursor`, `order` and `use_ranges` attributes for `BatchEnumerator`
 
     *fatkodima*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -154,6 +154,10 @@ module ActiveRecord
       end
       alias validated? validate?
 
+      def enforced?
+        options.fetch(:enforced, true)
+      end
+
       def export_name_on_schema_dump?
         !ActiveRecord::SchemaDumper.fk_ignore_pattern.match?(name) if name
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1230,6 +1230,14 @@ module ActiveRecord
       #
       #   ALTER TABLE "articles" ADD CONSTRAINT fk_rails_e74ce85cbc FOREIGN KEY ("author_id") REFERENCES "authors" ("id") ON DELETE CASCADE
       #
+      # ====== Creating a not enforced foreign key (PostgreSQL 18.4+)
+      #
+      #   add_foreign_key :articles, :authors, enforced: false
+      #
+      # generates:
+      #
+      #   ALTER TABLE "articles" ADD CONSTRAINT fk_rails_e74ce85cbc FOREIGN KEY ("author_id") REFERENCES "authors" ("id") NOT ENFORCED
+      #
       # The +options+ hash can include the following keys:
       # [<tt>:column</tt>]
       #   The foreign key column name on +from_table+. Defaults to <tt>to_table.singularize + "_id"</tt>.
@@ -1251,6 +1259,11 @@ module ActiveRecord
       # [<tt>:deferrable</tt>]
       #   (PostgreSQL only) Specify whether or not the foreign key should be deferrable. Valid values are booleans or
       #   +:deferred+ or +:immediate+ to specify the default behavior. Defaults to +false+.
+      # [<tt>:enforced</tt>]
+      #   (PostgreSQL 18.4+) Specify whether or not
+      #   the foreign key should be enforced. Defaults to +true+. When set to +false+, the
+      #   constraint is created as +NOT ENFORCED+, meaning referential integrity is not
+      #   checked during DML.
       def add_foreign_key(from_table, to_table, **options)
         return unless use_foreign_keys?
 
@@ -1303,6 +1316,13 @@ module ActiveRecord
         at.drop_foreign_key fk_name_to_delete
 
         execute schema_creation.accept(at)
+      end
+
+      # Changes an existing foreign key on a table. Currently only the PostgreSQL
+      # adapter (version 18.4+) implements this; see
+      # PostgreSQL::SchemaStatements#change_foreign_key for details.
+      def change_foreign_key(from_table, to_table = nil, **options)
+        raise NotImplementedError, "change_foreign_key is not implemented"
       end
 
       # Checks to see if a foreign key exists on a table for a given foreign key definition.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -515,6 +515,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support NOT ENFORCED foreign key constraints?
+      def supports_enforced_foreign_keys?
+        false
+      end
+
       # Does this adapter support creating check constraints?
       def supports_check_constraints?
         false

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -24,6 +24,7 @@ module ActiveRecord
           def visit_ForeignKeyDefinition(o)
             super.dup.tap do |sql|
               sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
+              sql << " NOT ENFORCED" unless o.enforced?
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -746,13 +746,18 @@ module ActiveRecord
         def add_foreign_key(from_table, to_table, **options)
           assert_valid_deferrable(options[:deferrable])
 
+          if options.key?(:enforced) && !supports_enforced_foreign_keys?
+            raise ArgumentError, "NOT ENFORCED foreign key constraints require PostgreSQL 18.4+ (got #{database_version})"
+          end
+
           super
         end
 
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
+          conenforced_column = supports_enforced_foreign_keys? ? ", c.conenforced AS enforced" : ""
           fk_info = query_all(<<~SQL)
-            SELECT t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid,
+            SELECT t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid#{conenforced_column},
               (
                 SELECT array_agg(a.attname ORDER BY idx)
                 FROM (
@@ -798,6 +803,7 @@ module ActiveRecord
             options[:deferrable] = extract_constraint_deferrable(row["deferrable"], row["deferred"])
 
             options[:validate] = row["valid"]
+            options[:enforced] = row["enforced"] if supports_enforced_foreign_keys?
 
             ForeignKeyDefinition.new(table_name, to_table, options)
           end
@@ -1101,6 +1107,47 @@ module ActiveRecord
           fk_name_to_validate = foreign_key_for!(from_table, to_table: to_table, **options).name
 
           validate_constraint from_table, fk_name_to_validate
+        end
+
+        # Changes an existing foreign key constraint on a table.
+        #
+        # The +enforced+ option toggles whether PostgreSQL checks referential integrity
+        # during DML. Requires PostgreSQL 18.4+.
+        #
+        # Like +validate_foreign_key+, this is a runtime helper rather than a migration
+        # command: it is not registered as reversible, so use it from application code
+        # or explicit +up+/+down+ methods. Accepted options are +:enforced+ plus
+        # identifying keys (+:column+, +:name+, +:to_table+).
+        #
+        # Changes the foreign key on +accounts.branch_id+ to NOT ENFORCED.
+        #
+        #   change_foreign_key :accounts, :branches, enforced: false
+        #
+        # Changes the foreign key on +accounts.branch_id+ back to ENFORCED.
+        #
+        #   change_foreign_key :accounts, :branches, enforced: true
+        #
+        # Changes the foreign key on +accounts.owner_id+.
+        #
+        #   change_foreign_key :accounts, column: :owner_id, enforced: false
+        #
+        # Changes the foreign key named +special_fk_name+ on the +accounts+ table.
+        #
+        #   change_foreign_key :accounts, name: :special_fk_name, enforced: false
+        #
+        def change_foreign_key(from_table, to_table = nil, **options)
+          unless supports_enforced_foreign_keys?
+            raise ArgumentError, "change_foreign_key requires PostgreSQL 18.4+ (got #{database_version})"
+          end
+
+          unless options.key?(:enforced)
+            raise ArgumentError, "change_foreign_key requires at least one option (e.g. enforced:)"
+          end
+
+          enforced = options[:enforced]
+          fk_name = foreign_key_for!(from_table, to_table: to_table, **options.except(:enforced)).name
+
+          execute "ALTER TABLE #{quote_table_name(from_table)} ALTER CONSTRAINT #{quote_column_name(fk_name)} #{enforced ? 'ENFORCED' : 'NOT ENFORCED'}"
         end
 
         # Validates the given check constraint.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -255,6 +255,13 @@ module ActiveRecord
         true
       end
 
+      def supports_enforced_foreign_keys?
+        # `NOT ENFORCED` foreign keys exist from PostgreSQL 18.0, but `DEFERRABLE` was lost on
+        # them until 18.4 ("Fix loss of deferrability of foreign-key triggers",
+        # https://www.postgresql.org/docs/release/18.4/).
+        database_version >= 18_00_04
+      end
+
       def supports_views?
         true
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -335,6 +335,7 @@ module ActiveRecord
             parts << "on_delete: #{foreign_key.on_delete.inspect}" if foreign_key.on_delete
             parts << "deferrable: #{foreign_key.deferrable.inspect}" if foreign_key.deferrable
             parts << "validate: #{foreign_key.validate?.inspect}" unless foreign_key.validate?
+            parts << "enforced: #{foreign_key.enforced?.inspect}" unless foreign_key.enforced?
 
             "  add_foreign_key #{parts.join(', ')}"
           end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -659,6 +659,207 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           end
         end
 
+        if ActiveRecord::Base.lease_connection.supports_enforced_foreign_keys?
+          def test_enforced_foreign_key_default
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
+
+            foreign_keys = @connection.foreign_keys("astronauts")
+            assert_equal 1, foreign_keys.size
+
+            fk = foreign_keys.first
+            assert_predicate fk, :enforced?
+          end
+
+          def test_not_enforced_foreign_key
+            assert_queries_match(/\("id"\)\s+NOT ENFORCED\W*\z/i) do
+              @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", enforced: false
+            end
+
+            foreign_keys = @connection.foreign_keys("astronauts")
+            assert_equal 1, foreign_keys.size
+
+            fk = foreign_keys.first
+            assert_not_predicate fk, :enforced?
+          end
+
+          # PostgreSQL marks NOT ENFORCED constraints as NOT VALID internally, overriding `validate: true`.
+          def test_not_enforced_foreign_key_with_validate_true
+            skip unless current_adapter?(:PostgreSQLAdapter)
+
+            assert_queries_match(/\("id"\)\s+NOT ENFORCED\W*\z/i) do
+              @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id",
+                enforced: false, validate: true
+            end
+
+            foreign_keys = @connection.foreign_keys("astronauts")
+            assert_equal 1, foreign_keys.size
+
+            fk = foreign_keys.first
+            assert_not_predicate fk, :enforced?
+            assert_not_predicate fk, :validate?
+          end
+
+          # Schema dump emits both axes; this verifies the resulting SQL is accepted by PostgreSQL.
+          def test_not_enforced_foreign_key_with_validate_false
+            skip unless current_adapter?(:PostgreSQLAdapter)
+
+            assert_queries_match(/\("id"\)\s+NOT ENFORCED\s+NOT VALID\W*\z/i) do
+              @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id",
+                enforced: false, validate: false
+            end
+
+            foreign_keys = @connection.foreign_keys("astronauts")
+            assert_equal 1, foreign_keys.size
+
+            fk = foreign_keys.first
+            assert_not_predicate fk, :enforced?
+            assert_not_predicate fk, :validate?
+          end
+
+          def test_add_reference_with_not_enforced_foreign_key
+            @connection.add_reference :astronauts, :myrocket, foreign_key: { to_table: :rockets, enforced: false }
+
+            fk = @connection.foreign_keys("astronauts").find { |k| k.column == "myrocket_id" }
+            assert_not_predicate fk, :enforced?
+          end
+
+          def test_create_table_with_not_enforced_foreign_key
+            @connection.create_table :test_planets, force: true do |t|
+              t.references :rocket
+              t.foreign_key :rockets, column: :rocket_id, enforced: false
+            end
+
+            fk = @connection.foreign_keys("test_planets").first
+            assert_not_predicate fk, :enforced?
+          ensure
+            @connection.drop_table :test_planets, if_exists: true
+          end
+
+          def test_not_enforced_deferrable_foreign_key
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id",
+              enforced: false, deferrable: :deferred
+
+            foreign_keys = @connection.foreign_keys("astronauts")
+            assert_equal 1, foreign_keys.size
+
+            fk = foreign_keys.first
+            assert_not_predicate fk, :enforced?
+            assert_equal :deferred, fk.deferrable
+          end
+
+          def test_not_enforced_allows_inserting_invalid_fk_reference
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", enforced: false
+
+            assert_nothing_raised do
+              @connection.execute("INSERT INTO astronauts(name, rocket_id) VALUES ('test', 999999)")
+            end
+          end
+
+          def test_schema_dumping_with_enforced_true
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", enforced: true
+
+            output = dump_table_schema "astronauts"
+
+            assert_match %r{\s+add_foreign_key "astronauts", "rockets"$}, output
+          end
+
+          def test_schema_dumping_with_enforced_false
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", enforced: false
+
+            output = dump_table_schema "astronauts"
+
+            assert_match %r{\s+add_foreign_key "astronauts", "rockets", validate: false, enforced: false$}, output
+          end
+
+          # PostgreSQL marks NOT ENFORCED constraints as NOT VALID internally, so the dump records both axes as false.
+          def test_schema_dumping_with_enforced_false_and_validate_true
+            skip unless current_adapter?(:PostgreSQLAdapter)
+
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id",
+              enforced: false, validate: true
+
+            output = dump_table_schema "astronauts"
+            assert_match %r{\s+add_foreign_key "astronauts", "rockets", validate: false, enforced: false$}, output
+          end
+
+          def test_schema_dumping_with_enforced_false_and_deferrable_deferred
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id",
+              enforced: false, deferrable: :deferred
+
+            output = dump_table_schema "astronauts"
+
+            assert_match %r{\s+add_foreign_key "astronauts", "rockets", deferrable: :deferred, validate: false, enforced: false$}, output
+          end
+
+          def test_change_foreign_key_enforced_to_not_enforced
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
+
+            @connection.change_foreign_key :astronauts, :rockets, enforced: false
+
+            fk = @connection.foreign_keys("astronauts").first
+            assert_not_predicate fk, :enforced?
+          end
+
+          def test_change_foreign_key_not_enforced_to_enforced
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", enforced: false
+
+            @connection.change_foreign_key :astronauts, :rockets, enforced: true
+
+            fk = @connection.foreign_keys("astronauts").first
+            assert_predicate fk, :enforced?
+          end
+
+          def test_change_foreign_key_by_name
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", name: "special_fk_name"
+
+            @connection.change_foreign_key :astronauts, name: "special_fk_name", enforced: false
+
+            fk = @connection.foreign_keys("astronauts").first
+            assert_not_predicate fk, :enforced?
+            assert_equal "special_fk_name", fk.name
+          end
+
+          def test_change_foreign_key_by_column
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
+
+            @connection.change_foreign_key :astronauts, column: "rocket_id", enforced: false
+
+            fk = @connection.foreign_keys("astronauts").first
+            assert_not_predicate fk, :enforced?
+            assert_equal "rocket_id", fk.column
+          end
+
+          def test_change_foreign_key_raises_without_options
+            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
+
+            error = assert_raises(ArgumentError) do
+              @connection.change_foreign_key :astronauts, :rockets
+            end
+            assert_match(/enforced/, error.message)
+          end
+
+        end
+
+        def test_enforced_option_raises_on_unsupported_database
+          skip unless current_adapter?(:PostgreSQLAdapter)
+          @connection.stub(:supports_enforced_foreign_keys?, false) do
+            error = assert_raises(ArgumentError) do
+              @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", enforced: false
+            end
+            assert_match(/NOT ENFORCED/, error.message)
+          end
+        end
+
+        def test_change_foreign_key_raises_on_unsupported_database
+          skip unless current_adapter?(:PostgreSQLAdapter)
+          @connection.stub(:supports_enforced_foreign_keys?, false) do
+            error = assert_raises(ArgumentError) do
+              @connection.change_foreign_key :astronauts, :rockets, enforced: false
+            end
+            assert_match(/change_foreign_key requires PostgreSQL 18\.4/, error.message)
+          end
+        end
+
         def test_does_not_create_foreign_keys_when_bypassed_by_config
           require "active_record/connection_adapters/sqlite3_adapter"
           connection = ActiveRecord::ConnectionAdapters::SQLite3Adapter.new(


### PR DESCRIPTION
This pull request adds `enforced:` option for foreign keys on PostgreSQL 18.4+

### Motivation / Background

On PostgreSQL 17 or earlier, bypassing foreign key checks requires `DISABLE TRIGGER ALL`, which needs superuser privileges. Re-enabling triggers does not re-validate existing rows — so invalid data can silently slip in.

PostgreSQL 18 introduces the NOT ENFORCED option for foreign keys, which fixes both: the table owner can toggle it (no superuser needed), and switching back to ENFORCED re-validates all rows. A remaining blocker — that toggling lost the DEFERRABLE / INITIALLY DEFERRED attributes Rails relies on — was fixed in PostgreSQL 18.4, so Active Record can finally support this.

A follow-up pull request will `update disable_referential_integrity` to use NOT ENFORCED on PostgreSQL 18.4+.

### Detail

- `NOT ENFORCED` foreign keys are available since PostgreSQL 18.0, but `DEFERRABLE` was lost on them until 18.4 ("Fix loss of deferrability of foreign-key triggers", https://www.postgresql.org/docs/release/18.4/). Rails therefore requires PostgreSQL 18.4 or later for this feature.

- When `enforced: false` is passed to `add_foreign_key`, the constraint is created as `NOT ENFORCED`, meaning PostgreSQL skips referential integrity checks during DML. PostgreSQL marks `NOT ENFORCED` constraints as `NOT VALID` internally (and `VALIDATE CONSTRAINT` does not apply to them), so the schema dumper outputs both `enforced: false` and `validate: false`.

- `change_foreign_key` toggles the enforced status of an existing foreign key. Without this method, users would need to issue raw `ALTER TABLE ... ALTER CONSTRAINT` SQL to disable enforcement temporarily (e.g., for bulk DML that loads the referenced and referencing tables in arbitrary order) and then re-enable it.

### Additional information

- [PostgreSQL 18.0 Release Notes](https://www.postgresql.org/docs/release/18.0/)
> Allow [CHECK](https://www.postgresql.org/docs/release/18.0/sql-createtable.html#SQL-CREATETABLE-PARMS-CHECK) and [foreign key](https://www.postgresql.org/docs/release/18.0/sql-createtable.html#SQL-CREATETABLE-PARMS-REFERENCES) constraints to be specified as NOT ENFORCED (Amul Sul) [§](https://postgr.es/c/ca87c415e) [§](https://postgr.es/c/eec0040c4)

- [PostgreSQL 18.4 Release Notes](https://www.postgresql.org/docs/release/18.4/)
> Fix loss of deferrability of foreign-key triggers (Yasuo Honda) [§](https://postgr.es/c/5db5e3396)

- A previous attempt to avoid the superuser requirement via SET CONSTRAINTS ALL DEFERRED was [reverted](https://github.com/rails/rails/commit/2812694aa65e4d0591e0ea6c5f7d8c97927be7dc) because referential actions other than NO ACTION cannot be deferred, even when the constraint is declared DEFERRABLE.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
