### PR TITLE
Sanitize HTTP authentication realms

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Strip unsafe characters from HTTP authentication realms before writing
+    `WWW-Authenticate` challenge headers.
+
+    *Andrii Furmanets*
+
 *   Release the executor state eagerly on rack hijack in
     `ActionDispatch::Executor`.
 

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -9,6 +9,12 @@ require "active_support/core_ext/array/access"
 module ActionController
   # HTTP Basic, Digest, and Token authentication.
   module HttpAuthentication
+    AUTHENTICATION_REALM_UNSAFE_CHARS = /[\x00-\x1F"]/
+
+    def self.authentication_realm(realm)
+      realm.to_s.gsub(AUTHENTICATION_REALM_UNSAFE_CHARS, "")
+    end
+
     # # HTTP Basic authentication
     #
     # ### Simple Basic example
@@ -137,7 +143,7 @@ module ActionController
 
       def authentication_request(controller, realm, message = nil, content_type = nil)
         message ||= "HTTP Basic: Access denied.\n"
-        controller.headers["WWW-Authenticate"] = %(Basic realm="#{realm.tr('"', "")}")
+        controller.headers["WWW-Authenticate"] = %(Basic realm="#{HttpAuthentication.authentication_realm(realm)}")
         controller.status = 401
         controller.content_type = content_type
         controller.response_body = message
@@ -276,7 +282,7 @@ module ActionController
         secret_key = secret_token(controller.request)
         nonce = self.nonce(secret_key)
         opaque = opaque(secret_key)
-        controller.headers["WWW-Authenticate"] = %(Digest realm="#{realm}", qop="auth", algorithm=MD5, nonce="#{nonce}", opaque="#{opaque}")
+        controller.headers["WWW-Authenticate"] = %(Digest realm="#{HttpAuthentication.authentication_realm(realm)}", qop="auth", algorithm=MD5, nonce="#{nonce}", opaque="#{opaque}")
       end
 
       def authentication_request(controller, realm, message = nil, content_type = nil)
@@ -556,7 +562,7 @@ module ActionController
       #
       def authentication_request(controller, realm, message = nil, content_type = nil)
         message ||= "HTTP Token: Access denied.\n"
-        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.tr('"', "")}")
+        controller.headers["WWW-Authenticate"] = %(Token realm="#{HttpAuthentication.authentication_realm(realm)}")
         controller.__send__ :render, plain: message, status: :unauthorized, content_type: content_type
       end
     end

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -8,6 +8,7 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     before_action :authenticate_with_request, only: :display
     before_action :authenticate_long_credentials, only: :show
     before_action :auth_with_special_chars, only: :special_creds
+    before_action :authenticate_with_unsafe_realm, only: :unsafe_realm
 
     http_basic_authenticate_with name: "David", password: "Goliath", only: :search
     http_basic_authenticate_with name: "David", password: "Goliath", content_type: "application/json", only: :search_with_content_type
@@ -26,6 +27,10 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
 
     def special_creds
       render plain: "Only for special credentials"
+    end
+
+    def unsafe_realm
+      render plain: "Only with a safe challenge"
     end
 
     def search
@@ -62,6 +67,10 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
         authenticate_or_request_with_http_basic do |username, password|
           username == 'login!@#$%^&*()_+{}[];"\',./<>?`~ \n\r\t' && password == 'pwd:!@#$%^&*()_+{}[];"\',./<>?`~ \n\r\t'
         end
+      end
+
+      def authenticate_with_unsafe_realm
+        request_http_basic_authentication("Super\r\nSecret\"")
       end
 
       def authenticate_long_credentials
@@ -137,6 +146,13 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
 
     assert_response :unauthorized
     assert_equal "Authentication Failed\n", @response.body
+    assert_equal 'Basic realm="SuperSecret"', @response.headers["WWW-Authenticate"]
+  end
+
+  test "authentication request strips unsafe realm characters" do
+    get :unsafe_realm
+
+    assert_response :unauthorized
     assert_equal 'Basic realm="SuperSecret"', @response.headers["WWW-Authenticate"]
   end
 

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -7,6 +7,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
   class DummyDigestController < ActionController::Base
     before_action :authenticate, only: :index
     before_action :authenticate_with_request, only: :display
+    before_action :authenticate_with_unsafe_realm, only: :unsafe_realm
 
     USERS = { "lifo" => "world", "pretty" => "please",
               "dhh" => OpenSSL::Digest::MD5.hexdigest(["dhh", "SuperSecret", "secret"].join(":")) }.freeze
@@ -17,6 +18,10 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
 
     def display
       render plain: "Definitely Maybe" if @logged_in
+    end
+
+    def unsafe_realm
+      render plain: "Only with a safe challenge"
     end
 
     private
@@ -33,6 +38,10 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
         else
           request_http_digest_authentication("SuperSecret", "Authentication Failed", "application/json")
         end
+      end
+
+      def authenticate_with_unsafe_realm
+        request_http_digest_authentication("Super\r\nSecret\"")
       end
   end
 
@@ -79,6 +88,14 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
     assert_response :unauthorized
     assert_equal "Authentication Failed", @response.body
     assert_equal "application/json", @response.media_type
+    credentials = decode_credentials(@response.headers["WWW-Authenticate"])
+    assert_equal "SuperSecret", credentials[:realm]
+  end
+
+  test "authentication request strips unsafe realm characters" do
+    get :unsafe_realm
+
+    assert_response :unauthorized
     credentials = decode_credentials(@response.headers["WWW-Authenticate"])
     assert_equal "SuperSecret", credentials[:realm]
   end

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -7,6 +7,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     before_action :authenticate, only: :index
     before_action :authenticate_with_request, only: :display
     before_action :authenticate_long_credentials, only: :show
+    before_action :authenticate_with_unsafe_realm, only: :unsafe_realm
 
     def index
       render plain: "Hello Secret"
@@ -18,6 +19,10 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
 
     def show
       render plain: "Only for loooooong credentials"
+    end
+
+    def unsafe_realm
+      render plain: "Only with a safe challenge"
     end
 
     private
@@ -33,6 +38,10 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
         else
           request_http_token_authentication("SuperSecret", "Authentication Failed\n", "application/json")
         end
+      end
+
+      def authenticate_with_unsafe_realm
+        request_http_token_authentication("Super\r\nSecret\"")
       end
 
       def authenticate_long_credentials
@@ -119,6 +128,13 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_response :unauthorized
     assert_equal "Authentication Failed\n", @response.body
     assert_equal "application/json", @response.media_type
+    assert_equal 'Token realm="SuperSecret"', @response.headers["WWW-Authenticate"]
+  end
+
+  test "authentication request strips unsafe realm characters" do
+    get :unsafe_realm
+
+    assert_response :unauthorized
     assert_equal 'Token realm="SuperSecret"', @response.headers["WWW-Authenticate"]
   end
 


### PR DESCRIPTION
### Motivation / Background

Fixes #57497.

HTTP authentication helpers allow applications to pass a custom challenge realm. Basic and Token challenges removed quotes from the realm, but still preserved control characters. Digest challenges interpolated the realm directly. The challenge header should normalize unsafe realm characters before writing `WWW-Authenticate`.

### Detail

This Pull Request adds a shared HTTP authentication realm sanitizer and uses it for Basic, Digest, and Token challenge headers. It also adds regression coverage for unsafe realm characters in all three authentication modes.

### Additional information

Validation run:

* `cd actionpack && bin/test test/controller/http_basic_authentication_test.rb`
* `cd actionpack && bin/test test/controller/http_token_authentication_test.rb`
* `cd actionpack && bin/test test/controller/http_digest_authentication_test.rb`
* `bundle exec rubocop actionpack/lib/action_controller/metal/http_authentication.rb actionpack/test/controller/http_basic_authentication_test.rb actionpack/test/controller/http_token_authentication_test.rb actionpack/test/controller/http_digest_authentication_test.rb`
* `git diff --check`

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.