### PR TITLE
Refactor ActiveJob::TestHelper to no longer walk descendants

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -12,42 +12,72 @@ module ActiveJob
 
     include ActiveSupport::Testing::Assertions
 
-    module TestQueueAdapter
-      extend ActiveSupport::Concern
+    module TestQueueAdapter # :nodoc:
+      @excluded_jobs = Set.new
+      @cache = {}
+      @adapters = {}
 
-      included do
-        class_attribute :_test_adapter, instance_accessor: false, instance_predicate: false
+      class << self
+        attr_accessor :test_adapter
+        attr_reader :excluded_jobs
+
+        def excluded?(job)
+          @cache.fetch(job) do
+            @cache[job] = compute_excluded(job)
+          end
+        end
+
+        def exclude(job)
+          excluded_jobs << job
+          @cache.clear
+        end
+
+        def reset
+          excluded_jobs.clear
+          @cache.clear
+          @adapters.clear
+          @test_adapter = nil
+          @default_test_adapter = nil
+        end
+
+        def adapter_for(job)
+          return if excluded?(job)
+
+          if test_adapter
+            test_adapter
+          elsif @adapters[job]
+            @adapters[job]
+          elsif job._queue_adapter.nil?
+            @default_test_adapter ||= ActiveJob::QueueAdapters::TestAdapter.new
+            @adapters[job] ||= @default_test_adapter
+          end
+        end
+
+        private
+          def compute_excluded(job)
+            while job <= ActiveJob::Base
+              return true if excluded_jobs.include?(job)
+              job = job.superclass
+            end
+            false
+          end
       end
 
-      module ClassMethods
-        def queue_adapter
-          self._test_adapter.nil? ? super : self._test_adapter
-        end
+      def queue_adapter
+        TestQueueAdapter.adapter_for(self) || super
+      end
 
-        def disable_test_adapter
-          self._test_adapter = nil
-        end
-
-        def enable_test_adapter(test_adapter)
-          self._test_adapter = test_adapter
-        end
+      def disable_test_adapter
+        TestQueueAdapter.exclude(self)
       end
     end
 
     ActiveSupport.on_load(:active_job) do
-      ActiveJob::Base.include(TestQueueAdapter)
+      ActiveJob::Base.extend(TestQueueAdapter)
     end
 
     def before_setup # :nodoc:
-      queue_adapter_specific_to_this_test_class = queue_adapter_for_test
-      queue_adapter_changed_jobs.each do |klass|
-        if queue_adapter_specific_to_this_test_class
-          klass.enable_test_adapter(queue_adapter_specific_to_this_test_class)
-        elsif klass._queue_adapter.nil?
-          klass.enable_test_adapter(ActiveJob::QueueAdapters::TestAdapter.new)
-        end
-      end
-
+      TestQueueAdapter.test_adapter = queue_adapter_for_test
       clear_enqueued_jobs
       clear_performed_jobs
       super
@@ -56,7 +86,7 @@ module ActiveJob
     def after_teardown # :nodoc:
       super
 
-      queue_adapter_changed_jobs.each { |klass| klass.disable_test_adapter }
+      TestQueueAdapter.reset
     end
 
     # Returns a queue adapter instance to use with all Active Job test helpers.
@@ -754,13 +784,6 @@ module ActiveJob
         job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
         job.send(:deserialize_arguments_if_needed) unless skip_deserialize_arguments
         job
-      end
-
-      def queue_adapter_changed_jobs
-        (ActiveJob::Base.descendants << ActiveJob::Base).select do |klass|
-          # only override explicitly set adapters, a quirk of `class_attribute`
-          klass.singleton_class.public_instance_methods(false).include?(:_queue_adapter)
-        end
       end
 
       def validate_option(only: nil, except: nil)

--- a/railties/test/application/active_storage/analyzers_integration_test.rb
+++ b/railties/test/application/active_storage/analyzers_integration_test.rb
@@ -10,6 +10,15 @@ module ApplicationTests
 
     self.file_fixture_path = "#{RAILS_FRAMEWORK_ROOT}/activestorage/test/fixtures/files"
 
+    def app(...)
+      super
+
+      # `app` runs `active_job.set_configs` initializer, which sets `ActiveJob::Base.queue_adapter = :async`,
+      # after `ActiveJob::TestHelper#before_setup`.
+      # So we need to reset it to `:test` for Active Job test helpers to work.
+      ActiveJob::Base._queue_adapter = nil
+    end
+
     def setup
       build_app
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/57440
Fix: https://github.com/rails/rails/issues/57441
Close: https://github.com/rails/rails/pull/57473

Instead of using a `class_attribute` which requires walking over all ActiveJob::Base descendants on teardown, we can store the overrides in a couple data structures that we can easily clear in O(1) during teardown.

cc @rafaelfranca @simonlevasseur
