### PR TITLE
Fix Enumerable#in_order_of dropping nil elements when filter: false

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -198,7 +198,7 @@ module Enumerable
     if filter
       group_by(&key).values_at(*series).flatten(1).compact
     else
-      sort_by { |v| series.index(v.public_send(key)) || series.size }.compact
+      sort_by { |v| series.index(v.public_send(key)) || series.size }
     end
   end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -391,6 +391,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [ Payment.new(1), Payment.new(5), Payment.new(3) ], values.in_order_of(:price, [ 1, 5 ], filter: false)
   end
 
+  def test_in_order_of_with_filter_false_preserves_nil_elements
+    values = [ 3, nil, 1, 2 ]
+    assert_equal [ 1, 2, 3, nil ], values.in_order_of(:itself, [ 1, 2, 3 ], filter: false)
+  end
+
   def test_sole
     expected_raise = Enumerable::SoleItemExpectedError
 


### PR DESCRIPTION
### Summary

`Enumerable#in_order_of` with `filter: false` is documented to keep elements that aren't named in the `series`:

> If the Enumerable has additional elements that aren't named in the `series`, these are not included in the result, **unless the `filter` option is set to `false`**.

But a stray `compact` (copied from the `filter: true` branch) silently removed `nil` elements:

```ruby
[3, nil, 1, 2].in_order_of(:itself, [1, 2, 3], filter: false)
# => [1, 2, 3]        (before — nil dropped)
# => [1, 2, 3, nil]   (after  — nil preserved)
```

### Why the compact is wrong here

The `filter: true` branch needs `compact` because `group_by(&key).values_at(*series)` produces `nil` for series entries with no matching element. The `filter: false` branch uses `sort_by`, which never introduces `nil`, so the `compact` only stripped genuine `nil` elements from the collection — contradicting the documented contract.

### Changes
- Remove the `compact` from the `filter: false` branch.
- Add a regression test.
- CHANGELOG entry.

All existing `activesupport` `enumerable_test.rb` tests pass.