### PR TITLE
[#57402] Fix Active Record Pool Reaper thread leak after `Parallelization#shutdown`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix Active Record Pool Reaper thread leak after `Parallelization#shutdown`.
+
+    After parallelized test runs, the parent process leaked the Active Record Pool
+    Reaper thread, holding open connection pools and file descriptors for up to
+    `reaping_frequency` seconds (or indefinitely if never reaped).
+
+    Three fixes: `Parallelization#shutdown` now calls `run_cleanup_hooks`;
+    Active Record registers a cleanup hook that discards all connection pools; and
+    `ConnectionPool#discard!` now calls `Reaper.discard_pool`, which immediately
+    kills and joins the reaper thread when no pools remain at that frequency.
+
+    *Ruy Rocha*
+
 *   Reset `lock_version` after a nested savepoint rollback.
 
     When a record was saved inside a `transaction(requires_new: true)` block

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -555,6 +555,7 @@ module ActiveRecord
         @reaper_lock.synchronize do
           synchronize do
             return if self.discarded?
+            Reaper.discard_pool(self)
             @connections.each do |conn|
               conn.discard!
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -53,6 +53,23 @@ module ActiveRecord
             end
           end
 
+          def discard_pool(pool) # :nodoc:
+            @mutex.synchronize do
+              @pools.each do |frequency, refs|
+                refs.reject! do |ref|
+                  ref.__getobj__ == pool
+                rescue WeakRef::RefError
+                  true
+                end
+
+                if refs.empty?
+                  @pools.delete(frequency)
+                  @threads.delete(frequency)&.tap { |t| t.kill; t.join }
+                end
+              end
+            end
+          end
+
           def pools(refs = nil) # :nodoc:
             refs ||= @mutex.synchronize { @pools.values.flatten(1) }
 

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -16,6 +16,10 @@ module ActiveRecord
       end
     end
 
+    ActiveSupport::Testing::Parallelization.run_cleanup_hook do
+      ActiveRecord::Base.connection_handler.each_connection_pool.each(&:discard!)
+    end
+
     def self.create_and_load_schema(i, env_name:)
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -200,6 +200,48 @@ module ActiveRecord
         pool.discard!
       end
 
+      def test_discard_pool_removes_pool_from_registry
+        pool_config = duplicated_pool_config(reaping_frequency: "0.1")
+        pool = ConnectionPool.new(pool_config)
+
+        assert ConnectionPool::Reaper.instance_variable_get(:@pools).any? { |_, refs|
+          refs.any? { |ref| ref.__getobj__ == pool rescue false }
+        }, "pool should be registered with the reaper"
+
+        pool.discard!
+
+        assert ConnectionPool::Reaper.instance_variable_get(:@pools).none? { |_, refs|
+          refs.any? { |ref| ref.__getobj__ == pool rescue false }
+        }, "pool should be removed from reaper registry after discard!"
+      end
+
+      def test_discard_pool_kills_reaper_thread_when_no_pools_remain
+        pool_config = duplicated_pool_config(reaping_frequency: "100")
+        pool = ConnectionPool.new(pool_config)
+
+        thread = ConnectionPool::Reaper.instance_variable_get(:@threads)[100.0]
+        assert thread&.alive?, "reaper thread should be alive before discard!"
+
+        pool.discard!
+
+        assert_not thread.alive?, "reaper thread should be dead after discard!"
+      end
+
+      def test_discard_pool_does_not_kill_thread_when_other_pools_remain
+        pool_config = duplicated_pool_config(reaping_frequency: "100")
+        pool1 = ConnectionPool.new(pool_config)
+        pool2 = ConnectionPool.new(pool_config)
+
+        thread = ConnectionPool::Reaper.instance_variable_get(:@threads)[100.0]
+        assert thread&.alive?, "reaper thread should be alive"
+
+        pool1.discard!
+
+        assert thread.alive?, "reaper thread should stay alive while pool2 is registered"
+      ensure
+        pool2.discard!
+      end
+
       private
         def duplicated_pool_config(merge_config_options = {})
           old_config = ActiveRecord::Base.connection_pool.db_config.configuration_hash.merge(merge_config_options)

--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -79,6 +79,8 @@ module ActiveSupport
         rescue Errno::ECHILD
           nil
         end
+
+        Parallelization.run_cleanup_hooks.each(&:call)
       end
     end
   end

--- a/activesupport/test/parallelization_test.rb
+++ b/activesupport/test/parallelization_test.rb
@@ -308,4 +308,17 @@ class ParallelizationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "shutdown calls run_cleanup_hooks" do
+    called = false
+    ActiveSupport::Testing::Parallelization.run_cleanup_hook { called = true }
+
+    parallelization = ActiveSupport::Testing::Parallelization.new(1)
+    parallelization.start
+    parallelization.shutdown
+
+    assert called, "run_cleanup_hooks should be called during shutdown"
+  ensure
+    ActiveSupport::Testing::Parallelization.class_variable_get(:@@run_cleanup_hooks).pop
+  end
 end


### PR DESCRIPTION


### Motivation / Background

After parallelized test runs, the parent process leaks the Active Record Pool Reaper thread, holding open connection pools and file descriptors indefinitely. In long-lived CI processes running many suites sequentially this accumulates threads and open DB connections.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #57402 

### Detail

Three layered bugs caused the leak:

1. `Parallelization#shutdown` never called `run_cleanup_hooks`, so no parent-side cleanup ran at all.
2. AR never registered a `run_cleanup_hook` to discard its pools.
3. `clear_all_connections!` calls `disconnect!` not `discard!`, so even if a hook had been registered the reaper thread would not have been stopped.

This PR fixes all three: `Parallelization#shutdown` now calls `run_cleanup_hooks` after workers finish; Active Record registers a cleanup hook that calls `discard!` on all connection pools; and `ConnectionPool#discard!` now calls `Reaper.discard_pool`, which removes the pool from the reaper's registry and immediately kills and joins the reaper thread if no pools remain at that frequency.

### Additional information

Reproduction script:

```ruby
require "bundler/inline"
gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end
require "active_support"
require "active_support/testing/parallelization"
require "active_record"
require "active_record/test_databases"
require "minitest/autorun"

ActiveRecord::Base.establish_connection(
  adapter: "sqlite3",
  database: ":memory:",
  reaping_frequency: 5
)
ActiveRecord::Base.connection_pool.with_connection { |c| c.execute("SELECT 1") }
sleep 0.1

class ARPoolReaperLeakTest < Minitest::Test
  def test_ar_pool_reaper_is_cleaned_up_after_parallelization_shutdown
    assert Thread.list.find { |t| t.name == "Active Record Pool Reaper" }

    parallelization = ActiveSupport::Testing::Parallelization.new(1)
    parallelization.start
    parallelization.shutdown

    assert_empty Thread.list.select { |t| t.alive? && t.name == "Active Record Pool Reaper" }
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
