### PR TITLE
Make the Event Reporter ractor safe

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -290,7 +290,7 @@ module ActiveSupport
     self.context_store = EventContext
 
     def initialize(*subscribers, raise_on_error: false)
-      @subscribers = []
+      @subscribers = [].freeze
       subscribers.each { |subscriber| subscribe(subscriber) }
       @debug_mode = true
       @raise_on_error = raise_on_error
@@ -318,7 +318,7 @@ module ActiveSupport
       unless subscriber.respond_to?(:emit)
         raise ArgumentError, "Event subscriber #{subscriber.class.name} must respond to #emit"
       end
-      @subscribers << { subscriber: subscriber, filter: filter }
+      @subscribers = (@subscribers | [{ subscriber: subscriber, filter: filter }]).freeze
     end
 
     # Unregister an event subscriber. Accepts either a subscriber or a class.
@@ -330,7 +330,7 @@ module ActiveSupport
     #   # or
     #   Rails.event.unsubscribe(MyEventSubscriber)
     def unsubscribe(subscriber)
-      @subscribers.delete_if { |s| subscriber === s[:subscriber] }
+      @subscribers = @subscribers.reject { |s| subscriber === s[:subscriber] }.freeze
     end
 
     # Reports an event to all registered subscribers. An event name and payload can be provided:

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -56,6 +56,7 @@ module ActiveSupport
       reporter = ActiveSupport::EventReporter.new
       subscribers = reporter.subscribe(@subscriber)
       assert_equal([{ subscriber: @subscriber, filter: nil }], subscribers)
+      assert_predicate @reporter.subscribers, :frozen?
     end
 
     test "#subscribe with filter" do
@@ -101,6 +102,7 @@ module ActiveSupport
 
       assert_empty first_subscriber.events.select(&event_matcher(name: "last_event", payload: { key: "value" }))
       assert_empty second_subscriber.events.select(&event_matcher(name: "last_event", payload: { key: "value" }))
+      assert_predicate @reporter.subscribers, :frozen?
     end
 
     test "#notify with name" do

--- a/activesupport/test/structured_event_subscriber_test.rb
+++ b/activesupport/test/structured_event_subscriber_test.rb
@@ -106,14 +106,11 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
   def test_no_event_reporter_subscribers
     ActiveSupport::StructuredEventSubscriber.attach_to :test, @subscriber
 
-    old_subscribers = ActiveSupport.event_reporter.subscribers.dup
-    ActiveSupport.event_reporter.subscribers.clear
-
-    assert_not_called @subscriber, :emit_event do
-      ActiveSupport::Notifications.instrument("event.test")
+    ActiveSupport.with(event_reporter: ActiveSupport::EventReporter.new) do
+      assert_not_called @subscriber, :emit_event do
+        ActiveSupport::Notifications.instrument("event.test")
+      end
     end
-  ensure
-    ActiveSupport.event_reporter.subscribers.push(*old_subscribers)
   end
 
   def test_emit_event_does_not_filter_payload


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to make the Event Reporter ractor safe.

### Detail

The Event Reporter contains an array of `subscribers`. To make this ractor safe we need to freeze that array, when we want to add / remove a subscriber we dup the array, add/remove the new one, freeze it and reassign it.

### Additional information

The subscriber's filter is problematic since it is not ractor safe, it needs to go through `Ractor.shareable_proc`. We _could_ try to do it on the users behalf, but its dangerous since we don't know what `self` of that proc should be. If the proc relies on calling a method a `self`, then we will raise at run time when the filter is called.

That's a general problem that will show up in other places I was already discussing with @gmcgibbon and we will have to think about the best way to solve.

But for now I think this PR is worthwhile as just the basic event reporter instance with no subscribers in `Rails.event` prevents the application from being shared in a Ractor.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
