### PR TITLE
Fix check_all_foreign_keys_valid! corrupts NOT VALID state on same-named FKs + same table name across schemas

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -90,7 +90,7 @@ module ActiveRecord
             BEGIN
             FOR r IN (
               SELECT FORMAT(
-                'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace AND conrelid::regclass = ''%3$I''::regclass; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
+                'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace AND conrelid::regclass = ''%2$I.%3$I''::regclass; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
                 constraint_name,
                 table_schema,
                 table_name

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -335,6 +335,40 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_schema "referential_integrity_test_schema", if_exists: true
   end
 
+  def test_check_all_foreign_keys_valid_does_not_corrupt_not_valid_state_across_schemas
+    @connection.execute("CREATE SCHEMA ri_schema_a")
+    @connection.execute("CREATE SCHEMA ri_schema_b")
+
+    @connection.execute("CREATE TABLE ri_schema_a.nodes (id bigint PRIMARY KEY)")
+    @connection.execute("CREATE TABLE ri_schema_b.nodes (id bigint PRIMARY KEY)")
+
+    @connection.execute(<<~SQL)
+    CREATE TABLE ri_schema_a.edges (
+      id     bigint PRIMARY KEY,
+      source bigint
+        CONSTRAINT fk_edges_source REFERENCES ri_schema_a.nodes (id) NOT VALID
+    )
+    SQL
+    @connection.execute(<<~SQL)
+    CREATE TABLE ri_schema_b.edges (
+      id     bigint PRIMARY KEY,
+      source bigint
+        CONSTRAINT fk_edges_source REFERENCES ri_schema_b.nodes (id) NOT VALID
+    )
+    SQL
+
+    assert_not all_validated?("ri_schema_a", "edges", "fk_edges_source")
+    assert_not all_validated?("ri_schema_b", "edges", "fk_edges_source")
+
+    @connection.check_all_foreign_keys_valid!
+
+    assert all_validated?("ri_schema_a", "edges", "fk_edges_source")
+    assert all_validated?("ri_schema_b", "edges", "fk_edges_source")
+  ensure
+    @connection.execute("DROP SCHEMA IF EXISTS ri_schema_a CASCADE")
+    @connection.execute("DROP SCHEMA IF EXISTS ri_schema_b CASCADE")
+  end
+
   def test_all_foreign_keys_valid_having_foreign_keys_with_partitioned_table
     @connection.execute <<~SQL
       CREATE TABLE table_referenced_by_partioned_table (
@@ -371,5 +405,17 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   private
     def assert_transaction_is_not_broken
       assert_equal 1, @connection.select_value("SELECT 1")
+    end
+
+    def all_validated?(schema, table, constraint)
+      @connection.query_value(<<~SQL)
+      SELECT convalidated
+      FROM pg_catalog.pg_constraint c
+      JOIN pg_catalog.pg_class     t  ON t.oid  = c.conrelid
+      JOIN pg_catalog.pg_namespace ns ON ns.oid = c.connamespace
+      WHERE ns.nspname = #{@connection.quote(schema)}
+        AND t.relname  = #{@connection.quote(table)}
+        AND c.conname  = #{@connection.quote(constraint)}
+      SQL
     end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
Follow up to https://github.com/rails/rails/pull/53636
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix `regclass` cast to be schema-qualified.

### Detail

The `UPDATE pg_constraint SET convalidated=false` inside `check_all_foreign_keys_valid!` matches by `conrelid::regclass = '%3$I'::regclass`, but `'orders'::regclass` resolves using `search_path` — so when two schemas each contain a table named `orders`, both their FK constraints get reset to `NOT VALID`, but only the one being processed gets re-validated. The other schema's FK is permanently left `NOT VALID`.

When two schemas each contain a table with the same name and a FK constraint with the same name, the unqualified `conrelid::regclass` cast in the `UPDATE` resolved via `search_path` and could reset `convalidated=false` on the *wrong* schema's constraint, leaving it permanently `NOT VALID`. After `check_all_foreign_keys_valid!` both must be `convalidated = true`. Before the fix, the `search_path`-ambiguous `UPDATE reset convalidated=false` on whichever schema came *second* in the loop, leaving it permanently invalid.

One token changes in the FORMAT string: replace the bare `'%3$I'::regclass` cast with a schema-qualified `'%2$I.%3$I'::regclass` cast. We have added a test case also.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
