### PR TITLE
Fix Array#to_query producing double && when array contains empty hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -59,7 +59,10 @@ class Array
     if empty?
       nil.to_query(prefix)
     else
-      collect { |value| value.to_query(prefix) }.join "&"
+      filter_map { |value|
+        q = value.to_query(prefix)
+        q unless q.empty?
+      }.join "&"
     end
   end
 end

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -52,6 +52,10 @@ class ToQueryTest < ActiveSupport::TestCase
     assert_equal "person%5B%5D", [].to_query("person")
   end
 
+  def test_array_with_empty_hash
+    assert_query_equal "a%5B%5D=1&a%5B%5D=2", a: [1, {}, 2]
+  end
+
   def test_nested_empty_hash
     assert_equal "",
       {}.to_query


### PR DESCRIPTION
### Motivation / Background

`Array#to_query` produces a malformed query string when the array contains an empty hash:

```ruby
{a: [1, {}, 2]}.to_query
# => "a%5B%5D=1&&a%5B%5D=2"  (before)
# => "a%5B%5D=1&a%5B%5D=2"   (after)
```

Per the [WHATWG URL Standard](https://url.spec.whatwg.org/#concept-urlencoded-parser), `application/x-www-form-urlencoded` parsing splits on `&`, so the empty string between two `&`s produces an unintended empty name/value pair.

### Detail

`Hash#to_query` returns `""` for empty hashes. `Array#to_query` now rejects empty strings before joining with `&`, consistent with how `Hash#to_query` already skips empty hashes at the top level.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.