### PR TITLE
Use registry to track jobs that change their queue adapter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Avoid rescanning all Active Job descendants in `ActiveJob::TestHelper`
+    before and after each test by tracking classes that explicitly change
+    their queue adapter.
+
+    *Rafael Mendonça França*
+
 *   Add `ActiveJob::Attributes` for declaring typed attributes that persist across
     job serialization and deserialization. It is included by `ActiveJob::Continuable`
     but can also be used standalone.

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/class/subclasses"
+require "active_support/descendants_tracker"
 require "active_support/testing/assertions"
 
 module ActiveJob
@@ -18,8 +19,25 @@ module ActiveJob
       included do
         class_attribute :_test_adapter, instance_accessor: false, instance_predicate: false
 
-        @_queue_adapter_changed_jobs = Set.new << self
+        @_queue_adapter_changed_jobs = ActiveSupport::DescendantsTracker::WeakSet.new
+        @_queue_adapter_changed_jobs << self
+        @_queue_adapter_changed_jobs_backfilled = false
         singleton_class.attr_reader :_queue_adapter_changed_jobs # :nodoc:
+        singleton_class.attr_accessor :_queue_adapter_changed_jobs_backfilled # :nodoc:
+
+        def self.backfill_queue_adapter_changed_jobs # :nodoc:
+          return if _queue_adapter_changed_jobs_backfilled
+
+          jobs_classes = ActiveJob::Base.descendants + [ActiveJob::Base]
+
+          jobs_classes.each do |klass|
+            if klass.singleton_class.private_method_defined?(:__class_attr__queue_adapter_owner, false)
+              _queue_adapter_changed_jobs << klass
+            end
+          end
+
+          self._queue_adapter_changed_jobs_backfilled = true
+        end
       end
 
       module ClassMethods
@@ -48,8 +66,10 @@ module ActiveJob
     end
 
     def before_setup # :nodoc:
+      ActiveJob::Base.backfill_queue_adapter_changed_jobs
+
       queue_adapter_specific_to_this_test_class = queue_adapter_for_test
-      ActiveJob::Base._queue_adapter_changed_jobs.each do |klass|
+      queue_adapter_changed_jobs.each do |klass|
         if queue_adapter_specific_to_this_test_class
           klass.enable_test_adapter(queue_adapter_specific_to_this_test_class)
         elsif klass._queue_adapter.nil?
@@ -65,7 +85,7 @@ module ActiveJob
     def after_teardown # :nodoc:
       super
 
-      ActiveJob::Base._queue_adapter_changed_jobs.each { |klass| klass.disable_test_adapter }
+      queue_adapter_changed_jobs.each { |klass| klass.disable_test_adapter }
     end
 
     # Returns a queue adapter instance to use with all Active Job test helpers.
@@ -763,6 +783,10 @@ module ActiveJob
         job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
         job.send(:deserialize_arguments_if_needed) unless skip_deserialize_arguments
         job
+      end
+
+      def queue_adapter_changed_jobs
+        ActiveJob::Base._queue_adapter_changed_jobs.to_a
       end
 
       def validate_option(only: nil, except: nil)

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -17,11 +17,20 @@ module ActiveJob
 
       included do
         class_attribute :_test_adapter, instance_accessor: false, instance_predicate: false
+
+        @_queue_adapter_changed_jobs = Set.new << self
+        singleton_class.attr_reader :_queue_adapter_changed_jobs # :nodoc:
       end
 
       module ClassMethods
         def queue_adapter
           self._test_adapter.nil? ? super : self._test_adapter
+        end
+
+        def queue_adapter=(name_or_adapter) # :nodoc:
+          super.tap do
+            ActiveJob::Base._queue_adapter_changed_jobs << self
+          end
         end
 
         def disable_test_adapter
@@ -40,7 +49,7 @@ module ActiveJob
 
     def before_setup # :nodoc:
       queue_adapter_specific_to_this_test_class = queue_adapter_for_test
-      queue_adapter_changed_jobs.each do |klass|
+      ActiveJob::Base._queue_adapter_changed_jobs.each do |klass|
         if queue_adapter_specific_to_this_test_class
           klass.enable_test_adapter(queue_adapter_specific_to_this_test_class)
         elsif klass._queue_adapter.nil?
@@ -56,7 +65,7 @@ module ActiveJob
     def after_teardown # :nodoc:
       super
 
-      queue_adapter_changed_jobs.each { |klass| klass.disable_test_adapter }
+      ActiveJob::Base._queue_adapter_changed_jobs.each { |klass| klass.disable_test_adapter }
     end
 
     # Returns a queue adapter instance to use with all Active Job test helpers.
@@ -754,13 +763,6 @@ module ActiveJob
         job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
         job.send(:deserialize_arguments_if_needed) unless skip_deserialize_arguments
         job
-      end
-
-      def queue_adapter_changed_jobs
-        (ActiveJob::Base.descendants << ActiveJob::Base).select do |klass|
-          # only override explicitly set adapters, a quirk of `class_attribute`
-          klass.singleton_class.public_instance_methods(false).include?(:_queue_adapter)
-        end
       end
 
       def validate_option(only: nil, except: nil)

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -799,7 +799,23 @@ class QueueAdapterTest < ActiveJob::TestCase
   end
 
   test "queue_adapter_changed_jobs includes jobs with explicit queue adapters" do
-    assert_includes ActiveJob::Base._queue_adapter_changed_jobs, JobWithAnAdapter
+    assert_includes ActiveJob::Base._queue_adapter_changed_jobs.to_a, JobWithAnAdapter
+  end
+
+  test "queue_adapter_changed_jobs does not retain garbage collected jobs" do
+    original_changed_jobs = ActiveJob::Base._queue_adapter_changed_jobs.to_a
+
+    Thread.new do
+      job_with_adapter = Class.new(ActiveJob::Base)
+      job_with_adapter.queue_adapter = :async
+
+      assert_includes ActiveJob::Base._queue_adapter_changed_jobs.to_a, job_with_adapter
+    end.join
+
+    4.times { GC.start }
+
+    assert_equal original_changed_jobs.map(&:object_id).sort,
+      ActiveJob::Base._queue_adapter_changed_jobs.to_a.map(&:object_id).sort
   end
 
   test "assert_enqueued_with enqueues a job with a queue_adapter and queue_adapter_for_test" do

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -798,6 +798,10 @@ class QueueAdapterTest < ActiveJob::TestCase
     ActiveJob::QueueAdapters::TestAdapter.new
   end
 
+  test "queue_adapter_changed_jobs includes jobs with explicit queue adapters" do
+    assert_includes ActiveJob::Base._queue_adapter_changed_jobs, JobWithAnAdapter
+  end
+
   test "assert_enqueued_with enqueues a job with a queue_adapter and queue_adapter_for_test" do
     assert_enqueued_with(job: JobWithAnAdapter) do
       JobWithAnAdapter.perform_later


### PR DESCRIPTION
This will avoid rescanning all Active Job descendants in `ActiveJob::TestHelper` before and after each test by tracking classes that explicitly change their queue adapter.

Fixes #57440.
Fixes #57441.