### PR TITLE
Disconnect test-local PostgreSQL adapters to prevent connection leak

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -99,42 +99,44 @@ module ActiveRecord
 
       def test_reconnect_after_bad_connection_on_check_version_with_0_return
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(connection_retries: 0))
-        connection.connect!
+        with_postgresql_adapter(db_config.configuration_hash.merge(connection_retries: 0)) do |connection|
+          connection.connect!
 
-        # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
-        connection.pool.instance_variable_set(:@server_version, nil)
-        connection.raw_connection.stub(:server_version, 0) do
-          error = assert_raises ActiveRecord::ConnectionNotEstablished do
+          # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
+          connection.pool.instance_variable_set(:@server_version, nil)
+          connection.raw_connection.stub(:server_version, 0) do
+            error = assert_raises ActiveRecord::ConnectionNotEstablished do
+              connection.reconnect!
+            end
+            assert_equal "Could not determine PostgreSQL version", error.message
+          end
+
+          # can reconnect after a bad connection
+          assert_nothing_raised do
             connection.reconnect!
           end
-          assert_equal "Could not determine PostgreSQL version", error.message
-        end
-
-        # can reconnect after a bad connection
-        assert_nothing_raised do
-          connection.reconnect!
         end
       end
 
       def test_reconnect_after_bad_connection_on_check_version_with_native_exception
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(connection_retries: 0))
-        connection.connect!
+        with_postgresql_adapter(db_config.configuration_hash.merge(connection_retries: 0)) do |connection|
+          connection.connect!
 
-        # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
-        connection.pool.instance_variable_set(:@server_version, nil)
-        # https://github.com/ged/ruby-pg/commit/a565e153d4d05955342ad24d4845378eee956935
-        connection.raw_connection.stub(:server_version, -> { raise PG::ConnectionBad, "PQserverVersion() can't get server version" }) do
-          error = assert_raises ActiveRecord::ConnectionNotEstablished do
+          # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
+          connection.pool.instance_variable_set(:@server_version, nil)
+          # https://github.com/ged/ruby-pg/commit/a565e153d4d05955342ad24d4845378eee956935
+          connection.raw_connection.stub(:server_version, -> { raise PG::ConnectionBad, "PQserverVersion() can't get server version" }) do
+            error = assert_raises ActiveRecord::ConnectionNotEstablished do
+              connection.reconnect!
+            end
+            assert_equal "PQserverVersion() can't get server version", error.message
+          end
+
+          # can reconnect after a bad connection
+          assert_nothing_raised do
             connection.reconnect!
           end
-          assert_equal "PQserverVersion() can't get server version", error.message
-        end
-
-        # can reconnect after a bad connection
-        assert_nothing_raised do
-          connection.reconnect!
         end
       end
 
@@ -351,14 +353,10 @@ module ActiveRecord
         queries = PostgreSQLAdapter.with(decode_dates: false, decode_money: false, decode_bytea: false) do
           with_timezone_config(default: :utc) do
             db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-            connection = PostgreSQLAdapter.new(
-              db_config.configuration_hash.merge(
-                intervalstyle: false,
-                min_messages: false,
-              )
-            )
-            capture_sql(include_schema: true) do
-              connection.select_value("SELECT 1+2")
+            with_postgresql_adapter(db_config.configuration_hash.merge(intervalstyle: false, min_messages: false)) do |connection|
+              capture_sql(include_schema: true) do
+                connection.select_value("SELECT 1+2")
+              end
             end
           end
         end.map(&:squish)
@@ -516,53 +514,57 @@ module ActiveRecord
       end
 
       def test_exec_insert_with_returning_disabled
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id", "postgresql_partitioned_table_parent_id_seq")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_with_returning_disabled_and_no_sequence_name_given
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert("insert into postgresql_partitioned_table_parent (number) VALUES (1)", nil, [], "id")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_default_values_with_returning_disabled_and_no_sequence_name_given
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert("insert into postgresql_partitioned_table_parent DEFAULT VALUES", nil, [], "id")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_exec_insert_default_values_quoted_schema_with_returning_disabled_and_no_sequence_name_given
-        connection = connection_without_insert_returning
-        result = assert_deprecated(ActiveRecord.deprecator) do
-          connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
+        connection_without_insert_returning do |connection|
+          result = assert_deprecated(ActiveRecord.deprecator) do
+            connection.exec_insert('insert into "public"."postgresql_partitioned_table_parent" DEFAULT VALUES', nil, [], "id")
+          end
+          expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
+          assert_equal expect.to_i, result.rows.first.first
         end
-        expect = connection.select_value("select max(id) from postgresql_partitioned_table_parent")
-        assert_equal expect.to_i, result.rows.first.first
       end
 
       def test_insert_uses_schema_cache_with_insert_returning_disabled
-        connection = connection_without_insert_returning
+        connection_without_insert_returning do |connection|
+          # First call might need to populate the schema cache
+          connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (0)")
 
-        # First call might need to populate the schema cache
-        connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (0)")
-
-        # We expect:
-        # 1. INSERT
-        # 2. SELECT pg_get_serial_sequence (ideally this would cached, but it's currently not)
-        # 3. SELECT currval
-        assert_queries_count(3, include_schema: true) do
-          connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (1)")
+          # We expect:
+          # 1. INSERT
+          # 2. SELECT pg_get_serial_sequence (ideally this would cached, but it's currently not)
+          # 3. SELECT currval
+          assert_queries_count(3, include_schema: true) do
+            connection.insert("INSERT INTO postgresql_partitioned_table_parent (number) VALUES (1)")
+          end
         end
       end
 
@@ -1256,62 +1258,62 @@ module ActiveRecord
 
       def test_date_decoding_enabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        with_postgresql_apdater_decode_dates do
-          date = connection.select_value("select '2024-01-01'::date")
-          assert_equal Date.new(2024, 01, 01), date
-          assert_equal Date, date.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          with_postgresql_apdater_decode_dates do
+            date = connection.select_value("select '2024-01-01'::date")
+            assert_equal Date.new(2024, 01, 01), date
+            assert_equal Date, date.class
+          end
         end
       end
 
       def test_date_decoding_disabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        date = connection.select_value("select '2024-01-01'::date")
-        assert_equal "2024-01-01", date
-        assert_equal String, date.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          date = connection.select_value("select '2024-01-01'::date")
+          assert_equal "2024-01-01", date
+          assert_equal String, date.class
+        end
       end
 
       def test_money_decoding_enabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        PostgreSQLAdapter.with(decode_money: true) do
-          money = connection.select_value("select '12.34'::money")
-          assert_equal BigDecimal("12.34"), money
-          assert_equal BigDecimal, money.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          PostgreSQLAdapter.with(decode_money: true) do
+            money = connection.select_value("select '12.34'::money")
+            assert_equal BigDecimal("12.34"), money
+            assert_equal BigDecimal, money.class
+          end
         end
       end
 
       def test_money_decoding_disabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        money = connection.select_value("select '12.34'::money")
-        assert_equal "$12.34", money
-        assert_equal String, money.class
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          money = connection.select_value("select '12.34'::money")
+          assert_equal "$12.34", money
+          assert_equal String, money.class
+        end
       end
 
       def test_bytea_decoding_enabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        PostgreSQLAdapter.with(decode_bytea: true) do
-          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-          assert_equal "Hello", bytea
-          assert_equal Encoding::BINARY, bytea.encoding
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          PostgreSQLAdapter.with(decode_bytea: true) do
+            bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+            assert_equal "Hello", bytea
+            assert_equal Encoding::BINARY, bytea.encoding
+          end
         end
       end
 
       def test_bytea_decoding_disabled
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
-
-        bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-        assert_equal "\\x48656c6c6f", bytea
-        assert_equal Encoding::UTF_8, bytea.encoding
+        with_postgresql_adapter(db_config.configuration_hash) do |connection|
+          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+          assert_equal "\\x48656c6c6f", bytea
+          assert_equal Encoding::UTF_8, bytea.encoding
+        end
       end
 
       def test_bytea_unescape_after_decode_prevents_corruption
@@ -1319,18 +1321,18 @@ module ActiveRecord
 
         PostgreSQLAdapter.with(decode_bytea: true) do
           # Need fresh connection after changing decode_bytea setting
-          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+          with_postgresql_adapter(db_config.configuration_hash) do |connection|
+            bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+            assert_equal "Hello", bytea
+            assert_equal Encoding::BINARY, bytea.encoding
 
-          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-          assert_equal "Hello", bytea
-          assert_equal Encoding::BINARY, bytea.encoding
-
-          # Attempting to unescape already-decoded data should prevent corruption
-          assert_deprecated(ActiveRecord.deprecator) do
-            unescaped = PG::Connection.unescape_bytea(bytea)
-            # Should return the already-decoded value, not corrupt it
-            assert_equal "Hello", unescaped
-            assert_equal Encoding::BINARY, unescaped.encoding
+            # Attempting to unescape already-decoded data should prevent corruption
+            assert_deprecated(ActiveRecord.deprecator) do
+              unescaped = PG::Connection.unescape_bytea(bytea)
+              # Should return the already-decoded value, not corrupt it
+              assert_equal "Hello", unescaped
+              assert_equal Encoding::BINARY, unescaped.encoding
+            end
           end
         end
       end
@@ -1347,15 +1349,15 @@ module ActiveRecord
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 
         PostgreSQLAdapter.with(decode_bytea: true) do
-          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash)
+          with_postgresql_adapter(db_config.configuration_hash) do |connection|
+            bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
+            assert bytea.instance_variable_defined?(:@ar_pg_bytea_decoded)
 
-          bytea = connection.select_value("select '\\x48656c6c6f'::bytea")
-          assert bytea.instance_variable_defined?(:@ar_pg_bytea_decoded)
+            type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
+            processed = type.deserialize(bytea)
 
-          type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea.new
-          processed = type.deserialize(bytea)
-
-          assert_not processed.instance_variable_defined?(:@ar_pg_bytea_decoded)
+            assert_not processed.instance_variable_defined?(:@ar_pg_bytea_decoded)
+          end
         end
       end
 
@@ -1457,9 +1459,19 @@ module ActiveRecord
           super(@connection, "ex", definition, &block)
         end
 
-        def connection_without_insert_returning
+        # Yields a freshly built PostgreSQLAdapter and disconnects it when the
+        # block exits. Used so tests don't leak the underlying PG socket
+        # waiting for the pg gem's finalizer to fire at GC time.
+        def with_postgresql_adapter(config_hash)
+          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(config_hash)
+          yield connection
+        ensure
+          connection&.disconnect!
+        end
+
+        def connection_without_insert_returning(&block)
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-          ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(insert_returning: false))
+          with_postgresql_adapter(db_config.configuration_hash.merge(insert_returning: false), &block)
         end
 
         def oid_lookup_query?(query)


### PR DESCRIPTION
### Motivation

The nightly `activerecord postgresql` job fails with `FATAL: sorry, too many clients already` (e.g. [build #128640](https://buildkite.com/rails/rails/builds/128640#019e4c87-ef26-4267-8987-f7440998fd9c)). This PR addresses one of three test-side leak sources identified during the investigation.

Earlier attempt: #57410 (closed; the BEFORE/AFTER numbers there were inflated by a binding leak in the diagnostic probe — see [`yahonda/pg-leak-repro`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-repro) for the corrected methodology).

### Detail

Many tests in `PostgreSQLAdapterTest` construct a one-off adapter via `PostgreSQLAdapter.new(...)` (directly, or via `connection_without_insert_returning`) and let `connection` go out of scope. The PG socket is then only closed by the pg gem's C-level finalizer, which runs at indeterminate GC time, so sockets accumulate against `max_connections=100`.

This PR introduces a `with_postgresql_adapter(config_hash) { |connection| ... }` private helper that disconnects the adapter in `ensure`. Affected tests are converted to use it. `connection_without_insert_returning` is refactored to take a block and delegate to the new helper.

### Measurement

`postgres:alpine` (PG 18), `max_connections=100`, only `postgresql_adapter_test.rb`, `--seed=37604` (worst case for the baseline), N=5, container restart per run:

| | peak (5 runs) |
| --- | --- |
| BEFORE | 13, 15, 17, 16, 13 |
| AFTER | 4, 5, 5, 5, 5 |

The residual 2–3 sessions above baseline come from tests that touch `@connection` (the pool-managed connection) in a way that triggers `verify!` / `reconnect!`; that path is out of scope for this PR.

Methodology: [`yahonda/pg-leak-repro`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-repro).

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message describes what changed and why.
- [x] Tests are updated.
- [ ] CHANGELOG — n/a, test-only fix.
