### PR TITLE
Clean up rails console subprocesses spawned by FullStackConsoleTest

### DIFF
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -9,6 +9,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
   include ConsoleHelpers
 
   def setup
+    @spawned_console_pids = []
     skip "PTY unavailable" unless available_pty?
 
     build_app
@@ -22,6 +23,12 @@ class FullStackConsoleTest < ActiveSupport::TestCase
   end
 
   def teardown
+    @spawned_console_pids.each do |pid|
+      Process.kill("KILL", pid)
+      Process.wait(pid)
+    rescue Errno::ESRCH, Errno::ECHILD, Errno::EPERM
+      # ESRCH: process already exited, ECHILD: already reaped, EPERM: not our process to kill
+    end
     teardown_app
   end
 
@@ -41,6 +48,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
       "#{app_path}/bin/rails console #{options}",
       in: @replica, out: @replica, err: @replica
     )
+    @spawned_console_pids << pid
 
     if wait_for_prompt
       assert_output "> ", @primary, 30


### PR DESCRIPTION
### Motivation / Background

`FullStackConsoleTest#spawn_console` starts a `rails console` subprocess via `Process.spawn`. The subprocess pid is returned but **nothing in the test class kills or waits on it**, so each invocation leaks one running subprocess.

### Detail

Each of the 29 test methods in `console_test.rb` calls `spawn_console` at least once (some twice). On a single Ruby process running the file, this leaves a stack of subprocesses behind. A check inside a running container shows the pattern:

```
=== ruby processes (PPid = test runner ruby) ===
112454 Z(zombie)      <- earlier spawn, exited, never reaped
112608 Z(zombie)
112762 Z(zombie)
...
113373 S(sleeping)    <- still-running rails console, 4 threads
114296 S(sleeping)
114449 S(sleeping)
...
```

`SIGKILL` rather than `SIGTERM` since the tests have no need for a graceful Rails shutdown — they only spawn the console to drive it via PTY. `Process.wait` rescues `Errno::ECHILD` for safety (in case the process was already reaped).

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. 