### PR TITLE
Invalidate query cache when UPDATE goes through `update_with_result`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -10,9 +10,9 @@ module ActiveRecord
 
       class << self
         def included(base) # :nodoc:
-          dirties_query_cache base, :exec_query, :execute, :create, :insert, :update, :delete, :truncate,
-            :truncate_tables, :rollback_to_savepoint, :rollback_db_transaction, :restart_db_transaction,
-            :exec_insert_all
+          dirties_query_cache base, :exec_query, :execute, :create, :insert, :update, :update_with_result,
+            :delete, :truncate, :truncate_tables, :rollback_to_savepoint, :rollback_db_transaction,
+            :restart_db_transaction, :exec_insert_all
         end
 
         def dirties_query_cache(base, *method_names)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -5,6 +5,7 @@ require "models/topic"
 require "models/task"
 require "models/category"
 require "models/post"
+require "models/default"
 
 class QueryCacheTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
@@ -1021,6 +1022,18 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
         task = Task.find(1)
         task.starting = Time.now.utc
         task.save!
+      end
+    end
+  end
+
+  if current_adapter?(:PostgreSQLAdapter) && ActiveRecord::Base.lease_connection.supports_virtual_columns?
+    def test_update_with_returning_clears_cache
+      Default.cache do
+        record = Default.create!(random_number: 1)
+        assert_called(Default.connection_pool.query_cache, :clear, times: 1) do
+          record.update!(random_number: 2)
+        end
+        assert_equal 2, Default.find(record.id).random_number
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the RETURNING-on-update path added
in #48628 routes UPDATEs through `update_with_result` instead of `update` when
a table has any PostgreSQL `GENERATED ... STORED` columns. Only `update` was
in the `dirties_query_cache` list, so subsequent SELECTs in the same
query-cache scope return pre-update rows.

Repro (vanilla Rails edge against PostgreSQL):

```ruby
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :counter1, null: false, default: 7
    t.virtual :sum, type: :integer, as: "counter1 + 1", stored: true
  end
end
class Post < ActiveRecord::Base; end
ActiveRecord::Base.connection.cache do
  p = Post.create!(counter1: 1)
  Post.find(p.id)              # caches the row
  p.update!(counter1: 99)      # goes through update_with_result
  Post.find(p.id).counter1     # => 1   (BUG: should be 99)
end
```

### Detail
This Pull Request adds :update_with_result to the dirties_query_cache
list in ActiveRecord::ConnectionAdapters::QueryCache, so the new
RETURNING-on-update path invalidates the query cache the same way the
existing update path does.

A regression test is added in query_cache_test.rb next to the existing
test_update, gated on PostgreSQL + supports_virtual_columns? and using
the existing Default model (which already has a virtual_stored_number
GENERATED STORED column).

### Additional information
Affects any app on Rails edge with a PostgreSQL table that has a
GENERATED ... STORED column and reads the same row twice inside a
query-cache scope around a save!/update!. The bug is invisible without
a virtual stored column because the model otherwise routes through the
unchanged update path that already dirties the cache.