### PR TITLE
Fix `assert_part` / `assert_no_part` for body parts nested under an attachment

### DIFF
--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -110,7 +110,7 @@ module ActionMailer
       #   end
       def assert_part(content_type, mail = last_delivered_mail!)
         mime_type = Mime[content_type]
-        part = [*mail.parts, mail].find { |part| mime_type.match?(part.mime_type) }
+        part = [*mail.all_parts, mail].find { |part| mime_type.match?(part.mime_type) }
         decoder = _decoders[mime_type]
 
         assert_not_nil part, "expected part matching #{mime_type} in #{mail.inspect}"
@@ -128,7 +128,7 @@ module ActionMailer
       #   assert_no_part :text
       def assert_no_part(content_type, mail = last_delivered_mail!)
         mime_type = Mime[content_type]
-        part = [*mail.parts, mail].find { |part| mime_type.match?(part.mime_type) }
+        part = [*mail.all_parts, mail].find { |part| mime_type.match?(part.mime_type) }
 
         assert_nil part, "expected no part matching #{mime_type} in #{mail.inspect}"
       end

--- a/actionmailer/test/assert_select_email_test.rb
+++ b/actionmailer/test/assert_select_email_test.rb
@@ -153,3 +153,47 @@ class AssertMultipartSelectEmailTest < ActionMailer::TestCase
     end
   end
 end
+
+class AssertMultipartWithAttachmentEmailTest < ActionMailer::TestCase
+  class AssertMultipartWithAttachmentMailer < ActionMailer::Base
+    def test(options)
+      attachments["example.png"] = { mime_type: "image/png", content: "PNGDATA" }
+      mail subject: "Test e-mail", from: "test@test.host", to: "test <test@test.host>" do |format|
+        format.text { render plain: options[:text] } if options.key?(:text)
+        format.html { render plain: options[:html] } if options.key?(:html)
+      end
+    end
+  end
+
+  tests AssertMultipartWithAttachmentMailer
+
+  # With an attachment and both a text and an html body, Action Mailer nests the
+  # body parts inside a multipart/alternative container that itself sits under
+  # the top-level multipart/mixed alongside the attachment. The body parts must
+  # still be found.
+  def test_assert_part_finds_body_parts_nested_under_attachment
+    AssertMultipartWithAttachmentMailer.test(html: "<div><p>foo</p></div>", text: "foo bar").deliver_now
+
+    assert_part :text do |text|
+      assert_includes text, "foo bar"
+    end
+    assert_part :html do |html|
+      assert_kind_of Rails::Dom::Testing.html_document, html
+
+      assert_dom html, "div" do
+        assert_dom "p", "foo"
+      end
+    end
+  end
+
+  def test_assert_no_part_detects_body_parts_nested_under_attachment
+    mail = AssertMultipartWithAttachmentMailer.test(html: "<p>foo</p>", text: "foo bar")
+
+    assert_raises Minitest::Assertion, match: "expected no part matching text/html" do
+      assert_no_part :html, mail
+    end
+    assert_raises Minitest::Assertion, match: "expected no part matching text/plain" do
+      assert_no_part :text, mail
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`ActionMailer::TestCase#assert_part` and `#assert_no_part` (added in #55348, currently unreleased on `main` / 8.2.0.alpha) only inspect the **top-level** parts of a message via `Mail#parts`. When a message has **both a text and an html body together with an attachment**, Action Mailer nests the body parts inside a `multipart/alternative` container that sits *below* the top-level `multipart/mixed` part, alongside the attachment. The assertions therefore can't see the body parts:

- `assert_part :html` / `assert_part :text` → **false negative** (the body part exists but is reported missing).
- `assert_no_part :html` / `assert_no_part :text` → **false positive**: the assertion *passes* even though the part is present. This is the more dangerous direction — a test written to guarantee "no html part" silently keeps passing when an html part is actually emitted, masking a regression.

## Root cause

`actionmailer/lib/action_mailer/test_case.rb`:

```ruby
part = [*mail.parts, mail].find { |part| mime_type.match?(part.mime_type) }
```

`Mail#parts` returns only the immediate children. For a message built by `create_parts_from_responses` with an attachment + multipart body, the structure is:

```
multipart/mixed
├── multipart/alternative      ← mail.parts sees only this
│   ├── text/plain             ← the body parts live here, one level down
│   └── text/html
└── image/png  (attachment)
```

## Fix

Use `Mail#all_parts`, which flattens nested parts recursively — the same method already used by `ActionMailer::InlinePreviewInterceptor` (`inline_preview_interceptor.rb:56`):

```ruby
part = [*mail.all_parts, mail].find { |part| mime_type.match?(part.mime_type) }
```

(applied to both `assert_part` and `assert_no_part`).

## Reproduction (verified red → green)

Added `AssertMultipartWithAttachmentEmailTest` to `actionmailer/test/assert_select_email_test.rb`. The mailer attaches a file and renders both a text and an html body:

```ruby
attachments["example.png"] = { mime_type: "image/png", content: "PNGDATA" }
mail(...) do |format|
  format.text { render plain: options[:text] } if options.key?(:text)
  format.html { render plain: options[:html] } if options.key?(:html)
end
```

- `test_assert_part_finds_body_parts_nested_under_attachment` — `assert_part :text` / `:html` must find the nested body parts.
- `test_assert_no_part_detects_body_parts_nested_under_attachment` — `assert_no_part` must *fail* (raise) when the nested body part is present.

**On `main` (before the fix), both tests fail:**

```
1) Failure: test_assert_no_part_detects_body_parts_nested_under_attachment
   Minitest::Assertion expected but nothing was raised.   # ← false positive

2) Failure: test_assert_part_finds_body_parts_nested_under_attachment
   expected part matching text/plain in #<Mail::Message ... multipart/mixed ...>
   Expected nil to not be nil.                             # ← false negative
```

**With the fix, the full file is green:**

```
11 runs, 106 assertions, 0 failures, 0 errors, 0 skips
```

No regressions in adjacent suites: `test_helper_test.rb` (54 runs), `base_test.rb` (102 runs) both green.

## Notes

- Not a long-dormant bug — the feature itself is unreleased (#55348, merged 2025-07-16, commit `8ee4ae23c9`), so this fix lands before the API ships and carries minimal regression risk.
- No existing upstream PR or issue addresses this (only the original feature PR #55348).