### PR TITLE
Fix bug where reload leaks ordinary scopes into all_queries lookups.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix bug with reloading models with all-queries default scopes. The previous
+    implementation allowed non-all-queries on the current scope to leak into
+    the scope used for reloading.
+
+    *Andrew Novoselac* and *Matthew Draper*
+
 *   `insert!` now accepts the `:unique_by` option, consistent with `insert`.
 
     *Kenta Ishizaki*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -874,7 +874,17 @@ module ActiveRecord
 
       def _find_record(options)
         all_queries = options ? options[:all_queries] : nil
-        base = self.class.all(all_queries: all_queries).preload(strict_loaded_associations)
+        base = if all_queries
+          self.class.default_scoped(all_queries: true)
+        else
+          self.class.all
+        end
+
+        if all_queries && (current_scope = self.class.global_current_scope)
+          base = base.merge!(current_scope)
+        end
+
+        base = base.preload(strict_loaded_associations)
 
         if options && options[:lock]
           base.lock(options[:lock]).find_by!(_in_memory_query_constraints_hash)

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -248,6 +248,28 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_no_match(/mentor_id/, reload_sql)
   end
 
+  def test_default_scope_with_all_queries_does_not_apply_current_scope_on_reload
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen", salary: 80000)
+
+    reload_sql = DeveloperWithDefaultMentorScopeAllQueries.where(salary: 80000).scoping do
+      capture_sql { dev.reload }.first
+    end
+
+    assert_match(/mentor_id/, reload_sql)
+    assert_no_match(/salary/, reload_sql)
+  end
+
+  def test_default_scope_with_all_queries_applies_all_queries_current_scope_on_reload
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen", salary: 80000)
+
+    reload_sql = DeveloperWithDefaultMentorScopeAllQueries.where(salary: 80000).scoping(all_queries: true) do
+      capture_sql { dev.reload }.first
+    end
+
+    assert_match(/mentor_id/, reload_sql)
+    assert_match(/salary/, reload_sql)
+  end
+
   def test_scope_overwrites_default
     expected = Developer.all.merge!(order: "salary DESC, name DESC").to_a.collect(&:name)
     received = DeveloperOrderedBySalary.by_name.to_a.collect(&:name)


### PR DESCRIPTION
### Motivation / Background

While working on https://github.com/rails/rails/pull/57123 @matthewd caught an existing bug on main. When we reload a model with `all_queries` default scopes, we call `all(all_queries)`. But `all` includes queries from the `current_scope` which means we can leak non `all_queries` scopes into what should be an all queries only query.

### Detail

Instead we should call `default_scoped(all_queries: true)` directly. Then we can check the `current_global_scope` to include any current `all_queries` scopes.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
