### PR TITLE
Enable per-pool query log tags formatter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Allow the query log tags format to be configured per connection pool.
+
+    A `query_log_tags_format` key in a `database.yml` entry overrides the global
+    `config.active_record.query_log_tags_format` for connections in that pool, so
+    different databases can emit `:legacy` or `:sqlcommenter` formatted comments.
+
+    ```yaml
+    production:
+      primary:
+        database: primary
+      analytics:
+        database: analytics
+        query_log_tags_format: sqlcommenter
+    ```
+
+    *Hartley McGuire*
+
 *   Fix `update_attribute`/`update_attribute!` to raise for a readonly attribute referenced by an alias.
 
     *Kenta Ishizaki*

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -105,6 +105,12 @@ module ActiveRecord
         configuration_hash[:query_cache]
       end
 
+      def query_log_tags_format # :nodoc:
+        return @query_log_tags_format if defined? @query_log_tags_format
+
+        @query_log_tags_format = configuration_hash[:query_log_tags_format]&.to_sym
+      end
+
       def max_queue
         max_threads * 4
       end

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -85,6 +85,17 @@ module ActiveRecord
   # using the {SQLCommenter}[https://open-telemetry.github.io/opentelemetry-sqlcommenter/] format. This can be changed
   # via {config.active_record.query_log_tags_format}[https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-format]
   #
+  # The format can also be overridden per connection pool by setting +query_log_tags_format+
+  # in a +database.yml+ entry. Connections checked out from that pool use the configured
+  # format, while pools without any explicit configuration fall back to the global default:
+  #
+  #     production:
+  #       primary:
+  #         database: primary
+  #       analytics:
+  #         database: analytics
+  #         query_log_tags_format: sqlcommenter
+  #
   # Tag comments can be prepended to the query:
   #
   #     config.active_record.query_log_tags_prepend_comment = true
@@ -130,7 +141,7 @@ module ActiveRecord
     @cache_query_log_tags = false
     @tags_formatter = false
 
-    thread_mattr_accessor :cached_comment, instance_accessor: false
+    thread_mattr_accessor :cached_comments, instance_accessor: false
 
     class << self
       attr_reader :tags, :taggings, :tags_formatter # :nodoc:
@@ -147,14 +158,7 @@ module ActiveRecord
       end
 
       def tags_formatter=(format) # :nodoc:
-        @formatter = case format
-        when :legacy
-          LegacyFormatter
-        when :sqlcommenter
-          SQLCommenter
-        else
-          raise ArgumentError, "Formatter is unsupported: #{format}"
-        end
+        @formatter = formatter_for(format)
         @tags_formatter = format
       end
 
@@ -171,7 +175,7 @@ module ActiveRecord
       end
 
       def clear_cache # :nodoc:
-        self.cached_comment = nil
+        self.cached_comments = nil
       end
 
       def query_source_location # :nodoc:
@@ -181,6 +185,25 @@ module ActiveRecord
       ActiveSupport::ExecutionContext.after_change { ActiveRecord::QueryLogs.clear_cache }
 
       private
+        def formatter_for(format)
+          case format
+          when :legacy
+            LegacyFormatter
+          when :sqlcommenter
+            SQLCommenter
+          else
+            raise ArgumentError, "Formatter is unsupported: #{format}"
+          end
+        end
+
+        def resolve_formatter(connection)
+          if (format = connection.pool.db_config.query_log_tags_format)
+            formatter_for(format)
+          else
+            @formatter
+          end
+        end
+
         def rebuild_handlers
           handlers = []
           @tags.each do |i|
@@ -213,15 +236,20 @@ module ActiveRecord
         # Returns an SQL comment +String+ containing the query log tags.
         # Sets and returns a cached comment if <tt>cache_query_log_tags</tt> is +true+.
         def comment(extra_context)
+          formatter = resolve_formatter(extra_context[:connection])
+
           if cache_query_log_tags
-            self.cached_comment ||= uncached_comment(extra_context)
+            cache = (self.cached_comments ||= {})
+            cache.fetch(formatter) do
+              cache[formatter] = uncached_comment(extra_context, formatter)
+            end
           else
-            uncached_comment(extra_context)
+            uncached_comment(extra_context, formatter)
           end
         end
 
-        def uncached_comment(extra_context)
-          content = tag_content(extra_context)
+        def uncached_comment(extra_context, formatter)
+          content = tag_content(extra_context, formatter)
 
           if content.present?
             "/*#{escape_sql_comment(content)}*/"
@@ -241,15 +269,15 @@ module ActiveRecord
           comment
         end
 
-        def tag_content(extra_context)
+        def tag_content(extra_context, formatter)
           context = ActiveSupport::ExecutionContext.to_h
           context.reverse_merge!(extra_context)
 
           pairs = @handlers.filter_map do |(key, handler)|
             val = handler.call(context)
-            @formatter.format(key, val) unless val.nil?
+            formatter.format(key, val) unless val.nil?
           end
-          @formatter.join(pairs)
+          formatter.join(pairs)
         end
     end
 

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -19,7 +19,7 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord.query_transformers += [ActiveRecord::QueryLogs]
     ActiveRecord::QueryLogs.prepend_comment = false
     ActiveRecord::QueryLogs.cache_query_log_tags = false
-    ActiveRecord::QueryLogs.cached_comment = nil
+    ActiveRecord::QueryLogs.clear_cache
     ActiveRecord::QueryLogs.taggings = {
       application: -> { "active_record" }
     }
@@ -200,6 +200,42 @@ class QueryLogsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_per_pool_format_overrides_global_format
+    ActiveRecord::QueryLogs.tags_formatter = :legacy
+    ActiveRecord::QueryLogs.tags = [ :application ]
+
+    with_query_log_tags_format("sqlcommenter") do |connection|
+      assert_equal "select 1 /*application='active_record'*/",
+        ActiveRecord::QueryLogs.call("select 1", connection)
+    end
+  end
+
+  def test_per_pool_format_falls_back_to_global_when_not_set
+    ActiveRecord::QueryLogs.tags_formatter = :sqlcommenter
+    ActiveRecord::QueryLogs.tags = [ :application ]
+
+    with_query_log_tags_format(nil) do |connection|
+      assert_equal "select 1 /*application='active_record'*/",
+        ActiveRecord::QueryLogs.call("select 1", connection)
+    end
+  end
+
+  def test_cache_is_kept_per_formatter
+    ActiveRecord::QueryLogs.cache_query_log_tags = true
+    ActiveRecord::QueryLogs.tags_formatter = :legacy
+    ActiveRecord::QueryLogs.tags = [ :application ]
+
+    with_query_log_tags_format(nil) do |legacy_connection|
+      with_query_log_tags_format("sqlcommenter") do |sqlcommenter_connection|
+        # Different formats must not serve each other's cached comment.
+        assert_equal "select 1 /*application:active_record*/",
+          ActiveRecord::QueryLogs.call("select 1", legacy_connection)
+        assert_equal "select 1 /*application='active_record'*/",
+          ActiveRecord::QueryLogs.call("select 1", sqlcommenter_connection)
+      end
+    end
+  end
+
   def test_custom_basic_tags
     ActiveRecord::QueryLogs.tags = [ :application, { custom_string: "test content" } ]
 
@@ -288,4 +324,17 @@ class QueryLogsTest < ActiveRecord::TestCase
       Dashboard.first
     end
   end
+
+  private
+    def with_query_log_tags_format(format, &block)
+      base_config = ActiveRecord::Base.connection_pool.db_config
+      configuration_hash = base_config.configuration_hash
+      configuration_hash = configuration_hash.merge(query_log_tags_format: format) if format
+      db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(base_config.env_name, base_config.name, configuration_hash)
+
+      pool = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :writing, :default).pool
+      pool.with_connection(&block)
+    ensure
+      pool&.disconnect!
+    end
 end


### PR DESCRIPTION
A `query_log_tags_format` key in a `database.yml` entry overrides the global `config.active_record.query_log_tags_format` for connections in that pool, so different databases can emit `:legacy` or `:sqlcommenter` formatted comments.

```yaml
production:
  primary:
    database: primary
  analytics:
    database: analytics
    query_log_tags_format: sqlcommenter
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
