### PR TITLE
Release reloader share on rack hijack in ActionDispatch::Executor

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Release the executor state eagerly on rack hijack in
+    `ActionDispatch::Executor`.
+
+    The executor completed its state via the response body's `close`
+    callback (or `rack.response_finished` where available). For WebSocket
+    upgrades and full rack hijack the body becomes a long-lived streaming
+    connection, so `close` never fires until the socket closes. Under
+    Puma this was masked because Action Cable's hijack detaches to a
+    worker pool; under fiber-scheduled servers (e.g. Falcon) the request
+    fiber stays inline and the reloader share is held until the client
+    disconnects, blocking every subsequent reload.
+
+    The executor now detects hijacked responses -- HTTP 101 upgrades and
+    `rack.hijack_io` -- and completes the state immediately rather than
+    waiting on body close.
+
+    *Joel Junström*
+
 *   Add `ActionController::Parameters#deep_transform_values` and `deep_transform_values!`.
 
     Mirrors the existing `deep_transform_keys` / `deep_transform_keys!` pair,

--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -12,8 +12,16 @@ module ActionDispatch
 
     def call(env)
       state = @executor.run!(reset: true)
+
+      completed = false
+      finalize = -> {
+        next if completed
+        completed = true
+        state.complete!
+      }
+
       if response_finished = env["rack.response_finished"]
-        response_finished << proc { state.complete! }
+        response_finished << proc { finalize.call }
       end
 
       begin
@@ -24,8 +32,12 @@ module ActionDispatch
           @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
         end
 
-        unless response_finished
-          response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
+        if hijacked?(env, response)
+          # `close` and `rack.response_finished` may never fire on hijack.
+          # Release eagerly; the request's autoloaded code is resolved by now.
+          finalize.call
+        elsif !response_finished
+          response << ::Rack::BodyProxy.new(response.pop) { finalize.call }
         end
         returned = true
         response
@@ -37,9 +49,16 @@ module ActionDispatch
         raise
       ensure
         if !returned && !response_finished
-          state.complete!
+          finalize.call
         end
       end
     end
+
+    private
+      def hijacked?(env, response)
+        return false unless response
+
+        env["rack.hijack_io"] || response.first == 101
+      end
   end
 end

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -207,7 +207,61 @@ class ExecutorTest < ActiveSupport::TestCase
     assert_equal 1, completed_count
   end
 
+  def test_complete_runs_eagerly_on_websocket_upgrade
+    completed = false
+    executor.to_complete { completed = true }
+
+    app = proc { [101, { "upgrade" => "websocket", "connection" => "upgrade" }, []] }
+    env = Rack::MockRequest.env_for
+
+    status, _, body = unlinted_middleware(app).call(env)
+
+    assert_equal 101, status
+    assert completed, "executor state should be completed eagerly on WebSocket upgrade rather than waiting for body close"
+
+    body.close if body.respond_to?(:close)
+  end
+
+  def test_complete_runs_eagerly_on_full_rack_hijack
+    completed = false
+    executor.to_complete { completed = true }
+
+    hijack_io = IO.pipe.first
+    app = proc do |hijack_env|
+      hijack_env["rack.hijack_io"] = hijack_io
+      [200, {}, []]
+    end
+    env = Rack::MockRequest.env_for
+
+    unlinted_middleware(app).call(env)
+
+    assert completed, "executor state should be completed eagerly when the app installs rack.hijack_io"
+  ensure
+    hijack_io&.close
+  end
+
+  def test_complete_runs_once_when_hijack_response_also_registers_response_finished
+    completed_count = 0
+    executor.to_complete { completed_count += 1 }
+
+    app = proc { [101, { "upgrade" => "websocket", "connection" => "upgrade" }, []] }
+    env = Rack::MockRequest.env_for
+    env["rack.response_finished"] = []
+
+    unlinted_middleware(app).call(env)
+
+    assert_equal 1, completed_count, "eager hijack completion should mark the executor done"
+
+    env["rack.response_finished"].each { |cb| cb.call(env, 101, {}, nil) }
+
+    assert_equal 1, completed_count, "the response_finished callback must not run a second complete!"
+  end
+
   private
+    def unlinted_middleware(inner_app)
+      ActionDispatch::Executor.new(inner_app, executor)
+    end
+
     def call_and_return_body(env = Rack::MockRequest.env_for, &block)
       app = block || proc { [200, {}, []] }
       _, _, body = middleware(app).call(env)


### PR DESCRIPTION
### Motivation / Background

`ActionDispatch::Executor` completes its executor state (and releases the reloader share) via the response body's `close` callback, or `rack.response_finished` where the server provides it. For WebSocket upgrades and full rack hijack the body becomes a long-lived streaming connection — `close` doesn't fire until the socket closes.

In development the reloader's `before_class_unload` needs the exclusive `:unload` lock, which can't be acquired while any share is held. Under fiber-scheduled servers (e.g. Falcon with async-cable) the request fiber stays inline reading the hijacked socket, so the share is held for the lifetime of the connection and subsequent reloads block until the client disconnects. Under Puma this is masked because Action Cable's hijack detaches the connection to a worker pool and the original request thread is freed.

In production the reloader isn't running, so there's no deadlock. The executor's per-request lifecycle still stretches to the full connection lifetime, so `to_complete` callbacks (query cache cleanup, `CurrentAttributes` reset, app-defined cleanup) fire when the socket closes rather than when the upgrade response is returned.

### Detail

Detect hijacked responses inside `Executor#call` — HTTP 101 upgrades and `rack.hijack_io` — and complete the executor state eagerly instead of relying on body close.

- A new private `hijacked?` checks `env["rack.hijack_io"]` and response status `101`. `rack.hijack?` indicates the server supports hijack, not that hijack happened, so it is not part of the detection.
- A single idempotent `finalize` closure replaces the three direct `state.complete!` call sites so the eager hijack path doesn't double-complete alongside `rack.response_finished`.
- Long-lived hijack consumers (Action Cable) manage reload via `before_class_unload` closing connections, so releasing the share at hijack time doesn't expose them to constants being cleared.

### Additional information

#57423 adjusts `ActiveSupport::Concurrency::ShareLock` to honor `isolation_level`. Without it, the dev deadlock described above is masked by a different keying bug on fiber-scheduled servers (the lock treats all request fibers as the same owner). The two should be independent.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
