### PR TITLE
Make Ractor shareability methods only available on 4.0 and above.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,9 +1,8 @@
 *   Add shims for `Ractor` shareability methods so framework code can call them
     unconditionally regardless of the Ruby version.
 
-    When `Ractor` is not defined, or the underlying method is not available, the
-    shim is a no-op that simply returns its argument (or the given block).
-    Otherwise the call is forwarded to the matching `Ractor` class method.
+    On Ruby 4.0 and above, these methods delegate to the corresponding +Ractor+ methods. On older
+    Ruby versions, these methods are no-ops that return their argument.
 
     ```ruby
     ractor_make_shareable(obj)        # => Ractor.make_shareable(obj)        or obj

--- a/activesupport/lib/active_support/core_ext/kernel/ractor_shareability.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/ractor_shareability.rb
@@ -3,9 +3,8 @@
 # Shims for +Ractor+ shareability methods so framework code can call them
 # unconditionally regardless of the Ruby version.
 #
-# When +Ractor+ is not defined, or the underlying method is not available, the
-# shim is a no-op that simply returns its argument (or the given block).
-# Otherwise the call is forwarded to the matching +Ractor+ class method.
+# On Ruby 4.0 and above, these methods delegate to the corresponding +Ractor+ methods. On older Ruby versions, these
+# methods are no-ops that return their argument.
 #
 #   ractor_make_shareable(obj)        # => Ractor.make_shareable(obj)        or obj
 #   ractor_shareable?(obj)            # => Ractor.shareable?(obj)            or obj
@@ -13,62 +12,53 @@
 #   ractor_shareable_lambda { ... }   # => Ractor.shareable_lambda { ... }   or the block
 module Kernel
   private
-    if defined?(Ractor) && Ractor.respond_to?(:make_shareable)
+    if RUBY_VERSION >= "4.0" && defined?(Ractor)
       # Makes +obj+ Ractor-shareable by delegating to +Ractor.make_shareable+.
       #
-      # The +copy:+ option is forwarded unchanged. On Ruby versions without
-      # +Ractor.make_shareable+, this shim returns +obj+ unchanged.
+      # The +copy:+ option is forwarded unchanged. This method is
+      # a no-op on Ruby version earlier than 4.0
       def ractor_make_shareable(obj, copy: false)
         Ractor.make_shareable(obj, copy: copy)
       end
-    else
-      def ractor_make_shareable(obj, copy: false)
-        obj
-      end
-    end
 
-    if defined?(Ractor) && Ractor.respond_to?(:shareable?)
       # Returns whether +obj+ is Ractor-shareable by delegating to
       # +Ractor.shareable?+.
       #
-      # On Ruby versions without +Ractor.shareable?+, this shim returns +obj+
-      # unchanged.
+      # This method is a no-op on Ruby version earlier than 4.0
       def ractor_shareable?(obj)
         Ractor.shareable?(obj)
       end
-    else
-      def ractor_shareable?(obj)
-        obj
-      end
-    end
 
-    if defined?(Ractor) && Ractor.respond_to?(:shareable_proc)
       # Returns a Ractor-shareable proc by delegating to +Ractor.shareable_proc+.
       #
-      # The optional +self:+ value is forwarded as the proc's receiver. On Ruby
-      # versions without +Ractor.shareable_proc+, this shim returns the block
-      # unchanged.
+      # The optional +self:+ value is forwarded as the proc's receiver. This method is
+      # a no-op on Ruby version earlier than 4.0
       def ractor_shareable_proc(self: nil, &block)
         Ractor.shareable_proc(self: { self: }[:self], &block)
       end
-    else
-      def ractor_shareable_proc(self: nil, &block)
-        block
-      end
-    end
 
-    if defined?(Ractor) && Ractor.respond_to?(:shareable_lambda)
       # Returns a Ractor-shareable lambda by delegating to
       # +Ractor.shareable_lambda+.
       #
-      # The optional +self:+ value is forwarded as the lambda's receiver. On Ruby
-      # versions without +Ractor.shareable_lambda+, this shim returns the block
-      # unchanged.
+      # The optional +self:+ value is forwarded as the lambda's receiver. This method is
+      # a no-op on Ruby version earlier than 4.0
       def ractor_shareable_lambda(self: nil, &block)
         Ractor.shareable_lambda(self: { self: }[:self], &block)
       end
     else
-      def ractor_shareable_lambda(&block)
+      def ractor_make_shareable(obj, copy: false)
+        obj
+      end
+
+      def ractor_shareable?(obj, copy: false)
+        obj
+      end
+
+      def ractor_shareable_proc(self: nil, &block)
+        block
+      end
+
+      def ractor_shareable_lambda(self: nil, &block)
         block
       end
     end


### PR DESCRIPTION
### Motivation / Background

Follow up to https://github.com/pulls?q=is%3Apr+author%3Aandrewn617+archived%3Afalse+is%3Aclosed

I realized that this is problematic for Ruby 3.x since `Ractor.make_shareable` is available but not `Ractor.shareable_proc`. 

Since we will define a shim for `make_shareable` but `shareable_proc` will be a no-op in that environment, it will lead us to calling `make_shareable` on objects containing unshareable procs and raising.

```
proc = ractor_shareable_proc { foo }

ractor_make_shareable(Bar.new(proc)) # => raises on 3.4 but works on 4.0
```

### Detail

Ruby 4.0 will be a hard requirement for using Ractors with Rails, so I think it is okay if we just define all these methods if we are on 4.0 and above, and have them all be no-ops on Ruby 3.x

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
