### PR TITLE
Fix typos and grammar in Form Helpers docs

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -75,7 +75,7 @@ Notice that for the search form we are using the `url` option of `form_with`. Se
 
 In general, passing `url: my_path` to `form_with` tells the form where to make the request. The other option is to pass Active Model objects to the form, as you will learn [below](#creating-forms-with-model-objects). You can also use [URL helpers](routing.html#path-and-url-helpers).
 
-The search form example above also shows the [form builder](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html) object. You will learn about the many helpers provided by the form builder object (like`form.label` and `form.text_field`) in the next section.
+The search form example above also shows the [form builder](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html) object. You will learn about the many helpers provided by the form builder object (like `form.label` and `form.text_field`) in the next section.
 
 TIP: For every form `input` element, an `id` attribute is generated from its name (`"query"` in above example). These IDs can be very useful for CSS styling or manipulation of form controls with JavaScript.
 
@@ -424,7 +424,7 @@ Rails works around this limitation by emulating other methods over POST with a h
 form_with(url: search_path, method: "patch")
 ```
 
-The above form Will generate this HTML output:
+The above form will generate this HTML output:
 
 ```html
 <form action="/search" accept-charset="UTF-8" method="post">
@@ -469,7 +469,7 @@ In this case, the "Update" button will be treated as `PATCH` and the "Delete" bu
 Making Select Boxes with Ease
 -----------------------------
 
-Select boxes, also known as drop-down list, allow users to select from a list of options. The HTML for select boxes requires a decent amount of markup - one `<option>` element for each option to choose from. Rails provides helper methods to help generate that markup.
+Select boxes, also known as drop-down lists, allow users to select from a list of options. The HTML for select boxes requires a decent amount of markup - one `<option>` element for each option to choose from. Rails provides helper methods to help generate that markup.
 
 For example, let's say we have a list of cities for the user to choose from. We can use the [`select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-select) helper:
 
@@ -1001,7 +1001,7 @@ This would result in `params[:person][:phone_number]` being an array containing 
 
 ### Combining Arrays and Hashes
 
-You can mix and match these two concepts. One element of a hash might be an array as in the previous example `params[:person]` hash has a key called `[:phone_number]` whose value is an array.
+You can mix and match these two concepts. One element of a hash might be an array, as in the previous example: the `params[:person]` hash has a key called `[:phone_number]` whose value is an array.
 
 You also can have an array of hashes. For example, you can create any number of addresses by repeating the following form fragment:
 
@@ -1207,7 +1207,7 @@ If the associated object is already saved, `fields_for` autogenerates a hidden i
     "name" => "John Doe",
     "addresses_attributes" => {
       "0" => {
-        "id" => 1,
+        "id" => "1",
         "kind" => "Home",
         "street" => "221b Baker Street"
       },


### PR DESCRIPTION
I encountered a handful of typos while reading the Action View Form Helper docs. These are my proposed changes to address them.

[ci skip]