### PR TITLE
Fix PostgreSQL range bounds parser corrupting comma-containing bounds

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -67,13 +67,40 @@ module ActiveRecord
             end
 
             def extract_bounds(value)
-              from, to = value[1..-2].split(",", 2)
+              from, to = split_bounds(value[1..-2])
               {
                 from:          (from == "" || from == "-infinity") ? infinity(negative: true) : unquote(from),
                 to:            (to == "" || to == "infinity") ? infinity : unquote(to),
                 exclude_start: value.start_with?("("),
                 exclude_end:   value.end_with?(")")
               }
+            end
+
+            # Matches the comma-separated lower and upper bounds of a range's
+            # textual representation when a bound is double-quoted. A quoted
+            # bound can itself contain a comma, so a naive split on the first
+            # comma would corrupt such values. Within a double-quoted bound,
+            # literal " and \ are escaped (as "" / \" and \\ respectively), so
+            # those escapes are skipped while scanning for the separating comma.
+            #
+            # An unquoted bound never contains a comma or a double-quote
+            # (PostgreSQL quotes the whole bound when it would), so the
+            # alternation matches an unquoted run with [^,"] rather than [^,].
+            # Excluding " keeps the two alternatives mutually exclusive, which
+            # removes any ambiguity over how a "-prefixed bound is consumed. The
+            # /m flag lets the captured upper bound (and quoted bounds) span
+            # newlines.
+            BOUNDS = /\A((?:"(?:[^"\\]|""|\\.)*"|[^,"])*),(.*)\z/m # :nodoc:
+
+            def split_bounds(value)
+              # Fast path: an unquoted representation (every built-in range
+              # type -- int/num/date/timestamp) has no embedded comma, so a
+              # plain split is correct and avoids the regexp. Only quoted
+              # bounds (custom text/varchar/money/... ranges) need the
+              # comma-skipping scan.
+              return value.split(",", 2) unless value.include?('"')
+
+              (match = BOUNDS.match(value)) ? [match[1], match[2]] : [value, nil]
             end
 
             INFINITE_FLOAT_RANGE = (-::Float::INFINITY)..(::Float::INFINITY) # :nodoc:
@@ -94,7 +121,7 @@ module ActiveRecord
             # * https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO
             # * https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-IO-SYNTAX
             def unquote(value)
-              if value.start_with?('"') && value.end_with?('"')
+              if value && value.start_with?('"') && value.end_with?('"')
                 unquoted_value = value[1..-2]
                 unquoted_value.gsub!('""', '"')
                 unquoted_value.gsub!("\\\\", "\\")

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -566,6 +566,76 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     assert_equal('ca"t'...'do\\g', escaped_range.string_range)
   end
 
+  def test_ranges_correctly_parse_quoted_bounds_with_commas
+    @connection.execute(<<~SQL)
+      INSERT INTO postgresql_ranges (id, string_range)
+      VALUES (107, '["a,b","c,d")')
+    SQL
+
+    range = PostgresqlRange.find(107)
+    assert_equal("a,b"..."c,d", range.string_range)
+  end
+
+  def test_ranges_parse_quoted_bounds_with_commas_quotes_and_backslashes
+    # Lower bound is `a,"b` (comma + embedded quote), upper is `c\,d`
+    # (backslash + comma); PostgreSQL emits these as ["a,""b","c\\,d").
+    @connection.execute(<<~SQL)
+      INSERT INTO postgresql_ranges (id, string_range)
+      VALUES (108, '["a,""b","c\\\\,d")')
+    SQL
+
+    assert_equal('a,"b'...'c\\,d', PostgresqlRange.find(108).string_range)
+  end
+
+  def test_ranges_parse_partially_quoted_bounds_with_commas
+    # Only the lower bound is quoted (it contains a comma); the upper bound
+    # is emitted bare, so the separating comma is the first unquoted one.
+    @connection.execute(<<~SQL)
+      INSERT INTO postgresql_ranges (id, string_range)
+      VALUES (109, '["x,y",z)')
+    SQL
+
+    assert_equal("x,y"..."z", PostgresqlRange.find(109).string_range)
+  end
+
+  def test_ranges_parse_open_bounds_with_commas
+    # Upper bound omitted (endless); lower bound quoted with a comma.
+    @connection.execute(<<~SQL)
+      INSERT INTO postgresql_ranges (id, string_range)
+      VALUES (110, '["a,b",)')
+    SQL
+    assert_equal("a,b"...nil, PostgresqlRange.find(110).string_range)
+
+    # Lower bound omitted (beginless); upper bound quoted with a comma.
+    @connection.execute(<<~SQL)
+      INSERT INTO postgresql_ranges (id, string_range)
+      VALUES (111, '[,"c,d")')
+    SQL
+    assert_equal(nil..."c,d", PostgresqlRange.find(111).string_range)
+  end
+
+  def test_ranges_parse_bounds_containing_newlines
+    # Bounds with a newline are double-quoted by PostgreSQL and the newline is
+    # kept verbatim; the upper bound's newline exercises the regexp's /m flag.
+    @connection.execute(<<~SQL)
+      INSERT INTO postgresql_ranges (id, string_range)
+      VALUES (112, stringrange('a' || chr(10) || 'b', 'c' || chr(10) || 'd', '[)'))
+    SQL
+
+    assert_equal("a\nb"..."c\nd", PostgresqlRange.find(112).string_range)
+  end
+
+  def test_ranges_parse_empty_string_bounds
+    # An empty-string bound is double-quoted ("") and must stay an empty
+    # string -- distinct from an omitted bound, which is infinity (nil).
+    @connection.execute(<<~SQL)
+      INSERT INTO postgresql_ranges (id, string_range)
+      VALUES (113, '["","z")')
+    SQL
+
+    assert_equal(""..."z", PostgresqlRange.find(113).string_range)
+  end
+
   def test_infinity_values
     PostgresqlRange.create!(int4_range: 1..Float::INFINITY,
                             int8_range: -Float::INFINITY..0,


### PR DESCRIPTION
## Summary

`PostgreSQL::OID::Range#extract_bounds` (`activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb:70`) parsed a range's textual representation with `value[1..-2].split(",", 2)` — splitting on the **first** comma. But PostgreSQL double-quotes any bound that itself contains a comma (which happens for range types over a text/varchar subtype). A value such as `["a,b","c,d")` was therefore split *inside* the first quoted bound and read back with **both endpoints corrupted**:

```ruby
# before
range.string_range # => "\"a"..."b\",\"c,d\""
# after
range.string_range # => "a,b"..."c,d"
```

Built-in `int4range` / `numrange` / `tsrange` / `daterange` never emit a comma inside a bound (numerics have no thousands separator; timestamps are quoted but comma-free), which is why this stayed hidden. But **any** range type whose bound serialization is double-quoted *and* contains a comma is corrupted, and custom range types are a fully supported live AR path: `PostgreSQL::OID::TypeMapInitializer` auto-registers every `pg_range` catalog entry (`typtype = "r"`) as `OID::Range.new(subtype, typname)` (`type_map_initializer.rb:33-37`).

### Affected subtypes (verified against live PostgreSQL, `lc_monetary = en_US.UTF-8`)

| subtype | PG text representation | reads back on `main` |
|---|---|---|
| `text` | `["a,b","c,d")` | `"\"a" ... "b\",\"c,d\""` |
| `varchar` | `["x,y",z)` | `"\"x" ... "y\",z"` |
| **`money`** (bounds ≥ $1,000) | `["$1,000.00","$2,000.50"]` | **`0.0 ... 0.0`** |
| `numeric` (no comma) | `[1.5,2.5]` | `1.5 ... 2.5` ✓ unaffected |
| `tsrange` (quoted, no comma) | `["2024-…","2024-…")` | ✓ unaffected |

The **`money` subtype is the most dangerous**: its output format embeds a thousands separator, so the corruption is triggered by the *magnitude* of the value, not by unusual data. End-to-end through ActiveRecord, a `moneyrange` column holding `[$1,000.00, $2,000.50]` reads back as **`0.0..0.0`** — silent, total loss of both monetary endpoints — because the mangled `"$1` fragment casts to zero via the money type.

## Fix

Replace the naive split with a quote-aware `split_bounds` that skips over double-quoted segments (honoring `""` and `\`-escapes) when locating the separating comma:

```ruby
BOUNDS = /\A((?:"(?:[^"\\]|""|\\.)*"|[^,"])*),(.*)\z/m # :nodoc:

def split_bounds(value)
  # Fast path: built-in range types (int/num/date/timestamp) have no
  # embedded comma or quote, so a plain split is correct and skips the regexp.
  return value.split(",", 2) unless value.include?('"')

  (m = BOUNDS.match(value)) ? [m[1], m[2]] : [value, nil]
end
```

The unquoted-run alternative is `[^,"]`, not `[^,]`: an unquoted PostgreSQL bound never contains a comma or a double-quote (it would be quoted otherwise), so excluding `"` keeps the two alternatives **mutually exclusive** and removes any ambiguity over how a quote-prefixed bound is consumed. The `/m` flag lets the captured upper bound (group 2) span newlines.

### Performance (hot path)

`extract_bounds` runs once per range value deserialized, so the original C-level `String#split(",", 2)` matters. Benchmarked on Ruby 4.0.2 (`benchmark-ips`):

| input | `split(",",2)` | regexp only | **hybrid (shipped)** |
|---|---|---|---|
| `1,10` (int) | 133 ns | 291 ns (2.2× slower) | **~1.2× of split** |
| `2024-01-01,2024-12-31` (date) | 129 ns | 356 ns (2.8× slower) | **~1.2× of split** |
| `"a,b","c,d"` (quoted) | 128 ns* | 285 ns | 320 ns |
| _*buggy result_ | | | |

A pure-Ruby one-pass scanner was also benchmarked and was **not** consistently faster than the regexp (slower on the date case), so it was rejected. Instead the shipped `split_bounds` keeps the unquoted representation — i.e. **every built-in range type**, the overwhelming majority of real usage — on the original `String#split` fast path (the only added cost is one `include?('"')` scan, ~1.2×), and runs the regexp **only** when a double-quote is actually present (custom text/varchar/money ranges). The regexp's absolute overhead (~160–230 ns) is in any case dwarfed by the surrounding `unquote` gsub, `subtype.deserialize`, and `Range` allocation.

### Backtracking / ReDoS

Measured with adversarial comma-less inputs (`'"a"' * n`, maximizing the quoted-segment grouping ambiguity) up to `n = 10,000` (len 30,000): both the `[^,]` and `[^,"]` forms match in **< 1 ms** — Ruby's regexp engine does not blow up. `[^,"]` is preferred regardless because it removes the ambiguity structurally.

### Robustness of the fallback

A valid range representation always carries the separating comma between its two bounds, and `cast_value` already returns early for `"empty"` / `""`, so `split_bounds` always matches for real PostgreSQL output. The `[value, nil]` fallback is therefore only reachable for malformed comma-less input — the same `to == nil` outcome the original `split(",", 2)` produced. For that path, `unquote` previously raised `NoMethodError` (`nil.start_with?`); it is now nil-tolerant and returns the value unchanged, so malformed input degrades gracefully instead of crashing. Valid input is completely unaffected.

## Age

The comma-split predates quoted-bound support. The latent inconsistency dates to `45d7dad578` (Chris Andreae, **2019-11-06**, "Handle quoted values in PostgreSQL range output") — which added the `unquote` helper for quoted bounds but left the split breaking on every comma. The current split line was last touched by `c65864cdca` (Ryuta Kamizono, **2020-05-29**, "Prefer no allocation `start/end_with?`…", which changed `split(",")` → `split(",", 2)`). So the two have been inconsistent for ~5.5 years.

## Tests

The existing `test_ranges_correctly_unescape_output` covers quotes and backslashes inside quoted bounds, but never a comma. Added six non-overlapping cases:

- `test_ranges_correctly_parse_quoted_bounds_with_commas` — `["a,b","c,d")`
- `test_ranges_parse_quoted_bounds_with_commas_quotes_and_backslashes` — `["a,""b","c\\,d")` (comma + embedded quote + backslash mixed)
- `test_ranges_parse_partially_quoted_bounds_with_commas` — `["x,y",z)` (only the lower bound quoted)
- `test_ranges_parse_open_bounds_with_commas` — `["a,b",)` (endless) and `[,"c,d")` (beginless)
- `test_ranges_parse_bounds_containing_newlines` — newline inside both bounds; documents/guards the `/m` flag (without `/m` the newline-bearing upper bound is lost). Not corrupted by the old code — green on both, kept for coverage.
- `test_ranges_parse_empty_string_bounds` — `["","z")`: an empty-string bound (quoted `""`) must stay `""`, distinct from an omitted/infinite bound (`nil`). Boundary guard; green on both.

**Verified red on `main`, green with the fix** against live PostgreSQL (the comma cases corrupt on `main`); full PG range suite 53 runs / 227 assertions / 0 failures. Test ids 107–113 do not collide with existing fixtures/tests (101–105 setup, 106 unescape).

## Severity

**High** — silent data corruption (wrong value on read) on a supported column type. No security implication.

No existing upstream issue or PR found.