### PR TITLE
Apply `has_many` `default_order:` when the association target is loaded

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -392,6 +392,7 @@ module ActiveRecord
         # Returns true if statement cache should be skipped on the association reader.
         def skip_statement_cache?(scope)
           reflection.has_scope? ||
+            reflection.options[:default_order].present? ||
             scope.eager_loading? ||
             klass.scope_attributes? ||
             reflection.source_reflection.active_record.default_scopes.any?

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -676,6 +676,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, comments.first.id
   end
 
+  def test_default_order_is_applied_when_the_target_is_loaded
+    author = authors(:david)
+
+    # The generated SQL (used by pluck/count/to_sql) honors default_order.
+    assert_equal [6, 5, 4, 2, 1], author.posts_with_default_order.pluck(:id)
+
+    # The materialized collection must honor it too, not come back in
+    # arbitrary database order.
+    assert_equal [6, 5, 4, 2, 1], author.posts_with_default_order.to_a.map(&:id)
+    assert_equal [6, 5, 4, 2, 1], author.posts_with_default_order.reload.map(&:id)
+  end
+
   def test_finding
     assert_equal 3, Firm.first.clients.length
   end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -10,6 +10,7 @@ class Author < ActiveRecord::Base
   has_many :posts_with_comments_sorted_by_comment_id, -> { includes(:comments).order("comments.id") }, class_name: "Post"
   has_many :posts_sorted_by_id, -> { order(:id) }, class_name: "Post"
   has_many :posts_sorted_by_id_limited, -> { order("posts.id").limit(1) }, class_name: "Post"
+  has_many :posts_with_default_order, class_name: "Post", default_order: "posts.id DESC"
   has_many :posts_with_categories, -> { includes(:categories) }, class_name: "Post"
   has_many :posts_with_comments_and_categories, -> { includes(:comments, :categories).order("posts.id") }, class_name: "Post"
   has_many :posts_with_special_categorizations, class_name: "PostWithSpecialCategorization"


### PR DESCRIPTION
### Summary

The `default_order:` association option (added by aa76590371, merged 2026-05-28 and not yet in a released version) is silently ignored on the normal association load path.

```ruby
class Author < ApplicationRecord
  has_many :posts, default_order: "posts.id DESC"
end

author = Author.first

author.posts.to_sql          # => "... ORDER BY posts.id DESC"   ✅
author.posts.pluck(:id)      # => [6, 5, 4, 2, 1]                ✅
author.posts.to_a.map(&:id)  # => [1, 2, 4, 5, 6]   ❌  arbitrary DB order
author.posts.map(&:id)       # => [1, 2, 4, 5, 6]   ❌
```

So the generated SQL advertises an `ORDER BY` while the materialized collection comes back in arbitrary database order — a silent wrong-result.

### Cause

`CollectionAssociation#scope` applies the option (`scope.default_order!(options[:default_order])`, `collection_association.rb:305`), so building a relation via `pluck`/`count`/`to_sql` does emit the `ORDER BY`.

But `Association#find_target` only uses `self.scope` on the slow path guarded by `skip_statement_cache?`. On the default fast path it builds SQL from the cached statement via `AssociationScope#scope`, which only merges `default_order_values` carried by reflection scope-chain item relations (`association_scope.rb:155`) — it never reads `options[:default_order]`. A plain `has_many ..., default_order: ...` has no scope block and no `default_scope`, so `skip_statement_cache?` returns `false` and the cached, `ORDER BY`-less SQL loads the target.

The existing feature tests pass only because they exercise the scope path (`pluck` / `.first`) or use `Comment`, which has a `default_scope` that already forces the slow path. No test loaded the *target* of a plain (no-`default_scope`) association.

### Fix

Treat a declared `default_order:` like a scope for statement-cache purposes, so the association loads through the scope that applies the order:

```ruby
def skip_statement_cache?(scope)
  reflection.has_scope? ||
    reflection.options[:default_order].present? ||
    scope.eager_loading? ||
    klass.scope_attributes? ||
    reflection.source_reflection.active_record.default_scopes.any?
end
```

This is the minimal correct fix and mirrors how `reflection.has_scope?` already opts scoped associations out of the cache. The trade-off is that `default_order:` associations no longer use the statement cache; an alternative would be to carry `options[:default_order]` into `AssociationScope` so the cached SQL itself includes the `ORDER BY`. Happy to take that shape instead if preferred.

### Test

`test_default_order_is_applied_when_the_target_is_loaded` in `has_many_associations_test.rb` adds a plain `has_many :posts_with_default_order, ..., default_order: "posts.id DESC"` on `Author` (no `default_scope`) and asserts the loaded target (`to_a` / `reload`) matches the SQL order, not just `pluck`.

Verified **red on `main` / green with the fix**. Full `has_many_associations_test` and `relations_test` green on **sqlite3, postgresql, mysql2, and trilogy**.

### Note

Sibling bug in the same feature: `reverse_order` discards a relation's `default_order` (separate PR). The two are independent (associations layer vs `relation/query_methods`).