### PR TITLE
Fixes #51780: prevent shared PostgreSQL queries from racing with reconnects

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add a `connection_lock` database configuration for applications that share
+    a connection across threads or fibers. When enabled, it prevents
+    PostgreSQL queries from racing with reconnects on that shared connection.
+
+    *oneearedrabbit*
+
 *   Fix deadlock when pool-less connection materializes while fetching database
     server version.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -373,7 +373,7 @@ module ActiveRecord
           @connections << @pinned_connection
         end
 
-        @pinned_connection.lock_thread = ActiveSupport::IsolatedExecutionState.context if lock_thread
+        @pinned_connection.install_execution_context_lock(ActiveSupport::IsolatedExecutionState.context) if lock_thread
         @pinned_connection.pinned = true
         @pinned_connection.begin_transaction joinable: false, _lazy: false
       end
@@ -398,7 +398,7 @@ module ActiveRecord
           if @pinned_connection.nil?
             connection.pinned = false
             connection.steal!
-            connection.lock_thread = nil
+            connection.restore_configured_connection_lock
             checkin(connection)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -178,7 +178,8 @@ module ActiveRecord
         @allow_preconnect = false
         @visitor = arel_visitor
         @statements = build_statement_pool
-        self.lock_thread = nil
+        @configured_connection_lock = @config[:connection_lock]
+        @lock = build_adapter_lock(effective_connection_lock)
 
         @prepared_statements = !ActiveRecord.disable_prepared_statements && self.class.type_cast_config_to_boolean(
           @config.fetch(:prepared_statements) { default_prepared_statements }
@@ -204,12 +205,50 @@ module ActiveRecord
         "#<#{self.class.name}:#{'%#016x' % (object_id << 1)} env_name=#{pool.db_config.env_name.inspect}#{name_field} role=#{role.inspect}#{shard_field}>"
       end
 
-      def lock_thread=(lock_thread) # :nodoc:
-        @lock =
-        case lock_thread
-        when Thread
+      def install_execution_context_lock(lock_context) # :nodoc:
+        @lock = build_adapter_lock(effective_connection_lock(lock_context))
+      end
+
+      def restore_configured_connection_lock # :nodoc:
+        @lock = build_adapter_lock(effective_connection_lock)
+      end
+
+      private def effective_connection_lock(lock_context = nil)
+        configured_lock =
+          case self.class.type_cast_config_to_boolean(@configured_connection_lock)
+          when nil, false
+            nil
+          when :thread, "thread"
+            :thread
+          when :monitor, "monitor"
+            :monitor
+          else
+            raise ArgumentError, "connection_lock must be one of nil, false, :thread, or :monitor"
+          end
+
+        return configured_lock unless lock_context
+
+        requested_lock =
+          case lock_context
+          when Thread
+            :thread
+          when Fiber
+            :monitor
+          else
+            raise ArgumentError, "lock_context must be a Thread or Fiber"
+          end
+
+        return :monitor if configured_lock == :monitor || requested_lock == :monitor
+        return :thread if configured_lock == :thread || requested_lock == :thread
+
+        nil
+      end
+
+      private def build_adapter_lock(lock_mode)
+        case lock_mode
+        when :thread
           ActiveSupport::Concurrency::ThreadMonitor.new
-        when Fiber
+        when :monitor
           ::Monitor.new
         else
           ActiveSupport::Concurrency::NullLock

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -15,7 +15,10 @@ module ActiveRecord
           intent = internal_build_intent(sql, name, allow_retry:, materialize_transactions:)
           intent.execute!
           result = intent.raw_result
-          result.map_types!(@type_map_for_results).values
+
+          @lock.synchronize do
+            result.map_types!(@type_map_for_results).values
+          end
         end
 
         READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
@@ -200,42 +203,44 @@ module ActiveRecord
           end
 
           def cast_result(result)
-            ar_result = if result.fields.empty?
-              ActiveRecord::Result.empty(affected_rows: result.cmd_tuples)
-            else
-              fields = result.fields
-              types = Array.new(fields.size)
-              field_types = Array.new(fields.size)
-              missing_oids = []
+            @lock.synchronize do
+              ar_result = if result.fields.empty?
+                ActiveRecord::Result.empty(affected_rows: result.cmd_tuples)
+              else
+                fields = result.fields
+                types = Array.new(fields.size)
+                field_types = Array.new(fields.size)
+                missing_oids = []
 
-              fields.size.times do |index|
-                ftype = result.ftype(index)
-                field_types[index] = ftype
-                missing_oids << ftype unless type_map.key?(ftype)
-              end
+                fields.size.times do |index|
+                  ftype = result.ftype(index)
+                  field_types[index] = ftype
+                  missing_oids << ftype unless type_map.key?(ftype)
+                end
 
-              if missing_oids.any?
-                load_additional_types(missing_oids)
+                if missing_oids.any?
+                  load_additional_types(missing_oids)
+
+                  fields.size.times do |index|
+                    ftype = field_types[index]
+                    next if type_map.key?(ftype)
+
+                    register_unknown_oid_type(ftype, fields[index])
+                  end
+                end
 
                 fields.size.times do |index|
                   ftype = field_types[index]
-                  next if type_map.key?(ftype)
-
-                  register_unknown_oid_type(ftype, fields[index])
+                  fmod  = result.fmod(index)
+                  types[index] = get_oid_type(ftype, fmod, fields[index])
                 end
+
+                ActiveRecord::Result.new(fields, result.values, types.freeze, affected_rows: result.cmd_tuples)
               end
 
-              fields.size.times do |index|
-                ftype = field_types[index]
-                fmod  = result.fmod(index)
-                types[index] = get_oid_type(ftype, fmod, fields[index])
-              end
-
-              ActiveRecord::Result.new(fields, result.values, types.freeze, affected_rows: result.cmd_tuples)
+              result.clear
+              ar_result
             end
-
-            result.clear
-            ar_result
           end
 
           def affected_rows(result)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -931,9 +931,11 @@ module ActiveRecord
         end
 
         def get_oid_type(oid, fmod, column_name, sql_type = "")
-          load_additional_types([oid]) unless type_map.key?(oid)
+          @lock.synchronize do
+            load_additional_types([oid]) unless type_map.key?(oid)
 
-          type_map.fetch(oid, fmod, sql_type) { register_unknown_oid_type(oid, column_name) }
+            type_map.fetch(oid, fmod, sql_type) { register_unknown_oid_type(oid, column_name) }
+          end
         end
 
         def load_additional_types(oids)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -145,6 +145,83 @@ module ActiveRecord
         end
       end
 
+      def test_connection_lock_blocks_shared_queries_while_reconnecting
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        with_postgresql_adapter(db_config.configuration_hash.merge(connection_lock: "thread", connection_retries: 0)) do |connection|
+          connection.connect!
+          assert_equal [1], connection.select_values("SELECT 1")
+
+          reconnect_waiting = Concurrent::Event.new
+          allow_reconnect_to_finish = Concurrent::Event.new
+          query_started = Concurrent::Event.new
+
+          original_configure_connection = connection.method(:configure_connection)
+          original_with_raw_connection = connection.method(:with_raw_connection)
+          pause_configure = true
+
+          connection.singleton_class.define_method(:configure_connection) do
+            if pause_configure
+              pause_configure = false
+              @type_map = nil
+              @type_map_for_results = nil
+              reconnect_waiting.set
+              raise "Timed out waiting for reconnect to resume" unless allow_reconnect_to_finish.wait(5)
+            end
+
+            original_configure_connection.call
+          end
+
+          connection.singleton_class.define_method(:with_raw_connection) do |*args, **kwargs, &block|
+            query_started.set if Thread.current[:shared_connection_query]
+            original_with_raw_connection.call(*args, **kwargs, &block)
+          end
+
+          reconnect_thread = nil
+          query_thread = nil
+          reconnect_error = nil
+          query_result = nil
+          query_error = nil
+
+          reconnect_thread = Thread.new do
+            connection.reconnect!
+          rescue => error
+            reconnect_error = error
+          end
+
+          assert reconnect_waiting.wait(5), "Timed out waiting for reconnect! to pause inside configure_connection"
+
+          query_thread = Thread.new do
+            Thread.current[:shared_connection_query] = true
+            query_result = connection.select_values("SELECT 1")
+          rescue => error
+            query_error = error
+          end
+
+          assert query_started.wait(5), "Timed out waiting for the shared query to start"
+
+          10.times do
+            break if query_error || query_result
+            sleep 0.01
+          end
+
+          assert_nil query_error
+          assert_nil query_result
+
+          allow_reconnect_to_finish.set
+
+          assert reconnect_thread.join(5), "Timed out waiting for reconnect! to finish"
+          assert query_thread.join(5), "Timed out waiting for the shared query to finish"
+
+          assert_nil reconnect_error
+          assert_nil query_error
+          assert_equal [1], query_result
+        ensure
+          allow_reconnect_to_finish.set
+          reconnect_thread&.join(5)
+          query_thread&.join(5)
+        end
+      end
+
       def test_set_standard_conforming_strings_deprecation
         assert_deprecated(ActiveRecord.deprecator) do
           @connection.set_standard_conforming_strings

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1059,6 +1059,20 @@ module ActiveRecord
         assert_predicate @pool, :connected?
       end
 
+      def test_connection_lock_configuration
+        assert_equal ActiveSupport::Concurrency::NullLock, new_pool_with_options(connection_lock: false).lease_connection.lock
+        assert_connection_lock new_pool_with_options(connection_lock: "thread").lease_connection.lock, :thread
+        assert_connection_lock new_pool_with_options(connection_lock: "monitor").lease_connection.lock, :monitor
+      end
+
+      def test_connection_lock_configuration_rejects_invalid_values
+        error = assert_raises ArgumentError do
+          new_pool_with_options(connection_lock: "bogus").lease_connection
+        end
+
+        assert_equal "connection_lock must be one of nil, false, :thread, or :monitor", error.message
+      end
+
       def test_pin_connection_synchronize_the_connection
         assert_equal ActiveSupport::Concurrency::NullLock, @pool.lease_connection.lock
         @pool.pin_connection!(true)
@@ -1068,6 +1082,32 @@ module ActiveRecord
 
         @pool.pin_connection!(false)
         assert_equal ActiveSupport::Concurrency::NullLock, @pool.lease_connection.lock
+      end
+
+      def test_pin_connection_restores_configured_lock
+        pool = new_pool_with_options(connection_lock: "thread")
+        connection = pool.lease_connection
+
+        assert_connection_lock connection.lock, :thread
+
+        pool.pin_connection!(true)
+        assert_connection_lock connection.lock, stronger_lock_mode(:thread, current_context_lock_mode)
+
+        pool.unpin_connection!
+        assert_connection_lock connection.lock, :thread
+      end
+
+      def test_pin_connection_does_not_weaken_monitor_connection_lock
+        pool = new_pool_with_options(connection_lock: "monitor")
+        connection = pool.lease_connection
+
+        assert_connection_lock connection.lock, :monitor
+
+        pool.pin_connection!(true)
+        assert_connection_lock connection.lock, :monitor
+
+        pool.unpin_connection!
+        assert_connection_lock connection.lock, :monitor
       end
 
       def test_pin_connection_opens_a_transaction
@@ -1139,6 +1179,23 @@ module ActiveRecord
 
         @pool.unpin_connection!
         assert_equal ActiveSupport::Concurrency::NullLock, @pool.lease_connection.lock
+      end
+
+      def test_pin_connection_nesting_restores_configured_lock
+        pool = new_pool_with_options(connection_lock: "thread")
+        connection = pool.lease_connection
+
+        pool.pin_connection!(false)
+        assert_connection_lock connection.lock, :thread
+
+        pool.pin_connection!(true)
+        assert_connection_lock connection.lock, stronger_lock_mode(:thread, current_context_lock_mode)
+
+        pool.unpin_connection!
+        assert_connection_lock connection.lock, stronger_lock_mode(:thread, current_context_lock_mode)
+
+        pool.unpin_connection!
+        assert_connection_lock connection.lock, :thread
       end
 
       def test_inspect_does_not_show_secrets
@@ -1240,6 +1297,33 @@ module ActiveRecord
           pool.connections.find_all(&:in_use?)
         end
 
+        def assert_connection_lock(lock, lock_mode)
+          case lock_mode
+          when nil
+            assert_equal ActiveSupport::Concurrency::NullLock, lock
+          when :thread
+            assert_instance_of ActiveSupport::Concurrency::ThreadMonitor, lock
+          when :monitor
+            assert_instance_of Monitor, lock
+          else
+            flunk "Unknown lock mode: #{lock_mode.inspect}"
+          end
+        end
+
+        def current_context_lock_mode
+          ActiveSupport::IsolatedExecutionState.context.is_a?(Fiber) ? :monitor : :thread
+        end
+
+        def stronger_lock_mode(*lock_modes)
+          lock_modes.compact.max_by do |lock_mode|
+            case lock_mode
+            when :thread then 1
+            when :monitor then 2
+            else 0
+            end
+          end
+        end
+
         def with_single_connection_pool(**options)
           config = @db_config.configuration_hash.merge(max_connections: 1, **options)
           db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary", config)
@@ -1284,7 +1368,7 @@ module ActiveRecord
 
       def test_lock_thread_allow_fiber_reentrency
         connection = @pool.checkout
-        connection.lock_thread = ActiveSupport::IsolatedExecutionState.context
+        connection.install_execution_context_lock(ActiveSupport::IsolatedExecutionState.context)
         connection.transaction do
           enumerator = Enumerator.new do |yielder|
             connection.transaction do

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1131,7 +1131,6 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def rollback_transaction(*args)
         @rollback_transaction_called = true
       end
-      def lock_thread=(lock_thread); end
       def connect!; end
     end.new
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -4028,6 +4028,28 @@ development:
   retry_deadline: 5 # Stop retrying queries after 5 seconds
 ```
 
+#### Configuring Connection Locks
+
+By default, Active Record connections do not synchronize general query execution.
+If your application shares a single adapter instance across threads, you can enable
+locking per database configuration with `connection_lock`.
+
+Supported values are:
+
+* `false` or omitted: no shared-connection lock
+* `thread`: use `ActiveSupport::Concurrency::ThreadMonitor`
+* `monitor`: use Ruby's `Monitor`
+
+```yaml
+development:
+  adapter: postgresql
+  connection_lock: thread
+```
+
+This is mainly useful for environments that manually share a connection object
+across threads and need reconnects and type-map reconfiguration to exclude
+concurrent queries on that adapter instance.
+
 #### Configuring Query Cache
 
 By default, Rails automatically caches the result sets returned by queries. If Rails encounters the same query


### PR DESCRIPTION
### Motivation / Background

abstract_adapter.rb with default settings has a race condition. Rails 7.1 introduced a regression in https://github.com/rails/rails/pull/46519 by assuming that connections are never shared across threads. In practice, that assumption doesn't always hold, especially in applications that use a connection pool together with RDS Proxy. PostgreSQLAdapter requires a lock since type_map is initialized lazily, a change made in https://github.com/rails/rails/pull/44570.

Cross-referencing https://github.com/rails/rails/issues/51780#issuecomment-4583353372.

### Detail

Add a `connection_lock` database config for applications that share a connection across threads or fibers. When enabled, ActiveRecord locks the adapter during reconnect and PostgreSQL result processing so a shared connection cannot be used while it is being reconnected.

I noticed that some type_map readers were not guarded, I added `@lock.synchronize` in a few additional places. I am leaving this to your best judgement since that work ballooned beyond connection_pool, abstract_adapter, and postgresql_adapter classes, and I am less familiar with database_statements class.

### Additional information

Repro of the original issue:
```ruby
$ cat Gemfile
ruby "3.3.4"
gem "activerecord", "=8.1.3"

$ cat database.yml
development:
  adapter: postgresql
  url: postgres://localhost:5432/giza_development
  database: giza_development
  username: postgres
  gssencmode: disable
  pool: 5

$ cat repro.rb
require "active_record"
require "yaml"
config = YAML.load(File.read("database.yml"))["development"]
ActiveRecord::Base.establish_connection(config)
Thread.abort_on_exception = true
ActiveRecord::Base.connection_pool.with_connection do |connection|
  Thread.new(connection) do |pg|
    pg.reconnect!
  end
  p connection.select_values("SELECT 1")
end

$ irb -r ./repro.rb
/opt/homebrew/lib/ruby/gems/3.3.0/gems/activerecord-8.1.3/lib/active_record/connection_adapters/postgresql_adapter.rb:876:in `get_oid_type': undefined method `key?' for nil (NoMethodError)

          if !type_map.key?(oid)
                      ^^^^^
```

After the following patch is applied, the error is no longer reproducible:
```ruby
module ActiveRecord::ConnectionAdapters::PostgreSQLAdapterPatch
  def initialize(
    config_or_deprecated_connection,
    deprecated_logger = nil,
    deprecated_connection_options = nil,
    deprecated_config = nil
  )
    super
    @lock = ActiveSupport::Concurrency::ThreadMonitor.new
  end
end

class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
  prepend ActiveRecord::ConnectionAdapters::PostgreSQLAdapterPatch
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.