### PR TITLE
Test Object#with returns the block's result

### DIFF
--- a/activesupport/test/core_ext/object/with_test.rb
+++ b/activesupport/test/core_ext/object/with_test.rb
@@ -92,6 +92,11 @@ class WithTest < ActiveSupport::TestCase
     assert_equal "1", @object.with(public_attr: "1", &:public_attr)
   end
 
+  test "returns the result of the block" do
+    result = @object.with(public_attr: "1") { :block_result }
+    assert_equal :block_result, result
+  end
+
   test "basic immediates don't respond to #with" do
     assert_not_respond_to nil, :with
     assert_not_respond_to true, :with


### PR DESCRIPTION
`Object#with` yields `self` to the block and returns the block's value. The existing test only proved the block receives `self` (it returned an attribute that happened to equal the value just set), so the return value of `#with` itself was never asserted.

This adds coverage confirming an arbitrary block result flows out. No production code changes — test-only.