### PR TITLE
Fix order-dependent test failures with `sqlite3_mem`

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -977,24 +977,26 @@ module ActiveRecord
       end
     end
 
-    test "suppresses notifications when sql_notifications=false" do
-      run_without_connection do |orig_connection|
-        ActiveRecord::Base.establish_connection(orig_connection.merge(sql_notifications: false))
+    unless in_memory_db?
+      test "suppresses notifications when sql_notifications=false" do
+        run_without_connection do |orig_connection|
+          ActiveRecord::Base.establish_connection(orig_connection.merge(sql_notifications: false))
 
+          notifications = capture_notifications("sql.active_record") do
+            Post.first
+          end
+
+          assert_empty notifications
+        end
+      end
+
+      test "sql_notifications are enabled by default" do
         notifications = capture_notifications("sql.active_record") do
           Post.first
         end
 
-        assert_empty notifications
+        assert_not_empty notifications
       end
-    end
-
-    test "sql_notifications are enabled by default" do
-      notifications = capture_notifications("sql.active_record") do
-        Post.first
-      end
-
-      assert_not_empty notifications
     end
   end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -607,17 +607,15 @@ class DirtyTest < ActiveRecord::TestCase
     assert_not pirate.previous_changes.key?("created_on")
   end
 
-  class Testings < ActiveRecord::Base; end
   def test_field_named_field
-    ActiveRecord::Base.lease_connection.create_table :testings do |t|
-      t.string :field
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "pirates"
+      attribute :field, :string
     end
+
     assert_nothing_raised do
-      Testings.new.attributes
+      klass.new.attributes
     end
-  ensure
-    ActiveRecord::Base.lease_connection.drop_table :testings rescue nil
-    ActiveRecord::Base.clear_cache!
   end
 
   def test_datetime_attribute_can_be_updated_with_fractional_seconds


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because running `ARCONN=sqlite3_mem bundle exec rake sqlite3_mem:test` produced ~3000 order-dependent test failures, all tracing back to two tests that are incompatible with SQLite in-memory databases. Individual test files passed in isolation, but the full suite cascaded into failures because these tests destroyed shared state that subsequent tests depended on.

Fixes #57589

### Detail

This Pull Request fixes two independent root causes:

**1. `DirtyTest#test_field_named_field` — SchemaCache corruption**

The test called `ActiveRecord::Base.clear_cache!` in its `ensure` block after `create_table`/`drop_table`. This replaced the global SchemaCache with an empty instance, causing "Could not find table" errors in all subsequent tests. Rewritten to use an anonymous class with the `attribute` API on the existing `pirates` table, following the patterns already established in the same file (e.g. `test "attribute_will_change! doesn't try to save non-persistable attributes"`). The top-level `Testings` class definition is also removed.

**2. `AdapterConnectionTest` sql_notifications tests — Database destruction**

Two tests (`test_suppresses_notifications_when_sql_notifications=false` and `test_sql_notifications_are_enabled_by_default`) were outside the `unless in_memory_db?` guard that protects the rest of `AdapterConnectionTest`. They use `run_without_connection`, which calls `remove_connection` followed by `establish_connection`. On SQLite `:memory:` databases, `remove_connection` destroys the in-memory database, and the subsequent `establish_connection` creates a fresh empty one with no schema. Wrapped both tests with `unless in_memory_db?`, consistent with the rest of the class.

### Additional information

The `unconnected_test.rb` already demonstrates the correct pattern for tests that must `remove_connection` on in-memory databases — it calls `load_schema if in_memory_db?` in its teardown to restore the schema after reconnecting.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #57589]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~