### PR TITLE
Clear the type column when removing a polymorphic `has_one`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix replacing or clearing a polymorphic `has_one` leaving a stale type column
+    on the removed record.
+
+    *Kenta Ishizaki*
+
 *   Add `sql_notifications` connection configuration option to disable SQL
     notifications for specific database connections.
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -120,6 +120,7 @@ module ActiveRecord
           Array(reflection.foreign_key).each do |foreign_key_column|
             record[foreign_key_column] = nil unless foreign_key_column.in?(Array(record.class.primary_key))
           end
+          record[reflection.type] = nil if reflection.type.present?
         end
 
         def transaction_if(value, &block)

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -25,6 +25,15 @@ require "models/room"
 require "models/user"
 require "models/dats"
 
+class HasOneStaleTypeChild < ActiveRecord::Base
+  self.table_name = "faces"
+end
+
+class HasOneStaleTypeOwner < ActiveRecord::Base
+  self.table_name = "humans"
+  has_one :stale_type_child, class_name: "HasOneStaleTypeChild", as: :poly_human_without_inverse
+end
+
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
@@ -137,6 +146,22 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_nil chef.employable_id
     assert_nil chef.employable_type
+  end
+
+  def test_replacing_a_polymorphic_has_one_nullifies_the_type_column
+    owner = HasOneStaleTypeOwner.create!
+    child = HasOneStaleTypeChild.create!
+    owner.stale_type_child = child
+
+    child.reload
+    assert_equal owner.id, child.poly_human_without_inverse_id
+    assert_equal "HasOneStaleTypeOwner", child.poly_human_without_inverse_type
+
+    owner.stale_type_child = nil
+
+    child.reload
+    assert_nil child.poly_human_without_inverse_id
+    assert_nil child.poly_human_without_inverse_type
   end
 
   def test_nullification_on_destroyed_association


### PR DESCRIPTION
### Summary

Replacing or clearing a polymorphic `has_one` (`owner.thing = other` / `owner.thing = nil`) nullifies the foreign key but leaves the polymorphic **type** column with its old value. The `dependent: :nullify` path clears both, so the two "nullify" routes disagree.

### Details

`HasOneAssociation#nullify_owner_attributes` only clears the foreign key:

```ruby
# activerecord/lib/active_record/associations/has_one_association.rb
def nullify_owner_attributes(record)
  Array(reflection.foreign_key).each do |foreign_key_column|
    record[foreign_key_column] = nil unless foreign_key_column.in?(Array(record.class.primary_key))
  end
end
```

The `dependent: :nullify` path uses `ForeignAssociation#nullified_owner_attributes`, which clears the type too:

```ruby
def nullified_owner_attributes
  Hash.new.tap do |attrs|
    Array(reflection.foreign_key).each { |foreign_key| attrs[foreign_key] = nil }
    attrs[reflection.type] = nil if reflection.type.present?
  end
end
```

So removing a polymorphic `has_one` by assignment leaves `<name>_type` set while `<name>_id` becomes `nil`.

In the common bidirectional setup (the removed record declares the inverse `belongs_to`), the `belongs_to` machinery happens to clear the type, hiding the issue. It surfaces for a **one-directional** polymorphic `has_one`, where the child carries the polymorphic columns but does not declare the inverse `belongs_to` — nothing else resets the type, so it is left dangling.

### Reproduction

```ruby
class Human < ActiveRecord::Base
  has_one :face, as: :describable          # Face has describable_id / describable_type
end
class Face < ActiveRecord::Base; end       # no belongs_to :describable

h = Human.create!
h.face = Face.create!                       # describable_id + describable_type = "Human"
h.face = nil

face.reload
face.describable_id    # => nil
face.describable_type  # => "Human"   (stale; should be nil)

# The dependent: :nullify path on the same models clears both.
```

### Fix

Null the type column in `nullify_owner_attributes` as well, mirroring `nullified_owner_attributes`:

```ruby
record[reflection.type] = nil if reflection.type.present?
```

For a non-polymorphic `has_one`, `reflection.type` is `nil`, so the line is a no-op.

### Testing

Added `test_replacing_a_polymorphic_has_one_nullifies_the_type_column` to `has_one_associations_test.rb`, using a one-directional polymorphic `has_one` (child without the inverse `belongs_to`). It asserts both the id and the type are cleared after `owner.child = nil`. The type assertion fails on `main` (`"…Owner"` left behind) and passes with this change. `has_one_associations_test.rb` (103), `has_one_through_associations_test.rb` (52), and `inverse_associations_test.rb` (93) are green on sqlite3, postgresql, and mysql2.