### PR TITLE
Action Cable: make duplicate subscribe idempotent

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Make duplicate `subscribe` commands idempotent.
+
+    When a client sends a `subscribe` command for an identifier it is already
+    subscribed to, re-transmit `confirm_subscription` instead of raising
+    `Subscriptions::AlreadySubscribedError`. The `subscribed` callback is not
+    invoked a second time and no new subscription is registered. This
+    addresses long-standing reports (#24875, #44652, #48292) where clients
+    that legitimately re-issue subscribe commands (e.g. Turbo
+    `<turbo-cable-stream-source>` across morph/refresh cycles, React/Vue
+    components, reconnect loops) would either spin retrying because no
+    confirmation arrived, or, more recently, crash the connection on the
+    raised exception.
+
+    The `Subscriptions::AlreadySubscribedError` class is removed; it was
+    introduced in the unreleased adapterization refactor and never shipped.
+
+    *Samuel Williams*
+
 *   Respect calls to `#reject` in `before_subscribe` callbacks.
 
     It doesn't call `#subscribed` if a `before_subscribe` callback calls `#reject`.

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -14,12 +14,6 @@ module ActionCable
     class Subscriptions # :nodoc:
       class Error < StandardError; end
 
-      class AlreadySubscribedError < Error
-        def initialize(identifier)
-          super "Already subscribed to #{identifier}"
-        end
-      end
-
       class ChannelNotFound < Error
         def initialize(channel_id)
           super "Channel not found: #{channel_id}"
@@ -64,7 +58,17 @@ module ActionCable
 
         raise MalformedCommandError, data unless id_key.present?
 
-        raise AlreadySubscribedError, id_key if subscriptions.key?(id_key)
+        # If the client re-subscribes to a channel it's already subscribed to,
+        # re-transmit the confirmation so the client's subscription guarantor
+        # can resolve. This is common with libraries that re-insert
+        # subscription tags into the DOM (e.g. Turbo's <turbo-cable-stream-source>
+        # across morph/refresh) and was the long-standing behaviour of
+        # ActionCable prior to its server adapterization refactor (see #44652,
+        # #48292, #24875).
+        if subscriptions.key?(id_key)
+          connection.transmit identifier: id_key, type: ActionCable::INTERNAL[:message_types][:confirmation]
+          return
+        end
 
         subscription = subscription_from_identifier(id_key)
 

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -6,7 +6,7 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
   class ChatChannelError < Exception; end
 
   class Connection < ActionCable::Connection::Base
-    attr_reader :exceptions
+    attr_reader :exceptions, :socket
 
     rescue_from ChatChannelError, with: :error_handler
 
@@ -72,13 +72,21 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     assert_empty @subscriptions.identifiers
   end
 
-  test "double subscribe command" do
+  test "double subscribe command re-transmits confirmation and is idempotent" do
     setup_connection
+    channel = subscribe_to_chat_channel
 
-    subscribe_to_chat_channel
+    # Resubscribing must not raise, must not invoke `#subscribed` a second
+    # time (which would re-run user code and double up side-effects like
+    # `stream_from`), must leave the subscription set unchanged, and must
+    # transmit another `confirm_subscription` so the client's subscription
+    # guarantor stops retrying.
+    confirmation = { identifier: @chat_identifier, type: ActionCable::INTERNAL[:message_types][:confirmation] }
 
-    assert_raises ActionCable::Connection::Subscriptions::AlreadySubscribedError do
-      subscribe_to_chat_channel
+    assert_not_called(channel, :subscribed) do
+      assert_called_with(@connection.socket, :transmit, [confirmation]) do
+        @subscriptions.execute_command "command" => "subscribe", "identifier" => @chat_identifier
+      end
     end
 
     assert_equal 1, @subscriptions.identifiers.size


### PR DESCRIPTION
Make Action Cable's handling of duplicate `subscribe` commands idempotent: when a client subscribes to a channel it is already subscribed to, the server re-transmits `confirm_subscription` and returns. The `subscribed` callback is not invoked again, no new subscription is registered, and the client's subscription guarantor receives a confirmation and resolves.

This replaces the current behaviour of raising `ActionCable::Connection::Subscriptions::AlreadySubscribedError` (introduced in the unreleased adapterization refactor in #50979 and not yet present in any tagged Rails release).

`Subscriptions::AlreadySubscribedError` is removed; the other error classes (`MalformedCommandError`, `ChannelNotFound`, `UnknownCommandError`, `UnknownSubscription`) are unaffected.

## Motivation

The right behaviour for duplicate `subscribe` has been an open question in Action Cable for nearly a decade. Multiple long-running issues describe the same underlying problem:

- **#24875 (2016)** "Cable: Should error on double-subscribe" — original debate; never resolved. @jeremy commented: *"Don't try to take action in an uncertain state. Kick an error back to the client."* Still open.
- **#44652 (2022)** "ActionCable: Repeated subscription attempts" — 25+ comments. Symptom: with the silent no-op, the client's subscription guarantor never receives `confirm_subscription` and retries every second forever. The reporter (@sj26) explicitly proposed *"send a subscription confirmation from the actioncable server when the client asks for a subscription which is already in place, instead of swallowing it silently."* That proposal is what this PR implements.
- **#48292 (2023)** "ActionCable sporadically fails to confirm subscribe because the subscription 'already exists'" — Turbo-specific reproduction; closed as stale.
- **#44653 (2022)** companion client-side workaround PR (still open).

A common theme across these reports is users either carrying a custom client-side patch or switching to AnyCable to escape the bug. The relevant code paths are now shared via the recent upstream sync, so the symptom now exists in stock Rails as well.

PR **#50979 ("Action Cable server adapterization", merged 2026-05-28)** changed the long-standing silent `return` to `raise AlreadySubscribedError`. That addresses #24875's request for an explicit signal, but it makes #44652 strictly worse: clients still don't receive the confirmation they need, and now there's also an unhandled exception propagating up the connection.

## Why idempotent re-transmit is the right answer

Realistic clients re-issue `subscribe` commands as a matter of normal operation, not as a programming error:

- Turbo's `<turbo-cable-stream-source>` is re-inserted into the DOM on morph/refresh cycles, which triggers a re-subscribe.
- React / Vue / Svelte components subscribe in lifecycle hooks; remounting re-subscribes.
- After a transient network issue, a client may resubscribe before the server has noticed the previous connection went away.
- The original race condition addressed by @palkan's #26547 in 2016 (which introduced the silent return in the first place): a deferred confirmation hadn't yet been sent when the client issued a follow-up command, so the client retried.

From the client's perspective, the meaningful response to *"please subscribe me to X"* when it is already subscribed is *"you are subscribed to X"* — exactly the `confirm_subscription` frame the client is waiting for. That's what this PR sends. It preserves the at-most-once semantics of `#subscribed` callbacks (no side-effect duplication) while resolving the client's state machine.

## Why removing `AlreadySubscribedError` is safe

The class was introduced by commit `7a8f26dcff` ("Improve exceptions in Action Cable subscriptions") inside PR #50979, which merged to `main` on 2026-05-28. The most recent tagged release is **v8.1.3** (2026-03-24), which predates the merge. Therefore `AlreadySubscribedError` has never appeared in a released Rails. No user code outside `rails/rails` main can be depending on its name today.

## Behavioural diff

|                                 | Before #50979 | After #50979 (current `main`) | This PR |
| ------------------------------- | :-----------: | :---------------------------: | :-----: |
| `subscriptions` Hash unchanged  | ✅            | ✅                            | ✅      |
| `#subscribed` runs only once    | ✅            | ✅                            | ✅      |
| Client receives a confirmation  | ❌ (#44652)   | ❌ + exception                 | ✅      |
| Exception propagates up         | ❌            | ✅ (`AlreadySubscribedError`)  | ❌      |

## Test

`actioncable/test/connection/subscriptions_test.rb` now asserts that resubscribing:

1. Does **not** invoke `#subscribed` a second time.
2. Transmits a fresh `confirm_subscription` to the client.
3. Leaves `subscriptions.identifiers.size` at 1.

Full ActionCable test suite passes (238 runs, 0 failures, 0 errors).

## Notes for reviewers

- The `Subscriptions::Error` base class and the remaining four error subclasses are unaffected.
- `MalformedCommandError` continues to be raised when `identifier` is missing (genuine protocol violation).
- The fix is purely server-side; clients (`@rails/actioncable`, ports, third parties) need no change. Existing `subscription.received` callbacks fire on the re-confirmation if registered, matching their behaviour for the initial confirmation.
