### PR TITLE
Fix typo in metaprogramming comment

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -175,7 +175,7 @@ module ActiveSupport # :nodoc:
       class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def #{unsafe_method}(*, **, &block)             # def gsub(*, **, &block)
           if block                                      #   if block
-            to_str.#{unsafe_method}(*, **) { |*params|  #     to_str.gsub(*, &&) { |*params|
+            to_str.#{unsafe_method}(*, **) { |*params|  #     to_str.gsub(*, **) { |*params|
               set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
               block.call(*params)                       #       block.call(*params)
             }                                           #     }


### PR DESCRIPTION
The comment doesn't match the implementation. `**` accidentally got replaced with `&&`.

Introduced in 47cec2bb17b5a65df66385325b7997bd32b409fc

@byroot 