### PR TITLE
Drop test databases when use_postgresql / use_mysql2 is given a block

### DIFF
--- a/railties/test/application/rake/dbs_postgresql_test.rb
+++ b/railties/test/application/rake/dbs_postgresql_test.rb
@@ -16,49 +16,45 @@ module ApplicationTests
       end
 
       test "db:create works when schema cache exists and database does not exist" do
-        use_postgresql
-
-        begin
+        use_postgresql do
           rails %w(db:create db:migrate db:schema:cache:dump)
 
           rails "db:drop"
           rails "db:create"
           assert_equal 0, $?.exitstatus
-        ensure
-          rails "db:drop" rescue nil
         end
       end
 
       test "db:schema:cache:dump dumps virtual columns" do
         Dir.chdir(app_path) do
-          use_postgresql
-          rails "db:drop", "db:create"
+          use_postgresql do
+            rails "db:drop", "db:create"
 
-          rails "runner", <<~RUBY
-            ActiveRecord::Base.lease_connection.create_table(:books) do |t|
-              t.integer :pages
-              t.virtual :pages_plus_1, type: :integer, as: "pages + 1", stored: true
-            end
-          RUBY
+            rails "runner", <<~RUBY
+              ActiveRecord::Base.lease_connection.create_table(:books) do |t|
+                t.integer :pages
+                t.virtual :pages_plus_1, type: :integer, as: "pages + 1", stored: true
+              end
+            RUBY
 
-          rails "db:schema:cache:dump"
+            rails "db:schema:cache:dump"
 
-          virtual_column_exists = rails("runner", "p ActiveRecord::Base.schema_cache.columns('books')[2].virtual?").strip
-          assert_equal "true", virtual_column_exists
+            virtual_column_exists = rails("runner", "p ActiveRecord::Base.schema_cache.columns('books')[2].virtual?").strip
+            assert_equal "true", virtual_column_exists
+          end
         end
       end
 
       test "db:prepare creates test database if it does not exist" do
         Dir.chdir(app_path) do
-          db_name = use_postgresql
-          rails "db:drop", "db:create"
-          rails "runner", "ActiveRecord::Base.lease_connection.drop_database(:#{db_name}_test)"
+          use_postgresql do |db_name|
+            rails "db:drop", "db:create"
+            rails "runner", "ActiveRecord::Base.lease_connection.drop_database(:#{db_name}_test)"
 
-          output = rails("db:prepare")
-          assert_match(%r{Created database '#{db_name}_test'}, output)
+            output = rails("db:prepare")
+            assert_match(%r{Created database '#{db_name}_test'}, output)
+          end
         end
-      ensure
-        rails "db:drop" rescue nil
       end
     end
   end

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -916,16 +916,16 @@ module ApplicationTests
 
       test "db:prepare setup the database even if schema does not exist" do
         Dir.chdir(app_path) do
-          use_postgresql(multi_db: true) # bug doesn't exist with sqlite3
-          output = rails("db:drop")
-          assert_match(/Dropped database/, output)
+          # bug doesn't exist with sqlite3
+          use_postgresql(multi_db: true) do
+            output = rails("db:drop")
+            assert_match(/Dropped database/, output)
 
-          rails "generate", "model", "recipe", "title:string"
-          output = rails("db:prepare")
-          assert_match(/CreateRecipes: migrated/, output)
+            rails "generate", "model", "recipe", "title:string"
+            output = rails("db:prepare")
+            assert_match(/CreateRecipes: migrated/, output)
+          end
         end
-      ensure
-        rails "db:drop" rescue nil
       end
 
       test "schema_cache is loaded on all connection db in multi-db app if it exists for the connection" do
@@ -1073,41 +1073,40 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         Dir.chdir(app_path) do
           # Bug not visible on SQLite3. Can be simplified when https://github.com/rails/rails/issues/36383 resolved
-          use_postgresql(multi_db: true)
-          generate_models_for_animals
+          use_postgresql(multi_db: true) do
+            generate_models_for_animals
 
-          rails "db:create:animals", "db:migrate:animals", "db:create:primary", "db:migrate:primary", "db:schema:dump"
-          rails "db:drop:primary"
-          Dog.create!
-          output = rails("db:prepare")
+            rails "db:create:animals", "db:migrate:animals", "db:create:primary", "db:migrate:primary", "db:schema:dump"
+            rails "db:drop:primary"
+            Dog.create!
+            output = rails("db:prepare")
 
-          assert_match(/Created database/, output)
-          assert_equal 1, Dog.count
-        ensure
-          Dog.lease_connection.disconnect!
-          rails "db:drop" rescue nil
+            assert_match(/Created database/, output)
+            assert_equal 1, Dog.count
+          ensure
+            Dog.lease_connection.disconnect!
+          end
         end
       end
 
       test "db:prepare runs seeds once" do
         require "#{app_path}/config/environment"
         Dir.chdir(app_path) do
-          use_postgresql(multi_db: true)
+          use_postgresql(multi_db: true) do
+            rails "db:drop"
+            generate_models_for_animals
+            rails "generate", "model", "recipe", "title:string"
 
-          rails "db:drop"
-          generate_models_for_animals
-          rails "generate", "model", "recipe", "title:string"
+            app_file "db/seeds.rb", <<-RUBY
+              Dog.create!
+            RUBY
 
-          app_file "db/seeds.rb", <<-RUBY
-            Dog.create!
-          RUBY
+            rails("db:prepare")
 
-          rails("db:prepare")
-
-          assert_equal 1, Dog.count
-        ensure
-          Dog.lease_connection.disconnect!
-          rails "db:drop" rescue nil
+            assert_equal 1, Dog.count
+          ensure
+            Dog.lease_connection.disconnect!
+          end
         end
       end
 

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -150,12 +150,13 @@ module ApplicationTests
     end
 
     def test_works_with_database_url
-      db_name = use_postgresql
-      previous_url = ENV["DATABASE_URL"]
-      ENV["DATABASE_URL"] = "postgres://localhost/#{db_name}"
-      assert_equal "1", rails("runner", "print 1")
-    ensure
-      ENV["DATABASE_URL"] = previous_url
+      use_postgresql do |db_name|
+        previous_url = ENV["DATABASE_URL"]
+        ENV["DATABASE_URL"] = "postgres://localhost/#{db_name}"
+        assert_equal "1", rails("runner", "print 1")
+      ensure
+        ENV["DATABASE_URL"] = previous_url
+      end
     end
   end
 end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -889,18 +889,18 @@ module ApplicationTests
     def test_parallel_testing_when_schema_is_not_up_to_date
       require "#{app_path}/config/environment"
       Dir.chdir(app_path) do
-        use_mysql2
+        use_mysql2 do
+          exercise_parallelization_regardless_of_machine_core_count(with: :processes)
 
-        exercise_parallelization_regardless_of_machine_core_count(with: :processes)
+          rails "generate", "scaffold", "User", "name:string"
+          rails "db:create"
+          rails "db:migrate"
 
-        rails "generate", "scaffold", "User", "name:string"
-        rails "db:create"
-        rails "db:migrate"
+          output = rails "test"
 
-        output = rails "test"
-
-        assert_match(/Finished in.*7 runs, 11 assertions, 0 failures, 0 errors, 0 skips/m, output)
-        assert_match %r{Running \d+ tests in parallel using \d+ processes}, output
+          assert_match(/Finished in.*7 runs, 11 assertions, 0 failures, 0 errors, 0 skips/m, output)
+          assert_match %r{Running \d+ tests in parallel using \d+ processes}, output
+        end
       end
     end
 

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -349,43 +349,42 @@ Expected: ["id", "name"]
     end
 
     test "database-dependent attribute types are resolved when parallel tests are run in eager load context" do
-      use_postgresql
-      rails "db:drop", "db:create"
+      use_postgresql do
+        rails "db:drop", "db:create"
 
-      output = rails("generate", "model", "user")
-      version = output.match(/(\d+)_create_users\.rb/)[1]
+        output = rails("generate", "model", "user")
+        version = output.match(/(\d+)_create_users\.rb/)[1]
 
-      app_file "db/schema.rb", <<~RUBY
-        ActiveRecord::Schema.define(version: #{version}) do
-          create_enum "user_favorite_color", ["red", "green", "blue"]
+        app_file "db/schema.rb", <<~RUBY
+          ActiveRecord::Schema.define(version: #{version}) do
+            create_enum "user_favorite_color", ["red", "green", "blue"]
 
-          create_table :users do |t|
-            t.enum :favorite_color, enum_type: :user_favorite_color
-          end
-        end
-      RUBY
-
-      app_file "config/initializers/enable_eager_load.rb", <<~RUBY
-        Rails.application.config.eager_load = true
-      RUBY
-
-      app_file "test/models/user_test.rb", <<~RUBY
-        require "test_helper"
-        class UserTest < ActiveSupport::TestCase
-          ENV.delete("PARALLEL_WORKERS")
-          parallelize threshold: 1, workers: 2
-
-          2.times do |i|
-            test "favorite_color uses database type (worker \#{i})" do
-              assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum, User.type_for_attribute("favorite_color")
+            create_table :users do |t|
+              t.enum :favorite_color, enum_type: :user_favorite_color
             end
           end
-        end
-      RUBY
+        RUBY
 
-      assert_successful_test_run "models/user_test.rb"
-    ensure
-      rails "db:drop" rescue nil
+        app_file "config/initializers/enable_eager_load.rb", <<~RUBY
+          Rails.application.config.eager_load = true
+        RUBY
+
+        app_file "test/models/user_test.rb", <<~RUBY
+          require "test_helper"
+          class UserTest < ActiveSupport::TestCase
+            ENV.delete("PARALLEL_WORKERS")
+            parallelize threshold: 1, workers: 2
+
+            2.times do |i|
+              test "favorite_color uses database type (worker \#{i})" do
+                assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum, User.type_for_attribute("favorite_color")
+              end
+            end
+          end
+        RUBY
+
+        assert_successful_test_run "models/user_test.rb"
+      end
     end
 
     private

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -17,6 +17,8 @@ require "active_support/testing/autorun"
 require "active_support/testing/stream"
 require "active_support/testing/method_call_assertions"
 require "active_support/test_case"
+require "active_record"
+require "active_record/tasks/database_tasks"
 require "minitest/retry"
 
 if ENV["BUILDKITE"]
@@ -102,6 +104,8 @@ module TestHelpers
   end
 
   module Generation
+    include ActiveSupport::Testing::Stream
+
     # Build an application by invoking the generator and going through the whole stack.
     def build_app(options = {})
       @prev_rails_app_class ||= Rails.app_class
@@ -159,6 +163,62 @@ module TestHelpers
       Rails.app_class = @prev_rails_app_class if @prev_rails_app_class
       Rails.application = @prev_rails_application if @prev_rails_application
       FileUtils.rm_rf(tmp_path)
+    end
+
+    def with_test_database_cleanup(adapter)
+      pre_existing_databases = list_test_databases(adapter) rescue nil
+      yield
+    ensure
+      if pre_existing_databases
+        drop_test_databases(adapter, list_test_databases(adapter) - pre_existing_databases)
+      end
+    end
+
+    def list_test_databases(adapter)
+      saved_db_config = ActiveRecord::Base.connection_pool.db_config rescue nil
+      ActiveRecord::Base.establish_connection(database_maintenance_config_for(adapter))
+      ActiveRecord::Base.lease_connection.select_values(database_list_sql_for(adapter))
+    ensure
+      ActiveRecord::Base.remove_connection
+      ActiveRecord::Base.establish_connection(saved_db_config) if saved_db_config
+    end
+
+    def drop_test_databases(adapter, databases)
+      saved_db_config = ActiveRecord::Base.connection_pool.db_config rescue nil
+      config = database_maintenance_config_for(adapter)
+      quietly do
+        databases.each do |db|
+          ActiveRecord::Tasks::DatabaseTasks.drop(config.merge(database: db))
+        end
+      end
+    ensure
+      if saved_db_config
+        ActiveRecord::Base.remove_connection rescue nil
+        ActiveRecord::Base.establish_connection(saved_db_config) rescue nil
+      end
+    end
+
+    def database_maintenance_config_for(adapter)
+      case adapter
+      when :postgresql
+        { adapter: "postgresql", database: "postgres" }
+      when :mysql
+        cfg = { adapter: "mysql2", database: "mysql", username: "root" }
+        cfg[:host] = ENV["MYSQL_HOST"] if ENV["MYSQL_HOST"]
+        cfg[:socket] = ENV["MYSQL_SOCK"] if ENV["MYSQL_SOCK"]
+        cfg
+      end
+    end
+
+    def database_list_sql_for(adapter)
+      conn = ActiveRecord::Base.lease_connection
+      pattern = conn.quote("railties_#{Process.pid}_%")
+      case adapter
+      when :postgresql
+        "SELECT datname FROM pg_database WHERE datname LIKE #{pattern}"
+      when :mysql
+        "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE #{pattern}"
+      end
     end
 
     def default_database_configs
@@ -536,7 +596,11 @@ module TestHelpers
           YAML
         end
       end
-      database_name
+      if block_given?
+        with_test_database_cleanup(:postgresql) { yield database_name }
+      else
+        database_name
+      end
     end
 
     def use_mysql2(multi_db: false)
@@ -592,7 +656,11 @@ module TestHelpers
           YAML
         end
       end
-      database_name
+      if block_given?
+        with_test_database_cleanup(:mysql) { yield database_name }
+      else
+        database_name
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This pull request makes `use_postgresql` and `use_mysql2`
(`TestHelpers::Generation`) drop any `railties_${Process.pid}_%`
database created inside the block they now accept. Existing callers
that create databases are updated to pass a block.

Without this, per-PID and per-worker databases (from
`ActiveRecord::TestDatabases.create_and_load_schema`) are left
behind, because `rails db:drop` only drops what is in
`config/database.yml`.

### Detail

`with_test_database_cleanup(adapter)` snapshots
`railties_${Process.pid}_%` databases on entry and drops the diff in
`ensure`.

The previous `ensure rails "db:drop"` clauses in the converted tests
are removed since the helper's cleanup is sufficient.

`Rails::Command::DevcontainerTest` is unchanged since its
`use_mysql2` call only writes `config/database.yml` and does not
create a database.

### Additional information

Verified by snapshotting `psql -d postgres -At -c 'SELECT datname
FROM pg_database'` before and after:

```
cd railties && bin/test \
  test/application/bin_setup_test.rb \
  test/application/rake/dbs_postgresql_test.rb \
  test/application/rake/multi_dbs_test.rb \
  test/application/runner_test.rb \
  test/application/test_runner_test.rb \
  test/application/test_test.rb \
  test/isolation/abstract_unit.rb
```

199 runs / 0 failures / 0 errors, no `railties_*` databases left.

The sibling PR #57457 covers a separate `app_development` /
`app_test` leak.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.