### PR TITLE
Use NOT ENFORCED in disable_referential_integrity on PostgreSQL 18.4+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   On PostgreSQL 18.4+, `disable_referential_integrity` uses `NOT ENFORCED`/`ENFORCED`
+    instead of `DISABLE TRIGGER ALL`/`ENABLE TRIGGER ALL`, requiring only table ownership
+    rather than superuser privileges. Only currently `ENFORCED` foreign keys are toggled;
+    intentionally `NOT ENFORCED` foreign keys are left unchanged.
+
+    Unlike `ENABLE TRIGGER ALL`, restoring `ENFORCED` checks existing rows against the
+    constraint, so FK violations raise `ActiveRecord::InvalidForeignKey` rather than
+    `RuntimeError`. The toggle and restore run in a single transaction so a restoration
+    failure rolls back the initial `NOT ENFORCED` toggle too — preventing originally-
+    `ENFORCED` constraints from being left in a `NOT ENFORCED` state indistinguishable
+    from intentional ones.
+
+    Fixtures sharing FK relationships must be passed together to
+    `FixtureSet.create_fixtures` to ensure all referenced rows are present when
+    enforcement is restored.
+
+    `check_all_foreign_keys_valid!` skips `NOT ENFORCED` constraints on PostgreSQL 18.4+,
+    as `VALIDATE CONSTRAINT` cannot be applied to them.
+
+    Unlike `SET CONSTRAINTS ALL DEFERRED` (the approach attempted in rails/rails#27636
+    and reverted), `NOT ENFORCED` also suppresses referential actions such as
+    `ON DELETE CASCADE`, `SET NULL`, and `SET DEFAULT`.
+
+    *Yasuo Honda*
+
 *   Add `exclusion_constraint_exists?` and `unique_constraint_exists?` helpers
 
     *fatkodima*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -5,40 +5,85 @@ module ActiveRecord
     module PostgreSQL
       module ReferentialIntegrity # :nodoc:
         def disable_referential_integrity # :nodoc:
-          original_exception = nil
+          if supports_enforced_foreign_keys?
+            # Only toggle FKs that are currently `ENFORCED`; leave `NOT ENFORCED` ones unchanged.
+            # `conparentid = 0` excludes constraints inherited from a partitioned parent —
+            # `ALTER CONSTRAINT` must be issued on the parent and is propagated to partitions.
+            enforced_fks = query_all(<<~SQL)
+              SELECT n.nspname AS schema_name, t.relname AS table_name, c.conname AS constraint_name
+              FROM pg_constraint c
+              JOIN pg_class t ON c.conrelid = t.oid
+              JOIN pg_namespace n ON c.connamespace = n.oid
+              WHERE c.contype = 'f'
+                AND c.conenforced = true
+                AND c.conparentid = 0
+                AND n.nspname = ANY (current_schemas(false))
+            SQL
 
-          begin
             transaction(requires_new: true) do
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+              enforced_fks.each do |fk|
+                execute("ALTER TABLE #{quote_table_name(fk["schema_name"])}.#{quote_table_name(fk["table_name"])} " \
+                        "ALTER CONSTRAINT #{quote_column_name(fk["constraint_name"])} NOT ENFORCED")
+              end
+
+              yield
+
+              enforced_fks.each do |fk|
+                execute("ALTER TABLE #{quote_table_name(fk["schema_name"])}.#{quote_table_name(fk["table_name"])} " \
+                        "ALTER CONSTRAINT #{quote_column_name(fk["constraint_name"])} ENFORCED")
+              end
             end
-          rescue ActiveRecord::ActiveRecordError => e
-            original_exception = e
-          end
+          else
+            original_exception = nil
 
-          begin
-            yield
-          rescue ActiveRecord::InvalidForeignKey => e
-            warn <<-WARNING
-WARNING: Rails was not able to disable referential integrity.
-
-This is most likely caused due to missing permissions.
-Rails needs superuser privileges to disable referential integrity.
-
-    cause: #{original_exception&.message}
-
-            WARNING
-            raise e
-          end
-
-          begin
-            transaction(requires_new: true) do
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+            begin
+              transaction(requires_new: true) do
+                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+              end
+            rescue ActiveRecord::ActiveRecordError => e
+              original_exception = e
             end
-          rescue ActiveRecord::ActiveRecordError
+
+            begin
+              yield
+            rescue ActiveRecord::InvalidForeignKey => e
+              warn <<~WARNING
+                WARNING: Rails was not able to disable referential integrity.
+
+                This is most likely caused due to missing permissions.
+                The user must be superuser to execute DISABLE TRIGGER ALL.
+
+                    cause: #{original_exception&.message}
+
+              WARNING
+              raise e
+            end
+
+            begin
+              transaction(requires_new: true) do
+                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+              end
+            rescue ActiveRecord::ActiveRecordError
+            end
           end
         end
 
         def check_all_foreign_keys_valid! # :nodoc:
+          # Skip `NOT ENFORCED` constraints (PG 18.4+): `VALIDATE CONSTRAINT` cannot be
+          # applied to them and raises an error.
+          if supports_enforced_foreign_keys?
+            enforced_join = <<~SQL
+              JOIN pg_catalog.pg_constraint c
+                ON c.conname = tc.constraint_name
+               AND c.conenforced = true
+              JOIN pg_catalog.pg_class cls ON cls.oid = c.conrelid
+               AND cls.relname = tc.table_name
+              JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace
+               AND ns.nspname = tc.table_schema
+               AND ns.nspname = tc.constraint_schema
+            SQL
+          end
+
           sql = <<~SQL
             do $$
               declare r record;
@@ -50,7 +95,9 @@ Rails needs superuser privileges to disable referential integrity.
                 table_schema,
                 table_name
               ) AS constraint_check
-              FROM information_schema.table_constraints WHERE constraint_type = 'FOREIGN KEY'
+              FROM information_schema.table_constraints tc
+              #{enforced_join}
+              WHERE tc.constraint_type = 'FOREIGN KEY'
             )
               LOOP
                 EXECUTE (r.constraint_check);

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -571,10 +571,10 @@ module ActiveRecord
     private
       def reset_fixtures(*fixture_names)
         ActiveRecord::FixtureSet.reset_cache
-
-        fixture_names.each do |fixture_name|
-          ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, fixture_name)
-        end
+        # Pass all fixtures at once: on PostgreSQL 18.4+, switching back to `ENFORCED` checks
+        # existing rows against the constraint, so loading child fixtures before parents
+        # would raise a FK violation.
+        ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, fixture_names)
       end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -33,9 +33,21 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
 
   def setup
     @connection = ActiveRecord::Base.lease_connection
+    if @connection.supports_enforced_foreign_keys?
+      @connection.create_table :ri_test_parents, force: true
+      @connection.create_table :ri_test_children, force: true do |t|
+        t.bigint :parent_id, null: false
+      end
+    end
   end
 
   def teardown
+    @connection.drop_table :ri_test_children, if_exists: true
+    @connection.drop_table :ri_test_parents, if_exists: true
+    @connection.drop_table :ri_pp_children_0, if_exists: true
+    @connection.drop_table :ri_pp_children, if_exists: true
+    @connection.drop_table :ri_pp_parents_0, if_exists: true
+    @connection.drop_table :ri_pp_parents, if_exists: true
     reset_connection
     if ActiveRecord::Base.lease_connection.is_a?(MissingSuperuserPrivileges)
       raise "MissingSuperuserPrivileges patch was not removed"
@@ -43,6 +55,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_should_reraise_invalid_foreign_key_exception_and_show_warning
+    skip if @connection.supports_enforced_foreign_keys?
     @connection.extend MissingSuperuserPrivileges
 
     warning = capture(:stderr) do
@@ -58,6 +71,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_does_not_print_warning_if_no_invalid_foreign_key_exception_was_raised
+    skip if @connection.supports_enforced_foreign_keys?
     @connection.extend MissingSuperuserPrivileges
 
     warning = capture(:stderr) do
@@ -72,7 +86,11 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_does_not_break_transactions
-    @connection.extend MissingSuperuserPrivileges
+    if @connection.supports_enforced_foreign_keys?
+      @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+    else
+      @connection.extend MissingSuperuserPrivileges
+    end
 
     @connection.transaction do
       @connection.disable_referential_integrity do
@@ -83,7 +101,11 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_does_not_break_nested_transactions
-    @connection.extend MissingSuperuserPrivileges
+    if @connection.supports_enforced_foreign_keys?
+      @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+    else
+      @connection.extend MissingSuperuserPrivileges
+    end
 
     @connection.transaction do
       @connection.transaction(requires_new: true) do
@@ -96,10 +118,194 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_only_catch_active_record_errors_others_bubble_up
+    skip if @connection.supports_enforced_foreign_keys?
     @connection.extend ProgrammerMistake
 
     assert_raises ArgumentError do
       @connection.disable_referential_integrity { }
+    end
+  end
+
+  def test_disable_referential_integrity_with_partitioned_to_partitioned_fk
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.create_table :ri_pp_parents, force: true,
+      options: "PARTITION BY RANGE (id)"
+    @connection.execute "CREATE TABLE ri_pp_parents_0 PARTITION OF ri_pp_parents FOR VALUES FROM (0) TO (1000)"
+
+    @connection.create_table :ri_pp_children, force: true,
+      options: "PARTITION BY RANGE (id)" do |t|
+      t.bigint :parent_id, null: false
+    end
+    @connection.execute "CREATE TABLE ri_pp_children_0 PARTITION OF ri_pp_children FOR VALUES FROM (0) TO (1000)"
+
+    @connection.add_foreign_key :ri_pp_children, :ri_pp_parents,
+      column: :parent_id, name: :ri_pp_fk
+
+    assert_nothing_raised do
+      @connection.disable_referential_integrity { }
+    end
+
+    fk_enforced = @connection.select_value(<<~SQL)
+      SELECT conenforced FROM pg_constraint WHERE conname = 'ri_pp_fk'
+    SQL
+    assert fk_enforced, "FK between partitioned tables should be ENFORCED after the block"
+  end
+
+  def test_not_enforced_foreign_keys_remain_not_enforced_after_block
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents,
+      column: :parent_id, name: :ri_test_fk, enforced: false
+
+    @connection.disable_referential_integrity { }
+
+    result = @connection.select_value(<<~SQL)
+      SELECT c.conenforced
+      FROM pg_constraint c
+      WHERE c.conname = 'ri_test_fk'
+    SQL
+
+    assert_not result, "NOT ENFORCED foreign key should remain NOT ENFORCED after disable_referential_integrity block"
+  end
+
+  def test_enforced_foreign_keys_are_restored_to_enforced_after_block
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+
+    fk_enforced_during_block = nil
+    @connection.disable_referential_integrity do
+      fk_enforced_during_block = @connection.select_value(<<~SQL)
+        SELECT c.conenforced
+        FROM pg_constraint c
+        WHERE c.conname = 'ri_test_fk'
+      SQL
+    end
+
+    assert_not fk_enforced_during_block,
+      "FK should be NOT ENFORCED inside the disable_referential_integrity block"
+
+    fk_enforced_after = @connection.select_value(<<~SQL)
+      SELECT c.conenforced
+      FROM pg_constraint c
+      WHERE c.conname = 'ri_test_fk'
+    SQL
+
+    assert fk_enforced_after,
+      "FK should be restored to ENFORCED after disable_referential_integrity block"
+  end
+
+  def test_deferrable_foreign_keys_are_restored_after_block
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents,
+      column: :parent_id, name: :ri_test_deferred_fk, deferrable: :deferred
+
+    @connection.disable_referential_integrity { }
+
+    condeferrable = @connection.select_value(<<~SQL)
+      SELECT c.condeferrable FROM pg_constraint c WHERE c.conname = 'ri_test_deferred_fk'
+    SQL
+    condeferred = @connection.select_value(<<~SQL)
+      SELECT c.condeferred FROM pg_constraint c WHERE c.conname = 'ri_test_deferred_fk'
+    SQL
+
+    assert condeferrable, "FK should remain DEFERRABLE after disable_referential_integrity block"
+    assert condeferred, "FK should remain INITIALLY DEFERRED after disable_referential_integrity block"
+  end
+
+  def test_validated_foreign_keys_are_restored_after_block
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents,
+      column: :parent_id, name: :ri_test_validated_fk
+
+    convalidated_before = @connection.select_value(<<~SQL)
+      SELECT c.convalidated FROM pg_constraint c WHERE c.conname = 'ri_test_validated_fk'
+    SQL
+    assert convalidated_before, "FK should be VALIDATED before disable_referential_integrity block"
+
+    @connection.disable_referential_integrity { }
+
+    convalidated_after = @connection.select_value(<<~SQL)
+      SELECT c.convalidated FROM pg_constraint c WHERE c.conname = 'ri_test_validated_fk'
+    SQL
+    assert convalidated_after, "FK should be restored to VALIDATED after disable_referential_integrity block"
+  end
+
+  def test_non_fk_error_in_block_propagates_original_exception
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+
+    original_error = nil
+    @connection.transaction do
+      original_error = assert_raises(ActiveRecord::StatementInvalid) do
+        @connection.disable_referential_integrity do
+          @connection.execute("SELECT 1/0")  # aborts the transaction
+        end
+      end
+      raise ActiveRecord::Rollback
+    end
+
+    assert_match(/division by zero/, original_error.message)
+
+    conenforced = @connection.select_value(<<~SQL)
+      SELECT conenforced FROM pg_constraint WHERE conname = 'ri_test_fk'
+    SQL
+    assert conenforced,
+      "FK should be restored to ENFORCED after the outer transaction rolls back"
+  end
+
+  def test_disable_referential_integrity_raises_invalid_foreign_key_on_fk_violation
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+
+    assert_raises(ActiveRecord::InvalidForeignKey) do
+      @connection.transaction do
+        @connection.disable_referential_integrity do
+          @connection.execute("INSERT INTO ri_test_children(parent_id) VALUES (999)")
+        end
+      end
+    end
+  end
+
+  def test_on_delete_cascade_does_not_fire_when_not_enforced
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents,
+      column: :parent_id, name: :ri_test_cascade_fk, on_delete: :cascade
+
+    parent_model = Class.new(ActiveRecord::Base) { self.table_name = "ri_test_parents" }
+    child_model  = Class.new(ActiveRecord::Base) { self.table_name = "ri_test_children" }
+
+    parent = parent_model.create!
+    child_model.create!(parent_id: parent.id)
+
+    @connection.disable_referential_integrity do
+      @connection.execute("DELETE FROM ri_test_parents WHERE id = #{parent.id}")
+      assert child_model.exists?(parent_id: parent.id),
+        "Child row must remain because ON DELETE CASCADE is suppressed under NOT ENFORCED"
+      @connection.execute("INSERT INTO ri_test_parents (id) VALUES (#{parent.id})")
+    end
+  end
+
+  def test_check_all_foreign_keys_valid_skips_not_enforced_constraints
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents,
+      column: :parent_id, name: :ri_test_not_enforced_fk, enforced: false
+
+    parent_model = Class.new(ActiveRecord::Base) { self.table_name = "ri_test_parents" }
+    child_model  = Class.new(ActiveRecord::Base) { self.table_name = "ri_test_children" }
+
+    parent_model.create!
+    child_model.create!(parent_id: 999)
+
+    assert_nothing_raised do
+      @connection.check_all_foreign_keys_valid!
     end
   end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -909,7 +909,11 @@ class FixturesWithForeignKeyViolationsTest < ActiveRecord::TestCase
     File.write(FIXTURES_ROOT + @path, fk_pointing_to_non_existent_object)
 
     with_verify_foreign_keys_for_fixtures do
-      if current_adapter?(:SQLite3Adapter, :PostgreSQLAdapter)
+      if current_adapter?(:PostgreSQLAdapter) && ActiveRecord::Base.lease_connection.supports_enforced_foreign_keys?
+        assert_raise ActiveRecord::InvalidForeignKey do
+          ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
+        end
+      elsif current_adapter?(:SQLite3Adapter, :PostgreSQLAdapter)
         error = assert_raise RuntimeError do
           ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
         end


### PR DESCRIPTION
This pull request uses NOT ENFORCED in disable_referential_integrity on PostgreSQL 18.4+.

### Motivation / Background

### Detail

- On PostgreSQL 18.4+, disable_referential_integrity uses NOT ENFORCED/ENFORCED instead of DISABLE TRIGGER ALL/ENABLE TRIGGER ALL, requiring only table ownership rather than superuser privileges. check_all_foreign_keys_valid! skips NOT ENFORCED constraints since VALIDATE CONSTRAINT cannot be applied to them.

- Within Rails, `disable_referential_integrity` is called by `insert_fixtures_set` (which already wraps the call in a transaction) and by `truncate_tables`. The toggle and restore here are also wrapped in a single transaction to protect public API callers that invoke `disable_referential_integrity` outside an outer transaction.
-  Without the wrap, if a foreign-key restoration fails (e.g., a row inserted in the block violates the constraint), the initial NOT ENFORCED toggle has already been committed, leaving originally-ENFORCED constraints in a NOT ENFORCED state that is indistinguishable from intentionally-NOT-ENFORCED ones on subsequent calls.

- NOT ENFORCED also suppresses referential actions (ON DELETE CASCADE, SET NULL, SET DEFAULT). This achieves the same goal as the reverted rails/rails#27636

### Additional information
Refer to https://github.com/rails/rails/pull/57377 how NOT ENFORCED / ENFORCED works.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
