### PR TITLE
Fix plain English explanation of nested query in Active Record Querying guide [ci-skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2518,8 +2518,8 @@ SELECT authors.* FROM authors
   INNER JOIN suppliers ON suppliers.id = books.supplier_id
 ```
 
-The SQL query will return all authors that have books with reviews _and_ have
-been ordered by a customer, _and_ the suppliers for those books.
+The SQL query will return all authors that have a book which has
+both a review from a customer that has placed an order _and_ a supplier.
 
 #### Specifying Conditions on the Joined Tables
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because [the current explanation for nested association joining](https://guides.rubyonrails.org/active_record_querying.html#joining-nested-associations-multiple-level) in the Active Record Querying guide is plain wrong.

### Detail

This Pull Request changes the explanation in the aforementioned subsection to reflect the actual structure of the query.

To explain how the plain English query deviates from the Active Record and SQL forms, consider a scenario in which an author's books have never been ordered, and have received reviews only from customers who haven't bought it (arguably weird, but not explicitly disallowed). In that case, the author would still be a part of the result set of the Active Record and SQL queries, while the plain English version excludes it.

Furthermore, the plain English explanation seems to suggest that details about suppliers are returned by the query. In fact, the join only acts as a filter to consider only books which have at least one supplier.

### Additional information

It seem like PR #56341 (not yet live on the deployed guides) updated the phrasing of the explanation, while leaving the content unchanged.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
