### PR TITLE
Test Array offset accessors when out of bounds

### DIFF
--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -32,6 +32,16 @@ class AccessTest < ActiveSupport::TestCase
     assert_equal array[-2], array.second_to_last
   end
 
+  def test_specific_accessor_out_of_bounds
+    assert_nil [].second
+    assert_nil [].third
+    assert_nil [].fourth
+    assert_nil [].fifth
+    assert_nil [].forty_two
+    assert_nil %w( a b ).third_to_last
+    assert_nil %w( a ).second_to_last
+  end
+
   def test_including
     assert_equal [1, 2, 3, 4, 5], [1, 2, 4].including(3, 5).sort
     assert_equal [1, 2, 3, 4, 5], [1, 2, 4].including([3, 5]).sort


### PR DESCRIPTION
`Array#second` through `#forty_two` and `#second_to_last`/`#third_to_last` return `nil` when the array is shorter than the requested position, but the only existing test (`test_specific_accessor`) used a 42-element array, so every accessor returned a real element and the `nil` path was never exercised.

This adds coverage for the out-of-bounds (`nil`) path. No production code changes — test-only.