### PR TITLE
Forward blob metadata to MirrorService mirrors

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
+
+    Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`
+    because `content_type`, `filename`, `disposition`, and `custom_metadata` were
+    dropped. Forward the blob's `service_metadata` to each mirror's upload.
+
+    Fixes #57270.
+
+    *Maksim Romanov* + *Andrii Furmanets*
+
 *   Offload ActiveStorage::Blob#metadata sync to background
 
     Problem:

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -313,6 +313,16 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.compose(keys, key, **service_metadata)
   end
 
+  def service_metadata # :nodoc:
+    if forcibly_serve_as_binary?
+      { content_type: ActiveStorage.binary_content_type, disposition: :attachment, filename: filename, custom_metadata: custom_metadata }
+    elsif !allowed_inline?
+      { content_type: content_type, disposition: :attachment, filename: filename, custom_metadata: custom_metadata }
+    else
+      { content_type: content_type, custom_metadata: custom_metadata }
+    end
+  end
+
   # Downloads the file associated with this blob. If no block is given, the entire file is read into memory and returned.
   # That'll use a lot of RAM for very large files. If a block is given, then the download is streamed and yielded in chunks.
   def download(&block)
@@ -413,16 +423,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
     def web_image?
       ActiveStorage.web_image_content_types.include?(content_type)
-    end
-
-    def service_metadata
-      if forcibly_serve_as_binary?
-        { content_type: ActiveStorage.binary_content_type, disposition: :attachment, filename: filename, custom_metadata: custom_metadata }
-      elsif !allowed_inline?
-        { content_type: content_type, disposition: :attachment, filename: filename, custom_metadata: custom_metadata }
-      else
-        { content_type: content_type, custom_metadata: custom_metadata }
-      end
     end
 
     def touch_attachments

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -68,12 +68,14 @@ module ActiveStorage
       instrument :mirror, key: key, checksum: checksum do
         mirrors_in_need_of_mirroring = mirrors_needing_mirroring(key)
         if mirrors_in_need_of_mirroring.any?
+          metadata = ActiveStorage::Blob.find_by(key: key)&.service_metadata || {}
+
           primary.open(key, checksum: checksum, verify: checksum.present?) do |io|
             io.rewind
             content = io.read.freeze
             tasks = mirrors_in_need_of_mirroring.map do |service|
               Concurrent::Promise.execute(executor: @executor) do
-                service.upload key, StringIO.new(content), checksum: checksum
+                service.upload key, StringIO.new(content), checksum: checksum, **metadata
               end
             end
             tasks.each(&:value!)

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "service/shared_service_tests"
+require "database/setup"
 
 class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
   mirror_config = (1..3).to_h do |i|
@@ -77,6 +78,58 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     assert_equal data, @service.mirrors.first.download(key)
     assert_equal data, @service.mirrors.second.download(key)
     assert_equal "Surprise!", @service.mirrors.third.download(key)
+  end
+
+  test "mirroring forwards blob metadata to the mirror services" do
+    key      = SecureRandom.base58(24)
+    data     = "Something else entirely!"
+    checksum = OpenSSL::Digest::MD5.base64digest(data)
+
+    @service.primary.upload key, StringIO.new(data), checksum: checksum
+    blob = ActiveStorage::Blob.create!(
+      key: key, filename: "report.txt", content_type: "text/plain",
+      byte_size: data.bytesize, checksum: checksum, service_name: "mirror"
+    )
+
+    received = Concurrent::Array.new
+    silence_warnings do
+      @service.mirrors.each do |mirror|
+        mirror.define_singleton_method(:upload) do |k, io, **opts|
+          received << opts
+          super(k, io, **opts)
+        end
+      end
+    end
+
+    @service.mirror key, checksum: checksum
+
+    assert_equal @service.mirrors.size, received.size
+    received.each do |opts|
+      assert_equal "text/plain", opts[:content_type]
+      assert_equal "report.txt", opts[:filename].to_s
+      assert_equal :attachment, opts[:disposition]
+    end
+  ensure
+    @service.mirrors.each do |mirror|
+      mirror.singleton_class.remove_method(:upload) if mirror.singleton_class.method_defined?(:upload, false)
+    end
+    blob&.destroy
+    @service.delete key
+  end
+
+  test "mirroring without a matching blob row still uploads (no metadata)" do
+    key  = SecureRandom.base58(24)
+    data = "Something else entirely!"
+
+    @service.primary.upload key, StringIO.new(data)
+
+    assert_nothing_raised { @service.mirror key, checksum: nil }
+
+    @service.mirrors.each do |mirror|
+      assert_equal data, mirror.download(key)
+    end
+  ensure
+    @service.delete key
   end
 
   test "mirroring a file without a checksum does not raise" do


### PR DESCRIPTION
### Motivation / Background

Fixes #57270.

`ActiveStorage::Service::MirrorService#mirror` (invoked asynchronously by `MirrorJob`) called the mirror's `upload` with only `checksum:`, so mirrored copies on S3, R2, Azure, and GCS lost `content_type`, `filename`, `disposition`, and `custom_metadata`. The mirror object ended up served as `application/octet-stream`, which is invisible when blobs are served via `rails_blob_url` (the signed URL overrides `response-content-type`) but breaks any flow that hits the bucket directly — CDN custom domains, `<img>` against the canonical URL, video range requests.

### Detail

Look up the blob by key inside `mirror` and forward its `service_metadata` to each mirror's `upload`, matching what `Blob#upload_without_unfurling` already passes to the primary at original-upload time. `Blob#service_metadata` is promoted from `private` to public (with `# :nodoc:`), matching how `unfurl`, `upload_without_unfurling`, `compose`, and `mirror_later` are already exposed for cross-class internal use. Falling back to `{}` when the blob row can't be found preserves correctness for orphan keys.

### Additional information

The issue reporter confirms this on Rails 7.1.5.1 in production with Cloudflare R2 + custom domain CDN. The Disk service is unaffected because it doesn't store headers; all cloud services (S3, R2, Azure, GCS) respect the upload-time `content_type`.

Alternative to #57276, which targets the same bug. Differences in this PR: exposes `Blob#service_metadata` as public with `# :nodoc:` instead of calling it via `send` (matches the convention used by `unfurl`, `upload_without_unfurling`, `compose`, and `mirror_later`), and adds a CHANGELOG entry. Happy to defer if #57276 is the preferred approach.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
