### PR TITLE
Fix incorrect SQL examples in ActiveRecord::QueryMethods docs

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -77,14 +77,14 @@ module ActiveRecord
       #
       #    Post.left_joins(:author).where.associated(:author)
       #    # SELECT "posts".* FROM "posts"
-      #    # LEFT OUTER JOIN "authors" "authors"."id" = "posts"."author_id"
+      #    # LEFT OUTER JOIN "authors" ON "authors"."id" = "posts"."author_id"
       #    # WHERE "authors"."id" IS NOT NULL
       #
       #    Post.left_joins(:comments).where.associated(:author)
       #    # SELECT "posts".* FROM "posts"
       #    # INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
       #    # LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id"
-      #   #  WHERE "author"."id" IS NOT NULL
+      #    # WHERE "authors"."id" IS NOT NULL
       def associated(*associations)
         associations.each do |association|
           reflection = scope_association_reflection(association)
@@ -583,10 +583,10 @@ module ActiveRecord
     # Allows you to change a previously set group statement.
     #
     #   Post.group(:title, :body)
-    #   # SELECT `posts`.`*` FROM `posts` GROUP BY `posts`.`title`, `posts`.`body`
+    #   # SELECT `posts`.* FROM `posts` GROUP BY `posts`.`title`, `posts`.`body`
     #
     #   Post.group(:title, :body).regroup(:title)
-    #   # SELECT `posts`.`*` FROM `posts` GROUP BY `posts`.`title`
+    #   # SELECT `posts`.* FROM `posts` GROUP BY `posts`.`title`
     #
     # This is short-hand for <tt>unscope(:group).group(fields)</tt>.
     # Note that we're unscoping the entire group statement.


### PR DESCRIPTION
### Summary

Three small docstring fixes in `activerecord/lib/active_record/relation/query_methods.rb`. The example SQL printed in the API docs didn't match what Rails actually generates.

### `where.associated` — missing `ON` keyword

```diff
-#    # LEFT OUTER JOIN "authors" "authors"."id" = "posts"."author_id"
+#    # LEFT OUTER JOIN "authors" ON "authors"."id" = "posts"."author_id"
```

### `where.associated` — wrong table name and misaligned comment

The sibling examples (and the actual generated SQL) join the `authors` table — the singular `"author"` was wrong. The same line also used `#   #  WHERE …` (3 spaces, double space) instead of the `#    # WHERE …` alignment used by every other line in the block.

```diff
-#   #  WHERE "author"."id" IS NOT NULL
+#    # WHERE "authors"."id" IS NOT NULL
```

### `regroup` — invalid backtick-quoted `*`

MySQL backticks quote identifiers; the `*` wildcard is not an identifier. `SELECT \`posts\`.\`*\`` would actually fail. Every other `regroup`/`group` example in this file renders `SELECT \`posts\`.*`.

```diff
-#   # SELECT `posts`.`*` FROM `posts` GROUP BY `posts`.`title`, `posts`.`body`
+#   # SELECT `posts`.* FROM `posts` GROUP BY `posts`.`title`, `posts`.`body`

-#   # SELECT `posts`.`*` FROM `posts` GROUP BY `posts`.`title`
+#   # SELECT `posts`.* FROM `posts` GROUP BY `posts`.`title`
```

### Notes

* Comment-only change, no behavior impact.
* CHANGELOG intentionally not updated (Rails convention for doc-only fixes).
* `[ci skip]` is in the commit subject.