### PR TITLE
Load image processing backend upfront

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Require image processing backend upfront when Active Storage is being loaded.
+
+    This removes extra overhead when processing first variant after deploy and improves copy-on-write for preforking web servers.
+
+    *Janko Marohnić*
+
 *   ActiveStorage ProxyController now set relevant `Last-Modified`
 
     It is now set to `Blob#created_at` instead of being hardcoded to January 1st 2011.

--- a/activestorage/lib/active_storage/transformers/image_magick.rb
+++ b/activestorage/lib/active_storage/transformers/image_magick.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "image_processing/mini_magick"
+
 module ActiveStorage
   module Transformers
     class ImageMagick < ImageProcessingTransformer

--- a/activestorage/lib/active_storage/transformers/vips.rb
+++ b/activestorage/lib/active_storage/transformers/vips.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "image_processing/vips"
+
 module ActiveStorage
   module Transformers
     class Vips < ImageProcessingTransformer


### PR DESCRIPTION
### Motivation / Background

Processing the first Active Storage variant after deploy has extra overhead today.

### Detail

The image_processing gem has autoloading that will load the referenced backend on-demand. However, that means the first processed variant after deploy is paying the penalty for loading the backend code.

We avoid this overhead by loading the backend upfront. This also improves copy-on-write for preforking web servers, decreasing memory usage of forked subprocesses.

### Additional information

Loading `image_processing/vips` has 19MB extra on top of `image_processing`, so that memory would now be shared across forked subprocesses.

I measured the require overhead to be 50-100ms on my M1 MacBook Air, but I haven't tested on a production Linux server with Bootsnap activated.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
