### PR TITLE
Read mysql2 affected_rows during perform_query

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -61,6 +61,7 @@ module ActiveRecord
             raw_connection.query_options[:database_timezone] = default_timezone
 
             result = nil
+            affected_rows = nil
             if !intent.has_binds?
               result = raw_connection.query(intent.processed_sql)
               # Ref: https://github.com/brianmario/mysql2/pull/1383
@@ -68,13 +69,13 @@ module ActiveRecord
               # from that same connection was GCed while `#query` released the GVL.
               # By avoiding to call `#affected_rows` when we have a result, we reduce the likeliness
               # of hitting the bug.
-              @affected_rows_before_warnings = result&.size || raw_connection.affected_rows
+              affected_rows = result&.size || raw_connection.affected_rows
             elsif intent.prepare
               retry_count = 1
               begin
                 stmt = @statements[intent.processed_sql] ||= raw_connection.prepare(intent.processed_sql)
                 result = stmt.execute(*intent.type_casted_binds)
-                @affected_rows_before_warnings = stmt.affected_rows
+                affected_rows = stmt.affected_rows
               rescue ::Mysql2::Error => error
                 @statements.delete(intent.processed_sql)
                 # Sometimes for an unknown reason, we get that error.
@@ -95,7 +96,7 @@ module ActiveRecord
 
               begin
                 result = stmt.execute(*intent.type_casted_binds)
-                @affected_rows_before_warnings = stmt.affected_rows
+                affected_rows = stmt.affected_rows
 
                 # Ref: https://github.com/brianmario/mysql2/pull/1383
                 # by eagerly closing uncached prepared statements, we also reduce the chances of
@@ -112,8 +113,15 @@ module ActiveRecord
               end
             end
 
-            intent.notification_payload[:affected_rows] = @affected_rows_before_warnings
+            intent.notification_payload[:affected_rows] = affected_rows
             intent.notification_payload[:row_count] = result&.size || 0
+
+            if result.nil?
+              result = ActiveRecord::Result.empty(affected_rows: affected_rows)
+            elsif result.fields.empty?
+              free_raw_result(result)
+              result = ActiveRecord::Result.empty(affected_rows: affected_rows)
+            end
 
             raw_connection.abandon_results!
 
@@ -126,25 +134,21 @@ module ActiveRecord
           end
 
           def cast_result(raw_result)
-            return ActiveRecord::Result.empty(affected_rows: @affected_rows_before_warnings) if raw_result.nil?
+            return raw_result if raw_result.is_a?(ActiveRecord::Result)
 
-            fields = raw_result.fields
-
-            result = if fields.empty?
-              ActiveRecord::Result.empty(affected_rows: @affected_rows_before_warnings)
-            else
-              ActiveRecord::Result.new(fields, raw_result.to_a)
-            end
-
+            result = ActiveRecord::Result.new(raw_result.fields, raw_result.to_a)
             free_raw_result(raw_result)
-
             result
           end
 
           def affected_rows(raw_result)
-            free_raw_result(raw_result) if raw_result
-
-            @affected_rows_before_warnings
+            if raw_result.is_a?(ActiveRecord::Result)
+              raw_result.affected_rows
+            else
+              affected_rows = raw_result.size
+              free_raw_result(raw_result)
+              affected_rows
+            end
           end
 
           def free_raw_result(raw_result)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -56,7 +56,6 @@ module ActiveRecord
       def initialize(...)
         super
 
-        @affected_rows_before_warnings = nil
         @config[:flags] ||= 0
 
         if @config[:flags].kind_of? Array

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
@@ -9,8 +9,12 @@ require "models/car"
 module ActiveRecord
   class CountDeletedRowsWithLockTest < ActiveRecord::AbstractMysqlTestCase
     test "delete and create in different threads synchronize correctly" do
+      expected_count = 13
+
       Bulb.unscoped.delete_all
-      Bulb.create!(name: "Jimmy", color: "blue")
+      expected_count.times do |i|
+        Bulb.create!(name: "Jimmy #{i}", color: "blue")
+      end
 
       delete_thread = Thread.new do
         Bulb.unscoped.delete_all
@@ -23,7 +27,7 @@ module ActiveRecord
       delete_thread.join
       create_thread.join
 
-      assert_equal 1, delete_thread.value
+      assert_equal expected_count, delete_thread.value
     end
   end
 end


### PR DESCRIPTION
This was failing semi-consistently locally for me while running the AR test suite.

I've changed the test in the vague hope it might make failures more likely upon future regressions.

The main change here is that Mysql2Adapter's raw-result type is switched from `Mysql2::Result`-or-`nil` to `Mysql2::Result`-or-`ActiveRecord::Result`.

For "full" results that have rows and columns, there is no change: we stick with `Mysql2::Result`, and only later cast to AR::Result.

But for results where affected-rows is the only info available (generally indicated by mysql2 returning nil), we need to introduce something that can convey that number. I could introduce a separate class just for this, but we already have Result -- and Sqlite3Adapter already re-uses it as its "raw".