### PR TITLE
Re-raise suppressed RedisClient errors in RedisCacheStore behavior tests

### DIFF
--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -326,6 +326,10 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     def capture_redis_commands(&block)
       capture_notifications("redis_query.active_support_test", &block).flat_map { |e| e.payload.fetch(:commands) }
     end
+
+    def lookup_store(options = {})
+      super(options.merge(error_handler: ->(method:, returning:, exception:) { raise exception }))
+    end
   end
 
   class RedisCacheStoreWithDistributedRedisTest < RedisCacheStoreCommonBehaviorTest


### PR DESCRIPTION
### Motivation / Background

`RedisCacheStoreCommonBehaviorTest` runs with `pool: false` and a short
`timeout: 0.1`. On a slow build — notably the Ruby trunk **debug** build in
rails-nightly — a redis connect/read can occasionally exceed that timeout and
raise a `RedisClient::ConnectionError` (`ReadTimeoutError` / `CannotConnectError`).
`RedisCacheStore#failsafe` rescues it and returns `nil`, so `@cache.write(...)`
returns `nil` and the test fails with:

```
Expected nil to be truthy.
```

There is no hint that the `0.1s` timeout was the cause, because nothing logs the
suppressed error in the test environment.

### Detail

This Pull Request overrides `lookup_store` in `RedisCacheStoreCommonBehaviorTest`
to add an `error_handler` that re-raises the error `RedisCacheStore#failsafe`
would otherwise suppress, so the failing test surfaces the `RedisClient` error
directly instead of an opaque nil. It is scoped to this class so the
`FailureSafety`/`FailureRaising` tests, which deliberately point at an
unavailable redis, are unaffected; it only fires when an error would be
suppressed, so passing runs are unaffected.

### Additional information

Failure output, before → after.

**Before** (e.g. [build 4372](https://buildkite.com/rails/rails-nightly/builds/4372#019e8a23-354c-4e6e-87cd-78afbf7acef0/L7946)):

```
  4) Failure:
ActiveSupport::Cache::RedisCacheStoreTests::RedisCacheStoreCommonBehaviorTest#test_retains_encoding [test/cache/behaviors/encoded_key_cache_behavior.rb:33]:
Expected nil to be truthy.
```

**After** — the test fails with the underlying error, so the timeout is obvious
and tied to the specific test:

```
  4) Error:
ActiveSupport::Cache::RedisCacheStoreTests::RedisCacheStoreCommonBehaviorTest#test_retains_encoding:
RedisClient::ReadTimeoutError: user specified timeout for redis:6379 (redis://redis:6379/1)
```

Verified locally by shrinking the timeout to reproduce the `RedisClient::ConnectionError`;
on the slow debug build CI hits the same path at `0.1s`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
