### PR TITLE
[ci skip] Simplify Association Callbacks examples in Active Record Guides

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -972,54 +972,35 @@ association callbacks:
 
 You can define association callbacks by adding options to the association.
 
-Suppose you have an example where an author can have many books. However, before
-adding a book to the authors collection, you want to ensure that the author has
-not reached their book limit. You can do this by adding a `before_add` callback
-to check the limit.
+Suppose you have an example where an author has many books. Before
+adding a book to the authors collection, you want to log the new addition.
+You can do this by adding a `before_add` callback. Rails passes the object 
+being added or removed to the callback for you to use.
 
 ```ruby
 class Author < ApplicationRecord
-  has_many :books, before_add: :check_limit
+  has_many :books, before_add: :log_book_addition
 
   private
-    def check_limit(_book)
-      if books.count >= 5
-        errors.add(:base, "Cannot add more than 5 books for this author")
-        throw(:abort)
-      end
+    def log_book_addition(book)
+      puts "Adding '#{book.title}' to #{name}'s collection"
     end
+end
+```
+
+At times you may want to perform multiple actions on the associated object. In
+this case, you can stack callbacks on a single event by passing them as an
+array.
+
+```ruby
+class Author < ApplicationRecord
+  has_many :books, before_add: [:callback_one, :callback_two]
+  # ...
 end
 ```
 
 If a `before_add` callback throws `:abort`, the object does not get added to the
-collection.
-
-At times you may want to perform multiple actions on the associated object. In
-this case, you can stack callbacks on a single event by passing them as an
-array. Additionally, Rails passes the object being added or removed to the
-callback for you to use.
-
-```ruby
-class Author < ApplicationRecord
-  has_many :books, before_add: [:check_limit, :calculate_shipping_charges]
-
-  def check_limit(_book)
-    if books.count >= 5
-      errors.add(:base, "Cannot add more than 5 books for this author")
-      throw(:abort)
-    end
-  end
-
-  def calculate_shipping_charges(book)
-    weight_in_pounds = book.weight_in_pounds || 1
-    shipping_charges = weight_in_pounds * 2
-
-    shipping_charges
-  end
-end
-```
-
-Similarly, if a `before_remove` callback throws `:abort`, the object does not
+collection. Similarly, if a `before_remove` callback throws `:abort`, the object does not
 get removed from the collection.
 
 NOTE: These callbacks are called only when the associated objects are added or

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -975,7 +975,7 @@ You can define association callbacks by adding options to the association.
 Suppose you have an example where an author has many books. Before
 adding a book to the authors collection, you want to log the new addition.
 You can do this by adding a `before_add` callback. Rails passes the object 
-being added or removed to the callback for you to use.
+being added to the callback for you to use.
 
 ```ruby
 class Author < ApplicationRecord


### PR DESCRIPTION
### Motivation / Background

There are a couple of examples in the Guides of how to use association callbacks (`before_add` etc). In one example, the callback loads an association (`books`) and performs validation based on the count of books. Personally, I avoid calling associations in callbacks because it can lead to N+1s and makes the code difficult to test. Plus, the validation in that kind of callback doesn't cover the scenario where one calls `Book.create(author: author)` directly.

I understand that many like to call associations in callbacks, so you'll find arguments on both sides. In any case, I think the example should be more agnostic and simpler to keep the focus on the callback mechanics and less on side-effects and usages. Readers may decide how best to use use the callback according to their preferences.

There was also an example with two callbacks, but I couldn't understand the goal of the second callback. It didn't appear to change any state and had a return value with no clear purpose.

### Detail

This Pull Request simplifies the first association callback example to use simple logging. The second example is shortened. I think it conveys the idea clearly enough. The PR also moves a couple of sentences to organize the flow of the text a bit. I kept the warning about the effects of `throw :abort` in there as reminder for people who might want to do validation in these.