### PR TITLE
Run LoadAsync*ThreadPoolExecutorTest on the replaced pool to prevent connection leak

### DIFF
--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -415,7 +415,7 @@ module ActiveRecord
 
       fixtures :posts, :comments
 
-      def setup
+      def before_setup
         @old_config = ActiveRecord.async_query_executor
         ActiveRecord.async_query_executor = :multi_thread_pool
 
@@ -424,9 +424,12 @@ module ActiveRecord
 
         ActiveRecord::Base.establish_connection(config_hash1)
         ARUnit2Model.establish_connection(config_hash2)
+
+        super
       end
 
-      def teardown
+      def after_teardown
+        super
         ActiveRecord.async_query_executor = @old_config
         clean_up_connection_handler
         ActiveRecord::Base.establish_connection(:arunit)
@@ -554,7 +557,7 @@ module ActiveRecord
 
       fixtures :posts, :comments, :other_dogs
 
-      def setup
+      def before_setup
         @previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
         @old_config = ActiveRecord.async_query_executor
         ActiveRecord.async_query_executor = :multi_thread_pool
@@ -570,9 +573,12 @@ module ActiveRecord
 
         ActiveRecord::Base.establish_connection(:primary)
         ARUnit2Model.establish_connection(:animals)
+
+        super
       end
 
-      def teardown
+      def after_teardown
+        super
         ENV["RAILS_ENV"] = @previous_env
         ActiveRecord::Base.configurations = @prev_configs
         ActiveRecord.async_query_executor = @old_config


### PR DESCRIPTION
### Motivation / Background

This addresses the same `FATAL: sorry, too many clients already` failure in the Rails nightly suite as #57409 and #57410:

https://buildkite.com/rails/rails-nightly/builds/4288/list?jid=019e420a-5a2d-49c4-8560-39d5b8989106&tab=output#L11746

`LoadAsyncMultiThreadPoolExecutorTest` and `LoadAsyncMixedThreadPoolExecutorTest` replace `ActiveRecord::Base` and `ARUnit2Model` connection pools in `setup` so the tests run against the `:multi_thread_pool` async executor configuration. Until 5e047f2015758285bd8f4b817ac44070722f5a6e ("Clean up async test", 2023-02) Multi's `establish_connection` calls were immediately reverted from `setup`'s `ensure`, so the configuration was never actually exercised. Removing the ensure made the tests correct at the cost of exposing a connection leak:

1. ActiveRecord's transactional-fixtures hook begins a transaction on the original arunit / arunit2 pools before `setup` runs.
2. `setup` then calls `Base.establish_connection(config_hash1)` and `ARUnit2Model.establish_connection(config_hash2)`, which swaps the pool. The fixture transaction still holds the existing connection.
3. `ConnectionPool#disconnect!` can't acquire that connection exclusively and silently times out — leaving the PG socket open.

Across the 10 tests in `Multi` (plus 2 in `Mixed`) this accumulates roughly 40 PG client backends. Combined with leaks in other test files it is enough to exhaust `max_connections=100` on the PG server.

### Detail

Move the pool swap to `before_setup` (calling `super` afterwards) and the restore to `after_teardown` (calling `super` first). The fixture transaction then opens on the already-swapped pool, so nothing needs to be disconnected mid-test and no socket leaks.

This change is independent of #57409 and #57410 (which fix unrelated leak sources in PG test teardowns and standalone adapter cleanup) and can be merged in any order.

### Per-class measurements

Captured with a diagnostic probe (see the topic branch [`yahonda/pg-leak-diagnostic-probe`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-diagnostic-probe) for reproduction) running each class in isolation against `postgres:alpine` (`max_connections=100`), TCP, YJIT off:

| Class                                       | runs | BEFORE pg_server peak | AFTER pg_server peak |
| ------------------------------------------- | ---- | --------------------- | -------------------- |
| LoadAsyncMultiThreadPoolExecutorTest        |   10 |                    38 |                    2 |
| LoadAsyncMixedThreadPoolExecutorTest        |    2 |                     4 |                    2 |

`pg_server peak` is the maximum number of PG client backends held by the test process at any point during the file's run (queried via `pg_stat_activity`, baseline ≈ 2 fixture-loaded sessions). All leaked sockets accumulate between tests (in the gap between one teardown's restore and the next test's setup), so per-test `+1` deltas are zero in both versions.

### Additional information

The diagnostic probe used to gather these numbers is on the topic branch [`yahonda/pg-leak-diagnostic-probe`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-diagnostic-probe). It is not part of this PR and must not be merged.

The investigation also confirmed that whether the Ruby binary is a debug build (`master-debug` vs `master`) is not actually relevant — the underlying leak reproduces in any non-YJIT build that lets connections accumulate faster than GC can reclaim them.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message describes what changed and why.
- [x] Tests are updated.
- [ ] CHANGELOG — n/a, test-only fix.