### PR TITLE
Test to_sentence with an empty array

### DIFF
--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -63,6 +63,12 @@ class OutputSafetyHelperTest < ActionView::TestCase
     assert_equal("&lt;script&gt;", actual)
   end
 
+  test "to_sentence handles an empty array" do
+    actual = to_sentence([])
+    assert_equal "", actual
+    assert_predicate actual, :html_safe?
+  end
+
   test "to_sentence does not double escape if single value is html_safe" do
     assert_equal("&lt;script&gt;", to_sentence([ERB::Util.html_escape("<script>")]))
     assert_equal("&lt;script&gt;", to_sentence(["&lt;script&gt;".html_safe]))


### PR DESCRIPTION
ActionView's `to_sentence` returns an empty `html_safe` string for an empty array, but that branch had no test (the single-, two-, and multi-element cases were already covered).

This adds coverage for the empty-array case. No production code changes — test-only.