### PR TITLE
Improve Date::DATE_FORMATS and Time::DATE_FORMAT deprecation

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -1,25 +1,17 @@
 # frozen_string_literal: true
 
 require "date"
+require "active_support/date_formats"
 require "active_support/inflector/methods"
 require "active_support/core_ext/date/zones"
 require "active_support/core_ext/module/redefine_method"
 
 class Date
-  DATE_FORMATS = { # rubocop:disable Style/MutableConstant
-    short: "%d %b",
-    long: "%B %d, %Y",
-    db: "%Y-%m-%d",
-    inspect: "%Y-%m-%d",
-    number: "%Y%m%d",
-    long_ordinal: lambda { |date|
-      day_format = ActiveSupport::Inflector.ordinalize(date.day)
-      date.strftime("%B #{day_format}, %Y") # => "April 25th, 2007"
-    },
-    rfc822: "%d %b %Y",
-    rfc2822: "%d %b %Y",
-    iso8601: lambda { |date| date.iso8601 }
-  }
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+
+  deprecate_constant :DATE_FORMATS, "ActiveSupport::DateFormats::DEPRECATED_LIST",
+    deprecator: ActiveSupport.deprecator,
+    message: "Date::DATE_FORMATS is deprecated, to register custom time formats use ActiveSupport::DateFormats.register"
 
   # Convert to a formatted string. See DATE_FORMATS for predefined formats.
   #

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -3,28 +3,14 @@
 require "time"
 require "active_support/inflector/methods"
 require "active_support/values/time_zone"
+require "active_support/time_formats"
 
 class Time
-  DATE_FORMATS = { # rubocop:disable Style/MutableConstant
-    db: "%Y-%m-%d %H:%M:%S",
-    inspect: "%Y-%m-%d %H:%M:%S.%9N %z",
-    number: "%Y%m%d%H%M%S",
-    nsec: "%Y%m%d%H%M%S%9N",
-    usec: "%Y%m%d%H%M%S%6N",
-    time: "%H:%M",
-    short: "%d %b %H:%M",
-    long: "%B %d, %Y %H:%M",
-    long_ordinal: lambda { |time|
-      day_format = ActiveSupport::Inflector.ordinalize(time.day)
-      time.strftime("%B #{day_format}, %Y %H:%M")
-    },
-    rfc822: lambda { |time|
-      offset_format = time.formatted_offset(false)
-      time.strftime("%a, %d %b %Y %H:%M:%S #{offset_format}")
-    },
-    rfc2822: lambda { |time| time.rfc2822 },
-    iso8601: lambda { |time| time.iso8601 }
-  }
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+
+  deprecate_constant :DATE_FORMATS, "ActiveSupport::TimeFormats::DEPRECATED_LIST",
+    deprecator: ActiveSupport.deprecator,
+    message: "Time::DATE_FORMATS is deprecated, to register custom time formats use ActiveSupport::TimeFormats.register"
 
   # Converts to a formatted string. See DATE_FORMATS for built-in formats.
   #

--- a/activesupport/lib/active_support/date_formats.rb
+++ b/activesupport/lib/active_support/date_formats.rb
@@ -1,15 +1,28 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/date/conversions"
-
 module ActiveSupport
   module DateFormats
-    @list = Date::DATE_FORMATS.dup.freeze
-    @deprecated_list = Date::DATE_FORMATS
-    Date.deprecate_constant :DATE_FORMATS
+    @list = {
+      short: "%d %b",
+      long: "%B %d, %Y",
+      db: "%Y-%m-%d",
+      inspect: "%Y-%m-%d",
+      number: "%Y%m%d",
+      long_ordinal: lambda { |date|
+        day_format = ActiveSupport::Inflector.ordinalize(date.day)
+        date.strftime("%B #{day_format}, %Y") # => "April 25th, 2007"
+      },
+      rfc822: "%d %b %Y",
+      rfc2822: "%d %b %Y",
+      iso8601: lambda { |date| date.iso8601 }
+    }.freeze
+
+    singleton_class.attr_reader :list # :nodoc:
+
+    DEPRECATED_LIST = @list.dup # :nodoc:
 
     def self.lookup(format) # :nodoc:
-      @list[format] || @deprecated_list[format]
+      @list[format] || DEPRECATED_LIST[format]
     end
 
     # Registers a new date format for formatting `Date` instances.

--- a/activesupport/lib/active_support/date_formats.rb
+++ b/activesupport/lib/active_support/date_formats.rb
@@ -25,7 +25,7 @@ module ActiveSupport
       @list[format] || DEPRECATED_LIST[format]
     end
 
-    # Registers a new date format for formatting `Date` instances.
+    # Registers a new date format for formatting Date instances.
     # See +Date::DATE_FORMATS+ for built-in formats.
     # Use the format name as the name and either a strftime string or
     # Proc instance that takes a date argument as the value.

--- a/activesupport/lib/active_support/date_formats.rb
+++ b/activesupport/lib/active_support/date_formats.rb
@@ -8,8 +8,7 @@ module ActiveSupport
     @deprecated_list = Date::DATE_FORMATS
     Date.deprecate_constant :DATE_FORMATS
 
-    # :nodoc:
-    def self.lookup(format)
+    def self.lookup(format) # :nodoc:
       @list[format] || @deprecated_list[format]
     end
 

--- a/activesupport/lib/active_support/time_formats.rb
+++ b/activesupport/lib/active_support/time_formats.rb
@@ -31,7 +31,7 @@ module ActiveSupport
       @list[format] || DEPRECATED_LIST[format]
     end
 
-    # Registers a new date format for formatting `Time` instances.
+    # Registers a new date format for formatting Time instances.
     # See +Time::DATE_FORMATS+ for built-in formats.
     # Use the format name as the name and either a strftime string or
     # Proc instance that takes a date argument as the value.

--- a/activesupport/lib/active_support/time_formats.rb
+++ b/activesupport/lib/active_support/time_formats.rb
@@ -8,8 +8,7 @@ module ActiveSupport
     @deprecated_list = Time::DATE_FORMATS
     Time.deprecate_constant :DATE_FORMATS
 
-    # :nodoc:
-    def self.lookup(format)
+    def self.lookup(format) # :nodoc:
       @list[format] || @deprecated_list[format]
     end
 

--- a/activesupport/lib/active_support/time_formats.rb
+++ b/activesupport/lib/active_support/time_formats.rb
@@ -1,15 +1,34 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/time/conversions"
-
 module ActiveSupport
   module TimeFormats
-    @list = Time::DATE_FORMATS.dup.freeze
-    @deprecated_list = Time::DATE_FORMATS
-    Time.deprecate_constant :DATE_FORMATS
+    @list = {
+      db: "%Y-%m-%d %H:%M:%S",
+      inspect: "%Y-%m-%d %H:%M:%S.%9N %z",
+      number: "%Y%m%d%H%M%S",
+      nsec: "%Y%m%d%H%M%S%9N",
+      usec: "%Y%m%d%H%M%S%6N",
+      time: "%H:%M",
+      short: "%d %b %H:%M",
+      long: "%B %d, %Y %H:%M",
+      long_ordinal: lambda { |time|
+        day_format = ActiveSupport::Inflector.ordinalize(time.day)
+        time.strftime("%B #{day_format}, %Y %H:%M")
+      },
+      rfc822: lambda { |time|
+        offset_format = time.formatted_offset(false)
+        time.strftime("%a, %d %b %Y %H:%M:%S #{offset_format}")
+      },
+      rfc2822: lambda { |time| time.rfc2822 },
+      iso8601: lambda { |time| time.iso8601 }
+    }.freeze
+
+    singleton_class.attr_reader :list # :nodoc:
+
+    DEPRECATED_LIST = @list.dup # :nodoc:
 
     def self.lookup(format) # :nodoc:
-      @list[format] || @deprecated_list[format]
+      @list[format] || DEPRECATED_LIST[format]
     end
 
     # Registers a new date format for formatting `Time` instances.

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -52,6 +52,15 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_deprecated_to_fs_custom_date_format
+    assert_deprecated(ActiveSupport.deprecator) do
+      Date::DATE_FORMATS[:custom] = "%B %Y"
+    end
+    assert_equal "February 2005", Date.new(2005, 2, 21).to_fs(:custom)
+  ensure
+    ActiveSupport::DateFormats::DEPRECATED_LIST.delete(:custom)
+  end
+
   def test_readable_inspect
     assert_equal "Mon, 21 Feb 2005", Date.new(2005, 2, 21).readable_inspect
     assert_equal Date.new(2005, 2, 21).readable_inspect, Date.new(2005, 2, 21).inspect

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -862,8 +862,18 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_to_fs_custom_date_format
     ActiveSupport::TimeFormats.stub(:lookup, ->(format) { { custom: "%Y%m%d%H%M%S" }[format] }) do
-      assert_equal "20050221143000", Time.local(2005, 2, 21, 14, 30, 0).to_fs(:custom)
+      assert_equal "20050221143000", Time.utc(2005, 2, 21, 14, 30, 0).to_fs(:custom)
     end
+  end
+
+  def test_deprecated_to_fs_custom_date_format
+    assert_equal "2005-02-21 14:30:00 UTC", Time.utc(2005, 2, 21, 14, 30, 0).to_fs(:custom)
+    assert_deprecated(ActiveSupport.deprecator) do
+      Time::DATE_FORMATS[:custom] = "%Y%m%d%H%M%S"
+    end
+    assert_equal "20050221143000", Time.utc(2005, 2, 21, 14, 30, 0).to_fs(:custom)
+  ensure
+    ActiveSupport::TimeFormats::DEPRECATED_LIST.delete(:custom)
   end
 
   def test_rfc3339_with_fractional_seconds


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/57345/

- Use ActiveSupport deprecator to emit warnings
- Include the new API in the warning message.
- Inverse the relationship between core exts and fomat modules
