### PR TITLE
Fix JSON encoding of hash keys whose `#as_json` returns a string

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix JSON encoding of hash keys whose `#as_json` returns a string.
+
+    On `json` gem >= 2.15.2 the `JSON::Coder`-based encoder serialized a
+    non-`String`/`Symbol` hash key through `#as_json` instead of `#to_s`
+    whenever that `#as_json` happened to return a string. A `Time`,
+    `DateTime`, or `TimeWithZone` used as a hash key therefore changed format
+    (`{"2009-01-01 12:30:00 UTC":1}` became
+    `{"2009-01-01T12:30:00.000Z":1}`), diverging from both the legacy
+    encoder and the value-vs-key handling. Keys are now serialized via `#to_s`
+    based on the key's own type, matching the legacy encoder.
+
+    *Kenta Ishizaki*
+
 *   Add shims for `Ractor` shareability methods so framework code can call them
     unconditionally regardless of the Ruby version.
 

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -150,10 +150,13 @@ module ActiveSupport
         class JSONGemCoderEncoder # :nodoc:
           JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
           CODER = ::JSON::Coder.new do |value, is_key|
-            json_value = value.as_json
+            # Serialize non-String/Symbol keys via #to_s based on the key's own type,
+            # mirroring the legacy `jsonify` encoder. (#as_json is intentionally not
+            # consulted here: Time#as_json returns an ISO8601 String, yet the key must
+            # still be emitted via #to_s for backward compatibility.)
+            next value.to_s if is_key && !(String === value) && !(Symbol === value)
 
-            # Keep compatibility by calling to_s on non-String keys
-            next value.to_s if is_key && !(String === json_value)
+            json_value = value.as_json
 
             # Handle objects returning self from as_json
             if json_value.equal?(value)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -142,6 +142,23 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal "some_value", parsed["custom_123"]
   end
 
+  def test_hash_with_keys_whose_as_json_returns_a_string
+    # Keys that are not String/Symbol must be serialized via #to_s, even when
+    # their #as_json returns a String (e.g. Time, DateTime). Otherwise the key
+    # format silently diverges from the historical encoder.
+    with_standard_json_time_format(true) do
+      time = Time.utc(2009, 1, 1, 12, 30, 0)
+      assert_equal %({"#{time}":1}), ActiveSupport::JSON.encode(time => 1)
+
+      datetime = DateTime.new(2009, 1, 1, 12, 30, 0)
+      assert_equal %({"#{datetime}":1}), ActiveSupport::JSON.encode(datetime => 1)
+
+      Time.use_zone("Tokyo") do
+        twz = Time.utc(2009, 1, 1, 12, 30, 0).in_time_zone
+        assert_equal %({"#{twz}":1}), ActiveSupport::JSON.encode(twz => 1)
+      end
+    end
+  end
 
   def test_hash_should_allow_key_filtering_with_only
     assert_equal %({"a":1}), ActiveSupport::JSON.encode({ "a" => 1, :b => 2, :c => 3 }, { only: "a" })


### PR DESCRIPTION
## Summary

On `json` gem **>= 2.15.2**, `ActiveSupport`'s `JSONGemCoderEncoder` (`activesupport/lib/active_support/json/encoding.rb:152-156`) decided whether to serialize a non-`String`/`Symbol` hash key via `#to_s` by inspecting the type of `value.as_json` rather than the key itself:

```ruby
json_value = value.as_json
next value.to_s if is_key && !(String === json_value)   # bug
```

`Time#as_json` / `DateTime#as_json` / `TimeWithZone#as_json` return an ISO8601 **string**, so those keys skipped the `to_s` path and were emitted in ISO8601 form. The legacy encoder (`jsonify`, used on `json` < 2.15.2) and every prior Rails version emit the `#to_s` form via `k.to_s unless Symbol === k || String === k`. The **same hash therefore produced different JSON depending on the installed `json` gem version**:

```ruby
{ Time.utc(2009,1,1,12,30) => 1 }.to_json
# json < 2.15.2 (and historically): {"2009-01-01 12:30:00 UTC":1}
# json >= 2.15.2 (bug):             {"2009-01-01T12:30:00.000Z":1}
```

## Fix

Decide based on the **key's own type**, mirroring `jsonify`:

```ruby
next value.to_s if is_key && !(String === value) && !(Symbol === value)
json_value = value.as_json
```

The guard retains explicit `String` / `Symbol` checks for symmetry with the legacy `jsonify` encoder (`k.to_s unless Symbol === k || String === k`), even though `JSON::Coder` does not currently invoke the block for native types.

Custom-object keys whose `as_json` returns a Hash (the #56784 case this guard was added for) still correctly go through `to_s`.

## Scope of change

Output only changes for keys where `#to_s != #as_json` — in practice `Time`, `DateTime`, and `TimeWithZone`. Keys whose `#to_s` and `#as_json` already agree (`Date`, `BigDecimal`, `URI`, `Pathname`, …) and custom-object keys whose `#as_json` returns a Hash (the #56784 case) are unaffected. Verified by encoding each type before and after the change.

## Age / nature

Not a coelacanth — this is a **recent regression**. `JSONGemCoderEncoder` is new (gated on `json` >= 2.15.2) and the faulty guard was introduced in `b619c8ffa3` (2026-02, the #56784 fix). Reported here because it is a silent, version-dependent output change on a very widely-used path (`to_json`).

## Tests

Added `test_hash_with_keys_whose_as_json_returns_a_string` covering `Time`, `DateTime`, and `TimeWithZone`. **Verified red on `main` (emits ISO8601), green with the fix**; full `encoding_test.rb` 158 runs / 267 assertions / 0 failures.

## Severity

**Medium–High** — silent, `json`-gem-version-dependent format divergence for `Time`/`DateTime`/`TimeWithZone` hash keys. No security implication.

No existing upstream issue or PR found.