### PR TITLE
Stabilize `say_with_time` regression tests

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1174,11 +1174,7 @@ class MigrationTest < ActiveRecord::TestCase
       end
     end
 
-    assert_equal <<~MSG, output
-      -- Bar
-         -> 0.0000s
-         -> 123 rows
-    MSG
+    assert_match(/\A-- Bar\n   -> \d+\.\d{4}s\n   -> 123 rows\n\z/, output)
   end
 
   def test_migration_say_with_time_with_non_integer_returning_in_block
@@ -1188,10 +1184,7 @@ class MigrationTest < ActiveRecord::TestCase
       end
     end
 
-    assert_equal <<~MSG, output
-      -- Bar
-         -> 0.0000s
-    MSG
+    assert_match(/\A-- Bar\n   -> \d+\.\d{4}s\n\z/, output)
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

This pull request addresses Rails Nightly CI failures:

- activerecord-mysql2-yjit: https://buildkite.com/rails/rails-nightly/builds/4288/list?jid=019e420a-5a01-4ecf-97fc-731926c3b2dd&tab=output#L11079
- activerecord-postgresql-yjit: https://buildkite.com/rails/rails-nightly/builds/4288/list?jid=019e420a-5a02-4c26-a23c-2102d092ccee&tab=output#L11794

```ruby
  3) Failure:
MigrationTest#test_migration_say_with_time_with_integer_returning_in_block [test/cases/migration_test.rb:1177]:
expected
actual
@@ -1,4 +1,4 @@
 "-- Bar
-   -> 0.0000s
+   -> 0.0001s
    -> 123 rows
 "
  4) Failure:
MigrationTest#test_migration_say_with_time_with_non_integer_returning_in_block [test/cases/migration_test.rb:1191]:
expected
actual
@@ -1,3 +1,3 @@
 "-- Bar
-   -> 0.0000s
+   -> 0.0001s
 "
```

### Detail

Both `say_with_time` regression tests asserted the literal `0.0000s` elapsed-time string, which holds only when the block finishes within the `%.4f` half-rounding threshold (~50µs). On rails-nightly Buildkite build 4288 the block took 0.0001s–0.0002s, so the assertions failed on both the mysql2 and postgresql runs:

Switch to `assert_match` with anchored regexes that pin the format (header line, subitem indent, 4-decimal `%.4f`, trailing `s`, optional row count, trailing newlines) while tolerating timing jitter.

### Additional information
Follow up https://github.com/rails/rails/pull/45705

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
