### PR TITLE
Test Float casting of Infinity and NaN strings

### DIFF
--- a/activemodel/test/cases/type/float_test.rb
+++ b/activemodel/test/cases/type/float_test.rb
@@ -18,6 +18,13 @@ module ActiveModel
         assert_equal 0.0, type.cast("bad")
       end
 
+      def test_type_cast_float_from_special_strings
+        type = Type::Float.new
+        assert_equal ::Float::INFINITY, type.cast("Infinity")
+        assert_equal(-::Float::INFINITY, type.cast("-Infinity"))
+        assert_predicate type.cast("NaN"), :nan?
+      end
+
       def test_changing_float
         type = Type::Float.new
 


### PR DESCRIPTION
`ActiveModel::Type::Float` documents that the strings `"Infinity"`, `"-Infinity"`, and `"NaN"` cast to the corresponding float values, but no test exercised these branches.

This adds coverage for casting those special strings. No production code changes — test-only.