### PR TITLE
Allow duplicate of readonly record to be modified

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -558,6 +558,10 @@ module ActiveRecord
     # and locking column.
 
     ##
+
+    # Original functionality was to retain readonly state.
+    mattr_accessor :dup_retains_readonly_state, default: true
+
     def initialize_dup(other) # :nodoc:
       @attributes = init_attributes(other)
 
@@ -566,6 +570,7 @@ module ActiveRecord
       @new_record               = true
       @previously_new_record    = false
       @destroyed                = false
+      @readonly                 = false unless dup_retains_readonly_state
       @_start_transaction_state = nil
 
       super

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -22,11 +22,21 @@ module ActiveRecord
     end
 
     def test_is_readonly
+      ActiveRecord::Core.dup_retains_readonly_state = true
       topic = Topic.first
       topic.readonly!
 
       duped = topic.dup
       assert_predicate duped, :readonly?, "should be readonly"
+    end
+
+    def test_not_readonly_even_if_original_is_readonly
+      ActiveRecord::Core.dup_retains_readonly_state = false
+      topic = Topic.first
+      topic.readonly!
+
+      duped = topic.dup
+      assert_not_predicate duped, :readonly?, "should not be readonly even if original is readonly"
     end
 
     def test_dup_not_persisted

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -65,7 +65,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_controller.rescue_from_event_backtrace`](#config-action-controller-rescue-from-event-backtrace): `:array`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `true`
-- [`config.active_record.core.dup_retains_readonly_state`](#config-active-record-core-dup-retains-readonly-state): `false`
+- [`config.active_record.dup_retains_readonly_state`](#config-active-record-dup-retains-readonly-state): `false`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 - [`config.active_storage.analyze`](#config-active-storage-analyze): `:immediately`
@@ -1595,7 +1595,7 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `false`              |
 | 7.1                   | `true`               |
 
-#### `config.active_record.core.dup_retains_readonly_state`
+#### `config.active_record.dup_retains_readonly_state`
 
 Specifies whether a duplicate record (initialized by calling `.dup`) should retain its readonly state.
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -65,6 +65,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_controller.rescue_from_event_backtrace`](#config-action-controller-rescue-from-event-backtrace): `:array`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `true`
+- [`config.active_record.core.dup_retains_readonly_state`](#config-active-record-core-dup-retains-readonly-state): `false`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 - [`config.active_storage.analyze`](#config-active-storage-analyze): `:immediately`
@@ -1593,6 +1594,24 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.1                   | `true`               |
+
+#### `config.active_record.core.dup_retains_readonly_state`
+
+Specifies whether a duplicate record (initialized by calling `.dup`) should retain its readonly state.
+
+```ruby
+record = User.new
+record.readonly!
+duplicate = record.dup
+duplicate.readonly? #=> false
+```
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 8.2                   | `false`              |
 
 #### `config.active_record.postgresql_adapter_decode_bytea`
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -719,7 +719,7 @@ value:
 ```
 
 As a last step, add the new configuration to configuration guide in
-`configuration.md`:
+`configuring.md`:
 
 ```markdown
 #### `config.active_job.existing_behavior

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -388,6 +388,7 @@ module Rails
           if respond_to?(:active_record)
             active_record.postgresql_adapter_decode_bytea = true
             active_record.postgresql_adapter_decode_money = true
+            active_record.core.dup_retains_readonly_state = false
           end
 
           if respond_to?(:active_storage)

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -388,7 +388,7 @@ module Rails
           if respond_to?(:active_record)
             active_record.postgresql_adapter_decode_bytea = true
             active_record.postgresql_adapter_decode_money = true
-            active_record.core.dup_retains_readonly_state = false
+            active_record.dup_retains_readonly_state = false
           end
 
           if respond_to?(:active_storage)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -63,7 +63,7 @@
 ###
 # Duplicated records are always read+write, instead of retaining the readonly state of the original.
 #++
-# Rails.application.config.active_record.core.dup_retains_readonly_state = false
+# Rails.application.config.active_record.dup_retains_readonly_state = false
 
 ###
 # Controls whether the PostgresqlAdapter should decode bytea and money columns automatically with manual queries.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -61,6 +61,11 @@
 # }
 
 ###
+# Duplicated records are always read+write, instead of retaining the readonly state of the original.
+#++
+# Rails.application.config.active_record.core.dup_retains_readonly_state = false
+
+###
 # Controls whether the PostgresqlAdapter should decode bytea and money columns automatically with manual queries.
 #
 # Example:


### PR DESCRIPTION
Because the API offers no means of resetting the readonly state, I believe it reasonable to ensure that a duplicate record should always have its readonly state set to false.

The original assertion goes all the way back to d717cb29136b8e4f557e6f6ddf076ae3de8476fc but it's not clear to me why it's required.

I have had to work around this using
```ruby
copy.instance_variable_set :@readonly, false
```
but this is relying on Rails internals which may change.

Fixes rails/rails#13902

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
