### PR TITLE
Test truncate when omission is longer than truncate_to

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -297,6 +297,11 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "Hello Wor...", "Hello World!!".truncate(12)
   end
 
+  def test_truncate_with_omission_longer_than_truncate_to
+    assert_equal "[truncated]", "Hello World!".truncate(3, omission: "[truncated]")
+    assert_equal "[...]", "Hello World!".truncate(2, omission: "[...]")
+  end
+
   def test_truncate_with_omission_and_separator
     assert_equal "Hello[...]", "Hello World!".truncate(10, omission: "[...]")
     assert_equal "Hello[...]", "Hello Big World!".truncate(13, omission: "[...]", separator: " ")


### PR DESCRIPTION
When the `:omission` string is longer than the requested length, `String#truncate` returns just the omission, so the result can exceed `truncate_to` — behavior the method documents ("The total length will not exceed `truncate_to` ... unless both `text` and `:omission` are longer than `truncate_to`"). Internally this is the branch where the offset goes negative, and it had no test.

This adds coverage for the omission-longer-than-`truncate_to` case. No production code changes — test-only.