### PR TITLE
Make exception wrapper ractor safe

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add a configuration for `ActionDispatch::ExceptionWrapper.wrapper_exceptions` at `config.action_dispatch.wrapper_exceptions`.
+
+    Exceptions on this list are unwrapped by the middleware and their cause is reported on instead.
+
+    *Andrew Novoselac*
+
 *   Release the executor state eagerly on rack hijack in
     `ActionDispatch::Executor`.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add a configuration for `ActionDispatch::ExceptionWrapper.silent_exceptions` at `config.action_dispatch.silent_exceptions`.
+
+    Exceptions on this list do not fall back to framework-level backtraces when there is no application backtrace.
+
+    *Andrew Novoselac*
+
 *   Add a configuration for `ActionDispatch::ExceptionWrapper.wrapper_exceptions` at `config.action_dispatch.wrapper_exceptions`.
 
     Exceptions on this list are unwrapped by the middleware and their cause is reported on instead.

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -26,7 +26,7 @@ module ActionDispatch
       "ActionController::TooManyRequests"                  => :too_many_requests,
       "Rack::QueryParser::ParameterTypeError"              => :bad_request,
       "Rack::QueryParser::InvalidParameterError"           => :bad_request
-    )
+    ).freeze
 
     cattr_accessor :rescue_templates, default: Hash.new("diagnostics").merge!(
       "ActionView::MissingTemplate"            => "missing_template",
@@ -35,7 +35,7 @@ module ActionDispatch
       "ActiveRecord::StatementInvalid"         => "invalid_statement",
       "ActionView::Template::Error"            => "template_error",
       "ActionController::MissingExactTemplate" => "missing_exact_template",
-    )
+    ).freeze
 
     cattr_accessor :wrapper_exceptions, default: [
       "ActionView::Template::Error"

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -39,7 +39,7 @@ module ActionDispatch
 
     cattr_accessor :wrapper_exceptions, default: [
       "ActionView::Template::Error"
-    ]
+    ].freeze
 
     cattr_accessor :silent_exceptions, default: [
       "ActionController::RoutingError",

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -44,7 +44,7 @@ module ActionDispatch
     cattr_accessor :silent_exceptions, default: [
       "ActionController::RoutingError",
       "ActionDispatch::Http::MimeNegotiation::InvalidType"
-    ]
+    ].freeze
 
     attr_reader :backtrace_cleaner, :wrapped_causes, :exception_class_name, :exception
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -18,6 +18,7 @@ module ActionDispatch
     config.action_dispatch.ignore_accept_header = false
     config.action_dispatch.rescue_templates = {}
     config.action_dispatch.rescue_responses = {}
+    config.action_dispatch.wrapper_exceptions = []
     config.action_dispatch.default_charset = nil
     config.action_dispatch.rack_cache = false
     config.action_dispatch.http_auth_salt = "http authentication"
@@ -88,6 +89,7 @@ module ActionDispatch
 
       ActionDispatch::ExceptionWrapper.rescue_responses = ActionDispatch::ExceptionWrapper.rescue_responses.merge(config.action_dispatch.rescue_responses).freeze
       ActionDispatch::ExceptionWrapper.rescue_templates = ActionDispatch::ExceptionWrapper.rescue_templates.merge(config.action_dispatch.rescue_templates).freeze
+      ActionDispatch::ExceptionWrapper.wrapper_exceptions = (ActionDispatch::ExceptionWrapper.wrapper_exceptions | config.action_dispatch.wrapper_exceptions).freeze
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -86,8 +86,8 @@ module ActionDispatch
         self.default_headers = app.config.action_dispatch.default_headers
       end
 
-      ActionDispatch::ExceptionWrapper.rescue_responses.merge!(config.action_dispatch.rescue_responses)
-      ActionDispatch::ExceptionWrapper.rescue_templates.merge!(config.action_dispatch.rescue_templates)
+      ActionDispatch::ExceptionWrapper.rescue_responses = ActionDispatch::ExceptionWrapper.rescue_responses.merge(config.action_dispatch.rescue_responses).freeze
+      ActionDispatch::ExceptionWrapper.rescue_templates = ActionDispatch::ExceptionWrapper.rescue_templates.merge(config.action_dispatch.rescue_templates).freeze
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -19,6 +19,7 @@ module ActionDispatch
     config.action_dispatch.rescue_templates = {}
     config.action_dispatch.rescue_responses = {}
     config.action_dispatch.wrapper_exceptions = []
+    config.action_dispatch.silent_exceptions = []
     config.action_dispatch.default_charset = nil
     config.action_dispatch.rack_cache = false
     config.action_dispatch.http_auth_salt = "http authentication"
@@ -90,6 +91,7 @@ module ActionDispatch
       ActionDispatch::ExceptionWrapper.rescue_responses = ActionDispatch::ExceptionWrapper.rescue_responses.merge(config.action_dispatch.rescue_responses).freeze
       ActionDispatch::ExceptionWrapper.rescue_templates = ActionDispatch::ExceptionWrapper.rescue_templates.merge(config.action_dispatch.rescue_templates).freeze
       ActionDispatch::ExceptionWrapper.wrapper_exceptions = (ActionDispatch::ExceptionWrapper.wrapper_exceptions | config.action_dispatch.wrapper_exceptions).freeze
+      ActionDispatch::ExceptionWrapper.silent_exceptions = (ActionDispatch::ExceptionWrapper.silent_exceptions | config.action_dispatch.silent_exceptions).freeze
 
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2436,6 +2436,25 @@ Use `ActionDispatch::ExceptionWrapper.wrapper_exceptions` to observe the configu
 ]
 ```
 
+#### `config.action_dispatch.rescue_templates`
+
+Configures the templates used to render exceptions. It accepts a hash and you can specify pairs of exception => template.
+
+Use `ActionDispatch::ExceptionWrapper.rescue_templates` to observe the configuration. By default, it is defined as:
+
+```ruby
+{
+  "ActionView::MissingTemplate"            => "missing_template",
+  "ActionController::RoutingError"         => "routing_error",
+  "AbstractController::ActionNotFound"     => "unknown_action",
+  "ActiveRecord::StatementInvalid"         => "invalid_statement",
+  "ActionView::Template::Error"            => "template_error",
+  "ActionController::MissingExactTemplate" => "missing_exact_template",
+}
+```
+
+All exceptions that are not configured will map to Rails' built in diagnostics template.
+
 #### `config.action_dispatch.cookies_same_site_protection`
 
 Configures the default value of the `SameSite` attribute when setting cookies.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2436,6 +2436,20 @@ Use `ActionDispatch::ExceptionWrapper.wrapper_exceptions` to observe the configu
 ]
 ```
 
+#### `config.action_dispatch.silent_exceptions`
+
+Configures which exceptions should not fall back to showing framework-level backtraces when there is no application
+backtrace. This is useful for silencing noisy backtraces for exceptions raised at the framework or plugin level.
+
+Use `ActionDispatch::ExceptionWrapper.silent_exceptions` to observe the configuration. By default, it is defined as:
+
+```ruby
+[
+  "ActionController::RoutingError",
+  "ActionDispatch::Http::MimeNegotiation::InvalidType"
+]
+```
+
 #### `config.action_dispatch.rescue_templates`
 
 Configures the templates used to render exceptions. It accepts a hash and you can specify pairs of exception => template.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2411,6 +2411,31 @@ Use `ActionDispatch::ExceptionWrapper.rescue_responses` to observe the configura
 
 Any exceptions that are not configured will be mapped to 500 Internal Server Error.
 
+#### `config.action_dispatch.wrapper_exceptions`
+
+Configures which exceptions are unwrapped. Wrapper exceptions will have their cause reported by the exception wrapper
+instead of themselves.
+
+```ruby
+config.action_dispatch.wrapper_exceptions += [WrapperException]
+
+begin
+  raise OriginalException
+rescue OriginalException
+  raise WrapperException
+end
+```
+
+In the above example the `WrapperException` will be unwrapped and the `OriginalException` will be reported.
+
+Use `ActionDispatch::ExceptionWrapper.wrapper_exceptions` to observe the configuration. By default, it is defined as:
+
+```ruby
+[
+  "ActionView::Template::Error"
+]
+```
+
 #### `config.action_dispatch.cookies_same_site_protection`
 
 Configures the default value of the `SameSite` attribute when setting cookies.


### PR DESCRIPTION
### Motivation / Background

`ActionDispatch::ExceptionWrapper` state needs to be made Ractor safe.

### Detail

`rescue_responses` and `rescue_templates` already have a config on the engine. So I just freeze the underlying hash and create a new frozen one when adding the configured values.

`wrapper_exceptions` and `silent_exceptions` have no public config so I added them.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
