### PR TITLE
Test ImmutableString custom boolean options and serialize

### DIFF
--- a/activemodel/test/cases/type/immutable_string_test.rb
+++ b/activemodel/test/cases/type/immutable_string_test.rb
@@ -17,6 +17,26 @@ module ActiveModel
         assert_same s, type.cast(s)
         assert_same s, type.deserialize(s)
       end
+
+      test "custom true and false strings" do
+        type = Type::ImmutableString.new(true: "aye", false: "nay")
+        assert_equal "aye", type.cast(true)
+        assert_equal "nay", type.cast(false)
+        assert_equal "aye", type.serialize(true)
+        assert_equal "nay", type.serialize(false)
+      end
+
+      test "booleans cast to their default string representations" do
+        type = Type::ImmutableString.new
+        assert_equal "t", type.cast(true)
+        assert_equal "f", type.cast(false)
+      end
+
+      test "serialize coerces numerics and symbols to strings" do
+        type = Type::ImmutableString.new
+        assert_equal "123", type.serialize(123)
+        assert_equal "sym", type.serialize(:sym)
+      end
     end
   end
 end


### PR DESCRIPTION
`ActiveModel::Type::ImmutableString` documents custom `true:`/`false:` constructor options and casts/serializes booleans, numerics, and symbols to strings, but the existing test only covered string frozenness.

This adds coverage for:

- the documented `true:`/`false:` constructor options (both `cast` and `serialize`)
- the default boolean string representations (`"t"`/`"f"`)
- the numeric and symbol `serialize` branches

No production code changes — test-only.