### PR TITLE
Fix `disable_joins` through associations grouping by composite key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `has_many`/`has_one :through` associations with `disable_joins: true`
+    silently returning an empty result when the source points to a composite
+    primary key model.
+
+    *Kenta Ishizaki*
+
 *   Fix collection association `ids=` writers (e.g. `author.book_ids=`) raising
     `ActiveRecord::RecordNotFound` for existing records when a composite primary
     key model is assigned string ids (the shape ids take from request params).

--- a/activerecord/lib/active_record/disable_joins_association_relation.rb
+++ b/activerecord/lib/active_record/disable_joins_association_relation.rb
@@ -27,7 +27,11 @@ module ActiveRecord
       records = @records
 
       records_by_id = records.group_by do |record|
-        record[key]
+        if key.is_a?(Array)
+          key.map { |column| record[column] }
+        else
+          record[key]
+        end
       end
 
       records = ids.flat_map { |id| records_by_id[id] }

--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -16,6 +16,10 @@ require "models/parrot"
 require "models/hotel"
 require "models/department"
 
+require "models/cpk/author"
+require "models/cpk/book"
+require "models/cpk/order"
+
 class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :authors, :comments, :pirates, :author_addresses
 
@@ -193,5 +197,16 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
   def test_limit_and_scope_in_double_join_applies_limit_in_memory
     disable_joins_sql = capture_sql { @author.no_joins_members.unnamed.first }
     assert_no_match(/LIMIT 1/, disable_joins_sql.last)
+  end
+
+  def test_ordered_disable_joins_through_with_composite_primary_key_source
+    author = Cpk::Author.create!(name: "Eddie")
+    order1 = Cpk::Order.create!(shop_id: 1, status: "open")
+    order2 = Cpk::Order.create!(shop_id: 1, status: "closed")
+    Cpk::Book.create!(id: [author.id, 1], title: "first", order: order1)
+    Cpk::Book.create!(id: [author.id, 2], title: "second", order: order2)
+
+    assert_equal author.orders.to_a, author.no_joins_orders.to_a
+    assert_equal [order2, order1], author.no_joins_orders.to_a
   end
 end

--- a/activerecord/test/models/cpk/author.rb
+++ b/activerecord/test/models/cpk/author.rb
@@ -5,5 +5,9 @@ module Cpk
     self.table_name = :cpk_authors
 
     has_many :books, class_name: "Cpk::Book", dependent: :delete_all
+
+    has_many :ordered_books, -> { order(id: :desc) }, class_name: "Cpk::Book"
+    has_many :orders, through: :ordered_books, source: :order
+    has_many :no_joins_orders, through: :ordered_books, source: :order, disable_joins: true
   end
 end


### PR DESCRIPTION
### Summary

A `has_many`/`has_one :through` association declared with `disable_joins: true` **silently returns an empty result** when the chain is ordered and the loaded records have to be grouped in memory by a composite primary/foreign key.

The records are fetched correctly from the database, but they are then dropped during the in-memory grouping step, so the association resolves to `[]`. No exception is raised — the data just disappears, which makes this hard to notice.

### Details

When `disable_joins: true` is used, `ActiveRecord::Associations::DisableJoinsAssociationScope` splits a joined query into separate queries. If any reflection in the chain is ordered (and the final scope itself has no order), the ordering has to be applied in memory, which routes through `ActiveRecord::DisableJoinsAssociationRelation#load`:

```ruby
records_by_id = records.group_by do |record|
  record[key]
end

records = ids.flat_map { |id| records_by_id[id] }
records.compact!
```

Here `key` is `reflection.join_primary_key`. For a composite key it is an **array of column names**, e.g. `["shop_id", "id"]`:

* a `belongs_to` source pointing at a composite-primary-key model (`BelongsToReflection#join_primary_key` → `association_primary_key`), or
* a `has_many`/`has_one` source with a composite foreign key (`AssociationReflection#join_primary_key` → `foreign_key`).

`record[["shop_id", "id"]]` reads an attribute *named after the array* (`'["shop_id", "id"]'.to_s`), which doesn't exist. Crucially this resolves to a `Null` attribute and returns `nil` **without raising** `MissingAttributeError`, so every record collapses under a single `nil` group. The subsequent `ids.flat_map { |id| records_by_id[id] }` looks up the real composite id tuples (`[1, 2]`, …), finds nothing under them, and `compact!` leaves `[]`.

### Fix

Read the grouping key component by component when it is composite, mirroring how the rest of the composite-key code handles array keys. Single-column keys are untouched:

```ruby
records_by_id = records.group_by do |record|
  if key.is_a?(Array)
    key.map { |column| record[column] }
  else
    record[key]
  end
end
```

### Reproduction

```ruby
class Cpk::Author < ActiveRecord::Base          # single-column pk
  has_many :ordered_books, -> { order(id: :desc) }, class_name: "Cpk::Book"
  has_many :orders, through: :ordered_books, source: :order
  has_many :no_joins_orders, through: :ordered_books, source: :order, disable_joins: true
end

class Cpk::Book < ActiveRecord::Base            # pk [:author_id, :id]
  belongs_to :order, foreign_key: [:shop_id, :order_id]   # Cpk::Order pk [:shop_id, :id]
end

author.orders.to_a          # => [#<Order ...>, #<Order ...>]   (joined)
author.no_joins_orders.to_a # => []  on main, correct list with the fix
```

### Testing

* Added `test_ordered_disable_joins_through_with_composite_primary_key_source` to `has_many_through_disable_joins_associations_test.rb` (reuses the existing `Cpk::Author` / `Cpk::Book` / `Cpk::Order` models). It is **red on `main`** (`no_joins_orders` returns `[]`) and **green with the fix**.
* Verified red→green on both **sqlite3** and **postgresql**.
* Full `has_many_through_disable_joins_associations_test` (29 runs) and `has_one_through_disable_joins_associations_test` (5 runs) pass on both adapters; `has_many_through_associations_test` (173) and `has_many_associations_test` (320) — which exercise the touched `Cpk` models — also pass.

### Notes

No existing `disable_joins` test used composite-key models, which is why the path was never covered. This is the same family as the recently fixed composite-key issues in `find` and the `ids=` writers, but a distinct mechanism: here the array is misused as an attribute **name** during grouping, rather than as a no-op **cast**.