### PR TITLE
live controller: copy thread variables to live controller thread too

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -454,4 +454,10 @@
 
     *Ruben Arakelyan*
 
+*   `ActionController::Live`: copy thread-local variables to stream controller thread
+
+    Previously it was only copying fiber-local (stored in `Thread#[]`) variables, now it'll also copy thread-local (accessbible via `Thread#thread_variable_get|set`) variables.
+
+    *Tiago Cardoso*
+
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -311,7 +311,8 @@ module ActionController
 
     def process(name)
       t1 = Thread.current
-      locals = t1.keys.map { |key| [key, t1[key]] }
+      thread_locals = t1.thread_variables.map { |key| [key, t1.thread_variable_get(key)] }
+      fiber_locals = t1.keys.map { |key| [key, t1[key]] }
 
       # The IsolatedExecutionState context may be a Fiber, not a Thread
       context = ActiveSupport::IsolatedExecutionState.context
@@ -326,7 +327,8 @@ module ActionController
 
           # Since we're processing the view in a different thread, copy the thread locals
           # from the main thread to the child thread. :'(
-          locals.each { |k, v| t2[k] = v }
+          thread_locals.each { |k, v| t2.thread_variable_set(k, v) }
+          fiber_locals.each { |k, v| t2[k] = v }
 
           ActiveSupport::IsolatedExecutionState.share_with(context, except: self.class.live_streaming_excluded_keys) do
             super(name)
@@ -345,7 +347,7 @@ module ActionController
               error = e
             end
           ensure
-            clean_up_thread_locals(locals, t2)
+            clean_up_thread_locals(thread_locals, fiber_locals, t2)
 
             @_response.commit!
           end
@@ -418,8 +420,9 @@ module ActionController
       end
 
       # Ensure we clean up any thread locals we copied so that the thread can reused.
-      def clean_up_thread_locals(locals, thread) # :nodoc:
-        locals.each { |k, _| thread[k] = nil }
+      def clean_up_thread_locals(thread_locals, fiber_locals, thread) # :nodoc:
+        thread_locals.each { |k, _| thread.thread_variable_set(k, nil) }
+        fiber_locals.each { |k, _| thread[k] = nil }
       end
 
       def self.live_thread_pool_executor

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -220,6 +220,7 @@ module ActionController
 
       def thread_locals
         tc.assert_equal "aaron", Thread.current[:setting]
+        tc.assert_equal "aaron", Thread.current.thread_variable_get(:setting)
 
         response.headers["Content-Type"] = "text/event-stream"
         %w{ hello world }.each do |word|
@@ -230,6 +231,7 @@ module ActionController
 
       def no_thread_locals
         tc.assert_nil Thread.current[:setting]
+        tc.assert_nil Thread.current.thread_variable_get(:setting)
 
         response.headers["Content-Type"] = "text/event-stream"
         %w{ hello world }.each do |word|
@@ -534,6 +536,8 @@ module ActionController
       @controller.tc = self
       Thread.current[:originating_thread] = Thread.current.object_id
       Thread.current[:setting]            = "aaron"
+      Thread.current.thread_variable_set(:originating_thread, Thread.current.object_id)
+      Thread.current.thread_variable_set(:setting, "aaron")
 
       get :thread_locals
     end
@@ -552,10 +556,13 @@ module ActionController
 
       Thread.current[:originating_thread] = Thread.current.object_id
       Thread.current[:setting]            = "aaron"
+      Thread.current.thread_variable_set(:originating_thread, Thread.current.object_id)
+      Thread.current.thread_variable_set(:setting, "aaron")
 
       get :thread_locals
 
       Thread.current[:setting] = nil
+      Thread.current.thread_variable_set(:setting, nil)
 
       get :no_thread_locals
     end
@@ -732,10 +739,12 @@ module ActionController
 
     def test_thread_locals_do_not_get_reset_in_test_environment
       Thread.current[:setting] = "aaron"
+      Thread.current.thread_variable_set(:setting, "aaron")
 
       get :greet
 
       assert_equal "aaron", Thread.current[:setting]
+      assert_equal "aaron", Thread.current.thread_variable_get(:setting)
     end
 
     def test_isolated_state_does_not_get_reset_in_test_environment


### PR DESCRIPTION
state from thread-local variables should also be copied to live controller thread.

### Motivation / Background

This Pull Request has been created because, in the rails application I work with, state is stored in thread-local variables to be shared across fibers explicitly. This recently broke an integration with an `ActionController:Live` enabled route. Considering the original patch, this should not have happened.

### Detail

This Pull Request copies thread-local variables in the same callsite where the fiber-local variables are also copied to the "live" thread.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
