### PR TITLE
Acquire reaper_lock in preconnect to avoid racing with the reaper

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -808,13 +808,15 @@ module ActiveRecord
       # having to wait for a connection to be established when first using it
       # after checkout.
       def preconnect
-        sequential_maintenance -> c { (!c.connected? || !c.verified?) && c.allow_preconnect } do |conn|
-          conn.connect!
-        rescue
-          # Wholesale rescue: there's nothing we can do but move on. The
-          # connection will go back to the pool, and the next consumer will
-          # presumably try to connect again -- which will either work, or
-          # fail and they'll be able to report the exception.
+        reaper_lock do
+          sequential_maintenance -> c { (!c.connected? || !c.verified?) && c.allow_preconnect } do |conn|
+            conn.connect!
+          rescue
+            # Wholesale rescue: there's nothing we can do but move on. The
+            # connection will go back to the pool, and the next consumer will
+            # presumably try to connect again -- which will either work, or
+            # fail and they'll be able to report the exception.
+          end
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

`test_preconnect` intermittently fails on CI, e.g., [rails-nightly build #4330](https://buildkite.com/rails/rails-nightly/builds/4330#019e6616-bb7b-43f3-be2d-465dbf507100/L11173):

```ruby
ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_preconnect
Expected #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x00000000118c40
  env_name="arunit" role=:writing> to be connected?.
```

The reaper thread calls `preconnect` as part of its maintenance cycle while holding `reaper_lock`. When the test also calls `pool.preconnect` concurrently, the reaper may have a connection checked out via `checkout_for_maintenance`, leaving it in a transient state (`allow_preconnect=false`, `@raw_connection=nil`) that the test's `preconnect` cannot process.

### Detail

This Pull Request wraps `preconnect` in `reaper_lock`, following the same pattern used by `disconnect`, `discard!`, and `with_exclusively_acquired_all_connections` in e45d8acc746. Since `reaper_lock` uses a reentrant `Monitor`, the reaper's own call to `preconnect` (already inside `reaper_lock`) passes through without blocking.

### Additional information

Follow-up to e45d8acc746 ("Lock the pool while performing global operations").

Reproduced locally with Docker MariaDB 11.4 (`--cpus=0.02 --memory=128m`) under concurrent load. Without the fix, `test_preconnect` failed at iterations 7, 16, 36, and 65. With the fix, 100+ iterations passed with `reaper_lock` wait triggered 86+ times. Diagnostic logging branch: https://github.com/yahonda/rails/tree/fix-preconnect-reaper-lock-race-debug

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)