### PR TITLE
Fix mutation of shared attachment_changes in becomes()

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -325,10 +325,19 @@ module ActiveStorage
 
     def becomes(klass) # :nodoc:
       super.tap do |became|
-        attachment_changes = @attachment_changes&.each_value do |change|
-          change.record = became
+        became_changes = (@attachment_changes || {}).transform_values do |change|
+          case change
+          when ActiveStorage::Attached::Changes::CreateOne
+            ActiveStorage::Attached::Changes::CreateOne.new(change.name, became, change.attachable)
+          when ActiveStorage::Attached::Changes::CreateMany
+            ActiveStorage::Attached::Changes::CreateMany.new(change.name, became, change.attachables)
+          when ActiveStorage::Attached::Changes::DeleteOne
+            ActiveStorage::Attached::Changes::DeleteOne.new(change.name, became)
+          when ActiveStorage::Attached::Changes::DeleteMany
+            ActiveStorage::Attached::Changes::DeleteMany.new(change.name, became)
+          end
         end
-        became.attachment_changes = attachment_changes
+        became.instance_variable_set(:@attachment_changes, became_changes)
       end
     end
   end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -444,6 +444,35 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     ActiveStorage.analyze = original
   end
 
+  test "becomes copies pending has_one_attached change to became record" do
+    user = User.new
+    user.avatar = fixture_file_upload("racecar.jpg")
+    special_user = user.becomes(SpecialUser)
+    assert special_user.avatar.attached?
+  end
+
+  test "becomes copies pending has_many_attached change to became record" do
+    user = User.new
+    user.highlights = [fixture_file_upload("racecar.jpg")]
+    special_user = user.becomes(SpecialUser)
+    assert special_user.highlights.attached?
+  end
+
+  test "becomes does not mutate the original record's attachment_changes" do
+    user = User.new
+    user.avatar = fixture_file_upload("racecar.jpg")
+    original_change = user.attachment_changes["avatar"]
+    _special_user = user.becomes(SpecialUser)
+    assert_same user, user.attachment_changes["avatar"].record
+    assert_same original_change, user.attachment_changes["avatar"]
+  end
+
+  test "becomes on record with no attachment changes is safe" do
+    user = User.new
+    special_user = user.becomes(SpecialUser)
+    assert_empty special_user.attachment_changes
+  end
+
   private
     def assert_blob_identified_before_owner_validated(owner, blob, content_type)
       validated_content_type = nil


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
Follow up to https://github.com/rails/rails/pull/46486
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to reconstruct new change objects for `became`, not mutate the shared ones.

### Detail

`@attachment_changes` is a plain hash of change objects. `super` (ActiveRecord's `becomes`) does not deep-copy them — both the original record and `became` hold references to the exact same `CreateOne/CreateMany` objects. When `instance_variable_set(:@record, became)` runs, it writes through to those shared objects, so `original_record.attachment_changes["avatar"].record` now points to `became` instead of to the original. Saving the original after the cast silently uploads the file to the wrong record or no-ops entirely. The fix should deep-dup the hash and create new change objects, not mutate shared ones.

With this PR `transform_values` on a new hash leaves the original hash and its objects completely untouched. `case change` on the concrete class - Each `change` class has a different constructor signature, so we can rebuild them cleanly; pattern-matching is safer than duck-typing here. `(@attachment_changes || {})` guards against the ivar being nil before lazy init, matching `initialize_dup's` pattern. Original `@attachment_changes` is never written to. The original record can still be saved independently after `becomes`. We have added relevant test cases in the PR.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
