### PR TITLE
Make the backtrace cleaner ractor shareable by default

### DIFF
--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -192,19 +192,19 @@ module ActiveSupport
 
         gems_regexp = %r{\A(#{gems_paths.join('|')})/(bundler/)?gems/([^/]+)-([\w.]+)/(.*)}
         gems_result = '\3 (\4) \5'
-        add_filter { |line| line.sub(gems_regexp, gems_result) }
+        add_filter(&Ractors.shareable_proc  { |line| line.sub(gems_regexp, gems_result) })
       end
 
       def add_core_silencer
-        add_silencer { |line| line.include?("<internal:") }
+        add_silencer(&Ractors.shareable_proc { |line| line.include?("<internal:") })
       end
 
       def add_gem_silencer
-        add_silencer { |line| FORMATTED_GEMS_PATTERN.match?(line) }
+        add_silencer(&Ractors.shareable_proc  { |line| FORMATTED_GEMS_PATTERN.match?(line) })
       end
 
       def add_stdlib_silencer
-        add_silencer { |line| line.start_with?(RbConfig::CONFIG["rubylibdir"]) }
+        add_silencer(&Ractors.shareable_proc  { |line| line.start_with?(RbConfig::CONFIG["rubylibdir"]) })
       end
 
       def filter_backtrace(backtrace)

--- a/activesupport/lib/active_support/testing/ractors_assertions.rb
+++ b/activesupport/lib/active_support/testing/ractors_assertions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Testing
+    module RactorsAssertions # :nodoc: all
+      private
+        if RUBY_VERSION >= "4.0"
+          def assert_ractor_shareable(obj)
+            assert_nothing_raised { Ractor.make_shareable(obj) }
+          end
+        else
+          def assert_ractor_shareable(obj)
+            assert true
+          end
+        end
+    end
+  end
+end

--- a/activesupport/test/backtrace_cleaner_test.rb
+++ b/activesupport/test/backtrace_cleaner_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "abstract_unit"
 require "rails/test_unit/line_filtering"
+require "active_support/testing/ractors_assertions"
 
 class BacktraceCleanerFilterTest < ActiveSupport::TestCase
   def setup
@@ -93,6 +94,8 @@ class BacktraceCleanerFilterAndSilencerTest < ActiveSupport::TestCase
 end
 
 class BacktraceCleanerDefaultFilterAndSilencerTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def setup
     @bc = ActiveSupport::BacktraceCleaner.new
   end
@@ -135,6 +138,10 @@ class BacktraceCleanerDefaultFilterAndSilencerTest < ActiveSupport::TestCase
     backtrace = [Gem.default_dir, *Gem.path].map { |path| "/parent#{path}/gems/nosuchgem-1.2.3/lib/foo.rb" }
 
     assert_equal backtrace, @bc.clean(backtrace)
+  end
+
+  test "backtrace cleaner is Ractor shareable" do
+    assert_ractor_shareable @bc
   end
 end
 

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -7,25 +7,35 @@ module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner # :nodoc:
     RENDER_TEMPLATE_PATTERN = /:in [`'].*_\w+_{2,3}\d+_\d+'/
 
+    class << self
+      def root
+        @root ||= Rails.root && "#{Rails.root}/"
+      end
+    end
+
     def initialize
       super
-      add_filter do |line|
+      add_filter(&ActiveSupport::Ractors.shareable_proc do |line|
         # We may be called before Rails.root is assigned.
         # When that happens we fallback to not truncating.
-        @root ||= Rails.root && "#{Rails.root}/"
-        @root && line.start_with?(@root) ? line.from(@root.size) : line
-      end
-      add_filter do |line|
+        BacktraceCleaner.root && line.start_with?(BacktraceCleaner.root) ? line.from(BacktraceCleaner.root.size) : line
+      end)
+      add_filter(&ActiveSupport::Ractors.shareable_proc do |line|
         if RENDER_TEMPLATE_PATTERN.match?(line)
           line.sub(RENDER_TEMPLATE_PATTERN, "")
         else
           line
         end
-      end
+      end)
 
-      add_silencer do |line|
+      add_silencer(&ActiveSupport::Ractors.shareable_proc do |line|
         line.start_with?(File::SEPARATOR, "vendor/", "bin/")
-      end
+      end)
+    end
+
+    def freeze
+      self.class.root
+      super
     end
 
     def clean(backtrace, kind = :silent)

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -2,8 +2,11 @@
 
 require "abstract_unit"
 require "rails/backtrace_cleaner"
+require "active_support/testing/ractors_assertions"
 
 class BacktraceCleanerTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def setup
     @cleaner = Rails::BacktraceCleaner.new
   end
@@ -88,5 +91,9 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     method_name = ActionView::Template.new(nil, "app/views/application/index.html.erb", nil, locals: []).send :method_name
     frame = @cleaner.clean_frame("app/views/application/index.html.erb:4:in 'block in #{method_name}'", :all)
     assert_equal "app/views/application/index.html.erb:4", frame
+  end
+
+  test "backtrace cleaner is Ractor shareable" do
+    assert_ractor_shareable @cleaner
   end
 end


### PR DESCRIPTION
### Motivation / Background

We are trying to make `Rails.application` ractor shareable. It contains a backtrace cleaner with some default filters and silencers which are not shareable. 

### Detail

Make the backtrace cleaner's default silencers and filters shareable with `Ractor.shareable_proc`.

The developer can add filters and we can't be sure if they are expecting to call methods on `self`. So we can't safely make these shareable by default since self is changed to `nil` inside of a shareable proc. If we did so for a proc calling a method on self it would only raise at call time which is a big footgun.

Perhaps we could update these apis to offer a way to opt in to making them shareable by default, or use prism to check if the proc calls self, but I don't have fully formed idea to propose yet.

On the other hand, for class macro type things where we `instance_exec` the block, we can make those shareable by default and we have a PR to do that on the way.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
