### PR TITLE
Fix grouped calculations by a `belongs_to` association with a composite primary key model

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix grouped calculations (e.g. `count`) grouped by a `belongs_to` association
+    that points to a composite primary key model.
+
+    `Book.group(:order).count`, where `Book belongs_to :order` and `Order` has a
+    composite primary key, raised `ArgumentError: Expected corresponding value
+    for ["shop_id", "id"] to be an Array`. The grouped result is now keyed by the
+    associated records as it already is for single-column keys.
+
+    *Kenta Ishizaki*
+
 *   Fix `has_many`/`has_one :through` associations with `disable_joins: true`
     silently returning an empty result when the source points to a composite
     primary key model.

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -572,7 +572,11 @@ module ActiveRecord
 
           result.then do |calculated_data|
             if association
-              key_ids     = calculated_data.collect { |row| row[group_aliases.first] }
+              key_ids = if association.klass.base_class.composite_primary_key?
+                calculated_data.collect { |row| group_aliases.map { |group_alias| row[group_alias] } }
+              else
+                calculated_data.collect { |row| row[group_aliases.first] }
+              end
               key_records = association.klass.base_class.where(association.klass.base_class.primary_key => key_ids)
               key_records = key_records.index_by(&:id)
             end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -29,7 +29,7 @@ require "models/cpk"
 class CalculationsTest < ActiveRecord::TestCase
   include AsyncHelper
 
-  fixtures :companies, :accounts, :authors, :author_addresses, :topics, :speedometers, :minivans, :books, :posts, :comments, :cpk_books
+  fixtures :companies, :accounts, :authors, :author_addresses, :topics, :speedometers, :minivans, :books, :posts, :comments, :cpk_books, :cpk_orders
 
   def test_should_sum_field
     assert_equal 318, Account.sum(:credit_limit)
@@ -441,6 +441,16 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_count_for_a_composite_primary_key_model_with_includes_and_references
     assert_equal Cpk::Book.count, Cpk::Book.includes(:chapters).references(:chapters).count
+  end
+
+  def test_group_by_a_belongs_to_association_with_a_composite_primary_key_model
+    order = cpk_orders(:cpk_book_order_1)
+    books = Cpk::Book.where(shop_id: order.shop_id, order_id: order.id)
+    assert_predicate books, :any?
+
+    result = books.group(:order).count
+
+    assert_equal({ order => books.count }, result)
   end
 
   def test_should_group_by_summed_field_having_condition


### PR DESCRIPTION
### Summary

Grouping a calculation by a `belongs_to` association that points to a composite primary key model raises `ArgumentError` instead of returning the grouped result:

```ruby
class Order < ApplicationRecord
  self.primary_key = [:shop_id, :id]
end

class Book < ApplicationRecord
  belongs_to :order, foreign_key: [:shop_id, :order_id]
end

Book.group(:order).count
# => ArgumentError: Expected corresponding value for ["shop_id", "id"] to be an Array
```

The single-column equivalent (`Comment.group(:post).count`, keyed by the associated records) has always worked; only the composite path is broken — it raises outright, so the feature is entirely unavailable for composite-key associations.

### Cause

When a grouped calculation is grouped by a `belongs_to` association, `execute_grouped_calculation` loads the associated records to key the result by them:

```ruby
key_ids     = calculated_data.collect { |row| row[group_aliases.first] }
key_records = association.klass.base_class.where(association.klass.base_class.primary_key => key_ids)
```

For a composite key, the grouped columns are the multiple foreign key components (`group_fields = Array(association.foreign_key)`), but `key_ids` only collects `group_aliases.first` — a single column. `primary_key` is then an array of column names, so `where(["shop_id", "id"] => [single, single, …])` hands the predicate builder a flat list of scalars where it expects an array of tuples, and it raises `ArgumentError`.

### Fix

When the associated model has a composite primary key, collect the full tuple of grouped columns per row, matching the value shape the predicate builder (and `index_by(&:id)`, which already returns the composite id tuple) expects. The single-column branch is unchanged.

### Tests

Added a regression test (`calculations_test.rb`) that groups `count` by a composite-key `belongs_to` and asserts the result is keyed by the associated records — **verified red on `main` (the `ArgumentError`), green with the fix** on both **sqlite3** and **postgresql**. Full `calculations_test.rb` passes on both adapters.