### PR TITLE
Active Job: pass job to `stopping?` for fine-grained control over interruption

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow queue adapters to inspect a job when deciding whether to interrupt at
+    a checkpoint, and to optionally return a specific interruption reason.
+
+    Queue adapters that implement `stopping?` must accept the job as an
+    optional positional argument, i.e. `def stopping?(job = nil)`, in order to
+    work with this version and older versions of Rails. A `true` return value
+    will use 'stopping' as the interruption reason, any other truthy value will
+    be used as-is.
+
+    *Bart de Water*
+
 *   Add `ActiveJob::Attributes` for declaring typed attributes that persist across
     job serialization and deserialization. It is included by `ActiveJob::Continuable`
     but can also be used standalone.

--- a/activejob/lib/active_job/continuable.rb
+++ b/activejob/lib/active_job/continuable.rb
@@ -61,7 +61,10 @@ module ActiveJob
     end
 
     def checkpoint! # :nodoc:
-      interrupt!(reason: :stopping) if queue_adapter.stopping?
+      if (reason = queue_adapter.stopping?(self))
+        reason = :stopping if reason == true
+        interrupt!(reason: reason)
+      end
     end
 
     def interrupt!(reason:) # :nodoc:

--- a/activejob/lib/active_job/continuation.rb
+++ b/activejob/lib/active_job/continuation.rb
@@ -131,8 +131,10 @@ module ActiveJob
   # === Checkpoints
   #
   # A checkpoint is where a job can be interrupted. At a checkpoint the job will call
-  # +queue_adapter.stopping?+. If it returns true, the job will raise an
-  # ActiveJob::Continuation::Interrupt exception.
+  # +queue_adapter.stopping?+ with the job. If it returns true, the job will raise
+  # an ActiveJob::Continuation::Interrupt exception with +:stopping+ as the
+  # reason. If it returns another truthy value, the job will use that value as
+  # the interruption reason.
   #
   # There is an automatic checkpoint before the start of each step except for the first for
   # each job execution. Within a step one is created when calling +set!+, +advance!+ or +checkpoint!+.

--- a/activejob/lib/active_job/continuation/test_helper.rb
+++ b/activejob/lib/active_job/continuation/test_helper.rb
@@ -33,9 +33,12 @@ module ActiveJob
       #    perform_enqueued_jobs
       #    assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], MyJob.items
       #  end
-      def interrupt_job_during_step(job, step, cursor: nil, &block)
+      #
+      # A custom interrupt reason can be provided with the +reason+ argument.
+      def interrupt_job_during_step(job_class, step, cursor: nil, reason: true, &block)
         require_active_job_test_adapter!("interrupt_job_during_step")
-        queue_adapter.with(stopping: ->() { during_step?(job, step, cursor: cursor) }, &block)
+        stopping = ->(job) { reason if job.is_a?(job_class) && during_step?(job, step, cursor: cursor) }
+        queue_adapter.with(stopping: stopping, &block)
       end
 
       # Interrupt a job after a step.
@@ -62,15 +65,17 @@ module ActiveJob
       #    perform_enqueued_jobs
       #    assert_equal [1, 2, 3, 4], MyJob.items
       #  end
-      def interrupt_job_after_step(job, step, &block)
+      #
+      # A custom interrupt reason can be provided with the +reason+ argument.
+      def interrupt_job_after_step(job_class, step, reason: true, &block)
         require_active_job_test_adapter!("interrupt_job_after_step")
-        queue_adapter.with(stopping: ->() { after_step?(job, step) }, &block)
+        stopping = ->(job) { reason if job.is_a?(job_class) && after_step?(job, step) }
+        queue_adapter.with(stopping: stopping, &block)
       end
 
       private
-        def continuation_for(klass)
-          job = ActiveSupport::ExecutionContext.to_h[:job]
-          job.send(:continuation)&.to_h if job && job.is_a?(klass)
+        def continuation_for(job)
+          job.send(:continuation)&.to_h
         end
 
         def during_step?(job, step, cursor: nil)

--- a/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
@@ -17,7 +17,7 @@ module ActiveJob
         raise NotImplementedError
       end
 
-      def stopping?
+      def stopping?(job = nil)
         !!@stopping
       end
     end

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -35,8 +35,8 @@ module ActiveJob
         perform_or_enqueue(perform_enqueued_at_jobs && !filtered?(job), job, job_data)
       end
 
-      def stopping?
-        @stopping.is_a?(Proc) ? @stopping.call : @stopping
+      def stopping?(job = nil)
+        @stopping.is_a?(Proc) ? @stopping.call(job) : @stopping
       end
 
       private

--- a/activejob/test/cases/continuation_test.rb
+++ b/activejob/test/cases/continuation_test.rb
@@ -179,7 +179,8 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
 
     assert_enqueued_jobs 0, only: DeletingJob do
       assert_raises StandardError do
-        queue_adapter.with(stopping: ->() { raise StandardError if during_step?(DeletingJob, :delete) }) do
+        stopping = ->(job) { raise StandardError if job.is_a?(DeletingJob) && during_step?(job, :delete) }
+        queue_adapter.with(stopping: stopping) do
           perform_enqueued_jobs
         end
       end
@@ -212,7 +213,8 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
 
     IteratingJob.perform_later
 
-    queue_adapter.with(stopping: ->() { raise StandardError if during_step?(IteratingJob, :rename, cursor: 433) }) do
+    stopping = ->(job) { raise StandardError if job.is_a?(IteratingJob) && during_step?(job, :rename, cursor: 433) }
+    queue_adapter.with(stopping: stopping) do
       assert_enqueued_jobs 1, only: IteratingJob do
         perform_enqueued_jobs
       end
@@ -246,6 +248,30 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
       assert_raises StandardError do
         perform_enqueued_jobs
       end
+    end
+  end
+
+  test "passes the job to the queue adapter stopping predicate" do
+    LinearJob.items = []
+    LinearJob.perform_later
+
+    jobs = []
+    queue_adapter.with(stopping: ->(job) { jobs << job; false }) do
+      perform_enqueued_jobs
+    end
+
+    assert_operator jobs.length, :>, 0
+    assert jobs.all? { |job| job.is_a?(LinearJob) }
+  end
+
+  test "uses queue adapter stopping reason when interrupting" do
+    LinearJob.items = []
+    LinearJob.perform_later
+
+    interrupt_job_after_step LinearJob, :step_one, reason: :queue_paused do
+      perform_enqueued_jobs
+
+      assert_match(/Interrupted ActiveJob::TestContinuation::LinearJob \(Job ID: [0-9a-f-]{36}\) after 'step_one' \(queue_paused\)/, @logger.messages)
     end
   end
 
@@ -598,19 +624,22 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
   test "limits resumes due to errors" do
     LimitedResumesJob.perform_later(10)
 
-    queue_adapter.with(stopping: ->() { raise StandardError if during_step?(LimitedResumesJob, :iterate, cursor: 1) }) do
+    stopping = ->(job) { raise StandardError if job.is_a?(LimitedResumesJob) && during_step?(job, :iterate, cursor: 1) }
+    queue_adapter.with(stopping: stopping) do
       assert_enqueued_jobs 1, only: LimitedResumesJob do
         perform_enqueued_jobs
       end
     end
 
-    queue_adapter.with(stopping: ->() { raise StandardError if during_step?(LimitedResumesJob, :iterate, cursor: 2) }) do
+    stopping = ->(job) { raise StandardError if job.is_a?(LimitedResumesJob) && during_step?(job, :iterate, cursor: 2) }
+    queue_adapter.with(stopping: stopping) do
       assert_enqueued_jobs 1, only: LimitedResumesJob do
         perform_enqueued_jobs
       end
     end
 
-    queue_adapter.with(stopping: ->() { raise StandardError if during_step?(LimitedResumesJob, :iterate, cursor: 3) }) do
+    stopping = ->(job) { raise StandardError if job.is_a?(LimitedResumesJob) && during_step?(job, :iterate, cursor: 3) }
+    queue_adapter.with(stopping: stopping) do
       assert_enqueued_jobs 0, only: LimitedResumesJob do
         exception = assert_raises ActiveJob::Continuation::ResumeLimitError do
           perform_enqueued_jobs
@@ -625,7 +654,8 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
     LimitedResumesJob.with(resume_errors_after_advancing: false) do
       LimitedResumesJob.perform_later(10)
 
-      queue_adapter.with(stopping: ->() { raise StandardError, "boom" if during_step?(LimitedResumesJob, :iterate, cursor: 5) }) do
+      stopping = ->(job) { raise StandardError, "boom" if job.is_a?(LimitedResumesJob) && during_step?(job, :iterate, cursor: 5) }
+      queue_adapter.with(stopping: stopping) do
         assert_enqueued_jobs 0, only: LimitedResumesJob do
           exception = assert_raises StandardError do
             perform_enqueued_jobs


### PR DESCRIPTION
### Motivation / Background

Active Job backends like [Solid Queue](https://github.com/rails/solid_queue/blob/176721e33f542e07923fe02964cd55d2c18b4389/app/models/solid_queue/queue.rb#L24), [Good Job](https://github.com/bensheldon/good_job/tree/6637ecc228305cc02f0cb070a0057df1b570b55c#pausing-jobs) and Sidekiq Pro (to name a few) support pausing job processing based on job attributes like queue name, but long running jobs using continuations currently ignore this and will keep running until a graceful shutdown is initiated. This PR allows job adapters to support interruptions for long running jobs based on any job attribute.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
