### PR TITLE
Reject malformed Mailgun signatures

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Return `401 Unauthorized` for malformed Mailgun signatures.
+
+    *Andrii Furmanets*
+
 *   Return `422 Unprocessable Content` for Mandrill inbound events that are missing a raw message.
 
     *Andrii Furmanets*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -95,7 +95,7 @@ module ActionMailbox
 
         private
           def signed?
-            ActiveSupport::SecurityUtils.secure_compare signature, expected_signature
+            signature.is_a?(String) && ActiveSupport::SecurityUtils.secure_compare(signature, expected_signature)
           end
 
           # Allow for 2 minutes of drift between Mailgun time and local server time.

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -114,6 +114,20 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
     assert_response :unauthorized
   end
 
+  test "rejecting an inbound email from Mailgun with a malformed signature" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      travel_to "2018-10-09 15:15:00 EDT"
+      post rails_mailgun_inbound_emails_url, params: {
+        timestamp: 1539112500,
+        token: "7VwW7k6Ak7zcTwoSoNm7aTtbk1g67MKAnsYLfUB7PdszbgR5Xi",
+        signature: [ "ef24c5225322217bb065b80bb54eb4f9206d764e3e16abab07f0a64d1cf477cc" ],
+        "body-mime" => file_fixture("../files/welcome.eml").read
+      }
+    end
+
+    assert_response :unauthorized
+  end
+
   test "raising when the configured Mailgun Signing key is nil" do
     switch_key_to nil do
       assert_raises ArgumentError do


### PR DESCRIPTION
Fixes #57484.

### Summary

This makes the Mailgun ingress reject malformed signature parameter shapes as authentication failures instead of passing them into `secure_compare`.

The current code assumes `signature` is a string. When a request parameter parses as an array, `secure_compare` raises before the ingress can return `401 Unauthorized`.

### Changes

* check that the submitted Mailgun signature is a string before comparing it
* add a regression for an array-shaped signature parameter
* add an Action Mailbox changelog entry

### Validation

* `cd actionmailbox && bin/test test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb`
* `bundle exec rubocop actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb`
