### PR TITLE
[ci skip] Add step to create path for redirection before launching the application

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -390,6 +390,15 @@ browser to bypass this validation. To prevent this and ensure the validation
 always runs, we use `.with_defaults(password_challenge: "")` to set a default
 value even if the `password_challenge` parameter is missing.
 
+Now let's add the route to redirect the user once the password is updated.
+
+```ruby#3
+namespace :settings do
+  resource :password, only: [ :show, :update ]
+  resource :profile, only: [ :show ]
+end
+```
+
 You can now visit http://localhost:3000/settings/password to update your
 password.
 
@@ -425,7 +434,7 @@ first and last name.
 
 ### Profile Routes & Controller
 
-In `config/routes.rb`, add a profile resource under the settings namespace. We
+In `config/routes.rb`, add an `update` action on the profile resource under the settings namespace. We
 can also add a root to the namespace to handle any visits to `/settings` and
 redirect them to profile settings.
 


### PR DESCRIPTION
Fixes #57471

### Motivation / Background

This PR adds a step in the Sign Up and Settings tutorial docs which create the route for redirecting the user once the password is updated.
 
This Pull Request has been created because currently the path helper `settings_profile_path` is used before is actually created. This might be confusing for someone that follows this tutorial.

### Detail

This PR adds a step in the Sign Up and Settings tutorial docs which create the route for redirecting the user once the password is updated.
