### PR TITLE
Update `SOLID_QUEUE_IN_PUMA` handling in `puma.rb` template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -35,7 +35,7 @@ plugin :tmp_restart
 
 <% unless skip_solid? -%>
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+plugin :solid_queue if !["", "false", "0"].include?(ENV["SOLID_QUEUE_IN_PUMA"].to_s.downcase)
 
 <% end -%>
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.


### PR DESCRIPTION
## Summary
Update the rails-generated `config/puma.rb` file to interpret `nil`, `""`, `"0"`, and `"false"` as falsy values for `ENV["SOLID_QUEUE_IN_PUMA"]`. For new apps and when running `rails app:update`.

## Details

`config/deploy.yml` has this by default:
```
# Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
# When you start using multiple servers, you should split out job processing to a dedicated machine.
SOLID_QUEUE_IN_PUMA: true
```
It's **really** easy to think setting `false` will turn it off.

Risk: Anyone *depending* on `""`/`"false"`/`"0"` to *enable* `SOLID_QUEUE_IN_PUMA` will have this change suggested by `rails app:update` next time they run that. Seems quite unlikely, and they do see the change in a git diff. 

### Alternative
Add an inline comment to `config/deploy.yml` like this:
```
SOLID_QUEUE_IN_PUMA: true # Comment out to disable; any value (even "false" or "") enables this.
```
But that's still easier to miss and get wrong.

----------

Prior PRs:
- https://github.com/rails/rails/pull/56210
- https://github.com/rails/rails/pull/53340