### PR TITLE
Fix reaper fork test by disabling GSS encryption.

### DIFF
--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -146,7 +146,7 @@ module ActiveRecord
 
       if Process.respond_to?(:fork)
         def test_connection_pool_starts_reaper_in_fork
-          pool_config = duplicated_pool_config(reaping_frequency: "0.0001")
+          pool_config = duplicated_pool_config(reaping_frequency: "0.0001", gssencmode: "disable")
           pool = ConnectionPool.new(pool_config)
           pool.checkout
 


### PR DESCRIPTION
### Motivation / Background

Fixes a segmentation fault in `ReaperTest#test_connection_pool_starts_reaper_in_fork` on macOS. The crash occurs because libpq's GSS encryption negotiation triggers macOS's non-fork-safe Heimdal/Keychain stack when the child process creates a new PostgreSQL connection after `fork()`.

### Detail

Sets `PGGSSENCMODE=disable` in the forked child process before creating the `ConnectionPool`, preventing the GSS code path that causes the segfault. This is a known upstream issue (PostgreSQL bug #16041, ruby-pg #538) with no permanent fix available.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [X] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~