### PR TITLE
Rescue `RedisClient::Error` in `RedisCacheStore` failsafe

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -497,9 +497,17 @@ module ActiveSupport
           @supports_expire_nx = redis_versions.all? { |v| Gem::Version.new(v) >= Gem::Version.new("7.0.0") }
         end
 
+        FAILSAFE_ERRORS = [
+          ::Redis::BaseError,
+          ConnectionPool::Error,
+          ConnectionPool::TimeoutError,
+          (::RedisClient::Error if defined?(::RedisClient::Error)),
+        ].compact.freeze
+        private_constant :FAILSAFE_ERRORS
+
         def failsafe(method, returning: nil)
           yield
-        rescue ::Redis::BaseError, ConnectionPool::Error, ConnectionPool::TimeoutError => error
+        rescue *FAILSAFE_ERRORS => error
           @error_handler&.call(method: method, exception: error, returning: returning)
           returning
         end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -396,6 +396,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
   end
 
+  class RedisClientErrorRedisClient < Redis::Client
+    def ensure_connected(...)
+      raise RedisClient::Error
+    end
+
+    def self.translate_error!(error, **)
+      raise error
+    end
+  end
+
   class FailureRaisingFromUnavailableClientTest < StoreTest
     include FailureRaisingBehavior
 
@@ -450,6 +460,21 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       def emulating_unavailability
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, MaxClientsReachedRedisClient)
+
+        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace)
+      ensure
+        Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, old_client)
+      end
+  end
+
+  class FailureSafetyFromRedisClientErrorTest < StoreTest
+    include FailureSafetyBehavior
+
+    private
+      def emulating_unavailability
+        old_client = Redis.send(:remove_const, :Client)
+        Redis.const_set(:Client, RedisClientErrorRedisClient)
 
         yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace)
       ensure


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::Cache::RedisCacheStore` is documented as fault tolerant — _"if the Redis server is unavailable, no exceptions are raised. Cache fetches are all misses and writes are dropped"_ — but in some configurations the contract silently doesn't hold.

`Redis::Client#translate_error!` is what converts the underlying `RedisClient::*` exceptions into the `Redis::*` hierarchy that the failsafe rescues. That translation is bypassed when the pooled connection is a bare `::RedisClient` rather than a `Redis::Client` — which is exactly what `Redis.new(sentinels: ...)` produces (`client_implementation: ::RedisClient` is forced in `redis/client.rb`). In that configuration, raw `RedisClient::Error` subclasses (e.g. `RedisClient::ConnectionError`, `RedisClient::ReadTimeoutError`) escape the failsafe and turn transient Redis blips into application errors at every `Rails.cache` callsite.

This is the same shape of bug as #54432 (`ConnectionPool::TimeoutError` slipping past the failsafe), which was addressed by widening the rescue list in #54440 / #54460.

### Detail

Widens `RedisCacheStore#failsafe` to also rescue `::RedisClient::Error`. The rescue list is extracted into a private `FAILSAFE_ERRORS` constant so the `::RedisClient::Error` entry can be guarded with `defined?` — preserving compatibility with redis-rb 4.x, which has no top-level `RedisClient` constant (the activesupport gemspec still allows `redis >= 4.0.1`).

Adds a `FailureSafetyFromRedisClientErrorTest` to `redis_cache_store_test.rb`, mirroring the existing `FailureSafetyFromUnavailableClientTest` / `FailureSafetyFromMaxClientsReachedErrorTest` pattern. The new `RedisClientErrorRedisClient` test double raises `RedisClient::Error` from `ensure_connected` and overrides `self.translate_error!` as a no-op re-raise. The no-op is needed because current redis-rb translates `RedisClient::Error` at two layers — `Redis::Client#call_v` and `Redis#send_command` — both of which look up `Client.translate_error!` lexically; under the existing `Redis.const_set(:Client, …)` test pattern, that lookup resolves to our stub, so a single override on the subclass neutralizes both layers and faithfully simulates the Sentinel path. The `FailureSafetyBehavior` suite then asserts every public cache method (`read`, `write`, `fetch`, `delete`, `increment`, `decrement`, `clear`, etc.) returns its documented failsafe default.

Adds a CHANGELOG entry.

### Additional information

Related: #54432, #54440, #54460 — all addressed the same "failsafe doesn't actually catch everything" problem from different angles.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
