### PR TITLE
Make Ractor shareability methods only available on 4.0 and above.

### DIFF
--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -5,7 +5,7 @@ module ActiveSupport
   # unconditionally regardless of the Ruby version.
   module Ractors # :nodoc:
     class << self
-      if defined?(Ractor) && Ractor.respond_to?(:make_shareable)
+      if defined?(Ractor) && RUBY_VERSION >= "4.0"
         # Makes +obj+ Ractor-shareable by delegating to +Ractor.make_shareable+.
         #
         # The +copy:+ option is forwarded unchanged. On Ruby versions without
@@ -13,13 +13,7 @@ module ActiveSupport
         def make_shareable(...)
           Ractor.make_shareable(...)
         end
-      else
-        def make_shareable(obj, copy: false)
-          obj
-        end
-      end
 
-      if defined?(Ractor) && Ractor.respond_to?(:shareable?)
         # Returns whether +obj+ is Ractor-shareable by delegating to
         # +Ractor.shareable?+.
         #
@@ -28,13 +22,7 @@ module ActiveSupport
         def shareable?(obj)
           Ractor.shareable?(obj)
         end
-      else
-        def shareable?(obj)
-          obj
-        end
-      end
 
-      if defined?(Ractor) && Ractor.respond_to?(:shareable_proc)
         # Returns a Ractor-shareable proc by delegating to +Ractor.shareable_proc+.
         #
         # The optional +self:+ value is forwarded as the proc's receiver. On Ruby
@@ -43,13 +31,7 @@ module ActiveSupport
         def shareable_proc(...)
           Ractor.shareable_proc(...)
         end
-      else
-        def shareable_proc(self: nil, &block)
-          block
-        end
-      end
 
-      if defined?(Ractor) && Ractor.respond_to?(:shareable_lambda)
         # Returns a Ractor-shareable lambda by delegating to
         # +Ractor.shareable_lambda+.
         #
@@ -60,7 +42,19 @@ module ActiveSupport
           Ractor.shareable_lambda(...)
         end
       else
-        def shareable_lambda(&block)
+        def make_shareable(obj, copy: false)
+          obj
+        end
+
+        def shareable?(obj)
+          obj
+        end
+
+        def shareable_proc(self: nil, &block)
+          block
+        end
+
+        def shareable_lambda(self: nil, &block)
           block
         end
       end


### PR DESCRIPTION
### Motivation / Background

Follow up to https://github.com/rails/rails/pull/57467, https://github.com/rails/rails/pull/57526

I realized that this is problematic for Ruby 3.x since `Ractor.make_shareable` is available but not `Ractor.shareable_proc`. 

Since we will define a shim for `make_shareable` but `shareable_proc` will be a no-op in that environment, it will lead us to calling `make_shareable` on objects containing unshareable procs and raising.

```
proc = ractor_shareable_proc { foo }

ractor_make_shareable(Bar.new(proc)) # => raises on 3.4 but works on 4.0
```

Note: I closed the other PR before I realized Jean's "revert" wasn't really a revert. GH wouldn't let me re-open it, thus the new PR.

### Detail

Ruby 4.0 will be a hard requirement for using Ractors with Rails, so I think it is okay if we just define all these methods if we are on 4.0 and above, and have them all be no-ops on Ruby 3.x

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
