### PR TITLE
fix: ParameterFilter not filtering nested ActionController::Parameters

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `ActiveSupport::ParameterFilter` not filtering sensitive keys nested
+    inside `ActionController::Parameters`. Since `ActionController::Parameters`
+    no longer inherits from `Hash`, the `value.is_a?(Hash)` guard in
+    `value_for_key` was never entered for nested parameter objects, silently
+    leaving sensitive values unfiltered in logs.
+
+    *Ruy Rocha*
+
 *   Fix `NumberHelper` raising `FloatDomainError` for `Infinity` / `NaN` with
     `significant: true`.
 

--- a/activesupport/lib/active_support/parameter_filter.rb
+++ b/activesupport/lib/active_support/parameter_filter.rb
@@ -189,6 +189,8 @@ module ActiveSupport
         value = @mask
       elsif value.is_a?(Hash)
         value = call(value, full_key, original_params)
+      elsif value.respond_to?(:to_unsafe_h)
+        value = call(value.to_unsafe_h, full_key, original_params)
       elsif value.is_a?(Array)
         value = value.map { |v| value_for_key(key, v, full_parent_key, original_params) }
       elsif @blocks

--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -3,6 +3,7 @@
 require_relative "abstract_unit"
 require "active_support/core_ext/hash"
 require "active_support/parameter_filter"
+require "action_controller"
 
 class ParameterFilterTest < ActiveSupport::TestCase
   test "process parameter filter" do
@@ -182,5 +183,66 @@ class ParameterFilterTest < ActiveSupport::TestCase
   test "precompile_filters eliminate dead patterns" do
     assert_equal [/token/i], ActiveSupport::ParameterFilter.precompile_filters(["user.token", "token"])
     assert_equal [/password/i], ActiveSupport::ParameterFilter.precompile_filters(["user_password", "password"])
+  end
+
+  test "filter does not skip nested action controller parameters" do
+    filter = ActiveSupport::ParameterFilter.new(["secret"])
+
+    params = ActionController::Parameters.new(
+      "secret" => "root_secret",
+      "safe"   => "visible",
+      "nested" => { "secret" => "nested_secret", "safe" => "also_visible" }
+    )
+
+    filtered = filter.filter(params)
+
+    assert_equal "[FILTERED]",   filtered["secret"]
+    assert_equal "visible",      filtered["safe"]
+    assert_equal "[FILTERED]",   filtered.dig("nested", "secret")
+    assert_equal "also_visible", filtered.dig("nested", "safe")
+  end
+
+  test "filter handles deeply nested action controller parameters" do
+    filter = ActiveSupport::ParameterFilter.new(["token"])
+
+    params = ActionController::Parameters.new(
+      "level1" => { "level2" => { "token" => "deep_secret", "safe" => "ok" } }
+    )
+
+    filtered = filter.filter(params)
+
+    assert_equal "[FILTERED]", filtered.dig("level1", "level2", "token")
+    assert_equal "ok",         filtered.dig("level1", "level2", "safe")
+  end
+
+  test "filter applies proc filters inside nested action controller parameters" do
+    seen_keys = []
+    filter = ActiveSupport::ParameterFilter.new([
+      ->(k, v) { seen_keys << k if v.is_a?(String) }
+    ])
+
+    params = ActionController::Parameters.new(
+      "top"    => "hello",
+      "nested" => { "inner" => "world" }
+    )
+
+    filter.filter(params)
+
+    assert_includes seen_keys, "top"
+    assert_includes seen_keys, "inner"
+  end
+
+  test "filter masks nested keys in action controller parameters the same as in plain hashes" do
+    filter = ActiveSupport::ParameterFilter.new(["secret"])
+
+    hash_params = { "secret" => 1234, "nested" => { "secret" => 5678 } }
+    filtered_hash = filter.filter(hash_params)
+    assert_equal "[FILTERED]", filtered_hash["secret"]
+    assert_equal "[FILTERED]", filtered_hash.dig("nested", "secret")
+
+    ac_params = ActionController::Parameters.new("secret" => 1234, "nested" => { "secret" => 5678 })
+    filtered_ac = filter.filter(ac_params)
+    assert_equal "[FILTERED]", filtered_ac["secret"]
+    assert_equal "[FILTERED]", filtered_ac.dig("nested", "secret")
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveSupport::ParameterFilter` silently skips filtering sensitive keys nested inside `ActionController::Parameters` objects. Since `ActionController::Parameters` stopped inheriting from `Hash` in #20868, the `value.is_a?(Hash)` guard in `value_for_key` is never entered for nested parameter objects. This is a security issue: sensitive keys such as `password`, `token`, and `secret` in nested params pass through unfiltered to logs and error trackers. Fixes #57474.

### Detail

This Pull Request changes `value_for_key` in `ActiveSupport::ParameterFilter` to add an `elsif value.respond_to?(:to_unsafe_h)` branch that converts the nested `ActionController::Parameters` to a plain Hash via `to_unsafe_h` before recursing. This keeps the `is_a?(Hash)` fast path untouched and avoids introducing an `activesupport` -> `actionpack` dependency.

### Additional information

The fix converts to a plain Hash before recursing rather than recursing into the `ActionController::Parameters` directly. This means the return type of a filtered nested value is a plain Hash, which is acceptable since filtered parameters are only used for logging and never returned to the application as params.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: [Fix #issue-number]
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.