### PR TITLE
Apply SameSite default to all session stores, not only CookieStore

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Respect `config.action_dispatch.cookies_same_site_protection` for session
+    cookies written by Rails session stores.
+
+    *Bart de Water*
+
 *   Deprecate `ActionDispatch::Cookies::HTTP_HEADER`.
 
     Use `Rack::SET_COOKIE` instead.

--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -19,8 +19,11 @@ module ActionDispatch
     end
 
     module Compatibility
+      DEFAULT_SAME_SITE = ActiveSupport::Ractors.shareable_proc { |request| request.cookies_same_site_protection } # :nodoc:
+
       def initialize(app, options = {})
         options[:key] ||= "_session_id"
+        options[:same_site] = DEFAULT_SAME_SITE if !options.key?(:same_site)
         super
       end
 

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -59,11 +59,8 @@ module ActionDispatch
         end
       end
 
-      DEFAULT_SAME_SITE = ActiveSupport::Ractors.shareable_proc { |request| request.cookies_same_site_protection } # :nodoc:
-
       def initialize(app, options = {})
         options[:cookie_only] = true
-        options[:same_site] = DEFAULT_SAME_SITE if !options.key?(:same_site)
         super
       end
 

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -3,6 +3,10 @@
 require "abstract_unit"
 
 class CacheStoreTest < ActionDispatch::IntegrationTest
+  SameSite = proc { :lax }
+
+  include CookieAssertions
+
   class TestController < ActionController::Base
     def no_session_access
       head :ok
@@ -251,7 +255,42 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
     assert_not_nil store.delete_session({}, sid, {})
   end
 
+  test "default same_site derives SameSite from env" do
+    with_test_route_set do
+      get "/set_session_value"
+      assert_set_cookie_attributes("_session_id", "SameSite=Lax")
+    end
+  end
+
+  test "explicit same_site sets SameSite" do
+    cache_store_options(same_site: :strict)
+
+    with_test_route_set do
+      get "/set_session_value"
+      assert_set_cookie_attributes("_session_id", "SameSite=Strict")
+    end
+  end
+
+  test "explicit nil same_site omits SameSite" do
+    cache_store_options(same_site: nil)
+
+    with_test_route_set do
+      get "/set_session_value"
+      assert_not_set_cookie_attributes("_session_id", "SameSite")
+    end
+  end
+
   private
+    # Overwrite `get` to set env hash
+    def get(path, **options)
+      options[:headers] ||= {}
+      options[:headers].tap do |config|
+        config["action_dispatch.cookies_same_site_protection"] ||= SameSite
+      end
+
+      super
+    end
+
     def cache_store_options(options = {})
       @cache_store_options ||= options
     end


### PR DESCRIPTION
### Motivation / Background

After switching over from the default cookie store to a cache backed store I noticed Rails wasn't explicitly setting SameSite=Lax anymore. I found that this was reported in a message on a closed issue back in 2024 as a regression in Rails 7.1: https://github.com/rails/rails/issues/45681#issuecomment-1974983825 introduced by https://github.com/rails/rails/pull/45688, so this should get backports (but with a regular `proc`)

### Additional information

The tests added are the same as in the cookie store test, I kept them to ensure there's no regression there.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
