### PR TITLE
Fix `reset_column_sequences!` for a table in a quoted schema

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `reset_column_sequences!` for tables in quoted schemas.
+
+    *Kenta Ishizaki*
+
 *   Fix `accepts_nested_attributes_for` `:limit` miscounting a single-record hash.
 
     *Kenta Ishizaki*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -370,7 +370,7 @@ module ActiveRecord
 
           def initialize(adapter, tables)
             @adapter = adapter
-            @tables = tables.to_h { |table, data| [table.to_s, Data.new(*data)] }
+            @tables = tables.to_h { |table, data| [Utils.extract_schema_qualified_name(table.to_s).to_s, Data.new(*data)] }
           end
 
           def reset
@@ -403,7 +403,7 @@ module ActiveRecord
               primary_key_column_and_sequences = @adapter.exec_query(sql, "SCHEMA")
 
               primary_key_column_and_sequences.rows.each do |table, column, namespace, sequence|
-                table = table.delete_prefix('"').delete_suffix('"')
+                table = Utils.extract_schema_qualified_name(table).to_s
                 @tables[table].column = column
                 @tables[table].sequence = PostgreSQL::Name.new(namespace, sequence) if sequence
               end
@@ -420,7 +420,7 @@ module ActiveRecord
               uuid_column_and_sequences = @adapter.exec_query(sql, "SCHEMA")
 
               uuid_column_and_sequences.rows.each do |table, column, namespace, sequence|
-                table = table.delete_prefix('"').delete_suffix('"')
+                table = Utils.extract_schema_qualified_name(table).to_s
                 @tables[table].column = column
                 @tables[table].sequence = PostgreSQL::Name.new(namespace, sequence) if sequence
               end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -555,6 +555,19 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     assert_equal 1, @connection.select_value("SELECT nextval('#{sequence_name}')")
   end
 
+  def test_reset_column_sequences_with_quoted_schema
+    @connection.execute('CREATE SCHEMA "Test_CamelSchema"')
+    @connection.execute('CREATE TABLE "Test_CamelSchema".widgets (id serial primary key)')
+    @connection.execute('INSERT INTO "Test_CamelSchema".widgets (id) VALUES (100)')
+
+    @connection.reset_column_sequences!([['"Test_CamelSchema".widgets']])
+
+    next_id = @connection.select_value(%Q{SELECT nextval(pg_get_serial_sequence('"Test_CamelSchema".widgets', 'id'))})
+    assert_operator next_id.to_i, :>, 100
+  ensure
+    @connection.execute('DROP SCHEMA IF EXISTS "Test_CamelSchema" CASCADE')
+  end
+
   def test_set_pk_sequence
     table_name = "#{SCHEMA_NAME}.#{PK_TABLE_NAME}"
     _, sequence_name = @connection.pk_and_sequence_for table_name


### PR DESCRIPTION
> Sibling PR (same root cause, different call site): **`foreign_keys` corrupting `to_table` in a quoted schema** (#57561). They're independent and can merge separately.

## Summary

`reset_column_sequences!` raises `NoMethodError` for any table in a quoted schema:

```ruby
# CREATE SCHEMA "App"; CREATE TABLE "App".widgets (id serial primary key)
connection.reset_column_sequences!([['"App".widgets']])
# => NoMethodError: undefined method 'column=' for nil
```

This also crashes `reset_pk_sequence!` and fixture loading, which call `reset_column_sequences!`.

## Root cause

`SequenceReset` builds an internal `@tables` map keyed by the caller's table name, then backfills it using a name from `regclass::text`. That value is schema-qualified and selectively quoted (e.g. `"App".widgets`), and was unquoted by `delete_prefix('"').delete_suffix('"')` — which only strips the outermost quote pair, so `"App".widgets` became `App".widgets` and no longer matched the map key. `nil.column = …` → `NoMethodError`.

The same mismatch existed in both the primary-key and UUID sequence loops. The existing tests used only a lowercase schema, so this went unnoticed.

## Fix

Parse the name with `Utils.extract_schema_qualified_name(...).to_s`, used consistently for the map key and both backfill lookups. Unquoted/lowercase names (the common case) are unaffected.

An audit of the other `unquote_identifier` call sites found them safe — they receive single, per-column identifiers or already use `extract_schema_qualified_name`.

## Tests

`test_reset_column_sequences_with_quoted_schema`: creates a table in `"Test_CamelSchema"`, inserts a row with explicit `id = 100`, resets, and asserts the sequence advanced past it.

Verified red→green on live PG (crashes with `NoMethodError` on `main`; sequence correctly resets to 101 with the fix). Full `schema_test.rb` 82 runs, 0 failures.