### PR TITLE
Handle invalid filenames when inferring send file content type

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fall back to the default send file content type when MIME inference cannot
+    read the provided filename extension.
+
+    *Andrii Furmanets*
+
 *   Rate limiting calls `cache_key` on `by:` if the object responds to it.
 
     ```ruby

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -138,7 +138,9 @@ module ActionController # :nodoc:
         else
           if !type_provided && options[:filename]
             # If type wasn't provided, try guessing from file extension.
-            content_type = Mime::Type.lookup_by_extension(File.extname(options[:filename]).downcase.delete(".")) || content_type
+            content_type = Mime::Type.lookup_by_extension(
+              ActionDispatch::Http::ContentDisposition.filename_extension(options[:filename])
+            ) || content_type
           end
           self.content_type = content_type
         end

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -392,7 +392,7 @@ module ActionController
       ActiveSupport::Notifications.instrument("send_stream.action_controller", payload) do
         response.headers["Content-Type"] =
           (type.is_a?(Symbol) ? Mime[type].to_s : type) ||
-          Mime::Type.lookup_by_extension(File.extname(filename).downcase.delete("."))&.to_s ||
+          Mime::Type.lookup_by_extension(ActionDispatch::Http::ContentDisposition.filename_extension(filename))&.to_s ||
           "application/octet-stream"
 
         response.headers["Content-Disposition"] =

--- a/actionpack/lib/action_dispatch/http/content_disposition.rb
+++ b/actionpack/lib/action_dispatch/http/content_disposition.rb
@@ -9,6 +9,12 @@ module ActionDispatch
         new(disposition: disposition, filename: filename).to_s
       end
 
+      def self.filename_extension(filename) # :nodoc:
+        File.extname(filename).downcase.delete(".")
+      rescue ArgumentError
+        ""
+      end
+
       attr_reader :disposition, :filename
 
       def initialize(disposition:, filename:)

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -175,6 +175,12 @@ module ActionController
         end
       end
 
+      def send_stream_with_null_byte_filename
+        send_stream(filename: "sample\0.csv") do |stream|
+          stream.write "streamed data"
+        end
+      end
+
       def send_stream_with_implicit_content_type
         send_stream(filename: "sample.csv", type: :csv) do |stream|
           stream.writeln "fruit,quantity"
@@ -444,6 +450,14 @@ module ActionController
       content_type = @response.headers.fetch("Content-Type")
       assert_equal String, content_type.class
       assert_equal "text/csv", content_type
+    end
+
+    def test_send_stream_with_null_byte_filename
+      get :send_stream_with_null_byte_filename
+
+      assert_equal "streamed data", @response.body
+      assert_equal "application/octet-stream", @response.headers.fetch("Content-Type")
+      assert_equal %(attachment; filename="sample%00.csv"; filename*=UTF-8''sample%00.csv), @response.headers["Content-Disposition"]
     end
 
     def test_delayed_autoload_after_write_within_interlock_hook

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -187,6 +187,13 @@ class SendFileTest < ActionController::TestCase
     end
   end
 
+  def test_send_file_headers_with_null_byte_in_filename
+    get :test_send_file_headers_guess_type_from_extension, params: { filename: "image\0.png" }
+
+    assert_equal "application/octet-stream", response.content_type
+    assert_equal %(attachment; filename="image%00.png"; filename*=UTF-8''image%00.png), response.get_header("Content-Disposition")
+  end
+
   def test_send_file_with_default_content_disposition_header
     process("data")
     assert_equal "attachment", @controller.headers["Content-Disposition"]


### PR DESCRIPTION
Summary:
- Avoid raising when send_data infers a content type from a filename that File.extname rejects.
- Use the same fallback for send_stream while keeping Content-Disposition filename escaping unchanged.
- Add coverage for null-byte filenames in send_data and send_stream.

Reproduction:
- The new send_data regression failed before the fix with ArgumentError: path name contains null byte at actionpack/lib/action_controller/metal/data_streaming.rb:141.

Tests:
- cd actionpack && bin/test test/controller/send_file_test.rb
- cd actionpack && bin/test test/controller/live_stream_test.rb
- cd actionpack && bin/test test/dispatch/content_disposition_test.rb
- RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache bundle exec rubocop actionpack/lib/action_dispatch/http/content_disposition.rb actionpack/lib/action_controller/metal/data_streaming.rb actionpack/lib/action_controller/metal/live.rb actionpack/test/controller/send_file_test.rb actionpack/test/controller/live_stream_test.rb