### PR TITLE
[ci skip] Update Ruby version requirement to 3.4 or newer in the Getting started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -72,7 +72,7 @@ TIP: Any commands prefaced with a dollar sign `$` should be run in the terminal.
 
 For this project, you will need:
 
-* Ruby 3.3 or newer
+* Ruby 3.4 or newer
 * Rails 8.2.0 or newer
 * A code editor
 


### PR DESCRIPTION

### Motivation / Background

Fixes #57513 

### Detail

This Pull Request changes the recommended ruby version in the Getting started guide

### Additional information

I suggest to update the ruby version, so that the tutorial can keep the new `it` syntax inside blocks, since as a newcomer I would find this syntax enticing to try ruby and Rails.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
