### PR TITLE
Cache fixtures parsing

### DIFF
--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -50,7 +50,7 @@ module ActiveRecord
 
         def raw_rows
           @raw_rows ||= begin
-            data = ActiveSupport::ConfigurationFile.parse(@file, context:
+            data = ActiveSupport::ConfigurationFile.parse(@file, freeze: true, context:
               ActiveRecord::FixtureSet::RenderContext.create_subclass.new.get_binding)
             data ? validate(data).to_a : []
           rescue RuntimeError => error

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -537,10 +537,19 @@ module ActiveRecord
     MAX_ID = 2**30 - 1
 
     @@all_cached_fixtures = Hash.new { |h, k| h[k] = {} }
+    @@parsing_cache ||= {}
 
     cattr_accessor :all_loaded_fixtures, default: {}
 
     class << self
+      def without_parsing_cache
+        parsing_cache_was = @@parsing_cache
+        @@parsing_cache = {}
+        yield
+      ensure
+        @@parsing_cache = parsing_cache_was
+      end
+
       def default_fixture_model_name(fixture_set_name, config = ActiveRecord::Base) # :nodoc:
         config.pluralize_table_names ?
           fixture_set_name.singularize.camelize :
@@ -770,7 +779,7 @@ module ActiveRecord
               []
             end
 
-        @ignored_fixtures << "DEFAULTS" unless @ignored_fixtures.include?("DEFAULTS")
+        @ignored_fixtures += ["DEFAULTS"] unless @ignored_fixtures.include?("DEFAULTS")
         @ignored_fixtures.compact
       end
 
@@ -786,13 +795,12 @@ module ActiveRecord
         raise ArgumentError, "No fixture files found for #{@name}" if yaml_files.empty?
 
         yaml_files.each_with_object({}) do |file, fixtures|
-          FixtureSet::File.open(file) do |fh|
-            self.model_class ||= fh.model_class if fh.model_class
-            self.model_class ||= default_fixture_model_class
-            self.ignored_fixtures ||= fh.ignored_fixtures
-            fh.each do |fixture_name, row|
-              fixtures[fixture_name] = ActiveRecord::Fixture.new(row, model_class)
-            end
+          fh = (@@parsing_cache[file] ||= FixtureSet::File.open(file))
+          self.model_class ||= fh.model_class if fh.model_class
+          self.model_class ||= default_fixture_model_class
+          self.ignored_fixtures ||= fh.ignored_fixtures
+          fh.each do |fixture_name, row|
+            fixtures[fixture_name] = ActiveRecord::Fixture.new(row.dup, model_class)
           end
         end
       end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -908,24 +908,25 @@ class FixturesWithForeignKeyViolationsTest < ActiveRecord::TestCase
     FIXTURE
     File.write(FIXTURES_ROOT + @path, fk_pointing_to_non_existent_object)
 
-    with_verify_foreign_keys_for_fixtures do
-      if current_adapter?(:PostgreSQLAdapter) && ActiveRecord::Base.lease_connection.supports_enforced_foreign_keys?
-        assert_raise ActiveRecord::InvalidForeignKey do
-          ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
-        end
-      elsif current_adapter?(:SQLite3Adapter, :PostgreSQLAdapter)
-        error = assert_raise RuntimeError do
-          ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
-        end
-        assert_includes error.message, "Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations."
-        assert_includes error.message, "fk_pointing_to_non_existent_objects"
-      else
-        assert_nothing_raised do
-          ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
+    ActiveRecord::FixtureSet.without_parsing_cache do
+      with_verify_foreign_keys_for_fixtures do
+        if current_adapter?(:PostgreSQLAdapter) && ActiveRecord::Base.lease_connection.supports_enforced_foreign_keys?
+          assert_raise ActiveRecord::InvalidForeignKey do
+            ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
+          end
+        elsif current_adapter?(:SQLite3Adapter, :PostgreSQLAdapter)
+          error = assert_raise RuntimeError do
+            ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
+          end
+          assert_includes error.message, "Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations."
+          assert_includes error.message, "fk_pointing_to_non_existent_objects"
+        else
+          assert_nothing_raised do
+            ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
+          end
         end
       end
     end
-
   ensure
     File.delete(FIXTURES_ROOT + @path)
     ActiveRecord::FixtureSet.reset_cache


### PR DESCRIPTION
Extracted from: https://github.com/rails/rails/pull/57326

Whenever a test with `use_transactional_tests = false` runs, we have to reset all fixtures, as we don't know which tables or records may have been mutated.

This is a source of major slowdown, particularly if non-transactional tests get intertwined between transactional ones.

With Minitest it's not too terrible because suites (test classes) get run as a unit, whereas with Megatest, it's very bad because the unit of work is individual test cases (test methods), which causes way more cache busts.

However, while we do have to reset the database, there is no reason why we go to the trouble of parsing the YAML files again, which based on some profile account for half the cost of busting the cache.

We can at least memoize that part.

On another note, the fixtures code is quite messy and really ripe from a ground up rewrite. In an ideal world resetting a table would just be executing a precomputed list of SQL commands, currently we do a ton more than that.

This change is just a quick small step toward that direction, but a much larger refactoring would be warranted.
