### PR TITLE
Parse all HTTP-date formats in If-Modified-Since

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -13,7 +13,11 @@ module ActionDispatch
 
         def if_modified_since
           if since = get_header(HTTP_IF_MODIFIED_SINCE)
-            Time.rfc2822(since) rescue nil
+            # `If-Modified-Since` carries an HTTP-date, which per RFC 9110 may be in
+            # any of the three legal formats (IMF-fixdate, RFC 850, or asctime).
+            # `Time.httpdate` accepts all three; it also matches how the response side
+            # parses `Last-Modified`/`Date`. `Time.rfc2822` only accepted IMF-fixdate.
+            Time.httpdate(since) rescue nil
           end
         end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1553,6 +1553,33 @@ class RequestBearerToken < BaseRequestTest
   end
 end
 
+class RequestIfModifiedSince < BaseRequestTest
+  # RFC 9110 §5.6.7 requires recipients to accept all three legal HTTP-date
+  # formats (IMF-fixdate, RFC 850, and asctime) in `If-Modified-Since`.
+  test "if_modified_since parses all three HTTP-date formats" do
+    expected = Time.utc(1994, 11, 6, 8, 49, 37)
+
+    {
+      "IMF-fixdate" => "Sun, 06 Nov 1994 08:49:37 GMT",
+      "RFC 850"     => "Sunday, 06-Nov-94 08:49:37 GMT",
+      "asctime"     => "Sun Nov  6 08:49:37 1994",
+    }.each do |format, header|
+      request = stub_request("HTTP_IF_MODIFIED_SINCE" => header)
+      assert_equal expected, request.if_modified_since, "expected #{format} If-Modified-Since to be parsed"
+      assert request.not_modified?(expected), "expected #{format} If-Modified-Since to satisfy not_modified?"
+    end
+  end
+
+  test "if_modified_since is nil for an unparseable header" do
+    request = stub_request("HTTP_IF_MODIFIED_SINCE" => "this is not a date")
+    assert_nil request.if_modified_since
+  end
+
+  test "if_modified_since is nil when the header is absent" do
+    assert_nil stub_request.if_modified_since
+  end
+end
+
 class RequestCacheControlDirectives < BaseRequestTest
   test "lazily initializes cache_control_directives" do
     request = stub_request


### PR DESCRIPTION
## Summary

`If-Modified-Since` carries an **HTTP-date**, which [RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.7) permits in three formats — IMF-fixdate, RFC 850, and asctime — and **requires recipients to accept all three**. `ActionDispatch::Http::Cache::Request#if_modified_since` parsed it with `Time.rfc2822`, which only accepts the IMF-fixdate format, and the `rescue nil` swallowed the parse failure:

```ruby
def if_modified_since
  if since = get_header(HTTP_IF_MODIFIED_SINCE)
    Time.rfc2822(since) rescue nil
  end
end
```

So a conditional `GET` whose `If-Modified-Since` used the RFC 850 or asctime format was treated as if the header were absent: `not_modified?` returned `false` and the full response was re-sent instead of a `304 Not Modified`.

This is also inconsistent with the response side of the same file, which already reads `Last-Modified` and `Date` with `Time.httpdate` (which accepts all three).

## Fix

```ruby
Time.httpdate(since) rescue nil
```

`Time.httpdate` accepts all three HTTP-date formats. IMF-fixdate (what browsers and Rails itself emit via `Time#httpdate`) keeps parsing identically, so the common path is unchanged.

## Reproduction

```ruby
req = ->(ims) { ActionDispatch::Request.new(Rack::MockRequest.env_for("/", "HTTP_IF_MODIFIED_SINCE" => ims)) }
mtime = Time.utc(1994, 11, 6, 8, 49, 37)

req.("Sun, 06 Nov 1994 08:49:37 GMT").not_modified?(mtime)   # IMF-fixdate => true
req.("Sunday, 06-Nov-94 08:49:37 GMT").not_modified?(mtime)  # RFC 850 => nil (BUG) -> true (fixed)
req.("Sun Nov  6 08:49:37 1994").not_modified?(mtime)        # asctime => nil (BUG) -> true (fixed)
```

## Tests

Added `RequestIfModifiedSince` to `actionpack/test/dispatch/request_test.rb`:
- all three HTTP-date formats parse and satisfy `not_modified?`
- unparseable header → `nil`
- absent header → `nil`

The new test **fails on the current code** (RFC 850 / asctime → `nil`) and passes with the fix. Verified locally:
- `request_test.rb`: 157 runs, 0 failures
- `controller/api/conditional_get_test.rb`: 10 runs, 0 failures

## Backward compatibility

HTTP-date is defined to use `GMT` ([RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.7)), so any spec-compliant `If-Modified-Since` is unaffected — IMF-fixdate (what browsers and Rails itself emit) keeps parsing identically, and the RFC 850 and asctime formats now parse where they previously didn't.

`Time.httpdate` is stricter than `Time.rfc2822` about the timezone: it requires `GMT` and rejects a numeric offset (e.g. `Sun, 06 Nov 1994 08:49:37 +0000`). Such a value is **not a valid HTTP-date**, so only a non-compliant client could have been sending it. The effect for that client is purely a missed `304` (the full — and still correct — response is returned), never an incorrect result. In exchange we gain the two other formats the spec requires and align request parsing with the response side, which already uses `Time.httpdate` for `Last-Modified` and `Date`.

## Notes

- Severity: Low–Medium. Spec-compliance (an RFC 9110 MUST) + a silent caching pessimization (no `304`, full body re-sent) for clients/proxies that use the RFC 850 or asctime date formats.
- ~15-year-old latent bug (the `Time.rfc2822` usage predates commit `92f49b5f1e`, 2010). Hidden by the `rescue nil` and by tests that only ever used IMF-fixdate values.
- No existing upstream issue/PR found.