### PR TITLE
Test Type::Integer#cast of a Symbol returns nil

### DIFF
--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -32,6 +32,11 @@ module ActiveModel
         assert_nil type.cast(::Object.new)
       end
 
+      test "casting a Symbol returns nil" do
+        type = Type::Integer.new
+        assert_nil type.cast(:not_an_integer)
+      end
+
       test "casting nan and infinity" do
         type = Type::Integer.new
         assert_nil type.cast(::Float::NAN)


### PR DESCRIPTION
`ActiveModel::Type::Integer`'s documentation uses a `Symbol` as the example of a value that casts to `nil` (because `Symbol` does not define `#to_i`):

```ruby
person.age = :not_an_integer
person.age # => nil
```

The closest existing test cast a bare `Object`, so the documented `Symbol` example was never exercised. This covers it. No production code changes — test-only.