### PR TITLE
[RF-Docs] [ci-skip] Active Job Basics guide (#57101)

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -1,4 +1,5 @@
-**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON <https://guides.rubyonrails.org>.**
+**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON
+<https://guides.rubyonrails.org>.**
 
 Active Job Basics
 =================
@@ -18,24 +19,29 @@ After reading this guide, you will know:
 What is Active Job?
 -------------------
 
-Active Job is a framework in Rails designed for declaring background jobs and
-executing them on a queuing backend. It provides a standardized interface for
-tasks like sending emails, processing data, or handling regular maintenance
-activities, such as clean-ups and billing charges. By offloading these tasks
-from the main application thread to a queuing backend like the default Solid
-Queue, Active Job ensures that time-consuming operations do not block the
-request-response cycle. This can improve the performance and responsiveness of
-the application, allowing it to handle tasks in parallel.
+The Active Job Rails framework allows you to declare background jobs and execute
+them on a queuing backend. It provides a consistent, high-level interface for
+common asynchronous tasks such as sending emails, processing data, or performing
+periodic maintenance tasks.
 
-Create and Enqueue Jobs
------------------------
+The goal of background jobs is to move long-running or non-critical work out of
+the HTTP request-response cycle and into a background queue (such as the default
+Solid Queue), and keep the web requests fast and responsive. This separation
+allows applications to perform work asynchronously, scale background processing
+independently, and execute multiple tasks in parallel without blocking user
+interactions.
 
-This section will provide a step-by-step guide to create a job and enqueue it.
+Creating Jobs
+-------------
 
-### Create the Job
+This section provides a step-by-step guide for defining a job Ruby class and
+then using the `perform_*` method to enqueue work to be executed in the
+background.
+
+### Defining a Job
 
 Active Job provides a Rails generator to create jobs. The following will create
-a job in `app/jobs` (with an attached test case under `test/jobs`):
+a job in the `app/jobs` directory (with tests under `test/jobs`):
 
 ```bash
 $ bin/rails generate job guests_cleanup
@@ -44,14 +50,8 @@ create    test/jobs/guests_cleanup_job_test.rb
 create  app/jobs/guests_cleanup_job.rb
 ```
 
-You can also create a job that will run on a specific queue:
-
-```bash
-$ bin/rails generate job guests_cleanup --queue urgent
-```
-
-If you don't want to use a generator, you could create your own file inside of
-`app/jobs`, just make sure that it inherits from `ApplicationJob`.
+If you don't want to use a generator, you can create your own file inside of
+`app/jobs` and define a class that inherits from `ApplicationJob`.
 
 Here's what a job looks like:
 
@@ -65,434 +65,218 @@ class GuestsCleanupJob < ApplicationJob
 end
 ```
 
-Note that you can define `perform` with as many arguments as you want.
+Note that you can define the `perform` method inside a job class with as many
+arguments as you want.
 
-If you already have an abstract class and its name differs from
-`ApplicationJob`, you can pass the `--parent` option to indicate you want a
-different abstract class:
+If your application uses a custom abstract job base class instead of
+`ApplicationJob`, you can use the `--parent` option with the generator. The
+parent class must itself inherit from `ApplicationJob`. This can be useful for
+grouping related functionality in one place.
+
+For example, given a custom abstract job class using
+[queue_as](https://api.rubyonrails.org/classes/ActiveJob/QueueName/ClassMethods.html#method-i-queue_as):
+
+```ruby
+class PaymentJob < ApplicationJob
+  queue_as :payments
+end
+```
+
+You can generate a new job that inherits from it:
 
 ```bash
 $ bin/rails generate job process_payment --parent=payment_job
 ```
 
+The above creates a class that will use the `payments` queue:
+
 ```ruby
 class ProcessPaymentJob < PaymentJob
-  queue_as :default
-
   def perform(*args)
-    # Do something later
+    # Do something later, uses the "payments" queue
   end
 end
 ```
 
-### Enqueue the Job
+### Calling the `perform_*` Methods
 
-Enqueue a job using [`perform_later`][] and, optionally, [`set`][]. Like so:
+Once you have defined a job class with a `perform` method, you'd typically call
+it using [`perform_later`][] to enqueue the work to be executed on a queuing
+backend. Or use [`perform_now`][] if you want the job to execute immediately
+without queueing. Both `perform_later` and `perform_now` call `perform` under
+the hood.
+
+In the examples below, the methods can be called from anywhere in your Rails
+application, most commonly from controllers, models, or other jobs.
 
 ```ruby
-# Enqueue a job to be performed as soon as the queuing system is
-# free.
-GuestsCleanupJob.perform_later guest
+# To run a job immediately without enqueuing it
+GuestsCleanupJob.perform_now(guest)
+
+# To enqueue a job to be performed later
+GuestsCleanupJob.perform_later(guest)
 ```
 
+Use the
+[`set`](https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set)
+method to specify exactly when to perform a job.
+
 ```ruby
-# Enqueue a job to be performed tomorrow at noon.
+# Enqueue a job to be performed tomorrow at noon
 GuestsCleanupJob.set(wait_until: Date.tomorrow.noon).perform_later(guest)
-```
 
-```ruby
-# Enqueue a job to be performed 1 week from now.
+# Enqueue a job to be performed one week from now
 GuestsCleanupJob.set(wait: 1.week).perform_later(guest)
 ```
 
+Since both `perform_now` and `perform_later` forward their arguments to
+`perform`, you can pass as many arguments as defined in `perform`, including
+keyword arguments:
+
 ```ruby
-# `perform_now` and `perform_later` will call `perform` under the hood so
-# you can pass as many arguments as defined in the latter.
 GuestsCleanupJob.perform_later(guest1, guest2, filter: "some_filter")
 ```
 
-That's it!
+#### Example: Sending Email
 
+One of the most common jobs in a modern web application is sending emails to
+users. Active Job can do this outside of the request-response cycle, so the user
+doesn't have to wait on it. Active Job is integrated with Action Mailer so you
+can easily send emails asynchronously:
+
+```ruby
+# If you want to send the email now, use #deliver_now
+UserMailer.welcome(@user).deliver_now
+
+# If you want to send the email asynchronously, use #deliver_later
+UserMailer.welcome(@user).deliver_later
+```
+
+The `deliver_now` and `deliver_later` methods are Action Mailer's counterparts
+to `perform_now` and `perform_later`. Under the hood, `deliver_later` works by
+enqueuing an `ActionMailer::MailDeliveryJob` — a built-in Active Job job that
+Rails provides — which goes through the same queuing pipeline as any job you
+define yourself, and will eventually call the `perform` method in your Job
+class.
+
+[`perform_now`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Execution.html#method-i-perform_now
 [`perform_later`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
+ https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]:
     https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
 
-### Enqueue Jobs in Bulk
+### Supported Argument Types for `perform`
 
-You can enqueue multiple jobs at once using
-[`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later).
-For more details see [Bulk Enqueuing](#bulk-enqueuing).
+ActiveJob supports the following types of arguments by default:
 
-Default Backend: Solid Queue
-------------------------------
+  - Basic types (`NilClass`, `String`, `Integer`, `Float`, `BigDecimal`,
+    `TrueClass`, `FalseClass`)
+  - `Symbol`
+  - `Date`
+  - `Time`
+  - `DateTime`
+  - `ActiveSupport::TimeWithZone`
+  - `ActiveSupport::Duration`
+  - `Hash` (Keys should be of `String` or `Symbol` type)
+  - `ActiveSupport::HashWithIndifferentAccess`
+  - `Array`
+  - `Range`
+  - `Module`
+  - `Class`
 
-Solid Queue, which is enabled by default from Rails version 8.0 and onward, is a
-database-backed queuing system for Active Job, allowing you to queue large
-amounts of data without requiring additional dependencies such as Redis.
+Active Job supports
+[GlobalID](https://github.com/rails/globalid/blob/main/README.md) for arguments.
+This makes it possible to pass live Active Record objects to your job instead of
+class/id pairs, which you then have to manually deserialize.
 
-Besides regular job enqueuing and processing, Solid Queue supports delayed jobs,
-concurrency controls, numeric priorities per job, priorities by queue order, and
-more.
-
-### Set Up
-
-#### Development
-
-In development, Rails provides an asynchronous in-process queuing system, which
-keeps the jobs in RAM. If the process crashes or the machine is reset, then all
-outstanding jobs are lost with the default async backend. This can be fine for
-smaller apps or non-critical jobs in development.
-
-However, if you use Solid Queue instead, you can configure it in the same way as
-in the production environment:
+For example, instead of having to do something like this:
 
 ```ruby
-# config/environments/development.rb
-config.active_job.queue_adapter = :solid_queue
-config.solid_queue.connects_to = { database: { writing: :queue } }
-```
-
-which sets the `:solid_queue` adapter as the default for Active Job in the
-development environment, and connects to the `queue` database for writing.
-
-Thereafter, you'd add `queue` to the development database configuration:
-
-```yaml
-# config/database.yml
-development:
-  primary:
-    <<: *default
-    database: storage/development.sqlite3
-  queue:
-    <<: *default
-    database: storage/development_queue.sqlite3
-    migrations_paths: db/queue_migrate
-```
-
-NOTE: The key `queue` from the database configuration needs to match the key
-used in the configuration for `config.solid_queue.connects_to`.
-
-You can then run `db:prepare` to ensure the `queue` database in `development` has all the required tables:
-
-```bash
-$ bin/rails db:prepare
-```
-
-TIP: You can find the default generated schema for the `queue` database in
-`db/queue_schema.rb`. They will contain tables like
-`solid_queue_ready_executions`, `solid_queue_scheduled_executions`, and more.
-
-Finally, to start the queue and start processing jobs you can run:
-
-```bash
-bin/jobs start
-```
-
-#### Production
-
-Solid Queue is already configured for the production environment. If you open
-`config/environments/production.rb`, you will see the following:
-
-```ruby
-# config/environments/production.rb
-# Replace the default in-process and non-durable queuing backend for Active Job.
-config.active_job.queue_adapter = :solid_queue
-config.solid_queue.connects_to = { database: { writing: :queue } }
-```
-
-Additionally, the database connection for the `queue` database is configured in
-`config/database.yml`:
-
-```yaml
-# config/database.yml
-# Store production database in the storage/ directory, which by default
-# is mounted as a persistent Docker volume in config/deploy.yml.
-production:
-  primary:
-    <<: *default
-    database: storage/production.sqlite3
-  queue:
-    <<: *default
-    database: storage/production_queue.sqlite3
-    migrations_paths: db/queue_migrate
-```
-
-Make sure you run `db:prepare` so your database is ready to use:
-
-```bash
-$ bin/rails db:prepare
-```
-
-
-### Configuration
-
-The configuration options for Solid Queue are defined in `config/queue.yml`.
-Here is an example of the default configuration:
-
-```yaml
-default: &default
-  dispatchers:
-    - polling_interval: 1
-      batch_size: 500
-  workers:
-    - queues: "*"
-      threads: 3
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.1
-```
-
-In order to understand the configuration options for Solid Queue, you must
-understand the different types of roles:
-
-- **Dispatchers**: They select jobs scheduled to run for the future. When it's
-  time for these jobs to run, dispatchers move them from the
-  `solid_queue_scheduled_executions` table to the `solid_queue_ready_executions`
-  table so workers can pick them up. They also manage concurrency-related
-  maintenance.
-- **Workers**: They pick up jobs that are ready to run. These jobs are taken
-  from the `solid_queue_ready_executions` table.
-- **Scheduler**: This takes care of recurring tasks, adding jobs to the queue
-  when they're due.
-- **Supervisor**: It oversees the whole system, managing workers and
-  dispatchers. It starts and stops them as needed, monitors their health, and
-  ensures everything runs smoothly.
-
-Everything is optional in the `config/queue.yml`. If no configuration is
-provided, Solid Queue will run with one dispatcher and one worker with default
-settings. Below are some of the configuration options you can set in
-`config/queue.yml`:
-
-| **Option**                           | **Description**                                                                                     | **Default Value**                             |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| **polling_interval**                 | Time in seconds workers/dispatchers wait before checking for more jobs.                             | 1 second (dispatchers), 0.1 seconds (workers) |
-| **batch_size**                       | Number of jobs dispatched in a batch.                                                               | 500                                           |
-| **concurrency_maintenance_interval** | Time in seconds the dispatcher waits before checking for blocked jobs that can be unblocked.        | 600 seconds                                   |
-| **queues**                           | List of queues workers fetch jobs from. Supports `*` for all queues or queue name prefixes.         | `*`                                           |
-| **threads**                          | Maximum size of the thread pool for each worker. Determines how many jobs a worker fetches at once. | 3                                             |
-| **processes**                        | Number of worker processes forked by the supervisor. Each process can dedicate a CPU core.          | 1                                             |
-| **concurrency_maintenance**          | Whether the dispatcher performs concurrency maintenance work.                                       | true                                          |
-
-You can read more about these [configuration options in the Solid Queue
-documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#configuration).
-There are also [additional configuration
-options](https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings)
-that can be set in `config/<environment>.rb` to further configure Solid Queue in
-your Rails Application.
-
-### Queue Order
-
-As per the configuration options in the [Configuration section](#configuration),
-the `queues` configuration option will list the queues that workers will pick
-jobs from. In a list of queues, the order matters. Workers will pick jobs from
-the first queue in the list - once there are no more jobs in the first queue,
-only then will it move onto the second, and so on.
-
-```yaml
-# config/queue.yml
-production:
-  workers:
-    - queues:[active_storage*, mailers]
-      threads: 3
-      polling_interval: 5
-```
-
-In the above example, workers will fetch jobs from queues starting with
-"active_storage", like  the `active_storage_analyse` queue and
-`active_storage_transform` queue. Only when no jobs remain in the
-`active_storage`-prefixed queues will workers move on to the `mailers` queue.
-
-NOTE: The wildcard `*` (like at the end of "active_storage") is only allowed on
-its own or at the end of a queue name to match all queues with the same prefix.
-You can't specify queue names such as `*_some_queue`.
-
-WARNING: Using wildcard queue names (e.g., `queues: active_storage*`) can slow
-down polling performance in SQLite and PostgreSQL due to the need for a `DISTINCT`
-query to identify all matching queues, which can be slow on large tables in these RDBMS.
-For better performance, it’s best to specify exact queue names instead of using
-wildcards. Read more about this in [Queues specification and performance in the
-Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#queues-specification-and-performance)
-
-Active Job supports positive integer priorities when enqueuing jobs (see
-[Priority section](#priority)). Within a single queue, jobs are picked based on
-their priority (with lower integers being higher priority). However, when you
-have multiple queues, the order of the queues themselves takes priority.
-
-For example, if you have two queues, `production` and `background`, jobs in the
-`production` queue will always be processed first, even if some jobs in the
-`background` queue have a higher priority.
-
-### Threads, Processes, and Signals
-
-In Solid Queue, parallelism is achieved through threads (configurable via the
-[`threads` parameter](#configuration)), processes (via the [`processes`
-parameter](#configuration)), or horizontal scaling. The supervisor manages
-processes and responds to the following signals:
-
-- **TERM, INT**: Starts graceful termination, sending a TERM signal and waiting
-  up to `SolidQueue.shutdown_timeout`. If not finished, a QUIT signal forces
-  processes to exit.
-- **QUIT**: Forces immediate termination of processes.
-
-If a worker is killed unexpectedly (e.g., with a `KILL` signal), in-flight jobs
-are marked as failed, and errors like `SolidQueue::Processes::ProcessExitError`
-or `SolidQueue::Processes::ProcessPrunedError` are raised. Heartbeat settings
-help manage and detect expired processes. Read more about [Threads, Processes
-and Signals in the Solid Queue
-documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#threads-processes-and-signals).
-
-### Errors When Enqueuing
-
-Solid Queue raises a `SolidQueue::Job::EnqueueError` when Active Record errors
-occur during job enqueuing. This is different from the `ActiveJob::EnqueueError`
-raised by Active Job, which handles the error and makes `perform_later` return
-false. This makes error handling trickier for jobs enqueued by Rails or
-third-party gems like `Turbo::Streams::BroadcastJob`.
-
-For recurring tasks, any errors encountered while enqueuing are logged, but they
-won’t be raised. Read more about [Errors When Enqueuing in the Solid Queue
-documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#errors-when-enqueuing).
-
-### Concurrency Controls
-
-Solid Queue extends Active Job with concurrency controls, allowing you to limit
-how many jobs of a certain type or with specific arguments can run at the same
-time. If a job exceeds the limit, it will be blocked until another job finishes
-or the duration expires. For example:
-
-```ruby
-class MyJob < ApplicationJob
-  limits_concurrency to: 2, key: ->(contact) { contact.account }, duration: 5.minutes
-
-  def perform(contact)
-    # perform job logic
+class GuestsCleanupJob < ApplicationJob
+  def perform(guests_class, guests_id, depth)
+    guests = guests_class.constantize.find(guests_id)
+    guest.cleanup(depth)
   end
 end
 ```
 
-In this example, only two `MyJob` instances for the same account will run
-concurrently. After that, other jobs will be blocked until one completes.
-
-The `group` parameter can be used to control concurrency across different job
-types. For instance, two different job classes that use the same group will have
-their concurrency limited together:
+Using GlobalID, you can simply do:
 
 ```ruby
-class Box::MovePostingsByContactToDesignatedBoxJob < ApplicationJob
-  limits_concurrency key: ->(contact) { contact }, duration: 15.minutes, group: "ContactActions"
-end
-
-class Bundle::RebundlePostingsJob < ApplicationJob
-  limits_concurrency key: ->(bundle) { bundle.contact }, duration: 15.minutes, group: "ContactActions"
-end
-```
-
-This ensures that only one job for a given contact can run at a time, regardless
-of the job class.
-
-Read more about [Concurrency Controls in the Solid Queue
-documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#concurrency-controls).
-
-### Error Reporting on Jobs
-
-If your error tracking service doesn’t automatically report job errors, you can
-manually hook into Active Job to report them. For example, you can add a
-`rescue_from` block in `ApplicationJob`:
-
-```ruby
-class ApplicationJob < ActiveJob::Base
-  rescue_from(Exception) do |exception|
-    Rails.error.report(exception)
-    raise exception
+class GuestsCleanupJob < ApplicationJob
+  def perform(guest, depth)
+    guest.cleanup(depth)
   end
 end
 ```
 
-If you use ActionMailer, you’ll need to handle errors for `MailDeliveryJob`
-separately:
+This works with any class that mixes in `GlobalID::Identification`, which is
+mixed into Active Record by default.
+
+#### Add Custom Types by Defining Serializers
+
+You can extend the list of supported argument types by defining your own
+serializer for your custom types. A serializer needs three methods: `serialize`,
+`deserialize`, and `klass`.
+
+The `serialize` method converts an object into a simpler representation using
+only supported types. The recommended approach is to return a Hash with string
+keys, calling `super` to let Active Job merge in the serializer's type
+information:
 
 ```ruby
-class ApplicationMailer < ActionMailer::Base
-  ActionMailer::MailDeliveryJob.rescue_from(Exception) do |exception|
-    Rails.error.report(exception)
-    raise exception
+# app/serializers/money_serializer.rb
+class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
+  def serialize(money)
+    super(
+      "amount" => money.amount,
+      "currency" => money.currency
+    )
+  end
+
+  def deserialize(hash)
+    Money.new(hash["amount"], hash["currency"])
+  end
+
+  def klass
+    Money
   end
 end
 ```
 
-### Transactional Integrity on Jobs
+The `deserialize` method receives that hash and reconstructs the original
+object. The `klass` method returns the class this serializer handles so Active
+Job can use it to determine which serializer to apply to a given argument.
 
-⚠️ Having your jobs in the same ACID-compliant database as your application data
-enables a powerful yet sharp tool: taking advantage of transactional integrity
-to ensure some action in your app is not committed unless your job is also committed
-and vice versa, and ensuring that your job won't be enqueued until the transaction
-within which you're enqueuing it is committed. This can be very powerful and useful,
-but it can also backfire if you base some of your logic on this behavior,
-and in the future, you move to another active job backend, or if you simply move
-Solid Queue to its own database, and suddenly the behavior changes under you.
-
-Because this can be quite tricky and many people shouldn't need to worry about it,
-by default Solid Queue is configured in a different database as the main app.
-
-However, if you use Solid Queue in the same database as your app, you can make sure you
-don't rely accidentallly on transactional integrity with Active Job’s
-`enqueue_after_transaction_commit` option which can be enabled for individual jobs or
-all jobs through `ApplicationJob`:
+Once a serializer is defined, it needs to be added to the list of serializers
+Rails knows about:
 
 ```ruby
-class ApplicationJob < ActiveJob::Base
-  self.enqueue_after_transaction_commit = true
+# config/initializers/custom_serializers.rb
+Rails.application.config.active_job.custom_serializers << MoneySerializer
+```
+
+Custom Active Job serializers are registered during application initialization
+and are expected to remain stable for the lifetime of the process. Reloadable
+autoloading is not supported in this context.
+
+To ensure serializers are loaded only once (and not reloaded in development),
+place them in an autoload_once_paths directory, such as:
+
+```ruby
+# config/application.rb
+module YourApp
+  class Application < Rails::Application
+    config.autoload_once_paths << "#{root}/app/serializers"
+  end
 end
 ```
 
-You can also configure Solid Queue to use the same database as your app while
-avoiding relying on transactional integrity by setting up a separate database
-connection for Solid Queue jobs. Read more about [Transactional Integrity in the
-Solid Queue
-documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#jobs-and-transactional-integrity)
+Enqueuing Jobs
+--------------
 
-### Recurring Tasks
-
-Solid Queue supports recurring tasks, similar to cron jobs. These tasks are
-defined in a configuration file (by default, `config/recurring.yml`) and can be
-scheduled at specific times. Here's an example of a task configuration:
-
-```yaml
-production:
-  a_periodic_job:
-    class: MyJob
-    args: [42, { status: "custom_status" }]
-    schedule: every second
-  a_cleanup_task:
-    command: "DeletedStuff.clear_all"
-    schedule: every day at 9am
-```
-
-Each task specifies a `class` or `command` and a `schedule` (parsed using
-[Fugit](https://github.com/floraison/fugit)). You can also pass arguments to
-jobs, such as in the example for `MyJob` where `args` are passed. This can be
-passed as a single argument, a hash, or an array of arguments that can also
-include kwargs as the last element in the array. This allows jobs to run
-periodically at specified times.
-
-Read more about [Recurring Tasks in the Solid Queue
-documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks).
-
-### Job Tracking and Management
-
-A tool like
-[`mission_control-jobs`](https://github.com/rails/mission_control-jobs) can help
-centralize the monitoring and management of failed jobs. It provides insights
-into job statuses, failure reasons, and retry behaviors, enabling you to track
-and resolve issues more effectively.
-
-For instance, if a job fails to process a large file due to a timeout,
-`mission_control-jobs` allows you to inspect the failure, review the job’s
-arguments and execution history, and decide whether to retry, requeue, or
-discard it.
-
-Queues
-------
+### Naming Queues
 
 With Active Job you can schedule the job to run on a specific queue using
 [`queue_as`][]:
@@ -502,6 +286,13 @@ class GuestsCleanupJob < ApplicationJob
   queue_as :low_priority
   # ...
 end
+```
+
+When using a generator, you can also create a job that will run on a specific
+queue:
+
+```bash
+$ bin/rails generate job guests_cleanup --queue low_priority
 ```
 
 You can prefix the queue name for all your jobs using
@@ -522,26 +313,23 @@ class GuestsCleanupJob < ApplicationJob
   queue_as :low_priority
   # ...
 end
-
-# Now your job will run on queue production_low_priority on your
-# production environment and on staging_low_priority
-# on your staging environment
 ```
+
+Now your job will run on queue `production_low_priority` on your production
+environment and on `staging_low_priority` on your staging environment.
 
 You can also configure the prefix on a per job basis.
 
 ```ruby
+# This will override the global prefix and this job won't be prefixed.
 class GuestsCleanupJob < ApplicationJob
   queue_as :low_priority
   self.queue_name_prefix = nil
   # ...
 end
-
-# Now your job's queue won't be prefixed, overriding what
-# was configured in `config.active_job.queue_name_prefix`.
 ```
 
-The default queue name prefix delimiter is '\_'.  This can be changed by setting
+The default queue name prefix delimiter is '_'.  This can be changed by setting
 [`config.active_job.queue_name_delimiter`][] in `application.rb`:
 
 ```ruby
@@ -560,15 +348,13 @@ class GuestsCleanupJob < ApplicationJob
   queue_as :low_priority
   # ...
 end
-
-# Now your job will run on queue production.low_priority on your
-# production environment and on staging.low_priority
-# on your staging environment
 ```
 
-To control the queue from the job level you can pass a block to `queue_as`. The
+Now the queue will be named `production.low_priority` or `staging.low_priority`.
+
+You can control the queue at the job level by passing a block to `queue_as`. The
 block will be executed in the job context (so it can access `self.arguments`),
-and it must return the queue name:
+and it's return value must be a queue name. For example:
 
 ```ruby
 class ProcessVideoJob < ApplicationJob
@@ -588,7 +374,8 @@ end
 ```
 
 ```ruby
-ProcessVideoJob.perform_later(Video.last)
+last_video = Video.last
+ProcessVideoJob.perform_later(last_video)
 ```
 
 If you want more control on what queue a job will be run you can pass a `:queue`
@@ -597,6 +384,12 @@ option to `set`:
 ```ruby
 MyJob.set(queue: :another_queue).perform_later(record)
 ```
+
+TIP: One way to name queues is based on latency. So instead of "critical",
+"default", or "low", queues could be named "within_30_seconds",
+"within_5_minutes", and "within_1_hour". This can be enforced like a contract by
+configuring your queuing backend to notify your engineering team if a job sits
+in a given queue longer than the corresponding time.
 
 NOTE: If you choose to use an [alternate queuing
 backend](#alternate-queuing-backends) you may need to specify the queues to
@@ -609,9 +402,7 @@ listen to.
 [`queue_as`]:
     https://api.rubyonrails.org/classes/ActiveJob/QueueName/ClassMethods.html#method-i-queue_as
 
-
-Priority
---------
+### Queue Priority
 
 You can schedule a job to run with a specific priority using
 `queue_with_priority`:
@@ -623,15 +414,14 @@ class GuestsCleanupJob < ApplicationJob
 end
 ```
 
-Solid Queue, the default queuing backend, prioritizes jobs based on the order of
-the queues.  You can read more about it in the [Order of Queues
-section](#queue-order). If you're using Solid Queue, and both the order of the
-queues and the priority option are used, the queue order will take precedence,
-and the priority option will only apply within each queue.
+Solid Queue, the default queuing backend, prioritizes jobs based on the [order
+of the queues](#queue-order). If you're using Solid Queue with both queue order
+and priority option, the queue order will take precedence, and the priority
+option will only apply within each queue.
 
 Other queuing backends may allow jobs to be prioritized relative to others
-within the same queue or across multiple queues. Refer to the documentation of
-your backend for more information.
+within the same queue or across multiple queues. You can check the documentation
+of your backend for the specifics.
 
 Similar to `queue_as`, you can also pass a block to `queue_with_priority` to be
 evaluated in the job context:
@@ -654,7 +444,8 @@ end
 ```
 
 ```ruby
-ProcessVideoJob.perform_later(Video.last)
+last_video = Video.last
+ProcessVideoJob.perform_later(last_video)
 ```
 
 You can also pass a `:priority` option to `set`:
@@ -664,143 +455,25 @@ MyJob.set(priority: 50).perform_later(record)
 ```
 
 NOTE: If a lower priority number performs before or after a higher priority
-number depends on the adapter implementation. Refer to documentation of your
+number depends on the adapter implementation. Refer to the documentation of your
 backend for more information. Adapter authors are encouraged to treat a lower
-number as more important.
+number as more important, as a convention.
 
 [`queue_with_priority`]:
     https://api.rubyonrails.org/classes/ActiveJob/QueuePriority/ClassMethods.html#method-i-queue_with_priority
 
-Job Continuations
------------------
-
-Jobs can be split into resumable steps using continuations. This is useful when
-a job may be interrupted - for example, during queue shutdown. When using
-continuations, the job can resume from the last completed step, avoiding the
-need to restart from the beginning.
-
-To use continuations, include the `ActiveJob::Continuable` module. You can then
-define each step using the `step` method inside the `perform` method. Each step can
-be declared with a block or by referencing a method name.
-
-```ruby
-class ProcessImportJob < ApplicationJob
-  include ActiveJob::Continuable
-
-  def perform(import_id)
-    # Always runs on job start, even when resuming from an interrupted step.
-    @import = Import.find(import_id)
-
-    # Step defined using a block
-    step :initialize do
-      @import.initialize
-    end
-
-    # Step with a cursor — progress is saved and resumed if the job is interrupted
-    step :process do |step|
-      @import.records.find_each(start: step.cursor) do |record|
-        record.process
-        step.advance! from: record.id
-      end
-    end
-
-    # Step defined by referencing a method
-    step :finalize
-  end
-
-  private
-    def finalize
-      @import.finalize
-    end
-end
-```
-
-Each step runs sequentially. If the job is interrupted between steps, or within a
-step that uses a cursor, the job resumes from the last recorded position. This
-makes it easier to build long-running or multi-phase jobs that can safely pause
-and resume without losing progress.
-For more details, see [ActiveJob::Continuation](https://api.rubyonrails.org/classes/ActiveJob/Continuation.html).
-
-Callbacks
----------
-
-Active Job provides hooks to trigger logic during the life cycle of a job. Like
-other callbacks in Rails, you can implement the callbacks as ordinary methods
-and use a macro-style class method to register them as callbacks:
-
-```ruby
-class GuestsCleanupJob < ApplicationJob
-  queue_as :default
-
-  around_perform :around_cleanup
-
-  def perform
-    # Do something later
-  end
-
-  private
-    def around_cleanup
-      # Do something before perform
-      yield
-      # Do something after perform
-    end
-end
-```
-
-The macro-style class methods can also receive a block. Consider using this
-style if the code inside your block is so short that it fits in a single line.
-For example, you could send metrics for every job enqueued:
-
-```ruby
-class ApplicationJob < ActiveJob::Base
-  before_enqueue { |job| $statsd.increment "#{job.class.name.underscore}.enqueue" }
-end
-```
-
-### Available Callbacks
-
-* [`before_enqueue`][]
-* [`around_enqueue`][]
-* [`after_enqueue`][]
-* [`before_perform`][]
-* [`around_perform`][]
-* [`after_perform`][]
-* [`after_discard`][]
-
-[`before_enqueue`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_enqueue
-[`around_enqueue`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_enqueue
-[`after_enqueue`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_enqueue
-[`before_perform`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_perform
-[`around_perform`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
-[`after_perform`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
-[`after_discard`]:
-    https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-after_discard
-
-Please note that when enqueuing jobs in bulk using `perform_all_later`,
-callbacks such as `around_enqueue` will not be triggered on the individual jobs.
-See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
-
-Bulk Enqueuing
---------------
+### Bulk Enqueuing
 
 You can enqueue multiple jobs at once using
 [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later).
-Bulk enqueuing reduces the number of round trips to the queue data store (like
-Redis or a database), making it a more performant operation than enqueuing the
-same jobs individually.
+Bulk enqueuing reduces the number of round trips to the queue data store (such
+as Redis or a database), making it a more performant operation than enqueuing
+the same jobs individually.
 
-`perform_all_later` is a top-level API on Active Job. It accepts instantiated
-jobs as arguments (note that this is different from `perform_later`).
-`perform_all_later` does call `perform` under the hood. The arguments passed to
-`new` will be passed on to `perform` when it's eventually called.
-
-Here is an example calling `perform_all_later` with `GuestsCleanupJob` instances:
+The `perform_all_later` method accepts instantiated jobs as arguments (note that
+this is different from `perform_later`) and calls `perform` under the hood. The
+arguments passed to `new`, when creating new job instances, will be passed on to
+`perform` when it's eventually called. For example:
 
 ```ruby
 # Create jobs to pass to `perform_all_later`.
@@ -816,14 +489,14 @@ cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest).set(wait: 1.d
 ActiveJob.perform_all_later(cleanup_jobs)
 ```
 
-`perform_all_later` logs the number of jobs successfully enqueued, for example
-if `Guest.all.map` above resulted in 3 `cleanup_jobs`, it would log
+The `perform_all_later` call logs the number of jobs successfully enqueued, for
+example if `Guest.all.map` above resulted in 3 `cleanup_jobs`, it would log
 `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` (assuming all were enqueued).
 
 The return value of `perform_all_later` is `nil`. Note that this is different
 from `perform_later`, which returns the instance of the queued job class.
 
-### Enqueue Multiple Active Job Classes
+#### Enqueue Multiple Active Job Classes
 
 With `perform_all_later`, it's also possible to enqueue different Active Job
 class instances in the same call. For example:
@@ -850,7 +523,7 @@ notify_job = NotifyGuestsJob.new(guest)
 ActiveJob.perform_all_later(cleanup_job, export_job, notify_job)
 ```
 
-### Bulk Enqueue Callbacks
+#### Bulk Enqueue Callbacks
 
 When enqueuing jobs in bulk using `perform_all_later`, callbacks such as
 `around_enqueue` will not be triggered on the individual jobs. This behavior is
@@ -865,161 +538,763 @@ The method
 [`successfully_enqueued?`](https://api.rubyonrails.org/classes/ActiveJob/Core.html#method-i-successfully_enqueued-3F)
 can be used to find out if a given job was successfully enqueued.
 
-### Queue Backend Support
+#### Queue Backend Support
 
 For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend.
 Solid Queue, the default queue backend, supports bulk enqueuing using
 `enqueue_all`.
 
 [Other backends](#alternate-queuing-backends) like Sidekiq have a `push_bulk`
-method, which can push a large number of jobs to Redis and prevent the round
-trip network latency. GoodJob also supports bulk enqueuing with the
-`GoodJob::Bulk.enqueue` method.
+method, which the Sidekiq adapter users. internally to push a large number of
+jobs to Redis and prevent the round trip network latency. GoodJob also supports
+bulk enqueuing with the `GoodJob::Bulk.enqueue` method.
 
 If the queue backend does *not* support bulk enqueuing, `perform_all_later` will
 enqueue jobs one by one.
 
-Action Mailer
-------------
+Callbacks
+---------
 
-One of the most common jobs in a modern web application is sending emails
-outside of the request-response cycle, so the user doesn't have to wait on it.
-Active Job is integrated with Action Mailer so you can easily send emails
-asynchronously:
+Active Job provides hooks to trigger logic during the life cycle of a job. Like
+other callbacks in Rails, you can implement them as ordinary methods and
+register them using a class-level method:
 
-```ruby
-# If you want to send the email now use #deliver_now
-UserMailer.welcome(@user).deliver_now
+```ruby#4
+class GuestsCleanupJob < ApplicationJob
+  queue_as :default
 
-# If you want to send the email through Active Job use #deliver_later
-UserMailer.welcome(@user).deliver_later
+  around_perform :around_cleanup
+
+  def perform
+    # Do something later
+  end
+
+  private
+    def around_cleanup
+      # Do something before perform
+      yield
+      # Do something after perform
+    end
+end
 ```
 
-NOTE: Using the asynchronous queue from a Rake task (for example, to send an
-email using `.deliver_later`) will generally not work because Rake will likely
-end, causing the in-process thread pool to be deleted, before any/all of the
-`.deliver_later` emails are processed. To avoid this problem, use `.deliver_now`
-or run a persistent queue in development.
-
-
-Internationalization
---------------------
-
-Each job uses the `I18n.locale` set when the job was created. This is useful if
-you send emails asynchronously:
+These class-level methods also accept a block, which works well when the
+callback logic is short enough to fit on a single line. For example, sending
+metrics for every enqueued job:
 
 ```ruby
-I18n.locale = :eo
-
-UserMailer.welcome(@user).deliver_later # Email will be localized to Esperanto.
+class ApplicationJob < ActiveJob::Base
+  before_enqueue { |job| Rails.logger.info "Enqueuing #{job.class.name}" }
+end
 ```
 
+### Available Callbacks
 
-Supported Types for Arguments
-----------------------------
+There are several callbacks that Active Job supports.
 
-ActiveJob supports the following types of arguments by default:
+* [`before_enqueue`][] runs before a job is enqueued.
+* [`around_enqueue`][] wraps the enqueuing process, allowing logic to run both
+  before and after.
+* [`after_enqueue`][] runs after a job is enqueued.
 
-  - Basic types (`NilClass`, `String`, `Integer`, `Float`, `BigDecimal`,
-    `TrueClass`, `FalseClass`)
-  - `Symbol`
-  - `Date`
-  - `Time`
-  - `DateTime`
-  - `ActiveSupport::TimeWithZone`
-  - `ActiveSupport::Duration`
-  - `Hash` (Keys should be of `String` or `Symbol` type)
-  - `ActiveSupport::HashWithIndifferentAccess`
-  - `Array`
-  - `Range`
-  - `Module`
-  - `Class`
-
-### GlobalID
-
-Active Job supports
-[GlobalID](https://github.com/rails/globalid/blob/main/README.md) for
-parameters. This makes it possible to pass live Active Record objects to your
-job instead of class/id pairs, which you then have to manually deserialize.
-Before, jobs would look like this:
+For example:
 
 ```ruby
-class TrashableCleanupJob < ApplicationJob
-  def perform(trashable_class, trashable_id, depth)
-    trashable = trashable_class.constantize.find(trashable_id)
-    trashable.cleanup(depth)
+class GuestsCleanupJob < ApplicationJob
+  before_enqueue { |job| Rails.logger.info "About to enqueue #{job.class.name}" }
+  around_enqueue { |job, block| block.call }
+  after_enqueue  { |job| Rails.logger.info "Successfully enqueued #{job.class.name}" }
+end
+```
+
+* [`before_perform`][] runs before a job is performed.
+* [`around_perform`][] wraps the perform process, allowing logic to run both
+  before and after.
+* [`after_perform`][] runs after a job is performed.
+
+For example:
+
+```ruby
+class GuestsCleanupJob < ApplicationJob
+  before_perform { |job| Rails.logger.info "About to perform #{job.class.name}" }
+  around_perform { |job, block| block.call }
+  after_perform  { |job| Rails.logger.info "#{job.class.name} performed successfully" }
+end
+```
+
+Lastly, [`after_discard`][] runs when a job is discarded due to an unhandled
+exception:
+
+```ruby
+class GuestsCleanupJob < ApplicationJob
+  after_discard { |job, exception| Rails.logger.error "#{job.class.name} discarded: #{exception.message}" }
+end
+```
+
+Please note that when enqueuing jobs in bulk using `perform_all_later`,
+callbacks such as `around_enqueue` will not be triggered on the individual jobs.
+See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
+
+[`before_enqueue`]:
+ https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_enqueue
+[`around_enqueue`]:
+https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_enqueue
+[`after_enqueue`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_enqueue
+[`before_perform`]:
+https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_perform
+[`around_perform`]:
+https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
+[`after_perform`]:
+https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
+[`after_discard`]:
+https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-after_discard
+
+### Halting Callbacks
+
+You can halt the callback chain by throwing `:abort`. This works the same way as
+in Active Record and other Rails callbacks. For example, to prevent a job from
+being enqueued based on a condition:
+
+```ruby
+class GuestsCleanupJob < ApplicationJob
+  before_enqueue do |job|
+    throw :abort if ENV.fetch("DISABLE_GUESTS_CLEANUP_JOB", true)
+  end
+
+  def perform(guest)
+    # ...
   end
 end
 ```
 
-Now you can simply do:
+When `:abort` is thrown in a `before_enqueue` callback, the job will not be
+enqueued and `perform_later` will return `false`. When thrown in a
+`before_perform` callback, the job will not be performed. It will also skip the
+execution of any subsequent before, around and after callbacks.
+
+NOTE: Throwing an `:abort` does not trigger `after_discard`. The `after_discard`
+callback is specifically tied to the `discard_on` mechanism.
+
+Job Continuations
+-----------------
+
+Active Job Continuations allow jobs to be split into resumable steps, so that
+long-running jobs can make progress after interruptions. When using
+continuations, the job automatically resumes from the last completed step,
+instead of restarting from the beginning.
+
+To use continuations, include the `ActiveJob::Continuable` module in your Job
+class. You can then define each step inside the `perform` method using
+[`step`](https://api.rubyonrails.org/classes/ActiveJob/Continuation/Step.html).
 
 ```ruby
-class TrashableCleanupJob < ApplicationJob
-  def perform(trashable, depth)
-    trashable.cleanup(depth)
+class ProcessImportJob < ApplicationJob
+  include ActiveJob::Continuable
+
+  def perform(import_id)
+    # Always runs on job start, even when resuming from an interrupted step.
+    @import = Import.find(import_id)
+
+    # Step defined using a block
+    step :initialize do
+      @import.initialize
+    end
+
+    step :process do
+      @import.records.find_each { |record| record.process }
+    end
+
+    # Step defined by referencing a method
+    step :finalize
+  end
+
+  private
+    def finalize
+      @import.finalize
+    end
+end
+```
+
+Each step can be declared with a block or by referencing a method name. The
+block will be called with the step object as an argument. Methods can either
+take no arguments or a single argument for the step object.
+
+Steps are executed as soon as they are encountered. Code that is not part of a
+step will be executed on each job run. If a job is interrupted, previously
+completed steps will be skipped. If a step is in progress, it will be restarted
+or resumed with the last recorded cursor if using cursors.
+
+### Using a Cursor
+
+Steps can also use an optional
+[cursor](https://api.rubyonrails.org/classes/ActiveJob/Continuation.html#class-ActiveJob::Continuation-label-Cursors)
+to track progress *within* the step. The code in the step is responsible for
+using the cursor to continue from the appropriate location after an
+interruption. For example:
+
+```ruby
+class ProcessImportJob < ApplicationJob
+  include ActiveJob::Continuable
+
+  def perform(import_id)
+    # Always runs on job start, even when resuming from an interrupted step.
+    @import = Import.find(import_id)
+
+    # Step with a cursor
+    step :process do |step|
+      @import.records.find_each(start: step.cursor) do |record|
+        record.process
+        step.advance!
+      end
+    end
+
   end
 end
 ```
 
-This works with any class that mixes in `GlobalID::Identification`, which by
-default has been mixed into Active Record classes.
+In the above example, the cursor tracks the `id` of the last successfully
+processed record. If the job is interrupted midway through a large import, it
+resumes from where it left off rather than reprocessing records from the
+beginning, passing the saved cursor value to `find_each`.
 
-### Serializers
+Default Backend: Solid Queue
+------------------------------
 
-You can extend the list of supported argument types. You just need to define
-your own serializer:
+Solid Queue is a database-backed queue backend for Active Job and the default
+queue backend for Rails version 8.0 onwards. Rather than requiring a separate
+infrastructure dependency like Redis, Solid Queue uses your existing database to
+persist and process jobs. It supports delayed jobs, job priorities, concurrency
+controls, recurring jobs, and bulk enqueuing.
+
+### Setup and Default Configuration
+
+Solid Queue is already configured for production by default. For example, if you
+open `config/environments/production.rb`, you will see the following:
+
+```ruby#3
+# config/environments/production.rb
+# Replace the default in-process and non-durable queuing backend for Active Job.
+config.active_job.queue_adapter = :solid_queue
+config.solid_queue.connects_to = { database: { writing: :queue } }
+```
+
+Additionally, the database connection for the `queue` database is configured in
+`config/database.yml`:
+
+```yaml#8
+# config/database.yml
+# Store production database in the storage/ directory, which by default
+# is mounted as a persistent Docker volume in config/deploy.yml.
+production:
+  primary:
+    <<: *default
+    database: storage/production.sqlite3
+  queue:
+    <<: *default
+    database: storage/production_queue.sqlite3
+    migrations_paths: db/queue_migrate
+```
+
+NOTE: The key `queue` from the database configuration needs to match the key
+used in the configuration for `config.solid_queue.connects_to` (as highlighted
+in the code snippets above).
+
+In order to start using Solid Queue, run `db:prepare` so your database has Solid
+Queue related tables:
+
+```bash
+$ bin/rails db:prepare
+```
+
+TIP: You can find the schema for the `queue` database in `db/queue_schema.rb`,
+which is generated automatically. It will contain tables like
+`solid_queue_jobs`, `solid_queue_recurring_executions`,
+`solid_queue_scheduled_executions`, and more.
+
+Finally, to start the queue and start processing jobs you can run:
+
+```bash
+$ bin/jobs start
+```
+
+#### Development Environment
+
+Rails provides an asynchronous in-process queuing backend, which keeps the jobs
+in memory. With the default `async` adapter, if the process crashes or the
+machine is reset, then all outstanding jobs are lost. This can be acceptable for
+non-critical jobs in development.
+
+Alternatively, you can use Solid Queue in development. It can be configured in
+the same way as in the production environment:
+
+```ruby#3
+# config/environments/development.rb
+config.active_job.queue_adapter = :solid_queue
+config.solid_queue.connects_to = { database: { writing: :queue } }
+```
+
+Add `queue` to the development database configuration:
+
+```yml
+# config/database.yml
+development:
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  queue:
+    <<: *default
+    database: storage/development_queue.sqlite3
+    migrations_paths: db/queue_migrate
+```
+
+### Workers, Dispatchers, Supervisors
+
+Solid Queue uses three types of processes to handle job queueing and execution:
+
+1. Workers poll queues for jobs that are ready to run and execute them.
+2. Dispatchers handle scheduled jobs — they check for jobs due to run in the
+future and move them into the ready queue for workers to pick up.
+3. A Supervisor manages both workers and dispatchers, by forking and monitoring
+   them.
+
+When you run `bin/jobs start`, you're starting the supervisor process, which in
+turn forks and manages the workers and dispatchers according to the
+configuration in `config/queue.yml`. Here is an example of the default
+configuration:
+
+```yaml
+# config/queue.yml
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+```
+
+The configuration in `config/queue.yml` is optional. If no configuration is
+provided, Solid Queue will run with one dispatcher and one worker with default
+settings. Below are some of the configuration options you can set along with
+their default values`:
+
+| **Option**                           | **Description**                                                                                     | **Default Value**                             |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| **polling_interval**                 | Time in seconds workers/dispatchers wait before checking for more jobs.                             | 1 second (dispatchers), 0.1 seconds (workers) |
+| **batch_size**                       | Number of jobs dispatched in a batch.                                                               | 500                                           |
+| **concurrency_maintenance_interval** | Time in seconds the dispatcher waits before checking for blocked jobs that can be unblocked.        | 600 seconds                                   |
+| **queues**                           | List of queues workers fetch jobs from. Supports `*` for all queues or queue name prefixes.         | `*`                                           |
+| **threads**                          | Maximum size of the thread pool for each worker. Determines how many jobs a worker fetches at once. | 3                                             |
+| **processes**                        | Number of worker processes forked by the supervisor. Each process can dedicate a CPU core.          | 1                                             |
+| **concurrency_maintenance**          | Whether the dispatcher performs concurrency maintenance work.                                       | true                                          |
+
+You can read more about these [configuration options in the Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#configuration).
+There are also [additional configuration
+options](https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings)
+that can be set in `config/<environment>.rb` to further configure Solid Queue in
+your Rails Application.
+
+### Queue Order and Priority
+
+Solid Queue offers two distinct mechanisms for controlling the order in which
+jobs are processed: queue ordering and numeric priorities. Understanding how
+they interact is important for getting the behavior you expect.
+
+#### Queue Order
+
+Queue order is the primary way to prioritize work in Solid Queue. The order in
+which queues are listed in `config/queue.yml` for a worker determines the
+polling order. A worker will not pull jobs from a lower priority queue (listed
+later in the array) until all higher priority queues are empty:
+
+```yaml
+production:
+  workers:
+    - queues: [critical, default, low]
+      threads: 5
+```
+
+With the above configuration, no jobs will be taken from the `default` queue
+while the `critical` queue has jobs waiting, and no jobs will be taken from
+`low` while either `critical` or `default` has jobs waiting. Solid Queue has
+strict ordering (unlike other queuing backend which may allow relative weights
+so that lower priority queues still receive a proportional share of processing
+time). It is possible for lower queues to be starved if higher queues are
+consistently busy.
+
+It is possible to use a wildcard `*` within queue names. For example if the
+worker is configured with `queues:[active_storage*, mailers]`, it will fetch
+jobs from queues starting with "active_storage", such as  the
+`active_storage_analyze` queue and `active_storage_transform` queue. Only when
+no jobs remain in the `active_storage`-prefixed queues will workers move on to
+the `mailers` queue.
+
+WARNING: Using wildcard queue names (e.g., `queues: active_storage*`) can slow
+down polling performance in SQLite and PostgreSQL due to the need for a
+`DISTINCT` query to identify all matching queues, which can be slow on large
+tables. For better performance, it’s best to specify exact queue names instead
+of using wildcards.
+
+#### Numeric Priorities
+
+Numeric priorities apply *within* a single queue. You can assign numeric
+priorities to jobs using `queue_with_priority`. Lower numbers indicate higher
+priority, with a default of 0:
 
 ```ruby
-# app/serializers/money_serializer.rb
-class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
-  # Converts an object to a simpler representative using supported object types.
-  # The recommended representative is a Hash with a specific key. Keys can be of basic types only.
-  # You should call `super` to add the custom serializer type to the hash.
-  def serialize(money)
-    super(
-      "amount" => money.amount,
-      "currency" => money.currency
-    )
-  end
+class CriticalReportJob < ApplicationJob
+  queue_as :default
+  queue_with_priority 0
+end
 
-  # Converts serialized value into a proper object.
-  def deserialize(hash)
-    Money.new(hash["amount"], hash["currency"])
-  end
+class RoutineCleanupJob < ApplicationJob
+  queue_as :default
+  queue_with_priority 10
+end
+```
 
-  # Checks if an argument should be serialized by this serializer.
-  def klass
-    Money
+When both jobs are in the `default` queue, `CriticalReportJob` will be picked up
+first. However, numeric priority only applies within a queue. It has no effect
+across queues. Queue order takes precedence, if you are using both mechanisms
+together.
+
+#### Polling Interval
+
+For Solid Queue the `polling_interval` setting for a worker directly affects how
+quickly it picks up new jobs. A high-priority queue paired with a slow polling
+interval may not feel very responsive in practice:
+
+```yaml
+production:
+  workers:
+    - queues: critical
+      threads: 5
+      polling_interval: 0.1  # Poll every 100ms — fast response
+    - queues: low
+      threads: 2
+      polling_interval: 10   # Poll every 10s — fine for low-priority work
+```
+
+Tuning `polling_interval` per worker is especially important for time-sensitive
+queues.
+
+#### Retries
+
+In Solid Queue, retries need to be configured explicitly using Active Job's
+`retry_on`:
+
+```ruby
+class ExternalApiJob < ApplicationJob
+  retry_on Net::TimeoutError, wait: :exponentially_longer, attempts: 5
+  retry_on ActiveRecord::Deadlocked, wait: 2.seconds, attempts: 3
+
+  def perform
+    # ...
   end
 end
 ```
 
-and add this serializer to the list:
+This can also be set globally in `ApplicationJob` if you want a default retry
+policy across all jobs. Failed jobs that aren't configured with `retry_on` will
+go straight to failed executions without retrying.
+
+### Concurrency Controls
+
+Solid Queue extends Active Job with concurrency controls, allowing you to limit
+how many jobs of a certain type can run at the same time. This is useful for
+protecting shared resources, such as ensuring only one export job runs per
+account at a time, or capping the number of concurrent API calls to an external
+service.
+
+Concurrency controls are declared using `limits_concurrency` in your job class:
 
 ```ruby
-# config/initializers/custom_serializers.rb
-Rails.application.config.active_job.custom_serializers << MoneySerializer
+class InvoiceExportJob < ApplicationJob
+  limits_concurrency to: 1, key: ->(account_id) { "invoice_export_#{account_id}" }, duration: 10.minutes
+
+  def perform(account_id)
+    # ...
+  end
+end
 ```
 
-Note that autoloading reloadable code during initialization is not supported.
-Thus it is recommended to set-up serializers to be loaded only once, e.g. by
-amending `config/application.rb` like this:
+In the above example:
+
+- The `:to` option sets the maximum number of jobs that can run concurrently.
+- The `:key` lambda computes a concurrency key from the job's arguments. In the
+  example above, the limit of 1 applies per account rather than globally.
+- The `:duration` option acts as a failsafe. So if a worker dies mid-job and
+  fails to release its lock, any blocked jobs become candidates for release once
+  duration has elapsed.
+
+When a job with concurrency controls is enqueued, Solid Queue checks a
+database-backed lock for the computed key. If the lock is available, the job is
+marked ready for execution. If not, the behavior depends on the `:on_conflict`
+option. If `on_conflict` is set to `:block` (the default), the job is held in a
+blocked state and marked ready only when a running job finishes. The other
+option is `:discard`, in which case the job is dropped entirely.
+
+You can also scope limits across *different* job classes using the `:group`
+option:
+
+```ruby
+class AnalyticsExportJob < ApplicationJob
+  limits_concurrency to: 1, key: ->(account_id) { account_id }, group: "account_exports", duration: 10.minutes
+end
+
+class InvoiceExportJob < ApplicationJob
+  limits_concurrency to: 1, key: ->(account_id) { account_id }, group: "account_exports", duration: 10.minutes
+end
+```
+
+In the above example, both job classes share the same concurrency limit per the
+"account_exports" group, which means only one export of either type will run at
+a time for a given account.
+
+NOTE: Concurrency controls do carry overhead since blocked executions must be
+tracked and locks created and updated. So they should be used sparingly. For
+simple throughput limiting, constraining the number of worker threads per queue
+is more efficient.
+
+WARNING: Concurrency controls are not compatible with bulk enqueuing via
+`perform_all_later`. Since concurrency-controlled jobs need to be enqueued
+one-by-one to respect the configured limits.
+
+### Error handling
+
+Solid Queue raises `SolidQueue::Job::EnqueueError` when an Active Record error
+occurs during job enqueuing. This differs from `ActiveJob::EnqueueError`, which
+Active Job handles internally by making `perform_later` return `false`. The
+practical consequence is that errors become harder to handle for jobs enqueued
+by Rails internals or third-party gems like `Turbo::Streams::BroadcastJob`,
+since you don't control the call to `perform_later` in those cases. For
+recurring tasks, enqueue errors are logged but not raised. See [Errors When
+Enqueuing](https://github.com/rails/solid_queue?tab=readme-ov-file#errors-when-enqueuing)
+in the Solid Queue documentation for more detail.
+
+If a worker process is killed unexpectedly — for example, with a `KILL` signal —
+any in-flight jobs are marked as failed, and errors such as
+`SolidQueue::Processes::ProcessExitError` or
+`SolidQueue::Processes::ProcessPrunedError` are raised. Heartbeat settings
+control how quickly Solid Queue detects and cleans up expired processes. See
+[Threads, Processes and
+Signals](https://github.com/rails/solid_queue?tab=readme-ov-file#threads-processes-and-signals)
+in the Solid Queue documentation for details on configuring this behavior.
+
+If your error tracking service doesn't automatically capture job errors, you can
+hook into Active Job's `rescue_from` in `ApplicationJob`:
+
+```ruby
+class ApplicationJob < ActiveJob::Base
+  rescue_from(Exception) do |exception|
+    Rails.error.report(exception)
+    raise exception
+  end
+end
+```
+
+If your application uses Action Mailer, note that mailer delivery runs through
+`ActionMailer::MailDeliveryJob`, which inherits from `ApplicationJob` but needs
+to be handled separately:
+
+```ruby
+class ApplicationMailer < ActionMailer::Base
+  ActionMailer::MailDeliveryJob.rescue_from(Exception) do |exception|
+    Rails.error.report(exception)
+    raise exception
+  end
+end
+```
+
+### Transactional Integrity on Jobs
+
+Since Solid Queue can use the same database as your application, it can
+participate in the same ACID transactions as your application data. But this
+behavior comes with important nuances worth understanding before you rely on it.
+
+When Solid Queue uses the same database as your application, job enqueuing
+happens inside the same transaction as any surrounding Active Record operations.
+This means a job won't be enqueued if the transaction rolls back, and the
+transaction won't commit unless the job enqueue also succeeds. This eliminates a
+class of race conditions common with Redis backends (e.g. a job running before
+the record it needs has been committed to the database).
+
+However, Rails 8 configures Solid Queue on a *separate database by default*,
+precisely to avoid implicit coupling to this behavior. If you build logic that
+depends on transactional integrity and later move Solid Queue to its own
+database or switch to a different backend, that behavior silently disappears.
+The separate database default is the safer choice for most applications.
+
+#### Using `enqueue_after_transaction_commit`
+
+The recommended way to get transactional safety — without depending on both your
+app and Solid Queue sharing the same database — is to use
+`enqueue_after_transaction_commit`. This defers job enqueuing until the
+surrounding Active Record transaction successfully commits, and can be enabled
+per job or globally:
+
+```ruby
+class ApplicationJob < ActiveJob::Base
+  self.enqueue_after_transaction_commit = true
+end
+```
+
+With this setting, a job enqueued inside a transaction that rolls back will
+simply not be enqueued. This gives you the guarantee portably, regardless of
+whether Solid Queue shares a database with your app or not.
+
+#### Enqueuing from `after_commit` Callbacks
+
+If you prefer not to use `enqueue_after_transaction_commit`, the alternative is
+to always enqueue jobs from `after_commit` callbacks rather than from within
+transactions directly:
+
+```ruby
+after_commit :schedule_cleanup, on: :create
+
+def schedule_cleanup
+  GuestsCleanupJob.perform_later(self)
+end
+```
+
+This ensures the job is only enqueued once the relevant data is durably
+committed to the database.
+
+#### The Risk of Implicit Reliance
+
+The subtle danger is enqueuing a job inside a transaction without either of the
+above safeguards in place. In that case, the job may run before the data it
+needs is visible to other connections, or it may be enqueued even if the
+transaction rolls back. This is easy to overlook if you're accustomed to
+Redis-backed backends where this problem doesn't arise in the same form. If
+you're unsure whether your code relies on transactional integrity, enabling
+`enqueue_after_transaction_commit` globally in `ApplicationJob` is the safest
+default.
+
+You can read more about [Transactional Integrity in the Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#jobs-and-transactional-integrity)
+
+### Recurring Tasks
+
+Solid Queue supports recurring tasks, similar to cron jobs. These tasks are
+defined in a configuration file (by default, `config/recurring.yml`) and can be
+scheduled at specific times. Here's an example of a task configuration:
+
+```yaml
+production:
+  a_periodic_job:
+    class: MyJob
+    args: [42, { status: "custom_status" }]
+    schedule: every second
+  a_cleanup_task:
+    command: "DeletedStuff.clear_all"
+    schedule: every day at 9am
+```
+
+Each task specifies a `class` or `command` and a `schedule` (parsed using
+[Fugit](https://github.com/floraison/fugit)). You can also pass arguments to
+jobs, such as in the example for `MyJob` where `args` are passed. This can be
+passed as a single argument, a hash, or an array of arguments that can also
+include keyword arguments as the last element in the array.
+
+You can learn more about [Recurring
+Tasks](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks)
+in the Solid Queue documentation.
+
+Alternate Queuing Backends
+--------------------------
+
+While Solid Queue is the default queuing backend in Rails, Active Job is
+designed to work seamlessly with different queuing backends. Switching to an
+alternative backend, such as [Sidekiq](https://github.com/sidekiq/sidekiq),
+[GoodJob](https://github.com/bensheldon/good_job), or
+[Resque](https://github.com/resque/resque), requires only a configuration change
+(typically with no modifications to your job code), along with adding the
+queuing backend's adapter to your Gemfile.
+
+Here is a noncomprehensive list of alternate queuing backends and documentation:
+
+- [Sidekiq](https://github.com/mperham/sidekiq/wiki/Active-Job)
+- [Resque](https://github.com/resque/resque/wiki/ActiveJob)
+- [Sneakers](https://github.com/jondot/sneakers/wiki/How-To:-Rails-Background-Jobs-with-ActiveJob)
+- [Queue Classic](https://github.com/QueueClassic/queue_classic#active-job)
+- [Delayed Job](https://github.com/collectiveidea/delayed_job#active-job)
+- [Que](https://github.com/que-rb/que#additional-rails-specific-setup)
+- [Good Job](https://github.com/bensheldon/good_job#readme)
+
+To switch backends globally, you can set `config.active_job.queue_adapter` in
+your application configuration:
 
 ```ruby
 # config/application.rb
 module YourApp
   class Application < Rails::Application
-    config.autoload_once_paths << "#{root}/app/serializers"
+    config.active_job.queue_adapter = :sidekiq
   end
 end
 ```
 
-Exceptions
-----------
+You can also set the adapter per-environment, which is useful if you want to use
+Solid Queue in production but a simpler adapter in development:
+
+```ruby
+# config/environments/development.rb
+config.active_job.queue_adapter = :async
+```
+
+If you want to migrate incrementally, you can set the adapter at the job class
+level. This is useful for moving one job at a time rather than switching
+everything at once:
+
+```ruby
+class MyJob < ApplicationJob
+  self.queue_adapter = :sidekiq
+end
+```
+
+Each backend requires its own gem and typically its own process. Once you add
+the adapter's gem to your `Gemfile`, you can refer to the adapter's
+documentation for any additional setup — most backends require a separate worker
+process to be started alongside your Rails application, and some (like Sidekiq)
+require additional infrastructure such as Redis.
+
+Note that switching backends doesn't migrate jobs already sitting in the old
+queue. You'll need to drain the old queue before switching, or run both backends
+in parallel temporarily to let existing jobs complete.
+
+NOTE: The early releases of Active Job had adapters built-in, but a decision was
+later made to let queueing backends providers manage the adapter themselves. Any
+backend can be used with Active Job regardless of whether the adapter is built
+in or not.
+
+TIP: If you use `config.active_job.queue_name_prefix`, make sure your new
+backend's worker configuration listens to the prefixed queue names, not the bare
+names.
+
+Monitoring and Handling Failed Jobs
+-----------------------------------
+
+### Monitoring With Mission Control
+
+The [Mission Control](https://github.com/rails/mission_control-jobs) engine is a
+Rails-based frontend to Active Job adapters to help centralize the monitoring
+and management of failed jobs. It provides insights into job status, failure
+reasons, and retry behaviors, enabling you to track and resolve issues more
+effectively.
+
+For instance, if a job fails to process a large file due to a timeout,
+`mission_control-jobs` allows you to inspect the failure, review the job’s
+arguments and execution history, and decide whether to retry, requeue, or
+discard it.
+
+### Detecting Errors With `rescue_from`
 
 Exceptions raised during the execution of the job can be handled with
-[`rescue_from`][]:
+[`rescue_from`](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from):
 
 ```ruby
 class GuestsCleanupJob < ApplicationJob
@@ -1038,24 +1313,24 @@ end
 If an exception from a job is not rescued, then the job is referred to as
 "failed".
 
-[`rescue_from`]:
-    https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from
+You can enable additional logging to figure out where jobs are coming from with
+[verbose logging](debugging_rails_applications.html#verbose-enqueue-logs).
 
 ### Retrying or Discarding Failed Jobs
 
 A failed job will not be retried, unless configured otherwise.
 
-It's possible to retry or discard a failed job by using [`retry_on`] or
+It's possible to either retry or discard a failed job by using [`retry_on`] or
 [`discard_on`], respectively. For example:
 
 ```ruby
 class RemoteServiceJob < ApplicationJob
   retry_on CustomAppException # defaults to 3s wait, 5 attempts
 
-  discard_on ActiveJob::DeserializationError
+  discard_on Net::OpenTimeout
 
   def perform(*args)
-    # Might raise CustomAppException or ActiveJob::DeserializationError
+    # Might raise CustomAppException or Net::OpenTimeout
   end
 end
 ```
@@ -1065,88 +1340,12 @@ end
 [`retry_on`]:
     https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on
 
-### Deserialization
+### Missing Records
 
-GlobalID allows serializing full Active Record objects passed to `#perform`.
+GlobalID will use the unique identifier to locate the full Active Record object
+when calling `#perform`.
 
 If a passed record is deleted after the job is enqueued but before the
 `#perform` method is called Active Job will raise an
-[`ActiveJob::DeserializationError`][] exception.
-
-[`ActiveJob::DeserializationError`]:
-    https://api.rubyonrails.org/classes/ActiveJob/DeserializationError.html
-
-Job Testing
---------------
-
-You can find detailed instructions on how to test your jobs in the [testing
-guide](testing.html#testing-jobs).
-
-Debugging
----------
-
-If you need help figuring out where jobs are coming from, you can enable
-[verbose logging](debugging_rails_applications.html#verbose-enqueue-logs).
-
-Alternate Queuing Backends
---------------------------
-
-Active Job can be used with multiple queuing backends.
-
-Here is a noncomprehensive list of queue backends supporting Active Job:
-
-- [Sidekiq](https://github.com/mperham/sidekiq/wiki/Active-Job)
-- [Resque](https://github.com/resque/resque#rails-example)
-- [Delayed Job](https://github.com/collectiveidea/delayed_job#active-job)
-- [Good Job](https://github.com/bensheldon/good_job)
-- [Solid Queue](https://github.com/rails/solid_queue)
-- [Que](https://github.com/que-rb/que#additional-rails-specific-setup)
-- [Sneakers](https://github.com/jondot/sneakers/wiki/How-To:-Rails-Background-Jobs-with-ActiveJob)
-- [Queue Classic](https://github.com/QueueClassic/queue_classic#active-job)
-
-The early releases of Active Job had adapters built-in, but a decision was later made to
-let queue backends manage the adapter themselves. Thus, there are only adapters for a few
-early backends. But any backend can be used regardless of whether the adapter is built in or not.
-For example, Solid Queue which is maintained by the Rails team, doesn't have a built-in adapter.
-
-For the list of built-in adapters see the API Documentation for [`ActiveJob::QueueAdapters`][].
-
-[`ActiveJob::QueueAdapters`]:
-    https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html
-
-### Configuring the Backend
-
-You can change your queuing backend with [`config.active_job.queue_adapter`]:
-
-```ruby
-# config/application.rb
-module YourApp
-  class Application < Rails::Application
-    # Be sure to have the adapter's gem in your Gemfile
-    # and follow the adapter's specific installation
-    # and deployment instructions.
-    config.active_job.queue_adapter = :sidekiq
-  end
-end
-```
-
-You can also configure your backend on a per job basis:
-
-```ruby
-class GuestsCleanupJob < ApplicationJob
-  self.queue_adapter = :resque
-  # ...
-end
-
-# Now your job will use `resque` as its backend queue adapter, overriding the default Solid Queue adapter.
-```
-
-[`config.active_job.queue_adapter`]:
-    configuring.html#config-active-job-queue-adapter
-
-### Starting the Backend
-
-Since jobs run in parallel to your Rails application, most queuing libraries
-require that you start a library-specific queuing service (in addition to
-starting your Rails app) for the job processing to work. Refer to library
-documentation for instructions on starting your queue backend.
+[`ActiveJob::DeserializationError`](https://api.rubyonrails.org/classes/ActiveJob/DeserializationError.html)
+exception.


### PR DESCRIPTION
The purpose of this PR is to update the Active Job Basics guide as part of the Rails Foundation documentation project.

Here's a high level of the changes:

- Restructured the entire guide top level sections and subsections so that it's more cohesive. Removed tiny sections that were not adding any value (as noted in the audit)
- Rewrite the big Solid Queue section and restructure it's subsections with the objective of giving the reader a more of a conceptual overview of how Solid Queue is designed, what's unique about it, how it compares to other queuing backends and highlighting it's features and how to use it in practice. I removed the existing content that was mirroring what is already in the Solid Queue README on Github, so we are not duplicating that.
- Addressed all of the comments from the initial audit

- [X] Nitpick: "Create and Enqueue Jobs" should probably be changed to "Creating and Enqueuing Jobs" which is more common in the guides.
- [X] Maybe the bulk enqueuing top section should be inlined under "2.3. Enqueue Jobs in Bulk" instead of linking to it? It's not a big section

Solid Queue
- [X] should “asynchronous in-process queuing system” be renamed to “asynchronous in-process queuing  backend”
- [X] The the queue in the database.yml examples for development and production could be made clearer by highlighting the queue lines. -> good call
- [X] The order of the defined queues having precedence over job priority might be made clearer if we show an example of the defined queues (production and background) -> Rewrote this
- [X] ⚠️ is used for warning. A WARNING block should probably be used instead. Although this would require some rewriting as we probably don’t want to wrap the whole section in a WARNING block.

Queues
- [X] Maybe this section should be renamed to something like "Enqueuing Jobs" to better describe what it is about? It's not really about the queues itself. -> Restructured the sections
- [X] Maybe add titles to split this up in sections: "Naming Queues" and "Dynamic Enqueuing"? -> Restructured
- [X] Maybe we should recommend a naming scheme for queues? [Latency based naming](https://engineering.gusto.com/scaling-sidekiq-at-gusto-3f9e3279e63) is a popular option. Jean Boussier: "You can mention it as a popular option without making it a recommendation." -> good one, added the recommendation.

Priority
- [X] I think this section can be a sub section of the "Queues/Enqueuing Job" section.

Callbacks
- [X] The callbacks examples could be made clearer by using line highlighting for just the callback code.
- [X] None of the callbacks are described unlike other guides where we describe the callbacks. -> added code snippets for all
- [X] There is an open PR to add a section about halting callbacks, which makes sense to mention: https://github.com/rails/rails/pull/53541 -> thanks for the heads up, added the halting section!

Bulk Enqueuing
- [X] "perform_all_later is a top-level API on Active Job." doesn't seem to add anything and could be removed?
- [X] If we have a "Enqueuing Jobs" section this could be a sub section.

ActionMailer
- [X] This section can probably be removed as this is already described in the ActionMailer guide. Other frameworks also use ActiveJob but aren't mentioned, for example ActionMailbox `incinerate_later` and ActiveStorage `purge_later`. -> +1 removed!

Internationalization
- [X] This section also doesn't add much and seems more related to ActionMailer.

Supported Types for Arguments
- [X] This section seems relevant to the "Enqueuing Jobs" jobs section and should probably be a sub section of that? -> moved to a new section about defining a job

Exceptions
- [X] I think renaming this title to something like "Handling Failed Jobs" better describes what this section is about.

Job Testing
- [X] Could probably be removed? Do we have sections like this for other frameworks? -> removed, doesn't add value agree.

Debugging
- [X] Maybe this should be a part of the "Exceptions" top section?
- [X] Verbose enqueuning logging is enabled by default in development so I don't think it deserves it's own section.

Alternate Queuing Backends
- [X] Maybe it makes sense to move this section after the Solid Queue section? Or we can keep it at the end if we really want to de-emphasize alternative backends. -> restructured such that those sections are next to each other.