### PR TITLE
Fix `FormBuilder#to_partial_path` returning nil for non-Builder subclasses

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `FormBuilder#to_partial_path` returning `nil` for subclasses whose
+    name does not end in `Builder`.
+
+    *Kenta Ishizaki*
+
 *   Fix `collection_radio_buttons` and `collection_check_boxes` generating
     a label `for` attribute that does not match the input `id` when a
     collection value is `nil`.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1706,7 +1706,7 @@ module ActionView
       end
 
       def self._to_partial_path
-        @_to_partial_path ||= name.demodulize.underscore.sub!(/_builder$/, "")
+        @_to_partial_path ||= name.demodulize.underscore.sub(/_builder$/, "")
       end
 
       def to_partial_path

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -4111,6 +4111,17 @@ class FormHelperTest < ActionView::TestCase
 
   class LabelledFormBuilderSubclass < LabelledFormBuilder; end
 
+  def test_to_partial_path_for_subclass_without_builder_suffix
+    path = nil
+
+    form_for(@post, builder: LabelledFormBuilderSubclass) do |f|
+      path = f.to_partial_path
+      ""
+    end
+
+    assert_equal "labelled_form_builder_subclass", path
+  end
+
   def test_form_for_with_labelled_builder_with_nested_fields_for_with_custom_builder
     klass = nil
 


### PR DESCRIPTION
## Motivation / Background

`ActionView::Helpers::FormBuilder._to_partial_path` returns `nil` for any `FormBuilder` subclass whose name does not end in `Builder`:

```ruby
class AdminForm < ActionView::Helpers::FormBuilder; end

AdminForm._to_partial_path  # => nil   (expected "admin_form")
AdminForm.new(...).to_partial_path  # => nil
# `render @admin_form_instance` then fails downstream
```

This is a classic Ruby spec misreading. `String#sub!` returns `nil` when the pattern does not match, so:

```ruby
"admin_form".sub!(/_builder$/, "")   # => nil
```

The `||=` then caches `nil` (and re-evaluates the right-hand side every subsequent call — also wasteful).

The bug dates back to commit 4ac9d391d337 (2009, Yehuda Katz), where this `sub!` expression was first introduced inside `self.model_name`. It survived subsequent renames to `_to_partial_path` (`b6b6e81a5c`, 2011) and has been masked by the long-standing convention of naming custom form builders `*Builder` — but Rails core's own test suite already defines a subclass that violates the convention:

```ruby
# actionview/test/template/form_helper_test.rb
class LabelledFormBuilderSubclass < LabelledFormBuilder; end
```

`LabelledFormBuilderSubclass.new(...).to_partial_path` returns `nil`, not `"labelled_form_builder_subclass"`.

## Detail

Switch from `String#sub!` to the non-bang `String#sub`, which returns a copy of the receiver when the pattern does not match, so the cached `@_to_partial_path` is always a usable string.

```diff
 def self._to_partial_path
-  @_to_partial_path ||= name.demodulize.underscore.sub!(/_builder$/, "")
+  @_to_partial_path ||= name.demodulize.underscore.sub(/_builder$/, "")
 end
```

After the fix:

```ruby
ActionView::Helpers::FormBuilder._to_partial_path  # "form"           (unchanged)
LabelledFormBuilder._to_partial_path                # "labelled_form"  (unchanged)
LabelledFormBuilderSubclass._to_partial_path        # "labelled_form_builder_subclass"
AdminForm._to_partial_path                          # "admin_form"
```

The conventional cases (default `FormBuilder` and any `*Builder` subclass) are unaffected — the suffix still matches and is still stripped. The broken case is fixed.

## Additional information

The existing `test_form_for_with_labelled_builder_path` test only exercises the convention-following case. This PR adds a regression test for the non-conforming subclass case using the `LabelledFormBuilderSubclass` already defined in the same file.

Full `actionview/test/template/form_helper_test.rb` (343 runs / 431 assertions) green.

## Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added.
* [x] CHANGELOG file is updated.