### PR TITLE
Simplify more ```activerecord``` tests with ```NotificationAssertions``` helpers

### DIFF
--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -45,33 +45,25 @@ module AsynchronousQueriesSharedTests
   end
 
   def test_async_query_foreground_fallback
-    status = {}
-
-    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-      if event.payload[:sql] == "SELECT * FROM does_not_exists"
-        status[:executed] = true
-        status[:async] = event.payload[:async]
-      end
-    end
-
-    @connection.pool.stub(:schedule_query, proc { }) do
-      if in_memory_db?
-        assert_raises ActiveRecord::StatementInvalid do
-          @connection.select_all "SELECT * FROM does_not_exists", async: true
-        end
-      else
-        future_result = @connection.select_all "SELECT * FROM does_not_exists", async: true
-        assert_kind_of ActiveRecord::FutureResult, future_result
-        assert_raises ActiveRecord::StatementInvalid do
-          future_result.result
+    events = capture_notifications("sql.active_record") do
+      @connection.pool.stub(:schedule_query, proc { }) do
+        if in_memory_db?
+          assert_raises ActiveRecord::StatementInvalid do
+            @connection.select_all "SELECT * FROM does_not_exists", async: true
+          end
+        else
+          future_result = @connection.select_all "SELECT * FROM does_not_exists", async: true
+          assert_kind_of ActiveRecord::FutureResult, future_result
+          assert_raises ActiveRecord::StatementInvalid do
+            future_result.result
+          end
         end
       end
     end
 
-    assert_equal true, status[:executed]
-    assert_equal false, status[:async]
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    event = events.find { _1.payload[:sql] == "SELECT * FROM does_not_exists" }
+    assert_not_nil event
+    assert_equal false, event.payload[:async]
   end
 
   private
@@ -90,28 +82,22 @@ class AsynchronousQueriesTest < ActiveRecord::TestCase
   end
 
   def test_async_select_all
-    status = {}
+    events = capture_notifications("sql.active_record") do
+      future_result = @connection.select_all "SELECT * FROM posts", async: true
 
-    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-      if event.payload[:sql] == "SELECT * FROM posts"
-        status[:executed] = true
-        status[:async] = event.payload[:async]
+      if in_memory_db?
+        assert_kind_of ActiveRecord::FutureResult::Complete, future_result
+      else
+        assert_kind_of ActiveRecord::FutureResult, future_result
+        wait_for_future_result(future_result)
       end
+
+      assert_kind_of ActiveRecord::Result, future_result.result
     end
 
-    future_result = @connection.select_all "SELECT * FROM posts", async: true
-
-    if in_memory_db?
-      assert_kind_of ActiveRecord::FutureResult::Complete, future_result
-    else
-      assert_kind_of ActiveRecord::FutureResult, future_result
-      wait_for_future_result(future_result)
-    end
-
-    assert_kind_of ActiveRecord::Result, future_result.result
-    assert_equal @connection.supports_concurrent_connections?, status[:async]
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    event = events.find { _1.payload[:sql] == "SELECT * FROM posts" }
+    assert_not_nil event
+    assert_equal @connection.supports_concurrent_connections?, event.payload[:async]
   end
 end
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -864,36 +864,31 @@ module ActiveRecord
       end
 
       def test_connection_notification_is_called
-        payloads = []
-        subscription = ActiveSupport::Notifications.subscribe("!connection.active_record") do |name, started, finished, unique_id, payload|
-          payloads << payload
+        events = capture_notifications("!connection.active_record") do
+          @connection_test_model_class.establish_connection :arunit
         end
 
-        @connection_test_model_class.establish_connection :arunit
-
-        assert_equal [:config, :connection_name, :role, :shard], payloads[0].keys.sort
-        assert_equal @connection_test_model_class.name, payloads[0][:connection_name]
-        assert_equal ActiveRecord::Base.default_shard, payloads[0][:shard]
-        assert_equal :writing, payloads[0][:role]
+        payload = events.first.payload
+        assert_equal [:config, :connection_name, :role, :shard], payload.keys.sort
+        assert_equal @connection_test_model_class.name, payload[:connection_name]
+        assert_equal ActiveRecord::Base.default_shard, payload[:shard]
+        assert_equal :writing, payload[:role]
       ensure
         @connection_test_model_class.remove_connection
-        ActiveSupport::Notifications.unsubscribe(subscription) if subscription
       end
 
       def test_connection_notification_is_called_for_shard
-        payloads = []
-        subscription = ActiveSupport::Notifications.subscribe("!connection.active_record") do |name, started, finished, unique_id, payload|
-          payloads << payload
+        events = capture_notifications("!connection.active_record") do
+          @connection_test_model_class.connects_to shards: { default: { writing: :arunit } }
         end
-        @connection_test_model_class.connects_to shards: { default: { writing: :arunit } }
 
-        assert_equal [:config, :connection_name, :role, :shard], payloads[0].keys.sort
-        assert_equal @connection_test_model_class.name, payloads[0][:connection_name]
-        assert_equal :default, payloads[0][:shard]
-        assert_equal :writing, payloads[0][:role]
+        payload = events.first.payload
+        assert_equal [:config, :connection_name, :role, :shard], payload.keys.sort
+        assert_equal @connection_test_model_class.name, payload[:connection_name]
+        assert_equal :default, payload[:shard]
+        assert_equal :writing, payload[:role]
       ensure
         @connection_test_model_class.remove_connection
-        ActiveSupport::Notifications.unsubscribe(subscription) if subscription
       end
 
       def test_sets_pool_schema_reflection

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -320,13 +320,20 @@ module ActiveRecord
       def test_simple_query
         expected_records = Post.where(author_id: 1).to_a
 
-        deferred_posts = Post.where(author_id: 1).load_async
-        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
+        status = {}
 
-        event = events.find { _1.payload[:name] == "Post Load" }
-        assert_not_nil event
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "Post Load"
+            status[:async] = event.payload[:async]
+          end
+        end
+
+        deferred_posts = Post.where(author_id: 1).load_async
+
         assert_equal expected_records, deferred_posts.to_a
-        assert_not_equal Post.lease_connection.supports_concurrent_connections?, event.payload[:async]
+        assert_not_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
 
       def test_load_async_from_transaction
@@ -346,21 +353,27 @@ module ActiveRecord
       def test_eager_loading_query
         expected_records = Post.where(author_id: 1).eager_load(:comments).to_a
 
+        status = {}
+
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "SQL"
+            status[:async] = event.payload[:async]
+          end
+        end
+
         deferred_posts = Post.where(author_id: 1).eager_load(:comments).load_async
 
         assert_not_predicate deferred_posts, :scheduled?
 
-        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
-
-        event = events.find { _1.payload[:name] == "SQL" }
-        assert_not_nil event
         assert_equal expected_records, deferred_posts.to_a
         assert_queries_count(0) do
           deferred_posts.each(&:comments)
         end
 
         assert_predicate Post.lease_connection, :supports_concurrent_connections?
-        assert_not event.payload[:async], "Expected async to be false with NullExecutor"
+        assert_not status[:async], "Expected async to be false with NullExecutor"
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
 
       def test_contradiction
@@ -449,15 +462,21 @@ module ActiveRecord
       def test_simple_query
         expected_records = Post.where(author_id: 1).to_a
 
+        status = {}
+
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "Post Load"
+            status[:async] = event.payload[:async]
+          end
+        end
+
         deferred_posts = Post.where(author_id: 1).load_async
         wait_for_async_query
 
-        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
-
-        event = events.find { _1.payload[:name] == "Post Load" }
-        assert_not_nil event
         assert_equal expected_records, deferred_posts.to_a
-        assert_equal Post.lease_connection.supports_concurrent_connections?, event.payload[:async]
+        assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
 
       def test_load_async_from_transaction
@@ -477,20 +496,26 @@ module ActiveRecord
       def test_eager_loading_query
         expected_records = Post.where(author_id: 1).eager_load(:comments).to_a
 
+        status = {}
+
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "Post Eager Load"
+            status[:async] = event.payload[:async]
+          end
+        end
+
         deferred_posts = Post.where(author_id: 1).eager_load(:comments).load_async
         wait_for_async_query
 
         assert_predicate deferred_posts, :scheduled?
 
-        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
-
-        event = events.find { _1.payload[:name] == "Post Eager Load" }
-        assert_not_nil event
         assert_equal expected_records, deferred_posts.to_a
         assert_queries_count(0) do
           deferred_posts.each(&:comments)
         end
-        assert_equal Post.lease_connection.supports_concurrent_connections?, event.payload[:async]
+        assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
 
       def test_contradiction
@@ -574,25 +599,32 @@ module ActiveRecord
         expected_records = Post.where(author_id: 1).to_a
         expected_dogs = OtherDog.where(id: 1).to_a
 
+        status = {}
+        dog_status = {}
+
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "Post Load"
+            status[:async] = event.payload[:async]
+          end
+
+          if event.payload[:name] == "OtherDog Load"
+            dog_status[:async] = event.payload[:async]
+          end
+        end
+
         deferred_posts = Post.where(author_id: 1).load_async
         deferred_dogs = OtherDog.where(id: 1).load_async
 
         wait_for_async_query
         wait_for_async_query
 
-        events = capture_notifications("sql.active_record") do
-          deferred_posts.to_a
-          deferred_dogs.to_a
-        end
-
-        post_event = events.find { _1.payload[:name] == "Post Load" }
-        dog_event = events.find { _1.payload[:name] == "OtherDog Load" }
-        assert_not_nil post_event
-        assert_not_nil dog_event
         assert_equal expected_records, deferred_posts.to_a
         assert_equal expected_dogs, deferred_dogs.to_a
-        assert_equal Post.lease_connection.async_enabled?, post_event.payload[:async]
-        assert_equal OtherDog.lease_connection.async_enabled?, dog_event.payload[:async]
+
+        assert_equal Post.lease_connection.async_enabled?, status[:async]
+        assert_equal OtherDog.lease_connection.async_enabled?, dog_status[:async]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
     end
   end

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -320,21 +320,13 @@ module ActiveRecord
       def test_simple_query
         expected_records = Post.where(author_id: 1).to_a
 
-        status = {}
-
-        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-          if event.payload[:name] == "Post Load"
-            status[:executed] = true
-            status[:async] = event.payload[:async]
-          end
-        end
-
         deferred_posts = Post.where(author_id: 1).load_async
+        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
 
+        event = events.find { _1.payload[:name] == "Post Load" }
+        assert_not_nil event
         assert_equal expected_records, deferred_posts.to_a
-        assert_not_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+        assert_not_equal Post.lease_connection.supports_concurrent_connections?, event.payload[:async]
       end
 
       def test_load_async_from_transaction
@@ -354,28 +346,21 @@ module ActiveRecord
       def test_eager_loading_query
         expected_records = Post.where(author_id: 1).eager_load(:comments).to_a
 
-        status = {}
-
-        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-          if event.payload[:name] == "SQL"
-            status[:executed] = true
-            status[:async] = event.payload[:async]
-          end
-        end
-
         deferred_posts = Post.where(author_id: 1).eager_load(:comments).load_async
 
         assert_not_predicate deferred_posts, :scheduled?
 
+        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
+
+        event = events.find { _1.payload[:name] == "SQL" }
+        assert_not_nil event
         assert_equal expected_records, deferred_posts.to_a
         assert_queries_count(0) do
           deferred_posts.each(&:comments)
         end
 
         assert_predicate Post.lease_connection, :supports_concurrent_connections?
-        assert_not status[:async], "Expected status[:async] to be false with NullExecutor"
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+        assert_not event.payload[:async], "Expected async to be false with NullExecutor"
       end
 
       def test_contradiction
@@ -464,21 +449,15 @@ module ActiveRecord
       def test_simple_query
         expected_records = Post.where(author_id: 1).to_a
 
-        status = {}
-        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-          if event.payload[:name] == "Post Load"
-            status[:executed] = true
-            status[:async] = event.payload[:async]
-          end
-        end
-
         deferred_posts = Post.where(author_id: 1).load_async
         wait_for_async_query
 
+        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
+
+        event = events.find { _1.payload[:name] == "Post Load" }
+        assert_not_nil event
         assert_equal expected_records, deferred_posts.to_a
-        assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+        assert_equal Post.lease_connection.supports_concurrent_connections?, event.payload[:async]
       end
 
       def test_load_async_from_transaction
@@ -498,26 +477,20 @@ module ActiveRecord
       def test_eager_loading_query
         expected_records = Post.where(author_id: 1).eager_load(:comments).to_a
 
-        status = {}
-        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-          if event.payload[:name] == "Post Eager Load"
-            status[:executed] = true
-            status[:async] = event.payload[:async]
-          end
-        end
-
         deferred_posts = Post.where(author_id: 1).eager_load(:comments).load_async
         wait_for_async_query
 
         assert_predicate deferred_posts, :scheduled?
 
+        events = capture_notifications("sql.active_record") { deferred_posts.to_a }
+
+        event = events.find { _1.payload[:name] == "Post Eager Load" }
+        assert_not_nil event
         assert_equal expected_records, deferred_posts.to_a
         assert_queries_count(0) do
           deferred_posts.each(&:comments)
         end
-        assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+        assert_equal Post.lease_connection.supports_concurrent_connections?, event.payload[:async]
       end
 
       def test_contradiction
@@ -601,34 +574,25 @@ module ActiveRecord
         expected_records = Post.where(author_id: 1).to_a
         expected_dogs = OtherDog.where(id: 1).to_a
 
-        status = {}
-        dog_status = {}
-
-        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
-          if event.payload[:name] == "Post Load"
-            status[:executed] = true
-            status[:async] = event.payload[:async]
-          end
-
-          if event.payload[:name] == "OtherDog Load"
-            dog_status[:executed] = true
-            dog_status[:async] = event.payload[:async]
-          end
-        end
-
         deferred_posts = Post.where(author_id: 1).load_async
         deferred_dogs = OtherDog.where(id: 1).load_async
 
         wait_for_async_query
         wait_for_async_query
 
+        events = capture_notifications("sql.active_record") do
+          deferred_posts.to_a
+          deferred_dogs.to_a
+        end
+
+        post_event = events.find { _1.payload[:name] == "Post Load" }
+        dog_event = events.find { _1.payload[:name] == "OtherDog Load" }
+        assert_not_nil post_event
+        assert_not_nil dog_event
         assert_equal expected_records, deferred_posts.to_a
         assert_equal expected_dogs, deferred_dogs.to_a
-
-        assert_equal Post.lease_connection.async_enabled?, status[:async]
-        assert_equal OtherDog.lease_connection.async_enabled?, dog_status[:async]
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+        assert_equal Post.lease_connection.async_enabled?, post_event.payload[:async]
+        assert_equal OtherDog.lease_connection.async_enabled?, dog_event.payload[:async]
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Follow-up to #57320, continuing to apply `NotificationAssertions` helpers to remaining `activerecord` tests that still used manual `ActiveSupport::Notifications.subscribe` and `subscribed` patterns.

### Detail

This PR changes tests in `asynchronous_queries_test.rb`, `connection_pool_test.rb`, and `relation/load_async_test.rb` to use `NotificationAssertions` helpers.

In each case where it is safe, manual subscribe/unsubscribe with an `asserted = true` flag or inline assertions inside the subscription callback is replaced with `capture_notifications` followed by filtering and assertions on the returned events.

In `load_async_test.rb`, tests that assert on notifications emitted from async query threads keep `ActiveSupport::Notifications.subscribe`, because `capture_notifications` uses `ActiveSupport::Notifications.subscribed`, which is thread-local and does not reliably observe cross-thread `sql.active_record` events. The remaining `load_async` tests in nested executor classes are converted to `capture_notifications` when notifications are observed on the test thread (for example, during `to_a` after `wait_for_async_query`).

### Additional information

Test-only refactor. No behavior changes.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.