### PR TITLE
Add test coverage for String filter boundary inputs

### DIFF
--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -401,6 +401,15 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "Hello Big[...]", "Hello Big World!".truncate_words(2, omission: "[...]")
   end
 
+  def test_truncate_words_with_zero_count
+    assert_equal "Hello Big World", "Hello Big World".truncate_words(0)
+    assert_equal "Hello Big World", "Hello Big World".truncate_words(0, omission: "[...]")
+  end
+
+  def test_truncate_words_with_negative_count
+    assert_equal "Hello Big World", "Hello Big World".truncate_words(-1)
+  end
+
   def test_truncate_words_with_separator
     assert_equal "Hello<br>Big<br>World!...", "Hello<br>Big<br>World!<br>".truncate_words(3, separator: "<br>")
     assert_equal "Hello<br>Big<br>World!", "Hello<br>Big<br>World!".truncate_words(3, separator: "<br>")
@@ -449,6 +458,22 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "This is a good day to die", original
     assert_equal "This is a good day", original.remove!(" to ", /die/)
     assert_equal "This is a good day", original
+  end
+
+  def test_remove_with_no_patterns_returns_unchanged_copy
+    original = "This is a good day to die"
+    result = original.remove
+
+    assert_equal original, result
+    assert_not_same original, result
+  end
+
+  def test_remove_bang_with_no_patterns_returns_self
+    original = +"This is a good day to die"
+    result = original.remove!
+
+    assert_equal "This is a good day to die", result
+    assert_same original, result
   end
 
   def test_constantize


### PR DESCRIPTION
Adds coverage for several untested no-op / boundary inputs to the `String` filter methods in `active_support/core_ext/string/filters.rb`. All test-only; no production code changes.

- `String#remove` with no patterns returns an unchanged copy (a distinct object, not the receiver)
- `String#remove!` with no patterns returns `self` unchanged
- `String#truncate_words` with a zero word count returns the string unchanged
- `String#truncate_words` with a negative word count returns the string unchanged

The existing `remove`/`remove!` tests only passed matching patterns, and `truncate_words` was only tested with positive counts (and counts ≥ the word count), so these boundary cases were unexercised.