### PR TITLE
Fix grammar in ActiveRecord errors and integration doc comments

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -306,7 +306,7 @@ module ActiveRecord
   class ExclusionViolation < StatementInvalid
   end
 
-  # Raised when a record cannot be inserted or updated because a value too long for a column type.
+  # Raised when a record cannot be inserted or updated because a value is too long for a column type.
   class ValueTooLong < StatementInvalid
   end
 

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -34,7 +34,7 @@ module ActiveRecord
 
     # Returns a +String+, which Action Pack uses for constructing a URL to this
     # object. The default implementation returns this record's id as a +String+,
-    # or +nil+ if this record's unsaved.
+    # or +nil+ if this record is unsaved.
     #
     # For example, suppose that you have a User model, and that you have a
     # <tt>resources :users</tt> route. Normally, +user_path+ will


### PR DESCRIPTION
Two small grammar fixes in user-facing API docs. Comment-only diff, no behavior or test impact.

### `activerecord/lib/active_record/errors.rb`

The `ValueTooLong` exception description was missing the verb in its subordinate clause. Sibling entries in the same file all use grammatically complete clauses (e.g. line 234 "because it would violate a uniqueness constraint").

```diff
- # Raised when a record cannot be inserted or updated because a value too long for a column type.
+ # Raised when a record cannot be inserted or updated because a value is too long for a column type.
```

### `activerecord/lib/active_record/integration.rb`

`to_param`'s docstring used the contraction `record's unsaved`, which reads as a possessive (the record's [attribute called] unsaved) rather than the intended "record is unsaved".

```diff
- # or +nil+ if this record's unsaved.
+ # or +nil+ if this record is unsaved.
```

### Notes

* Comment-only edit, no behavior impact.
* No CHANGELOG entry (Rails convention for doc-only fixes).
* `[ci skip]` is in the commit subject.