### PR TITLE
Fix `Duration#in_*` truncating sub-second precision

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -383,42 +383,42 @@ module ActiveSupport
     #
     #   1.day.in_minutes # => 1440.0
     def in_minutes
-      in_seconds / SECONDS_PER_MINUTE.to_f
+      value / SECONDS_PER_MINUTE.to_f
     end
 
     # Returns the amount of hours a duration covers as a float
     #
     #   1.day.in_hours # => 24.0
     def in_hours
-      in_seconds / SECONDS_PER_HOUR.to_f
+      value / SECONDS_PER_HOUR.to_f
     end
 
     # Returns the amount of days a duration covers as a float
     #
     #   12.hours.in_days # => 0.5
     def in_days
-      in_seconds / SECONDS_PER_DAY.to_f
+      value / SECONDS_PER_DAY.to_f
     end
 
     # Returns the amount of weeks a duration covers as a float
     #
     #   2.months.in_weeks # => 8.696
     def in_weeks
-      in_seconds / SECONDS_PER_WEEK.to_f
+      value / SECONDS_PER_WEEK.to_f
     end
 
     # Returns the amount of months a duration covers as a float
     #
     #   9.weeks.in_months # => 2.07
     def in_months
-      in_seconds / SECONDS_PER_MONTH.to_f
+      value / SECONDS_PER_MONTH.to_f
     end
 
     # Returns the amount of years a duration covers as a float
     #
     #   30.days.in_years # => 0.082
     def in_years
-      in_seconds / SECONDS_PER_YEAR.to_f
+      value / SECONDS_PER_YEAR.to_f
     end
 
     # Returns +true+ if +other+ is also a Duration instance, which has the

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -81,6 +81,12 @@ class DurationTest < ActiveSupport::TestCase
     assert_in_delta 1.0, 365.days.in_years
   end
 
+  def test_in_units_preserve_sub_second_precision
+    assert_in_delta 1.5083333, 90.5.seconds.in_minutes, 0.0000001
+    assert_in_delta 1.0170833, 3661.5.seconds.in_hours, 0.0000001
+    assert_in_delta 0.0000058, 0.5.seconds.in_days, 0.0000001
+  end
+
   def test_eql
     assert 1.minute.eql?(1.minute)
     assert 1.minute.eql?(60.seconds)


### PR DESCRIPTION
## Summary

`ActiveSupport::Duration#in_minutes`, `#in_hours`, `#in_days`, `#in_weeks`, `#in_months`, and `#in_years` divide `in_seconds` — which is aliased to `to_i` and therefore **truncates the duration to a whole number of seconds** — instead of dividing the exact `value`. Any fractional-second component of the duration is silently dropped before the conversion, so these methods return wrong floats for sub-second durations.

```ruby
90.5.seconds.in_minutes   # => 1.5                 (expected 1.5083333333333333)
0.5.seconds.in_days       # => 0.0                 (expected ~5.78e-06)
3661.5.seconds.in_hours   # => 1.0169444444444444  (expected 1.0170833333333333)
```

The methods are documented as returning "the amount of X a duration covers as a **float**", so the loss of precision is a bug, not the documented contract. `in_seconds` / `to_i` keep their documented integer-truncating behavior; only the float-returning `in_*` conversions change. Whole-second durations are completely unaffected (`Integer / 60.0 == Integer.to_i / 60.0`), and all six existing RDoc examples (`1440.0`, `8.696`, `2.07`, `0.082`, …) still hold.

## Root cause

`activesupport/lib/active_support/duration.rb`

```ruby
def to_i
  @value.to_i
end
alias :in_seconds :to_i

def in_minutes
  in_seconds / SECONDS_PER_MINUTE.to_f   # truncates @value before dividing
end
```

Fix: divide `value` (the exact, possibly-fractional amount) rather than `in_seconds`.

## Age

Introduced in `7bd9603778c` (2020-03-11) and renamed to `in_*` in `a2535d9fe9` (2020-08-26) — ~5.7 years. The path has been untested the whole time: every existing `in_*` test in `duration_test.rb` uses whole-second durations only.

## Tests

Added `test_in_units_preserve_sub_second_precision` to `activesupport/test/core_ext/duration_test.rb`. Verified **red on `main`, green with the fix**; full `duration_test.rb` (80 runs, 396 assertions) green.

## Severity

Low–Medium. Correctness bug in a public API, silent (no error), affects only durations carrying a sub-second fraction. No security implication.

No existing upstream issue or PR found.