### PR TITLE
Fix PostgreSQL range column schema dump producing invalid Ruby

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix PostgreSQL `daterange` / `tsrange` / `tstzrange` schema dump producing
+    invalid Ruby.
+
+    The schema dumper used to render range defaults via `Range#inspect`, which
+    falls back to `Date#inspect` / `Time#inspect` for the bounds. The resulting
+    `schema.rb` literal (for example `default: Mon, 01 Jan 2024..Wed, 01 Jan 2025`)
+    raised a `SyntaxError` on `db:schema:load`. The bounds are now rendered via
+    the subtype's `type_cast_for_schema`, so date and timestamp range defaults
+    round-trip through `schema.rb` like any other column.
+
+    *Kenta Ishizaki*
+
 *   Respect `schema_search_path` on `rails dbconsole` for PostgreSQL.
 
     *Gabriel Sobrinho*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -14,7 +14,10 @@ module ActiveRecord
           end
 
           def type_cast_for_schema(value)
-            value.inspect.gsub("Infinity", "::Float::INFINITY")
+            from = bound_for_schema(value.begin)
+            to   = bound_for_schema(value.end)
+            op   = value.exclude_end? ? "..." : ".."
+            "#{from}#{op}#{to}"
           end
 
           def cast_value(value)
@@ -58,6 +61,19 @@ module ActiveRecord
           end
 
           private
+            def bound_for_schema(bound)
+              case bound
+              when nil
+                "nil"
+              when ::Float::INFINITY
+                "::Float::INFINITY"
+              when -::Float::INFINITY
+                "-::Float::INFINITY"
+              else
+                @subtype.type_cast_for_schema(bound)
+              end
+            end
+
             def type_cast_single(value)
               infinity?(value) ? value : @subtype.deserialize(value)
             end

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -676,6 +676,90 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     assert_nil record.float_range
   end
 
+  def test_type_cast_for_schema_with_integer_subtype
+    type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(
+      ActiveModel::Type::Integer.new, :int4range
+    )
+    assert_equal "1...10",  type.type_cast_for_schema(1...10)
+    assert_equal "1..10",   type.type_cast_for_schema(1..10)
+  end
+
+  def test_type_cast_for_schema_with_date_subtype
+    type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(
+      ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date.new, :daterange
+    )
+    assert_equal %("2024-01-01"..."2025-01-01"),
+                 type.type_cast_for_schema(::Date.new(2024, 1, 1)...::Date.new(2025, 1, 1))
+  end
+
+  def test_type_cast_for_schema_with_timestamp_subtype
+    type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(
+      ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Timestamp.new, :tsrange
+    )
+    assert_equal %("2024-01-01 00:00:00"..."2025-01-01 00:00:00"),
+                 type.type_cast_for_schema(Time.utc(2024, 1, 1)...Time.utc(2025, 1, 1))
+  end
+
+  def test_type_cast_for_schema_with_infinity
+    type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(
+      ActiveModel::Type::Float.new, :numrange
+    )
+    assert_equal "-::Float::INFINITY..::Float::INFINITY",
+                 type.type_cast_for_schema(-::Float::INFINITY..::Float::INFINITY)
+  end
+
+  def test_type_cast_for_schema_with_nil_bounds
+    type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(
+      ActiveModel::Type::Integer.new, :int4range
+    )
+    # beginless / endless ranges round-trip as nil literals (valid Ruby).
+    assert_equal "nil..10", type.type_cast_for_schema(::Range.new(nil, 10))
+    assert_equal "1..nil", type.type_cast_for_schema(::Range.new(1, nil))
+  end
+
+  def test_type_cast_for_schema_with_infinity_date_range
+    type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(
+      ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date.new, :daterange
+    )
+    assert_equal %(-::Float::INFINITY..."2025-01-01"),
+                 type.type_cast_for_schema(::Range.new(-::Float::INFINITY, ::Date.new(2025, 1, 1), true))
+    assert_equal %("2024-01-01"...::Float::INFINITY),
+                 type.type_cast_for_schema(::Range.new(::Date.new(2024, 1, 1), ::Float::INFINITY, true))
+  end
+
+  def test_type_cast_for_schema_with_nil_date_range
+    type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(
+      ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date.new, :daterange
+    )
+    assert_equal %(nil..."2025-01-01"),
+                 type.type_cast_for_schema(::Range.new(nil, ::Date.new(2025, 1, 1), true))
+    assert_equal %("2024-01-01"...nil),
+                 type.type_cast_for_schema(::Range.new(::Date.new(2024, 1, 1), nil, true))
+  end
+
+  def test_type_cast_for_schema_returns_valid_ruby
+    # Regression: previously a daterange / tsrange / tstzrange default was
+    # dumped via Range#inspect, producing literals like
+    # `"Mon, 01 Jan 2024..Wed, 01 Jan 2025"` that cannot be loaded as
+    # Ruby in schema.rb. Now every supported subtype must round-trip.
+    [
+      [::ActiveModel::Type::Integer.new, :int4range,   1...10],
+      [::ActiveModel::Type::Float.new,   :numrange,    1.5..2.5],
+      [ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Date.new, :daterange, ::Date.new(2024, 1, 1)...::Date.new(2025, 1, 1)],
+      [ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Timestamp.new, :tsrange, Time.utc(2024, 1, 1)...Time.utc(2025, 1, 1)],
+      [ActiveRecord::ConnectionAdapters::PostgreSQL::OID::TimestampWithTimeZone.new, :tstzrange, Time.utc(2024, 1, 1)...Time.utc(2025, 1, 1)],
+    ].each do |subtype, sql_type, range|
+      type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Range.new(subtype, sql_type)
+      dump = type.type_cast_for_schema(range)
+      compiled = begin
+        RubyVM::InstructionSequence.compile(dump)
+      rescue SyntaxError => e
+        flunk "schema literal #{dump.inspect} for #{sql_type} is not valid Ruby: #{e.message}"
+      end
+      assert_kind_of RubyVM::InstructionSequence, compiled
+    end
+  end
+
   private
     def assert_equal_round_trip(range, attribute, value)
       round_trip(range, attribute, value)


### PR DESCRIPTION
### Motivation / Background

`OID::Range#type_cast_for_schema` is used by the schema dumper to render the default value of a PostgreSQL range column (`int4range`, `numrange`, `daterange`, `tsrange`, `tstzrange`, …) as a Ruby literal in `schema.rb`. It currently delegates the whole job to `Range#inspect`:

```ruby
# activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
def type_cast_for_schema(value)
  value.inspect.gsub("Infinity", "::Float::INFINITY")
end
```

`Range#inspect` in turn calls `inspect` on each bound. That is Ruby-parseable for `Integer`, `Float`, infinite (`Float::INFINITY`) and beginless / endless bounds — those cases all round-trip today — but it breaks for `Date` and `Time` bounds, which are formatted by ActiveSupport's `inspect` overrides as human-readable strings:

```ruby
(Date.new(2024, 1, 1)...Date.new(2025, 1, 1)).inspect
# => "Mon, 01 Jan 2024...Wed, 01 Jan 2025"

(Time.utc(2024, 1, 1)...Time.utc(2025, 1, 1)).inspect
# => "2024-01-01 00:00:00 UTC...2025-01-01 00:00:00 UTC"
```

Neither of those is a valid Ruby expression. With a migration like

```ruby
create_table :events do |t|
  t.daterange :period, default: "[2024-01-01,2025-01-01)"
end
```

`bin/rails db:schema:dump` writes a `schema.rb` containing

```ruby
t.daterange "period", default: Mon, 01 Jan 2024...Wed, 01 Jan 2025
```

and a subsequent `bin/rails db:schema:load` (or `db:setup`) blows up with a `SyntaxError`. The same happens for `tsrange` and `tstzrange` defaults.

For comparison, plain `date` / `timestamp` / `timestamptz` columns are unaffected because their AM/AR types override `type_cast_for_schema` to call `value.to_fs(:db).inspect`, returning a proper quoted-string literal. Only `OID::Range` skips the subtype.

### Detail

Render each bound through the subtype's `type_cast_for_schema`, then glue them back together with the range operator. `nil` (beginless / endless) and `::Float::INFINITY` (introduced via `sanitize_bounds` when the DB sends `infinity`) are handled explicitly so their literals stay self-documenting:

```ruby
def type_cast_for_schema(value)
  from = bound_for_schema(value.begin)
  to   = bound_for_schema(value.end)
  op   = value.exclude_end? ? "..." : ".."
  "#{from}#{op}#{to}"
end

private
  def bound_for_schema(bound)
    case bound
    when nil
      "nil"
    when ::Float::INFINITY
      "::Float::INFINITY"
    when -::Float::INFINITY
      "-::Float::INFINITY"
    else
      @subtype.type_cast_for_schema(bound)
    end
  end
```

The behaviour change is restricted to `Date` / `Time` subtypes; the integer, float, infinity, beginless and endless cases produce equivalent or merely more explicit literals (all of which were valid Ruby before and remain valid after).

Resulting schema dumps:

| Range                                                  | Before                                                 | After                                              |
| ------------------------------------------------------ | ------------------------------------------------------ | -------------------------------------------------- |
| `1...10` (`int4range`)                                 | `1...10`                                               | `1...10` (unchanged)                               |
| `1.5..2.5` (`numrange`)                                | `1.5..2.5`                                             | `1.5..2.5` (unchanged)                             |
| `(-Float::INFINITY..Float::INFINITY)` (`numrange`)     | `-::Float::INFINITY..::Float::INFINITY`                | `-::Float::INFINITY..::Float::INFINITY` (unchanged)|
| `Date.new(2024,1,1)...Date.new(2025,1,1)` (`daterange`)| `Mon, 01 Jan 2024...Wed, 01 Jan 2025` ❌               | `"2024-01-01"..."2025-01-01"` ✅                   |
| `Time.utc(2024,1,1)...Time.utc(2025,1,1)` (`tsrange`)  | `2024-01-01 00:00:00 UTC...2025-01-01 00:00:00 UTC` ❌ | `"2024-01-01 00:00:00"..."2025-01-01 00:00:00"` ✅ |
| `nil..10` (beginless)                                  | `..10` (valid)                                         | `nil..10` (also valid; explicit)                   |
| `1..nil` (endless)                                     | `1..` (valid)                                          | `1..nil` (also valid; explicit)                    |

The reloaded range literals (e.g. `"2024-01-01"..."2025-01-01"`) flow back into `OID::Range#serialize` via `type_cast_single_for_database`, which already does `subtype.serialize(subtype.cast(bound))`. Round-trip through the actual `OID::Date` / `OID::Timestamp` / `OID::TimestampWithTimeZone` subtypes was verified on PostgreSQL 17.

### Additional information

- **Age.** `OID::Range#type_cast_for_schema` has rendered range bounds via `Range#inspect` since the range types were introduced. The Date / Time cases have been silently broken since then; there were no `type_cast_for_schema` tests for `OID::Range` at all.
- **Severity.** Loud failure (`SyntaxError`) during `db:schema:load` whenever an app uses a `daterange` / `tsrange` / `tstzrange` column with a default value. Range columns without defaults, and `int4range` / `numrange` defaults (including infinity cases), are unaffected.
- **Repro & verification.**
  - Direct reproduction of the failure mode using just the public `OID::Range` constructor + `RubyVM::InstructionSequence.compile`:
    ```
    [Range<Date>]      dump="Mon, 01 Jan 2024...Wed, 01 Jan 2025"               => SyntaxError
    [Range<Timestamp>] dump="2024-01-01 00:00:00 UTC...2025-01-01 00:00:00 UTC" => SyntaxError
    ```
    After the patch all five supported subtypes (Integer, Float, Date, Timestamp, TimestampWithTimeZone) compile cleanly.
  - End-to-end round-trip against a live PostgreSQL 17 instance for all four range subtypes (`int4range`, `daterange`, `tsrange`, `tstzrange`): dump literal → `eval` → `OID::Range#serialize` produced a Range that compared equal to the deserialized DB default in every case.
  - `activerecord/test/cases/adapters/postgresql/range_test.rb` — 55 runs, 236 assertions, 0 failures (47 existing + 8 new `test_type_cast_for_schema_*` cases, including a regression test that asserts every subtype dump compiles as Ruby, plus explicit `daterange` coverage for `Float::INFINITY` and `nil` bounds).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.