### PR TITLE
[#57552] Fix concurrent saves of `has_rich_text` raising `ActiveRecord::RecordNotUnique`.

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix concurrent saves of `has_rich_text` raising `ActiveRecord::RecordNotUnique`.
+
+    *Ruy Rocha*
+
 *   Dispatch all Active Storage `direct-upload:`-prefixed events
 
     Add support for `direct-upload:before-blob-request` and `direct-upload:before-storage-request`.

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -128,6 +128,41 @@ module ActionText
     end
 
     delegate :blank?, :empty?, :present?, to: :to_plain_text
+
+    # Saves the RichText record, transparently handling a concurrent-save race
+    # condition that can occur when two requests create rich text for the same
+    # record and attribute at the same time.
+    #
+    # Because +has_rich_text+ is backed by an autosaved +has_one+ association,
+    # two concurrent saves of the parent record may both build a new RichText
+    # in memory and attempt to INSERT it. The database unique index on
+    # <tt>(record_type, record_id, name)</tt> guarantees that only one succeeds.
+    #
+    # When the loser raises +ActiveRecord::RecordNotUnique+, this method finds
+    # the winning row, updates it with the current body (and any embeds
+    # extracted by the +before_validation+ callback), adopts its primary key,
+    # and marks the in-memory object as persisted so the parent save can
+    # continue normally.
+    #
+    # RecordNotUnique errors on already-persisted records are re-raised.
+    def save(**options)
+      super
+    rescue ActiveRecord::RecordNotUnique => error
+      if new_record?
+        if (existing = self.class.find_by(record: record, name: name))
+          existing.update!(body: body)
+          self.id = existing.id
+          @new_record = false
+          @previously_new_record = true
+          @transaction_state = nil
+          true
+        else
+          raise error
+        end
+      else
+        raise error
+      end
+    end
   end
 end
 

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -179,4 +179,21 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message2.content = ""
     assert_not_predicate message2, :valid?
   end
+
+  test "concurrent save of new rich text reconciles instead of raising" do
+    message = Message.create!
+
+    request_a = Message.find(message.id)
+    request_b = Message.find(message.id)
+
+    request_a.content = "from request A"
+    request_b.update!(content: "from request B")
+
+    assert_nothing_raised do
+      request_a.save!
+    end
+
+    assert_equal 1, ActionText::RichText.where(record: message, name: "content").count
+    assert_equal "from request A", request_a.reload.content.to_plain_text
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because #57552

### Detail

When two requests simultaneously save rich text content for the same record and attribute, both build a new `ActionText::RichText` in memory and attempt to `INSERT` it on the parent save. The database unique index on `(record_type, record_id, name)` guarantees that only one succeeds; the loser raises `ActiveRecord::RecordNotUnique`. 

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
