### PR TITLE
Fix handling of `precision` in timestamp columns in Postgres migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Fix PostgreSQL migrations ignoring `precision` option for `timestamptz` columns.
+
+    Previously, columns with an explicit `timestamptz` type were always created
+    without a precision specifier, regardless if the `precision` option was passed
+    and what it was set to.
+
+    *Kuba Suder*
+
+*   Change default precision for `timestamp` and `timestamptz` columns in
+    PostgreSQL migrations to be 6 like in `datetime` columns.
+
+    `datetime` column type maps to either `timestamp` or `timestamptz` in
+    PostgreSQL databases, depending on the `datetime_type` setting. However,
+    while `datetime` has a default precision of 6 since Rails 7.0, migrations
+    that added columns with type passed as explicit `timestamp` or `timestamptz`
+    used a default precision of `nil` if no `precision` option was added.
+
+    This change makes the `timestamp` and `timestamptz` columns always use a
+    default precision of 6, regardless if the type is specified as `datetime`
+    or an explicit `timestamp(tz)` in the migration. This also affects how
+    columns with these types (if they aren't rendered as `datetime`) are dumped
+    into the `schema.rb`: `precision: nil` is added if the column doesn't have
+    a precision specifier, and `precision: 6` is not added if the precision is 6.
+
+    *Kuba Suder*
+
 *   Fix collection association `ids=` writers (e.g. `author.book_ids=`) raising
     `ActiveRecord::RecordNotFound` for existing records when a composite primary
     key model is assigned string ids (the shape ids take from request params).

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -268,6 +268,8 @@ module ActiveRecord
           case type
           when :virtual
             type = options[:type]
+          when :timestamp, :timestamptz
+            options[:precision] = 6 unless options.key?(:precision)
           end
 
           super

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -131,6 +131,21 @@ module ActiveRecord
             end
           end
 
+          def schema_precision(column)
+            if [:timestamp, :timestamptz].include?(column.type)
+              case column.precision
+              when nil
+                "nil"
+              when DEFAULT_DATETIME_PRECISION
+                nil
+              else
+                column.precision.inspect
+              end
+            else
+              super
+            end
+          end
+
           def schema_expression(column)
             super unless column.serial?
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1069,6 +1069,14 @@ module ActiveRecord
               raise ArgumentError, "enum_type is required for enums" if enum_type.nil?
 
               enum_type
+            when "timestamptz"
+              if precision.nil?
+                super
+              elsif (0..6) === precision
+                "timestamptz(#{precision})"
+              else
+                raise ArgumentError, "The timestamptz type does not allow a precision of #{precision}. The allowed range is from 0 to 6."
+              end
             else
               super
             end

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -207,3 +207,68 @@ class PostgresqlTimestampMigrationTest < ActiveRecord::PostgreSQLTestCase
     $stdout = original
   end
 end
+
+class PostgresqlTimestampPrecisionTest < ActiveRecord::PostgreSQLTestCase
+  setup do
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.create_table(:postgresql_timestamp_precisions, force: true) do |t|
+      t.timestamp :timestamp_with_precision, precision: 3
+      t.timestamp :timestamp_with_precision_0, precision: 0
+      t.timestamp :timestamp_without_precision, precision: nil
+      t.timestamp :timestamp_default
+
+      t.timestamptz :timestamptz_with_precision, precision: 3
+      t.timestamptz :timestamptz_with_precision_0, precision: 0
+      t.timestamptz :timestamptz_without_precision, precision: nil
+      t.timestamptz :timestamptz_default
+    end
+  end
+
+  teardown do
+    @connection.drop_table :postgresql_timestamp_precisions, if_exists: true
+  end
+
+  def test_timestamp_with_default_precision
+    assert_equal 6, column(:timestamp_default).precision
+  end
+
+  def test_timestamptz_with_default_precision
+    assert_equal 6, column(:timestamptz_default).precision
+  end
+
+  def test_timestamp_with_explicit_precision
+    assert_equal 3, column(:timestamp_with_precision).precision
+  end
+
+  def test_timestamptz_with_explicit_precision
+    assert_equal 3, column(:timestamptz_with_precision).precision
+  end
+
+  def test_timestamp_with_zero_precision
+    assert_equal 0, column(:timestamp_with_precision_0).precision
+  end
+
+  def test_timestamptz_with_zero_precision
+    assert_equal 0, column(:timestamptz_with_precision_0).precision
+  end
+
+  def test_timestamp_with_nil_precision
+    assert_nil column(:timestamp_without_precision).precision
+  end
+
+  def test_timestamptz_with_nil_precision
+    assert_nil column(:timestamptz_without_precision).precision
+  end
+
+  def test_timestamptz_rejects_invalid_precision
+    assert_raises ArgumentError do
+      @connection.add_column :postgresql_timestamp_precisions, :timestamptz_with_invalid_precision, :timestamptz, precision: 7
+    end
+  end
+
+  private
+
+  def column(name)
+    @connection.columns(:postgresql_timestamp_precisions).detect { |column| column.name == name.to_s }
+  end
+end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -274,7 +274,7 @@ module ActiveRecord
         assert_equal :datetime, column.type
 
         if current_adapter?(:PostgreSQLAdapter)
-          assert_equal "timestamp without time zone", column.sql_type
+          assert_equal "timestamp(6) without time zone", column.sql_type
         elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
           assert_equal "timestamp", column.sql_type
         else
@@ -327,7 +327,7 @@ module ActiveRecord
         assert_equal :datetime, column.type
 
         if current_adapter?(:PostgreSQLAdapter)
-          assert_equal "timestamp without time zone", column.sql_type
+          assert_equal "timestamp(6) without time zone", column.sql_type
         elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
           assert_equal "timestamp", column.sql_type
         else

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -679,6 +679,92 @@ class SchemaDumperTest < ActiveRecord::TestCase
       $stdout = original
     end
 
+    def test_schema_dump_with_timestamp_precision
+      original, $stdout = $stdout, StringIO.new
+
+      migration = Class.new(ActiveRecord::Migration::Current) do
+        def up
+          create_table("timestamps") do |t|
+            t.timestamp :timestamp_default
+            t.timestamp :timestamp_with_precision0, precision: 0
+            t.timestamp :timestamp_with_precision3, precision: 3
+            t.timestamp :timestamp_with_precision6, precision: 6
+            t.timestamp :timestamp_without_precision, precision: nil
+            t.timestamptz :timestamptz_default
+            t.timestamptz :timestamptz_with_precision0, precision: 0
+            t.timestamptz :timestamptz_with_precision3, precision: 3
+            t.timestamptz :timestamptz_with_precision6, precision: 6
+            t.timestamptz :timestamptz_without_precision, precision: nil
+          end
+        end
+        def down
+          drop_table("timestamps")
+        end
+      end
+
+      migration.migrate(:up)
+      output = dump_table_schema("timestamps")
+
+      assert_match %r{t\.datetime "timestamp_default"$}, output
+      assert_match %r{t\.datetime "timestamp_with_precision0", precision: 0$}, output
+      assert_match %r{t\.datetime "timestamp_with_precision3", precision: 3$}, output
+      assert_match %r{t\.datetime "timestamp_with_precision6"$}, output
+      assert_match %r{t\.datetime "timestamp_without_precision", precision: nil$}, output
+
+      assert_match %r{t\.timestamptz "timestamptz_default"$}, output
+      assert_match %r{t\.timestamptz "timestamptz_with_precision0", precision: 0$}, output
+      assert_match %r{t\.timestamptz "timestamptz_with_precision3", precision: 3$}, output
+      assert_match %r{t\.timestamptz "timestamptz_with_precision6"$}, output
+      assert_match %r{t\.timestamptz "timestamptz_without_precision", precision: nil$}, output
+    ensure
+      migration.migrate(:down)
+      $stdout = original
+    end
+
+    def test_schema_dump_with_timestamp_precision_and_datetime_as_timestamptz
+      migration, original, $stdout = nil, $stdout, StringIO.new
+
+      with_postgresql_datetime_type(:timestamptz) do
+        migration = Class.new(ActiveRecord::Migration::Current) do
+          def up
+            create_table("timestamps") do |t|
+              t.timestamp :timestamp_default
+              t.timestamp :timestamp_with_precision0, precision: 0
+              t.timestamp :timestamp_with_precision3, precision: 3
+              t.timestamp :timestamp_with_precision6, precision: 6
+              t.timestamp :timestamp_without_precision, precision: nil
+              t.timestamptz :timestamptz_default
+              t.timestamptz :timestamptz_with_precision0, precision: 0
+              t.timestamptz :timestamptz_with_precision3, precision: 3
+              t.timestamptz :timestamptz_with_precision6, precision: 6
+              t.timestamptz :timestamptz_without_precision, precision: nil
+            end
+          end
+          def down
+            drop_table("timestamps")
+          end
+        end
+
+        migration.migrate(:up)
+        output = dump_table_schema("timestamps")
+
+        assert_match %r{t\.timestamp "timestamp_default"$}, output
+        assert_match %r{t\.timestamp "timestamp_with_precision0", precision: 0$}, output
+        assert_match %r{t\.timestamp "timestamp_with_precision3", precision: 3$}, output
+        assert_match %r{t\.timestamp "timestamp_with_precision6"$}, output
+        assert_match %r{t\.timestamp "timestamp_without_precision", precision: nil$}, output
+
+        assert_match %r{t\.datetime "timestamptz_default"$}, output
+        assert_match %r{t\.datetime "timestamptz_with_precision0", precision: 0$}, output
+        assert_match %r{t\.datetime "timestamptz_with_precision3", precision: 3$}, output
+        assert_match %r{t\.datetime "timestamptz_with_precision6"$}, output
+        assert_match %r{t\.datetime "timestamptz_without_precision", precision: nil$}, output
+      end
+    ensure
+      migration.migrate(:down)
+      $stdout = original
+    end
+
     def test_timestamps_schema_dump_before_rails_7
       migration, original, $stdout = nil, $stdout, StringIO.new
 


### PR DESCRIPTION
### Motivation / Background

While migrating my app from SQLite to Postgres some time ago, I've noticed some inconsistencies in how the precision is set in timestamp columns depending on how they're declared in the migration DSL. I made an example repo here that demonstrates the problem: https://github.com/mackuba/rails-timestamp-precision-demo.

It creates a table with 3 sets of 4 timestamp fields each: `datetime`, `timestamp`, and `timestamptz`, with `precision` set to 0, 6, `nil` and not specified. These columns all end up as either `timestamp` or `timestamptz` in the database, since `datetime` maps to one of those depending on the `datetime_type` setting, but where they differ is in the precision flags. I would have expected the 4 precision options to end up with the same result in each of the 3 sets, but they don't:

- the `timestamptz` set of columns have no precision at all, none of the 4 fields
- the `timestamp` and `timestamptz` with no precision set default to a precision `nil`, instead of 6 as `datetime` does

Note, this is all Postgres specific, since in MySQL `datetime` and `timestamp` are two very different column types.


### Detail

I've made a number of fixes in:

- `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#type_to_sql`
- `ActiveRecord::ConnectionAdapters::PostgreSQL::ColumnMethods::TableDefinition#new_column_definition`
- `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#schema_precision`

which make the precision behave the same across Postgres columns declared as `datetime`, `timestamp` and `timestamptz`, both with `datetime_type` set to `:timestamptz` and with the default setting, in how the `schema.rb` is written and in what actually ends up in the database structure. Plus I've added some tests that I think should cover all of this.

### Additional information

I made all the changes in the `PostgreSQL` subclasses of the components, since these are all Postgres-specific things. Alternatively, some changes could be made in the abstract base class instead, e.g. the first commit could just be replaced with adding `:timestamptz` here to the base `SchemaStatements`:

```rb
elsif [:datetime, :timestamp, :time, :interval].include?(type) && precision ||= native[:precision]
```

since the `:interval`, which I think is also Postgres-specific, is already there. But it felt more appropriate to put it in the Postgres subclasses.

We could also move the `:interval` from there to the Postgres subclass now for consistency.

One thing to note is that this will create diffs in some people's `schema.rb` on update and after regenerating the schema, because of the changed defaults:

- if someone had a `t.timestamptz` field (or a `t.timestamp` field in `datetime_type = :timestamptz` mode), it would have no precision and be printed to `schema.rb` with no precision option, but now it will be dumped as `..., precision: nil`, since the default will now be 6
- in `datetime_type = :timestamptz` mode, if someone had a `t.timestamp` field with `precision: 6`, it will be dumped to `schema.rb` with the option omitted since that's now the default as in `datetime`
