### PR TITLE
Test Mime::Type#=== and nil matching

### DIFF
--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -221,6 +221,16 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_not Mime[:js].match?("text/html")
   end
 
+  test "=~ and match? return false for nil" do
+    assert_not (Mime[:js] =~ nil)
+    assert_not Mime[:js].match?(nil)
+  end
+
+  test "=== matches when the type is included in an array" do
+    assert Mime[:html] === [Mime[:html], Mime[:xml]]
+    assert_not Mime[:html] === [Mime[:xml], Mime[:json]]
+  end
+
   test "can be initialized with wildcards" do
     assert_equal "*/*", Mime::Type.new("*/*").to_s
     assert_equal "text/*", Mime::Type.new("text/*").to_s


### PR DESCRIPTION
`Mime::Type#===` matches when the type is included in a given array (used for `case`/`when` against a list of mime types), and `#=~`/`#match?` guard against a `nil` argument by returning false. Neither the array form of `#===` nor the `nil` guard had a test.

This adds coverage for both. No production code changes — test-only.