### PR TITLE
Test Range#sole with an endless range

### DIFF
--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -298,5 +298,9 @@ class RangeTest < ActiveSupport::TestCase
     assert_raises(Enumerable::SoleItemExpectedError, match: "infinite range '..1' cannot represent a sole item") do
       (..1).sole
     end
+
+    assert_raises(Enumerable::SoleItemExpectedError, match: "infinite range '1..' cannot represent a sole item") do
+      (1..).sole
+    end
   end
 end


### PR DESCRIPTION
`Range#sole` raises `SoleItemExpectedError` for an infinite range, where either end is `nil`. The beginless case (`(..1).sole`) was tested, but the endless case (`(1..).sole`) — the other half of the `self.begin.nil? || self.end.nil?` guard — was not.

This adds coverage for the endless range. No production code changes — test-only.