### PR TITLE
Hash PostgreSQL cable channel identifiers by byte size

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -59,7 +59,13 @@ module ActionCable
 
       private
         def channel_identifier(channel)
-          channel.size > 63 ? OpenSSL::Digest::SHA1.hexdigest(channel) : channel
+          # PostgreSQL identifiers are limited to NAMEDATALEN-1 (63) *bytes*, not
+          # characters, and are silently truncated past that. Truncation makes the
+          # name we LISTEN/subscribe under differ from the one wait_for_notify hands
+          # back, so notifications would miss their subscribers. Hash on byte length
+          # so multibyte channel names that exceed the limit stay within it.
+          # See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+          channel.bytesize > 63 ? OpenSSL::Digest::SHA1.hexdigest(channel) : channel
         end
 
         def listener

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -64,6 +64,33 @@ class PostgresqlAdapterTest < ActionCable::TestCase
     assert_predicate adapter, :active?
   end
 
+  def test_long_multibyte_identifiers
+    # PostgreSQL identifiers are limited to 63 *bytes*. A multibyte name with <= 63
+    # characters but > 63 bytes must still be hashed, otherwise PostgreSQL silently
+    # truncates it: the adapter subscribes under the full name but dispatches by the
+    # name wait_for_notify reports back (truncated), so the keys disagree.
+    long = ("あ" * 30) + "X"   # 31 chars / 91 bytes -> over the 63-byte limit
+    short = "あ" * 21          # 21 chars / 63 bytes == long's 63-byte truncation target
+
+    subscribe_as_queue(long) do |long_queue|
+      subscribe_as_queue(short) do |short_queue|
+        @tx_adapter.broadcast(long, "long payload")
+
+        # The long channel's own subscriber must receive the broadcast. Bounded wait
+        # so the buggy String#size behavior (which truncates and drops the message)
+        # fails here instead of blocking forever.
+        assert_equal "long payload", long_queue.pop(timeout: WAIT_WHEN_EXPECTING_EVENT),
+          "broadcast to a >63-byte multibyte channel must reach its own subscribers"
+
+        # A different channel whose name equals long's 63-byte truncation must not
+        # receive it. Under the bug, PostgreSQL truncates long down to short and the
+        # broadcast is misrouted there.
+        assert_nil short_queue.pop(timeout: WAIT_WHEN_NOT_EXPECTING_EVENT),
+          "broadcast must not leak to a channel sharing long's 63-byte truncation"
+      end
+    end
+  end
+
   def test_default_subscription_connection_identifier
     subscribe_as_queue("channel") { }
 


### PR DESCRIPTION
## Summary

The Action Cable PostgreSQL subscription adapter hashes channel names that exceed the PostgreSQL identifier limit so they aren't silently truncated. That limit is **63 bytes** (`NAMEDATALEN - 1`), but the guard measured the **character count** (`String#size`):

```ruby
def channel_identifier(channel)
  channel.size > 63 ? OpenSSL::Digest::SHA1.hexdigest(channel) : channel
end
```

A multibyte channel name with ≤ 63 characters but > 63 bytes (e.g. a Japanese stream name — 3 bytes/char crosses 63 bytes at just **22 characters**) has `size <= 63`, so it skips hashing and is passed straight to `LISTEN`/`NOTIFY`. PostgreSQL then silently truncates the identifier to 63 bytes:

```
NOTICE: identifier "ああ…X" (91 bytes) will be truncated to "あ"*21 (63 bytes)
```

## Impact

The adapter registers subscribers in an in-memory map keyed by `channel_identifier(channel)` (the **un-truncated** name), but the listener thread dispatches incoming notifications using the channel name `PG#wait_for_notify` reports back — which is the name **after** PostgreSQL truncated it. When truncation happens those two keys no longer agree, which produces two failure modes:

1. **Silent message loss (unconditional).** A long multibyte channel's subscribers are registered under the full name, but its notifications are dispatched under the truncated name, so the lookup misses and the channel's *own* subscribers receive nothing.

2. **Cross-stream delivery (conditional).** If a *different* stream happens to subscribe under a name that equals the 63-byte truncation target, the truncated delivery key matches *that* subscriber. The broadcast meant for the long channel is then delivered to the unrelated short channel — while the intended channel still receives nothing.

## Reproduction (real `LISTEN`/`NOTIFY`, UTF-8 DB)

```ruby
S = "あ" * 21          # 21 chars / 63 bytes  — NOT hashed (size 21 <= 63)
L = ("あ" * 30) + "X"  # 31 chars / 91 bytes  — NOT hashed; PG truncates NOTIFY to "あ"*21 == S
```

Driving the real adapter end-to-end against PostgreSQL:

| | `channel_identifier(L)` | delivery key (`wait_for_notify`) | only `S` subscribed | `S` **and** `L` subscribed, broadcast to `L` |
|---|---|---|---|---|
| **before** (`size`) | `L` unhashed, **91 B** → PG truncates to 63 B (`= S`) | **63 B (= S)** | ❌ `S` receives `L`'s message | `S` ❌ receives `L`'s message · `L` 🟥 receives nothing |
| **after** (`bytesize`) | SHA1, **40 B** (no truncation) | **40 B (= hash)** | ✅ no cross-delivery | `S` ✅ unaffected · `L` ✅ delivered |

The instrumented listener confirms the mechanism in the `before` case:

```
wait_for_notify returned key = 63 B          # PG-truncated NOTIFY channel
registered keys = [63 B (S), 91 B (L)]       # match hits S, misses L
→ S (unrelated stream) gets L's payload; L gets nothing
```

## Fix

Measure the length with `String#bytesize` so multibyte names over the byte limit are hashed like long ASCII names already are. Hashed names are a 40-byte SHA-1 digest, so they never reach the 63-byte limit and the registration and delivery keys agree again. ASCII names are unaffected (`size == bytesize`).

```ruby
def channel_identifier(channel)
  channel.bytesize > 63 ? OpenSSL::Digest::SHA1.hexdigest(channel) : channel
end
```

## Test

Adds `test_long_multibyte_identifiers` to `actioncable/test/subscription_adapter/postgresql_test.rb`, an end-to-end test on the existing `subscribe_as_queue` / `@rx_adapter` / `@tx_adapter` harness (real `LISTEN`/`NOTIFY`). It subscribes to both `long` (91 bytes) and `short` (`"あ"*21`, the 63-byte truncation target of `long`), broadcasts to `long`, and asserts:

- `long`'s own subscriber receives the payload (fails on `String#size`, which drops it — *silent loss*), and
- `short` receives nothing (fails on `String#size`, which misroutes the broadcast there — *cross-stream delivery*).

Both reads use a bounded `Queue#pop(timeout:)` so the old behavior fails fast instead of hanging. Verified red→green: with `String#size` the test fails on both assertions; with `String#bytesize` it passes.

## Notes

- **Severity: Low–Medium.** Requires the PostgreSQL adapter and a multibyte stream name over 63 bytes. Silent loss is unconditional for such names; cross-delivery additionally requires another live stream subscribed under the exact 63-byte truncation target.
- No existing upstream issue/PR found.
- Related history: the hashing guard was introduced in #28751 (commit `2bce7777b7`) to keep over-long identifiers from being truncated by PostgreSQL; this aligns the length check with PostgreSQL's byte-based limit.