### PR TITLE
Add RFC 9110 compliant Accept header content negotiation opt-in

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `config.action_dispatch.strict_accept_header` to stop forcing an
+    HTML response when the `Accept` header contains the `*/*` wildcard.
+
+    Rails used to treat any `Accept` header containing `*/*` as a browser and default
+    to HTML. When enabled, a request with `Accept: application/json, */*` returns JSON.
+
+    Defaults to `false`; new applications enable it via `load_defaults 8.2`.
+
+    *Willian Tenfen Wazilewski*, *Hartley McGuire*
+
 *   Rate limiting calls `cache_key` on `by:` if the object responds to it.
 
     ```ruby

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -18,6 +18,7 @@ module ActionDispatch
 
       included do
         mattr_accessor :ignore_accept_header, default: false
+        mattr_accessor :strict_accept_header, default: false
       end
 
       # The MIME type of the HTTP request, such as [Mime](:xml).
@@ -227,8 +228,11 @@ module ActionDispatch
         end
 
         def valid_accept_header
-          (xhr? && (accept.present? || content_mime_type)) ||
-            (accept.present? && !accept.match?(BROWSER_LIKE_ACCEPTS))
+          if xhr?
+            accept.present? || content_mime_type
+          elsif accept.present?
+            self.class.strict_accept_header || !accept.match?(BROWSER_LIKE_ACCEPTS)
+          end
         end
 
         def use_accept_header

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -16,6 +16,7 @@ module ActionDispatch
     config.action_dispatch.show_exceptions = :all
     config.action_dispatch.tld_length = 1
     config.action_dispatch.ignore_accept_header = false
+    config.action_dispatch.strict_accept_header = false
     config.action_dispatch.rescue_templates = {}
     config.action_dispatch.rescue_responses = {}
     config.action_dispatch.wrapper_exceptions = []
@@ -80,6 +81,7 @@ module ActionDispatch
 
       ActiveSupport.on_load(:action_dispatch_request) do
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
+        self.strict_accept_header = app.config.action_dispatch.strict_accept_header
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       end
 

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/core_ext/object/with"
 require "active_support/log_subscriber/test_helper"
 
 class RespondToController < ActionController::Base
@@ -606,6 +607,15 @@ class RespondToControllerTest < ActionController::TestCase
     @request.accept = "application/json, application/xml, */*"
     get :json_xml_or_html
     assert_equal "HTML", @response.body
+
+    ActionDispatch::Request.with(strict_accept_header: true) do
+      get :json_xml_or_html
+      assert_equal "JSON", @response.body
+
+      @request.accept = "application/xml, */*"
+      get :json_xml_or_html
+      assert_equal "XML", @response.body
+    end
   end
 
   def test_handle_any_with_template

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -64,6 +64,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_controller.forgery_protection_verification_strategy`](#config-action-controller-forgery-protection-verification-strategy): `:header_only`
 - [`config.action_controller.rescue_from_event_backtrace`](#config-action-controller-rescue-from-event-backtrace): `:array`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
+- [`config.action_dispatch.strict_accept_header`](#config-action-dispatch-strict-accept-header): `true`
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `true`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
@@ -2309,6 +2310,19 @@ config.action_dispatch.domain_extractor = CustomDomainExtractor
 #### `config.action_dispatch.ignore_accept_header`
 
 Is used to determine whether to ignore accept headers from a request. Defaults to `false`.
+
+#### `config.action_dispatch.strict_accept_header`
+
+Controls whether an `Accept` header containing `*/*` forces an HTML response.
+When enabled, Rails honors more specific types instead — e.g. `Accept:
+application/json, */*` returns JSON instead of HTML.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 8.2                   | `true`               |
 
 #### `config.action_dispatch.x_sendfile_header`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -376,6 +376,7 @@ module Rails
           end
 
           if respond_to?(:action_dispatch)
+            action_dispatch.strict_accept_header = true
             action_dispatch.default_headers = {
               "X-Frame-Options" => "SAMEORIGIN",
               "X-Content-Type-Options" => "nosniff",

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -101,3 +101,10 @@
 # Otherwise, when set to `nil`, only the first string of the backtrace is included, stripping the `Rails.root` from the controller path.
 #++
 # Rails.application.config.action_controller.rescue_from_event_backtrace = :array
+
+###
+# Honor specific formats in the `Accept` header even when it contains the `*/*`
+# wildcard, instead of always defaulting to HTML. For example, a request with
+# `Accept: application/json, */*` now returns JSON.
+#++
+# Rails.application.config.action_dispatch.strict_accept_header = true


### PR DESCRIPTION


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request adds RFC 9110 compliant Accept header content negotiation while maintaining backward compatibility. Rails has used a workaround since 2010 that assumes any Accept header containing `*/*` is from a browser and defaults to HTML. This was necessary for IE7, but modern browsers properly follow RFC 9110 and no longer need this special handling.

  The feature is opt-in via `config.action_dispatch.respect_accept_header_rfc9110` and defaults to `false`, ensuring no breaking changes for existing applications.

Added as opt-in flag, future versions can deprecate and major version can remove workaround for IE7 I think... 

  Fixes #57353

### Detail

This Pull Request adds:

  1. **New Configuration Flag** (`config.action_dispatch.respect_accept_header_rfc9110`)
     - Defaults to `false` for backward compatibility
     - When enabled, respects RFC 9110 media type specificity and quality values
     - When disabled, uses the existing IE7 workaround (`BROWSER_LIKE_ACCEPTS` filter)

  2. **Configuration Conflict Warning**
     - If both `ignore_accept_header` and `respect_accept_header_rfc9110` are enabled, a warning is logged
     - Explains that `ignore_accept_header` takes precedence

  3. **Upgrade Path**
     - Documentation in `new_framework_defaults_8_2.rb.tt` with commented-out opt-in
     - Clear explanation of the change and its impact
     - CHANGELOG entry for users

  4. **Comprehensive Tests**
     - `test_rfc9110_accept_header_respects_specificity`: Verifies specific types are prioritized over wildcards
     - `test_rfc9110_with_xhr_request`: Ensures XHR requests work correctly in both modes

### Additional information

  **Example Use Case:**
  ```ruby
  # Before (current behavior):
  # Accept: application/json, */*
  # Returns: HTML (due to IE7 workaround)

  # After (with respect_accept_header_rfc9110 = true):
  # Accept: application/json, */*
  # Returns: JSON (RFC 9110 compliant)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
