### PR TITLE
Classify MySQL check-read errors as serialization failures

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -916,6 +916,7 @@ module ActiveRecord
         ER_NO_REFERENCED_ROW_2  = 1452
         ER_DATA_TOO_LONG        = 1406
         ER_OUT_OF_RANGE         = 1264
+        ER_CHECKREAD            = 1020
         ER_LOCK_DEADLOCK        = 1213
         ER_CANNOT_ADD_FOREIGN   = 1215
         ER_CANNOT_CREATE_TABLE  = 1005
@@ -962,6 +963,8 @@ module ActiveRecord
             NotNullViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when ER_CHECK_CONSTRAINT_VIOLATED, ER_CONSTRAINT_FAILED
             CheckViolation.new(message, sql: sql, binds: binds, connection_pool: @pool)
+          when ER_CHECKREAD
+            SerializationFailure.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when ER_LOCK_DEADLOCK
             Deadlocked.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when ER_LOCK_WAIT_TIMEOUT


### PR DESCRIPTION
MariaDB reports 1020 by default under repeatable-read in recent versions; this doesn't _prevent_ that, but means we at least correctly understand the full transaction has been invalidated and avoid further failure on a bad savepoint rollback.

Related #53727, #57535