### PR TITLE
Preserve IPv6 prefix when dumping PostgreSQL `cidr`/`inet` defaults to schema.rb

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Preserve IPv6 prefix when dumping PostgreSQL `cidr` / `inet` defaults to `schema.rb`.
+
+    The schema dumper used to omit the prefix whenever it equaled `/32`, which
+    is the full mask for IPv4 but not for IPv6. As a result, an IPv6 default
+    such as `"::/32"` was written as `"::"` in `schema.rb` and reloaded as
+    `::/128`, silently dropping the subnet information. The prefix is now only
+    omitted when it covers the full address (`/32` for IPv4, `/128` for IPv6).
+
+    *Kenta Ishizaki*
+
 *   Fix deadlock when pool-less connection materializes while fetching database
     server version.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
@@ -12,8 +12,8 @@ module ActiveRecord
           end
 
           def type_cast_for_schema(value)
-            # If the subnet mask is equal to /32, don't output it
-            if value.prefix == 32
+            # If the subnet mask covers the full address, don't output it
+            if value.prefix == (value.ipv6? ? 128 : 32)
               "\"#{value}\""
             else
               "\"#{value}/#{value.prefix}\""

--- a/activerecord/test/cases/adapters/postgresql/cidr_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/cidr_test.rb
@@ -22,6 +22,23 @@ module ActiveRecord
           assert_equal "foo", type.serialize("foo")
         end
 
+        test "type_cast_for_schema keeps full IPv4 mask short" do
+          type = OID::Cidr.new
+
+          assert_equal %("192.168.1.0"),    type.type_cast_for_schema(IPAddr.new("192.168.1.0/32"))
+          assert_equal %("192.168.1.0/24"), type.type_cast_for_schema(IPAddr.new("192.168.1.0/24"))
+          assert_equal %("10.0.0.0/8"),     type.type_cast_for_schema(IPAddr.new("10.0.0.0/8"))
+        end
+
+        test "type_cast_for_schema keeps full IPv6 mask short" do
+          type = OID::Cidr.new
+
+          assert_equal %("::/32"),     type.type_cast_for_schema(IPAddr.new("::/32"))
+          assert_equal %("::/0"),      type.type_cast_for_schema(IPAddr.new("::/0"))
+          assert_equal %("fe80::/10"), type.type_cast_for_schema(IPAddr.new("fe80::/10"))
+          assert_equal %("::1"),       type.type_cast_for_schema(IPAddr.new("::1/128"))
+        end
+
         test "changed? with nil values" do
           type = OID::Cidr.new
 


### PR DESCRIPTION
### Motivation / Background

`OID::Cidr#type_cast_for_schema` is used by the schema dumper to render the default value of a PostgreSQL `cidr` (or `inet`) column as a Ruby string literal in `schema.rb`. It currently omits the prefix whenever it equals `/32`:

```ruby
# activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
def type_cast_for_schema(value)
  # If the subnet mask is equal to /32, don't output it
  if value.prefix == 32
    "\"#{value}\""
  else
    "\"#{value}/#{value.prefix}\""
  end
end
```

The comment makes the assumption explicit: `/32` is the full mask for IPv4. For IPv6 the full mask is `/128`, and `/32` is just one of many possible subnet prefixes (commonly assigned to ISPs, regions, etc.). As a result, an IPv6 default such as `"::/32"` is dumped as `"::"` in `schema.rb` and silently reloaded as `::/128`, dropping the subnet information.

```ruby
require "ipaddr"

orig = IPAddr.new("::/32")
# Current dumper output for IPv6 /32:
dump_literal = orig.prefix == 32 ? %("#{orig}") : %("#{orig}/#{orig.prefix}")
dump_literal                                  # => "\"::\""

reloaded = IPAddr.new(dump_literal[1..-2])
reloaded                                      # => #<IPAddr: IPv6:0000:0000:...:0000/ffff:ffff:...:ffff>
reloaded.prefix                               # => 128   # was 32 before the schema round-trip
```

So a migration like

```ruby
create_table :networks do |t|
  t.cidr :address, default: "::/32"
end
```

would, after `bin/rails db:schema:dump` followed by `db:schema:load`, end up with a default of `::/128`. The data the migration documents and the data the schema reproduces no longer agree.

### Detail

The fix is to ask `IPAddr` whether the value is IPv6 and pick the right "full-mask" prefix for that family:

```ruby
def type_cast_for_schema(value)
  # If the subnet mask covers the full address, don't output it
  if value.prefix == (value.ipv6? ? 128 : 32)
    "\"#{value}\""
  else
    "\"#{value}/#{value.prefix}\""
  end
end
```

This:

- preserves the existing IPv4 behavior (`192.168.1.0/32` → `"192.168.1.0"`, `192.168.1.0/24` → `"192.168.1.0/24"`),
- preserves IPv6 partial-prefix values that are currently corrupted (`::/32` → `"::/32"`, `fe80::/10` → `"fe80::/10"`, `::/0` → `"::/0"`),
- additionally drops the now-redundant `/128` from IPv6 full-host values for symmetry with IPv4 (`::1/128` → `"::1"`). This is a cosmetic change to `schema.rb` only — round-tripping the literal back through `IPAddr.new` yields the same address with the default `/128` prefix.

`OID::Inet` inherits from `OID::Cidr` and does not override `type_cast_for_schema`, so the fix applies to both `cidr` and `inet` columns.

Tests for `type_cast_for_schema` did not previously exist; two are added to `CidrTest` covering the IPv4-preserved cases and the IPv6 cases above.

### Additional information

- **Age.** `type_cast_for_schema` was introduced in 4321cd09a5 (May 2014, Yves Senn). The IPv4-only `/32` assumption has been carried unchanged since then.
- **Severity.** Silent corruption of `schema.rb` for PostgreSQL `cidr`/`inet` columns whose default is an IPv6 address with a non-`/128` prefix. Apps that don't store IPv6 networks in `cidr`/`inet` columns are unaffected.
- **Repro & verification.**
  - Self-contained reproduction (`IPAddr` only, no DB required):
    ```
    $ ruby -ripaddr -e '
      orig = IPAddr.new("::/32")
      dump = orig.prefix == 32 ? %("#{orig}") : %("#{orig}/#{orig.prefix}")
      reload = IPAddr.new(dump[1..-2])
      puts "dump=#{dump}  reload=#{reload}/#{reload.prefix}  prefix lost? #{orig.prefix != reload.prefix}"
    '
    dump="::"  reload=::/128  prefix lost? true
    ```
  - Local test runs against PostgreSQL 17:
    - `activerecord/test/cases/adapters/postgresql/cidr_test.rb` — 5 runs, 21 assertions, 0 failures (3 existing + 2 new).
    - `activerecord/test/cases/adapters/postgresql/network_test.rb` — 8 runs, 48 assertions, 0 failures (covers the existing IPv4 default `t.cidr "cidr_address", default: "192.168.1.0/24"` schema-dump assertion, confirming no IPv4 regression).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.