### PR TITLE
Handle malformed Mandrill events payloads in Action Mailbox

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Return `422 Unprocessable Content` for Mandrill events payloads that don't parse to a JSON array of objects.
+
+    Previously, valid JSON of the wrong shape (e.g. `null`, a scalar, an object, or an array containing non-objects)
+    raised an unhandled `NoMethodError` and resulted in a 500. This now matches the existing behavior for invalid JSON.
+
+    *Nesan Vettivel*
+
 *   Deprecate `Mail::Address.wrap` because it isn't used.
 
     *Gannon McGibbon*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
@@ -20,7 +20,7 @@ module ActionMailbox
     def create
       raw_emails.each { |raw_email| ActionMailbox::InboundEmail.create_and_extract_message_id! raw_email }
       head :ok
-    rescue JSON::ParserError => error
+    rescue JSON::ParserError, MalformedEventsError => error
       logger.error error.message
       head ActionDispatch::Constants::UNPROCESSABLE_CONTENT
     end
@@ -30,12 +30,20 @@ module ActionMailbox
     end
 
     private
+      class MalformedEventsError < StandardError
+        def initialize(message = "Malformed Mandrill events payload")
+          super
+        end
+      end
+
       def raw_emails
         events.select { |event| event["event"] == "inbound" }.collect { |event| event.dig("msg", "raw_msg") }
       end
 
       def events
-        JSON.parse params.require(:mandrill_events)
+        JSON.parse(params.require(:mandrill_events)).tap do |parsed|
+          raise MalformedEventsError unless parsed.is_a?(Array) && parsed.all?(Hash)
+        end
       end
 
 

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -2,10 +2,16 @@
 
 require "test_helper"
 
-ENV["MAILGUN_INGRESS_SIGNING_KEY"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
-
 class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDispatch::IntegrationTest
-  setup { ActionMailbox.ingress = :mailgun }
+  setup do
+    @previous_key = ENV["MAILGUN_INGRESS_SIGNING_KEY"]
+    ENV["MAILGUN_INGRESS_SIGNING_KEY"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
+    ActionMailbox.ingress = :mailgun
+  end
+
+  teardown do
+    ENV["MAILGUN_INGRESS_SIGNING_KEY"] = @previous_key
+  end
 
   test "receiving an inbound email from Mailgun" do
     assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do

--- a/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
@@ -29,6 +29,46 @@ class ActionMailbox::Ingresses::Mandrill::InboundEmailsControllerTest < ActionDi
     assert_equal "0CB459E0-0336-41DA-BC88-E6E28C697DDB@37signals.com", inbound_email.message_id
   end
 
+  test "rejecting a Mandrill events payload that is not a JSON array" do
+    events = JSON.generate({ event: "inbound" })
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_mandrill_inbound_emails_url,
+        headers: { "X-Mandrill-Signature" => signature_for(events) }, params: { mandrill_events: events }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test "rejecting a Mandrill events payload that parses to null" do
+    events = "null"
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_mandrill_inbound_emails_url,
+        headers: { "X-Mandrill-Signature" => signature_for(events) }, params: { mandrill_events: events }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test "rejecting a Mandrill events array that contains non-objects" do
+    events = JSON.generate([{ event: "inbound" }, "not-a-hash"])
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_mandrill_inbound_emails_url,
+        headers: { "X-Mandrill-Signature" => signature_for(events) }, params: { mandrill_events: events }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test "rejecting a Mandrill events payload that parses to a scalar" do
+    events = "42"
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_mandrill_inbound_emails_url,
+        headers: { "X-Mandrill-Signature" => signature_for(events) }, params: { mandrill_events: events }
+    end
+
+    assert_response :unprocessable_content
+  end
+
   test "rejecting a forged inbound email from Mandrill" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       post rails_mandrill_inbound_emails_url,
@@ -65,6 +105,11 @@ class ActionMailbox::Ingresses::Mandrill::InboundEmailsControllerTest < ActionDi
   end
 
   private
+    def signature_for(events)
+      message = rails_mandrill_inbound_emails_url + { "mandrill_events" => events }.sort.flatten.join
+      Base64.strict_encode64 OpenSSL::HMAC.digest(OpenSSL::Digest::SHA1.new, ENV["MANDRILL_INGRESS_API_KEY"], message)
+    end
+
     def switch_key_to(new_key)
       previous_key, ENV["MANDRILL_INGRESS_API_KEY"] = ENV["MANDRILL_INGRESS_API_KEY"], new_key
       yield

--- a/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
@@ -2,12 +2,16 @@
 
 require "test_helper"
 
-ENV["MANDRILL_INGRESS_API_KEY"] = "1l9Qf7lutEf7h73VXfBwhw"
-
 class ActionMailbox::Ingresses::Mandrill::InboundEmailsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    @previous_key = ENV["MANDRILL_INGRESS_API_KEY"]
+    ENV["MANDRILL_INGRESS_API_KEY"] = "1l9Qf7lutEf7h73VXfBwhw"
     ActionMailbox.ingress = :mandrill
     @events = JSON.generate([{ event: "inbound", msg: { raw_msg: file_fixture("../files/welcome.eml").read } }])
+  end
+
+  teardown do
+    ENV["MANDRILL_INGRESS_API_KEY"] = @previous_key
   end
 
   test "verifying existence of Mandrill inbound route" do

--- a/actionmailbox/test/test_helper.rb
+++ b/actionmailbox/test/test_helper.rb
@@ -3,7 +3,6 @@
 require_relative "../../tools/strict_warnings"
 
 ENV["RAILS_ENV"] = "test"
-ENV["RAILS_INBOUND_EMAIL_PASSWORD"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
 
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../test/dummy/db/migrate", __dir__) ]
@@ -28,6 +27,15 @@ class ActiveSupport::TestCase
 end
 
 class ActionDispatch::IntegrationTest
+  setup do
+    @previous_inbound_email_password = ENV["RAILS_INBOUND_EMAIL_PASSWORD"]
+    ENV["RAILS_INBOUND_EMAIL_PASSWORD"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
+  end
+
+  teardown do
+    ENV["RAILS_INBOUND_EMAIL_PASSWORD"] = @previous_inbound_email_password
+  end
+
   private
     def credentials
       ActionController::HttpAuthentication::Basic.encode_credentials "actionmailbox", ENV["RAILS_INBOUND_EMAIL_PASSWORD"]


### PR DESCRIPTION
### Motivation / Background

The Mandrill ingress returns `422 Unprocessable Content` for invalid JSON in `mandrill_events`, but valid JSON of the wrong shape (`null`, a scalar, a hash, or an array containing non-objects) makes `.select` raise `NoMethodError` (or `TypeError` for non-object elements). That's a 500 instead of a 422.

### Detail

Validate that the parsed payload is an Array of Hashes before iterating. A malformed payload now raises `MalformedEventsError`, which the existing `rescue` handles alongside `JSON::ParserError`, returning `422 Unprocessable Content` without creating inbound emails.

### Additional information

Before the fix, a malformed-shape payload raised `NoMethodError: private method 'select' called for nil:NilClass` from `raw_emails`.

Validation:

```bash
cd actionmailbox && bin/test test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
cd actionmailbox && bin/test
bundle exec rubocop actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
git diff --check