### PR TITLE
Fix `find` silently returning `[]` for composite primary key ids passed as strings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix `find` with multiple composite primary key ids passed as strings
+    silently returning `[]`.
+
+    `Model.find([["1", "10"], ["1", "20"]])` (the shape ids take when they come
+    from request parameters) returned an empty array instead of the records and
+    without raising `RecordNotFound`. The ids were cast against the array of key
+    column names as a whole — which is a no-op — so the string tuples never
+    compared equal to the records' integer ids when ordering the result. Each
+    component is now cast against its own column type, matching the documented
+    coercion already performed for single-column keys.
+
+    *Kenta Ishizaki*
+
 *   Fix PostgreSQL `daterange` / `tsrange` / `tstzrange` schema dump producing
     invalid Ruby.
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -574,9 +574,17 @@ module ActiveRecord
         result = relation.records
 
         if result.size == ids.size
-          result.in_order_of(:id, ids.map { |id| model.type_for_attribute(primary_key).cast(id) })
+          result.in_order_of(:id, ids.map { |id| cast_primary_key(id) })
         else
           raise_record_not_found_exception!(ids, result.size, ids.size)
+        end
+      end
+
+      def cast_primary_key(id)
+        if model.composite_primary_key?
+          primary_key.zip(id).map! { |attr, value| model.type_for_attribute(attr).cast(value) }
+        else
+          model.type_for_attribute(primary_key).cast(id)
         end
       end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -2058,6 +2058,13 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal books.map(&:id), Cpk::Book.order(author_id: :asc).find(books.map(&:id)).map(&:id)
   end
 
+  test "find with multiple sets of composite primary key given as strings" do
+    books = [cpk_books(:cpk_great_author_first_book), cpk_books(:cpk_great_author_second_book)]
+    string_ids = books.map { |book| book.id.map(&:to_s) }
+
+    assert_equal books.map(&:id), Cpk::Book.find(string_ids).map(&:id)
+  end
+
   test "#find_by with composite primary key" do
     book = cpk_books(:cpk_book_with_generated_pk)
     assert_equal cpk_reviews(:first_book_review), Cpk::Review.find_by(book: book)


### PR DESCRIPTION
### Summary

For a composite primary key model, calling `find` with two or more ids whose components are **strings** — the shape ids take when they come from request parameters, URLs, or JSON — silently returns an **empty array**, without even raising `RecordNotFound`:

```ruby
class Book < ApplicationRecord
  self.primary_key = [:author_id, :id]
end

# integers work
Book.find([[1, 10], [1, 20]])         # => [#<Book...>, #<Book...>]

# the same ids as strings (e.g. from params) silently return nothing
Book.find([["1", "10"], ["1", "20"]]) # => []   (expected the two books)
```

This is the most dangerous kind of failure: no exception, just missing data. A controller doing `Book.find(params[:ids])` returns nothing and the bug surfaces far downstream. Single-column primary keys are unaffected — `Model.find("1")` has always coerced strings (and is documented to).

### Cause

`FinderMethods#find_some_ordered` fetches the rows with `where(primary_key => ids)` (the database coerces the string components, so the rows *are* found), then restores the requested order with `result.in_order_of(:id, ...)`. The ids were cast with:

```ruby
ids.map { |id| model.type_for_attribute(primary_key).cast(id) }
```

For a composite key, `primary_key` is an **array** of column names (`["author_id", "id"]`). `type_for_attribute` can't resolve an array to a real attribute type and returns a generic `ActiveModel::Type::Value`, whose `cast` is a no-op — so the string tuples stay strings. `result` is an Array, so `Enumerable#in_order_of(:id, series)` compares each record's `id` (an **integer** tuple `[1, 10]`) against the **string** series (`["1", "10"]`). They never `==`, so every row is filtered out and the result is `[]`.

### Fix

Cast each id component against its own column type, mirroring the `primary_key.zip(id)` pattern already used by `find_one`:

```ruby
def cast_primary_key(id)
  if model.composite_primary_key?
    primary_key.zip(id).map { |attr, value| model.type_for_attribute(attr).cast(value) }
  else
    model.type_for_attribute(primary_key).cast(id)
  end
end
```

The single-column branch is byte-for-byte the previous behavior; only the composite path changes.

### Scope / trigger

- Composite primary key model, **and**
- `find` called with **2+ id tuples** (a single tuple goes through `find_one`, which uses `where` and already works), **and**
- no explicit `order` on the relation (the default `find_some_ordered` path; `order(...).find(...)` happens to route elsewhere and was unaffected), **and**
- id components not already the column's native type (i.e. strings from params).

### Related fixes

The same class of bug — a finder path mishandling a composite `primary_key` (an array of column names) — has been fixed before in `find_by_token_for` (`8617a7c`) and `find_signed` (#57245). `find_some_ordered` is a remaining path, and the only one that failed *silently* (no-op cast → empty result) rather than raising, which is likely why it went unnoticed.

Note this code path doesn't go through `find_by` / the predicate builder (the rows are already loaded; only the ordering cast is wrong), so it casts the key components directly with `type_for_attribute(column).cast` — the same per-column primitive the single-column branch already used. Happy to adjust the shape if a different form is preferred.

### Age

The no-op cast dates to the `in_order_of` introduction (`9cb09411e1`, 2021), which predates composite primary keys. It became reachable when CPK shipped in **Rails 7.1** and affects `main` (8.x). The existing CPK `find` tests (`finder_test.rb`) only pass already-cast integer tuples read back from the database, so the string path was never exercised.

### Tests

Added a regression test (`finder_test.rb`) that passes string composite ids to `find` — **verified red on `main`, green with the fix** on both **sqlite3** and **postgresql**. Full `finder_test.rb` passes on both adapters (275 runs).