### PR TITLE
Fix incorrect callback ordering note in Active Record callbacks docs

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -173,8 +173,7 @@ module ActiveRecord
   #
   # If a <tt>before_*</tt> callback throws +:abort+, all the later callbacks and
   # the associated action are cancelled.
-  # \Callbacks are generally run in the order they are defined, with the exception of callbacks defined as
-  # methods on the model, which are called last.
+  # \Callbacks are run in the order they are defined.
   #
   # == Ordering callbacks
   #


### PR DESCRIPTION
### Summary

The "Canceling callbacks" section of the `ActiveRecord::Callbacks` documentation states:

> \Callbacks are generally run in the order they are defined, **with the
> exception of callbacks defined as methods on the model, which are called last.**

The "called last" exception is false. Callbacks run strictly in the order they are defined, regardless of whether each one is a method (symbol), proc, or block.

### Evidence

```ruby
class Widget < ActiveRecord::Base
  attr_reader :log
  after_initialize { @log = [] }

  before_save -> { log << :proc1 }
  before_save :method1
  before_save -> { log << :proc2 }
  before_save :method2
  def method1 = log << :method1
  def method2 = log << :method2
end

Widget.create!.log
# => [:proc1, :method1, :proc2, :method2]
```

If the doc were correct, the method callbacks would be deferred to the end: `[:proc1, :proc2, :method1, :method2]`. They are not — they run exactly where defined.

This note dates back to [`823554eafe`](https://github.com/rails/rails/commit/823554eafe) (January 2005, pre-Rails 1.0) and was accurate at the time. The original callback dispatcher ran macro-registered callbacks first (`callbacks_for(method).each`), then called the overwritable method (`def before_save() end`) last via `invoke_and_notify` / `send(method)` — exactly the behavior described by the removed sentence. The [v2.3.8 API docs](https://api.rubyonrails.org/v2.3.8/classes/ActiveRecord/Callbacks.html) still document both styles. When `ActiveSupport::Callbacks` unified the mechanism, the two-track dispatch was removed and all callbacks became definition-order, but this sentence survived unchanged for over 20 years.

### Change

Documentation only — drops the incorrect "with the exception … called last" clause so the section simply reads:

> \Callbacks are run in the order they are defined.

No code or behavior changes.