### PR TITLE
Update Active Storage for ImageProcessing 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,9 @@ group :storage do
   gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.11", require: false
 
-  gem "image_processing", "~> 1.2"
+  gem "image_processing", "~> 2.0"
+  gem "ruby-vips", "~> 2.3"
+  gem "mini_magick", "~> 5.0"
 end
 
 # Action Mailbox

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,9 +278,7 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
-      ruby-vips (>= 2.0.17, < 3)
+    image_processing (2.0.1)
     importmap-rails (2.1.0)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -517,7 +515,7 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
+    ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
     ruby2_keywords (0.0.5)
@@ -693,7 +691,7 @@ DEPENDENCIES
   dartsass-rails
   debug (>= 1.1.0)
   google-cloud-storage (~> 1.11)
-  image_processing (~> 1.2)
+  image_processing (~> 2.0)
   importmap-rails (>= 1.2.3)
   jbuilder
   jsbundling-rails
@@ -703,6 +701,7 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   mdl (!= 0.13.0)
+  mini_magick (~> 5.0)
   minitest (~> 6.0)
   minitest-mock
   minitest-retry
@@ -733,6 +732,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rails-omakase
+  ruby-vips (~> 2.3)
   rubyzip (~> 2.0)
   sdoc (~> 2.6.4)
   selenium-webdriver (>= 4.20.0)
@@ -846,7 +846,7 @@ CHECKSUMS
   hashdiff (1.1.2) sha256=2c30eeded6ed3dce8401d2b5b99e6963fe5f14ed85e60dd9e33c545a44b71a77
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
+  image_processing (2.0.1) sha256=69c93216dafe1179343a6c3ae8bfa554e3c1f5eece4043f255595e76df2cbf3f
   importmap-rails (2.1.0) sha256=9f10c67d60651a547579f448100d033df311c5d5db578301374aeb774faae741
   io-console (0.8.1) sha256=1e15440a6b2f67b6ea496df7c474ed62c860ad11237f29b3bd187f054b925fcb
   irb (1.15.2) sha256=222f32952e278da34b58ffe45e8634bf4afc2dc7aa9da23fed67e581aa50fdba
@@ -955,7 +955,7 @@ CHECKSUMS
   rubocop-rails (2.30.3) sha256=fc5a6506daa916d15e282cc806943afa64a020bf592b93a94025d89a2a78a715
   rubocop-rails-omakase (1.0.0) sha256=26635821283d6a03dc8b68172123716a62db96123eb035f736ebb91283f96418
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  ruby-vips (2.2.2) sha256=af5be8e9f2857a98424d7606ecfc2c21c5e107d0802915190dcc093f56e4dd5b
+  ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   rufus-scheduler (3.9.2) sha256=55fa9e4db0ff69d7f38c804f17baba0c9bce5cba39984ae3c5cf6c039d1323b9

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Update Active Storage for ImageProcessing 2.0.
+
+    ImageProcessing 2.0 now requires adding `ruby-vips` or `mini_magick` gems explicitly to the Gemfile.
+
+    *Janko Marohnić*
+
 *   Prevent `ActiveStorage.touch_attachment_records = false` from crashing the attachment of a Blob.
 
     When `ActiveStorage.touch_attachment_records` was set to `false`, attaching a existing Blob to a Record

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -11,7 +11,7 @@
 # default, images will be processed with {libvips}[http://libvips.github.io/libvips/] using the
 # {ruby-vips}[https://github.com/libvips/ruby-vips] gem, but you can also switch to the
 # {ImageMagick}[http://imagemagick.org] processor operated by the {MiniMagick}[https://github.com/minimagick/minimagick]
-# gem).
+# gem). You'll need to add either <tt>gem "ruby-vips"</tt> or <tt>gem "mini_magick"</tt> to your Gemfile.
 #
 #   Rails.application.config.active_storage.variant_processor
 #   # => :vips

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -114,8 +114,18 @@ module ActiveStorage
           when /image_processing/
             ActiveStorage.logger.warn <<~WARNING.squish
               Generating image variants require the image_processing gem.
-              Please add `gem "image_processing", "~> 1.2"` to your Gemfile
+              Please add `gem "image_processing", "~> 2.0"` to your Gemfile
               or set `config.active_storage.variant_processor = :disabled`.
+            WARNING
+          when /ruby-vips/
+            ActiveStorage.logger.warn <<~WARNING.squish
+              Generating image variants with libvips requires the ruby-vips gem.
+              Please add `gem "ruby-vips", "~> 2.3"` to your Gemfile.
+            WARNING
+          when /mini_magick/
+            ActiveStorage.logger.warn <<~WARNING.squish
+              Generating image variants with ImageMagick requires the mini_magick gem.
+              Please add `gem "mini_magick", "~> 5.0"` to your Gemfile.
             WARNING
           else
             raise

--- a/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
@@ -5,7 +5,7 @@ begin
 rescue LoadError
   raise LoadError, <<~ERROR.squish
     Generating image variants require the image_processing gem.
-    Please add `gem "image_processing", "~> 1.2"` to your Gemfile.
+    Please add `gem "image_processing", "~> 2.0"` to your Gemfile.
   ERROR
 end
 

--- a/activestorage/lib/active_storage/transformers/vips.rb
+++ b/activestorage/lib/active_storage/transformers/vips.rb
@@ -2,6 +2,8 @@
 
 require "image_processing/vips"
 
+Vips.block_untrusted(false) if Vips.respond_to?(:block_untrusted) && !ENV["VIPS_BLOCK_UNTRUSTED"]
+
 module ActiveStorage
   module Transformers
     class Vips < ImageProcessingTransformer

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -965,7 +965,10 @@ transformations or parameters to variant processors. This can potentially enable
 command injection vulnerabilities in your app. It is also recommended to
 implement a strict [ImageMagick security
 policy](https://imagemagick.org/script/security-policy.php) when MiniMagick is
-the variant processor of choice.
+the variant processor of choice. With ruby-vips, you can
+[block untrusted formats][https://www.libvips.org/2022/05/28/What's-new-in-8.13.html#blocking-of-unfuzzed-loaders]
+by setting `VIPS_BLOCK_UNTRUSTED` environment variable or calling
+`Vips.block_untrusted(true)` in an initializer.
 
 ### Non-image Previews
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -37,7 +37,8 @@ gem "thruster", require: false
 <% unless skip_active_storage? -%>
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 2.0"
+gem "ruby-vips", "~> 2.3"
 <% end -%>
 <%- if options.api? -%>
 

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -37,19 +37,20 @@ module ApplicationTests
     def test_default_transformer_missing_gem_warning
       output = run_command("puts ActiveStorage.variant_transformer")
 
-      assert_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile')
+      assert_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 2.0"` to your Gemfile')
     end
 
     def test_default_transformer_with_gem_no_warning
       File.open("#{app_path}/Gemfile", "a") do |f|
         f.puts <<~GEMFILE
-          gem "image_processing", "~> 1.2"
+          gem "image_processing", "~> 2.0"
+          gem "ruby-vips", "~> 2.3"
         GEMFILE
       end
 
       output = run_command("puts ActiveStorage.variant_transformer")
 
-      assert_not_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile')
+      assert_not_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 2.0"` to your Gemfile')
       assert_includes(output, "ActiveStorage::Transformers::Vips")
     end
 
@@ -58,7 +59,7 @@ module ApplicationTests
 
       output = run_command("puts ActiveStorage.variant_transformer")
 
-      assert_not_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile')
+      assert_not_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 2.0"` to your Gemfile')
       assert_includes(output, "ActiveStorage::Transformers::NullTransformer")
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -419,12 +419,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     FileUtils.cd(destination_root) do
       config = "config/application.rb"
       content = File.read(config)
-      File.write(config, content.gsub(/config\.load_defaults #{Rails::VERSION::STRING.to_f}/, "config.load_defaults 5.1"))
+      File.write(config, content.gsub(/config\.load_defaults #{Rails::VERSION::STRING.to_f}/, "config.load_defaults 8.0"))
     end
 
     run_app_update
 
-    assert_file "config/application.rb", /\s+config\.load_defaults 5\.1/
+    assert_file "config/application.rb", /\s+config\.load_defaults 8\.0/
   end
 
   def test_app_update_generates_new_framework_defaults_when_load_defaults_is_previous_version


### PR DESCRIPTION
### Motivation / Background

[ImageProcessing 2.0](https://github.com/janko/image_processing/blob/master/CHANGELOG.md#200-2026-05-20) has been released, which brings some breaking changes.

### Detail

ImageProcessing 2.0 now requires adding `ruby-vips` and/or `mini_magick` gems explicitly to the Gemfile, so I updated instructions and the generator. I also added `LoadError` branches for those gems.

The new version now also [blocks untrusted formats](https://www.libvips.org/2022/05/28/What's-new-in-8.13.html#blocking-of-unfuzzed-loaders) by default on libvips 8.13+. These include BPM, PSD and ICO, which are currently accepted as "variable" content types by Active Storage. Not sure what's the best way to handle this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
