### PR TITLE
Replace deprecated US/Eastern timezone with America/New_York in tests

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       # Force known GUC defaults at connect time so query-count
       # assertions are deterministic regardless of server configuration.
       # TimeZone must be non-UTC so the :utc/:local distinction is visible.
-      KNOWN_SERVER_DEFAULTS = "-c TimeZone=US/Eastern -c IntervalStyle=postgres -c standard_conforming_strings=on -c client_min_messages=notice"
+      KNOWN_SERVER_DEFAULTS = "-c TimeZone=America/New_York -c IntervalStyle=postgres -c standard_conforming_strings=on -c client_min_messages=notice"
 
       def setup
         @connection = ActiveRecord::Base.lease_connection

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -215,7 +215,7 @@ module ActiveRecord
       adapter.remove_instance_variable(:@native_database_types) if adapter.instance_variable_defined?(:@native_database_types)
     end
 
-    def with_env_tz(new_tz = "US/Eastern")
+    def with_env_tz(new_tz = "America/New_York")
       old_tz, ENV["TZ"] = ENV["TZ"], new_tz
       yield
     ensure


### PR DESCRIPTION
### Motivation / Background

Fixes #57586

`US/Eastern` was removed as a valid PostgreSQL timezone name in recent IANA tzdata updates, causing `ActiveRecord::ConnectionNotEstablished` on systems with updated PostgreSQL builds (e.g. Homebrew). `America/New_York` is the canonical IANA name and is universally supported.

### Detail

Replaces `US/Eastern` with `America/New_York` in:
- `postgresql_adapter_test.rb` (`KNOWN_SERVER_DEFAULTS` connection option)
- `test_case.rb` (`with_env_tz` default)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~