### PR TITLE
Drop generated app databases after test_bin_setup_output

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -58,6 +58,8 @@ module ApplicationTests
 
           == Removing old logs and tempfiles ==
         OUTPUT
+      ensure
+        rails "db:drop", allow_failure: true
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

This pull request drops the `app_development` and `app_test`
databases created by
`ApplicationTests::BinSetupTest#test_bin_setup_output`.

The test switches the generated app's adapter to PostgreSQL and runs
`bin/setup`, which creates `app_development` and `app_test`.
`teardown_app` only removes the tmp app directory, so the two
databases are not cleaned up.

### Detail

The test now drops the generated app's databases in an `ensure`
clause inside the existing `Dir.chdir` block. `allow_failure: true`
matches the `rails "db:drop"` call already made earlier in the same
test method.

### Additional information

Verified by taking snapshots of `psql -d postgres -At -c 'SELECT
datname FROM pg_database'` before and after running
`cd railties && bin/test test/application/bin_setup_test.rb`. No
`app_development` / `app_test` remain after the run.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.