### PR TITLE
Deep-freeze `NumberConverter::DEFAULTS`

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -33,7 +33,7 @@ module ActiveSupport
           significant: false,
           # If set, the zeros after the decimal separator will always be stripped (e.g.: 1.200 will be 1.2)
           strip_insignificant_zeros: false
-        },
+        }.freeze,
 
         # Used in number_to_currency
         currency: {
@@ -47,23 +47,23 @@ module ActiveSupport
             precision: 2,
             significant: false,
             strip_insignificant_zeros: false
-          }
-        },
+          }.freeze
+        }.freeze,
 
         # Used in number_to_percentage
         percentage: {
           format: {
             delimiter: "",
             format: "%n%"
-          }
-        },
+          }.freeze
+        }.freeze,
 
         # Used in number_to_rounded
         precision: {
           format: {
             delimiter: ""
-          }
-        },
+          }.freeze
+        }.freeze,
 
         # Used in number_to_human_size and number_to_human
         human: {
@@ -73,7 +73,7 @@ module ActiveSupport
             precision: 3,
             significant: true,
             strip_insignificant_zeros: true
-          },
+          }.freeze,
           # Used in number_to_human_size
           storage_units: {
             # Storage units output formatting.
@@ -85,8 +85,8 @@ module ActiveSupport
               mb: "MB",
               gb: "GB",
               tb: "TB"
-            }
-          },
+            }.freeze
+          }.freeze,
           # Used in number_to_human
           decimal_units: {
             format: "%n %u",
@@ -112,9 +112,9 @@ module ActiveSupport
               billion: "Billion",
               trillion: "Trillion",
               quadrillion: "Quadrillion"
-            }
-          }
-        }
+            }.freeze
+          }.freeze
+        }.freeze
       }.freeze
 
       def self.convert(number, options)


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because we are working on freezing constants that are meant to be immutable to help unblock using Rails with Ractors. This is a follow up to https://github.com/rails/rails/pull/57323

### Detail

This Pull Request changes `NumberConverter::DEFAULTS` to be deeply frozen. The outer `Hash` was already `.freeze`d by the `Style/MutableConstant` cop, but the nested Hashes underneath weren't, so the constant wasn't deeply frozen, and thus not shareable.

Add `.freeze` to each nested Hash literal so the whole tree is frozen and shareable.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
