### PR TITLE
Rename `reset_connection` to `reset_pool`; have `reset_connection` reset just the existing connection

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
@@ -36,7 +36,7 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   teardown do
-    reset_connection
+    reset_pool
   end
 
   def test_add_index

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -323,7 +323,7 @@ module ActiveRecord
       end
 
       def test_queries_executed_on_fresh_connection_through_first_select
-        reset_connection
+        reset_pool
 
         queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
           with_timezone_config(default: :utc) do
@@ -344,11 +344,11 @@ module ActiveRecord
         assert_equal expected_queries.size, queries.size
         assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
       ensure
-        reset_connection
+        reset_pool
       end
 
       def test_queries_executed_on_fresh_connection_with_all_settings_skipped
-        reset_connection
+        reset_pool
 
         queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
           with_timezone_config(default: :utc) do
@@ -370,7 +370,7 @@ module ActiveRecord
         assert_equal expected_queries.size, queries.size
         assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
       ensure
-        reset_connection
+        reset_pool
       end
 
       def test_queries_executed_on_fresh_connection_with_first_custom_type_lookup
@@ -379,7 +379,7 @@ module ActiveRecord
           t.column :value, :postgresql_startup_lookup_enum
         end
         @connection.execute "INSERT INTO postgresql_startup_lookup_enums (value) VALUES ('good')"
-        reset_connection
+        reset_pool
 
         queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
           with_timezone_config(default: :utc) do
@@ -404,7 +404,7 @@ module ActiveRecord
       ensure
         @connection.drop_table "postgresql_startup_lookup_enums", if_exists: true
         @connection.drop_enum "postgresql_startup_lookup_enum", if_exists: true
-        reset_connection
+        reset_pool
       end
 
       def test_queries_executed_on_fresh_connection_with_two_multi_oid_type_lookups
@@ -413,7 +413,7 @@ module ActiveRecord
 
         first_sql = "SELECT 'one'::postgresql_startup_lookup_one_a AS value_a, 'one'::postgresql_startup_lookup_one_b AS value_b"
         second_sql = "SELECT 'one'::postgresql_startup_lookup_two_a AS value_a, 'one'::postgresql_startup_lookup_two_b AS value_b"
-        reset_connection
+        reset_pool
 
         first_queries = nil
         second_queries = nil
@@ -457,7 +457,7 @@ module ActiveRecord
         @connection.drop_enum "postgresql_startup_lookup_one_b", if_exists: true
         @connection.drop_enum "postgresql_startup_lookup_two_a", if_exists: true
         @connection.drop_enum "postgresql_startup_lookup_two_b", if_exists: true
-        reset_connection
+        reset_pool
       end
 
       def test_schema_search_path_uses_parameter_status_on_pg18
@@ -943,11 +943,11 @@ module ActiveRecord
         assert_not @connection.send(:type_map).key?(enum_oid)
       ensure
         @connection.drop_enum "feeling", if_exists: true
-        reset_connection
+        reset_pool
       end
 
       def test_only_reload_type_map_once_for_every_unrecognized_type
-        reset_connection
+        reset_pool
         connection = ActiveRecord::Base.lease_connection
         connection.select_all "SELECT 1" # eagerly initialize the connection
 
@@ -970,7 +970,7 @@ module ActiveRecord
         assert_equal expected_queries.size, queries.size
         assert expected_queries.zip(queries).all? { |expected, actual| expected === actual }
       ensure
-        reset_connection
+        reset_pool
       end
 
       def test_bulk_loads_domains_after_first_unknown_oid_lookup
@@ -982,7 +982,7 @@ module ActiveRecord
         @connection.create_table("postgresql_domain_type_map_bulk_loads_two", force: true) do |t|
           t.column :value, :postgresql_domain_two
         end
-        reset_connection
+        reset_pool
 
         connection = ActiveRecord::Base.lease_connection
         connection.select_all "SELECT 1" # eagerly initialize the connection
@@ -1013,7 +1013,7 @@ module ActiveRecord
         @connection.drop_table "postgresql_domain_type_map_bulk_loads_two", if_exists: true
         @connection.execute "DROP DOMAIN IF EXISTS postgresql_domain_one"
         @connection.execute "DROP DOMAIN IF EXISTS postgresql_domain_two"
-        reset_connection
+        reset_pool
       end
 
       def test_bulk_oid_lookup_query_excludes_system_catalog_types_for_known_servers
@@ -1041,7 +1041,7 @@ module ActiveRecord
         @connection.execute "CREATE DOMAIN postgresql_domain_base AS integer"
         @connection.execute "CREATE DOMAIN postgresql_domain_nested AS postgresql_domain_base[]"
         nested_array_oid = @connection.query_value("SELECT 'postgresql_domain_nested[]'::regtype::oid").to_i
-        reset_connection
+        reset_pool
 
         connection = ActiveRecord::Base.lease_connection
         lookup_sql = "SELECT '{}'::postgresql_domain_nested[] AS value"
@@ -1076,11 +1076,11 @@ module ActiveRecord
       ensure
         @connection.execute "DROP DOMAIN IF EXISTS postgresql_domain_nested"
         @connection.execute "DROP DOMAIN IF EXISTS postgresql_domain_base"
-        reset_connection
+        reset_pool
       end
 
       def test_load_additional_types_cascades_dependency_lookups_after_initial_bulk_load
-        reset_connection
+        reset_pool
         connection = ActiveRecord::Base.lease_connection
         silence_warnings { connection.select_all "select 'pg_catalog.pg_class'::regclass" }
 
@@ -1097,11 +1097,11 @@ module ActiveRecord
       ensure
         connection&.execute "DROP DOMAIN IF EXISTS postgresql_domain_nested_after_bulk"
         connection&.execute "DROP DOMAIN IF EXISTS postgresql_domain_base_after_bulk"
-        reset_connection
+        reset_pool
       end
 
       def test_only_warn_on_first_encounter_of_unrecognized_oid
-        reset_connection
+        reset_pool
         connection = ActiveRecord::Base.lease_connection
 
         warning = capture(:stderr) {
@@ -1111,7 +1111,7 @@ module ActiveRecord
         }
         assert_match(/\Aunknown OID \d+: failed to recognize type of 'regclass'\. It will be treated as String\.\n\z/, warning)
       ensure
-        reset_connection
+        reset_pool
       end
 
       def test_unparsed_defaults_are_at_least_set_when_saving

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -48,7 +48,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_table :ri_pp_children, if_exists: true
     @connection.drop_table :ri_pp_parents_0, if_exists: true
     @connection.drop_table :ri_pp_parents, if_exists: true
-    reset_connection
+    reset_pool
     if ActiveRecord::Base.lease_connection.is_a?(MissingSuperuserPrivileges)
       raise "MissingSuperuserPrivileges patch was not removed"
     end

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         end
 
         def teardown
-          reset_connection
+          reset_pool
         end
 
         def test_boolean_types

--- a/activerecord/test/support/connection_helper.rb
+++ b/activerecord/test/support/connection_helper.rb
@@ -8,8 +8,13 @@ module ConnectionHelper
     ActiveRecord::Base.establish_connection(original_connection)
   end
 
-  # Used to drop all cache query plans in tests.
+  # Resets state (cached plans, session settings) on the existing connection.
   def reset_connection
+    @connection.reset!
+  end
+
+  # Replaces the connection pool, yielding a fresh adapter instance.
+  def reset_pool
     original_connection = ActiveRecord::Base.remove_connection
     ActiveRecord::Base.establish_connection(original_connection)
   end


### PR DESCRIPTION
### Motivation

The nightly `activerecord postgresql` job fails with `FATAL: sorry, too many clients already` (e.g. [build #128640](https://buildkite.com/rails/rails/builds/128640#019e4c87-ef26-4267-8987-f7440998fd9c)). This PR addresses one of three test-side leak sources identified during the investigation.

Earlier attempt: #57409 (closed; the BEFORE/AFTER numbers there were inflated by a binding leak in the diagnostic probe — see [`yahonda/pg-leak-repro`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-repro) for the corrected methodology).

### Detail

`PostgresqlRangeTest`, `PostgresqlEnumTest`, `PostgresqlCompositeTest`, and `PostgresqlDomainTest` call `reset_connection` in their teardown to drop cached query plans. The helper was implemented as `remove_connection` + `establish_connection`, swapping the whole pool. With transactional fixtures the fixture transaction still holds the existing connection, so `ConnectionPool#disconnect!` silently times out and the PG socket is leaked.

These four files only need to clear cached plans / session state — not swap the pool. The fix changes `reset_connection`'s implementation to `@connection.reset!` (`DISCARD ALL` on the existing connection), and renames the previous pool-swap implementation to `reset_pool` for the callers that genuinely need a fresh adapter (e.g. `PostgreSQLReferentialIntegrityTest`, which extends a module onto the adapter and needs that module unextended).

Note: the four test files mentioned above are the origin of the leak but **do not appear in this PR's diff** — they keep calling `reset_connection` unchanged (vs `main`), and silently benefit from the new helper implementation. The diff only shows the helper itself plus the callers that migrate to `reset_pool`.

### Measurement

`postgres:alpine` (PG 18, `max_connections=100`), running only the four files that originally leaked, `--seed=22021` (worst case for the baseline), N=5, container restart per run:

| | peak (5 runs) |
| --- | --- |
| BEFORE | 9, 12, 7, 7, 8 |
| AFTER | 2, 2, 2, 2, 2 (= fixture baseline) |

Methodology: [`yahonda/pg-leak-repro`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-repro).

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message describes what changed and why.
- [x] Tests are updated.
- [ ] CHANGELOG — n/a, test-only fix.
