### PR TITLE
Fix `number_to_delimited` mangling non-finite floats

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix `number_to_delimited` mangling non-finite floats.
+
+    `number_to_delimited(Float::INFINITY)` returned `"In,fin,ity"` because the
+    fast-path manual slicing introduced in commit `2d485aecf5` and made the
+    default in commit `33fbedb1b1` treated `Float::INFINITY.to_s` (the string
+    `"Infinity"`) as a sequence of digits to group every three characters.
+    `-Float::INFINITY` was similarly mangled to `"-In,fin,ity"`. `Float::NAN`
+    happened to survive only because `"NaN"` is exactly three characters long.
+
+    Now returns the underlying string representation (`"Infinity"`,
+    `"-Infinity"`, `"NaN"`) for non-finite floats, matching the pre-`2d485aecf5`
+    behavior.
+
+    *Kenta Ishizaki*
+
 *   Duplicate the `context` hash passed to `ActiveSupport::ErrorReport#handle` for each subscriber.
     This prevents mutations done on the `context` by one subscriber from effecting the others.
 

--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -13,6 +13,8 @@ module ActiveSupport
 
       private
         def parts
+          return [number.to_s] if number.respond_to?(:finite?) && !number.finite?
+
           left, right = number.to_s.split(".")
           if delimiter_pattern
             left.gsub!(delimiter_pattern) do |digit_to_delimit|

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -158,6 +158,14 @@ module ActiveSupport
         end
       end
 
+      def test_to_delimited_with_non_finite_floats
+        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+          assert_equal "Infinity", number_helper.number_to_delimited(Float::INFINITY)
+          assert_equal "-Infinity", number_helper.number_to_delimited(-Float::INFINITY)
+          assert_equal "NaN", number_helper.number_to_delimited(Float::NAN)
+        end
+      end
+
       def test_to_delimited_with_options_hash
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal "12 345 678", number_helper.number_to_delimited(12345678, delimiter: " ")


### PR DESCRIPTION
## Motivation / Background

`number_to_delimited(Float::INFINITY)` returns `"In,fin,ity"` on `main`.

```ruby
ActiveSupport::NumberHelper.number_to_delimited(Float::INFINITY)   # => "In,fin,ity"   💀
ActiveSupport::NumberHelper.number_to_delimited(-Float::INFINITY)  # => "-In,fin,ity"
ActiveSupport::NumberHelper.number_to_delimited(Float::NAN)        # => "NaN"          (lucky)
```

This is a regression introduced in the recent performance work for `NumberToDelimitedConverter`:

- `2d485aecf5` (2026-03-04, CVE-2026-33169) — introduced the manual-slicing fast path that groups every three characters.
- `33fbedb1b1` (2026-03-26) — made the fast path the default by changing `delimiter_pattern` to default to `nil`.

Before those commits, the regex `gsub!(/(\d)(?=(\d\d\d)+(?!\d))/)` tolerated non-finite floats by coincidence: `Float::INFINITY.to_s` is `"Infinity"`, which contains no digits, so the regex matched nothing and the string was returned unchanged. The new fast path treats `"Infinity"` as an 8-character digit string and inserts commas every three characters from the right.

`Float::NAN` only avoided the regression because `"NaN"` is exactly three characters long (`offset = 0`, one iteration produces `"NaN"`).

## Detail

Short-circuit at the top of `parts` when the number responds to `finite?` and is not finite, returning `[number.to_s]` so the eventual `join` returns the underlying string representation:

```diff
 def parts
+  return [number.to_s] if number.respond_to?(:finite?) && !number.finite?
+
   left, right = number.to_s.split(".")
   if delimiter_pattern
```

Output after the fix:

```ruby
number_to_delimited(Float::INFINITY)   # => "Infinity"
number_to_delimited(-Float::INFINITY)  # => "-Infinity"
number_to_delimited(Float::NAN)        # => "NaN"
```

This is consistent with `number_to_phone(Float::INFINITY)` which already returns `"Infinity"`.

## Additional information

This is in the same family as #57451 (significant-mode `FloatDomainError`), but a distinct converter and a separate code path. `number_to_human` and `number_to_human_size` raise `FloatDomainError` on `Float::INFINITY` and remain follow-up candidates as documented in #57451's PR body.

## Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added.
* [x] CHANGELOG file is updated.