### PR TITLE
Match HTML attribute quotes to actual output in ActionView docs [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/debug_helper.rb
+++ b/actionview/lib/action_view/helpers/debug_helper.rb
@@ -17,7 +17,7 @@ module ActionView
       #   @user = User.new({ username: 'testing', password: 'xyz', age: 42})
       #   debug(@user)
       #   # =>
-      #   <pre class='debug_dump'>--- !ruby/object:User
+      #   <pre class="debug_dump">--- !ruby/object:User
       #   attributes:
       #     updated_at:
       #     username: testing

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2620,7 +2620,7 @@ module ActionView
       #
       # ==== Examples
       #   button("Create article")
-      #   # => <button name='button' type='submit'>Create article</button>
+      #   # => <button name="button" type="submit">Create article</button>
       #
       #   button(:draft, value: true)
       #   # => <button id="article_draft" name="article[draft]" value="true" type="submit">Create article</button>
@@ -2628,14 +2628,14 @@ module ActionView
       #   button do
       #     content_tag(:strong, 'Ask me!')
       #   end
-      #   # => <button name='button' type='submit'>
+      #   # => <button name="button" type="submit">
       #   #      <strong>Ask me!</strong>
       #   #    </button>
       #
       #   button do |text|
       #     content_tag(:strong, text)
       #   end
-      #   # => <button name='button' type='submit'>
+      #   # => <button name="button" type="submit">
       #   #      <strong>Create article</strong>
       #   #    </button>
       #

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -370,7 +370,7 @@ module ActionView
       #   # => "<p>We want to put a paragraph...</p>\n\n<p>...right there.</p>"
       #
       #   simple_format("Look ma! A class!", class: 'description')
-      #   # => "<p class='description'>Look ma! A class!</p>"
+      #   # => "<p class=\"description\">Look ma! A class!</p>"
       #
       #   simple_format("<blink>Unblinkable.</blink>")
       #   # => "<p>Unblinkable.</p>"


### PR DESCRIPTION
### Motivation / Background

Several RDoc examples in ActionView helpers show HTML attributes wrapped in single quotes, but the helpers themselves emit double-quoted attributes. Copy-pasting an example into a spec, fixture, or test assertion silently disagrees with what the helper actually produces:

```ruby
# simple_format
> simple_format("Look ma! A class!", class: "description")
=> "<p class=\"description\">Look ma! A class!</p>"
# Doc says: "<p class='description'>Look ma! A class!</p>"

# button
> button("Create article")
=> "<button name=\"button\" type=\"submit\">Create article</button>"
# Doc says: <button name='button' type='submit'>Create article</button>
```

The discrepancy has been in the docs since these examples were added. None of the tests catch it because the tests assert on the real output, not the docs.

### Detail

Five RDoc examples updated to match the real helpers:

- `actionview/lib/action_view/helpers/text_helper.rb` — `simple_format` example with `class: 'description'`. The output line is wrapped in a Ruby string literal (consistent with the other `simple_format` examples), so the inner attribute quotes are escaped: `"<p class=\"description\">…</p>"`.
- `actionview/lib/action_view/helpers/debug_helper.rb` — `debug` example, bare-HTML style: `<pre class="debug_dump">`.
- `actionview/lib/action_view/helpers/form_helper.rb` — three `button` examples, bare-HTML style: `<button name="button" type="submit">…`.

`select_tag` (`form_tag_helper.rb:177`) intentionally keeps `selected='selected'` because that's the literal string the example passes through `raw(...)` — that markup flows verbatim to the output and is not a Rails-generated attribute.

### Additional information

- **Severity.** Documentation-only; no behavior change. `[ci skip]`.
- **Verification.**
  - Each helper was run locally to confirm it emits double-quoted attributes:
    ```
    > simple_format("Look ma! A class!", class: "description")
    => "<p class=\"description\">Look ma! A class!</p>"
    > debug(some_user)
    => "<pre class=\"debug_dump\">…</pre>"
    > button("Create article")
    => "<button name=\"button\" type=\"submit\">Create article</button>"
    ```
  - A `grep -rnE "# =>.*<[a-z]+ [a-z]+='[^']+'" actionview/lib actionpack/lib` confirms these were the only mismatched RDoc examples after the patch (the remaining hit is the intentional `select_tag` case above).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
