### PR TITLE
Test Mime::Type#html? predicate

### DIFF
--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -192,6 +192,13 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   end
 
+  test "html? is true for the html symbol and for any type whose string contains \"html\"" do
+    assert_predicate Mime[:html], :html?
+    assert_predicate Mime::Type.new("application/xhtml+xml"), :html?
+    assert_not_predicate Mime[:json], :html?
+    assert_not_predicate Mime[:xml], :html?
+  end
+
   test "references gives preference to symbols before strings" do
     assert_equal :html, Mime[:html].ref
     another = Mime::Type.lookup("foo/bar")


### PR DESCRIPTION
`Mime::Type#html?` is true when the symbol is `:html` or when the type string contains `"html"` (e.g. `application/xhtml+xml`), and false otherwise. The method had no direct test.

This adds coverage for both truthy paths (symbol match and string-substring match) and the false case. No production code changes — test-only.