### PR TITLE
Fix MessagePack serialization of records with a `time` column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `ActiveRecord::MessagePack` serialization raising `NoMethodError`
+    for any record with a populated `time` column, which made such records
+    uncacheable through the MessagePack cache serializer.
+
+    *Kenta Ishizaki*
+
 *   Fix replacing or clearing a polymorphic `has_one` leaving a stale type column
     on the removed record.
 

--- a/activerecord/lib/active_record/message_pack.rb
+++ b/activerecord/lib/active_record/message_pack.rb
@@ -23,6 +23,11 @@ module ActiveRecord
       extend self
 
       def install(registry)
+        registry.register_type 118, ActiveRecord::Type::Time::Value,
+          packer: method(:write_time_value),
+          unpacker: method(:read_time_value),
+          recursive: true
+
         registry.register_type 119, ActiveModel::Type::Binary::Data,
           packer: :to_s,
           unpacker: :new
@@ -31,6 +36,14 @@ module ActiveRecord
           packer: method(:write_record),
           unpacker: method(:read_record),
           recursive: true
+      end
+
+      def write_time_value(value, packer)
+        packer.write(value.__getobj__)
+      end
+
+      def read_time_value(unpacker)
+        ActiveRecord::Type::Time::Value.new(unpacker.read)
       end
 
       def write_record(record, packer)

--- a/activerecord/test/cases/message_pack_test.rb
+++ b/activerecord/test/cases/message_pack_test.rb
@@ -5,6 +5,7 @@ require "models/author"
 require "models/binary"
 require "models/comment"
 require "models/post"
+require "models/topic"
 require "active_support/message_pack"
 require "active_record/message_pack"
 
@@ -13,6 +14,7 @@ class ActiveRecordMessagePackTest < ActiveRecord::TestCase
 
   test "enshrines type IDs" do
     expected = {
+      118 => ActiveRecord::Type::Time::Value,
       119 => ActiveModel::Type::Binary::Data,
       120 => ActiveRecord::Base,
     }
@@ -64,6 +66,11 @@ class ActiveRecordMessagePackTest < ActiveRecord::TestCase
   test "roundtrips binary attribute" do
     binary = Binary.new(data: Marshal.dump("data"))
     assert_equal binary.attributes, roundtrip(binary).attributes
+  end
+
+  test "roundtrips time attribute" do
+    topic = Topic.new(bonus_time: "09:30:00")
+    assert_equal topic.attributes, roundtrip(topic).attributes
   end
 
   test "raises ActiveSupport::MessagePack::MissingClassError if record class no longer exists" do


### PR DESCRIPTION
## Summary

Serializing any record with a populated `time` column through `ActiveRecord::MessagePack` raises:

```
NoMethodError: undefined method 'to_msgpack' for an instance of ActiveRecord::Type::Time::Value
```

The railtie wires `ActiveRecord::MessagePack::Extensions` into `ActiveSupport::MessagePack::CacheSerializer`, so this crashes `Rails.cache.write` for any record with a `time` column (e.g. via Solid Cache).

## Root cause

`attributes_for_database` wraps a `time` column value in `ActiveRecord::Type::Time::Value` — a `DelegateClass(::Time)` subclass introduced in 2016 (`28ec8c4a57`). The MessagePack factory registers `::Time` by exact class match, so the delegate subclass never matches and falls through to a missing `to_msgpack`.

`datetime`/`date`/`decimal` are unaffected because they serialize to plain `Time`/`Date`/`BigDecimal`.

The existing `message_pack_test.rb` only exercises models without a `time` column (Post/Comment/Author/Binary), so this has been latent since MessagePack support shipped in Rails 7.1 (2023).

## Fix

Register `ActiveRecord::Type::Time::Value` as type 118 in the factory (recursive, mirroring the existing Binary::Data and Base registrations).

## Tests

- `test_roundtrips_time_attribute` — roundtrips a `Topic` (`bonus_time` is a `time` column). Errors on `main`, passes with the fix.
- `test_enshrines_type_IDs` — updated to include type 118.

Verified red→green on sqlite3 and postgresql (6 runs, 19 assertions, 0 failures).