### PR TITLE
Improve insert_all error message to show key mismatch

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Include the mismatched keys in the error raised by `insert_all` / `upsert_all`
+    when the inserted objects have inconsistent attributes.
+
+    ```ruby
+    Book.insert_all [{ name: "Rework", author_id: 1 }, { name: "Remote", author_id: 1, isbn: "x" }]
+    # ArgumentError: All objects being inserted must have the same keys (extra: [:isbn])
+    ```
+
+    *Hammad Khan*
+
 *   Allow `create_join_table` to accept a primary key.
 
     This is useful for databases like PostgreSQL where logical replication requires primary

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -206,7 +206,12 @@ module ActiveRecord
 
       def verify_attributes(attributes)
         if keys_including_timestamps != attributes.keys.sort!
-          raise ArgumentError, "All objects being inserted must have the same keys"
+          missing = keys_including_timestamps - attributes.keys
+          extra = attributes.keys - keys_including_timestamps
+          details = []
+          details << "missing: #{missing.inspect}" if missing.any?
+          details << "extra: #{extra.inspect}" if extra.any?
+          raise ArgumentError, "All objects being inserted must have the same keys (#{details.join(", ")})"
         end
       end
 

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -543,6 +543,27 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_raises_with_key_diff_when_attributes_mismatch
+    error = assert_raises ArgumentError do
+      Book.insert_all [
+        { name: "Rework", author_id: 1 },
+        { name: "Remote", author_id: 1, isbn: "1974522598" }
+      ]
+    end
+    assert_match(/All objects being inserted must have the same keys/, error.message)
+    assert_match(/extra: \["isbn"\]/, error.message)
+  end
+
+  def test_insert_all_raises_with_missing_key_when_attributes_mismatch
+    error = assert_raises ArgumentError do
+      Book.insert_all [
+        { name: "Rework", author_id: 1, isbn: "1974522598" },
+        { name: "Remote", author_id: 1 }
+      ]
+    end
+    assert_match(/missing: \["isbn"\]/, error.message)
+  end
+
   def test_upsert_all_only_updates_the_column_provided_via_update_only
     skip unless supports_insert_on_duplicate_update?
 


### PR DESCRIPTION
### Motivation

`insert_all` / `upsert_all` raise an `ArgumentError` when the inserted objects don't all share the same set of keys, but the message gives no hint at *which* keys are wrong:

```ruby
Book.insert_all [
  { name: "Rework", author_id: 1 },
  { name: "Remote", author_id: 1, isbn: "1974522598" }
]
# ArgumentError: All objects being inserted must have the same keys
```

For wide tables or long batches this is painful — you have to eyeball every hash to find the odd one out. Reporting the missing and extra keys is a meaningful debugging UX improvement.

### After

```ruby
# ArgumentError: All objects being inserted must have the same keys (extra: ["isbn"])
```

```ruby
# ArgumentError: All objects being inserted must have the same keys (missing: ["isbn"])
```

### Implementation

`activerecord/lib/active_record/insert_all.rb`: compute the symmetric difference inline in `verify_attributes` and append a parenthesised summary. No new helper methods, no extra allocations on the happy path (the diff is only computed when the error is about to be raised). KISS/YAGNI honoured.

### Tests

Two new tests in `insert_all_test.rb` covering both the `extra` and `missing` paths. I confirmed with `grep` that no existing test asserted on the prior message text, so this PR doesn't change anyone's expectations of an exact string.

### Verification

```
$ ARCONN=sqlite3_mem bundle exec ruby -Itest test/cases/insert_all_test.rb
97 runs, 227 assertions, 0 failures, 0 errors, 4 skips
$ bundle exec rubocop activerecord/lib/active_record/insert_all.rb activerecord/test/cases/insert_all_test.rb
2 files inspected, no offenses detected
```

CHANGELOG entry added at the top of `activerecord/CHANGELOG.md`.