### PR TITLE
Fix HTML-aware ERB compiler errors in bundled templates so they apss strict validations

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
@@ -4,7 +4,7 @@ Routing Error
 <% unless @exception.failures.empty? %>
 Failure reasons:
 <% @exception.failures.each do |route, reason| %>
-  - <%= route.inspect.delete('\\') %></code> failed because <%= reason.downcase %>
+  - <%= route.inspect.delete('\\') %> failed because <%= reason.downcase %>
 <% end %>
 <% end %>
 

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -68,9 +68,9 @@
           <span id="version-switcher" class="js-only">
             <label for="version-switcher-select">Version: <span class="visibly-hidden">pick from the list to go to that Rails version's guides</span></label>
             <select id="version-switcher-select" class="guides-version">
-              <option value="https://edgeguides.rubyonrails.org/"<%= " selected" if @edge %>>Edge</option>
+              <option value="https://edgeguides.rubyonrails.org/"<% if @edge %> selected<% end %>>Edge</option>
               <% %w[8.1 8.0 7.2 7.1 7.0 6.1 6.0 5.2 5.1 5.0 4.2 4.1 4.0 3.2 3.1 3.0 2.3].each do |version| %>
-                <option value="https://guides.rubyonrails.org/v<%= version %>/<%= @path %>"<%= " selected" if @version&.start_with?("v#{version}") %>><%= version %></option>
+                <option value="https://guides.rubyonrails.org/v<%= version %>/<%= @path %>"<% if @version&.start_with?("v#{version}") %> selected<% end %>><%= version %></option>
               <% end %>
             </select>
           </span>

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -117,8 +117,8 @@
     <% if @email.html_part && @email.text_part %>
       <dd>
         <select id="part" onchange="refreshBody(false);">
-          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="<%= part_query('text/html') %>">View as HTML email</option>
-          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="<%= part_query('text/plain') %>">View as plain-text email</option>
+          <option<% if request.format == Mime[:html] %> selected<% end %> value="<%= part_query('text/html') %>">View as HTML email</option>
+          <option<% if request.format == Mime[:text] %> selected<% end %> value="<%= part_query('text/plain') %>">View as plain-text email</option>
         </select>
       </dd>
     <% elsif @part %>
@@ -132,7 +132,7 @@
       <dd>
         <select id="locale" onchange="refreshBody(true);">
           <% I18n.available_locales.each do |locale| %>
-            <option <%= I18n.locale == locale ? 'selected' : '' %> value="<%= locale_query(locale) %>"><%= locale %></option>
+            <option<% if I18n.locale == locale %> selected<% end %> value="<%= locale_query(locale) %>"><%= locale %></option>
           <% end %>
         </select>
       </dd>

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -617,21 +617,21 @@ module ApplicationTests
       get "/rails/mailers/notifier/foo.html"
       assert_equal 200, last_response.status
       assert_match '<option selected value="locale=en">en', last_response.body
-      assert_match '<option  value="locale=ja">ja', last_response.body
+      assert_match '<option value="locale=ja">ja', last_response.body
 
       get "/rails/mailers/notifier/foo.html?locale=ja"
       assert_equal 200, last_response.status
-      assert_match '<option  value="locale=en">en', last_response.body
+      assert_match '<option value="locale=en">en', last_response.body
       assert_match '<option selected value="locale=ja">ja', last_response.body
 
       get "/rails/mailers/notifier/foo.txt"
       assert_equal 200, last_response.status
       assert_match '<option selected value="locale=en">en', last_response.body
-      assert_match '<option  value="locale=ja">ja', last_response.body
+      assert_match '<option value="locale=ja">ja', last_response.body
 
       get "/rails/mailers/notifier/foo.txt?locale=ja"
       assert_equal 200, last_response.status
-      assert_match '<option  value="locale=en">en', last_response.body
+      assert_match '<option value="locale=en">en', last_response.body
       assert_match '<option selected value="locale=ja">ja', last_response.body
     end
 
@@ -708,7 +708,7 @@ module ApplicationTests
       assert_equal 200, last_response.status
       assert_match '<iframe name="messageBody" src="?part=text%2Fplain">', last_response.body
       assert_match '<option selected value="part=text%2Fplain">', last_response.body
-      assert_match '<option  value="part=text%2Fhtml">', last_response.body
+      assert_match '<option value="part=text%2Fhtml">', last_response.body
 
       get "/rails/mailers/notifier/foo?part=text%2Fplain"
       assert_equal 200, last_response.status
@@ -718,7 +718,7 @@ module ApplicationTests
       assert_equal 200, last_response.status
       assert_match '<iframe name="messageBody" src="?name=Ruby&amp;part=text%2Fhtml">', last_response.body
       assert_match '<option selected value="name=Ruby&amp;part=text%2Fhtml">', last_response.body
-      assert_match '<option  value="name=Ruby&amp;part=text%2Fplain">', last_response.body
+      assert_match '<option value="name=Ruby&amp;part=text%2Fplain">', last_response.body
 
       get "/rails/mailers/notifier/foo?name=Ruby&part=text%2Fhtml"
       assert_equal 200, last_response.status


### PR DESCRIPTION
The Herb gem (0.10+) ships a strict, HTML-aware ERB compiler that performs HTML5 nesting and ERB-attribute-position validation at compile time. Apps that adopt it raise `Herb::Engine::*Error` when Rails autoloads its own bundled templates. Three issues remained:

- `rescues/routing_error.text.erb` carried a stray `</code>` closing tag with no opener since the file was added in 2013 (a725a453b3). The literal text `</code>` was being rendered into xhr/text error responses unnoticed.

- The mailer preview's `email.html.erb` rendered the `selected` HTML attribute via ERB output (`<%= ... %>`) sitting in the attribute-name slot of `<option>`. Switch to control-flow ERB (`<% if %> selected<% end %>`) so the attribute is static text. Side effect: the unselected branch no longer emits a stray double space inside `<option  value=...>`; the mailer previews tests are updated accordingly.

- `guides/source/layout.html.erb`'s version switcher used the same ERB-in-attribute-position idiom; converted to control flow.

After this change every bundled `.erb` template compiles cleanly under Herb 0.10's strict validator - and it's  generally more correct HTML.

### Motivation / Background

This Pull Request has been created because apps using the Herb 0.10 gem as their ERB engine cannot boot on Rails 8.1.x: as soon as Rails autoloads one of its bundled templates, Herb's compile-time HTML-aware validator raises `Herb::Engine::InvalidNestingError` or `Herb::Engine::SecurityError` and the template never compiles.

Commit 84023dfd1f ("h2 and ol are no valid tags inside paragraphs") already fixed the most visible case: `<p><h2/><ol/></p>` in `rescues/routing_error.html.erb`. Auditing every other shipped `.erb` template surfaced three further violations that prevent clean compilation, plus one latent rendering bug from 2013. This PR closes them.

A parallel issue was filed at herb (https://github.com/marcoroth/herb/issues/1744) asking for per-path validator scoping as a downstream mitigation, but invalid markup in Rails' own bundled templates is IMHO the correct thing to fix here.

### Detail

This Pull Request changes four files:

- **`actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb`**: Remove a stray `</code>` closing tag with no opening counterpart. Introduced 2013 in a725a453b3 when the text template was created alongside the HTML one; the closing tag was kept but the opening `<code>` was dropped. The literal characters `</code>` have been rendered into xhr/text routing-error responses ever since. Herb's HTML-aware parser flagged it, that's how I actually found it.

- **`railties/lib/rails/templates/rails/mailers/email.html.erb`**: Three `<option>` tags rendered the `selected` HTML attribute via `<%= cond ? 'selected' : '' %>` sitting in the attribute-name slot of `<option>`. Switched to control-flow ERB (`<% if cond %> selected<% end %>`) so the rendered attribute text is static. The attribute order (`<option selected value="...">`) and selected branch output are unchanged. The unselected branch no longer emits the stray double space inside `<option  value=...>` that the previous template produced from the empty `<%= '' %>`.

- **`railties/test/application/mailer_previews_test.rb`**: Six assertions of the form `'<option  value="..."'` (note the double space) are updated to `'<option value="..."'` to match the cleaned-up unselected output. The `<option selected value="...">` assertions are unchanged.

- **`guides/source/layout.html.erb`**: Two `<option>` tags in the guides version switcher used `<%= " selected" if cond %>` in attribute position; converted to the same control-flow idiom. The rendered output is byte-equivalent in both branches.

### Additional information

Verified by running `herb compile` (herb gem 0.10.1) against every bundled `.erb` template in the repository (66 files across `actionpack/`, `actionmailbox/`, `actiontext/`, `railties/`, `guides/`, `tools/`, `tasks/`):

- Before this PR: 3 failures (1 `MissingOpeningTag`, 2 `SecurityError`).
- After this PR: 0 failures.

Rendered HTML is semantically identical to the previous output in every branch (selected and unselected) for the `<option>` changes. The only visible runtime differences are:

- The literal text `</code>` is no longer present in `routing_error.text.erb`'s rendered output.
- The stray double space in unselected `<option  value=...>` collapses to a single space.

Note: `rescues/routing_error.html.erb` is unchanged by this PR — already fixed on `main` in 84023dfd1f by @pardeyke - so this PR is basically closing the loop of all occurrences. A backport of that commit to `8-1-stable` would unblock Herb users on Rails 8.1.x.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit
  message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes
and documentation changes should not be included.
