### PR TITLE
Accept and discard unused block in `ReflectionProxy#all_includes`

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -106,7 +106,7 @@ module ActiveRecord
             @aliased_table = aliased_table
           end
 
-          def all_includes; nil; end
+          def all_includes(&); nil; end
         end
 
         def get_chain(reflection, association, tracker)


### PR DESCRIPTION
### Motivation / Background

We turned on Ruby 3.4's `strict_unused_block` warning category at @buildkite and noticed Active Record itself emits a warning whenever an association with a `ReflectionProxy` in the chain is loaded. The override of `all_includes` in `ReflectionProxy` is a no-op that intentionally discards the block passed by its caller in `add_constraints`, but it doesn't declare a block parameter, so `strict_unused_block` flags it.

### Detail

Accept and explicitly discard the block using anonymous block forwarding. No behaviour change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.