### PR TITLE
Make the error reporter ractor safe

### DIFF
--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -35,7 +35,7 @@ module ActiveSupport
     UnexpectedError = Class.new(Exception)
 
     def initialize(*subscribers, logger: nil)
-      @subscribers = subscribers.flatten
+      @subscribers = subscribers.flatten.freeze
       @logger = logger
       @debug_mode = false
       @context_middlewares = ErrorContextMiddlewareStack.new
@@ -165,7 +165,7 @@ module ActiveSupport
       unless subscriber.respond_to?(:report)
         raise ArgumentError, "Error subscribers must respond to #report"
       end
-      @subscribers << subscriber
+      @subscribers = (@subscribers | [subscriber]).freeze
     end
 
     # Unregister an error subscriber. Accepts either a subscriber or a class.
@@ -177,7 +177,7 @@ module ActiveSupport
     #   # or
     #   Rails.error.unsubscribe(MyErrorSubscriber)
     def unsubscribe(subscriber)
-      @subscribers.delete_if { |s| subscriber === s }
+      @subscribers = @subscribers.reject { |s| subscriber === s }.freeze
     end
 
     # Prevent a subscriber from being notified of errors for the
@@ -299,7 +299,7 @@ module ActiveSupport
 
       class ErrorContextMiddlewareStack # :nodoc:
         def initialize
-          @stack = []
+          @stack = [].freeze
         end
 
         # Add a middleware to the error context stack.
@@ -308,7 +308,7 @@ module ActiveSupport
             raise ArgumentError, "Error context middleware must respond to #call"
           end
 
-          @stack << middleware
+          @stack = (@stack | [middleware]).freeze
         end
 
         # Run all middlewares in the stack

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -232,6 +232,7 @@ class ErrorReporterTest < ActiveSupport::TestCase
 
     assert_equal 1, @subscriber.events.size
     assert_equal 1, second_subscriber.events.size
+    assert_predicate @reporter.instance_variable_get(:@subscribers), :frozen?
   end
 
   test "can unsubscribe" do
@@ -257,6 +258,7 @@ class ErrorReporterTest < ActiveSupport::TestCase
 
     assert_equal 2, @subscriber.events.size
     assert_equal 1, second_subscriber.events.size
+    assert_predicate @reporter.instance_variable_get(:@subscribers), :frozen?
   end
 
   test "handled errors default to :warning severity" do


### PR DESCRIPTION


### Motivation / Background

This Pull Request has been created to make the error reporter ractor safe.

### Detail

We need the subscribers as well as the middleware stack to be frozen. These are already behind an API, so we can freeze them then dup, add and freeze when a new one is added.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
