### PR TITLE
Format non-finite numbers consistently in NumberHelper significant mode

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix `NumberHelper` raising `FloatDomainError` for `Infinity` / `NaN` with
+    `significant: true`.
+
+    `number_to_rounded(Float::INFINITY, precision: 3, significant: true)` (and
+    its callers `number_to_percentage`, `number_to_currency`, etc.) raised
+    `FloatDomainError` because `RoundingHelper#digit_count` called
+    `Math.log10(Float::INFINITY).floor`. The non-`significant` path already
+    formatted these values as `"Inf"` / `"-Inf"` / `"NaN"`; the two paths now
+    agree.
+
+    *Kenta Ishizaki*
+
 *   Fix `number_to_delimited` mangling non-finite floats.
 
     `number_to_delimited(Float::INFINITY)` returned `"In,fin,ity"` because the

--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -19,6 +19,7 @@ module ActiveSupport
 
       def digit_count(number)
         return 1 if number.zero?
+        return 1 unless number.respond_to?(:finite?) && number.finite?
         (Math.log10(number.abs) + 1).floor
       end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -248,6 +248,16 @@ module ActiveSupport
         end
       end
 
+      def test_to_rounded_with_significant_true_and_non_finite_value
+        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+          assert_equal "Inf",  number_helper.number_to_rounded(Float::INFINITY,  precision: 3, significant: true)
+          assert_equal "-Inf", number_helper.number_to_rounded(-Float::INFINITY, precision: 3, significant: true)
+          assert_equal "NaN",  number_helper.number_to_rounded(Float::NAN,       precision: 3, significant: true)
+          assert_equal "Inf%", number_helper.number_to_percentage(Float::INFINITY, precision: 3, significant: true)
+          assert_equal "$Inf", number_helper.number_to_currency(Float::INFINITY,   precision: 3, significant: true)
+        end
+      end
+
       def test_to_rounded_with_strip_insignificant_zeros
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal "9775.43", number_helper.number_to_rounded(9775.43, precision: 4, strip_insignificant_zeros: true)


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::NumberHelper.number_to_rounded` already formats infinities and NaN as `"Inf"`, `"-Inf"`, `"NaN"`:

```ruby
ActiveSupport::NumberHelper.number_to_rounded(Float::INFINITY, precision: 3)
# => "Inf"
ActiveSupport::NumberHelper.number_to_rounded(Float::NAN, precision: 3)
# => "NaN"
```

This is the explicit `rounded_number.finite?` branch in `NumberToRoundedConverter#convert` that falls back to `"%f" % rounded_number`.

Once `significant: true` is added, however, the same input raises `FloatDomainError`:

```ruby
ActiveSupport::NumberHelper.number_to_rounded(Float::INFINITY, precision: 3, significant: true)
# => FloatDomainError: Infinity
```

The crash propagates to every helper that routes through `RoundingHelper` with the same options — `number_to_percentage`, `number_to_currency`, `number_to_delimited`. The default options for `number_to_human` and `number_to_human_size` use `significant: true` internally too, but those helpers have additional `log10` / `log` calls of their own that are out of scope here (see *Additional information*).

The bug shows up most often when a calculation can produce `Infinity` — division by zero on a Float, an overflowed `**`, an imported value with a literal `"Infinity"` — and the result is then handed to a formatter:

```ruby
total   = 100.0
seconds = 0
rate    = total / seconds                                      # => Infinity
number_to_rounded(rate, precision: 3, significant: true)
# Expected: "Inf" (consistent with the non-significant path)
# Actual:   FloatDomainError
```

### Detail

The crash is on this line in `RoundingHelper#digit_count`:

```ruby
def digit_count(number)
  return 1 if number.zero?
  (Math.log10(number.abs) + 1).floor   # ← Math.log10(Infinity) → Infinity; .floor → FloatDomainError
end
```

`digit_count` is called both from `RoundingHelper#absolute_precision` (when `significant: true && precision > 0`) and from `NumberToRoundedConverter#convert` when reducing the precision for significant-digit rounding.

The smallest fix is to make `digit_count` aware of non-finite inputs:

```ruby
def digit_count(number)
  return 1 if number.zero?
  return 1 unless number.respond_to?(:finite?) && number.finite?
  (Math.log10(number.abs) + 1).floor
end
```

`1` is the value the rest of the pipeline already tolerates well — `absolute_precision` becomes `precision - 1`, `BigDecimal("Infinity").round(n)` returns `Infinity` unchanged for any `n`, and the converter's `rounded_number.finite?` branch formats it via `"%f"`. The cases that previously worked (`number_to_rounded(0)`, `Float#zero?` → `return 1`) are unaffected because the early return for `zero?` is checked before the new guard.

### Prior art

A 2016 attempt — #25946 — tried to fix `number_to_rounded`, `number_to_percentage`, and `number_to_human` together. It was closed in 2019 after review feedback (matthewd) that `"Inf"` / `"NaN"` aren't particularly *human*-readable output for `number_to_human`. This PR intentionally addresses only the `RoundingHelper` path (`number_to_rounded` / `_percentage` / `_currency` / `_delimited`), where the non-significant path *already* returns `"Inf"` / `"-Inf"` / `"NaN"` — so we're restoring consistency within a single helper's two paths, not introducing a new formatting convention. `number_to_human` is explicitly left out for that reason.

### Additional information

- **Age.** `digit_count` has used `Math.log10(number.abs).floor` since the helper was introduced. The `rounded_number.finite?` formatting branch in the converter was already in place, so the design intent was clearly to support these values — `digit_count` just never got the matching guard.
- **Severity.** Low–Medium. Rare input but a hard crash with no in-helper workaround; once the value reaches the formatter it's already too late. Same `Infinity` input on the non-significant path returns `"Inf"`, so the two paths of the same helper currently disagree.
- **Scope.** This PR only touches `RoundingHelper#digit_count`, which fixes `number_to_rounded`, `number_to_percentage`, `number_to_currency`, and `number_to_delimited` for `Infinity` / `-Infinity` / `NaN` with `significant: true`. `number_to_human` and `number_to_human_size` call `Math.log10` / `Math.log` directly inside their own `calculate_exponent` / `exponent` methods and will still raise on `Infinity`. I deliberately kept that out of this PR (different code path, different fix surface) — happy to follow up in a separate PR if reviewers prefer.
- **Verification.**
  - Standalone reproduction (each is a fresh process to confirm the crash is not state-dependent):
    ```
    Infinity   significant=true => "Inf"   (was FloatDomainError)
    -Infinity  significant=true => "-Inf"  (was FloatDomainError)
    NaN        significant=true => "NaN"   (was FloatDomainError)
    Infinity   number_to_percentage(.., significant: true) => "Inf%"
    Infinity   number_to_currency(..,   significant: true) => "$Inf"
    ```
  - `activesupport/test/number_helper_test.rb` — 23 runs, 843 assertions, 0 failures, 0 errors. A new `test_to_rounded_with_significant_true_and_non_finite_value` test asserts the formatted strings for `Inf`, `-Inf`, `NaN` through `number_to_rounded`, `number_to_percentage`, and `number_to_currency`.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.