### PR TITLE
Remove support for Rails 6.1 Active Record Marshal format

### DIFF
--- a/activerecord/lib/active_record/marshalling.rb
+++ b/activerecord/lib/active_record/marshalling.rb
@@ -2,15 +2,13 @@
 
 module ActiveRecord
   module Marshalling
-    @format_version = 6.1
+    @format_version = 7.1
 
     class << self
       attr_reader :format_version
 
       def format_version=(version)
         case version
-        when 6.1
-          Methods.remove_method(:marshal_dump) if Methods.method_defined?(:marshal_dump)
         when 7.1
           Methods.alias_method(:marshal_dump, :_marshal_dump_7_1)
         else
@@ -39,6 +37,7 @@ module ActiveRecord
 
         payload
       end
+      alias_method :marshal_dump, :_marshal_dump_7_1
 
       def marshal_load(state)
         attributes_from_database, new_record, associations = state

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -103,7 +103,6 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.encryption.hash_digest_class`](#config-active-record-encryption-hash-digest-class): `OpenSSL::Digest::SHA256`
 - [`config.active_record.encryption.support_sha1_for_non_deterministic_encryption`](#config-active-record-encryption-support-sha1-for-non-deterministic-encryption): `false`
 - [`config.active_record.generate_secure_token_on`](#config-active-record-generate-secure-token-on): `:initialize`
-- [`config.active_record.marshalling_format_version`](#config-active-record-marshalling-format-version): `7.1`
 - [`config.active_record.query_log_tags_format`](#config-active-record-query-log-tags-format): `:sqlcommenter`
 - [`config.active_record.raise_on_assign_to_attr_readonly`](#config-active-record-raise-on-assign-to-attr-readonly): `true`
 - [`config.active_record.run_after_transaction_callbacks_in_order_defined`](#config-active-record-run-after-transaction-callbacks-in-order-defined): `true`
@@ -1337,16 +1336,12 @@ to get the parent every time the child record was updated, even when parent has 
 
 #### `config.active_record.marshalling_format_version`
 
-When set to `7.1`, enables a more efficient serialization of Active Record instance with `Marshal.dump`.
+Define which format to use when an Active Record object is serialized with Marshal.
 
-This changes the serialization format, so models serialized this
-way cannot be read by older (< 7.1) versions of Rails. However, messages that
-use the old format can still be read, regardless of whether this optimization is
-enabled.
+As of Rails 8.0, only the `7.1` is supported.
 
 | Starting with version | The default value is |
 | --------------------- | -------------------- |
-| (original)            | `6.1`                |
 | 7.1                   | `7.1`                |
 
 #### `config.active_record.action_on_strict_loading_violation`

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -82,6 +82,13 @@ Upgrading from Rails 8.1 to Rails 8.2
 
 For more information on changes made to Rails 8.2 please see the [release notes](8_2_release_notes.html).
 
+### The old Active Record 6.1 marshalling format was removed.
+
+If your application still sets `active_record.marshalling_format_version = 6.1`, which may
+be done by not calling `config.load_defaults` or calling it with a version older or equal to `6.1`,
+you MUST opt-in to the newer `7.1` marshal format before upgrading, and ensure all caches were
+either flushed or upgraded.
+
 ### The negative scopes for enums now include records with `nil` values.
 
 Active Record negative scopes for enums now include records with `nil` values.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -289,7 +289,6 @@ module Rails
             active_record.default_column_serializer = nil
             active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
             active_record.encryption.support_sha1_for_non_deterministic_encryption = false
-            active_record.marshalling_format_version = 7.1
             active_record.run_after_transaction_callbacks_in_order_defined = true
             active_record.generate_secure_token_on = :initialize
           end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/53362

No longer supporting it will allow us to evolve the internal representation of Active Record objects without breaking compatibility.

Unfortunately I don't see any realistic solution for emitting deprecation warnings if the format is still in use by an application.

For now loading 6.1 record will still work, so I left the associated tests, but we might break it at any point when evolving the various `Attribute` / `AttributeSet` private APIs.
