### PR TITLE
Test ContentDisposition.format class method

### DIFF
--- a/actionpack/test/dispatch/content_disposition_test.rb
+++ b/actionpack/test/dispatch/content_disposition_test.rb
@@ -41,5 +41,15 @@ module ActionDispatch
 
       assert_equal "inline", disposition.to_s
     end
+
+    test ".format builds the header string" do
+      expected = Http::ContentDisposition.new(disposition: :inline, filename: "racecar.jpg").to_s
+
+      assert_equal expected, Http::ContentDisposition.format(disposition: :inline, filename: "racecar.jpg")
+    end
+
+    test ".format without filename" do
+      assert_equal "inline", Http::ContentDisposition.format(disposition: :inline, filename: nil)
+    end
   end
 end


### PR DESCRIPTION
`ActionDispatch::Http::ContentDisposition.format` is the public shortcut that builds the header string (used by data streaming and ActiveStorage), but every existing test constructed an instance and called `#to_s` directly — the class method itself was never exercised.

This adds coverage for `.format` with and without a filename. No production code changes — test-only.