### PR TITLE
Test ParameterFilter#filter with empty filters returns a dup

### DIFF
--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -88,6 +88,15 @@ class ParameterFilterTest < ActiveSupport::TestCase
     assert_equal "bar", parameter_filter.filter_param("foo", "bar")
   end
 
+  test "filter with empty filters returns a dup of the params" do
+    parameter_filter = ActiveSupport::ParameterFilter.new
+    original = { "foo" => "bar" }
+    filtered = parameter_filter.filter(original)
+
+    assert_equal original, filtered
+    assert_not_same original, filtered
+  end
+
   test "parameter filter should maintain hash with indifferent access" do
     test_hashes = [
       [{ "foo" => "bar" }.with_indifferent_access, ["blah"]],


### PR DESCRIPTION
When constructed with no filters, `ActiveSupport::ParameterFilter#filter` takes a fast path that returns `params.dup` rather than the same object. `filter_param` was tested for the empty-filters case, but `#filter` was not.

This adds coverage asserting the result is equal to but not the same object as the input. No production code changes — test-only.