### PR TITLE
Fix Mysql2Adapter#discard! corrupting parent connection after fork

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -130,6 +130,7 @@ module ActiveRecord
       def discard! # :nodoc:
         @lock.synchronize do
           super
+          IO.for_fd(@raw_connection.socket, autoclose: false).reopen(IO::NULL) if @raw_connection rescue nil
           @raw_connection&.automatic_close = false
           @raw_connection = nil
         end


### PR DESCRIPTION
### Motivation / Background

The rails-nightly job `activerecord mysql2 (master) [prepared_statements]` started failing with:

```
ActiveRecord::ConnectionAdapters::ConnectionHandlerTest#test_forked_child_doesnt_mangle_parent_connection:
ActiveRecord::ConnectionFailed: Mysql2::Error::ConnectionError: Lost connection to MySQL server during query
```

Build: https://buildkite.com/rails/rails-nightly/builds/4318#019e5bca-de7d-47b5-b76d-ce50fc9d8706/L11126

Only the `mysql2` + `MYSQL_PREPARED_STATEMENTS=true` configuration is affected. Other MySQL/MariaDB/Trilogy jobs pass.

### Detail

When `MYSQL_PREPARED_STATEMENTS=true`, the parent's `@statements` cache holds `Mysql2::Statement` objects. After `fork`, the child inherits both the `Mysql2::Client` socket file descriptor and the Ruby `Statement` references.

`Mysql2Adapter#discard!` previously only neutralized the `Client` finalizer (`automatic_close = false`); the inherited `Statement` objects remained intact in the child's heap. When the child runs `exit`, finalizers on those `Statement` objects write `COM_STMT_CLOSE` to the file descriptor shared with the parent. The MySQL server then closes the connection, causing the parent's next query to fail.

This Pull Request changes `Mysql2Adapter#discard!` to redirect the inherited socket fd to `/dev/null` in the child, so writes triggered by finalizers cannot reach the parent's connection. This mirrors `PostgreSQLAdapter#discard!` (`@raw_connection&.socket_io&.reopen(IO::NULL) rescue nil` at `postgresql_adapter.rb:443`) and continues the fork-safety work originally introduced in [f32cff5563](https://github.com/rails/rails/commit/f32cff5563).

### Additional information

**Reproduction (no Rails required, demonstrates root cause):**

```ruby
require "mysql2"

client = Mysql2::Client.new(
  host: "127.0.0.1", username: "rails",
  database: "activerecord_unittest"
)

statements = {}
statements["sql1"] = client.prepare("SELECT 1")
statements["sql1"].execute.to_a
statements["sql2"] = client.prepare("SELECT 2")
statements["sql2"].execute.to_a

pid = fork do
  client.automatic_close = false
  Mysql2::Client.new(
    host: "127.0.0.1", username: "rails",
    database: "activerecord_unittest"
  ).query("SELECT 1").to_a
  exit
end
Process.waitpid pid

client.query("SELECT 1")
# => Mysql2::Error::ConnectionError: Lost connection to MySQL server during query
```

Applying the fix's `reopen(IO::NULL)` in the child branch makes the same script succeed.

**Local verification** (Ruby 4.0.5 + mysql2 0.5.6 + MySQL 9.6.0 via TCP):

```sh
cd activerecord
MYSQL_PREPARED_STATEMENTS=true bundle exec rake db:mysql:rebuild
MYSQL_PREPARED_STATEMENTS=true ARCONN=mysql2 bundle exec ruby -Itest \
  test/cases/connection_adapters/connection_handler_test.rb
# 26 runs, 73 assertions, 0 failures, 0 errors, 0 skips
```

Also verified: full connection-adapter test suite (178 runs) green, fork/discard-tagged tests across `test:mysql2` (6 runs) green.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. *(Existing `test_forked_child_doesnt_mangle_parent_connection` is the regression test; no new test added, following the [f32cff5563](https://github.com/rails/rails/commit/f32cff5563) precedent for fork-safety fixes.)*
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. 