### PR TITLE
Handle malformed signed cache payloads gracefully

### DIFF
--- a/activesupport/lib/active_support/cache/coder.rb
+++ b/activesupport/lib/active_support/cache/coder.rb
@@ -53,13 +53,18 @@ module ActiveSupport
           end
         end
 
-        type = dumped.unpack1(PACKED_TYPE_TEMPLATE)
-        expires_at = dumped.unpack1(PACKED_EXPIRES_AT_TEMPLATE)
-        version_length = dumped.unpack1(PACKED_VERSION_LENGTH_TEMPLATE)
+        begin
+          type = dumped.unpack1(PACKED_TYPE_TEMPLATE)
+          expires_at = dumped.unpack1(PACKED_EXPIRES_AT_TEMPLATE)
+          version_length = dumped.unpack1(PACKED_VERSION_LENGTH_TEMPLATE)
 
-        expires_at = nil if expires_at < 0
-        version = load_version(dumped.byteslice(PACKED_VERSION_INDEX, version_length)) if version_length >= 0
-        payload = dumped.byteslice((PACKED_VERSION_INDEX + [version_length, 0].max)..)
+          expires_at = nil if expires_at < 0
+          version = load_version(dumped.byteslice(PACKED_VERSION_INDEX, version_length)) if version_length >= 0
+          payload = dumped.byteslice((PACKED_VERSION_INDEX + [version_length, 0].max)..)
+        rescue ArgumentError, TypeError => error
+          ActiveSupport.error_reporter.report(error, source: "active_support.cache")
+          return
+        end
 
         compressor = @compressor if type & COMPRESSED_FLAG > 0
         serializer = STRING_DESERIALIZERS[type & ~COMPRESSED_FLAG] || @serializer

--- a/activesupport/test/cache/cache_coder_test.rb
+++ b/activesupport/test/cache/cache_coder_test.rb
@@ -30,6 +30,10 @@ class CacheCoderTest < ActiveSupport::TestCase
       assert_nil coder.load(payload.byteslice(1..-1))
     end
 
+    assert_error_reported do
+      assert_nil coder.load(payload.byteslice(0, 2))
+    end
+
     lazy_entry = coder.load(payload.byteslice(0..-2))
     assert_raises ActiveSupport::Cache::DeserializationError do
       lazy_entry.value


### PR DESCRIPTION
## Summary

A malformed cache payload that still starts with the signed cache frame prefix can currently raise while `ActiveSupport::Cache::Coder#load` is unpacking the header.

For example:

```ruby
coder = ActiveSupport::Cache::Coder.new(Marshal, Zlib)
coder.load("\x00\x11".b)
# => ArgumentError: @ outside of string
```

That exception escapes the normal corrupted-payload handling, so instead of being treated like a cache miss it can bubble out as an error.

This change makes the signed-header parse path behave like the other corrupted payload cases: report the error and return `nil` when the frame is too malformed to even build a `LazyEntry`.

I also added a regression to the existing corrupted payload test to cover the signed-but-too-short case.

## Why this happens

`Coder#load` already handles deserialization failures for unsigned or legacy payloads, but the signed-frame path was unpacking header fields without any protection. If the payload had the signature but not enough bytes for the header, `unpack1` raised before the existing cache-miss behavior could kick in.

## Tests

- `BUNDLE_WITHOUT=db bundle exec ruby -w -Itest test/cache/cache_coder_test.rb`
