### PR TITLE
Avoid rebuilding the default encryption key provider on every with_encryption_context call

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Avoid rebuilding the default encryption key provider on every
+    `ActiveRecord::Encryption.with_encryption_context` call.
+
+    `with_encryption_context` dups the default context and pops it after the
+    block. `Context#key_provider` is lazily memoized. If it had never been
+    called on the default context, every dup built its own
+    `DerivedSecretKeyProvider` from scratch - running an expensive PBKDF2
+    derivation — and discarded it on pop. Once the default context's
+    `@key_provider` was initialized (for example by any direct read outside of
+    `with_encryption_context`), subsequent dups inherited the reference and
+    the problem disappeared, which made the bug order-dependent and easy to
+    miss.
+
+    `with_encryption_context` now memoizes `@key_provider` on the default
+    context before duping it, so the original is built once and every dup
+    inherits the same reference.
+
+    *Michał Zaporski*
+
 *   Fix Active Record Pool Reaper thread leak after `Parallelization#shutdown`.
 
     After parallelized test runs, the parent process leaked the Active Record Pool

--- a/activerecord/lib/active_record/encryption/contexts.rb
+++ b/activerecord/lib/active_record/encryption/contexts.rb
@@ -32,6 +32,10 @@ module ActiveRecord
         # Encryption contexts can be nested.
         def with_encryption_context(properties)
           self.custom_contexts ||= []
+          # Memoize +@key_provider+ on the default context before duping it.
+          # Without this, every dup may build +DerivedSecretKeyProvider+ from
+          # scratch, running an expensive PBKDF2 derivation.
+          default_context.key_provider
           self.custom_contexts << default_context.dup
           properties.each do |key, value|
             self.current_custom_context.send("#{key}=", value)

--- a/activerecord/test/cases/encryption/contexts_test.rb
+++ b/activerecord/test/cases/encryption/contexts_test.rb
@@ -51,6 +51,31 @@ class ActiveRecord::Encryption::ContextsTest < ActiveRecord::EncryptionTestCase
     end
   end
 
+  test ".with_encryption_context dups share the default context's key provider" do
+    ActiveRecord::Encryption.reset_default_context
+
+    providers = []
+    3.times do
+      ActiveRecord::Encryption.with_encryption_context(message_serializer: ActiveRecord::Encryption::MessageSerializer.new) do
+        providers << ActiveRecord::Encryption.key_provider
+      end
+    end
+
+    assert_equal 1, providers.uniq(&:object_id).size
+    assert_same ActiveRecord::Encryption.default_context.key_provider, providers.first
+  end
+
+  test ".with_encryption_context(key_provider:) still overrides the inherited key provider" do
+    ActiveRecord::Encryption.reset_default_context
+    override = ActiveRecord::Encryption::DerivedSecretKeyProvider.new("a different 256 bits key for now")
+
+    ActiveRecord::Encryption.with_encryption_context(key_provider: override) do
+      assert_same override, ActiveRecord::Encryption.key_provider
+    end
+
+    assert_not_same override, ActiveRecord::Encryption.default_context.key_provider
+  end
+
   test ".without_encryption won't decrypt or encrypt data automatically" do
     ActiveRecord::Encryption.without_encryption do
       assert_equal @title_ciphertext, @post.reload.title


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveRecord::Encryption.with_encryption_context` could repeatedly perform an expensive PBKDF2 derivation when called in a hot path.

`with_encryption_context` dups the default context and pops it after the block. `Context#key_provider` is lazily memoized. If `key_provider` had never been called on the default context, every dup built its own `DerivedSecretKeyProvider` from scratch (running an expensive PBKDF2 derivation) and discarded it on pop. Once the default context's `@key_provider` was initialized (for example by any direct read outside of `with_encryption_context`), subsequent dups inherited the reference and the problem disappeared, which made the bug order-dependent and easy to miss.

In practice this is triggered by any encrypted attribute declared with context-level properties (e.g. `encrypts :foo, message_serializer: ...`, `cipher: ...`, `encryptor: ...`), since `Scheme#with_context` wraps every read/write in `with_encryption_context`.

### Detail

This Pull Request changes `ActiveRecord::Encryption::Contexts#with_encryption_context` to force memoization of `@key_provider` on the default context **before** duping it. Once memoized on the source, the dup inherits the reference via shallow copy, so the PBKDF2 derivation runs once per process instead of potentially once per `with_encryption_context` call.

Two regression tests were added to `activerecord/test/cases/encryption/contexts_test.rb`:

- `.with_encryption_context dups share the default context's key provider` — asserts that across multiple `with_encryption_context` calls, the `key_provider` returned inside the block is the same object as `default_context.key_provider`.
- `.with_encryption_context(key_provider:) still overrides the inherited key provider` — asserts that explicit `key_provider:` overrides still take effect inside the block without leaking back to the default context.

### Additional information

The full Active Record encryption test suite passes locally on SQLite (`bundle exec rake test:sqlite3 TEST=test/cases/encryption/*_test.rb` — 214 runs, 900 assertions, 0 failures).

Public API of `with_encryption_context(key_provider: X)` is preserved: the override assignment happens after `dup`, so it still overrides whatever the dup inherited from the source.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
