### PR TITLE
Fix nested touch_later parent touches leaking to next transaction

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix nested `touch_later` calls from touching parent records again in the next
+    transaction.
+
+    *Sergei Voronin*
+
 *   Fix grouped calculations (e.g. `count`) grouped by a `belongs_to` association
     that points to a composite primary key model.
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -107,7 +107,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
         model.after_destroy callback.(:changes_to_save)
       end
 
-      model.after_touch callback.(:changes_to_save)
+      model.after_touch callback.(:changes_to_save), unless: :applying_deferred_touch?
     end
 
     def self.add_default_callbacks(model, reflection)

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -52,7 +52,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       model.after_create_commit { association(name).reset_negative_cache }
       model.after_update callback, if: :saved_changes?
       model.after_destroy callback
-      model.after_touch callback
+      model.after_touch callback, unless: :applying_deferred_touch?
     end
 
     private_class_method :macro, :valid_options, :valid_dependent_options, :add_destroy_callbacks,

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -49,6 +49,7 @@ module ActiveRecord
       def init_internals
         super
         @_defer_touch_attrs = nil
+        @_applying_deferred_touch = false
       end
 
       def surreptitiously_touch(attr_names)
@@ -60,11 +61,19 @@ module ActiveRecord
 
       def touch_deferred_attributes
         @_skip_dirty_tracking = true
+        previous_applying_deferred_touch = @_applying_deferred_touch
+        @_applying_deferred_touch = true
         touch(time: @_touch_time)
+      ensure
+        @_applying_deferred_touch = previous_applying_deferred_touch
       end
 
       def has_defer_touch_attrs?
         @_defer_touch_attrs.present?
+      end
+
+      def applying_deferred_touch?
+        @_applying_deferred_touch
       end
   end
 end

--- a/activerecord/test/cases/touch_later_test.rb
+++ b/activerecord/test/cases/touch_later_test.rb
@@ -123,6 +123,21 @@ class TouchLaterTest < ActiveRecord::TestCase
     assert_not_equal trees(:root).reload.updated_at, previous_tree_updated_at
   end
 
+  def test_nested_touch_later_does_not_touch_parent_on_next_transaction
+    tree = nil
+
+    ActiveRecord::Base.transaction do
+      tree = Tree.create!
+      parent = Node.create!(tree: tree)
+      Node.create!(tree: tree, parent: parent)
+    end
+
+    timestamp = 4.days.ago
+    tree.update!(updated_at: timestamp)
+
+    assert_equal timestamp.to_i, tree.updated_at.to_i
+  end
+
   def test_touching_through_nested_attributes_without_before_committed_on_all_records
     original = ActiveRecord.before_committed_on_all_records
     ActiveRecord.before_committed_on_all_records = false


### PR DESCRIPTION
### Motivation / Background

Fixes #50152.

Nested associations using `touch: true` can enqueue a parent `touch_later` while deferred touches are being applied during `before_commit`. If that parent record has already run its `before_commit` callbacks, the deferred touch can survive into the next transaction and overwrite a manually assigned timestamp.

### Detail

This Pull Request changes `ActiveRecord::TouchLater` to track when deferred touch attributes are being applied. During that phase, Rails' built-in association touch propagation callbacks for `belongs_to` and `has_one` are skipped so a previously scheduled deferred touch is consumed without enqueueing another framework-generated touch for the next transaction.

Ordinary `touch` behavior is preserved: user-defined `after_touch` callbacks still run, and association touch propagation still runs for non-deferred touch paths.

### Additional information

Validated with:

```text
bin/test test/cases/touch_later_test.rb
bin/test test/cases/timestamp_test.rb
bin/test test/cases/associations/belongs_to_associations_test.rb
bin/test test/cases/associations/has_one_associations_test.rb
```

Also verified the reproduction script from #50152 directly against this checkout.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
