### PR TITLE
fix: validate subcommand in `rails plugin` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Validate subcommand in `rails plugin` command.
+
+    `rails plugin foo bar` silently ignored the invalid subcommand "foo"
+    and proceeded to create a plugin named "bar". Now it prints an error
+    and exits with status 1.
+
+    Fixes #57430.
+
+    *Ruy Rocha*
+
 *   Prevent the internal development welcome route from being duplicated on route reloads.
 
     *Elliot Temple*

--- a/railties/lib/rails/commands/plugin/plugin_command.rb
+++ b/railties/lib/rails/commands/plugin/plugin_command.rb
@@ -21,7 +21,16 @@ module Rails
       class_option :no_rc, desc: "Skip evaluating .railsrc."
 
       def perform(type = nil, *plugin_args)
-        plugin_args << "--help" unless type == "new"
+        if type
+          unless type == "new"
+            error "'#{type}' is not a valid plugin subcommand. Valid subcommand: new."
+            error "Run '#{self.class.executable} -h' for help."
+            exit 1
+          end
+        else
+          plugin_args << "--help"
+        end
+
 
         unless options.key?("no_rc") # Thor's not so indifferent access hash.
           railsrc = File.expand_path(options[:rc])

--- a/railties/test/commands/plugin_test.rb
+++ b/railties/test/commands/plugin_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+require "rails/generators/rails/plugin/plugin_generator"
+
+class Rails::Command::PluginTest < ActiveSupport::TestCase
+  setup :build_app
+  teardown :teardown_app
+
+  def test_plugin_with_invalid_subcommand
+    output = run_plugin_command("foo", "bar", allow_failure: true)
+
+    assert_equal 1, $?.exitstatus
+    assert_match "'foo' is not a valid plugin subcommand. Valid subcommand: new.", output
+  end
+
+  def test_plugin_new_without_path_shows_help
+    output = run_plugin_command("new", allow_failure: true)
+
+    assert_match "rails plugin new APP_PATH", output
+  end
+
+  def test_plugin_help
+    output = run_plugin_command("--help", allow_failure: true)
+
+    assert_match "rails plugin new", output
+  end
+
+  def test_plugin_new_with_mountable_option
+    assert_plugin_generator_called_with("my_plugin", "--mountable", "--pretend") do
+      invoke_plugin_command("new", "my_plugin", "--mountable", "--pretend")
+    end
+  end
+
+  def test_plugin_new_with_full_option
+    assert_plugin_generator_called_with("my_plugin", "--full", "--pretend") do
+      invoke_plugin_command("new", "my_plugin", "--full", "--pretend")
+    end
+  end
+
+  def test_plugin_new_with_skip_test_option
+    assert_plugin_generator_called_with("my_plugin", "--skip-test", "--pretend") do
+      invoke_plugin_command("new", "my_plugin", "--skip-test", "--pretend")
+    end
+  end
+
+  private
+    def assert_plugin_generator_called_with(*arguments, &block)
+      assert_called_with(Rails::Generators::PluginGenerator, :start, [arguments], &block)
+    end
+
+    def invoke_plugin_command(*arguments)
+      Rails::Command.invoke(:plugin, arguments)
+    end
+
+    def run_plugin_command(*arguments, allow_failure: false)
+      rails "plugin", *arguments, allow_failure: allow_failure
+    end
+end


### PR DESCRIPTION
`rails plugin foo bar` silently ignored the invalid subcommand "foo" and proceeded to create a plugin named "bar" as if `rails plugin new bar` had been run. Now it prints an error and exits with status 1.

Fixes #57430

### Motivation / Background

Running `rails plugin` with an invalid subcommand (anything other than `new`) silently discarded the invalid subcommand and proceeded as if `rails plugin new` had been run. This is confusing and error-prone, as
typos or misunderstandings of the available subcommands go unnoticed.

### Detail

`PluginCommand#perform` now validates the subcommand argument before proceeding. If the subcommand is anything other than `"new"`, it prints an error message and exits with status 1.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.