### PR TITLE
Document endless range inconsistency for where [ci-skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1560,6 +1560,11 @@ This will generate SQL like:
 SELECT * FROM books WHERE books.created_at >= "2008-12-21 00:00:00"
 ```
 
+NOTE: While beginless ranges support both `<=` and `<` by using `..end` and
+`...end`, endless ranges will always result in `>=` for both `start..` and
+`start...` ranges. As Ruby doesn't yet support excluding the start of a range,
+Rails doesn't support this either.
+
 #### Subset Conditions
 
 If you want to find records using the `IN` expression you can pass an array to


### PR DESCRIPTION
Both `where(start..)` and `where(start...)` will generate the same SQL: `>= start`, but this hasn't been documented.

<img width="844" height="130" alt="image" src="https://github.com/user-attachments/assets/a198babe-210c-46d6-94a6-402d6839224f" />

See discussion here: https://github.com/rails/rails/issues/45821#issuecomment-1212977193 and https://github.com/rails/rails/issues/55967#issuecomment-3432698291

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
