### PR TITLE
Disconnect test-local PostgreSQL adapters to prevent connection leak

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -99,42 +99,44 @@ module ActiveRecord
 
       def test_reconnect_after_bad_connection_on_check_version_with_0_return
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(connection_retries: 0))
-        connection.connect!
+        with_postgresql_adapter(db_config.configuration_hash.merge(connection_retries: 0)) do |connection|
+          connection.connect!
 
-        # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
-        connection.pool.instance_variable_set(:@server_version, nil)
-        connection.raw_connection.stub(:server_version, 0) do
-          error = assert_raises ActiveRecord::ConnectionNotEstablished do
+          # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
+          connection.pool.instance_variable_set(:@server_version, nil)
+          connection.raw_connection.stub(:server_version, 0) do
+            error = assert_raises ActiveRecord::ConnectionNotEstablished do
+              connection.reconnect!
+            end
+            assert_equal "Could not determine PostgreSQL version", error.message
+          end
+
+          # can reconnect after a bad connection
+          assert_nothing_raised do
             connection.reconnect!
           end
-          assert_equal "Could not determine PostgreSQL version", error.message
-        end
-
-        # can reconnect after a bad connection
-        assert_nothing_raised do
-          connection.reconnect!
         end
       end
 
       def test_reconnect_after_bad_connection_on_check_version_with_native_exception
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(connection_retries: 0))
-        connection.connect!
+        with_postgresql_adapter(db_config.configuration_hash.merge(connection_retries: 0)) do |connection|
+          connection.connect!
 
-        # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
-        connection.pool.instance_variable_set(:@server_version, nil)
-        # https://github.com/ged/ruby-pg/commit/a565e153d4d05955342ad24d4845378eee956935
-        connection.raw_connection.stub(:server_version, -> { raise PG::ConnectionBad, "PQserverVersion() can't get server version" }) do
-          error = assert_raises ActiveRecord::ConnectionNotEstablished do
+          # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
+          connection.pool.instance_variable_set(:@server_version, nil)
+          # https://github.com/ged/ruby-pg/commit/a565e153d4d05955342ad24d4845378eee956935
+          connection.raw_connection.stub(:server_version, -> { raise PG::ConnectionBad, "PQserverVersion() can't get server version" }) do
+            error = assert_raises ActiveRecord::ConnectionNotEstablished do
+              connection.reconnect!
+            end
+            assert_equal "PQserverVersion() can't get server version", error.message
+          end
+
+          # can reconnect after a bad connection
+          assert_nothing_raised do
             connection.reconnect!
           end
-          assert_equal "PQserverVersion() can't get server version", error.message
-        end
-
-        # can reconnect after a bad connection
-        assert_nothing_raised do
-          connection.reconnect!
         end
       end
 
@@ -351,14 +353,10 @@ module ActiveRecord
         queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
           with_timezone_config(default: :utc) do
             db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-            connection = PostgreSQLAdapter.new(
-              db_config.configuration_hash.merge(
-                intervalstyle: false,
-                min_messages: false,
-              )
-            )
-            capture_sql(include_schema: true) do
-              connection.select_value("SELECT 1+2")
+            with_postgresql_adapter(db_config.configuration_hash.merge(intervalstyle: false, min_messages: false)) do |connection|
+              capture_sql(include_schema: true) do
+                connection.select_value("SELECT 1+2")
+              end
             end
           end
         end.map(&:squish)
@@ -516,53 +514,57 @@ module ActiveRecord
       end
 
       def test_exec_insert_with_returning_disabled
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_with_returning_disabled_and_no_sequence_name_given
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_default_values_with_returning_disabled_and_no_sequence_name_given
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_default_values_quoted_schema_with_returning_disabled_and_no_sequence_name_given
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_insert_uses_schema_cache_with_insert_returning_disabled
-        connection = connection_without_insert_returning
+        connection_without_insert_returning do |connection|
+          # First call might need to populate the schema cache
+          connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (0)")
 
-        # First call might need to populate the schema cache
-        connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (0)")
-
-        # We expect:
-        # 1. INSERT
-        # 2. SELECT pg_get_serial_sequence (ideally this would cached, but it's currently not)
-        # 3. SELECT currval
-        assert_queries_count(3, include_schema: true) do
-          connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (1)")
+          # We expect:
+          # 1. INSERT
+          # 2. SELECT pg_get_serial_sequence (ideally this would cached, but it's currently not)
+          # 3. SELECT currval
+          assert_queries_count(3, include_schema: true) do
+            connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (1)")
+          end
         end
       end
 
@@ -1256,62 +1258,62 @@ module ActiveRecord
 
       def test_date_decoding_enabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        with_postgresql_apdater_decode_dates do
-          date = connection.select_value("select '2024-01-01'::date")
-          assert_equal Date.new(2024, 01, 01), date
-          assert_equal Date, date.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          with_postgresql_apdater_decode_dates do
+            date = connection.select_value("select '2024-01-01'::date")
+            assert_equal Date.new(2024, 01, 01), date
+            assert_equal Date, date.class
+          end
         end
       end
 
       def test_date_decoding_disabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        date = connection.select_value("select '2024-01-01'::date")
-        assert_equal "2024-01-01", date
-        assert_equal String, date.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          date = connection.select_value("select '2024-01-01'::date")
+          assert_equal "2024-01-01", date
+          assert_equal String, date.class
+        end
       end
 
       def test_money_decoding_enabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        PostgreSQLAdapter.with(decode_money: true) do
-          money = connection.select_value("select '12.34'::money")
-          assert_equal BigDecimal("12.34"), money
-          assert_equal BigDecimal, money.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          PostgreSQLAdapter.with(decode_money: true) do
+            money = connection.select_value("select '12.34'::money")
+            assert_equal BigDecimal("12.34"), money
+            assert_equal BigDecimal, money.class
+          end
         end
       end
 
       def test_money_decoding_disabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        money = connection.select_value("select '12.34'::money")
-        assert_equal "$12.34", money
-        assert_equal String, money.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          money = connection.select_value("select '12.34'::money")
+          assert_equal "$12.34", money
+          assert_equal String, money.class
+        end
       end
 
       def test_bytea_decoding_enabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        PostgreSQLAdapter.with(decode_bytea: true) do
-          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-          assert_equal "Hello", bytea
-          assert_equal Encoding::BINARY, bytea.encoding
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          PostgreSQLAdapter.with(decode_bytea: true) do
+            bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+            assert_equal "Hello", bytea
+            assert_equal Encoding::BINARY, bytea.encoding
+          end
         end
       end
 
       def test_bytea_decoding_disabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-        assert_equal "\\x48656c6c6f", bytea
-        assert_equal Encoding::UTF_8, bytea.encoding
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+          assert_equal "\\x48656c6c6f", bytea
+          assert_equal Encoding::UTF_8, bytea.encoding
+        end
       end
 
       def test_bytea_unescape_after_decode_prevents_corruption
@@ -1319,18 +1321,18 @@ module ActiveRecord
 
         PostgreSQLAdapter.with(decode_bytea: true) do
           # Need fresh connection after changing decode_bytea setting
-          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+          with_postgresql_adapter(db_config.configuration_hash) do |connection|
+            bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+            assert_equal "Hello", bytea
+            assert_equal Encoding::BINARY, bytea.encoding
 
-          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-          assert_equal "Hello", bytea
-          assert_equal Encoding::BINARY, bytea.encoding
-
-          # Attempting to unescape already-decoded data should prevent corruption
-          assert_deprecated(ActiveRecord.deprecator) do
-            unescaped = PG::Connection.unescape_bytea(bytea)
-            # Should return the already-decoded value, not corrupt it
-            assert_equal "Hello", unescaped
-            assert_equal Encoding::BINARY, unescaped.encoding
+            # Attempting to unescape already-decoded data should prevent corruption
+            assert_deprecated(ActiveRecord.deprecator) do
+              unescaped = PG::Connection.unescape_bytea(bytea)
+              # Should return the already-decoded value, not corrupt it
+              assert_equal "Hello", unescaped
+              assert_equal Encoding::BINARY, unescaped.encoding
+            end
           end
         end
       end
@@ -1347,15 +1349,15 @@ module ActiveRecord
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 
         PostgreSQLAdapter.with(decode_bytea: true) do
-          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+          with_postgresql_adapter(db_config.configuration_hash) do |connection|
+            bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+            assert bytea.instance_variable_defined?(:@ar_pg_bytea_decoded)
 
-          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-          assert bytea.instance_variable_defined?(:@ar_pg_bytea_decoded)
+            type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+            processed = type.deserialize(bytea)
 
-          type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
-          processed = type.deserialize(bytea)
-
-          assert_not processed.instance_variable_defined?(:@ar_pg_bytea_decoded)
+            assert_not processed.instance_variable_defined?(:@ar_pg_bytea_decoded)
+          end
         end
       end
 
@@ -1457,9 +1459,19 @@ module ActiveRecord
           super(@connection, "ex", definition, &block)
         end
 
-        def connection_without_insert_returning
+        # Yields a freshly built PostgreSQLAdapter and disconnects it when the
+        # block exits. Used so tests don't leak the underlying PG socket
+        # waiting for the pg gem's finalizer to fire at GC time.
+        def with_postgresql_adapter(config_hash)
+          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(config_hash)
+          yield connection
+        ensure
+          connection&.disconnect!
+        end
+
+        def connection_without_insert_returning(&block)
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(insert_returning: false))
+          with_postgresql_adapter(db_config.configuration_hash.merge(insert_returning: false), &block)
         end
 
         def oid_lookup_query?(query)


### PR DESCRIPTION
### Motivation / Background

This addresses the same `FATAL: sorry, too many clients already` failure in the Rails nightly suite as #57409:

https://buildkite.com/rails/rails-nightly/builds/4288/list?jid=019e420a-5a2d-49c4-8560-39d5b8989106&tab=output#L11746

Many tests in `PostgreSQLAdapterTest` construct a one-off adapter via `PostgreSQLAdapter.new(...)` (directly, or via the `connection_without_insert_returning` test helper) and let the local `connection` go out of scope at the end of the test body. The underlying PG socket is then only closed by the pg gem's C-level finalizer, which runs at indeterminate GC time. Across the suite, those sockets stack up against the `max_connections=100` ceiling on the server.

### Detail

Introduce a `with_postgresql_adapter(config_hash) { |connection| ... }` private helper that builds the adapter, yields it, and disconnects it in an `ensure` block. Convert the affected tests to use the helper so the PG socket is closed deterministically as soon as the test exits the block. `connection_without_insert_returning` is refactored to take a block and delegate to the new helper.

This change is independent of #57409 (which converts `reset_connection` to `@connection.reset!` in 4 different PG test files) and can be merged in either order.

### Per-test-file measurements

Captured with a diagnostic probe (see the topic branch [`yahonda/pg-leak-diagnostic-probe`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-diagnostic-probe) for reproduction) running `postgresql_adapter_test.rb` in isolation against `postgres:alpine` (`max_connections=100`), TCP, YJIT off:

| Metric                       | BEFORE | AFTER |
| ---------------------------- | ------ | ----- |
| runs                         |    107 |   107 |
| pg_server peak               |     23 |     7 |
| per-test +1 PG-side events   |     29 |    14 |

`pg_server peak` is the maximum number of PG client backends held by the test process at any point during the file's run (queried via `pg_stat_activity`, baseline ≈ 2 fixture-loaded sessions). `+1 events` are individual tests whose teardown was credited a direct +1 PG-side delta.

The fix removes the 15 leak events attributable to local `PostgreSQLAdapter.new(...)` adapters that the new helper closes deterministically. The remaining 14 events come from tests that touch `@connection` (the pool-managed connection) in a way that triggers `verify!`/`reconnect!`, which is out of scope for this PR.

### Additional information

The diagnostic probe used to gather these numbers is on the topic branch [`yahonda/pg-leak-diagnostic-probe`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-diagnostic-probe). It is not part of this PR and must not be merged.

The investigation also confirmed that whether the Ruby binary is a debug build (`master-debug` vs `master`) is not actually relevant — the underlying leak reproduces in any non-YJIT build that lets connections accumulate faster than GC can reclaim them.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message describes what changed and why.
- [x] Tests are updated.
- [ ] CHANGELOG — n/a, test-only fix.