### PR TITLE
[#57387] Fix STI subclass records leaking into preloaded has_many :through...

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `has_many :through` preload leaking sibling STI records into subclass associations.
+
+    Preloading a base-class through association (e.g. `:categories`) alongside an STI
+    subclass through association (e.g. `:special_categories`) would cause the subclass
+    association to contain records of sibling STI types. `ThroughAssociation#records_by_owner`
+    now filters records by the reflection's class when the association targets an STI subclass.
+
+    *Ruy Rocha*
+
 *   Fix `ActiveRecord::MessagePack` serialization raising `NoMethodError`
     for any record with a populated `time` column, which made such records
     uncacheable through the MessagePack cache serializer.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `has_many :through` preload leaking sibling STI records into subclass associations.
+
+    Preloading a base-class through association (e.g. `:categories`) alongside an STI
+    subclass through association (e.g. `:special_categories`) would cause the subclass
+    association to contain records of sibling STI types. `ThroughAssociation#records_by_owner`
+    now filters records by the reflection's class when the association targets an STI subclass.
+
+    *Ruy Rocha*
+
 *   Apply `all_queries: true` default scopes consistently across counter caches,
     uniqueness validations, fixture lookups, and record reloads, while those
     operations continue to bypass ordinary default scopes.

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -29,6 +29,10 @@ module ActiveRecord
               source_records_by_owner[record]
             end
 
+            if reflection.klass != reflection.klass.base_class
+              records = records.select { |r| r.is_a?(reflection.klass) }
+            end
+
             records.compact!
             records.sort_by! { |rhs| preload_index[rhs] } if scope.order_values.any?
             records.uniq! if scope.distinct_value

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1738,6 +1738,20 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [[comment.blog_id, comment.id]], ids
   end
 
+  def test_preload_sti_subclass_association_alongside_base_class_association
+    post = Post.create!(title: "STI preload test", body: "body")
+    category         = Category.create!(name: "General")
+    special_category = SpecialCategory.create!(name: "Sports")
+    Categorization.create!(post: post, category: category)
+    Categorization.create!(post: post, category: special_category)
+
+    preloaded = Post.preload(:named_categories, :special_named_categories).find(post.id)
+
+    assert_no_queries { preloaded.special_named_categories.to_a }
+    assert_equal [special_category], preloaded.special_named_categories,
+      "expected only SpecialCategory, got: #{preloaded.special_named_categories.map { |c| [c.class.name, c.name] }}"
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1752,6 +1752,20 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [[comment.blog_id, comment.id]], ids
   end
 
+  def test_preload_sti_subclass_association_alongside_base_class_association
+    post = Post.create!(title: "STI preload test", body: "body")
+    category         = Category.create!(name: "General")
+    special_category = SpecialCategory.create!(name: "Sports")
+    Categorization.create!(post: post, category: category)
+    Categorization.create!(post: post, category: special_category)
+
+    preloaded = Post.preload(:named_categories, :special_named_categories).find(post.id)
+
+    assert_no_queries { preloaded.special_named_categories.to_a }
+    assert_equal [special_category], preloaded.special_named_categories,
+      "expected only SpecialCategory, got: #{preloaded.special_named_categories.map { |c| [c.class.name, c.name] }}"
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -186,6 +186,7 @@ class Post < ActiveRecord::Base
   has_many :author_using_custom_pk,  through: :standard_categorizations
   has_many :authors_using_custom_pk, through: :standard_categorizations
   has_many :named_categories, through: :standard_categorizations
+  has_many :special_named_categories, through: :standard_categorizations, class_name: "SpecialCategory", source: :category
 
   has_many :readers
   has_many :secure_readers


### PR DESCRIPTION
when a base-class association is preloaded alongside a subclass association.

Fixes #57387

### Motivation / Background

When preloading a base-class `has_many :through` association (e.g. `:categories`)
alongside an STI subclass `has_many :through` association (e.g. `:special_categories`)
on the same through table, the subclass association's target would be incorrectly
populated with records of sibling STI types.

### Detail

`ThroughAssociation#records_by_owner` builds its result by flat-mapping
`source_records_by_owner` over the through records. Because `source_records_by_owner`
is seeded from the through join model's `belongs_to :source` reflection — which points
to the base class — the SQL query it issues has no STI `WHERE type = ?` filter.
When the base-class association has already been preloaded (and thus the through
records are already cached), all source records of all STI sibling types end up in
`source_records_by_owner`, and the subclass association gets all of them.

The fix filters `records` by `reflection.klass` after the flat-map when the
association targets an STI subclass (`reflection.klass != reflection.klass.base_class`).
`reflection.klass` is `SpecialCategory` (from `class_name: "SpecialCategory"`), so
`is_a?(reflection.klass)` correctly rejects sibling types without affecting
non-STI associations.

### Additional information

The bug is reproducible with any preload order that includes both a base-class
through association and an STI subclass through association sharing the same
join model. Standalone loads and single-association preloads are unaffected because
they hit the correct filtered SQL path directly.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.