### PR TITLE
Fix collection `ids=` writers raising `RecordNotFound` for composite primary key models with string ids

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix collection association `ids=` writers (e.g. `author.book_ids=`) raising
+    `ActiveRecord::RecordNotFound` for existing records when a composite primary
+    key model is assigned string ids (the shape ids take from request params).
+
+    Each id component is now cast against its own column type, instead of casting
+    the whole tuple against an array of column names, which `type_for_attribute`
+    can't resolve to a real type (so the cast was a no-op and the string ids
+    never matched the loaded records).
+
+    *Kenta Ishizaki*
+
 *   Fix `find` with multiple composite primary key ids passed as strings
     silently returning `[]`.
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -61,15 +61,19 @@ module ActiveRecord
       # Implements the ids writer method, e.g. foo.item_ids= for Foo.has_many :items
       def ids_writer(ids)
         primary_key = reflection.association_primary_key
-        pk_type = klass.type_for_attribute(primary_key)
         ids = Array(ids).compact_blank
-        ids.map! { |id| pk_type.cast(id) }
 
         records = if klass.composite_primary_key?
+          pk_types = primary_key.map { |column| klass.type_for_attribute(column) }
+          ids.map! { |id| pk_types.zip(id).map! { |type, value| type.cast(value) } }
+
           klass.where(primary_key => ids).index_by do |record|
             primary_key.map { |primary_key| record._read_attribute(primary_key) }
           end
         else
+          pk_type = klass.type_for_attribute(primary_key)
+          ids.map! { |id| pk_type.cast(id) }
+
           klass.where(primary_key => ids).index_by do |record|
             record._read_attribute(primary_key)
           end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3267,6 +3267,16 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal great_author.books.ids, Cpk::Author.preload(:books).find(great_author.id).book_ids
   end
 
+  def test_ids_writer_with_composite_primary_key_and_string_ids
+    great_author = cpk_authors(:cpk_great_author)
+    book_ids = great_author.books.ids
+
+    # ids coming from request params, URLs, or JSON are strings.
+    great_author.book_ids = book_ids.map { |id| id.map(&:to_s) }
+
+    assert_equal book_ids.sort, great_author.reload.books.ids.sort
+  end
+
   private
     def force_signal37_to_load_all_clients_of_firm
       companies(:first_firm).clients_of_firm.load_target


### PR DESCRIPTION
### Summary

For a composite primary key model, assigning a collection association's ids writer (e.g. `author.book_ids=`) ids whose components are **strings** — the shape ids take from request params, URLs, or JSON — raises `ActiveRecord::RecordNotFound` for records that **exist**:

```ruby
class Author < ApplicationRecord
  has_many :books              # Book.primary_key = [:author_id, :id]
end

ids = author.books.ids                             # => [[1, 10], [1, 20]]

author.book_ids = ids                              # integers: works
author.book_ids = ids.map { |t| t.map(&:to_s) }   # raises RecordNotFound (records exist!)
```

A form built with `collection_select` / check boxes submits these ids as strings, so `author.book_ids = params[:book_ids]` rejects valid selections.

### Cause

`CollectionAssociation#ids_writer` cast the ids with:

```ruby
pk_type = klass.type_for_attribute(primary_key)
ids.map! { |id| pk_type.cast(id) }
```

For a composite key, `primary_key` (`association_primary_key`) is an **array** of column names (`["author_id", "id"]`). `type_for_attribute` can't resolve an array to a real attribute type and returns a generic `ActiveModel::Type::Value`, whose `cast` is a no-op — so the string tuples stay strings. The rows are still found (`where(primary_key => ids)`, the database coerces the components), but they are then indexed by their **integer** id tuples (`[1, 10]`) and looked up with `values_at` using the uncast **string** tuples (`["1", "10"]`). They never match, so every record is dropped and the size check raises `RecordNotFound`.

### Fix

Cast each id component against its own column type. The single-column branch keeps its previous behavior; only the composite path changes. Since `has_and_belongs_to_many` shares this writer, it's covered too. Happy to adjust the shape if a different form is preferred.

### Related fixes

Same class of bug — a path mishandling a composite `primary_key` (an array of column names) by passing it to `type_for_attribute`, getting a no-op cast — previously fixed in `find_by_token_for` (`8617a7c`) and `find_signed` (#57245); a sibling fix for `find` is in #57530. This is the collection `ids=` writer path.

### Tests

Added a regression test (`has_many_associations_test.rb`) that assigns string composite ids to a collection writer — **verified red on `main`, green with the fix** on both **sqlite3** and **postgresql**. Full `has_many_associations_test.rb` (320 runs) and `has_and_belongs_to_many_associations_test.rb` (96 runs) pass on both adapters.