### PR TITLE
Allow showing server URL under Puma via config.server_host

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -569,6 +569,17 @@ in `config/credentials.yml.enc`. See the [`secret_key_base` API documentation](
 https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base)
 for more information and alternative configuration methods.
 
+#### `config.server_host`
+
+Sets a host name to display in the `bin/rails server` boot banner. When set, the
+URL line uses this host instead of the value passed to `--binding`/`-b`, and is
+shown even when running under Puma.
+
+Defaults to `nil`.
+
+Useful for developers using a custom local hostname (such as `myapp.local`) who
+want it surfaced in the boot output.
+
 #### `config.server_timing`
 
 When `true`, adds the [`ServerTiming` middleware](#actiondispatch-servertiming)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `config.server_host` to display a custom host in the boot banner.
+
+    When set, the server URL line in `bin/rails server`'s boot output uses the configured
+    host instead of the bind address and is shown even under Puma, where it would
+    otherwise be suppressed. When unset, behavior is unchanged.
+
+    *Brendan Minder*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -17,7 +17,7 @@ module Rails
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters, :precompile_filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
                     :log_tags, :silence_healthcheck_path, :railties_order, :relative_url_root,
-                    :ssl_options, :public_file_server,
+                    :server_host, :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x,
                     :content_security_policy_report_only,
@@ -87,6 +87,7 @@ module Rails
         @dom_testing_default_html_version        = :html4
         @yjit                                    = false
         @action_on_early_load_hook               = :log
+        @server_host                             = nil
       end
 
       # Loads default configuration values for a target version. This includes

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -56,10 +56,18 @@ module Rails
     end
 
     def served_url
-      "#{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}" unless use_puma?
+      "#{options[:SSLEnable] ? 'https' : 'http'}://#{display_host}:#{options[:Port]}" unless suppress_served_url?
     end
 
     private
+      def display_host
+        Rails.application&.config&.server_host || options[:Host]
+      end
+
+      def suppress_served_url?
+        use_puma? && Rails.application&.config&.server_host.nil?
+      end
+
       def setup_dev_caching
         if options[:environment] == "development"
           Rails::DevCaching.enable_by_argument(options[:caching])

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -348,9 +348,9 @@ class Rails::Command::ServerTest < ActiveSupport::TestCase
       Rails::Command::ServerCommand.new([], args).server_options
     end
 
-    def with_application_config(server_host:)
+    def with_application_config(server_host:, &block)
       config = Struct.new(:server_host).new(server_host)
       app = Struct.new(:config).new(config)
-      Rails.stub(:application, app) { yield }
+      Rails.stub(:application, app, &block)
     end
 end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -308,11 +308,31 @@ class Rails::Command::ServerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_served_url_when_server_prints_it
+  def test_served_url_suppressed_under_puma_without_server_host
     with_rails_env "development" do
       args = %w(-u puma -b 127.0.0.1 -p 4567)
       server = Rails::Server.new(parse_arguments(args))
       assert_nil server.served_url
+    end
+  end
+
+  def test_served_url_under_puma_when_config_server_host_set
+    with_rails_env "development" do
+      with_application_config(server_host: "example.com") do
+        args = %w(-u puma -b 127.0.0.1 -p 4567)
+        server = Rails::Server.new(parse_arguments(args))
+        assert_equal "http://example.com:4567", server.served_url
+      end
+    end
+  end
+
+  def test_served_url_config_server_host_overrides_bind_for_non_puma
+    with_rails_env "development" do
+      with_application_config(server_host: "example.com") do
+        args = %w(-u webrick -b 127.0.0.1 -p 4567)
+        server = Rails::Server.new(parse_arguments(args))
+        assert_equal "http://example.com:4567", server.served_url
+      end
     end
   end
 
@@ -326,5 +346,11 @@ class Rails::Command::ServerTest < ActiveSupport::TestCase
 
     def parse_arguments(args = [])
       Rails::Command::ServerCommand.new([], args).server_options
+    end
+
+    def with_application_config(server_host:)
+      config = Struct.new(:server_host).new(server_host)
+      app = Struct.new(:config).new(config)
+      Rails.stub(:application, app) { yield }
     end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Rails currently suppresses the server URL in the boot banner when running under Puma (introduced in #29902 to avoid showing an incorrect URL when `config/puma.rb` overrides the host or port).

### Detail

This Pull Request adds a new application config option, `config.server_host`. When set, the boot banner displays a URL using that host, even under Puma. When unset, the existing behavior is preserved. The URL line is shown for non-Puma handlers and suppressed under Puma.

### Additional information

The `display_host` helper falls back to `options[:Host]` (the bind address) when `config.server_host` is unset, so non-Puma handlers continue to display the bound address as before.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message describes what changed and why.
- [x] Tests are added covering: opt-in under Puma, override for non-Puma, and the existing suppress-under-Puma default.
- [x] CHANGELOG update