### PR TITLE
Support `only:` and `except:` on `_deliver` callbacks in ActionMailer

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add support for `config.action_mailer.raise_on_missing_callback_actions`
+    when using `_deliver` callbacks with `only:` and `except:` options.
+
+    *Iaroslav*
+
 *   Add `assert_part` and `assert_no_part` to `ActionMailer::TestCase`
 
     ```ruby

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -475,7 +475,6 @@ module ActionMailer
   # * <tt>deliver_later_queue_name</tt> - The queue name used by <tt>deliver_later</tt> with the default
   #   <tt>delivery_job</tt>. Mailers can set this to use a custom queue name.
   class Base < AbstractController::Base
-    include Callbacks
     include DeliveryMethods
     include QueuedDelivery
     include Rescuable
@@ -493,6 +492,8 @@ module ActionMailer
     include AbstractController::AssetPaths
     include AbstractController::Callbacks
     include AbstractController::Caching
+
+    include Callbacks
 
     include ActionView::Layouts
 

--- a/actionmailer/lib/action_mailer/callbacks.rb
+++ b/actionmailer/lib/action_mailer/callbacks.rb
@@ -16,7 +16,7 @@ module ActionMailer
       # message is sent to the delivery method.
       def before_deliver(*filters, &blk)
         _insert_callbacks(filters, blk) do |name, options|
-          set_callback(:deliver, :before, name, options, &blk)
+          set_callback(:deliver, :before, name, options)
         end
       end
 
@@ -24,14 +24,14 @@ module ActionMailer
       # message's delivery method is finished.
       def after_deliver(*filters, &blk)
         _insert_callbacks(filters, blk) do |name, options|
-          set_callback(:deliver, :after, name, options, &blk)
+          set_callback(:deliver, :after, name, options)
         end
       end
 
       # Defines a callback that will get called around the message's deliver method.
       def around_deliver(*filters, &blk)
         _insert_callbacks(filters, blk) do |name, options|
-          set_callback(:deliver, :around, name, options, &blk)
+          set_callback(:deliver, :around, name, options)
         end
       end
 

--- a/actionmailer/lib/action_mailer/callbacks.rb
+++ b/actionmailer/lib/action_mailer/callbacks.rb
@@ -15,18 +15,24 @@ module ActionMailer
       # Defines a callback that will get called right before the
       # message is sent to the delivery method.
       def before_deliver(*filters, &blk)
-        set_callback(:deliver, :before, *filters, &blk)
+        _insert_callbacks(filters, blk) do |name, options|
+          set_callback(:deliver, :before, name, options, &blk)
+        end
       end
 
       # Defines a callback that will get called right after the
       # message's delivery method is finished.
       def after_deliver(*filters, &blk)
-        set_callback(:deliver, :after, *filters, &blk)
+        _insert_callbacks(filters, blk) do |name, options|
+          set_callback(:deliver, :after, name, options, &blk)
+        end
       end
 
       # Defines a callback that will get called around the message's deliver method.
       def around_deliver(*filters, &blk)
-        set_callback(:deliver, :around, *filters, &blk)
+        _insert_callbacks(filters, blk) do |name, options|
+          set_callback(:deliver, :around, name, options, &blk)
+        end
       end
 
       def internal_methods # :nodoc:

--- a/actionmailer/test/callbacks_test.rb
+++ b/actionmailer/test/callbacks_test.rb
@@ -11,6 +11,7 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
   setup do
     @previous_delivery_method = ActionMailer::Base.delivery_method
     ActionMailer::Base.delivery_method = :test
+    CallbackMailer.raise_on_missing_callback_actions = false
     CallbackMailer.rescue_from_error = nil
     CallbackMailer.after_deliver_instance = nil
     CallbackMailer.around_deliver_instance = nil
@@ -23,6 +24,7 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
   teardown do
     ActionMailer::Base.deliveries.clear
     ActionMailer::Base.delivery_method = @previous_delivery_method
+    CallbackMailer.raise_on_missing_callback_actions = false
     CallbackMailer.rescue_from_error = nil
     CallbackMailer.after_deliver_instance = nil
     CallbackMailer.around_deliver_instance = nil
@@ -100,6 +102,32 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
     assert_not_includes CallbackMailer.deliver_callback_log, :after_only
     assert_not_includes CallbackMailer.deliver_callback_log, :around_only_before
     assert_not_includes CallbackMailer.deliver_callback_log, :around_only_after
+  end
+
+  test "deliver callbacks with only option follow the mailer action name" do
+    CallbackMailer.test_raise_action.deliver_now
+    assert_not_includes CallbackMailer.deliver_callback_log, [:only_action, "test_raise_action"]
+
+    CallbackMailer.test_message.deliver_now
+    assert_includes CallbackMailer.deliver_callback_log, [:only_action, "test_message"]
+  end
+
+  test "deliver callbacks with except option ignore missing actions by default" do
+    CallbackMailer.test_raise_action.deliver_now
+    assert_includes CallbackMailer.deliver_callback_log, [:except_action, "test_raise_action"]
+
+    CallbackMailer.test_message.deliver_now
+    assert_not_includes CallbackMailer.deliver_callback_log, [:except_action, "test_message"]
+  end
+
+  test "raise_on_missing_callback_actions raises for missing deliver callback actions" do
+    CallbackMailer.raise_on_missing_callback_actions = true
+
+    error = assert_raises(AbstractController::ActionNotFound) do
+      CallbackMailer.test_raise_action.deliver_now
+    end
+
+    assert_match(/The non_existent_action action could not be found/, error.message)
   end
 
   test "around_deliver is called after rescue_from on action processing exceptions" do

--- a/actionmailer/test/callbacks_test.rb
+++ b/actionmailer/test/callbacks_test.rb
@@ -17,6 +17,7 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
     CallbackMailer.abort_before_deliver = nil
     CallbackMailer.abort_before_action = nil
     CallbackMailer.around_handles_error = nil
+    CallbackMailer.deliver_callback_log = []
   end
 
   teardown do
@@ -28,6 +29,7 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
     CallbackMailer.abort_before_deliver = nil
     CallbackMailer.abort_before_action = nil
     CallbackMailer.around_handles_error = nil
+    CallbackMailer.deliver_callback_log = []
   end
 
   test "deliver_now should call after_deliver callback and can access sent message" do
@@ -72,6 +74,32 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
     end
     assert_kind_of CallbackMailer, CallbackMailer.after_deliver_instance
     assert_not_empty CallbackMailer.after_deliver_instance.message.message_id
+  end
+
+  test "deliver callbacks support only conditions" do
+    CallbackMailer.test_message.deliver_now
+
+    assert_includes CallbackMailer.deliver_callback_log, :before_only
+    assert_includes CallbackMailer.deliver_callback_log, :after_only
+    assert_includes CallbackMailer.deliver_callback_log, :around_only_before
+    assert_includes CallbackMailer.deliver_callback_log, :around_only_after
+    assert_not_includes CallbackMailer.deliver_callback_log, :before_except
+    assert_not_includes CallbackMailer.deliver_callback_log, :after_except
+    assert_not_includes CallbackMailer.deliver_callback_log, :around_except_before
+    assert_not_includes CallbackMailer.deliver_callback_log, :around_except_after
+  end
+
+  test "deliver callbacks support except conditions" do
+    CallbackMailer.another_test_message.deliver_now
+
+    assert_includes CallbackMailer.deliver_callback_log, :before_except
+    assert_includes CallbackMailer.deliver_callback_log, :after_except
+    assert_includes CallbackMailer.deliver_callback_log, :around_except_before
+    assert_includes CallbackMailer.deliver_callback_log, :around_except_after
+    assert_not_includes CallbackMailer.deliver_callback_log, :before_only
+    assert_not_includes CallbackMailer.deliver_callback_log, :after_only
+    assert_not_includes CallbackMailer.deliver_callback_log, :around_only_before
+    assert_not_includes CallbackMailer.deliver_callback_log, :around_only_after
   end
 
   test "around_deliver is called after rescue_from on action processing exceptions" do

--- a/actionmailer/test/mailers/callback_mailer.rb
+++ b/actionmailer/test/mailers/callback_mailer.rb
@@ -8,6 +8,7 @@ class CallbackMailer < ActionMailer::Base
   cattr_accessor :abort_before_action
   cattr_accessor :abort_before_deliver
   cattr_accessor :around_handles_error
+  cattr_accessor :deliver_callback_log
 
   rescue_from CallbackMailerError do |error|
     @@rescue_from_error = error
@@ -21,8 +22,24 @@ class CallbackMailer < ActionMailer::Base
     throw :abort if @@abort_before_deliver
   end
 
+  before_deliver(only: :test_message) do
+    CallbackMailer.deliver_callback_log << :before_only
+  end
+
+  before_deliver(except: :test_message) do
+    CallbackMailer.deliver_callback_log << :before_except
+  end
+
   after_deliver do
     @@after_deliver_instance = self
+  end
+
+  after_deliver(only: :test_message) do
+    CallbackMailer.deliver_callback_log << :after_only
+  end
+
+  after_deliver(except: :test_message) do
+    CallbackMailer.deliver_callback_log << :after_except
   end
 
   around_deliver do |mailer, block|
@@ -32,8 +49,24 @@ class CallbackMailer < ActionMailer::Base
     raise unless @@around_handles_error
   end
 
+  around_deliver(only: :test_message) do |mailer, block|
+    CallbackMailer.deliver_callback_log << :around_only_before
+    block.call
+    CallbackMailer.deliver_callback_log << :around_only_after
+  end
+
+  around_deliver(except: :test_message) do |mailer, block|
+    CallbackMailer.deliver_callback_log << :around_except_before
+    block.call
+    CallbackMailer.deliver_callback_log << :around_except_after
+  end
+
   def test_message(*)
     mail(from: "test-sender@test.com", to: "test-receiver@test.com", subject: "Test Subject", body: "Test Body")
+  end
+
+  def another_test_message(*)
+    mail(from: "test-sender@test.com", to: "test-receiver@test.com", subject: "Another Test Subject", body: "Another Test Body")
   end
 
   def test_raise_action

--- a/actionmailer/test/mailers/callback_mailer.rb
+++ b/actionmailer/test/mailers/callback_mailer.rb
@@ -30,6 +30,14 @@ class CallbackMailer < ActionMailer::Base
     CallbackMailer.deliver_callback_log << :before_except
   end
 
+  before_deliver(only: :test_message) do
+    CallbackMailer.deliver_callback_log << [:only_action, action_name]
+  end
+
+  before_deliver(except: [:test_message, :non_existent_action]) do
+    CallbackMailer.deliver_callback_log << [:except_action, action_name]
+  end
+
   after_deliver do
     @@after_deliver_instance = self
   end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2973,6 +2973,10 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `ActionMailer::MailDeliveryJob` |
 | 6.0                   | `"ActionMailer::MailDeliveryJob"` |
 
+#### `config.action_mailer.raise_on_missing_callback_actions`
+
+Mirrors `config.action_controller.raise_on_missing_callback_actions`, but applies to mailers. Defaults to `false`.
+
 ### Configuring Active Support
 
 There are a few configuration options available in Active Support:


### PR DESCRIPTION
### Motivation / Background

`only:` and `except:` options are ignored in ActionMailer callbacks when added in #47630. This feels inconsistent so this uses the same normalization wrapper from AbstractController to support them.

cc @bensheldon 

Closes #50830.

### Detail

This uses the same normalization as `*_action` callbacks to be consistent:

https://github.com/rails/rails/blob/fa8f0812160665bff083a089d2bb2fc1817ea03e/actionpack/lib/abstract_controller/callbacks.rb#L232-L237

https://github.com/rails/rails/blob/fa8f0812160665bff083a089d2bb2fc1817ea03e/actionpack/lib/abstract_controller/callbacks.rb#L95-L98

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
