### PR TITLE
Fix pre-serialized String values skipping cast in insert_all hot path

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -243,7 +243,7 @@ module ActiveRecord
               connection.default_insert_value(model.columns_hash[key])
             else
               type = types[key]
-              value = type.cast(value) unless type.serialized?
+              value = type.cast(value) unless type.serialized? && !value.is_a?(String)
               ActiveModel::Type::SerializeCastValue.serialize(type, value)
             end
           end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -10,6 +10,7 @@ require "models/ship"
 require "models/speedometer"
 require "models/subscription"
 require "models/subscriber"
+require "models/topic"
 
 class ReadonlyNameBook < Book
   attr_readonly :name
@@ -1101,6 +1102,79 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_not_deprecated(ActiveRecord.deprecator) do
       author.books.upsert({ title: "New Book" })
     end
+  end
+  class ReverseCoder
+    def self.dump(value)
+      return nil if value.nil?
+
+      "encoded:#{value.is_a?(String) ? value : value.inspect}"
+    end
+
+    def self.load(value)
+      return nil if value.nil?
+      value.delete_prefix("encoded:")
+    end
+  end
+
+  def test_insert_all_with_string_value_on_custom_coder_serialized_column_matches_create
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      serialize :content, coder: ReverseCoder
+    end
+
+    string_val = "hello world"
+
+    klass.insert_all!([{ title: "insert_str", content: string_val }])
+    klass.create!(title: "create_str", content: string_val)
+
+    via_insert = klass.find_by(title: "insert_str").content
+    via_create = klass.find_by(title: "create_str").content
+
+    assert_equal via_create, via_insert
+  end
+
+  def test_insert_all_with_string_does_not_double_encode_through_non_idempotent_coder
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      serialize :content, coder: ReverseCoder
+    end
+
+    klass.insert_all!([{ title: "double_enc", content: "plain text" }])
+    row = klass.find_by(title: "double_enc")
+
+    assert_equal "plain text", row.content
+  end
+
+  def test_insert_all_with_hash_value_on_custom_coder_serialized_column_still_takes_fast_path
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      serialize :content, coder: ReverseCoder
+    end
+
+    hash_val = { "key" => "value" }
+
+    klass.insert_all!([{ title: "insert_hash", content: hash_val }])
+    klass.create!(title: "create_hash", content: hash_val)
+
+    via_insert = klass.find_by(title: "insert_hash").content
+    via_create = klass.find_by(title: "create_hash").content
+
+    assert_equal via_create, via_insert
+  end
+
+  def test_insert_all_with_string_on_json_serialized_column_matches_create
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      serialize :content, coder: JSON
+    end
+
+    string_val = "a plain string"
+
+    klass.insert_all!([{ title: "json_str_insert", content: string_val }])
+    klass.create!(title: "json_str_create", content: string_val)
+
+    assert_equal klass.find_by(title: "json_str_create").content,
+                 klass.find_by(title: "json_str_insert").content
   end
 
   private


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
Follow up to https://github.com/rails/rails/pull/56855
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because this restores parity between `insert_all` and `create` for all value types, while preserving the performance gain for the common case.

### Detail

PR #56855 added a fast path in `InsertAll::Builder#values_list` that skips `type.cast(value)` when the column type is serialized. The rationale is sound for Hash/Array input: `Mutable#cast` is `deserialize(serialize(value))`, which for a serialized column means `coder.load(coder.dump(value))` — an expensive round-trip that produces the same Ruby object back, so calling it before `SerializeCastValue.serialize` is redundant.

However the optimisation is incorrect when `value` is already a String. In that case the call chain is:
 ```
  SerializeCastValue.serialize(type, "already_encoded")
  # => type.serialize("already_encoded")
  # => coder.dump("already_encoded")   # encodes *again*
  # => double-encoded garbage in the DB
```

With `create` the path is:
 ```
  type.cast("already_encoded")
  # => coder.load(coder.dump("already_encoded"))  # round-trip normalises it
  # then type.serialize(normalised_value)
  # => coder.dump(normalised_value)               # correct single encoding
```

The fix is minimal: only skip `cast` when the incoming value is *not* already a String. Non-String values (Hash, Array, custom objects) are the ones that benefit from the optimization and are safe to skip. String values must still go through `cast` to match `create` behavior. 
 
Mutable#cast is `deserialize(serialize(value))`. For `Type::Serialized`, serialize calls `coder.dump(value)` and deserialize calls `coder.load(...)`. So `cast("already_encoded_string") → coder.load(coder.dump("already_encoded_string"))` — which is the right normalization behaviour matching create. It skips this entirely for serialized types, so a String value bypasses cast and goes straight to `SerializeCastValue.serialize(type, value) → type.serialize(value) → coder.dump(value)` — one encoding on top of the already-encoded string.

The Mutable#cast round-trip is only redundant when the value is already the canonical Ruby-domain object the coder expects to receive (Hash, Array, custom class). A String is ambiguous — it could be a raw Ruby String object being stored, or it could be a pre-encoded database representation — and only running cast disambiguates it the same way create does. The check is cheap (is_a? is O(1)) and only activates the full path when actually needed.

Four test cases are covered, all using `topics.content` (a text column with serialize). `ReverseCoder` is deliberately non-idempotent: `dump("foo") → "encoded:foo"`, so a second dump on that would produce "encoded:encoded:foo", which is immediately visible as corruption in the assertion.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
