### PR TITLE
Serialize concurrent Active Storage attach calls

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Serialize concurrent `attach` calls on the same record instance.
+
+    Fixes #52660.
+
+    *Sergei Voronin*
+
 *   Update Active Storage for ImageProcessing 2.0.
 
     ImageProcessing 2.0 now requires adding `ruby-vips` or `mini_magick` gems explicitly to the Gemfile.

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -49,11 +49,13 @@ module ActiveStorage
     #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpeg")
     #   document.images.attach([ first_blob, second_blob ])
     def attach(*attachables)
-      record.public_send("#{name}=", blobs + attachables.flatten)
-      if record.persisted? && !record.changed?
-        return if !record.save
+      record.attachment_changes_lock.exclusive do
+        record.public_send("#{name}=", blobs + attachables.flatten)
+        if record.persisted? && !record.changed?
+          return if !record.save
+        end
+        record.public_send("#{name}")
       end
-      record.public_send("#{name}")
     end
 
     # Calls attach, and raises an exception if the record was meant to be saved but at least one of the validations failed.

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/concurrency/share_lock"
 require "active_support/core_ext/object/try"
 
 module ActiveStorage
@@ -309,6 +310,10 @@ module ActiveStorage
       @attachment_changes ||= {}
     end
 
+    def attachment_changes_lock # :nodoc:
+      @attachment_changes_lock ||= ActiveSupport::Concurrency::ShareLock.new
+    end
+
     def changed_for_autosave? # :nodoc:
       super || attachment_changes.any?
     end
@@ -317,6 +322,7 @@ module ActiveStorage
       super
       @active_storage_attached = nil
       @attachment_changes = nil
+      @attachment_changes_lock = nil
     end
 
     def reload(*) # :nodoc:

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -62,11 +62,13 @@ module ActiveStorage
     #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpeg")
     #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
     def attach(attachable)
-      record.public_send("#{name}=", attachable)
-      if record.persisted? && !record.changed?
-        return if !record.save
+      record.attachment_changes_lock.exclusive do
+        record.public_send("#{name}=", attachable)
+        if record.persisted? && !record.changed?
+          return if !record.save
+        end
+        record.public_send("#{name}")
       end
-      record.public_send("#{name}")
     end
 
     # Calls attach, and raises an exception if the record was meant to be saved but at least one of the validations failed.

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -95,6 +95,25 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal "town.jpg", @user.highlights.second.filename.to_s
   end
 
+  test "attaching files concurrently to the same record instance" do
+    barrier = Concurrent::CyclicBarrier.new(20)
+    errors = Queue.new
+
+    threads = 20.times.map do
+      Thread.new do
+        barrier.wait
+        @user.highlights.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
+      rescue => error
+        errors << error
+      end
+    end
+
+    threads.each(&:join)
+
+    assert_predicate errors, :empty?, -> { errors.size.times.map { errors.pop.full_message }.join("\n") }
+    assert_predicate @user.reload.highlights, :attached?
+  end
+
   test "attaching new blobs from uploaded files to an existing, changed record" do
     @user.name = "Tina"
     assert_predicate @user, :changed?

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -85,6 +85,25 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_equal "town.jpg", @user.avatar.filename.to_s
   end
 
+  test "attaching files concurrently to the same record instance" do
+    barrier = Concurrent::CyclicBarrier.new(20)
+    errors = Queue.new
+
+    threads = 20.times.map do
+      Thread.new do
+        barrier.wait
+        @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
+      rescue => error
+        errors << error
+      end
+    end
+
+    threads.each(&:join)
+
+    assert_predicate errors, :empty?, -> { errors.size.times.map { errors.pop.full_message }.join("\n") }
+    assert_predicate @user.reload.avatar, :attached?
+  end
+
   test "attaching a new blob from a Hash with a path traversal key raises on Disk service" do
     assert_raises ActiveStorage::InvalidKeyError do
       @user.avatar.attach key: "../../etc/passwd", io: StringIO.new("malicious"), filename: "exploit.txt", content_type: "text/plain"


### PR DESCRIPTION
### Motivation / Background

Fixes #52660.

Active Storage keeps pending attachment changes on the record instance. Concurrent `attach` calls against the same record instance can race while replacing and saving that per-record state, which can surface in async/fiber contexts as inconsistent Active Storage or Active Record errors.

### Detail

This Pull Request adds a per-record lock for attachment changes and uses it to serialize `has_one_attached` and `has_many_attached` `attach` operations. The lock is reset when records are duplicated so duplicated records do not share synchronization state.

Concurrent attach coverage was added for both one and many attachments.

### Additional information

Validated locally with:

* `activestorage/test/models/attached/one_test.rb`
* `activestorage/test/models/attached/many_test.rb`
* PostgreSQL reproducer based on the async/fiber scenario from #52660

The async/fiber PostgreSQL reproducer fails before this change and passes with the lock in place.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
