### PR TITLE
Add shims for Ractor shareability methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add shims for `Ractor` shareability methods so framework code can call them
+    unconditionally regardless of the Ruby version.
+
+    When `Ractor` is not defined, or the underlying method is not available, the
+    shim is a no-op that simply returns its argument (or the given block).
+    Otherwise the call is forwarded to the matching `Ractor` class method.
+
+    ```ruby
+    ractor_make_shareable(obj)        # => Ractor.make_shareable(obj)        or obj
+    ractor_shareable?(obj)            # => Ractor.shareable?(obj)            or obj
+    ractor_shareable_proc   { ... }   # => Ractor.shareable_proc   { ... }   or the block
+    ractor_shareable_lambda { ... }   # => Ractor.shareable_lambda { ... }   or the block
+    ```
+
+    *Andrew Novoselac*
+
 *   Fix `NumberHelper` raising `FloatDomainError` for `Infinity` / `NaN` with
     `significant: true`.
 

--- a/activesupport/lib/active_support/core_ext/kernel.rb
+++ b/activesupport/lib/active_support/core_ext/kernel.rb
@@ -2,4 +2,5 @@
 
 require_relative "kernel/concern"
 require_relative "kernel/reporting"
+require_relative "kernel/ractor_shareability"
 require_relative "kernel/singleton_class"

--- a/activesupport/lib/active_support/core_ext/kernel/ractor_shareability.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/ractor_shareability.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Shims for +Ractor+ shareability methods so framework code can call them
+# unconditionally regardless of the Ruby version.
+#
+# When +Ractor+ is not defined, or the underlying method is not available, the
+# shim is a no-op that simply returns its argument (or the given block).
+# Otherwise the call is forwarded to the matching +Ractor+ class method.
+#
+#   ractor_make_shareable(obj)        # => Ractor.make_shareable(obj)        or obj
+#   ractor_shareable?(obj)            # => Ractor.shareable?(obj)            or obj
+#   ractor_shareable_proc   { ... }   # => Ractor.shareable_proc   { ... }   or the block
+#   ractor_shareable_lambda { ... }   # => Ractor.shareable_lambda { ... }   or the block
+module Kernel
+  private
+    if defined?(Ractor) && Ractor.respond_to?(:make_shareable)
+      # Makes +obj+ Ractor-shareable by delegating to +Ractor.make_shareable+.
+      #
+      # The +copy:+ option is forwarded unchanged. On Ruby versions without
+      # +Ractor.make_shareable+, this shim returns +obj+ unchanged.
+      def ractor_make_shareable(obj, copy: false)
+        Ractor.make_shareable(obj, copy: copy)
+      end
+    else
+      def ractor_make_shareable(obj, copy: false)
+        obj
+      end
+    end
+
+    if defined?(Ractor) && Ractor.respond_to?(:shareable?)
+      # Returns whether +obj+ is Ractor-shareable by delegating to
+      # +Ractor.shareable?+.
+      #
+      # On Ruby versions without +Ractor.shareable?+, this shim returns +obj+
+      # unchanged.
+      def ractor_shareable?(obj)
+        Ractor.shareable?(obj)
+      end
+    else
+      def ractor_shareable?(obj)
+        obj
+      end
+    end
+
+    if defined?(Ractor) && Ractor.respond_to?(:shareable_proc)
+      # Returns a Ractor-shareable proc by delegating to +Ractor.shareable_proc+.
+      #
+      # The optional +self:+ value is forwarded as the proc's receiver. On Ruby
+      # versions without +Ractor.shareable_proc+, this shim returns the block
+      # unchanged.
+      def ractor_shareable_proc(self: nil, &block)
+        Ractor.shareable_proc(self: { self: }[:self], &block)
+      end
+    else
+      def ractor_shareable_proc(self: nil, &block)
+        block
+      end
+    end
+
+    if defined?(Ractor) && Ractor.respond_to?(:shareable_lambda)
+      # Returns a Ractor-shareable lambda by delegating to
+      # +Ractor.shareable_lambda+.
+      #
+      # The optional +self:+ value is forwarded as the lambda's receiver. On Ruby
+      # versions without +Ractor.shareable_lambda+, this shim returns the block
+      # unchanged.
+      def ractor_shareable_lambda(self: nil, &block)
+        Ractor.shareable_lambda(self: { self: }[:self], &block)
+      end
+    else
+      def ractor_shareable_lambda(&block)
+        block
+      end
+    end
+end

--- a/activesupport/test/core_ext/kernel/ractor_shareability_test.rb
+++ b/activesupport/test/core_ext/kernel/ractor_shareability_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/kernel/ractor_shareability"
+
+class KernelRactorShareabilityTest < ActiveSupport::TestCase
+  if RUBY_VERSION >= "4.0"
+    def test_ractor_make_shareable_returns_a_shareable_object
+      string = +"hello"
+      assert_not ractor_shareable?(string)
+
+      shareable_string = ractor_make_shareable(string)
+
+      assert_same string, shareable_string
+      assert ractor_shareable?(string)
+    end
+
+    def test_ractor_shareable_proc_returns_a_shareable_proc_that_runs_the_block
+      proc = ractor_shareable_proc { 1 + 1 }
+
+      assert ractor_shareable?(proc)
+      assert_equal 2, proc.call
+    end
+
+    def test_ractor_shareable_proc_with_self
+      bar = 2
+      proc = ractor_shareable_proc(self: bar) { to_s }
+
+      assert ractor_shareable?(proc)
+      assert_equal "2", proc.call
+    end
+
+    def test_ractor_shareable_lambda_returns_a_shareable_lambda_that_runs_the_block
+      lambda = ractor_shareable_lambda { 1 + 1 }
+
+      assert_predicate lambda, :lambda?
+      assert ractor_shareable?(lambda)
+      assert_equal 2, lambda.call
+    end
+
+    def test_ractor_shareable_lambda_with_self
+      bar = 2
+      lambda = ractor_shareable_lambda(self: bar) { to_s }
+
+      assert ractor_shareable?(lambda)
+      assert_equal "2", lambda.call
+    end
+  end
+end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -522,6 +522,46 @@ NOTE: Defined in `active_support/core_ext/kernel/reporting.rb`.
 [Kernel#silence_warnings]: https://api.rubyonrails.org/classes/Kernel.html#method-i-silence_warnings
 [Kernel#suppress]: https://api.rubyonrails.org/classes/Kernel.html#method-i-suppress
 
+### Ractor shareability
+
+Active Support provides shims for Ruby's Ractor shareability APIs so framework
+code can call them regardless of the Ruby version.
+
+The method [`ractor_make_shareable`][Kernel#ractor_make_shareable] delegates to
+`Ractor.make_shareable` when available, and otherwise returns the object
+unchanged:
+
+```ruby
+ractor_make_shareable({})
+# => Ractor.make_shareable({}) if supported, otherwise {}
+```
+
+The predicate [`ractor_shareable?`][Kernel#ractor_shareable?] delegates to
+`Ractor.shareable?` when available, and otherwise returns the object unchanged:
+
+```ruby
+ractor_shareable?(Object.new)
+# => Ractor.shareable?(Object.new) if supported, otherwise the object
+```
+
+The methods [`ractor_shareable_proc`][Kernel#ractor_shareable_proc] and
+[`ractor_shareable_lambda`][Kernel#ractor_shareable_lambda] delegate to
+`Ractor.shareable_proc` and `Ractor.shareable_lambda` when available. On Ruby
+versions without those APIs, they return the given block unchanged:
+
+```ruby
+handler = ractor_shareable_proc { |event| event.name }
+# => Ractor.shareable_proc { |event| event.name } if supported,
+#    otherwise the block
+```
+
+NOTE: Defined in `active_support/core_ext/kernel/ractor_shareability.rb`.
+
+[Kernel#ractor_make_shareable]: https://api.rubyonrails.org/classes/Kernel.html#method-i-ractor_make_shareable
+[Kernel#ractor_shareable?]: https://api.rubyonrails.org/classes/Kernel.html#method-i-ractor_shareable-3F
+[Kernel#ractor_shareable_proc]: https://api.rubyonrails.org/classes/Kernel.html#method-i-ractor_shareable_proc
+[Kernel#ractor_shareable_lambda]: https://api.rubyonrails.org/classes/Kernel.html#method-i-ractor_shareable_lambda
+
 ### `in?`
 
 The predicate [`in?`][Object#in?] tests if an object is included in another object. An `ArgumentError` exception will be raised if the argument passed does not respond to `include?`.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we are going to start adding Ractor support to the framework. This is going to lead us to call `Ractor.make_shareable`, `Ractor.shareable_proc` etc. in many places which will necessitate checking the ruby version. Let's add a shim so we don't have to litter the code base with those checks.

### Detail

I added new core extension to Kernel which defines `ractor_shareable?`, `ractor_make_shareable`, `ractor_shareable_proc` and `ractor_shareable_lamda`. In environments where those are available, it forwards them to the Ractor method, otherwise they are a no-op.

I realize that adding new core extensions especially to Kernel can be a hot button topic, tho IMO its the right way to go so I started here. But if there is push back, we could do something like `RactorShareability.shareable?` instead. I am open to feedback or suggestions.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
