### PR TITLE
Test ArrayInquirer#any? without candidates

### DIFF
--- a/activesupport/test/array_inquirer_test.rb
+++ b/activesupport/test/array_inquirer_test.rb
@@ -25,6 +25,11 @@ class ArrayInquirerTest < ActiveSupport::TestCase
     assert @array_inquirer.any?(:api)
   end
 
+  def test_any_without_candidates
+    assert @array_inquirer.any?
+    assert_not ActiveSupport::ArrayInquirer.new([]).any?
+  end
+
   def test_any_with_block
     assert @array_inquirer.any? { |v| v == :mobile }
     assert_not @array_inquirer.any? { |v| v == :desktop }


### PR DESCRIPTION
`ActiveSupport::ArrayInquirer#any?` documents that, when called with no candidates, it returns whether the array has any elements (delegating to `Array#any?`):

```ruby
variants = ActiveSupport::ArrayInquirer.new([:phone, :tablet])
variants.any? # => true
```

Only the with-candidates and with-block forms were tested. This adds coverage for the no-argument case (true for a populated inquirer, false for an empty one). No production code changes — test-only.