### PR TITLE
Reset `lock_version` after a nested savepoint rollback

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Reset `lock_version` after a nested savepoint rollback.
+
+    When a record was saved inside a `transaction(requires_new: true)` block
+    that later rolled back, the in-memory `lock_version` was left at the
+    incremented value while the database row was reverted by the savepoint.
+    Saving the same instance again raised `ActiveRecord::StaleObjectError`
+    because the WHERE clause used the bumped value that no longer existed in
+    the database.
+
+    Restore the locking column from the snapshot on savepoint rollback in
+    addition to the outermost transaction rollback handled in #57363.
+
+    *Kenta Ishizaki*
+
 *   Fix duplicate `WHERE` conditions in `create_or_find_by`.
 
     When `create_or_find_by` catches a `RecordNotUnique` error and retries the query, it now uses `rewhere` and `take!` to prevent duplicating existing scope conditions.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -528,6 +528,19 @@ module ActiveRecord
               end
             end
             freeze if restore_state[:frozen?]
+          elsif self.class.locking_enabled?
+            # Nested savepoint rollback. The full restore above only runs at the
+            # outermost level, but the same `_update_row` mutation that bumps the
+            # in-memory locking column happens for saves performed inside the
+            # savepoint too. Leaving the bumped value in memory after the
+            # savepoint reverts those rows raises `StaleObjectError` on the next
+            # save in the surrounding transaction. Reset just the locking column
+            # so subsequent saves can match the row that the savepoint restored.
+            locking_column = self.class.locking_column
+            attr = restore_state[:attributes][locking_column]
+            if attr
+              @attributes.write_from_database(locking_column, attr.original_value)
+            end
           end
         end
       end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1050,4 +1050,57 @@ class OptimisticLockingRollbackTest < ActiveRecord::TestCase
     assert_equal 1, p.lock_version
     assert_equal "after-rollback", Person.find(@person.id).first_name
   end
+
+  def test_lock_version_restored_after_savepoint_rollback
+    p = Person.find(@person.id)
+    assert_equal 0, p.lock_version
+
+    Person.transaction do
+      Person.transaction(requires_new: true) do
+        p.update!(first_name: "savepoint-target")
+        assert_equal 1, p.lock_version
+        raise ActiveRecord::Rollback
+      end
+
+      # The savepoint rolled back lock_version to 0 in the database. The in-memory
+      # record should match so the next save inside the surrounding transaction
+      # doesn't raise `StaleObjectError` against a row the savepoint just reverted.
+      assert_equal 0, Person.find(@person.id).lock_version
+      assert_equal 0, p.lock_version
+      assert_not p.will_save_change_to_attribute?(:lock_version)
+      assert_nothing_raised do
+        p.update!(first_name: "after-savepoint-rollback")
+      end
+      assert_equal 1, p.lock_version
+    end
+
+    assert_equal 1, Person.find(@person.id).lock_version
+    assert_equal "after-savepoint-rollback", Person.find(@person.id).first_name
+  end
+
+  def test_lock_version_restored_after_savepoint_rollback_when_outer_commits
+    p = Person.find(@person.id)
+    assert_equal 0, p.lock_version
+
+    Person.transaction do
+      Person.transaction(requires_new: true) do
+        p.update!(first_name: "savepoint-target")
+        assert_equal 1, p.lock_version
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    # After the savepoint rolled back and the outer transaction committed without
+    # touching the record again, the database row is back to lock_version 0.
+    # The in-memory record should match so the next save outside the transaction
+    # doesn't raise `StaleObjectError`.
+    assert_equal 0, Person.find(@person.id).lock_version
+    assert_equal 0, p.lock_version
+    assert_not p.will_save_change_to_attribute?(:lock_version)
+    assert_nothing_raised do
+      p.update!(first_name: "after-tx")
+    end
+    assert_equal 1, p.lock_version
+    assert_equal "after-tx", Person.find(@person.id).first_name
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Follow-up to #57363.

That PR reset the in-memory `lock_version` after the **outermost** transaction rolls back, but the same symptom still occurs when a save lives inside a `requires_new: true` savepoint that rolls back. The next save against the in-memory record raises `ActiveRecord::StaleObjectError` because the WHERE clause keeps using the bumped value while the database row has been reverted by the savepoint.

```ruby
widget = Widget.create!(name: "a")              # lock_version: 0

Widget.transaction do
  Widget.transaction(requires_new: true) do
    widget.update!(name: "b")                   # lock_version: 0 -> 1
    raise ActiveRecord::Rollback                # savepoint rollback: DB lock_version -> 0
  end

  widget.lock_version                           # => 1 (stale; DB has 0)
  widget.update!(name: "c")                     # raises ActiveRecord::StaleObjectError
end
```

The same shape also fails when the outer transaction commits cleanly and the next save happens after the block:

```ruby
Widget.transaction do
  Widget.transaction(requires_new: true) do
    widget.update!(name: "b")
    raise ActiveRecord::Rollback
  end
end

widget.update!(name: "c")                       # raises ActiveRecord::StaleObjectError
```

This is the "savepoint rollbacks at deeper levels" case I noted as out of scope in #57363.

### Detail

`restore_transaction_record_state` short-circuits when `force_restore_state` is false and `restore_state[:level] > 1`, which is the path taken on every nested savepoint rollback (`SavepointTransaction#full_rollback? = false`). Nothing on the record gets reset, so the locking column stays at the value `_update_row` bumped it to inside the savepoint.

The comment above `rolledback!` already describes the intended behavior:

```ruby
# Call the #after_rollback callbacks. The +force_restore_state+ argument indicates if the record
# state should be rolled back to the beginning or just to the last savepoint.
```

The implementation just never delivered the "just to the last savepoint" half for the locking column.

This PR adds an `elsif self.class.locking_enabled?` branch alongside the existing full-restore branch. It rebuilds the locking column from the snapshot's `original_value` via `write_from_database`, matching the approach #57363 used at the outermost level. Both the WHERE clause and the dirty-tracking state on the next save then behave as if the savepoint's increment never happened.

Two regression tests are added to the existing `OptimisticLockingRollbackTest` class (`self.use_transactional_tests = false`):

- `test_lock_version_restored_after_savepoint_rollback` — savepoint rolls back, the next save inside the surrounding transaction must succeed.
- `test_lock_version_restored_after_savepoint_rollback_when_outer_commits` — savepoint rolls back, the outer transaction commits without touching the record, the next save outside the block must succeed.

Both fail on `main` (`StaleObjectError`) and pass with the patch.

### Additional information

- **Scope.** This handles the common shape `outer { inner(requires_new: true) { update!; raise Rollback }; … }`, where the snapshot's `original_value` matches the database value the savepoint restored. There is still one corner case that is **not** fixed: if the outer transaction itself saves the same record before the savepoint, the snapshot's `original_value` predates that outer save, so it no longer matches the post-savepoint-rollback database value. Without per-level snapshots there is no source of truth for "the value just before this savepoint", and adding per-level snapshots to `remember_transaction_record_state` felt larger than this PR. The symptom in that corner case is unchanged — the next save still raises `StaleObjectError`, just with a different value mismatch — so this PR strictly improves the common case without regressing the corner case. Happy to fold a per-level snapshot into this PR if reviewers prefer.
- **Repro & verification.**
  - Self-contained SQLite repro: `/tmp/lock_savepoint_rollback.rb` (`StaleObjectError` on `main`, passes after the patch).
  - Active Record suites passing locally on sqlite3: `locking_test.rb` (72), `transactions_test.rb` (109), `autosave_association_test.rb` (217).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.