### PR TITLE
Reject malformed hosts with extra ports

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -74,14 +74,26 @@ module ActionDispatch
 
         def sanitize_string(host)
           if host.start_with?(".")
-            /\A#{SUBDOMAIN_REGEX}?#{Regexp.escape(host[1..-1])}#{PORT_REGEX}?\z/i
+            /\A#{SUBDOMAIN_REGEX}?#{Regexp.escape(host[1..-1])}#{port_regexp(host)}\z/i
           else
-            /\A#{Regexp.escape host}#{PORT_REGEX}?\z/i
+            /\A#{Regexp.escape host}#{port_regexp(host)}\z/i
           end
         end
 
         def extract_hostname(host)
           host.slice(VALID_IP_HOSTNAME, "host") || host
+        end
+
+        def port_regexp(host)
+          host_with_port?(host) ? "" : "#{PORT_REGEX}?"
+        end
+
+        def host_with_port?(host)
+          if host.start_with?("[")
+            host.match?(/\]:\d+\z/)
+          else
+            host.count(":") == 1 && host.match?(/:\d+\z/)
+          end
         end
     end
 

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -274,6 +274,39 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_match "Success", response.body
   end
 
+  test "hosts configured with explicit port work" do
+    @app = build_app(["host.test:3000"])
+
+    get "/", env: {
+      "HOST" => "host.test:3000",
+      "action_dispatch.show_detailed_exceptions" => true
+    }
+
+    assert_response :ok
+    assert_match "Success", response.body
+  end
+
+  test "blocks malformed hosts with extra ports" do
+    redirect_app = -> env do
+      request = ActionDispatch::Request.new(env)
+      uri = URI.parse("/login")
+      uri.scheme = request.scheme
+      uri.host = request.host
+
+      [301, { Rack::LOCATION => uri.to_s }, []]
+    end
+
+    @app = build_app(["www.example.com:80"], lint: false, app: redirect_app)
+
+    get "/", env: {
+      "HOST" => "www.example.com:80:80",
+      "action_dispatch.show_detailed_exceptions" => true
+    }
+
+    assert_response :forbidden
+    assert_match "Blocked hosts: www.example.com:80:80", response.body
+  end
+
   test "blocks requests with spoofed X-FORWARDED-HOST" do
     @app = build_app([IPAddr.new("127.0.0.1")])
 


### PR DESCRIPTION
### Motivation / Background

Fixes #37956.

When an allowed host is configured with an explicit port, HostAuthorization currently appends another optional port segment to the generated regexp. That lets a malformed Host value such as `www.example.com:80:80` pass the allowlist and reach downstream redirect code that expects a valid host.

### Detail

This Pull Request keeps the existing optional-port behavior for hosts configured without a port, while avoiding the extra optional port when the configured host already includes one. It also adds coverage for exact explicit-port hosts and malformed extra-port hosts.

### Additional information

Validation:

- `cd actionpack && bin/test test/dispatch/host_authorization_test.rb -i "/extra ports/"`
- `cd actionpack && bin/test test/dispatch/host_authorization_test.rb`
- `cd actionpack && bundle exec rubocop lib/action_dispatch/middleware/host_authorization.rb test/dispatch/host_authorization_test.rb`
- `git diff --check`

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.