### PR TITLE
Reject malformed Mandrill inbound events without raw messages

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Return `422 Unprocessable Content` for Mandrill inbound events that are missing a raw message.
+
+    *Andrii Furmanets*
+
 *   Return `422 Unprocessable Content` for Mandrill events payloads that don't parse to a JSON array of objects.
 
     Previously, valid JSON of the wrong shape (e.g. `null`, a scalar, an object, or an array containing non-objects)

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
@@ -37,7 +37,14 @@ module ActionMailbox
       end
 
       def raw_emails
-        events.select { |event| event["event"] == "inbound" }.collect { |event| event.dig("msg", "raw_msg") }
+        events.select { |event| event["event"] == "inbound" }.collect do |event|
+          message = event["msg"]
+          raise MalformedEventsError unless message.is_a?(Hash)
+
+          message["raw_msg"].tap do |raw_email|
+            raise MalformedEventsError unless raw_email.is_a?(String)
+          end
+        end
       end
 
       def events

--- a/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
@@ -63,6 +63,16 @@ class ActionMailbox::Ingresses::Mandrill::InboundEmailsControllerTest < ActionDi
     assert_response :unprocessable_content
   end
 
+  test "rejecting a Mandrill inbound event without a raw message" do
+    events = JSON.generate([{ event: "inbound", msg: {} }])
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_mandrill_inbound_emails_url,
+        headers: { "X-Mandrill-Signature" => signature_for(events) }, params: { mandrill_events: events }
+    end
+
+    assert_response :unprocessable_content
+  end
+
   test "rejecting a Mandrill events payload that parses to a scalar" do
     events = "42"
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do


### PR DESCRIPTION
### Motivation / Background

Fixes #57462.

Mandrill event payloads can parse to an array of hashes while still omitting the raw MIME message for an inbound event. In that case the ingress passed `nil` to `ActionMailbox::InboundEmail.create_and_extract_message_id!`, raising `TypeError` and returning a 500.

### Detail

This Pull Request validates each inbound Mandrill event's `msg.raw_msg` value before creating inbound emails. Missing or non-string raw messages now raise the existing malformed events error and return `422 Unprocessable Content`, matching the surrounding malformed payload handling.

### Additional information

Validation:

* `cd actionmailbox && bin/test test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb -i "/without a raw message/"`
* `cd actionmailbox && bin/test test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb`
* `cd actionmailbox && bin/test test/controllers/ingresses`
* `cd actionmailbox && bundle exec rubocop app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb`
* `git diff --check`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
