### PR TITLE
Reject malformed Action Mailbox original recipients

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Return `422 Unprocessable Content` for malformed Mailgun and Postmark original recipient parameters.
+
+    *Andrii Furmanets*
+
 *   Return `401 Unauthorized` for malformed Mailgun signatures.
 
     *Andrii Furmanets*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -48,12 +48,27 @@ module ActionMailbox
 
     def create
       ActionMailbox::InboundEmail.create_and_extract_message_id! mail
+    rescue MalformedRecipientError => error
+      logger.error error.message
+      head ActionDispatch::Constants::UNPROCESSABLE_CONTENT
     end
 
     private
+      class MalformedRecipientError < StandardError
+        def initialize(message = "Malformed Mailgun recipient")
+          super
+        end
+      end
+
       def mail
         params.require("body-mime").tap do |raw_email|
-          raw_email.prepend("X-Original-To: ", params.require(:recipient), "\n") if params.key?(:recipient)
+          raw_email.prepend("X-Original-To: ", recipient, "\n") if params.key?(:recipient)
+        end
+      end
+
+      def recipient
+        params.require(:recipient).tap do |recipient|
+          raise MalformedRecipientError unless recipient.is_a?(String)
         end
       end
 

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb
@@ -50,7 +50,7 @@ module ActionMailbox
 
     def create
       ActionMailbox::InboundEmail.create_and_extract_message_id! mail
-    rescue ActionController::ParameterMissing => error
+    rescue ActionController::ParameterMissing, MalformedOriginalRecipientError => error
       logger.error <<~MESSAGE
         #{error.message}
 
@@ -61,9 +61,21 @@ module ActionMailbox
     end
 
     private
+      class MalformedOriginalRecipientError < StandardError
+        def initialize(message = "Malformed Postmark original recipient")
+          super
+        end
+      end
+
       def mail
         params.require("RawEmail").tap do |raw_email|
-          raw_email.prepend("X-Original-To: ", params.require("OriginalRecipient"), "\n") if params.key?("OriginalRecipient")
+          raw_email.prepend("X-Original-To: ", original_recipient, "\n") if params.key?("OriginalRecipient")
+        end
+      end
+
+      def original_recipient
+        params.require("OriginalRecipient").tap do |original_recipient|
+          raise MalformedOriginalRecipientError unless original_recipient.is_a?(String)
         end
       end
   end

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -68,6 +68,21 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
     assert_equal "replies@example.com", mail.header["X-Original-To"].decoded
   end
 
+  test "rejecting an inbound email from Mailgun with a malformed recipient" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      travel_to "2018-10-09 15:15:00 EDT"
+      post rails_mailgun_inbound_emails_url, params: {
+        timestamp: 1539112500,
+        token: "7VwW7k6Ak7zcTwoSoNm7aTtbk1g67MKAnsYLfUB7PdszbgR5Xi",
+        signature: "ef24c5225322217bb065b80bb54eb4f9206d764e3e16abab07f0a64d1cf477cc",
+        "body-mime" => file_fixture("../files/welcome.eml").read,
+        recipient: [ "replies@example.com" ]
+      }
+    end
+
+    assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
+  end
+
   test "rejecting a delayed inbound email from Mailgun" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       travel_to "2018-10-09 15:26:00 EDT"

--- a/actionmailbox/test/controllers/ingresses/postmark/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/postmark/inbound_emails_controller_test.rb
@@ -47,6 +47,18 @@ class ActionMailbox::Ingresses::Postmark::InboundEmailsControllerTest < ActionDi
     assert_equal "thisguy@domain.abcd", mail.header["X-Original-To"].decoded
   end
 
+  test "rejecting an inbound email from Postmark with a malformed original recipient" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_postmark_inbound_emails_url,
+        headers: { authorization: credentials }, params: {
+          RawEmail: file_fixture("../files/welcome.eml").read,
+          OriginalRecipient: [ "thisguy@domain.abcd" ],
+        }
+    end
+
+    assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
+  end
+
   test "rejecting when RawEmail param is missing" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       post rails_postmark_inbound_emails_url,


### PR DESCRIPTION
## Summary

Fixes #57491.

Mailgun and Postmark both prepend optional original-recipient parameters into the raw email as an `X-Original-To` header. If those parameters are present but malformed, they currently reach `String#prepend` and raise `TypeError`.

This validates the optional Mailgun `recipient` and Postmark `OriginalRecipient` values before prepending them, returning `422 Unprocessable Content` when they are malformed.

## Validation

- `cd actionmailbox && bin/test test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb -i "/malformed recipient/"`
- `cd actionmailbox && bin/test test/controllers/ingresses/postmark/inbound_emails_controller_test.rb -i "/malformed original recipient/"`
- `cd actionmailbox && bin/test test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb`
- `cd actionmailbox && bin/test test/controllers/ingresses/postmark/inbound_emails_controller_test.rb`
- `cd actionmailbox && bin/test test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb test/controllers/ingresses/postmark/inbound_emails_controller_test.rb test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb test/controllers/ingresses/relay/inbound_emails_controller_test.rb`
- `bundle exec rubocop actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb actionmailbox/test/controllers/ingresses/postmark/inbound_emails_controller_test.rb`
- `git diff --check`