### PR TITLE
Allow `reorder` to be called without arguments

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Allow `reorder` to be called without arguments to remove an existing order.
+
+    Previously `reorder` required at least one argument and raised an
+    `ArgumentError` when called with none, so removing an order meant calling
+    `reorder(nil)`. It can now be called without arguments as a shorthand:
+
+    ```ruby
+    Post.order(:title).reorder # => no ORDER BY clause, same as reorder(nil)
+    ```
+
+    *Jean Mendonça*
+
 *   Raise `ActiveRecord::MultiparameterAssignmentErrors` instead of `NoMethodError`
     when assigning a malformed multiparameter attribute name.
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -775,10 +775,15 @@ module ActiveRecord
     #   User.order('email DESC').reorder('id ASC').order('name ASC')
     #
     # generates a query with <tt>ORDER BY id ASC, name ASC</tt>.
+    #
+    # Calling +reorder+ without arguments (or with +nil+) removes any existing
+    # order, equivalent to <tt>reorder(nil)</tt>:
+    #
+    #   User.order('email DESC').reorder # generated SQL has no 'ORDER BY' clause
     def reorder(*args)
-      check_if_method_has_arguments!(__callee__, args) do
-        sanitize_order_arguments(args)
-      end
+      sanitize_order_arguments(args) unless args.empty?
+      args.flatten!
+      args.compact_blank!
       spawn.reorder!(*args)
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -588,7 +588,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, person_with_reader_and_post.size
   end
 
-  %w( references includes preload eager_load group order reorder reselect unscope
+  %w( references includes preload eager_load group order reselect unscope
       joins left_joins left_outer_joins optimizer_hints annotate regroup ).each do |method|
     class_eval <<~RUBY
       def test_no_arguments_to_#{method}_raise_errors
@@ -2016,6 +2016,13 @@ class RelationTest < ActiveRecord::TestCase
     relation = Post.order(:title).reorder(nil)
 
     assert_nil relation.order_values.first
+  end
+
+  def test_order_with_reorder_without_arguments_removes_the_order
+    relation = Post.order(:title).reorder
+
+    assert_empty relation.order_values
+    assert relation.reordering_value
   end
 
   def test_reverse_order_with_reorder_nil_removes_the_order


### PR DESCRIPTION
### Summary

`reorder` currently requires at least one argument and raises `ArgumentError: The method .reorder() must contain arguments.` when called with none. As a result, the only way to strip an existing order off a relation is to pass an explicit `nil`:

```ruby
Post.order(:title).reorder(nil) # removes the ORDER BY
Post.order(:title).reorder      # before: ArgumentError
```

This makes the no-argument call a shorthand for `reorder(nil)`, so it simply removes any existing order:

```ruby
Post.order(:title).reorder # => no ORDER BY clause
```

The behavior for all existing call styles is unchanged — `reorder(:id)`, `reorder("id desc")`, `reorder(nil)`, `reorder([])` all behave exactly as before. The argument-sanitizing pipeline (`sanitize_order_arguments` + flatten + `compact_blank!`) is preserved for the non-empty case; only the "must contain arguments" guard is dropped for `reorder`.

### Other Information

- `reorder` is removed from the shared `test_no_arguments_to_*_raise_errors` list, and a new test (`test_order_with_reorder_without_arguments_removes_the_order`) covers the empty call clearing the order while still flipping `reordering_value`.
- CHANGELOG entry added.

All `activerecord` relation tests pass on SQLite, and RuboCop reports no offenses on the changed files.