### PR TITLE
Return a completed promise for async_count with limit(0)

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -483,7 +483,7 @@ module ActiveRecord
       def execute_simple_calculation(operation, column_name, distinct) # :nodoc:
         if build_count_subquery?(operation, column_name, distinct)
           # Shortcut when limit is zero.
-          return 0 if limit_value == 0
+          return @async ? Promise::Complete.new(0) : 0 if limit_value == 0
 
           relation = self
           query_builder = build_count_subquery(spawn, column_name, distinct)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -306,7 +306,10 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_count_should_shortcut_with_limit_zero
     accounts = Account.limit(0)
 
-    assert_no_queries { assert_equal 0, accounts.count }
+    assert_no_queries do
+      assert_equal 0, accounts.count
+      assert_async_equal 0, accounts.async_count
+    end
   end
 
   def test_limit_is_kept


### PR DESCRIPTION
## Summary

`async_count` is documented to return an `ActiveRecord::Promise`, but `Post.limit(0).async_count` currently returns the raw integer `0`.

That happens because the `limit(0)` shortcut in `execute_simple_calculation` returns before the async path has a chance to wrap the result. In practice that means callers can get an `Integer` back from `async_count`, so methods like `value`, `then`, and `pending?` are not available.

This keeps the existing synchronous shortcut in place and returns a completed promise in async mode.

I also extended the existing zero-limit count test to cover `async_count` while keeping the no-query expectation.

This is the same kind of early return mismatch that was fixed for contradicted async aggregations, just through the `limit(0)` fast path.

## Before

```ruby
result = Post.limit(0).async_count
result.class
# => Integer
```

## After

```ruby
result = Post.limit(0).async_count
result.value
# => 0
```

## Tests

- `ARCONN=sqlite3 BUNDLE_WITHOUT=db bundle exec ruby -w -Itest test/cases/calculations_test.rb -i test_count_should_shortcut_with_limit_zero`
- `ARCONN=sqlite3 BUNDLE_WITHOUT=db bundle exec ruby -w -Itest test/cases/calculations_test.rb -i test_count_with_empty_in`
