### PR TITLE
Fix ShareLock ownership under :fiber isolation

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_locks.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_locks.rb
@@ -13,9 +13,10 @@ module ActionDispatch
   #     config.middleware.insert_before ActionDispatch::Executor, ActionDispatch::DebugLocks
   #
   # After restarting the application and re-triggering the deadlock condition, the
-  # route `/rails/locks` will show a summary of all threads currently known to the
-  # interlock, which lock level they are holding or awaiting, and their current
-  # backtrace.
+  # route `/rails/locks` will show a summary of all execution contexts (threads
+  # or fibers, depending on `config.active_support.isolation_level`) currently
+  # known to the interlock, which lock level they are holding or awaiting, and
+  # their current backtrace.
   #
   # Generally a deadlock will be caused by the interlock conflicting with some
   # other external lock or blocking I/O call. These cannot be automatically
@@ -47,7 +48,7 @@ module ActionDispatch
 
     private
       def render_details(req)
-        threads = ActiveSupport::Dependencies.interlock.raw_state do |raw_threads|
+        owners = ActiveSupport::Dependencies.interlock.raw_state do |raw_owners|
           # The Interlock itself comes to a complete halt as long as this block is
           # executing. That gives us a more consistent picture of everything, but creates
           # a pretty strong Observer Effect.
@@ -57,15 +58,15 @@ module ActionDispatch
           # (to be used when something has gone wrong), and not for any sort of general
           # monitoring.
 
-          raw_threads.each.with_index do |(thread, info), idx|
+          raw_owners.each.with_index do |(owner, info), idx|
             info[:index] = idx
-            info[:backtrace] = thread.backtrace
+            info[:backtrace] = owner.backtrace
           end
 
-          raw_threads
+          raw_owners
         end
 
-        str = threads.map do |thread, info|
+        str = owners.map do |owner, info|
           if info[:exclusive]
             lock_state = +"Exclusive"
           elsif info[:sharing] > 0
@@ -79,7 +80,7 @@ module ActionDispatch
             lock_state << " (yielded share)"
           end
 
-          msg = +"Thread #{info[:index]} [0x#{thread.__id__.to_s(16)} #{thread.status || 'dead'}]  #{lock_state}\n"
+          msg = +"#{owner.class} #{info[:index]} [0x#{owner.__id__.to_s(16)} #{owner_status(owner)}]  #{lock_state}\n"
 
           if info[:sleeper]
             msg << "  Waiting in #{info[:sleeper]}"
@@ -91,11 +92,11 @@ module ActionDispatch
               msg << "  may be pre-empted for: #{compat.join(', ')}\n"
             end
 
-            blockers = threads.values.select { |binfo| blocked_by?(info, binfo, threads.values) }
+            blockers = owners.values.select { |binfo| blocked_by?(info, binfo, owners.values) }
             msg << "  blocked by: #{blockers.map { |i| i[:index] }.join(', ')}\n" if blockers.any?
           end
 
-          blockees = threads.values.select { |binfo| blocked_by?(binfo, info, threads.values) }
+          blockees = owners.values.select { |binfo| blocked_by?(binfo, info, owners.values) }
           msg << "  blocking: #{blockees.map { |i| i[:index] }.join(', ')}\n" if blockees.any?
 
           msg << "\n#{info[:backtrace].join("\n")}\n" if info[:backtrace]
@@ -105,7 +106,14 @@ module ActionDispatch
                 Rack::CONTENT_LENGTH => str.size.to_s }, [str]]
       end
 
-      def blocked_by?(victim, blocker, all_threads)
+      def owner_status(owner)
+        case owner
+        when Thread then owner.status || "dead"
+        when Fiber then owner.alive? ? "alive" : "dead"
+        end
+      end
+
+      def blocked_by?(victim, blocker, all_owners)
         return false if victim.equal?(blocker)
 
         case victim[:sleeper]
@@ -122,7 +130,7 @@ module ActionDispatch
           blocker[:exclusive] ||
             victim[:compatible] &&
             victim[:compatible].include?(blocker[:purpose]) &&
-            all_threads.all? { |other| !other[:compatible] || blocker.equal?(other) || other[:compatible].include?(blocker[:purpose]) }
+            all_owners.all? { |other| !other[:compatible] || blocker.equal?(other) || other[:compatible].include?(blocker[:purpose]) }
         end
       end
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix `ActiveSupport::Concurrency::ShareLock` to honor `isolation_level`.
+
+    Lock ownership was keyed on `Thread.current`. Under
+    `config.active_support.isolation_level = :fiber`, all request fibers
+    on the same thread were treated as a single owner, and the reloader
+    interlock could admit an exclusive `:unload` while another fiber
+    still held a share — clearing autoloaded constants mid-request.
+
+    `ShareLock` now keys ownership on
+    `ActiveSupport::IsolatedExecutionState.context`, the same scope used
+    by `CurrentAttributes` and other per-execution state. Behavior under
+    `:thread` isolation is unchanged.
+
+    *Joel Junström*
+
 *   Introduce `ActiveSupport::TimeFormats` and `ActiveSupport::DateFormats`
     for registering custom date formats.
 

--- a/activesupport/lib/active_support/concurrency/share_lock.rb
+++ b/activesupport/lib/active_support/concurrency/share_lock.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "monitor"
+require "active_support/isolated_execution_state"
 
 module ActiveSupport
   module Concurrency
@@ -10,28 +11,29 @@ module ActiveSupport
     class ShareLock
       include MonitorMixin
 
-      # We track Thread objects, instead of just using counters, because
-      # we need exclusive locks to be reentrant, and we need to be able
-      # to upgrade share locks to exclusive.
+      # We track execution-context objects (Threads or Fibers, depending on
+      # +ActiveSupport::IsolatedExecutionState.isolation_level+), instead of
+      # just using counters, because we need exclusive locks to be reentrant,
+      # and we need to be able to upgrade share locks to exclusive.
 
       def raw_state # :nodoc:
         synchronize do
-          threads = @sleeping.keys | @sharing.keys | @waiting.keys
-          threads |= [@exclusive_thread] if @exclusive_thread
+          owners = @sleeping.keys | @sharing.keys | @waiting.keys
+          owners |= [@exclusive_owner] if @exclusive_owner
 
           data = {}
 
-          threads.each do |thread|
-            purpose, compatible = @waiting[thread]
+          owners.each do |owner|
+            purpose, compatible = @waiting[owner]
 
-            data[thread] = {
-              thread: thread,
-              sharing: @sharing[thread],
-              exclusive: @exclusive_thread == thread,
+            data[owner] = {
+              owner: owner,
+              sharing: @sharing[owner],
+              exclusive: @exclusive_owner == owner,
               purpose: purpose,
               compatible: compatible,
-              waiting: !!@waiting[thread],
-              sleeper: @sleeping[thread],
+              waiting: !!@waiting[owner],
+              sleeper: @sleeping[owner],
             }
           end
 
@@ -54,7 +56,7 @@ module ActiveSupport
         @sharing = Hash.new(0)
         @waiting = {}
         @sleeping = {}
-        @exclusive_thread = nil
+        @exclusive_owner = nil
         @exclusive_depth = 0
       end
 
@@ -62,19 +64,19 @@ module ActiveSupport
       # immediately available. Otherwise, returns true after the lock
       # has been acquired.
       #
-      # +purpose+ and +compatible+ work together; while this thread is
+      # +purpose+ and +compatible+ work together; while this owner is
       # waiting for the exclusive lock, it will yield its share (if any)
       # to any other attempt whose +purpose+ appears in this attempt's
       # +compatible+ list. This allows a "loose" upgrade, which, being
       # less strict, prevents some classes of deadlocks.
       #
-      # For many resources, loose upgrades are sufficient: if a thread
+      # For many resources, loose upgrades are sufficient: if an owner
       # is awaiting a lock, it is not running any other code. With
       # +purpose+ matching, it is possible to yield only to other
-      # threads whose activity will not interfere.
+      # owners whose activity will not interfere.
       def start_exclusive(purpose: nil, compatible: [], no_wait: false)
         synchronize do
-          unless @exclusive_thread == Thread.current
+          unless @exclusive_owner == current_owner
             if busy_for_exclusive?(purpose)
               return false if no_wait
 
@@ -82,7 +84,7 @@ module ActiveSupport
                 wait_for(:start_exclusive) { busy_for_exclusive?(purpose) }
               end
             end
-            @exclusive_thread = Thread.current
+            @exclusive_owner = current_owner
           end
           @exclusive_depth += 1
 
@@ -90,19 +92,19 @@ module ActiveSupport
         end
       end
 
-      # Relinquish the exclusive lock. Must only be called by the thread
+      # Relinquish the exclusive lock. Must only be called by the owner
       # that called start_exclusive (and currently holds the lock).
       def stop_exclusive(compatible: [])
         synchronize do
-          raise "invalid unlock" if @exclusive_thread != Thread.current
+          raise "invalid unlock" if @exclusive_owner != current_owner
 
           @exclusive_depth -= 1
           if @exclusive_depth == 0
-            @exclusive_thread = nil
+            @exclusive_owner = nil
 
             if eligible_waiters?(compatible)
               yield_shares(compatible: compatible, block_share: true) do
-                wait_for(:stop_exclusive) { @exclusive_thread || eligible_waiters?(compatible) }
+                wait_for(:stop_exclusive) { @exclusive_owner || eligible_waiters?(compatible) }
               end
             end
             @cv.broadcast
@@ -112,27 +114,29 @@ module ActiveSupport
 
       def start_sharing
         synchronize do
-          if @sharing[Thread.current] > 0 || @exclusive_thread == Thread.current
+          owner = current_owner
+          if @sharing[owner] > 0 || @exclusive_owner == owner
             # We already hold a lock; nothing to wait for
-          elsif @waiting[Thread.current]
+          elsif @waiting[owner]
             # We're nested inside a +yield_shares+ call: we'll resume as
             # soon as there isn't an exclusive lock in our way
-            wait_for(:start_sharing) { @exclusive_thread }
+            wait_for(:start_sharing) { @exclusive_owner }
           else
             # This is an initial / outermost share call: any outstanding
             # requests for an exclusive lock get to go first
             wait_for(:start_sharing) { busy_for_sharing?(false) }
           end
-          @sharing[Thread.current] += 1
+          @sharing[owner] += 1
         end
       end
 
       def stop_sharing
         synchronize do
-          if @sharing[Thread.current] > 1
-            @sharing[Thread.current] -= 1
+          owner = current_owner
+          if @sharing[owner] > 1
+            @sharing[owner] -= 1
           else
-            @sharing.delete Thread.current
+            @sharing.delete owner
             @cv.broadcast
           end
         end
@@ -169,14 +173,15 @@ module ActiveSupport
       # to proceed.
       def yield_shares(purpose: nil, compatible: [], block_share: false)
         loose_shares = previous_wait = nil
+        owner = current_owner
         synchronize do
-          if loose_shares = @sharing.delete(Thread.current)
-            if previous_wait = @waiting[Thread.current]
+          if loose_shares = @sharing.delete(owner)
+            if previous_wait = @waiting[owner]
               purpose = nil unless purpose == previous_wait[0]
               compatible &= previous_wait[1]
             end
             compatible |= [false] unless block_share
-            @waiting[Thread.current] = [purpose, compatible]
+            @waiting[owner] = [purpose, compatible]
           end
 
           @cv.broadcast
@@ -186,39 +191,45 @@ module ActiveSupport
           yield
         ensure
           synchronize do
-            wait_for(:yield_shares) { @exclusive_thread && @exclusive_thread != Thread.current }
+            wait_for(:yield_shares) { @exclusive_owner && @exclusive_owner != owner }
 
             if previous_wait
-              @waiting[Thread.current] = previous_wait
+              @waiting[owner] = previous_wait
             else
-              @waiting.delete Thread.current
+              @waiting.delete owner
             end
-            @sharing[Thread.current] = loose_shares if loose_shares
+            @sharing[owner] = loose_shares if loose_shares
           end
         end
       end
 
       private
+        def current_owner
+          ActiveSupport::IsolatedExecutionState.context
+        end
+
         # Must be called within synchronize
         def busy_for_exclusive?(purpose)
           busy_for_sharing?(purpose) ||
-            @sharing.size > (@sharing[Thread.current] > 0 ? 1 : 0)
+            @sharing.size > (@sharing[current_owner] > 0 ? 1 : 0)
         end
 
         def busy_for_sharing?(purpose)
-          (@exclusive_thread && @exclusive_thread != Thread.current) ||
-            @waiting.any? { |t, (_, c)| t != Thread.current && !c.include?(purpose) }
+          owner = current_owner
+          (@exclusive_owner && @exclusive_owner != owner) ||
+            @waiting.any? { |o, (_, c)| o != owner && !c.include?(purpose) }
         end
 
         def eligible_waiters?(compatible)
-          @waiting.any? { |t, (p, _)| compatible.include?(p) && @waiting.all? { |t2, (_, c2)| t == t2 || c2.include?(p) } }
+          @waiting.any? { |o, (p, _)| compatible.include?(p) && @waiting.all? { |o2, (_, c2)| o == o2 || c2.include?(p) } }
         end
 
         def wait_for(method, &block)
-          @sleeping[Thread.current] = method
+          owner = current_owner
+          @sleeping[owner] = method
           @cv.wait_while(&block)
         ensure
-          @sleeping.delete Thread.current
+          @sleeping.delete owner
         end
     end
   end

--- a/activesupport/test/share_lock_test.rb
+++ b/activesupport/test/share_lock_test.rb
@@ -574,3 +574,169 @@ class ShareLockTest < ActiveSupport::TestCase
       stuck_thread.join # clean up
     end
 end
+
+# +ShareLock+ keys ownership on +IsolatedExecutionState.context+ (Thread or
+# Fiber, depending on the configured isolation level). These tests exercise
+# the +:fiber+ path: multiple fibers on the same thread must be treated as
+# distinct owners. Under the previous +Thread.current+ keying they would
+# collide and the reloader interlock could clear constants from under an
+# in-flight request fiber.
+#
+# The +no_wait+ option lets us probe lock state synchronously without
+# spinning up a fiber scheduler, so the suite stays self-contained.
+class ShareLockFiberTest < ActiveSupport::TestCase
+  setup do
+    @original_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
+    ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+    @lock = ActiveSupport::Concurrency::ShareLock.new
+  end
+
+  teardown do
+    ActiveSupport::IsolatedExecutionState.isolation_level = @original_isolation_level
+  end
+
+  def test_two_fibers_on_same_thread_are_distinct_share_owners
+    fiber_a_holds = false
+    fiber_b_saw_lock_busy = nil
+
+    fiber_a = Fiber.new do
+      @lock.start_sharing
+      fiber_a_holds = true
+      Fiber.yield
+      @lock.stop_sharing
+    end
+
+    fiber_b = Fiber.new do
+      # Fiber A's share must block fiber B's attempt at an exclusive lock.
+      # Under the old +Thread.current+ keying, fiber B would have looked
+      # like the same owner and proceeded.
+      fiber_b_saw_lock_busy = @lock.start_exclusive(no_wait: true) == false
+    end
+
+    fiber_a.resume
+    assert fiber_a_holds
+    fiber_b.resume
+    assert fiber_b_saw_lock_busy, "fiber B should observe fiber A's share and decline the exclusive lock"
+    fiber_a.resume # drain stop_sharing
+  end
+
+  def test_exclusive_held_by_one_fiber_blocks_exclusive_in_another_fiber
+    fiber_a = Fiber.new do
+      @lock.start_exclusive
+      Fiber.yield
+      @lock.stop_exclusive
+    end
+
+    second_attempt_blocked = nil
+    fiber_b = Fiber.new do
+      second_attempt_blocked = @lock.start_exclusive(no_wait: true) == false
+    end
+
+    fiber_a.resume
+    fiber_b.resume
+
+    assert second_attempt_blocked, "a second fiber must not be able to claim the exclusive lock"
+    fiber_a.resume
+  end
+
+  def test_stop_exclusive_from_a_different_fiber_raises
+    acquirer = Fiber.new do
+      @lock.start_exclusive
+      Fiber.yield
+      @lock.stop_exclusive
+    end
+
+    releaser = Fiber.new do
+      error = assert_raises(RuntimeError) do
+        @lock.stop_exclusive
+      end
+      assert_equal "invalid unlock", error.message
+    end
+
+    acquirer.resume
+    releaser.resume
+    acquirer.resume
+  end
+
+  def test_exclusive_is_reentrant_within_a_single_fiber
+    inner_executed = false
+
+    fiber = Fiber.new do
+      @lock.exclusive do
+        @lock.exclusive do
+          inner_executed = true
+        end
+      end
+    end
+
+    fiber.resume
+    assert inner_executed
+  end
+
+  def test_sharing_upgradeable_to_exclusive_within_a_single_fiber
+    upgraded = false
+
+    fiber = Fiber.new do
+      @lock.sharing do
+        @lock.exclusive do
+          upgraded = true
+        end
+      end
+    end
+
+    fiber.resume
+    assert upgraded
+  end
+
+  def test_share_count_is_per_fiber_not_per_thread
+    fiber_a = Fiber.new do
+      @lock.start_sharing
+      Fiber.yield
+      @lock.stop_sharing
+    end
+
+    fiber_b = Fiber.new do
+      @lock.start_sharing
+      Fiber.yield
+      @lock.stop_sharing
+    end
+
+    fiber_a.resume
+    fiber_b.resume
+
+    @lock.raw_state do |data|
+      owners_with_share = data.select { |_, info| info[:sharing] && info[:sharing] > 0 }.keys
+      assert_equal 2, owners_with_share.size, "expected two distinct fiber owners to hold shares"
+      assert owners_with_share.all? { |o| o.is_a?(Fiber) }, "owners should be Fibers under :fiber isolation"
+    end
+
+    fiber_a.resume
+    fiber_b.resume
+  end
+
+  def test_thread_isolation_level_still_collapses_fibers_to_one_owner
+    ActiveSupport::IsolatedExecutionState.isolation_level = :thread
+    lock = ActiveSupport::Concurrency::ShareLock.new
+
+    fiber_a = Fiber.new do
+      lock.start_sharing
+      Fiber.yield
+      lock.stop_sharing
+    end
+
+    can_acquire_exclusive_inline = nil
+    fiber_b = Fiber.new do
+      # Same thread, +:thread+ isolation: fiber B looks like the same owner
+      # as fiber A and is allowed to take the exclusive lock despite the
+      # outstanding share.
+      can_acquire_exclusive_inline = lock.start_exclusive(no_wait: true)
+      lock.stop_exclusive if can_acquire_exclusive_inline
+    end
+
+    fiber_a.resume
+    fiber_b.resume
+
+    assert can_acquire_exclusive_inline, "under :thread isolation, fibers on the same thread share an owner identity"
+    fiber_a.resume
+  end
+end


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::Concurrency::ShareLock` keys ownership on `Thread.current`. With `config.active_support.isolation_level = :fiber`, all request fibers run on one thread and the lock sees them as a single owner.

The reloader interlock then fails its job: a reload fiber can acquire the exclusive `:unload` lock while another fiber still holds a share, clearing constants mid-request. Under a fiber-scheduled server (e.g. Falcon) the symptom is random `NoMethodError`s from views on the first file change after boot.

### Detail

Key ownership on `ActiveSupport::IsolatedExecutionState.context` instead. Seem to be what `CurrentAttributes` and the rest of the framework already use to decide what counts as a ”current execution” so the lock is aligned. Behavior under `:thread` isolation (the default) should be unchanged.

Downstream of that change:

- `@exclusive_thread` → `@exclusive_owner` and the `:thread` key in `raw_state` (`# :nodoc:`) → `:owner`; the fields hold a `Fiber` under fiber isolation and shouldn't claim otherwise.
- `ActionDispatch::DebugLocks` is the only consumer of `raw_state` and is updated in step, including a small fix so it doesn't crash on `Fiber#status` (which doesn't exist) when rendering `/rails/locks`.
- New `ShareLockFiberTest` alongside `ShareLockTest` covers the `:fiber` path, plus a regression check that `:thread` isolation still collapses fibers to one owner.

### Additional information

The new tests exercise ownership semantics with `start_exclusive(no_wait: true)` and manual `Fiber.resume`, which keeps them self-contained. The scheduler-driven blocking paths in `wait_for` aren't covered — adding a `Fiber.scheduler` test harness felt like a separate change. Happy to fold one in if reviewers prefer.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.