### PR TITLE
Test BigInteger serializing string values

### DIFF
--- a/activemodel/test/cases/type/big_integer_test.rb
+++ b/activemodel/test/cases/type/big_integer_test.rb
@@ -31,6 +31,13 @@ module ActiveModel
         assert_equal 9999999999999999999999999999999, type.serialize(9999999999999999999999999999999)
       end
 
+      def test_serialize_string
+        type = Type::BigInteger.new
+        assert_equal 0, type.serialize("0")
+        assert_equal 123, type.serialize("123abc")
+        assert_nil type.serialize("not a number")
+      end
+
       def test_integer_like_classes_that_are_greater_than_4_bytes_still_serialize
         type = Type::BigInteger.new
         large_number = 9999999999999999999999999999999


### PR DESCRIPTION
`ActiveModel::Type::BigInteger#serialize` accepts strings: a numeric string serializes to its integer, a leading-numeric string is truncated to its integer prefix (`"123abc" => 123`), and a non-numeric string serializes to `nil`. Only Integer and integer-like inputs were tested.

This adds coverage for the string serialization branches. No production code changes — test-only.