### PR TITLE
`http_cache_forever` now accept an optional `last_modified:` keyword parameter.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `http_cache_forever` now accept an optional `last_modified:` keyword parameter.
+
+    It still defaults to January 1st 2011, but you now can subtitute it for a relevant
+    time if there is one.
+
+    *Jean Boussier*
+
 *   Accept render options and block in `render` calls made with `:renderable`
 
     ```ruby

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -318,11 +318,13 @@ module ActionController
     # *   `public`: By default, HTTP responses are private, cached only on the
     #     user's web browser. To allow proxies to cache the response, set `true` to
     #     indicate that they can serve the cached response to all users.
-    def http_cache_forever(public: false, &block)
+    # *   `last_modified`: Default to a fixed date in the past, but can be passed to
+    #     a more relevant time.
+    def http_cache_forever(public: false, last_modified: nil, &block)
       expires_in 100.years, public: public, immutable: true
 
       yield if stale?(etag: request.fullpath,
-                      last_modified: Time.new(2011, 1, 1).utc,
+                      last_modified: (last_modified || Time.new(2011, 1, 1)).utc,
                       public: public)
     end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1025,6 +1025,13 @@ end
 class HttpCacheForeverTest < ActionController::TestCase
   class HttpCacheForeverController < ActionController::Base
     def cache_me_forever
+      last_modified = params[:last_modified] && Time.iso8601(params[:last_modified])
+      http_cache_forever(public: params[:public], last_modified: last_modified) do
+        render plain: "hello"
+      end
+    end
+
+    def cache_me_forever_last_modified
       http_cache_forever(public: params[:public]) do
         render plain: "hello"
       end
@@ -1056,6 +1063,13 @@ class HttpCacheForeverTest < ActionController::TestCase
     @request.if_modified_since = @response.headers["Last-Modified"]
     get :cache_me_forever
     assert_response :not_modified
+  end
+
+  def test_cache_response_code_with_last_modified
+    now = Time.now
+    get :cache_me_forever, params: { last_modified: now.iso8601 }
+    assert_response :ok
+    assert_equal now.utc.httpdate, @response.headers["Last-Modified"]
   end
 
   def test_cache_response_code_with_etag

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   ActiveStorage ProxyController now set relevant `Last-Modified`
+
+    It is now set to `Blob#created_at` instead of being hardcoded to January 1st 2011.
+
+    *Jean Boussier*
+
 *   Preserve attachment changes when converting record to another class using STI.
 
     *fatkodima*

--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -29,7 +29,7 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
     if request.headers["Range"].present?
       send_blob_byte_range_data @blob, request.headers["Range"]
     else
-      http_cache_forever public: true do
+      http_cache_forever public: true, last_modified: @blob.created_at do
         response.headers["Accept-Ranges"] = "bytes"
         response.headers["Content-Length"] = @blob.byte_size.to_s
 


### PR DESCRIPTION
It still defaults to January 1st 2011, but you now can substitute it for a relevant time if there is one.

Then use that new option in Active Storage ProxyController.