### PR TITLE
Run LoadAsync\*ThreadPoolExecutorTest on the replaced pool to prevent connection leak

### DIFF
--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -415,7 +415,7 @@ module ActiveRecord
 
       fixtures :posts, :comments
 
-      def setup
+      def before_setup
         @old_config = ActiveRecord.async_query_executor
         ActiveRecord.async_query_executor = :multi_thread_pool
 
@@ -424,9 +424,12 @@ module ActiveRecord
 
         ActiveRecord::Base.establish_connection(config_hash1)
         ARUnit2Model.establish_connection(config_hash2)
+
+        super
       end
 
-      def teardown
+      def after_teardown
+        super
         ActiveRecord.async_query_executor = @old_config
         clean_up_connection_handler
         ActiveRecord::Base.establish_connection(:arunit)
@@ -554,7 +557,7 @@ module ActiveRecord
 
       fixtures :posts, :comments, :other_dogs
 
-      def setup
+      def before_setup
         @previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
         @old_config = ActiveRecord.async_query_executor
         ActiveRecord.async_query_executor = :multi_thread_pool
@@ -570,9 +573,12 @@ module ActiveRecord
 
         ActiveRecord::Base.establish_connection(:primary)
         ARUnit2Model.establish_connection(:animals)
+
+        super
       end
 
-      def teardown
+      def after_teardown
+        super
         ENV["RAILS_ENV"] = @previous_env
         ActiveRecord::Base.configurations = @prev_configs
         ActiveRecord.async_query_executor = @old_config


### PR DESCRIPTION
### Motivation

The nightly `activerecord postgresql` job fails with `FATAL: sorry, too many clients already` (e.g. [build #128640](https://buildkite.com/rails/rails/builds/128640#019e4c87-ef26-4267-8987-f7440998fd9c)). This PR addresses one of three test-side leak sources identified during the investigation.

Earlier attempt: #57412 (closed; the BEFORE/AFTER numbers there were inflated by a binding leak in the diagnostic probe — see [`yahonda/pg-leak-repro`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-repro) for the corrected methodology).

### Detail

`LoadAsyncMultiThreadPoolExecutorTest` and `LoadAsyncMixedThreadPoolExecutorTest` replace `ActiveRecord::Base` / `ARUnit2Model` connection pools in `setup` so the tests actually run against `:multi_thread_pool`. Until 5e047f2015 ("Clean up async test", 2023-02) those `establish_connection` calls were immediately reverted in `setup`'s `ensure`, so the configuration was never exercised. Removing that `ensure` made the tests correct but exposed a leak:

1. Transactional fixtures begin a transaction on the original arunit / arunit2 pools before `setup` runs.
2. `setup` swaps the pool. The fixture transaction still holds the existing connection.
3. `ConnectionPool#disconnect!` cannot acquire that connection exclusively, silently times out, and the PG socket is leaked.

Moving the pool swap to `before_setup` (calling `super` afterwards) and the restore to `after_teardown` (calling `super` first) makes the fixture transaction open on the already-swapped pool, so nothing needs to be disconnected mid-test.

### Measurement

`postgres:alpine` (PG 18), `max_connections=100`, only the two `*ThreadPoolExecutorTest` classes in `load_async_test.rb` (`-n /LoadAsync(Multi|Mixed)ThreadPoolExecutorTest/`), `--seed=15223` (worst case for the baseline), N=5, container restart per run:

| | peak (5 runs) |
| --- | --- |
| BEFORE | 25, 23, 23, 26, 28 |
| AFTER | 2, 2, 2, 2, 2 (= fixture baseline) |

Methodology: [`yahonda/pg-leak-repro`](https://github.com/yahonda/rails/tree/yahonda/pg-leak-repro).

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message describes what changed and why.
- [x] Tests are updated.
- [ ] CHANGELOG — n/a, test-only fix.
