### PR TITLE
Reject malformed Action Mailbox raw email params

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Return `422 Unprocessable Content` for malformed Mailgun, Postmark, and SendGrid raw email parameters.
+
+    *Andrii Furmanets*
+
 *   Return `422 Unprocessable Content` for malformed Mailgun and Postmark original recipient parameters.
 
     *Andrii Furmanets*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -48,12 +48,18 @@ module ActionMailbox
 
     def create
       ActionMailbox::InboundEmail.create_and_extract_message_id! mail
-    rescue MalformedRecipientError => error
+    rescue MalformedEmailError, MalformedRecipientError => error
       logger.error error.message
       head ActionDispatch::Constants::UNPROCESSABLE_CONTENT
     end
 
     private
+      class MalformedEmailError < StandardError
+        def initialize(message = "Malformed Mailgun raw email")
+          super
+        end
+      end
+
       class MalformedRecipientError < StandardError
         def initialize(message = "Malformed Mailgun recipient")
           super
@@ -62,6 +68,8 @@ module ActionMailbox
 
       def mail
         params.require("body-mime").tap do |raw_email|
+          raise MalformedEmailError unless raw_email.is_a?(String)
+
           raw_email.prepend("X-Original-To: ", recipient, "\n") if params.key?(:recipient)
         end
       end

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb
@@ -50,7 +50,7 @@ module ActionMailbox
 
     def create
       ActionMailbox::InboundEmail.create_and_extract_message_id! mail
-    rescue ActionController::ParameterMissing, MalformedOriginalRecipientError => error
+    rescue ActionController::ParameterMissing, MalformedEmailError, MalformedOriginalRecipientError => error
       logger.error <<~MESSAGE
         #{error.message}
 
@@ -61,6 +61,12 @@ module ActionMailbox
     end
 
     private
+      class MalformedEmailError < StandardError
+        def initialize(message = "Malformed Postmark raw email")
+          super
+        end
+      end
+
       class MalformedOriginalRecipientError < StandardError
         def initialize(message = "Malformed Postmark original recipient")
           super
@@ -69,6 +75,8 @@ module ActionMailbox
 
       def mail
         params.require("RawEmail").tap do |raw_email|
+          raise MalformedEmailError unless raw_email.is_a?(String)
+
           raw_email.prepend("X-Original-To: ", original_recipient, "\n") if params.key?("OriginalRecipient")
         end
       end

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
@@ -50,12 +50,18 @@ module ActionMailbox
 
     def create
       ActionMailbox::InboundEmail.create_and_extract_message_id! mail
-    rescue JSON::ParserError, MalformedEnvelopeError => error
+    rescue JSON::ParserError, MalformedEmailError, MalformedEnvelopeError => error
       logger.error error.message
       head ActionDispatch::Constants::UNPROCESSABLE_CONTENT
     end
 
     private
+      class MalformedEmailError < StandardError
+        def initialize(message = "Malformed SendGrid raw email")
+          super
+        end
+      end
+
       class MalformedEnvelopeError < StandardError
         def initialize(message = "Malformed SendGrid envelope")
           super
@@ -64,6 +70,8 @@ module ActionMailbox
 
       def mail
         params.require(:email).tap do |raw_email|
+          raise MalformedEmailError unless raw_email.is_a?(String)
+
           envelope_recipients.each { |to| raw_email.prepend("X-Original-To: ", to, "\n") } if params.key?(:envelope)
         end
       end

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -83,6 +83,20 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
     assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
   end
 
+  test "rejecting an inbound email from Mailgun with a malformed raw email" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      travel_to "2018-10-09 15:15:00 EDT"
+      post rails_mailgun_inbound_emails_url, params: {
+        timestamp: 1539112500,
+        token: "7VwW7k6Ak7zcTwoSoNm7aTtbk1g67MKAnsYLfUB7PdszbgR5Xi",
+        signature: "ef24c5225322217bb065b80bb54eb4f9206d764e3e16abab07f0a64d1cf477cc",
+        "body-mime" => [ file_fixture("../files/welcome.eml").read ]
+      }
+    end
+
+    assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
+  end
+
   test "rejecting a delayed inbound email from Mailgun" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       travel_to "2018-10-09 15:26:00 EDT"

--- a/actionmailbox/test/controllers/ingresses/postmark/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/postmark/inbound_emails_controller_test.rb
@@ -59,6 +59,17 @@ class ActionMailbox::Ingresses::Postmark::InboundEmailsControllerTest < ActionDi
     assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
   end
 
+  test "rejecting an inbound email from Postmark with a malformed raw email" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_postmark_inbound_emails_url,
+        headers: { authorization: credentials }, params: {
+          RawEmail: [ file_fixture("../files/welcome.eml").read ],
+        }
+    end
+
+    assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
+  end
+
   test "rejecting when RawEmail param is missing" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       post rails_postmark_inbound_emails_url,

--- a/actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb
@@ -63,6 +63,15 @@ class ActionMailbox::Ingresses::Sendgrid::InboundEmailsControllerTest < ActionDi
     assert_rejects_malformed_envelope "{\"to\":[1],\"from\":\"jason@37signals.com\"}"
   end
 
+  test "rejecting an inbound email from Sendgrid with a malformed raw email" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_sendgrid_inbound_emails_url,
+        headers: { authorization: credentials }, params: { email: [ file_fixture("../files/welcome.eml").read ] }
+    end
+
+    assert_response ActionDispatch::Constants::UNPROCESSABLE_CONTENT
+  end
+
   test "rejecting an unauthorized inbound email from Sendgrid" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       post rails_sendgrid_inbound_emails_url, params: { email: file_fixture("../files/welcome.eml").read }


### PR DESCRIPTION
### Motivation / Background

Fixes #57494.

Mailgun, Postmark, and SendGrid ingress controllers required their raw email parameter, but did not validate the parameter shape before passing it to `ActionMailbox::InboundEmail.create_and_extract_message_id!`. Array-shaped values reached checksum extraction and raised `TypeError` instead of returning the existing malformed-input `422 Unprocessable Content` response.

### Detail

This pull request validates the raw email parameter is a string for:

- Mailgun `body-mime`
- Postmark `RawEmail`
- SendGrid `email`

Malformed raw email values now use the same 422 response path as adjacent malformed recipient and envelope metadata.

### Additional information

Tested with:

- `cd actionmailbox && bin/test test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb test/controllers/ingresses/postmark/inbound_emails_controller_test.rb test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb -i "/malformed raw email/"`
- `cd actionmailbox && bin/test test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb test/controllers/ingresses/postmark/inbound_emails_controller_test.rb test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb`
- `cd actionmailbox && bin/test`
- `bundle exec rubocop actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb actionmailbox/test/controllers/ingresses/postmark/inbound_emails_controller_test.rb actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb`
- `git diff --check`
