### PR TITLE
Freeze `LookupContext` default proc internals

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -15,12 +15,15 @@ module ActionView
   class LookupContext # :nodoc:
     attr_accessor :prefixes
 
-    singleton_class.attr_accessor :registered_details
-    self.registered_details = []
+    singleton_class.attr_accessor :default_procs
+    self.default_procs = {}.freeze
+
+    def self.registered_details
+      self.default_procs.keys
+    end
 
     def self.register_detail(name, &block)
-      registered_details << name
-      Accessors::DEFAULT_PROCS[name] = block
+      self.default_procs = self.default_procs.merge(name => block).freeze
 
       Accessors.define_method(:"default_#{name}", &block)
       Accessors.module_eval <<-METHOD, __FILE__, __LINE__ + 1
@@ -37,7 +40,6 @@ module ActionView
 
     # Holds accessors for the registered details.
     module Accessors # :nodoc:
-      DEFAULT_PROCS = {} # rubocop:disable Style/MutableConstant
     end
 
     register_detail(:locale) do
@@ -193,7 +195,7 @@ module ActionView
             if k == :variants
               details[k] = :any
             else
-              details[k] = Accessors::DEFAULT_PROCS[k].call
+              details[k] = LookupContext.default_procs[k].call
             end
           end
 
@@ -252,7 +254,7 @@ module ActionView
 
     def initialize_details(target, details)
       LookupContext.registered_details.each do |k|
-        target[k] = details[k] || Accessors::DEFAULT_PROCS[k].call
+        target[k] = details[k] || LookupContext.default_procs[k].call
       end
       target
     end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because we are working on freezing constants that are meant to be immutable to help unblock using Rails with Ractors. This is a follow up to https://github.com/rails/rails/pull/57323

### Detail

This Pull Request turns `DEFAULT_PROCS` into a class ivar. We can't freeze the `DEFAULT_PROCS` constant on `LookupContext::Accessors`, but we can turn the constant into a frozen class instance variable that we keep updating with a new copy every time a new detail is registered.

Moreover, we can use the keys of the same list as the `registered_details` list, thus removing a class instance variable in the process.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
