### PR TITLE
Fix store accessor `*_change` and `saved_change_to_*` reporting unchanged keys as changed

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -160,7 +160,8 @@ module ActiveRecord
               return unless attribute_changed?(store_attribute)
               prev_store, new_store = changes[store_attribute]
               accessor = store_accessor_for(store_attribute)
-              [accessor.get(prev_store, key), accessor.get(new_store, key)]
+              prev_value, new_value = accessor.get(prev_store, key), accessor.get(new_store, key)
+              [prev_value, new_value] unless prev_value == new_value
             end
 
             define_method("#{accessor_key}_was") do
@@ -181,7 +182,8 @@ module ActiveRecord
               return unless saved_change_to_attribute?(store_attribute)
               prev_store, new_store = saved_changes[store_attribute]
               accessor = store_accessor_for(store_attribute)
-              [accessor.get(prev_store, key), accessor.get(new_store, key)]
+              prev_value, new_value = accessor.get(prev_store, key), accessor.get(new_store, key)
+              [prev_value, new_value] unless prev_value == new_value
             end
 
             define_method("#{accessor_key}_before_last_save") do

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -138,6 +138,20 @@ class StoreTest < ActiveRecord::TestCase
     assert_not @john.color_changed?
   end
 
+  test "changing one accessor does not report a change for a sibling accessor" do
+    @john.homepage = "http://www.example.com"
+    @john.save!
+
+    @john.color = "red"
+    assert_predicate @john, :color_changed?
+    assert_not @john.homepage_changed?
+    assert_nil @john.homepage_change
+
+    @john.save!
+    assert_predicate @john, :saved_change_to_color?
+    assert_nil @john.saved_change_to_homepage
+  end
+
   test "nullifying the store mark accessor as changed" do
     color = @john.color
     @john.settings = nil


### PR DESCRIPTION
## Summary

`ActiveRecord::Store` generates `<key>_change` and `saved_change_to_<key>` dirty methods per accessor (`activerecord/lib/active_record/store.rb`). They guarded only on `attribute_changed?` / `saved_change_to_attribute?` (store column level), then unconditionally returned the pair:

```ruby
define_method("#{accessor_key}_change") do
  return unless attribute_changed?(store_attribute)
  prev_store, new_store = changes[store_attribute]
  accessor = store_accessor_for(store_attribute)
  [accessor.get(prev_store, key), accessor.get(new_store, key)]   # bug
end
```

The same pattern appeared in `saved_change_to_<key>`.

So whenever **any** key in a store column changed, **both** `<key>_change` and `saved_change_to_<key>` of every **other** key in that column returned a `[value, value]` pair — even though:

- their own predicates (`<key>_changed?` / `saved_change_to_<key>?`) correctly return `false` (they compare per key), and
- the standard `ActiveModel` `attr_change` / `saved_change_to_attribute` contract returns `nil` when a value is unchanged.

```ruby
user = User.create!(color: "black", size: "L").reload
user.color = "white"          # only color changes
user.size_changed?            # => false          (correct)
user.size_change              # => ["L", "L"]     (bug, expected nil)

user.save!
user.saved_change_to_size?    # => false          (correct)
user.saved_change_to_size     # => ["L", "L"]     (bug, expected nil)
```

## Fix

Return the pair only when this specific key actually changed, mirroring the predicate counterparts:

```ruby
prev_value, new_value = accessor.get(prev_store, key), accessor.get(new_store, key)
[prev_value, new_value] unless prev_value == new_value
```

Applied to both `<key>_change` and `saved_change_to_<key>`.

Note: `<key>_was` and `<key>_before_last_save` are left unchanged — they return the current value for an unchanged key, matching the standard `attr_was` / `attribute_before_last_save` contract.

## Age

Dormant since store dirty methods were added in `61a39ffcc6` (**2019-03-25**, ~7 years). The 2025 commit `97df37b898` only changed value extraction (`dig` → `accessor.get`), keeping the faulty guard. Existing tests check `<key>_changed?` on an unchanged sibling but never the pair-returning variants.

## Tests

Added a regression test with a **value-bearing sibling** (`homepage` set to a real URL) asserting both `homepage_change` and `saved_change_to_homepage` are `nil` when only `color` changed. **Verified red on `main`, green with the fix**; full `store_test.rb` passing (sqlite3).

## Severity

**Medium** — silent wrong result on a public dirty-tracking API. The predicates stay correct, so impact is limited to code that reads the pair directly (e.g. `prev, cur = record.size_change`). No security implication.

No existing upstream issue or PR found.