### PR TITLE
Use `...` and anonymous splats when possible

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -35,7 +35,7 @@ module ActiveSupport # :nodoc:
       end
     end
 
-    def [](*args)
+    def [](*)
       if html_safe?
         new_string = super
 
@@ -43,12 +43,12 @@ module ActiveSupport # :nodoc:
 
         string_into_safe_buffer(new_string, true)
       else
-        to_str[*args]
+        to_str[*]
       end
     end
     alias_method :slice, :[]
 
-    def slice!(*args)
+    def slice!(...)
       new_string = super
 
       return new_string if !html_safe? || new_string.nil?
@@ -159,11 +159,11 @@ module ActiveSupport # :nodoc:
     UNSAFE_STRING_METHODS.each do |unsafe_method|
       if unsafe_method.respond_to?(unsafe_method)
         class_eval <<~RUBY, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)       # def capitalize(*args, &block)
-            to_str.#{unsafe_method}(*args, &block)  #   to_str.capitalize(*args, &block)
+          def #{unsafe_method}(...)                 # def capitalize(...)
+            to_str.#{unsafe_method}(...)            #   to_str.capitalize(...)
           end                                       # end
 
-          def #{unsafe_method}!(*args)              # def capitalize!(*args)
+          def #{unsafe_method}!(...)                # def capitalize!(...)
             @html_unsafe = true                     #   @html_unsafe = true
             super                                   #   super
           end                                       # end
@@ -173,21 +173,21 @@ module ActiveSupport # :nodoc:
 
     UNSAFE_STRING_METHODS_WITH_BACKREF.each do |unsafe_method|
       class_eval <<~RUBY, __FILE__, __LINE__ + 1
-        def #{unsafe_method}(*args, &block)             # def gsub(*args, &block)
+        def #{unsafe_method}(*, **, &block)             # def gsub(*, **, &block)
           if block                                      #   if block
-            to_str.#{unsafe_method}(*args) { |*params|  #     to_str.gsub(*args) { |*params|
+            to_str.#{unsafe_method}(*, **) { |*params|  #     to_str.gsub(*, &&) { |*params|
               set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
               block.call(*params)                       #       block.call(*params)
             }                                           #     }
           else                                          #   else
-            to_str.#{unsafe_method}(*args)              #     to_str.gsub(*args)
+            to_str.#{unsafe_method}(*, **)              #     to_str.gsub(*, **)
           end                                           #   end
         end                                             # end
 
-        def #{unsafe_method}!(*args, &block)            # def gsub!(*args, &block)
+        def #{unsafe_method}!(*, **, &block)            # def gsub!(*, **, &block)
           @html_unsafe = true                           #   @html_unsafe = true
           if block                                      #   if block
-            super(*args) { |*params|                    #     super(*args) { |*params|
+            super(*, **) { |*params|                    #     super(*, **) { |*params|
               set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
               block.call(*params)                       #       block.call(*params)
             }                                           #     }


### PR DESCRIPTION
Gives us some minor allocation reduction, but simply is nicer.