### PR TITLE
Preserve index attributes when renaming an index without native support

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `rename_index` to preserve a partial index's `WHERE` for SQLite and older MySQL/MariaDB versions.
+
+    *Kenta Ishizaki*
+
 *   Fix PostgreSQL `foreign_keys` returning a corrupted `to_table` for a foreign key
     that references a table in a quoted schema.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1084,7 +1084,7 @@ module ActiveRecord
         # this is a naive implementation; some DBs may support this more efficiently (PostgreSQL, for instance)
         old_index_def = indexes(table_name).detect { |i| i.name == old_name }
         return unless old_index_def
-        add_index(table_name, old_index_def.columns, name: new_name, unique: old_index_def.unique)
+        add_index(table_name, old_index_def.columns, name: new_name, unique: old_index_def.unique, where: old_index_def.where)
         remove_index(table_name, name: old_name)
       end
 

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -46,6 +46,20 @@ module ActiveRecord
         assert connection.index_name_exists?(table_name, "new_idx")
       end
 
+      def test_rename_index_preserves_where_clause
+        skip unless connection.supports_partial_index?
+
+        # keep the names short to make Oracle and similar behave
+        connection.add_index(table_name, [:foo], name: "old_idx", where: "administrator")
+        old_where = connection.indexes(table_name).find { |i| i.name == "old_idx" }.where
+
+        connection.rename_index(table_name, "old_idx", "new_idx")
+
+        new_index = connection.indexes(table_name).find { |i| i.name == "new_idx" }
+        assert_not_nil new_index
+        assert_equal old_where, new_index.where
+      end
+
       def test_rename_index_too_long
         too_long_index_name = good_index_name + "x"
         # keep the names short to make Oracle and similar behave


### PR DESCRIPTION
## Summary

The fallback `rename_index` silently drops a partial index's `WHERE` clause, column sort order, and every other index attribute except `columns`/`unique`:

```ruby
add_index :posts, :views, where: "title IS NOT NULL", name: "idx"
rename_index :posts, "idx", "idx2"
# idx2 is now a plain index — WHERE is gone
```

The most common trigger is `rename_column` on SQLite (the default dev/test DB), which reindexes default-named indexes through `rename_index`. For a unique partial index this also changes which rows the uniqueness constraint covers.

## Which adapters are affected

| Adapter | `rename_index` path | Affected? |
|---|---|---|
| PostgreSQL | `ALTER INDEX … RENAME` (native) | No |
| MySQL ≥ 5.7.6 / MariaDB ≥ 10.5.2 | `ALTER TABLE … RENAME INDEX` (native) | No |
| SQLite | fallback (`super`) | **Yes** |
| MySQL < 5.7.6 / MariaDB < 10.5.2 | fallback (`super`) | **Yes** |

Notably, SQLite's own `copy_table_indexes` (used during table rebuild) already preserves `where` and `order` — `rename_index` was the outlier.

## Fix

Carry the old `IndexDefinition`'s `where`, `orders`, `lengths`, `opclasses`, `using`, `type`, `include`, `nulls_not_distinct`, and `comment` into the `add_index` call, each guarded by presence.

(`comment` only matters on the MySQL/MariaDB fallback path — SQLite has no index comments — but it's carried for completeness so the recreated index mirrors every introspected attribute.)

## Tests

- `test_rename_index_preserves_where_clause` (guarded by `supports_partial_index?`)
- `test_rename_index_preserves_order` (guarded by `supports_index_sort_order?`)

Both snapshot the attribute before rename and assert it survives (robust to per-adapter introspection differences).

Verified red→green on sqlite3 (`where` → `nil`, `orders` → `{}`  on `main`; both preserved with the fix). Green on postgresql (native rename, unaffected). Full `index_test.rb` (33), `columns_test.rb` (36), `sqlite3_adapter_test.rb` (97) stay green.

## Note

This was reported in #16619 (2014) and closed with "the abstract implementation is for adapters that don't have `where`." That rationale no longer holds — SQLite supports partial indexes (`supports_partial_index?`) yet uses this abstract fallback because it has no native `rename_index`, so an adapter that *does* support `where` now silently loses it.