### PR TITLE
Test ValidationError exposes model and message

### DIFF
--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -370,6 +370,18 @@ class ValidationsTest < ActiveModel::TestCase
     end
   end
 
+  def test_validate_with_bang_exposes_model_and_message
+    Topic.validates :title, presence: true
+
+    topic = Topic.new
+    error = assert_raise(ActiveModel::ValidationError) do
+      topic.validate!
+    end
+
+    assert_same topic, error.model
+    assert_equal "Validation failed: Title can't be blank", error.message
+  end
+
   def test_validate_with_bang_and_context
     Topic.validates :title, presence: true, on: :context
 


### PR DESCRIPTION
`ActiveModel::ValidationError` documents that the invalid model is available via `#model`, and it builds a "Validation failed: ..." message. The existing `validate!` tests only asserted that the error was raised, never inspecting the rescued exception.

This adds coverage asserting the raised error exposes the model (`#model`) and the generated message. No production code changes — test-only.