### PR TITLE
Use `connection.reset!` instead of `reset_connection` to prevent connection leak in PG test teardowns

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -33,7 +33,7 @@ module PostgresqlCompositeBehavior
 
     @connection.drop_table "postgresql_composites", if_exists: true
     @connection.execute "DROP TYPE IF EXISTS full_address"
-    reset_connection
+    @connection.reset!
     PostgresqlComposite.reset_column_information
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -23,7 +23,7 @@ class PostgresqlDomainTest < ActiveRecord::PostgreSQLTestCase
   teardown do
     @connection.drop_table "postgresql_domains", if_exists: true
     @connection.execute "DROP DOMAIN IF EXISTS custom_money"
-    reset_connection
+    @connection.reset!
   end
 
   def test_column

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -30,10 +30,10 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   end
 
   teardown do
-    reset_connection
+    @connection.reset!
     @connection.drop_table "postgresql_enums", if_exists: true
     @connection.drop_enum "mood", if_exists: true
-    reset_connection
+    @connection.reset!
   end
 
   def test_column
@@ -191,7 +191,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     $stdout = original_stdout
     @connection.drop_table "pg_enum_array_schema_dump_accounts", if_exists: true
     @connection.drop_enum "pg_enum_array_schema_dump_account_type", if_exists: true
-    reset_connection
+    @connection.reset!
   end
 
   def test_drop_enum

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -99,7 +99,7 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_table "postgresql_ranges", if_exists: true
     @connection.execute "DROP TYPE IF EXISTS floatrange"
     @connection.execute "DROP TYPE IF EXISTS stringrange"
-    reset_connection
+    @connection.reset!
   end
 
   def test_data_type_of_range_types


### PR DESCRIPTION
### Motivation / Background

The Rails nightly suite `activerecord postgresql` job fails with `FATAL: sorry, too many clients already`, e.g.

https://buildkite.com/rails/rails-nightly/builds/4288/list?jid=019e420a-5a2d-49c4-8560-39d5b8989106&tab=output#L11746

Each affected test's teardown ends with `reset_connection`, defined in `activerecord/test/support/connection_helper.rb` as:

```ruby
def reset_connection
  original_connection = ActiveRecord::Base.remove_connection
  ActiveRecord::Base.establish_connection(original_connection)
end
```

That is, it swaps the whole pool. With transactional fixtures the fixture transaction still holds the existing connection, so `ConnectionPool#disconnect!` silently times out trying to acquire it exclusively and the PG socket is leaked. Across the suite (especially `PostgresqlRangeTest`, which has 46 tests) this is enough to exhaust `max_connections=100` on the PG server and cause the `too many clients already` failure.

### Detail

Replacing `reset_connection` with `@connection.reset!` keeps the existing connection but issues `DISCARD ALL` on PostgreSQL, which clears the same cached plans / session state without disconnecting, so no pool swap and no leak.

The `reset_connection` helper itself is intentionally left untouched because `PostgreSQLReferentialIntegrityTest` relies on it for a different purpose — getting a fresh adapter instance after monkey-patching `@connection` with `MissingSuperuserPrivileges`. That use case genuinely needs the pool swap; `reset!` would not unextend the module. So `reset_connection` has two distinct usages today:

| Use | Required action |
| --- | --- |
| query plan cache clear (enum, range, composite, domain) | `reset!` is enough |
| fresh adapter instance (referential_integrity) | pool swap is required |

Renaming `reset_connection` to reflect the "fresh adapter" semantics it provides today is a worthwhile follow-up but out of scope here.

The investigation also confirmed that whether the Ruby binary is a debug build (`master-debug` vs `master`) is not actually relevant — the underlying leak reproduces in any non-YJIT build that lets connections accumulate faster than GC can reclaim them.

### Per-test-class measurements

Captured with a diagnostic probe (see the branch [`yahonda/pg-leak-diagnostic-probe`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-diagnostic-probe) for reproduction) running each test file in isolation against `postgres:alpine` (`max_connections=100`), TCP, YJIT off:

| Test file       | runs | BEFORE: pg peak / in-test +1 events | AFTER: pg peak / in-test +1 events |
| --------------- | ---- | ----------------------------------- | ---------------------------------- |
| enum_test       |   20 |                              42 / 20 |                              2 / 0 |
| range_test      |   46 |                               48 / 0 |                              2 / 0 |
| composite_test  |    3 |                                5 / 0 |                              2 / 0 |
| domain_test     |    2 |                                3 / 0 |                              2 / 0 |

`pg peak` is the maximum number of PG client backends held by the test process at any point during the file's run (queried via `pg_stat_activity`, baseline ≈ 2 fixture-loaded sessions). `+1 events` are individual tests whose teardown was credited a direct +1 PG-side delta; `range_test`'s leak is entirely between-tests (every per-test teardown's `reset_connection` adds a connection to the next test's baseline).

Across the full PG suite, this fix drops total PG peak from ~94/100 to ~46/100 (combined with separate fixes for LoadAsync and standalone adapter tests, which are not in this PR).

### Additional information

The diagnostic probe used to gather these numbers is on the topic branch [`yahonda/pg-leak-diagnostic-probe`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-diagnostic-probe). It is not part of this PR and must not be merged.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message describes what changed and why.
- [x] Tests are updated.
- [ ] CHANGELOG — n/a, test-only fix.