### PR TITLE
fix `start_with_delimiter?` has a false-positive when the number coincidentally begins with the delimiter string in number_to_phone

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -30,14 +30,10 @@ module ActiveSupport
 
         def convert_without_area_code(number)
           default_pattern = /(\d{0,3})(\d{3})(\d{4})$/
-          number.gsub!(regexp_pattern(default_pattern),
-                       "\\1#{delimiter}\\2#{delimiter}\\3")
-          number.slice!(0, delimiter.length) if start_with_delimiter?(number)
+          number.gsub!(regexp_pattern(default_pattern)) do
+            $1.empty? ? "#{$2}#{delimiter}#{$3}" : "#{$1}#{delimiter}#{$2}#{delimiter}#{$3}"
+          end
           number
-        end
-
-        def start_with_delimiter?(number)
-          delimiter.present? && number.start_with?(delimiter)
         end
 
         def delimiter

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -68,6 +68,8 @@ module ActiveSupport
           assert_equal("800-555-1212", number_helper.number_to_phone(8005551212, extension: "  "))
           assert_equal("555.1212", number_helper.number_to_phone(5551212, delimiter: "."))
           assert_equal("555 - 1234", number_helper.number_to_phone(5551234, delimiter: " - "))
+          assert_equal("9009001234", number_helper.number_to_phone(9001234, delimiter: "900"))
+          assert_equal("9009009009001234", number_helper.number_to_phone(9009001234, delimiter: "900"))
           assert_equal("800 - 555 - 1212", number_helper.number_to_phone(8005551212, delimiter: " - "))
           assert_equal("555—1234", number_helper.number_to_phone(5551234, delimiter: "—"))
           assert_equal("800-555-1212", number_helper.number_to_phone("8005551212"))


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
Follows up to https://github.com/rails/rails/pull/57375
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to replace the string-replacement + post-hoc `slice!` pattern with a `gsub` block that handles the empty-group case directly at substitution time in `number_to_phone`.

### Detail

`start_with_delimiter?` simply performs a string-content checks `number.start_with?(delimiter)` on the already-substituted string. This is meant to detect the case where the first capture group `(\d{0,3})` is empty, producing a leading delimiter. But consider:
```
number_to_phone(9001234, delimiter: "900")
# gsub produces: "900900-1234"  (first group = "900", non-empty)
# start_with_delimiter?("900900-1234") → true (it starts with "900"!)
# slice!(0, 3) → "900-1234"  ← WRONG, drops the area-code digits
```
It can't tell whether the leading delimiter came from an empty \1 capture group or from real digits that happen to equal the delimiter string. 

With this PR when `$1` (the optional `\d{0,3}` group) is empty, we simply don't emit a leading delimiter. When it's non-empty, we emit `part1 + delim + part2 + delim + part3` as before. The `start_with_delimiter?` method is no longer needed and is removed entirely. Two new regression cases added alongside the existing multi-char delimiter tests.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
