### PR TITLE
[RF-DOCS] Update the guide for using Rails as an API

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -5,174 +5,104 @@ Using Rails for API-only Applications
 
 In this guide you will learn:
 
-* What Rails provides for API-only applications
-* How to configure Rails to start without any browser features
-* How to decide which middleware you will want to include
-* How to decide which modules to use in your controller
+- Why you should use Rails to build an API.
+- How to configure Rails without any browser features.
+- Rendering JSON and XML responses.
+- The Rack middleware stack in API applications.
+- The Action Controller modules excluded from API applications.
 
 --------------------------------------------------------------------------------
 
 What is an API Application?
 ---------------------------
 
-Traditionally, when people said that they used Rails as an "API", they meant
-providing a programmatically accessible API alongside their web application.
-For example, GitHub provides [an API](https://developer.github.com) that you
-can use from your own custom clients.
+An API application speaks a data-interchange format such as JSON or XML, rather
+than HTML which is used to paint a user interface. Its purpose is to integrate
+with another piece of software, as opposed to being used by a human.
 
-With the advent of client-side frameworks, more developers are using Rails to
-build a back-end that is shared between their web application and other native
-applications.
+While Rails
+[provides a mechanism to build an API](action_view_overview.html#jbuilder)
+alongside your full-stack application, a Rails application that only speaks JSON
+(or another similar format) can be a useful configuration. The same Rails API
+could service the JavaScript frontend in the browser, as well as the native
+mobile apps and other integrations.
 
-For example, X uses its [public API](https://developer.x.com/) in its web
-application, which is built as a static site that consumes JSON resources.
+[Basecamp](https://github.com/basecamp/bc3-api) is a good example of the former
+approach where HTML is used for web browsers, but a JSON API is also provided
+for external software integrations. [X](https://x.com) uses the latter approach
+in its web application which is built using a frontend that consumes JSON
+resources from an internal API.
 
-Instead of using Rails to generate HTML that communicates with the server
-through forms and links, many developers are treating their web application as
-just an API client delivered as HTML with JavaScript that consumes a JSON API.
+This guide covers Rails' support for building an API application without any
+HTML rendering or browser-related features.
 
-This guide covers building a Rails application that serves JSON resources to an
-API client, including client-side frameworks.
-
-Why Use Rails for JSON APIs?
-----------------------------
-
-The first question a lot of people have when thinking about building a JSON API
-using Rails is: "isn't using Rails to spit out some JSON overkill? Shouldn't I
-just use something like Sinatra?".
-
-For very simple APIs, this may be true. However, even in very HTML-heavy
-applications, most of an application's logic lives outside of the view
-layer.
-
-The reason most people use Rails is that it provides a set of defaults that
-allows developers to get up and running quickly, without having to make a lot of trivial
-decisions.
-
-Let's take a look at some of the things that Rails provides out of the box that are
-still applicable to API applications.
-
-Handled at the middleware layer:
-
-- Reloading: Rails applications support transparent reloading. This works even if
-  your application gets big and restarting the server for every request becomes
-  non-viable.
-- Development Mode: Rails applications come with smart defaults for development,
-  making development pleasant without compromising production-time performance.
-- Test Mode: Ditto development mode.
-- Logging: Rails applications log every request, with a level of verbosity
-  appropriate for the current mode. Rails logs in development include information
-  about the request environment, database queries, and basic performance
-  information.
-- Security: Rails detects and thwarts [IP spoofing
-  attacks](https://en.wikipedia.org/wiki/IP_address_spoofing) and handles
-  cryptographic signatures in a [timing
-  attack](https://en.wikipedia.org/wiki/Timing_attack) aware way. Don't know what
-  an IP spoofing attack or a timing attack is? Exactly.
-- Parameter Parsing: Want to specify your parameters as JSON instead of as a
-  URL-encoded String? No problem. Rails will decode the JSON for you and make
-  it available in `params`. Want to use nested URL-encoded parameters? That
-  works too.
-- Conditional GETs: Rails handles conditional `GET` (`ETag` and `Last-Modified`)
-  processing request headers and returning the correct response headers and status
-  code. All you need to do is use the
-  [`stale?`](https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html#method-i-stale-3F)
-  check in your controller, and Rails will handle all of the HTTP details for you.
-- HEAD requests: Rails will transparently convert `HEAD` requests into `GET` ones,
-  and return just the headers on the way out. This makes `HEAD` work reliably in
-  all Rails APIs.
-
-While you could obviously build these up in terms of existing Rack middleware,
-this list demonstrates that the default Rails middleware stack provides a lot
-of value, even if you're "just generating JSON".
-
-Handled at the Action Pack layer:
-
-- Resourceful Routing: If you're building a RESTful JSON API, you want to be
-  using the Rails router. Clean and conventional mapping from HTTP to controllers
-  means not having to spend time thinking about how to model your API in terms
-  of HTTP.
-- URL Generation: The flip side of routing is URL generation. A good API based
-  on HTTP includes URLs (see [the GitHub Gist API](https://docs.github.com/en/rest/reference/gists)
-  for an example).
-- Header and Redirection Responses: `head :no_content` and
-  `redirect_to user_url(current_user)` come in handy. Sure, you could manually
-  add the response headers, but why?
-- Caching: Rails provides page, action, and fragment caching. Fragment caching
-  is especially helpful when building up a nested JSON object.
-- Basic, Digest, and Token Authentication: Rails comes with out-of-the-box support
-  for three kinds of HTTP authentication.
-- Instrumentation: Rails has an instrumentation API that triggers registered
-  handlers for a variety of events, such as action processing, sending a file or
-  data, redirection, and database queries. The payload of each event comes with
-  relevant information (for the action processing event, the payload includes
-  the controller, action, parameters, request format, request method, and the
-  request's full path).
-- Generators: It is often handy to generate a resource and get your model,
-  controller, test stubs, and routes created for you in a single command for
-  further tweaking. Same for migrations and others.
-- Plugins: Many third-party libraries come with support for Rails that reduce
-  or eliminate the cost of setting up and gluing together the library and the
-  web framework. This includes things like overriding default generators, adding
-  Rake tasks, and honoring Rails choices (like the logger and cache back-end).
-
-Of course, the Rails boot process also glues together all registered components.
-For example, the Rails boot process is what uses your `config/database.yml` file
-when configuring Active Record.
-
-**The short version is**: you may not have thought about which parts of Rails
-are still applicable even if you remove the view layer, but the answer turns out
-to be most of it.
-
-The Basic Configuration
+Why Use Rails for APIs?
 -----------------------
 
-If you're building a Rails application that will be an API server first and
-foremost, you can start with a more limited subset of Rails and add in features
-as needed.
+When using Rails as an API, we replace a view layer that generates HTML with one
+that generates JSON, XML, or a similar data-interchage format. Nothing else
+changes.
 
-### Creating a New Application
+Rails still provides a feature-rich environment to develop server applications
+with its security features, MVC architecture, and resourceful routing. Tools
+such as [Active Record][], [Active Job][], [Active Storage][], [Action
+Mailer][], and [native caching][] are all still available in API applications.
 
-You can generate a new api Rails app:
+Most of Rails' features are still relevant even when building an API-only
+application.
+
+[Active Record]: active_record_basics.html
+[Active Job]: active_job_basics.html
+[Active Storage]: active_storage_overview.html
+[Action Mailer]: action_mailer_basics.html
+[native caching]: caching_with_rails.html
+
+Using Rails for API-only Applications
+-------------------------------------
+
+Rails can be configured to be used only as an API, which will exclude the HTML
+rendering and browser-related features. Some features can be added back in as
+required.
+
+### Creating a New API Application
+
+You can generate a new API-only Rails app using:
 
 ```bash
-$ rails new my_api --api
+$ rails new my_api_app --api
 ```
 
-This will do three main things for you:
+This will:
 
-- Configure your application to start with a more limited set of middleware
-  than normal. Specifically, it will not include any middleware primarily useful
-  for browser applications (like cookies support) by default.
-- Make `ApplicationController` inherit from `ActionController::API` instead of
-  `ActionController::Base`. As with middleware, this will leave out any Action
-  Controller modules that provide functionalities primarily used by browser
-  applications.
+- Set `ApplicationController` to inherit from [`ActionController::API`][]
+  instead of [`ActionController::Base`][], which
+  [excludes the modules](#api-controller-modules) for browser-related
+  functionality.
 - Configure the generators to skip generating views, helpers, and assets when
-  you generate a new resource.
+  you scaffold a new resource.
+- Exclude [Rack middleware](https://guides.rubyonrails.org/rails_on_rack.html)
+  related to browser applications, such as support for cookies.
 
-### Generating a New Resource
+[`ActionController::API`]:
+  https://api.rubyonrails.org/classes/ActionController/API.html
+[`ActionController::Base`]:
+  https://api.rubyonrails.org/classes/ActionController/Base.html
 
-To see how our newly created API handles generating a new resource, let's create
-a new Group resource. Each group will have a name.
+### Scaffolding API Resources
+
+The `bin/rails generate scaffold` command will skip HTML views for API
+applications:
 
 ```bash
 $ bin/rails g scaffold Group name:string
 ```
 
-Before we can use our scaffolded code, we need to update our database scheme.
-
-```bash
-$ bin/rails db:migrate
-```
-
-Now if we open our `GroupsController`, we should notice that with an API Rails
-app we are rendering JSON data only. On the index action we query for `Group.all`
-and assign it to an instance variable called `@groups`. Passing it to `render` with the
-`:json` option will automatically render the groups as JSON.
+This will create the `GroupsController` demonstrated below along with an empty
+`Group` model.
 
 ```ruby
 # app/controllers/groups_controller.rb
+
 class GroupsController < ApplicationController
   before_action :set_group, only: %i[ show update destroy ]
 
@@ -195,7 +125,7 @@ class GroupsController < ApplicationController
     if @group.save
       render json: @group, status: :created, location: @group
     else
-      render json: @group.errors, status: :unprocessable_entity
+      render json: @group.errors, status: :unprocessable_content
     end
   end
 
@@ -204,19 +134,19 @@ class GroupsController < ApplicationController
     if @group.update(group_params)
       render json: @group
     else
-      render json: @group.errors, status: :unprocessable_entity
+      render json: @group.errors, status: :unprocessable_content
     end
   end
 
   # DELETE /groups/1
   def destroy
-    @group.destroy
+    @group.destroy!
   end
 
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_group
-      @group = Group.find(params[:id])
+      @group = Group.find(params.expect(:id))
     end
 
     # Only allow a list of trusted parameters through.
@@ -226,328 +156,360 @@ class GroupsController < ApplicationController
 end
 ```
 
-Finally we can add some groups to our database from the Rails console:
+The controller is set up to render JSON by default. Any objects passed to
+`render json:` will be converted to JSON using `to_json`.
 
-```irb
-irb> Group.create(name: "Rails Founders")
-irb> Group.create(name: "Rails Contributors")
-```
+Assuming we have two `Group`s in our database named _Rails Founders_ and _Rails
+Contributors_, the `/groups` endpoint will generate the following JSON response.
 
-With some data in the app, we can boot up the server and visit <http://localhost:3000/groups.json> to see our JSON data.
-
-```json
+```bash
+$ curl -s localhost:3000/groups | jq
 [
-{"id":1, "name":"Rails Founders", "created_at": ...},
-{"id":2, "name":"Rails Contributors", "created_at": ...}
+  {
+    "id": 1,
+    "name": "Rails Founders",
+    "created_at": "2026-03-24T13:39:22.357Z",
+    "updated_at": "2026-03-24T13:39:22.357Z"
+  },
+  {
+    "id": 2,
+    "name": "Rails Contributors",
+    "created_at": "2026-03-24T13:39:25.386Z",
+    "updated_at": "2026-03-24T13:39:25.386Z"
+  }
 ]
 ```
 
-### Changing an Existing Application
+NOTE: The above example, and more examples further down use the `jq` command
+line utility to format JSON output. If it isn't installed on your system,
+consult the [download page](https://jqlang.org/download/) to for instructions.
 
-If you want to take an existing application and make it an API one, read the
-following steps.
+### Building JSON using JBuilder
 
-In `config/application.rb`, add the following line at the top of the `Application`
-class definition:
+For more fine-grained control over the JSON structure, or to build complex JSON
+objects, you can use the [JBuilder](https://github.com/rails/jbuilder) gem. It
+isn't installed by default — you'll need to uncomment it in your `Gemfile` and
+run `bundle install`.
 
-```ruby
-config.api_only = true
-```
-
-In `config/environments/development.rb`, set [`config.debug_exception_response_format`][]
-to configure the format used in responses when errors occur in development mode.
-
-To render an HTML page with debugging information, use the value `:default`.
+JBuilder provides a handy DSL for building JSON objects, and requires a view
+file:
 
 ```ruby
-config.debug_exception_response_format = :default
-```
+# app/views/groups/index.json.jbuilder
 
-To render debugging information preserving the response format, use the value `:api`.
-
-```ruby
-config.debug_exception_response_format = :api
-```
-
-By default, `config.debug_exception_response_format` is set to `:api`, when `config.api_only` is set to true.
-
-Finally, inside `app/controllers/application_controller.rb`, instead of:
-
-```ruby
-class ApplicationController < ActionController::Base
+json.array! @groups do |group|
+  json.name(group.name)
 end
 ```
 
-do:
+Using this technique, we still have a view layer, only simpler than if it was
+HTML — and we still get the benefits of MVC separation.
+
+NOTE: When the `jbuilder` gem is present in your Gemfile,
+`bin/rails generate scaffold` will automatically create `.json.jbuilder` views
+along with the controller and model.
+
+Ensure the controller's index action implicitly renders the JBuilder template,
+and doesn't call `render`:
+
+```ruby
+def index
+  @groups = Group.all
+end
+```
+
+The `/groups` endpoint will now only return the group names:
+
+```bash
+$ curl -s localhost:3000/groups | jq
+[
+  {
+    "name": "Rails Founders"
+  },
+  {
+    "name": "Rails Contributors"
+  }
+]
+```
+
+TIP: You can optionally add `render formats: :json` in your controller action to
+render JBuilder responses if you wish to be more explicit.
+
+### XML Responses
+
+While JSON is the default, Rails API applications can also render XML. Rails
+includes the [`builder`](https://github.com/rails/builder) gem which provides a
+DSL to build XML data structures.
+
+```ruby
+# app/views/groups/index.xml.builder
+
+xml.groups do
+  @groups.each do |group|
+    xml.group do
+      xml.name group.name
+    end
+  end
+end
+```
+
+You'll also need to add two modules to your Application Controller. These are
+[excluded by default](#api-controller-modules) for API applications. The
+`jbuilder` gem automatically adds them back in, but `builder` does not.
+
+```ruby
+class ApplicationController < ActionController::API
+  include ActionView::Rendering
+  include ActionController::ImplicitRender
+end
+```
+
+Ensure your controller action is rendering implicitly (alternatively, you can
+use `render formats: :xml`):
+
+```ruby
+def index
+  @groups = Group.all
+end
+```
+
+```ruby
+def index
+  @groups = Group.all
+  render formats: :xml
+end
+```
+
+The `/groups` endpoint will now render XML!
+
+```bash
+$ curl -s localhost:3000/groups
+<groups>
+  <group>
+    <name>Rails Founders</name>
+  </group>
+  <group>
+    <name>Rails Contributors</name>
+  </group>
+</groups>
+```
+
+NOTE: If `ActionView::Rendering` is not included, attempting to render a
+template of any format will silently return a `204 No Content` response. It will
+not raise an error.
+
+#### ERB
+
+If you don't wish to use `builder`, you can use ERB to write your XML views.
+
+```html+erb
+<%# app/views/groups/index.xml.erb -%>
+
+<groups>
+  <% @groups.each do |group| %>
+  <group>
+    <name><%= group.name %></name>
+  </group>
+  <% end %>
+</groups>
+```
+
+### Reconfiguring an Existing Application
+
+Reconfigure an existing fully-featured Rails application to function as API-only
+by setting `config.api_only`:
+
+```ruby
+# config/application.rb
+
+# ...
+module MyRailsApp
+  class Application < Rails::Application
+    # ...
+    config.api_only = true
+  end
+end
+```
+
+This will also change [`config.debug_exception_response_format`][] to `:api`. To
+preserve rendering errors as HTML pages, set it to `:default` in your
+`config/environments/development.rb`.
+
+Change your `ApplicationController`'s super-class:
 
 ```ruby
 class ApplicationController < ActionController::API
 end
 ```
 
-[`config.debug_exception_response_format`]: configuring.html#config-debug-exception-response-format
+That's everything you need to do to reconfigure your app to work solely as an
+API.
 
-Choosing Middleware
---------------------
+[`config.debug_exception_response_format`]:
+  configuring.html#config-debug-exception-response-format
 
-An API application comes with the following middleware by default:
+Rack Middleware in API Applications
+-----------------------------------
 
-- `ActionDispatch::HostAuthorization`
-- `Rack::Sendfile`
-- `ActionDispatch::Static`
-- `ActionDispatch::Executor`
-- `ActionDispatch::ServerTiming`
-- `ActiveSupport::Cache::Strategy::LocalCache::Middleware`
-- `Rack::Runtime`
-- `ActionDispatch::RequestId`
-- `ActionDispatch::RemoteIp`
-- `Rails::Rack::Logger`
-- `ActionDispatch::ShowExceptions`
-- `ActionDispatch::DebugExceptions`
-- `ActionDispatch::ActionableExceptions`
-- `ActionDispatch::Reloader`
-- `ActionDispatch::Callbacks`
-- `ActiveRecord::Migration::CheckPending`
-- `Rack::Head`
-- `Rack::ConditionalGet`
-- `Rack::ETag`
-
-See the [internal middleware](rails_on_rack.html#internal-middleware-stack)
-section of the Rack guide for further information on them.
-
-Other plugins, including Active Record, may add additional middleware. In
-general, these middleware are agnostic to the type of application you are
-building, and make sense in an API-only Rails application.
-
-You can get a list of all middleware in your application via:
-
-```bash
-$ bin/rails middleware
-```
-
-### Using Rack::Cache
-
-When used with Rails, `Rack::Cache` uses the Rails cache store for its
-entity and meta stores. This means that if you use memcache, for your
-Rails app, for instance, the built-in HTTP cache will use memcache.
-
-To make use of `Rack::Cache`, you first need to add the `rack-cache` gem
-to `Gemfile`, and set `config.action_dispatch.rack_cache` to `true`.
-To enable its functionality, you will want to use `stale?` in your
-controller. Here’s an example of `stale?` in use.
+A Rails API application builds the following middleware stack by default:
 
 ```ruby
-def show
-  @post = Post.find(params[:id])
+use ActionDispatch::HostAuthorization
+use Rack::Sendfile
+use ActionDispatch::Static
+use ActionDispatch::Executor
+use ActionDispatch::ServerTiming
+use ActiveSupport::Cache::Strategy::LocalCache::Middleware
+use Rack::Runtime
+use ActionDispatch::RequestId
+use ActionDispatch::RemoteIp
+use Rails::Rack::Logger
+use ActionDispatch::ShowExceptions
+use ActionDispatch::DebugExceptions
+use ActionDispatch::ActionableExceptions
+use ActionDispatch::Reloader
+use ActionDispatch::Callbacks
+use ActiveRecord::Migration::CheckPending
+use Rack::Head
+use Rack::ConditionalGet
+use Rack::ETag
+run MyApp::Application.routes
+```
 
-  if stale?(last_modified: @post.updated_at)
-    render json: @post
-  end
+Browser-specific middleware such as `ActionDispatch::Cookies`,
+`ActionDispatch::Flash`, and `ActionDispatch::ContentSecurityPolicy::Middleware`
+are excluded for API applications.
+
+They can be manually added back in if you wish. For further information on Rack
+middleware, see the
+[Rails on Rack guide](rails_on_rack.html#internal-middleware-stack).
+
+### Session Middleware
+
+The Rack middleware for
+[Rails sessions](action_controller_overview.html#session) is excluded by default
+for API applications. To add it back in, you need to manually
+[configure your session store](configuring.html#config-session-store) before
+adding the middleware to the stack, then pass `session_options` when including
+the store's middleware.
+
+```ruby
+# config/initializers/session_store.rb
+
+Rails.application.config.tap do |config|
+  # Configure the session to use cookies
+  config.session_store :cookie_store, key: "_my_app_session"
+
+  # Required for all session management regardless of the session store
+  config.middleware.use ActionDispatch::Cookies
+
+  # Add the middleware for the cookie store to the stack
+  config.middleware.use \
+    config.session_store, config.session_options
 end
 ```
 
-The call to `stale?` will compare the `If-Modified-Since` header in the request
-with `@post.updated_at`. If the header is newer than the last modified, this
-action will return a "304 Not Modified" response. Otherwise, it will render the
-response and include a `Last-Modified` header in it.
+You can set up other session stores such as
+`ActionDispatch::Session::CacheStore` or
+`ActionDispatch::Session::MemCacheStore` using the same technique.
 
-Normally, this mechanism is used on a per-client basis. `Rack::Cache`
-allows us to share this caching mechanism across clients. We can enable
-cross-client caching in the call to `stale?`:
+API Controller Modules
+----------------------
 
-```ruby
-def show
-  @post = Post.find(params[:id])
+The base class for API-only controllers, [`ActionController::API`][], includes a
+subset of the modules included [`ActionController::Base`][] which is used in
+full-stack Rails applications.
 
-  if stale?(last_modified: @post.updated_at, public: true)
-    render json: @post
-  end
-end
-```
+### Included Modules
 
-This means that `Rack::Cache` will store off the `Last-Modified` value
-for a URL in the Rails cache, and add an `If-Modified-Since` header to any
-subsequent inbound requests for the same URL.
+Some of the included modules are:
 
-Think of it as page caching using HTTP semantics.
+|                                          |                                                                                                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`ActionController::UrlFor`][]           | Makes `url_for` and similar helpers available.                                                                                                                                                   |
+| [`ActionController::Redirecting`][]      | Support for `redirect_to`.                                                                                                                                                                       |
+| [`ActionController::ApiRendering`][]     | Basic support for rendering.                                                                                                                                                                     |
+| [`ActionController::Renderers::All`][]   | Support for `:json`, `:xml` and similar renderers.                                                                                                                                               |
+| [`ActionController::ConditionalGet`][]   | Support for `stale?`.                                                                                                                                                                            |
+| [`ActionController::StrongParameters`][] | Support for parameters filtering in combination with Active Model mass assignment.                                                                                                               |
+| [`ActionController::Caching`][]          | Enables controller-level caching techniques such as Russian Doll caching                                                                                                                         |
+| [`ActionController::DataStreaming`][]    | Support for `send_file` and `send_data`.                                                                                                                                                         |
+| [`ActionController::Instrumentation`][]  | Support for the instrumentation hooks defined by Action Controller (see [the instrumentation guide](active_support_instrumentation.html#action-controller) for more information regarding this). |
+| [`ActionController::ParamsWrapper`][]    | Wraps the parameters hash into a nested hash, so that you don't have to specify root elements sending POST requests for instance.                                                                |
+| [`ActionController::Head`][]             | Support for returning a response with no content, only headers.                                                                                                                                  |
 
-### Using Rack::Sendfile
-
-When you use the `send_file` method inside a Rails controller, it sets the
-`X-Sendfile` header. `Rack::Sendfile` is responsible for actually sending the
-file.
-
-If your front-end server supports accelerated file sending, `Rack::Sendfile`
-will offload the actual file sending work to the front-end server.
-This enables Rails to finish request handling and free resources earlier.
-
-You can configure the name of the header that your front-end server uses for
-this purpose using [`config.action_dispatch.x_sendfile_header`][] in the appropriate
-environment's configuration file.
-
-You can learn more about how to use `Rack::Sendfile` with popular
-front-ends in [the Rack::Sendfile
-documentation](https://rack.github.io/rack/main/Rack/Sendfile.html).
-
-Here are some values for this header for some popular servers, once these servers are configured to support
-accelerated file sending:
-
-```ruby
-# Apache and lighttpd
-config.action_dispatch.x_sendfile_header = "X-Sendfile"
-
-# Nginx
-config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
-```
-
-Make sure to configure your server to support these options following the
-instructions in the `Rack::Sendfile` documentation.
-
-[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-dispatch-x-sendfile-header
-
-### Using ActionDispatch::Request
-
-`ActionDispatch::Request#params` will take parameters from the client in the JSON
-format and make them available in your controller inside `params`.
-
-To use this, your client will need to make a request with JSON-encoded parameters
-and specify the `Content-Type` as `application/json`.
-
-Here's an example:
-
-```js
-fetch('/people', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ person: { firstName: 'Yehuda', lastName: 'Katz' } })
-}).then(response => response.json())
-```
-
-`ActionDispatch::Request` will see the `Content-Type` and your parameters
-will be:
-
-```ruby
-{ person: { firstName: "Yehuda", lastName: "Katz" } }
-```
-
-### Using Session Middlewares
-
-The following middlewares, used for session management, are excluded from API apps since they normally don't need sessions.  If one of your API clients is a browser, you might want to add one of these back in:
-
-- `ActionDispatch::Session::CacheStore`
-- `ActionDispatch::Session::CookieStore`
-- `ActionDispatch::Session::MemCacheStore`
-
-The trick to adding these back in is that, by default, they are passed `session_options`
-when added (including the session key), so you can't just add a `session_store.rb` initializer, add
-`use ActionDispatch::Session::CookieStore` and have sessions functioning as usual.  (To be clear: sessions
-may work, but your session options will be ignored - i.e. the session key will default to `_session_id`)
-
-Instead of the initializer, you'll have to set the relevant options somewhere before your middleware is
-built (like `config/application.rb`) and pass them to your preferred middleware, like this:
-
-```ruby
-# This also configures session_options for use below
-config.session_store :cookie_store, key: "_your_app_session"
-
-# Required for all session management (regardless of session_store)
-config.middleware.use ActionDispatch::Cookies
-
-config.middleware.use config.session_store, config.session_options
-```
-
-### Other Middleware
-
-Rails ships with a number of other middleware that you might want to use in an
-API application, especially if one of your API clients is the browser:
-
-- `Rack::MethodOverride`
-- `ActionDispatch::Cookies`
-- `ActionDispatch::Flash`
-
-Any of these middleware can be added via:
-
-```ruby
-config.middleware.use Rack::MethodOverride
-```
-
-### Removing Middleware
-
-If you don't want to use a middleware that is included by default in the API-only
-middleware set, you can remove it with:
-
-```ruby
-config.middleware.delete ::Rack::Sendfile
-```
-
-Keep in mind that removing these middlewares will remove support for certain
-features in Action Controller.
-
-Choosing Controller Modules
----------------------------
-
-An API application (using `ActionController::API`) comes with the following
-controller modules by default:
-
-|   |   |
-|---|---|
-| `ActionController::UrlFor` | Makes `url_for` and similar helpers available. |
-| `ActionController::Redirecting` | Support for `redirect_to`. |
-| `AbstractController::Rendering` and `ActionController::ApiRendering` | Basic support for rendering. |
-| `ActionController::Renderers::All` | Support for `render :json` and friends. |
-| `ActionController::ConditionalGet` | Support for `stale?`. |
-| `ActionController::BasicImplicitRender` | Makes sure to return an empty response, if there isn't an explicit one. |
-| `ActionController::StrongParameters` | Support for parameters filtering in combination with Active Model mass assignment. |
-| `ActionController::DataStreaming` | Support for `send_file` and `send_data`. |
-| `AbstractController::Callbacks` | Support for `before_action` and similar helpers. |
-| `ActionController::Rescue` | Support for `rescue_from`. |
-| `ActionController::Instrumentation` | Support for the instrumentation hooks defined by Action Controller (see [the instrumentation guide](active_support_instrumentation.html#action-controller) for more information regarding this). |
-| `ActionController::ParamsWrapper` | Wraps the parameters hash into a nested hash, so that you don't have to specify root elements sending POST requests for instance.
-| `ActionController::Head` | Support for returning a response with no content, only headers. |
-
-Other plugins may add additional modules. You can get a list of all modules
-included into `ActionController::API` in the rails console:
+View the full list of included modules in your Rails console:
 
 ```irb
-irb> ActionController::API.ancestors - ActionController::Metal.ancestors
-=> [ActionController::API,
-    ActiveRecord::Railties::ControllerRuntime,
-    ActionDispatch::Routing::RouteSet::MountedHelpers,
-    ActionController::ParamsWrapper,
-    ... ,
-    AbstractController::Rendering,
-    ActionView::ViewPaths]
+irb> ActionController::API.ancestors.select { it.name.include? "Controller" }
 ```
 
-### Adding Other Modules
+Further information on each module is available in the
+[API documentation](https://api.rubyonrails.org/).
 
-All Action Controller modules know about their dependent modules, so you can feel
-free to include any modules into your controllers, and all dependencies will be
-included and set up as well.
+[`ActionController::UrlFor`]:
+  https://api.rubyonrails.org/classes/ActionController/UrlFor.html
+[`ActionController::Redirecting`]:
+  https://api.rubyonrails.org/classes/ActionController/Redirecting.html
+[`ActionController::ApiRendering`]:
+  https://api.rubyonrails.org/classes/ActionController/ApiRendering.html
+[`ActionController::Renderers::All`]:
+  https://api.rubyonrails.org/classes/ActionController/Renderers/All.html
+[`ActionController::ConditionalGet`]:
+  https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html
+[`ActionController::StrongParameters`]:
+  https://api.rubyonrails.org/classes/ActionController/StrongParameters.html
+[`ActionController::Caching`]:
+  https://api.rubyonrails.org/classes/ActionController/Caching.html
+[`ActionController::DataStreaming`]:
+  https://api.rubyonrails.org/classes/ActionController/DataStreaming.html
+[`ActionController::Instrumentation`]:
+  https://api.rubyonrails.org/classes/ActionController/Instrumentation.html
+[`ActionController::ParamsWrapper`]:
+  https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html
+[`ActionController::Head`]:
+  https://api.rubyonrails.org/classes/ActionController/Head.html
 
-Some common modules you might want to add:
+### Excluded Modules
 
-- `AbstractController::Translation`: Support for the `l` and `t` localization
-  and translation methods.
-- Support for basic, digest, or token HTTP authentication:
-  * `ActionController::HttpAuthentication::Basic::ControllerMethods`
-  * `ActionController::HttpAuthentication::Digest::ControllerMethods`
-  * `ActionController::HttpAuthentication::Token::ControllerMethods`
-- `ActionView::Layouts`: Support for layouts when rendering.
-- `ActionController::MimeResponds`: Support for `respond_to`.
-- `ActionController::Cookies`: Support for `cookies`, which includes
-  support for signed and encrypted cookies. This requires the cookies middleware.
-- `ActionController::Caching`: Support view caching for the API controller. Please note
-  that you will need to manually specify the cache store inside the controller like this:
+View the modules excluded from [`ActionController::API`][], but included in
+[`ActionController::Base`][] in your Rails console:
 
-    ```ruby
-    class ApplicationController < ActionController::API
-      include ::ActionController::Caching
-      self.cache_store = :mem_cache_store
-    end
-    ```
+```irb
+irb> ActionController::Base.ancestors - ActionController::API.ancestors
+```
 
-    Rails does *not* pass this configuration automatically.
+Any excluded modules can be `include`d manually in your `ApplicationController`:
 
-The best place to add a module is in your `ApplicationController`, but you can
-also add modules to individual controllers.
+```ruby
+class ApplicationController < ActionController::API
+  include AbstractController::Translation
+end
+```
+
+Some useful modules you may wish to include are:
+
+|                                                                       |                                                                                                                                            |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`ActionController::MimeResponds`][]                                  | Use `respond_to` in controllers for multi-format responses                                                                                 |
+| [`AbstractController::Translation`][]                                 | Support for the `l` and `t` localization and translation methods                                                                           |
+| [`ActionController::HttpAuthentication::Basic::ControllerMethods`][]  | Basic HTTP Authentication                                                                                                                  |
+| [`ActionController::HttpAuthentication::Digest::ControllerMethods`][] | Authentication using HTTP digests                                                                                                          |
+| [`ActionController::HttpAuthentication::Token::ControllerMethods`][]  | Athentication using tokens                                                                                                                 |
+| [`ActionView::Layouts`][]                                             | Support for layouts when rendering. This might be useful with JBuilder                                                                     |
+| [`ActionController::Cookies`][]                                       | Support for cookies, which includes support for signed and encrypted cookies. This requires the `ActionDispatch::Cookies` Rack middleware. |
+
+[`ActionController::MimeResponds`]:
+  https://api.rubyonrails.org/classes/ActionController/MimeResponds.html
+[`AbstractController::Translation`]:
+  https://api.rubyonrails.org/classes/AbstractController/Translation.html
+[`ActionController::HttpAuthentication::Basic::ControllerMethods`]:
+  https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic/ControllerMethods.html
+[`ActionController::HttpAuthentication::Digest::ControllerMethods`]:
+  https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Digest/ControllerMethods.html
+[`ActionController::HttpAuthentication::Token::ControllerMethods`]:
+  https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html
+[`ActionView::Layouts`]:
+  https://api.rubyonrails.org/classes/ActionView/Layouts.html
+[`ActionController::Cookies`]:
+  https://api.rubyonrails.org/classes/ActionController/Cookies.html

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -499,15 +499,27 @@ end
 
 Some useful modules you may wish to include are:
 
-|                                                                       |                                                                                                                                            |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`ActionController::MimeResponds`][]                                  | Use `respond_to` in controllers for multi-format responses                                                                                 |
-| [`AbstractController::Translation`][]                                 | Support for the `l` and `t` localization and translation methods                                                                           |
-| [`ActionController::HttpAuthentication::Basic::ControllerMethods`][]  | Basic HTTP Authentication                                                                                                                  |
-| [`ActionController::HttpAuthentication::Digest::ControllerMethods`][] | Authentication using HTTP digests                                                                                                          |
-| [`ActionController::HttpAuthentication::Token::ControllerMethods`][]  | Athentication using tokens                                                                                                                 |
-| [`ActionView::Layouts`][]                                             | Support for layouts when rendering. This might be useful with JBuilder                                                                     |
-| [`ActionController::Cookies`][]                                       | Support for cookies, which includes support for signed and encrypted cookies. This requires the `ActionDispatch::Cookies` Rack middleware. |
+* [`ActionController::MimeResponds`][] <br>
+  Use `respond_to` in controllers for multi-format responses
+
+* [`AbstractController::Translation`][] <br>
+  Support for the `l` and `t` localization and translation methods
+
+* [`ActionController::HttpAuthentication::Basic::ControllerMethods`][] <br>
+  Basic HTTP Authentication
+
+* [`ActionController::HttpAuthentication::Digest::ControllerMethods`][] <br>
+  Authentication using HTTP digests
+
+* [`ActionController::HttpAuthentication::Token::ControllerMethods`][] <br>
+  Athentication using tokens
+
+* [`ActionView::Layouts`][] <br>
+  Support for layouts when rendering. This might be useful with JBuilder.
+
+* [`ActionController::Cookies`][] <br>
+  Support for cookies, which includes support for signed and encrypted
+  cookies. This requires the `ActionDispatch::Cookies` Rack middleware.
 
 [`ActionController::MimeResponds`]:
   https://api.rubyonrails.org/classes/ActionController/MimeResponds.html

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -5,174 +5,103 @@ Using Rails for API-only Applications
 
 In this guide you will learn:
 
-* What Rails provides for API-only applications
-* How to configure Rails to start without any browser features
-* How to decide which middleware you will want to include
-* How to decide which modules to use in your controller
+- Why you should use Rails to build an API.
+- How to configure Rails without any browser features.
+- Rendering JSON and XML responses.
+- The Rack middleware stack in API applications.
+- The Action Controller modules excluded from API applications.
 
 --------------------------------------------------------------------------------
 
 What is an API Application?
 ---------------------------
 
-Traditionally, when people said that they used Rails as an "API", they meant
-providing a programmatically accessible API alongside their web application.
-For example, GitHub provides [an API](https://developer.github.com) that you
-can use from your own custom clients.
+An API application speaks a data-interchange format such as JSON or XML, rather
+than HTML which is used to paint a user interface. Its purpose is to integrate
+with another piece of software, as opposed to being used by a human.
 
-With the advent of client-side frameworks, more developers are using Rails to
-build a back-end that is shared between their web application and other native
-applications.
+While Rails
+[provides a mechanism to build an API](action_view_overview.html#jbuilder)
+alongside your full-stack application, a Rails application that only speaks JSON
+(or another similar format) can be a useful configuration. The same Rails API
+could service the JavaScript frontend in the browser, as well as the native
+mobile apps and other integrations.
 
-For example, X uses its [public API](https://developer.x.com/) in its web
-application, which is built as a static site that consumes JSON resources.
+[Basecamp](https://github.com/basecamp/bc3-api) is a good example of the former
+approach where HTML is used for web browsers, but a JSON API is also provided
+for external software integrations. [X](https://x.com) uses the latter approach
+in its web application which is built using a frontend that consumes JSON
+resources from an internal API.
 
-Instead of using Rails to generate HTML that communicates with the server
-through forms and links, many developers are treating their web application as
-just an API client delivered as HTML with JavaScript that consumes a JSON API.
+This guide covers Rails' support for building an API application without any
+HTML rendering or browser-related features.
 
-This guide covers building a Rails application that serves JSON resources to an
-API client, including client-side frameworks.
-
-Why Use Rails for JSON APIs?
-----------------------------
-
-The first question a lot of people have when thinking about building a JSON API
-using Rails is: "isn't using Rails to spit out some JSON overkill? Shouldn't I
-just use something like Sinatra?".
-
-For very simple APIs, this may be true. However, even in very HTML-heavy
-applications, most of an application's logic lives outside of the view
-layer.
-
-The reason most people use Rails is that it provides a set of defaults that
-allows developers to get up and running quickly, without having to make a lot of trivial
-decisions.
-
-Let's take a look at some of the things that Rails provides out of the box that are
-still applicable to API applications.
-
-Handled at the middleware layer:
-
-- Reloading: Rails applications support transparent reloading. This works even if
-  your application gets big and restarting the server for every request becomes
-  non-viable.
-- Development Mode: Rails applications come with smart defaults for development,
-  making development pleasant without compromising production-time performance.
-- Test Mode: Ditto development mode.
-- Logging: Rails applications log every request, with a level of verbosity
-  appropriate for the current mode. Rails logs in development include information
-  about the request environment, database queries, and basic performance
-  information.
-- Security: Rails detects and thwarts [IP spoofing
-  attacks](https://en.wikipedia.org/wiki/IP_address_spoofing) and handles
-  cryptographic signatures in a [timing
-  attack](https://en.wikipedia.org/wiki/Timing_attack) aware way. Don't know what
-  an IP spoofing attack or a timing attack is? Exactly.
-- Parameter Parsing: Want to specify your parameters as JSON instead of as a
-  URL-encoded String? No problem. Rails will decode the JSON for you and make
-  it available in `params`. Want to use nested URL-encoded parameters? That
-  works too.
-- Conditional GETs: Rails handles conditional `GET` (`ETag` and `Last-Modified`)
-  processing request headers and returning the correct response headers and status
-  code. All you need to do is use the
-  [`stale?`](https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html#method-i-stale-3F)
-  check in your controller, and Rails will handle all of the HTTP details for you.
-- HEAD requests: Rails will transparently convert `HEAD` requests into `GET` ones,
-  and return just the headers on the way out. This makes `HEAD` work reliably in
-  all Rails APIs.
-
-While you could obviously build these up in terms of existing Rack middleware,
-this list demonstrates that the default Rails middleware stack provides a lot
-of value, even if you're "just generating JSON".
-
-Handled at the Action Pack layer:
-
-- Resourceful Routing: If you're building a RESTful JSON API, you want to be
-  using the Rails router. Clean and conventional mapping from HTTP to controllers
-  means not having to spend time thinking about how to model your API in terms
-  of HTTP.
-- URL Generation: The flip side of routing is URL generation. A good API based
-  on HTTP includes URLs (see [the GitHub Gist API](https://docs.github.com/en/rest/reference/gists)
-  for an example).
-- Header and Redirection Responses: `head :no_content` and
-  `redirect_to user_url(current_user)` come in handy. Sure, you could manually
-  add the response headers, but why?
-- Caching: Rails provides page, action, and fragment caching. Fragment caching
-  is especially helpful when building up a nested JSON object.
-- Basic, Digest, and Token Authentication: Rails comes with out-of-the-box support
-  for three kinds of HTTP authentication.
-- Instrumentation: Rails has an instrumentation API that triggers registered
-  handlers for a variety of events, such as action processing, sending a file or
-  data, redirection, and database queries. The payload of each event comes with
-  relevant information (for the action processing event, the payload includes
-  the controller, action, parameters, request format, request method, and the
-  request's full path).
-- Generators: It is often handy to generate a resource and get your model,
-  controller, test stubs, and routes created for you in a single command for
-  further tweaking. Same for migrations and others.
-- Plugins: Many third-party libraries come with support for Rails that reduce
-  or eliminate the cost of setting up and gluing together the library and the
-  web framework. This includes things like overriding default generators, adding
-  Rake tasks, and honoring Rails choices (like the logger and cache back-end).
-
-Of course, the Rails boot process also glues together all registered components.
-For example, the Rails boot process is what uses your `config/database.yml` file
-when configuring Active Record.
-
-**The short version is**: you may not have thought about which parts of Rails
-are still applicable even if you remove the view layer, but the answer turns out
-to be most of it.
-
-The Basic Configuration
+Why Use Rails for APIs?
 -----------------------
 
-If you're building a Rails application that will be an API server first and
-foremost, you can start with a more limited subset of Rails and add in features
-as needed.
+When using Rails as an API, we remove the components from the view layer which
+generate HTML. Nothing else changes.
 
-### Creating a New Application
+Rails still provides a feature-rich environment to develop server applications
+with its security features, MVC architecture, and resourceful routing. Tools
+such as [Active Record][], [Active Job][], [Active Storage][], [Action
+Mailer][], and [native caching][] are all still available in API applications.
 
-You can generate a new api Rails app:
+Most of Rails' features are still relevant even when building an API-only
+application.
+
+[Active Record]: active_record_basics.html
+[Active Job]: active_job_basics.html
+[Active Storage]: active_storage_overview.html
+[Action Mailer]: action_mailer_basics.html
+[native caching]: caching_with_rails.html
+
+Using Rails for API-only Applications
+-------------------------------------
+
+Rails can be configured to be used only as an API, which will exclude the HTML
+rendering and browser-related features. Some features can be added back in as
+required.
+
+### Creating a New API Application
+
+You can generate a new API-only Rails app using the `--api` flag:
 
 ```bash
-$ rails new my_api --api
+$ rails new my_api_app --api
 ```
 
-This will do three main things for you:
+This will:
 
-- Configure your application to start with a more limited set of middleware
-  than normal. Specifically, it will not include any middleware primarily useful
-  for browser applications (like cookies support) by default.
-- Make `ApplicationController` inherit from `ActionController::API` instead of
-  `ActionController::Base`. As with middleware, this will leave out any Action
-  Controller modules that provide functionalities primarily used by browser
-  applications.
+- Set `ApplicationController` to inherit from [`ActionController::API`][]
+  instead of [`ActionController::Base`][], which
+  [excludes the modules](#api-controller-modules) for browser-related
+  functionality.
 - Configure the generators to skip generating views, helpers, and assets when
-  you generate a new resource.
+  you scaffold a new resource.
+- Exclude [Rack middleware](https://guides.rubyonrails.org/rails_on_rack.html)
+  related to browser applications, such as support for cookies.
 
-### Generating a New Resource
+[`ActionController::API`]:
+  https://api.rubyonrails.org/classes/ActionController/API.html
+[`ActionController::Base`]:
+  https://api.rubyonrails.org/classes/ActionController/Base.html
 
-To see how our newly created API handles generating a new resource, let's create
-a new Group resource. Each group will have a name.
+### Scaffolding API Resources
+
+The `bin/rails generate scaffold` command will skip HTML views for API
+applications:
 
 ```bash
 $ bin/rails g scaffold Group name:string
 ```
 
-Before we can use our scaffolded code, we need to update our database scheme.
-
-```bash
-$ bin/rails db:migrate
-```
-
-Now if we open our `GroupsController`, we should notice that with an API Rails
-app we are rendering JSON data only. On the index action we query for `Group.all`
-and assign it to an instance variable called `@groups`. Passing it to `render` with the
-`:json` option will automatically render the groups as JSON.
+This will create the `GroupsController` demonstrated below along with an empty
+`Group` model.
 
 ```ruby
 # app/controllers/groups_controller.rb
+
 class GroupsController < ApplicationController
   before_action :set_group, only: %i[ show update destroy ]
 
@@ -195,7 +124,7 @@ class GroupsController < ApplicationController
     if @group.save
       render json: @group, status: :created, location: @group
     else
-      render json: @group.errors, status: :unprocessable_entity
+      render json: @group.errors, status: :unprocessable_content
     end
   end
 
@@ -204,19 +133,19 @@ class GroupsController < ApplicationController
     if @group.update(group_params)
       render json: @group
     else
-      render json: @group.errors, status: :unprocessable_entity
+      render json: @group.errors, status: :unprocessable_content
     end
   end
 
   # DELETE /groups/1
   def destroy
-    @group.destroy
+    @group.destroy!
   end
 
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_group
-      @group = Group.find(params[:id])
+      @group = Group.find(params.expect(:id))
     end
 
     # Only allow a list of trusted parameters through.
@@ -226,328 +155,371 @@ class GroupsController < ApplicationController
 end
 ```
 
-Finally we can add some groups to our database from the Rails console:
+The controller is set up to render JSON by default. Any objects passed to
+`render json:` will be converted to JSON using `to_json`.
 
-```irb
-irb> Group.create(name: "Rails Founders")
-irb> Group.create(name: "Rails Contributors")
-```
+Assuming we have two `Group`s in our database named _Rails Founders_ and _Rails
+Contributors_, the `/groups` endpoint will generate the following JSON response.
 
-With some data in the app, we can boot up the server and visit <http://localhost:3000/groups.json> to see our JSON data.
-
-```json
+```bash
+$ curl -s localhost:3000/groups | jq
 [
-{"id":1, "name":"Rails Founders", "created_at": ...},
-{"id":2, "name":"Rails Contributors", "created_at": ...}
+  {
+    "id": 1,
+    "name": "Rails Founders",
+    "created_at": "2026-03-24T13:39:22.357Z",
+    "updated_at": "2026-03-24T13:39:22.357Z"
+  },
+  {
+    "id": 2,
+    "name": "Rails Contributors",
+    "created_at": "2026-03-24T13:39:25.386Z",
+    "updated_at": "2026-03-24T13:39:25.386Z"
+  }
 ]
 ```
 
-### Changing an Existing Application
+NOTE: The above example, and more examples further down, use the `jq` command
+line utility to format JSON output. If it isn't installed on your system,
+consult the [download page](https://jqlang.org/download/) for instructions.
 
-If you want to take an existing application and make it an API one, read the
-following steps.
+### Building JSON using JBuilder
 
-In `config/application.rb`, add the following line at the top of the `Application`
-class definition:
+For more fine-grained control over the JSON structure, or to build complex JSON
+objects, you can use the [JBuilder](https://github.com/rails/jbuilder) gem. It
+isn't installed by default — you'll need to uncomment it in your `Gemfile` and
+run `bundle install`.
 
-```ruby
-config.api_only = true
-```
-
-In `config/environments/development.rb`, set [`config.debug_exception_response_format`][]
-to configure the format used in responses when errors occur in development mode.
-
-To render an HTML page with debugging information, use the value `:default`.
+JBuilder provides a handy DSL for building JSON objects, and requires a view
+file:
 
 ```ruby
-config.debug_exception_response_format = :default
-```
+# app/views/groups/index.json.jbuilder
 
-To render debugging information preserving the response format, use the value `:api`.
-
-```ruby
-config.debug_exception_response_format = :api
-```
-
-By default, `config.debug_exception_response_format` is set to `:api`, when `config.api_only` is set to true.
-
-Finally, inside `app/controllers/application_controller.rb`, instead of:
-
-```ruby
-class ApplicationController < ActionController::Base
+json.array! @groups do |group|
+  json.group_name(group.name)
 end
 ```
 
-do:
+Using this technique, we still have a view layer, only simpler than if it was
+HTML — and we still get the benefits of MVC separation.
+
+NOTE: When the `jbuilder` gem is present in your Gemfile,
+`bin/rails generate scaffold` will automatically create `.json.jbuilder` views
+along with the controller and model.
+
+Ensure the controller's index action implicitly renders the JBuilder template,
+and doesn't call `render`:
+
+```ruby
+def index
+  @groups = Group.all
+end
+```
+
+The `/groups` endpoint will now only return the group names:
+
+```bash
+$ curl -s localhost:3000/groups | jq
+[
+  {
+    "group_name": "Rails Founders"
+  },
+  {
+    "group_name": "Rails Contributors"
+  }
+]
+```
+
+WARNING: Accessing `localhost:3000/groups` in a browser will cause an
+`ActionController::UnknownFormat` error. Browsers include an `Accept` HTTP header
+requesting an HTML response, so Rails will look for an HTML template which
+doesn't exist, causing the error. <br><br>
+`curl` sets `Accept` to `*/*` telling Rails that any response format is acceptable,
+hence the JSON is implicitly rendered. You can optionally add `render formats: :json`
+in your controller action to force Rails to render JSON (using JBuilder in this case)
+irrespective of the `Accept` header.
+
+### XML Responses
+
+While JSON is the default, Rails API applications can also render XML. Rails
+includes the [`builder`](https://github.com/rails/builder) gem which provides a
+DSL to build XML data structures.
+
+```ruby
+# app/views/groups/index.xml.builder
+
+xml.groups do
+  @groups.each do |group|
+    xml.group do
+      xml.title group.name
+    end
+  end
+end
+```
+
+You'll also need to add two modules to your Application Controller. These are
+[excluded by default](#api-controller-modules) for API applications. The
+`jbuilder` gem automatically adds them back in, but `builder` does not.
+
+```ruby
+class ApplicationController < ActionController::API
+  include ActionView::Rendering
+  include ActionController::ImplicitRender
+end
+```
+
+Ensure your controller action is rendering implicitly (alternatively, you can
+use `render formats: :xml`):
+
+```ruby
+def index
+  @groups = Group.all
+end
+```
+
+```ruby
+def index
+  @groups = Group.all
+  render formats: :xml
+end
+```
+
+The `/groups` endpoint will now render XML!
+
+```bash
+$ curl -s localhost:3000/groups
+<groups>
+  <group>
+    <title>Rails Founders</title>
+  </group>
+  <group>
+    <title>Rails Contributors</title>
+  </group>
+</groups>
+```
+
+NOTE: If `ActionView::Rendering` is not included, attempting to render a
+template of any format will silently return a `204 No Content` response. It will
+not raise an error.
+
+WARNING: Similar to JSON responses, accessing `localhost:3000/groups` in a web browser
+will raise an `ActionController::UnknownFormat` because Rails will look
+for an HTML template based on the `Accept` header. <br><br>
+Use `render formats: :xml` in the controller action to force XML responses.
+
+#### ERB
+
+If you don't wish to use `builder`, you can use ERB to write your XML views.
+
+```html+erb
+<%# app/views/groups/index.xml.erb -%>
+
+<groups>
+  <% @groups.each do |group| %>
+  <group>
+    <name><%= group.name %></name>
+  </group>
+  <% end %>
+</groups>
+```
+
+### Reconfiguring an Existing Application
+
+Reconfigure an existing fully-featured Rails application to function as API-only
+by setting `config.api_only`:
+
+```ruby
+# config/application.rb
+
+# ...
+module MyRailsApp
+  class Application < Rails::Application
+    # ...
+    config.api_only = true
+  end
+end
+```
+
+This will also change [`config.debug_exception_response_format`][] to `:api`. To
+preserve rendering errors as HTML pages, set it to `:default` in your
+`config/environments/development.rb`.
+
+Lastly, change your `ApplicationController`'s super-class:
 
 ```ruby
 class ApplicationController < ActionController::API
 end
 ```
 
-[`config.debug_exception_response_format`]: configuring.html#config-debug-exception-response-format
+That's everything you need to do to reconfigure your app to work solely as an
+API.
 
-Choosing Middleware
---------------------
+[`config.debug_exception_response_format`]:
+  configuring.html#config-debug-exception-response-format
 
-An API application comes with the following middleware by default:
+Rack Middleware in API Applications
+-----------------------------------
 
-- `ActionDispatch::HostAuthorization`
-- `Rack::Sendfile`
-- `ActionDispatch::Static`
-- `ActionDispatch::Executor`
-- `ActionDispatch::ServerTiming`
-- `ActiveSupport::Cache::Strategy::LocalCache::Middleware`
-- `Rack::Runtime`
-- `ActionDispatch::RequestId`
-- `ActionDispatch::RemoteIp`
-- `Rails::Rack::Logger`
-- `ActionDispatch::ShowExceptions`
-- `ActionDispatch::DebugExceptions`
-- `ActionDispatch::ActionableExceptions`
-- `ActionDispatch::Reloader`
-- `ActionDispatch::Callbacks`
-- `ActiveRecord::Migration::CheckPending`
-- `Rack::Head`
-- `Rack::ConditionalGet`
-- `Rack::ETag`
-
-See the [internal middleware](rails_on_rack.html#internal-middleware-stack)
-section of the Rack guide for further information on them.
-
-Other plugins, including Active Record, may add additional middleware. In
-general, these middleware are agnostic to the type of application you are
-building, and make sense in an API-only Rails application.
-
-You can get a list of all middleware in your application via:
-
-```bash
-$ bin/rails middleware
-```
-
-### Using Rack::Cache
-
-When used with Rails, `Rack::Cache` uses the Rails cache store for its
-entity and meta stores. This means that if you use memcache, for your
-Rails app, for instance, the built-in HTTP cache will use memcache.
-
-To make use of `Rack::Cache`, you first need to add the `rack-cache` gem
-to `Gemfile`, and set `config.action_dispatch.rack_cache` to `true`.
-To enable its functionality, you will want to use `stale?` in your
-controller. Here’s an example of `stale?` in use.
+A Rails API application builds the following middleware stack by default:
 
 ```ruby
-def show
-  @post = Post.find(params[:id])
+use ActionDispatch::HostAuthorization
+use Rack::Sendfile
+use ActionDispatch::Static
+use ActionDispatch::Executor
+use ActionDispatch::ServerTiming
+use ActiveSupport::Cache::Strategy::LocalCache::Middleware
+use Rack::Runtime
+use ActionDispatch::RequestId
+use ActionDispatch::RemoteIp
+use Rails::Rack::Logger
+use ActionDispatch::ShowExceptions
+use ActionDispatch::DebugExceptions
+use ActionDispatch::ActionableExceptions
+use ActionDispatch::Reloader
+use ActionDispatch::Callbacks
+use ActiveRecord::Migration::CheckPending
+use Rack::Head
+use Rack::ConditionalGet
+use Rack::ETag
+run MyApp::Application.routes
+```
 
-  if stale?(last_modified: @post.updated_at)
-    render json: @post
-  end
+Browser-specific middleware such as `ActionDispatch::Cookies`,
+`ActionDispatch::Flash`, and `ActionDispatch::ContentSecurityPolicy::Middleware`
+are excluded for API applications.
+
+They can be manually added back in if you wish. For further information on Rack
+middleware, see the
+[Rails on Rack guide](rails_on_rack.html#internal-middleware-stack).
+
+### Session Middleware
+
+The Rack middleware for
+[Rails sessions](action_controller_overview.html#session) is excluded by default
+for API applications. To add it back in, you need to manually
+[configure your session store](configuring.html#config-session-store) before
+adding the middleware to the stack, then pass `session_options` when including
+the store's middleware.
+
+```ruby
+# config/initializers/session_store.rb
+
+Rails.application.config.tap do |config|
+  # Configure the session to use cookies
+  config.session_store :cookie_store, key: "_my_app_session"
+
+  # Required for all session management regardless of the session store
+  config.middleware.use ActionDispatch::Cookies
+
+  # Add the middleware for the cookie store to the stack
+  config.middleware.use \
+    config.session_store, config.session_options
 end
 ```
 
-The call to `stale?` will compare the `If-Modified-Since` header in the request
-with `@post.updated_at`. If the header is newer than the last modified, this
-action will return a "304 Not Modified" response. Otherwise, it will render the
-response and include a `Last-Modified` header in it.
+You can set up other session stores such as
+`ActionDispatch::Session::CacheStore` or
+`ActionDispatch::Session::MemCacheStore` using the same technique.
 
-Normally, this mechanism is used on a per-client basis. `Rack::Cache`
-allows us to share this caching mechanism across clients. We can enable
-cross-client caching in the call to `stale?`:
+API Controller Modules
+----------------------
 
-```ruby
-def show
-  @post = Post.find(params[:id])
+The base class for API-only controllers, [`ActionController::API`][], includes a
+subset of the modules included by [`ActionController::Base`][] which is used in
+full-stack Rails applications.
 
-  if stale?(last_modified: @post.updated_at, public: true)
-    render json: @post
-  end
-end
-```
+### Included Modules
 
-This means that `Rack::Cache` will store off the `Last-Modified` value
-for a URL in the Rails cache, and add an `If-Modified-Since` header to any
-subsequent inbound requests for the same URL.
+Some of the included modules are:
 
-Think of it as page caching using HTTP semantics.
+|                                          |                                                                                                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`ActionController::UrlFor`][]           | Makes `url_for` and similar helpers available.                                                                                                                                                   |
+| [`ActionController::Redirecting`][]      | Adds support for `redirect_to`.                                                                                                                                                                       |
+| [`ActionController::ApiRendering`][]     | Adds basic support for rendering.                                                                                                                                                                     |
+| [`ActionController::Renderers::All`][]   | Adds support for `:json`, `:xml` and similar renderers.                                                                                                                                               |
+| [`ActionController::ConditionalGet`][]   | Adds support for `stale?`.                                                                                                                                                                            |
+| [`ActionController::StrongParameters`][] | Adds support for parameters filtering in combination with Active Model mass assignment.                                                                                                               |
+| [`ActionController::Caching`][]          | Enables controller-level caching techniques such as Russian Doll caching                                                                                                                         |
+| [`ActionController::DataStreaming`][]    | Adds support for `send_file` and `send_data`.                                                                                                                                                         |
+| [`ActionController::Instrumentation`][]  | Adds support for the instrumentation hooks defined by Action Controller (see [the instrumentation guide](active_support_instrumentation.html#action-controller) for more information regarding this). |
+| [`ActionController::ParamsWrapper`][]    | Wraps the parameters hash into a nested hash, so that you don't have to specify root elements when sending POST requests.                                                                |
+| [`ActionController::Head`][]             | Adds support for returning a response with no content, only headers.                                                                                                                                  |
 
-### Using Rack::Sendfile
-
-When you use the `send_file` method inside a Rails controller, it sets the
-`X-Sendfile` header. `Rack::Sendfile` is responsible for actually sending the
-file.
-
-If your front-end server supports accelerated file sending, `Rack::Sendfile`
-will offload the actual file sending work to the front-end server.
-This enables Rails to finish request handling and free resources earlier.
-
-You can configure the name of the header that your front-end server uses for
-this purpose using [`config.action_dispatch.x_sendfile_header`][] in the appropriate
-environment's configuration file.
-
-You can learn more about how to use `Rack::Sendfile` with popular
-front-ends in [the Rack::Sendfile
-documentation](https://rack.github.io/rack/main/Rack/Sendfile.html).
-
-Here are some values for this header for some popular servers, once these servers are configured to support
-accelerated file sending:
-
-```ruby
-# Apache and lighttpd
-config.action_dispatch.x_sendfile_header = "X-Sendfile"
-
-# Nginx
-config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
-```
-
-Make sure to configure your server to support these options following the
-instructions in the `Rack::Sendfile` documentation.
-
-[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-dispatch-x-sendfile-header
-
-### Using ActionDispatch::Request
-
-`ActionDispatch::Request#params` will take parameters from the client in the JSON
-format and make them available in your controller inside `params`.
-
-To use this, your client will need to make a request with JSON-encoded parameters
-and specify the `Content-Type` as `application/json`.
-
-Here's an example:
-
-```js
-fetch('/people', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ person: { firstName: 'Yehuda', lastName: 'Katz' } })
-}).then(response => response.json())
-```
-
-`ActionDispatch::Request` will see the `Content-Type` and your parameters
-will be:
-
-```ruby
-{ person: { firstName: "Yehuda", lastName: "Katz" } }
-```
-
-### Using Session Middlewares
-
-The following middlewares, used for session management, are excluded from API apps since they normally don't need sessions.  If one of your API clients is a browser, you might want to add one of these back in:
-
-- `ActionDispatch::Session::CacheStore`
-- `ActionDispatch::Session::CookieStore`
-- `ActionDispatch::Session::MemCacheStore`
-
-The trick to adding these back in is that, by default, they are passed `session_options`
-when added (including the session key), so you can't just add a `session_store.rb` initializer, add
-`use ActionDispatch::Session::CookieStore` and have sessions functioning as usual.  (To be clear: sessions
-may work, but your session options will be ignored - i.e. the session key will default to `_session_id`)
-
-Instead of the initializer, you'll have to set the relevant options somewhere before your middleware is
-built (like `config/application.rb`) and pass them to your preferred middleware, like this:
-
-```ruby
-# This also configures session_options for use below
-config.session_store :cookie_store, key: "_your_app_session"
-
-# Required for all session management (regardless of session_store)
-config.middleware.use ActionDispatch::Cookies
-
-config.middleware.use config.session_store, config.session_options
-```
-
-### Other Middleware
-
-Rails ships with a number of other middleware that you might want to use in an
-API application, especially if one of your API clients is the browser:
-
-- `Rack::MethodOverride`
-- `ActionDispatch::Cookies`
-- `ActionDispatch::Flash`
-
-Any of these middleware can be added via:
-
-```ruby
-config.middleware.use Rack::MethodOverride
-```
-
-### Removing Middleware
-
-If you don't want to use a middleware that is included by default in the API-only
-middleware set, you can remove it with:
-
-```ruby
-config.middleware.delete ::Rack::Sendfile
-```
-
-Keep in mind that removing these middlewares will remove support for certain
-features in Action Controller.
-
-Choosing Controller Modules
----------------------------
-
-An API application (using `ActionController::API`) comes with the following
-controller modules by default:
-
-|   |   |
-|---|---|
-| `ActionController::UrlFor` | Makes `url_for` and similar helpers available. |
-| `ActionController::Redirecting` | Support for `redirect_to`. |
-| `AbstractController::Rendering` and `ActionController::ApiRendering` | Basic support for rendering. |
-| `ActionController::Renderers::All` | Support for `render :json` and friends. |
-| `ActionController::ConditionalGet` | Support for `stale?`. |
-| `ActionController::BasicImplicitRender` | Makes sure to return an empty response, if there isn't an explicit one. |
-| `ActionController::StrongParameters` | Support for parameters filtering in combination with Active Model mass assignment. |
-| `ActionController::DataStreaming` | Support for `send_file` and `send_data`. |
-| `AbstractController::Callbacks` | Support for `before_action` and similar helpers. |
-| `ActionController::Rescue` | Support for `rescue_from`. |
-| `ActionController::Instrumentation` | Support for the instrumentation hooks defined by Action Controller (see [the instrumentation guide](active_support_instrumentation.html#action-controller) for more information regarding this). |
-| `ActionController::ParamsWrapper` | Wraps the parameters hash into a nested hash, so that you don't have to specify root elements sending POST requests for instance.
-| `ActionController::Head` | Support for returning a response with no content, only headers. |
-
-Other plugins may add additional modules. You can get a list of all modules
-included into `ActionController::API` in the rails console:
+View the full list of included modules in your Rails console:
 
 ```irb
-irb> ActionController::API.ancestors - ActionController::Metal.ancestors
-=> [ActionController::API,
-    ActiveRecord::Railties::ControllerRuntime,
-    ActionDispatch::Routing::RouteSet::MountedHelpers,
-    ActionController::ParamsWrapper,
-    ... ,
-    AbstractController::Rendering,
-    ActionView::ViewPaths]
+irb> ActionController::API.ancestors.select { it.name.include? "Controller" }
 ```
 
-### Adding Other Modules
+Further information on each module is available in the
+[API documentation](https://api.rubyonrails.org/).
 
-All Action Controller modules know about their dependent modules, so you can feel
-free to include any modules into your controllers, and all dependencies will be
-included and set up as well.
+[`ActionController::UrlFor`]:
+  https://api.rubyonrails.org/classes/ActionController/UrlFor.html
+[`ActionController::Redirecting`]:
+  https://api.rubyonrails.org/classes/ActionController/Redirecting.html
+[`ActionController::ApiRendering`]:
+  https://api.rubyonrails.org/classes/ActionController/ApiRendering.html
+[`ActionController::Renderers::All`]:
+  https://api.rubyonrails.org/classes/ActionController/Renderers/All.html
+[`ActionController::ConditionalGet`]:
+  https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html
+[`ActionController::StrongParameters`]:
+  https://api.rubyonrails.org/classes/ActionController/StrongParameters.html
+[`ActionController::Caching`]:
+  https://api.rubyonrails.org/classes/ActionController/Caching.html
+[`ActionController::DataStreaming`]:
+  https://api.rubyonrails.org/classes/ActionController/DataStreaming.html
+[`ActionController::Instrumentation`]:
+  https://api.rubyonrails.org/classes/ActionController/Instrumentation.html
+[`ActionController::ParamsWrapper`]:
+  https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html
+[`ActionController::Head`]:
+  https://api.rubyonrails.org/classes/ActionController/Head.html
 
-Some common modules you might want to add:
+### Excluded Modules
 
-- `AbstractController::Translation`: Support for the `l` and `t` localization
-  and translation methods.
-- Support for basic, digest, or token HTTP authentication:
-  * `ActionController::HttpAuthentication::Basic::ControllerMethods`
-  * `ActionController::HttpAuthentication::Digest::ControllerMethods`
-  * `ActionController::HttpAuthentication::Token::ControllerMethods`
-- `ActionView::Layouts`: Support for layouts when rendering.
-- `ActionController::MimeResponds`: Support for `respond_to`.
-- `ActionController::Cookies`: Support for `cookies`, which includes
-  support for signed and encrypted cookies. This requires the cookies middleware.
-- `ActionController::Caching`: Support view caching for the API controller. Please note
-  that you will need to manually specify the cache store inside the controller like this:
+View the modules excluded from [`ActionController::API`][], but included in
+[`ActionController::Base`][] in your Rails console:
 
-    ```ruby
-    class ApplicationController < ActionController::API
-      include ::ActionController::Caching
-      self.cache_store = :mem_cache_store
-    end
-    ```
+```irb
+irb> ActionController::Base.ancestors - ActionController::API.ancestors
+```
 
-    Rails does *not* pass this configuration automatically.
+Any excluded modules can be `include`d manually in your `ApplicationController`:
 
-The best place to add a module is in your `ApplicationController`, but you can
-also add modules to individual controllers.
+```ruby
+class ApplicationController < ActionController::API
+  include AbstractController::Translation
+end
+```
+
+Some useful modules you may wish to include are:
+
+|                                                                       |                                                                                                                                            |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`ActionController::MimeResponds`][]                                  | Use `respond_to` in controllers for multi-format responses                                                                                 |
+| [`AbstractController::Translation`][]                                 | Support for the `l` and `t` localization and translation methods                                                                           |
+| [`ActionController::HttpAuthentication::Basic::ControllerMethods`][]  | Basic HTTP Authentication                                                                                                                  |
+| [`ActionController::HttpAuthentication::Digest::ControllerMethods`][] | Authentication using HTTP digests                                                                                                          |
+| [`ActionController::HttpAuthentication::Token::ControllerMethods`][]  | Athentication using tokens                                                                                                                 |
+| [`ActionView::Layouts`][]                                             | Support for layouts when rendering. This might be useful with JBuilder                                                                     |
+| [`ActionController::Cookies`][]                                       | Support for cookies, which includes support for signed and encrypted cookies. This requires the `ActionDispatch::Cookies` Rack middleware. |
+
+[`ActionController::MimeResponds`]:
+  https://api.rubyonrails.org/classes/ActionController/MimeResponds.html
+[`AbstractController::Translation`]:
+  https://api.rubyonrails.org/classes/AbstractController/Translation.html
+[`ActionController::HttpAuthentication::Basic::ControllerMethods`]:
+  https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic/ControllerMethods.html
+[`ActionController::HttpAuthentication::Digest::ControllerMethods`]:
+  https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Digest/ControllerMethods.html
+[`ActionController::HttpAuthentication::Token::ControllerMethods`]:
+  https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html
+[`ActionView::Layouts`]:
+  https://api.rubyonrails.org/classes/ActionView/Layouts.html
+[`ActionController::Cookies`]:
+  https://api.rubyonrails.org/classes/ActionController/Cookies.html


### PR DESCRIPTION
### Motivation / Background

Update and simplify the guide for using Rails as an API.

### Detail

- Changed the structure of the guide to be more general and less like a step-by-step tutorial. This is in keeping with the rest of the guides as they may not always be read or followed all the way from beginning to end.
- Simplified the section on why we would use Rails as an API. It read like a feature-list for Rails. I've removed all that detail and replaced it with a simple pitch stating the majority of Rails still applies in API applications. I've also removed language which makes assumptions about the reader's opinions.
- Added sections on JBuilder and Builder, as well as XML responses which, while not as popular as JSON, is still a valid API data-interchange format.
- Updated the sections on Rack middleware and Action Controller modules. Some of the information was out of date — for example, the `ActionController::Caching` module is now included in `ActionController::API`.

I considered adding a new section on authenticating HTTP requests for an API, but it's not suitable for a general Rails guide. It would make too many assumption about the internal authentication model of the application. Instead, I've linked the modules for HTTP authentication included in Rails which the developer can use to build their authentication system.

### Internal Audit

This guide sometimes uses lowercase "api". I think it should always be "API".
This guide is about a JSON API, where we don't mention GraphQL which is another popular API implementation.

The Basic Configuration
- Should this section be renamed to something like "Setting Up an Application as an  API" or "Using Rails as an API".

Choosing Middleware
- Rack::Cache is described but it's not in the intro list of middlewares.
