### PR TITLE
Support engine routes in rails routes --unused

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -107,31 +107,47 @@ module ActionDispatch
     # executes `bin/rails routes` or looks at the RoutingError page. People should
     # not use this class.
     class RoutesInspector # :nodoc:
-      def initialize(routes)
+      def initialize(routes, filter = {})
+        @filter = filter
         @routes = wrap_routes(routes)
         @engines = load_engines_routes
+        apply_filter!
       end
 
-      def format(formatter, filter = {})
+      def filter_routes!(&block)
+        @routes.select!(&block)
+        @engines.transform_values! { |routes| routes.select(&block) }
+      end
+
+      def no_routes?
+        @routes.none? && @engines.all? { |_, routes| routes.none? }
+      end
+
+      def format(formatter, options = {})
         all_routes = { nil => @routes }.merge(@engines)
 
         all_routes.each do |engine_name, routes|
-          format_routes(formatter, filter, engine_name, routes)
+          next if options[:brief] && routes.none?
+          format_routes(formatter, engine_name, routes)
+        end
+
+        if options[:brief] && no_routes?
+          formatter.no_routes(nil, [], @filter)
         end
 
         formatter.result
       end
 
       private
-        def format_routes(formatter, filter, engine_name, routes)
-          routes = filter_routes(routes, normalize_filter(filter)).map(&:to_h)
+        def format_routes(formatter, engine_name, routes)
+          routes = routes.map(&:to_h)
 
           formatter.section_title "Routes for #{engine_name || "application"}" if @engines.any?
           if routes.any?
             formatter.header routes
             formatter.section routes
           else
-            formatter.no_routes engine_name, routes, filter
+            formatter.no_routes engine_name, routes, @filter
           end
           formatter.footer routes
         end
@@ -141,15 +157,20 @@ module ActionDispatch
         end
 
         def load_engines_routes
-          engine_routes = @routes.select(&:engine?)
+          collect_engine_routes(@routes, {})
+        end
 
-          engines = engine_routes.to_h do |engine_route|
+        def collect_engine_routes(routes, engines)
+          routes.select(&:engine?).each do |engine_route|
+            next if engines.key?(engine_route.endpoint)
+
             engine_app_routes = engine_route.rack_app.routes
             engine_app_routes = engine_app_routes.routes if engine_app_routes.is_a?(ActionDispatch::Routing::RouteSet)
 
-            [engine_route.endpoint, wrap_routes(engine_app_routes)]
+            wrapped = wrap_routes(engine_app_routes)
+            engines[engine_route.endpoint] = wrapped
+            collect_engine_routes(wrapped, engines)
           end
-
           engines
         end
 
@@ -172,13 +193,12 @@ module ActionDispatch
           end
         end
 
-        def filter_routes(routes, filter)
-          if filter
-            routes.select do |route|
-              filter.any? { |filter_type, value| route.matches_filter?(filter_type, value) }
-            end
-          else
-            routes
+        def apply_filter!
+          filter = normalize_filter(@filter)
+          return unless filter
+
+          filter_routes! do |route|
+            filter.any? { |filter_type, value| route.matches_filter?(filter_type, value) }
           end
         end
     end

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -87,6 +87,33 @@ module ActionDispatch
         ], output
       end
 
+      def test_displaying_routes_for_engine_mounted_twice_is_not_repeated
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = draw do
+          mount engine => "/blog", as: "blog"
+          mount engine => "/feed", as: "feed"
+        end
+
+        assert_equal [
+          "Routes for application:",
+          "Prefix Verb URI Pattern Controller#Action",
+          "  blog      /blog       Blog::Engine",
+          "  feed      /feed       Blog::Engine",
+          "",
+          "Routes for Blog::Engine:",
+          "Prefix Verb URI Pattern     Controller#Action",
+          "  cart GET  /cart(.:format) cart#show"
+        ], output
+      end
+
       def test_cart_inspect
         output = draw do
           get "/cart", to: "cart#show"
@@ -688,8 +715,8 @@ module ActionDispatch
       private
         def draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Sheet.new, **options, &block)
           @set.draw(&block)
-          inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes)
-          inspector.format(formatter, options).split("\n")
+          inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes, options)
+          inspector.format(formatter).split("\n")
         end
     end
   end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Support engine routes in `rails routes --unused` and add `--brief` to
+    quiet output of sections with no matching routes.
+
+    *Bruno Carvalho*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -9,6 +9,7 @@ module Rails
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
       class_option :unused, type: :boolean, aliases: "-u", desc: "Print unused routes."
+      class_option :brief, type: :boolean, desc: "Skip sections with no matching routes."
 
       no_commands do
         def invoke_command(*)
@@ -25,12 +26,12 @@ module Rails
         boot_application!
         require "action_dispatch/routing/inspector"
 
-        say inspector.format(formatter, routes_filter)
+        say inspector.format(formatter, brief: options[:brief])
       end
 
       private
         def inspector
-          ActionDispatch::Routing::RoutesInspector.new(Rails.application.routes.routes)
+          ActionDispatch::Routing::RoutesInspector.new(Rails.application.routes.routes, routes_filter)
         end
 
         def formatter

--- a/railties/lib/rails/commands/unused_routes/unused_routes_command.rb
+++ b/railties/lib/rails/commands/unused_routes/unused_routes_command.rb
@@ -8,6 +8,7 @@ module Rails
       hide_command!
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
+      class_option :brief, type: :boolean, desc: "Skip sections with no matching routes."
 
       class RouteInfo
         def initialize(route)
@@ -35,7 +36,7 @@ module Rails
           end
 
           def action_missing?
-            @controller_class && @controller_class.instance_methods.exclude?(@action_name.to_sym)
+            @controller_class && @controller_class.action_methods.exclude?(@action_name.to_s)
           end
       end
 
@@ -43,26 +44,15 @@ module Rails
         boot_application!
         require "action_dispatch/routing/inspector"
 
-        say(inspector.format(formatter, routes_filter))
+        inspector = ActionDispatch::Routing::RoutesInspector.new(Rails.application.routes.routes, routes_filter)
+        inspector.filter_routes! { |route| RouteInfo.new(route).unused? }
 
-        exit(1) if routes.any?
+        say(inspector.format(formatter, brief: options[:brief]))
+
+        exit(1) unless inspector.no_routes?
       end
 
       private
-        def inspector
-          ActionDispatch::Routing::RoutesInspector.new(routes)
-        end
-
-        def routes
-          @routes ||= begin
-            routes = Rails.application.routes.routes.select do |route|
-              RouteInfo.new(route).unused?
-            end
-
-            ActionDispatch::Journey::Routes.new(routes)
-          end
-        end
-
         def formatter
           ActionDispatch::Routing::ConsoleFormatter::Unused.new
         end

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -419,6 +419,109 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
     MESSAGE
   end
 
+  test "rails routes with mounted engines" do
+    engine "blog" do |e|
+      e.write "lib/blog.rb", <<-RUBY
+        module Blog
+          class Engine < Rails::Engine
+            isolate_namespace Blog
+          end
+        end
+      RUBY
+
+      e.write "app/controllers/blog/posts_controller.rb", <<-RUBY
+        class Blog::PostsController < ActionController::Base
+          def index; end
+        end
+      RUBY
+
+      e.write "config/routes.rb", <<-RUBY
+        Blog::Engine.routes.draw do
+          mount Auth::Engine => "/auth"
+          get "/posts", to: "posts#index"
+        end
+      RUBY
+    end
+
+    engine "auth" do |e|
+      e.write "lib/auth.rb", <<-RUBY
+        module Auth
+          class Engine < Rails::Engine; end
+        end
+      RUBY
+
+      e.write "config/routes.rb", <<-RUBY
+        Auth::Engine.routes.draw do
+          get "/login", to: "sessions#create"
+        end
+      RUBY
+    end
+
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "/cart", to: "cart#show"
+        mount Blog::Engine => "/blog"
+      end
+    RUBY
+
+    output = run_routes_command
+    s = " " * 73
+
+    assert_includes output, <<~OUTPUT
+      Routes for application:
+                                        Prefix Verb URI Pattern         #{s}     Controller#Action
+                                          cart GET  /cart(.:format)     #{s}     cart#show
+                                          blog      /blog               #{s}     Blog::Engine
+    OUTPUT
+    assert_includes output, <<~OUTPUT
+      Routes for Blog::Engine:
+           Prefix Verb URI Pattern      Controller#Action
+      auth_engine      /auth            Auth::Engine
+            posts GET  /posts(.:format) blog/posts#index
+
+      Routes for Auth::Engine:
+      Prefix Verb URI Pattern      Controller#Action
+       login GET  /login(.:format) sessions#create
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_routes_command([ "-c", "blog/posts" ])
+      Routes for application:
+      No routes were found for this controller.
+      For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.
+
+      Routes for Blog::Engine:
+      Prefix Verb URI Pattern      Controller#Action
+       posts GET  /posts(.:format) blog/posts#index
+
+      Routes for Auth::Engine:
+      No routes were found for this controller.
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_routes_command([ "--brief", "-c", "blog/posts" ])
+      Routes for Blog::Engine:
+      Prefix Verb URI Pattern      Controller#Action
+       posts GET  /posts(.:format) blog/posts#index
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_routes_command([ "-g", "cart|login" ])
+      Routes for application:
+      Prefix Verb URI Pattern     Controller#Action
+        cart GET  /cart(.:format) cart#show
+
+      Routes for Blog::Engine:
+      No routes were found for this grep pattern.
+
+      Routes for Auth::Engine:
+      Prefix Verb URI Pattern      Controller#Action
+       login GET  /login(.:format) sessions#create
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_routes_command([ "--brief", "-g", "unknown" ])
+      No routes were found for this grep pattern.
+      For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.
+    OUTPUT
+  end
+
   test "rails routes with unused option" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do

--- a/railties/test/commands/unused_routes_test.rb
+++ b/railties/test/commands/unused_routes_test.rb
@@ -74,8 +74,8 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
   test "multiple unused routes" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do
-        get "/one", to: "action#one"
-        get "/two", to: "action#two"
+        get "/one", to: "my#one"
+        get "/two", to: "my#two"
       end
     RUBY
 
@@ -83,8 +83,8 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       Found 2 unused routes:
 
       Prefix Verb URI Pattern    Controller#Action
-         one GET  /one(.:format) action#one
-         two GET  /two(.:format) action#two
+         one GET  /one(.:format) my#one
+         two GET  /two(.:format) my#two
     OUTPUT
   end
 
@@ -142,8 +142,163 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
     OUTPUT
   end
 
+  test "engine with unused routes" do
+    setup_blog_engines_app!
+
+    diagnostic = <<~OUTPUT
+      Routes for Blog::Engine:
+      Found 1 unused route:
+
+      Prefix Verb URI Pattern      Controller#Action
+             POST /posts(.:format) blog/posts#create
+
+      Routes for Auth::Engine:
+      Found 1 unused route:
+
+      Prefix Verb URI Pattern      Controller#Action
+       login GET  /login(.:format) sessions#new
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_unused_routes_command(allow_failure: true)
+      Routes for application:
+      No unused routes found.
+
+      #{diagnostic.rstrip}
+    OUTPUT
+
+    assert_equal diagnostic, run_unused_routes_command(["--brief"], allow_failure: true)
+  end
+
+  test "engine with unused routes filtered" do
+    setup_blog_engines_app!
+
+    assert_equal <<~OUTPUT, run_unused_routes_command(["-c", "posts"], allow_failure: true)
+      Routes for application:
+      No unused routes found for this controller.
+
+      Routes for Blog::Engine:
+      Found 1 unused route:
+
+      Prefix Verb URI Pattern      Controller#Action
+             POST /posts(.:format) blog/posts#create
+
+      Routes for Auth::Engine:
+      No unused routes found for this controller.
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_unused_routes_command(["-g", "new"], allow_failure: true)
+      Routes for application:
+      No unused routes found for this grep pattern.
+
+      Routes for Blog::Engine:
+      No unused routes found for this grep pattern.
+
+      Routes for Auth::Engine:
+      Found 1 unused route:
+
+      Prefix Verb URI Pattern      Controller#Action
+       login GET  /login(.:format) sessions#new
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_unused_routes_command(["--brief", "-g", "new"], allow_failure: true)
+      Routes for Auth::Engine:
+      Found 1 unused route:
+
+      Prefix Verb URI Pattern      Controller#Action
+       login GET  /login(.:format) sessions#new
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_unused_routes_command(["--brief", "-c", "nothing"])
+      No unused routes found for this controller.
+    OUTPUT
+  end
+
+  test "engine with no unused routes" do
+    setup_blog_engines_app!
+
+    # remove the blog route and implement the auth route.
+    engine "blog" do |e|
+      e.write "config/routes.rb", <<-RUBY
+        Blog::Engine.routes.draw do
+          get "/posts", to: "posts#index"
+          # post "/posts", to: "posts#create"
+          mount Auth::Engine => "/auth"
+        end
+      RUBY
+    end
+
+    engine "auth" do |e|
+      e.write "app/controllers/sessions_controller.rb", <<-RUBY
+        class SessionsController < ActionController::Base
+          def new; end
+        end
+      RUBY
+    end
+
+    assert_equal <<~OUTPUT, run_unused_routes_command
+      Routes for application:
+      No unused routes found.
+
+      Routes for Blog::Engine:
+      No unused routes found.
+
+      Routes for Auth::Engine:
+      No unused routes found.
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_unused_routes_command(["--brief"])
+      No unused routes found.
+    OUTPUT
+  end
+
   private
     def run_unused_routes_command(args = [], allow_failure: false)
       rails "unused_routes", args, allow_failure: allow_failure
+    end
+
+    def setup_blog_engines_app!
+      engine "blog" do |e|
+        e.write "lib/blog.rb", <<-RUBY
+          module Blog
+            class Engine < Rails::Engine
+              isolate_namespace Blog
+            end
+          end
+        RUBY
+
+        e.write "app/controllers/blog/posts_controller.rb", <<-RUBY
+          class Blog::PostsController < ActionController::Base
+            def index; end
+          end
+        RUBY
+
+        e.write "config/routes.rb", <<-RUBY
+          Blog::Engine.routes.draw do
+            get "/posts", to: "posts#index"
+            post "/posts", to: "posts#create" # no action
+            mount Auth::Engine => "/auth"
+          end
+        RUBY
+      end
+
+      engine "auth" do |e|
+        e.write "lib/auth.rb", <<-RUBY
+          module Auth
+            class Engine < Rails::Engine; end
+          end
+        RUBY
+
+        e.write "config/routes.rb", <<-RUBY
+          Auth::Engine.routes.draw do
+            get "/login", to: "sessions#new" # no controller
+          end
+        RUBY
+      end
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          mount Blog::Engine => "/blog"
+        end
+      RUBY
     end
 end


### PR DESCRIPTION
### Motivation / Background

Some improvements and fixes to make `rails routes --unused --brief` a more solid CI check.

- Extend `rails routes` to visit engine route sets recursively.
- Extend `rails routes --unused` to work on engines like regular `rails routes`.
- Add `--brief` to omit (app or engine) sections where no routes matched the filters.
- Check `action_methods` instead of `instance_methods` in `rails routes --unused`.

Also apply -c and -g filters before checking if a route is unused.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @gmcgibbon