### PR TITLE
Test Type::Boolean#serialize and #serialize_cast_value

### DIFF
--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -49,6 +49,23 @@ module ActiveModel
         assert_equal false, type.cast(:off)
         assert_equal false, type.cast(:OFF)
       end
+
+      def test_serialize_boolean
+        type = Type::Boolean.new
+        assert_nil type.serialize("")
+        assert_nil type.serialize(nil)
+        assert_equal true, type.serialize(true)
+        assert_equal true, type.serialize("yes")
+        assert_equal false, type.serialize(false)
+        assert_equal false, type.serialize("0")
+      end
+
+      def test_serialize_cast_value_passes_the_value_through
+        type = Type::Boolean.new
+        assert_equal true, type.serialize_cast_value(true)
+        assert_equal false, type.serialize_cast_value(false)
+        assert_nil type.serialize_cast_value(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
`ActiveModel::Type::Boolean#serialize` mirrors `#cast` (false-values serialize to `false`, blank/`nil` to `nil`, anything else to `true`), and `#serialize_cast_value` passes the already-cast value through unchanged. Only `#cast` was tested.

This adds coverage for both serialize methods. No production code changes — test-only.