### PR TITLE
Fix syntax for Rack response in Rack guide

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -572,7 +572,7 @@ A Rack response can be written in a Rails controller as:
 ```ruby
 class HomeController
   def index
-    self.response = [200, {}, ["I'm Home!"]]
+    self.response = Rack::Response[200, {}, ["I'm Home!"]]
   end
 end
 ```


### PR DESCRIPTION
### Motivation / Background

There's a small mistake in the syntax to define a Rack response in the Rack guide.

### Detail

This PR corrects the syntax to use a `Rack::Response` object as required by Rails, rather than an array.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
