### PR TITLE
Reverse `default_order` in `reverse_order` instead of discarding it

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1574,7 +1574,13 @@ module ActiveRecord
 
     def reverse_order! # :nodoc:
       orders = order_values.compact_blank
-      self.order_values = reverse_sql_order(orders)
+      default_orders = default_order_values.compact_blank
+
+      if orders.empty? && default_orders.any?
+        self.default_order_values = reverse_sql_order(default_orders)
+      else
+        self.order_values = reverse_sql_order(orders)
+      end
       self
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2038,6 +2038,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, comments.first.id
   end
 
+  def test_reverse_order_reverses_default_order
+    # reverse_order should reverse the default order, just like a regular
+    # order, rather than discarding it in favor of the primary key.
+    assert_equal Post.order("title ASC").reverse_order.ids, Post.default_order("title ASC").reverse_order.ids
+
+    relation = Post.default_order("title ASC").reverse_order
+    assert_match(/ORDER BY title DESC/, relation.to_sql)
+  end
+
   def test_reorder_with_first
     post = nil
 


### PR DESCRIPTION
### Summary

On a relation ordered only by `default_order` (no explicit `order`), `reverse_order` drops the default order entirely and falls back to the primary key:

```ruby
Model.default_order("name ASC").to_sql
# => "... ORDER BY name ASC"

Model.default_order("name ASC").reverse_order.to_sql
# => "... ORDER BY \"models\".\"id\" DESC"   ❌  expected ORDER BY name DESC

Model.order("name ASC").reverse_order.to_sql
# => "... ORDER BY name DESC"                ✅  (explicit order, for contrast)
```

So reversing a default-ordered relation produces a meaningless primary-key ordering — a silent wrong-result.

### Cause

`reverse_order!` only reverses `order_values`:

```ruby
def reverse_order! # :nodoc:
  orders = order_values.compact_blank
  self.order_values = reverse_sql_order(orders)
  self
end
```

For a `default_order`-only relation `order_values` is empty, so `reverse_sql_order([])` takes its empty branch and returns the implicit `_reverse_order_columns` (primary-key DESC), which is then assigned to `order_values`. From then on `build_order` sees a non-empty `order_values` and never consults `default_order_values`, so the default order is fully shadowed.

The feature commit (aa76590371) taught `build_order` and `ordered_relation` to fall back to `default_order_values` when `order_values` is empty, but `reverse_order!` was not given the same awareness.

### Fix

Reverse `default_order_values` when there is no explicit order, mirroring the fallback the rest of the ordering code already performs. The reversed order stays in `default_order_values`, so it remains overridable by a later `order`:

```ruby
def reverse_order! # :nodoc:
  orders = order_values.compact_blank
  if orders.empty? && (default_orders = default_order_values.compact_blank).any?
    self.default_order_values = reverse_sql_order(default_orders)
  else
    self.order_values = reverse_sql_order(orders)
  end
  self
end
```

With this, `default_order("name ASC").reverse_order` yields `ORDER BY name DESC`; `default_order("name ASC").order("id").reverse_order` still reverses the explicit `order`; and a relation with neither order behaves exactly as before (`reverse_sql_order([])` → primary-key DESC or `IrreversibleOrderError`).

### Test

`test_reverse_order_reverses_default_order` in `relations_test.rb` asserts the reversed default order matches the reversed explicit order and that `to_sql` contains `ORDER BY title DESC` (not the PK fallback).

Verified **red on `main` / green with the fix**. Full `relations_test` and `mutation_test` green on **sqlite3, postgresql, mysql2, and trilogy**.

### Note

Sibling bug in the same feature: `has_many` `default_order:` is ignored when the association target is loaded (#57538). The two are independent (`relation/query_methods` vs the associations layer).