### PR TITLE
Fix nested attributes `:limit` miscounting a single-record hash

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `accepts_nested_attributes_for` `:limit` miscounting a single-record hash.
+
+    *Kenta Ishizaki*
+
 *   Fix `rename_index` to preserve a partial index's `WHERE` for SQLite and older MySQL/MariaDB versions.
 
     *Kenta Ishizaki*

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -496,8 +496,6 @@ module ActiveRecord
           raise ArgumentError, "Hash or Array expected for `#{association_name}` attributes, got #{attributes_collection.class.name}"
         end
 
-        check_record_limit!(options[:limit], attributes_collection)
-
         if attributes_collection.is_a? Hash
           keys = attributes_collection.keys
           attributes_collection = if keys.include?("id") || keys.include?(:id)
@@ -506,6 +504,8 @@ module ActiveRecord
             attributes_collection.values
           end
         end
+
+        check_record_limit!(options[:limit], attributes_collection)
 
         association = association(association_name)
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -983,6 +983,13 @@ module NestedAttributesLimitTests
                                                       "car" => { name: "The Happening" } } }
     end
   end
+
+  def test_limit_does_not_count_the_attributes_of_a_single_record_hash
+    parrot = @pirate.parrots.create!(name: "Polly")
+
+    @pirate.attributes = { parrots_attributes: { "id" => parrot.id, "name" => "New Name", "color" => "green", "breed" => 1 } }
+    assert_equal "New Name", parrot.name
+  end
 end
 
 class TestNestedAttributesLimitNumeric < ActiveRecord::TestCase


### PR DESCRIPTION
## Summary

`accepts_nested_attributes_for ..., limit: N` raises a spurious `TooManyRecords` when updating **one** record through a bare `id`-keyed attributes hash that carries more than `N` keys:

```ruby
class Pirate < ApplicationRecord
  has_many :parrots
  accepts_nested_attributes_for :parrots, limit: 2
end

pirate.parrots_attributes = { "id" => 1, "name" => "Polly", "color" => "green", "breed" => 1 }
# => TooManyRecords: Maximum 2 records are allowed. Got 4 records instead.
```

That hash is one record, not four.

## Root cause

`check_record_limit!` ran before the hash-to-array normalization that wraps an `id`-keyed hash into a single-element array. It measured `Hash#size` (key/value pairs) instead of the record count. The hash-of-hashes form (`{ "0" => {...}, "1" => {...} }`) was unaffected only by coincidence — there `Hash#size` equals the record count.

## Fix

Move `check_record_limit!` after the normalization, so it always counts records. Genuine over-limit inputs (arrays and hash-of-hashes) still raise — verified.

## Tests

`test_limit_does_not_count_the_attributes_of_a_single_record_hash` — added to the shared `NestedAttributesLimitTests` module, so it runs under all three limit configurations (numeric/symbol/proc). Updates one parrot through a 4-key `id`-hash under `limit: 2` and asserts no error + the update applied.

Verified red→green in all three limit test classes (`Got 4 records instead` on `main`). Full `nested_attributes_test.rb` 170 runs, 0 failures.