### PR TITLE
Fix PostgreSQL `foreign_keys` for a target table in a quoted schema

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix PostgreSQL `foreign_keys` returning a corrupted `to_table` for a foreign key
+    that references a table in a quoted schema.
+
+    *Kenta Ishizaki*
+
 *   Fix grouped calculations (e.g. `count`) grouped by a `belongs_to` association
     that points to a composite primary key model.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -788,7 +788,7 @@ module ActiveRecord
           SQL
 
           fk_info.map do |row|
-            to_table = Utils.unquote_identifier(row["to_table"])
+            to_table = Utils.extract_schema_qualified_name(row["to_table"]).to_s
 
             column = decode_string_array(row["conkey_names"])
             primary_key = decode_string_array(row["confkey_names"])

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -659,6 +659,25 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           end
         end
 
+        if current_adapter?(:PostgreSQLAdapter)
+          def test_foreign_key_to_table_in_quoted_schema
+            @connection.execute('DROP SCHEMA IF EXISTS "Aerospace" CASCADE')
+            @connection.execute('CREATE SCHEMA "Aerospace"')
+            @connection.execute('CREATE TABLE "Aerospace".boosters (id serial primary key)')
+            @connection.add_column :astronauts, :booster_id, :integer
+            @connection.execute(<<~SQL)
+              ALTER TABLE astronauts
+              ADD CONSTRAINT fk_booster FOREIGN KEY (booster_id) REFERENCES "Aerospace".boosters(id)
+            SQL
+
+            fk = @connection.foreign_keys("astronauts").find { |k| k.name == "fk_booster" }
+            assert_not_nil fk
+            assert_equal "Aerospace.boosters", fk.to_table
+          ensure
+            @connection.execute('DROP SCHEMA IF EXISTS "Aerospace" CASCADE')
+          end
+        end
+
         if ActiveRecord::Base.lease_connection.supports_enforced_foreign_keys?
           def test_enforced_foreign_key_default
             @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"


### PR DESCRIPTION
> Sibling PR (same root cause, different call site): **`reset_column_sequences!` crash in a quoted schema** (#57563). They're independent and can merge separately.

## Summary

`foreign_keys` corrupts the `to_table` of any FK whose referenced table lives in a quoted schema, so `rails db:schema:dump` emits a broken `add_foreign_key` that fails to reload.

```ruby
# Given: "App".customers referenced by orders.customer_id
connection.foreign_keys("orders").first.to_table
# => "App\".customer"   (expected "App.customers")
```

## Root cause

The referenced table is read from `regclass::text`, which returns a schema-qualified and selectively-quoted identifier. It was then passed through `Utils.unquote_identifier`, which assumes a single identifier and strips only the first and last character:

| `regclass::text` | `unquote_identifier` | Expected |
|---|---|---|
| `"App".customers` | `App".customer` ❌ | `App.customers` |
| `public."Mixed"` | `public."Mixed"` (quotes kept) ❌ | `public.Mixed` |
| `"Schema"."Table"` | `Schema"."Table` ❌ | `Schema.Table` |
| `"Mixed"` | `Mixed` ✓ | — |
| `customers` | `customers` ✓ | — |

The common unqualified case round-trips fine, which is why this went unnoticed.

## Fix

Parse the name with `Utils.extract_schema_qualified_name(...).to_s`, which already understands the full range of schema-qualified and quoted references. Unqualified targets (the common case) are unaffected.

## Tests

`test_foreign_key_to_table_in_quoted_schema` (PostgreSQL-only): creates a table in a mixed-case schema `"Aerospace"`, adds an FK, and asserts `to_table == "Aerospace.boosters"`.

Verified red→green on live PG 17 (`Actual: "Aerospace\".booster"` on `main`). Full `foreign_key_test.rb` (91), `references_foreign_key_test.rb` (23), `schema_test.rb` (81) stay green.

## Notes

- Related (older, closed, about cross-schema FK support generally): #16907, #28654. No open issue/PR for this specific corruption.