### PR TITLE
Skip Proc and Regexp filter_attributes when syncing to filter_parameters

### DIFF
--- a/activerecord/lib/active_record/filter_attribute_handler.rb
+++ b/activerecord/lib/active_record/filter_attribute_handler.rb
@@ -64,9 +64,12 @@ module ActiveRecord
         list.each do |attribute|
           next if klass.abstract_class? || klass == Base
 
-          klass_name = klass.name ? klass.model_name.element : nil
-          filter = [klass_name, attribute.to_s].compact.join(".")
-          app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
+          case attribute
+          when Symbol, String
+            klass_name = klass.name ? klass.model_name.element : nil
+            filter = [klass_name, attribute.to_s].compact.join(".")
+            app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
+          end
         end
       end
   end

--- a/railties/test/application/active_record_railtie_test.rb
+++ b/railties/test/application/active_record_railtie_test.rb
@@ -68,6 +68,22 @@ module ApplicationTests
       assert_includes Rails.application.config.filter_parameters, "message.special_attr"
     end
 
+    test "filter_parameters omit Proc and Regexp filter_attributes" do
+      app "development"
+
+      class Post < ActiveRecord::Base
+        self.table_name = "posts"
+        self.filter_attributes += [:special_attr, /secret/i, ->(key, value) { value.reverse! }]
+      end
+
+      assert_includes Rails.application.config.filter_parameters, "post.special_attr"
+
+      garbage = Rails.application.config.filter_parameters.grep(String).select do |filter|
+        filter.include?("#<Proc") || filter.include?("(?i-mx:")
+      end
+      assert_empty garbage
+    end
+
     test "filter_parameters are inherited from AR parent classes" do
       app "development"
 


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord::FilterAttributeHandler` (added in #55251) syncs model `filter_attributes` into `Rails.application.config.filter_parameters` as `"<model_element>.<attribute>"` strings, so sensitive model attributes are also filtered from parameter logging. `apply_filter` calls `attribute.to_s` on every declared entry, but `filter_attributes` also accepts Procs and Regexps (for `#inspect` filtering via `ActiveSupport::ParameterFilter`), and stringifying those produces filters that can never match a parameter key:

```ruby
class User < ApplicationRecord
  self.filter_attributes += [:token, /secret/i, ->(key, value) { value.reverse! }]
end

Rails.application.config.filter_parameters
# => [..., "user.token",
#          "user.(?i-mx:secret)",
#          "user.#<Proc:0x000000010a3c5d68 ...>"]
```

### Detail

I first noticed this while upgrading an application to Rails 8.1 that uses a redaction lambda in `config.filter_parameters`: after boot, `config.filter_parameters` had accumulated a stringified copy of the lambda for each model. The dead entries are visible to every downstream consumer of `config.filter_parameters` (log formatters, gems that inspect it for diagnostics, audit specs), and the Proc form embeds an object ID, so the array contents aren't stable across boots. This is just effectively garbage.

This change makes `apply_filter` skip entries that aren't Symbols or Strings, the only types that compose meaningfully with a model-name prefix (`ActiveSupport::ParameterFilter` treats dotted strings as nested key filters). Proc and Regexp filters keep working as before, globally through `ActiveSupport::ParameterFilter` and per model through the inspection filter.

### Additional information

The config-level path I originally hit was already fixed on main by #56759, which has not been backported to 8-1-stable. On 8.1 it might be worth considering backporting both that change and this one, since together they cover all the ways these entries can leak; this fix applies cleanly to both branches.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
