### PR TITLE
Include valid values in ActiveRecord::Enum invalid-value error

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Include the list of valid values in the `ArgumentError` raised when assigning
+    an invalid value to an enum attribute.
+
+    ```ruby
+    Book.new(status: "bogus")
+    # ArgumentError: 'bogus' is not a valid status. Valid values are: "proposed", "written", "published"
+    ```
+
+    *Hammad Khan*
+
 *   Include the mismatched keys in the error raised by `insert_all` / `upsert_all`
     when the inserted objects have inconsistent attributes.
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -203,7 +203,7 @@ module ActiveRecord
         return unless @_raise_on_invalid_values
 
         unless value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
-          raise ArgumentError, "'#{value}' is not a valid #{name}"
+          raise ArgumentError, "'#{value}' is not a valid #{name}. Valid values are: #{mapping.keys.map(&:inspect).join(", ")}"
         end
       end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -317,7 +317,8 @@ class EnumTest < ActiveRecord::TestCase
     e = assert_raises(ArgumentError) do
       @book.status = :unknown
     end
-    assert_equal "'unknown' is not a valid status", e.message
+    assert_match(/\A'unknown' is not a valid status\./, e.message)
+    assert_match(/"proposed"/, e.message)
   end
 
   test "validation with 'validate: true' option" do


### PR DESCRIPTION
### Motivation

When assigning a value that isn't a member of an enum, the `ArgumentError` Rails raises gives no hint at what *is* valid:

```ruby
Book.new(status: "bogus")
# ArgumentError: 'bogus' is not a valid status
```

For any model with more than a couple of enum members, the developer then has to open the model definition just to find out which value to use. Listing the valid values directly in the error message is a meaningful debugging UX improvement and zero behavior risk — same exception class, same trigger.

### After

```ruby
Book.new(status: "bogus")
# ArgumentError: 'bogus' is not a valid status. Valid values are: "proposed", "written", "published"
```

### Implementation

One-line change in `activerecord/lib/active_record/enum.rb` — appends the mapping keys to the existing message. Uses `Symbol#inspect` so the strings render with quotes and remain unambiguous regardless of whether the enum was defined with symbols or strings.

### Tests

Exactly one test in `enum_test.rb` asserted the previous message verbatim. It now uses two `assert_match` checks: one for the unchanged prefix, one confirming a known valid value (`"proposed"`) is present. This keeps the test robust if a future contributor reorders the mapping.

### CHANGELOG

Top entry added in `activerecord/CHANGELOG.md` with a before/after example.

### Verification

```
$ ARCONN=sqlite3_mem bundle exec ruby -Itest test/cases/enum_test.rb
100 runs, 477 assertions, 0 failures, 0 errors, 0 skips
$ bundle exec rubocop activerecord/lib/active_record/enum.rb activerecord/test/cases/enum_test.rb
2 files inspected, no offenses detected
```