### PR TITLE
Resolve attribute aliases in the `update_attribute` readonly check

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `update_attribute`/`update_attribute!` to raise for a readonly attribute referenced by an alias.
+
+    *Kenta Ishizaki*
+
 *   Fix `reset_column_sequences!` for tables in quoted schemas.
 
     *Kenta Ishizaki*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -546,6 +546,7 @@ module ActiveRecord
     # Also see #update_column.
     def update_attribute(name, value)
       name = name.to_s
+      name = self.class.attribute_aliases[name] || name
       verify_readonly_attribute(name)
       public_send("#{name}=", value)
 
@@ -568,6 +569,7 @@ module ActiveRecord
     # ActiveRecord::Callbacks for further details.
     def update_attribute!(name, value)
       name = name.to_s
+      name = self.class.attribute_aliases[name] || name
       verify_readonly_attribute(name)
       public_send("#{name}=", value)
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -81,6 +81,7 @@ previous_value, ActiveRecord.raise_on_assign_to_attr_readonly = ActiveRecord.rai
 
 class NonRaisingPost < Post
   attr_readonly :title
+  alias_attribute :headline, :title
 end
 
 ActiveRecord.raise_on_assign_to_attr_readonly = previous_value
@@ -837,6 +838,16 @@ class BasicsTest < ActiveRecord::TestCase
     post.reload
     assert_equal "cannot change this", post.title
     assert_equal "changed via []=", post.body
+  end
+
+  def test_update_attribute_raises_for_a_readonly_aliased_attribute_when_configured_to_not_raise
+    post = NonRaisingPost.create!(title: "cannot change this", body: "changeable")
+
+    assert_raises(ActiveRecord::ActiveRecordError) { post.update_attribute(:headline, "changed") }
+    assert_raises(ActiveRecord::ActiveRecordError) { post.update_attribute!(:headline, "changed") }
+
+    post.reload
+    assert_equal "cannot change this", post.title
   end
 
   def test_readonly_attributes_on_belongs_to_association


### PR DESCRIPTION
### Summary

`update_attribute` / `update_attribute!` are documented to raise `ActiveRecord::ActiveRecordError` when the attribute is marked as readonly, but the readonly check does not resolve attribute aliases. Passing an **alias** of a readonly attribute skips the guard. With `raise_on_assign_to_attr_readonly` disabled (the framework default; it becomes `true` under `config.load_defaults 7.1`), the write is then silently applied in memory and `update_attribute` returns `true` without persisting anything — inconsistent with passing the canonical name, which raises.

### Details

```ruby
# activerecord/lib/active_record/persistence.rb
def update_attribute(name, value)
  name = name.to_s
  verify_readonly_attribute(name)   # <- alias not resolved
  public_send("#{name}=", value)
  save(validate: false)
end
```

`verify_readonly_attribute(name)` → `readonly_attribute?(name)` → `_attr_readonly.include?(name)`, and `_attr_readonly` stores the **canonical** column name. So an alias never matches and the guard is skipped.

`update_columns` already handles this correctly — it resolves the alias before the check:

```ruby
name = self.class.attribute_aliases[name] || name
verify_readonly_attribute(name) || name
```

When `raise_on_assign_to_attr_readonly` is `true`, the writer (`HasReadonlyAttributes#_write_attribute`) raises on the resolved canonical name, so the end result is the same (it raises). But when it's `false`, nothing raises: the alias setter writes the readonly column in memory, `save(validate: false)` drops it from the UPDATE, and `update_attribute` returns `true`. The write is silently lost, and the behavior diverges from the canonical name (which always raises from `update_attribute`'s own guard).

### Reproduction

```ruby
# with config.active_record.raise_on_assign_to_attr_readonly = false
class Account < ActiveRecord::Base
  alias_attribute :available_credit, :credit_limit
  attr_readonly :credit_limit
end

a = Account.create!(credit_limit: 5)

a.update_attribute(:credit_limit, 77)       # raises ActiveRecord::ActiveRecordError (correct)
a.update_columns(available_credit: 99)      # raises ActiveRecord::ActiveRecordError (correct)

a.update_attribute(:available_credit, 88)   # => true   (no raise!)
a.credit_limit                              # => 88      (changed in memory)
Account.find(a.id).credit_limit             # => 5       (write silently dropped)
```

### Fix

Resolve the alias before the readonly check in both `update_attribute` and `update_attribute!`, exactly as `update_columns` does:

```ruby
name = name.to_s
name = self.class.attribute_aliases[name] || name
verify_readonly_attribute(name)
```

Non-aliased names are unaffected (`attribute_aliases[name]` is `nil`, so `name` is kept).

### Prior discussion (#45060)

[#45060](https://github.com/rails/rails/pull/45060) touched a nearby area but a different case: it declared the **alias itself** readonly (`alias_attribute :name, :title; attr_readonly :name`) and asked whether `update(name: ...)` should raise. It was closed without merging because the maintainers couldn't agree on whether an alias *should* inherit the canonical attribute's readonly status (the `alias_method` analogy — an alias can have different visibility from its target).

This change does not reopen that question. Here the **canonical** attribute is the one marked readonly (`attr_readonly :credit_limit`), and the only issue is that one entry point (`update_attribute`) fails to resolve the alias while another (`update_columns`) already does — and has since [`0c508aeb61`](https://github.com/rails/rails/commit/0c508aeb61) (April 2022). So the behavior of treating an alias of a readonly canonical attribute as readonly is already shipped; this is purely an internal-consistency fix to align `update_attribute`/`update_attribute!` with `update_columns`, not a new design decision about alias semantics.

### Testing

Added `test_update_attribute_raises_for_a_readonly_aliased_attribute_when_configured_to_not_raise` to `base_test.rb`, alongside the existing `NonRaisingPost` (`raise_on_assign_to_attr_readonly = false`) coverage — given an `alias_attribute :headline, :title` on that readonly `title`, it asserts both the canonical name and the alias raise from `update_attribute`/`update_attribute!`. The alias assertions fail on `main` (nothing raised) and pass with this change. `base_test.rb` (204) and `persistence_test.rb` (170) are green on sqlite3, postgresql, and mysql2.