### PR TITLE
Dump enum types with fully qualified names for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -108,7 +108,7 @@ module ActiveRecord
               spec = { type: schema_type(column).inspect }.merge!(spec)
             end
 
-            spec[:enum_type] = column.sql_type.inspect if column.enum?
+            spec[:enum_type] = relation_name(column.sql_type).inspect if column.enum?
 
             spec
           end

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -270,11 +270,28 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
 
       assert_includes output, 'create_enum "public.mood", ["sad", "ok", "happy"]'
       assert_includes output, 'create_enum "test_schema.mood_in_test_schema", ["sad", "ok", "happy"]'
-      assert_includes output, 't.enum "current_mood", enum_type: "mood_in_test_schema"'
+      assert_includes output, 't.enum "current_mood", enum_type: "test_schema.mood_in_test_schema"'
       assert_not_includes output, 'create_enum "other_schema.mood_in_other_schema"'
     end
   ensure
     @connection.drop_schema("other_schema")
+  end
+
+  def test_schema_dump_enums_with_same_name_in_different_schemas
+    with_test_schema("test_schema") do
+      # Need to explicitly include the schema name to avoid conflicting with the existing enum in `public` schema
+      @connection.create_enum("test_schema.mood", ["angry", "frustrated", "content"])
+
+      @connection.create_table("postgresql_enums_in_test_schema") do |t|
+        t.column :current_mood, "mood"
+      end
+
+      output = dump_table_schema("postgresql_enums_in_test_schema")
+
+      assert_includes output, 'create_enum "public.mood", ["sad", "ok", "happy"]'
+      assert_includes output, 'create_enum "test_schema.mood", ["angry", "frustrated", "content"]'
+      assert_includes output, 't.enum "current_mood", enum_type: "test_schema.mood"'
+    end
   end
 
   def test_schema_load_scoped_to_schemas


### PR DESCRIPTION
This is a rebase and rework of #56278.
Closes #56278.