### PR TITLE
Fix NullPool#server_version deadlock

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix deadlock when pool-less connection materializes while fetching database
+    server version.
+
+    *Hartley McGuire*
+
 *   Add `#default_order` query method and association option which can be used to order records when no other order is specified.
 
     This extends the functionality offered by `#implicit_order_column` to scopes and associations.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -18,12 +18,12 @@ module ActiveRecord
 
       def initialize
         super()
-        @mutex = Mutex.new
+        @monitor = Monitor.new
         @server_version = nil
       end
 
       def server_version(connection) # :nodoc:
-        @server_version || @mutex.synchronize { @server_version ||= connection.get_database_version }
+        @server_version || @monitor.synchronize { @server_version ||= connection.get_database_version }
       end
 
       def schema_reflection

--- a/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
+++ b/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
@@ -18,6 +18,12 @@ module ActiveRecord
         assert_equal [[1]], result.rows
       end
 
+      def test_database_version_with_null_pool
+        assert_nothing_raised do
+          @connection.database_version
+        end
+      end
+
       def test_async_fallback
         result = @connection.select_all("SELECT 1", async: true)
         assert_instance_of FutureResult::Complete, result


### PR DESCRIPTION
### Motivation / Background

When the first thing a fresh connection does is query its server version, it has to `#connect!` -> `#configure_connection` -> `#check_version`. This re-enters the same `#server_version` method on the connection's pool, which is synchronized. On a normal `ConnectionPool`, the synchronization primitive is a `Monitor`, so this re-entrancy isn't an issue. However, a bare connection uses a `NullPool`, which uses a `Mutex` instead of a `Monitor` (which is _not_ re-entrant, and so will deadlock).

### Detail

This commit fixes the issue by switching the `NullPool` to use a `Monitor`, matching the `ConnectionPool`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
