### PR TITLE
JSONGemCoderEncoder: serialize non-String keys with `to_s` instead of `as_json`

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -150,10 +150,20 @@ module ActiveSupport
         class JSONGemCoderEncoder # :nodoc:
           JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
           CODER = ::JSON::Coder.new do |value, is_key|
-            json_value = value.as_json
+            # Serialize non-String/Symbol keys via #to_s based on the key's own type,
+            # mirroring the legacy `jsonify` encoder. (#as_json is intentionally not
+            # consulted here: Time#as_json returns an ISO8601 String, yet the key must
+            # still be emitted via #to_s for backward compatibility.)
+            if is_key
+              # Keep compatibility by calling to_s on non-String keys
+              if Symbol === value
+                next value # Symbol#to_s needlessly allocate a string.
+              else
+                next value.to_s
+              end
+            end
 
-            # Keep compatibility by calling to_s on non-String keys
-            next value.to_s if is_key && !(String === json_value)
+            json_value = value.as_json
 
             # Handle objects returning self from as_json
             if json_value.equal?(value)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -142,6 +142,23 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal "some_value", parsed["custom_123"]
   end
 
+  def test_hash_with_keys_whose_as_json_returns_a_string
+    # Keys that are not String/Symbol must be serialized via #to_s, even when
+    # their #as_json returns a String (e.g. Time, DateTime). Otherwise the key
+    # format silently diverges from the historical encoder.
+    with_standard_json_time_format(true) do
+      time = Time.utc(2009, 1, 1, 12, 30, 0)
+      assert_equal %({"#{time}":1}), ActiveSupport::JSON.encode(time => 1)
+
+      datetime = DateTime.new(2009, 1, 1, 12, 30, 0)
+      assert_equal %({"#{datetime}":1}), ActiveSupport::JSON.encode(datetime => 1)
+
+      Time.use_zone("Tokyo") do
+        twz = Time.utc(2009, 1, 1, 12, 30, 0).in_time_zone
+        assert_equal %({"#{twz}":1}), ActiveSupport::JSON.encode(twz => 1)
+      end
+    end
+  end
 
   def test_hash_should_allow_key_filtering_with_only
     assert_equal %({"a":1}), ActiveSupport::JSON.encode({ "a" => 1, :b => 2, :c => 3 }, { only: "a" })


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/57520

That is what the old encoder used to do.
