### PR TITLE
Fix docs for ActiveSupport::SecurityUtils.fixed_length_secure_compare

### DIFF
--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -2,12 +2,11 @@
 
 module ActiveSupport
   module SecurityUtils
-    # Constant time string comparison, for fixed length strings.
-    #
-    # The values compared should be of fixed length, such as strings
-    # that have already been processed by HMAC. Raises in case of length mismatch.
-
     if defined?(OpenSSL.fixed_length_secure_compare)
+      # Constant time string comparison, for fixed length strings.
+      #
+      # The values compared should be of fixed length, such as strings
+      # that have already been processed by HMAC. Raises in case of length mismatch.
       def fixed_length_secure_compare(a, b)
         OpenSSL.fixed_length_secure_compare(a, b)
       end


### PR DESCRIPTION
### Motivation / Background

Working on https://github.com/rails/rails/pull/57467 I noticed the docs for `ActiveSupport::SecurityUtils.fixed_length_secure_compare` don't show up

https://api.rubyonrails.org/classes/ActiveSupport/SecurityUtils.html#method-c-fixed_length_secure_compare

### Detail

Fix it by moving the comment above the first method definition. Verified locally.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
