### PR TITLE
Action Cable: only skip eager loading for Redis and Postgres

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -41,7 +41,10 @@ Zeitwerk::Loader.for_gem.tap do |loader|
   )
 
   loader.do_not_eager_load(
-    "#{lib}/action_cable/subscription_adapter", # Adapters are required and loaded on demand.
+    # These adapters trigger optional dependencies so they are required and loaded on demand.
+    "#{lib}/action_cable/subscription_adapter/redis.rb",
+    "#{lib}/action_cable/subscription_adapter/postgresql.rb",
+
     "#{lib}/action_cable/test_helper.rb",
     Dir["#{lib}/action_cable/**/test_case.rb"]
   )

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -7,9 +7,6 @@ require "redis-client"
 
 require "active_support/core_ext/hash/except"
 
-require "action_cable/subscription_adapter/base"
-require "action_cable/subscription_adapter/channel_prefix"
-
 module ActionCable
   module SubscriptionAdapter
     class Redis < Base # :nodoc:


### PR DESCRIPTION
Better fix for: https://github.com/rails/rails/pull/57249

The other adapters are small enough that it's not really worth skipping them.

FYI @gotrevor-notarize, after merging I realized this would be a better fix.