### PR TITLE
Reflect a variant's format in its representation URL filename

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Reflect a variant's format in its representation URL filename.
+
+    When a variant changed the format (e.g. `variant(format: :webp)`), the generated
+    URL still used the original blob's filename, so it ended with the original
+    extension (e.g. `.jpg`) instead of the variant's (e.g. `.webp`). This could
+    confuse CDNs, download tools, and browsers. The URL now uses the variant's
+    filename, which reflects the variant format.
+
+    Processed preview URLs likewise reflect the preview image's format (e.g. `.png`
+    for a PDF, `.jpg` for a video) rather than the source file's extension, matching
+    what is served. Unprocessed previews still fall back to the blob's filename, so
+    generating a URL never triggers preview processing.
+
+    *Dominic Baratta*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Reflect a variant's format in its representation URL filename.
+
+    When a variant changed the format (e.g. `variant(format: :webp)`), the generated
+    URL still used the original blob's filename, so it ended with the original
+    extension (e.g. `.jpg`) instead of the variant's (e.g. `.webp`). This could
+    confuse CDNs, download tools, and browsers. The URL now uses the variant's
+    filename, which reflects the variant format.
+
+    Processed preview URLs likewise reflect the preview image's format (e.g. `.png`
+    for a PDF, `.jpg` for a video) rather than the source file's extension, matching
+    what is served. Unprocessed previews still fall back to the blob's filename, so
+    generating a URL never triggers preview processing.
+
+    *Dominic Baratta*
+
 *   Allow ffmpeg and ffprobe input arguments to be configured.
 
     Two new configuration parameters are introduced.

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -35,7 +35,9 @@ class ActiveStorage::Preview
 
   class UnprocessedError < StandardError; end
 
-  delegate :filename, :content_type, to: :presentation
+  # +content_type+ is read only when serving an already-processed preview, so (unlike
+  # +filename+, which builds URLs before processing) it can resolve via the presentation.
+  delegate :content_type, to: :presentation
 
   attr_reader :blob, :variation
 
@@ -58,6 +60,20 @@ class ActiveStorage::Preview
   # Returns the blob's attached preview image.
   def image
     blob.preview_image
+  end
+
+  # Returns the filename of the processed preview image (e.g. +report.png+ for a PDF
+  # or +report.jpg+ for a video). Falls back to the blob's filename until the preview
+  # has been processed, so it can be used to build URLs without triggering processing
+  # (a preview's actual format isn't known until a previewer has run). The variant's
+  # filename is derived from the format alone, so it's read without forcing the
+  # variant to be processed.
+  def filename
+    if processed?
+      variant? ? variant.filename : image.filename
+    else
+      blob.filename
+    end
   end
 
   # Returns the URL of the preview's variant on the service. Raises ActiveStorage::Preview::UnprocessedError if the

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
     else
       signed_blob_id = model.blob.signed_id(expires_in: expires_in, expires_at: expires_at)
       variation_key  = model.variation.key
-      filename       = model.blob.filename
+      filename       = model.filename
 
       route_for(
         :rails_blob_representation_proxy,
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
     else
       signed_blob_id = model.blob.signed_id(expires_in: expires_in, expires_at: expires_at)
       variation_key  = model.variation.key
-      filename       = model.blob.filename
+      filename       = model.filename
 
       route_for(
         :rails_blob_representation,

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -118,4 +118,30 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
 
     assert_equal "local_public", preview.image.blob.service_name
   end
+
+  test "filename falls back to the blob filename until the preview is processed" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    preview = blob.preview(resize_to_limit: [640, 280])
+
+    assert_not_predicate preview, :processed?
+    assert_equal "report.pdf", preview.filename.to_s
+
+    preview.processed
+    assert_equal "report.png", preview.filename.to_s
+  end
+
+  test "filename does not process the variant" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    blob.preview_image.attach(
+      io: file_fixture("racecar.jpg").open, filename: "report.png",
+      content_type: "image/png", identify: false
+    )
+    preview = blob.preview(resize_to_limit: [640, 280])
+
+    assert_predicate preview, :processed?
+    assert_not_predicate preview.send(:variant), :processed?
+
+    assert_equal "report.png", preview.filename.to_s
+    assert_not_predicate preview.send(:variant), :processed?
+  end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -104,6 +104,14 @@ class ActiveSupport::TestCase
       ActiveStorage.track_variants = variant_tracking_was
     end
 
+    def with_variant_tracking(&block)
+      variant_tracking_was = ActiveStorage.track_variants
+      ActiveStorage.track_variants = true
+      yield
+    ensure
+      ActiveStorage.track_variants = variant_tracking_was
+    end
+
     def with_raise_on_open_redirects(service)
       old_raise_on_open_redirects = ActionController::Base.raise_on_open_redirects
       old_service = ActiveStorage::Blob.service

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -131,6 +131,14 @@ class ActiveSupport::TestCase
       ActiveStorage.track_variants = variant_tracking_was
     end
 
+    def with_variant_tracking(&block)
+      variant_tracking_was = ActiveStorage.track_variants
+      ActiveStorage.track_variants = true
+      yield
+    ensure
+      ActiveStorage.track_variants = variant_tracking_was
+    end
+
     def with_raise_on_open_redirects(service)
       old_raise_on_open_redirects = ActionController::Base.raise_on_open_redirects
       old_service = ActiveStorage::Blob.service

--- a/activestorage/test/urls/rails_storage_proxy_url_test.rb
+++ b/activestorage/test/urls/rails_storage_proxy_url_test.rb
@@ -36,4 +36,35 @@ class RailsStorageProxyUrlTest < ActiveSupport::TestCase
     variant = @blob.variant(resize_to_limit: [100, 100])
     assert_includes rails_representation_path(variant, only_path: true), "/rails/active_storage/representations/proxy/"
   end
+
+  test "rails_blob_path for a variant that changes the format uses the variant's extension" do
+    variant = @blob.variant(resize_to_limit: [100, 100], format: :webp)
+    assert rails_blob_path(variant, only_path: true).end_with?("/racecar.webp")
+  end
+
+  test "rails_blob_path for a variant that keeps the format uses the blob's extension" do
+    variant = @blob.variant(resize_to_limit: [100, 100])
+    assert rails_blob_path(variant, only_path: true).end_with?("/racecar.jpg")
+  end
+
+  test "rails_blob_path for a tracked variant that changes the format uses the variant's extension" do
+    with_variant_tracking do
+      variant = @blob.variant(resize_to_limit: [100, 100], format: :webp)
+      assert_kind_of ActiveStorage::VariantWithRecord, variant
+      assert rails_blob_path(variant, only_path: true).end_with?("/racecar.webp")
+    end
+  end
+
+  test "rails_blob_path for an unprocessed preview falls back to the blob's filename" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    preview = ActiveStorage::Preview.new(blob, resize_to_limit: [100, 100])
+    assert_not_predicate preview, :processed?
+
+    assert rails_blob_path(preview, only_path: true).end_with?("/report.pdf")
+  end
+
+  test "rails_blob_path for a processed preview uses the preview image's extension" do
+    preview = create_file_blob(filename: "report.pdf", content_type: "application/pdf").preview(resize_to_limit: [100, 100]).processed
+    assert rails_blob_path(preview, only_path: true).end_with?("/report.png")
+  end
 end

--- a/activestorage/test/urls/rails_storage_redirect_url_test.rb
+++ b/activestorage/test/urls/rails_storage_redirect_url_test.rb
@@ -36,4 +36,35 @@ class RailsStorageRedirectUrlTest < ActiveSupport::TestCase
     variant = @blob.variant(resize_to_limit: [100, 100])
     assert_includes rails_representation_path(variant, only_path: true), "/rails/active_storage/representations/redirect/"
   end
+
+  test "rails_blob_path for a variant that changes the format uses the variant's extension" do
+    variant = @blob.variant(resize_to_limit: [100, 100], format: :webp)
+    assert rails_blob_path(variant, only_path: true).end_with?("/racecar.webp")
+  end
+
+  test "rails_blob_path for a variant that keeps the format uses the blob's extension" do
+    variant = @blob.variant(resize_to_limit: [100, 100])
+    assert rails_blob_path(variant, only_path: true).end_with?("/racecar.jpg")
+  end
+
+  test "rails_blob_path for a tracked variant that changes the format uses the variant's extension" do
+    with_variant_tracking do
+      variant = @blob.variant(resize_to_limit: [100, 100], format: :webp)
+      assert_kind_of ActiveStorage::VariantWithRecord, variant
+      assert rails_blob_path(variant, only_path: true).end_with?("/racecar.webp")
+    end
+  end
+
+  test "rails_blob_path for an unprocessed preview falls back to the blob's filename" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    preview = ActiveStorage::Preview.new(blob, resize_to_limit: [100, 100])
+    assert_not_predicate preview, :processed?
+
+    assert rails_blob_path(preview, only_path: true).end_with?("/report.pdf")
+  end
+
+  test "rails_blob_path for a processed preview uses the preview image's extension" do
+    preview = create_file_blob(filename: "report.pdf", content_type: "application/pdf").preview(resize_to_limit: [100, 100]).processed
+    assert rails_blob_path(preview, only_path: true).end_with?("/report.png")
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #57596.

When you create a variant that changes the format, the URL still comes out with the original blob's extension:

```ruby
variant = item.image.variant(resize_to_fill: [600, 300], format: "webp")
image_tag variant
```

The image itself is a correct `webp`, but the URL ends in `.jpg`. That trips up CDNs, download prompts, and anything that keys off the extension.

### Detail

`rails_storage_redirect` and `rails_storage_proxy` build the URL's trailing filename from `model.blob.filename` (the original blob) instead of `model.filename` (the representation), so the variant's format never made it into the URL. The representation's `#filename` already encodes the format, so I pointed both helpers at it.

Nothing changes for a variant that keeps its format: `blob.variant` defaults the variation format to the blob's own format, so `model.filename` still ends in `.jpg` there.

Previews needed some care. `Preview#filename` used to delegate to its (processed) `presentation`, so pointing the routes at `model.filename` would make URL generation either raise on an unprocessed preview or, worse, process the variant inline (a `service.exist?` check, or a full transform and upload when the preview image already exists). Building a URL shouldn't touch the service. A preview's filename is just `base + format`, so `Preview#filename` now builds that directly without forcing processing, and falls back to the blob's filename until the preview has run. Unprocessed preview URLs are unchanged; once a preview is processed its URL picks up the preview image's real format (`.png` for a PDF, `.jpg` for a video), which is what gets served anyway.

### Additional information

Added URL helper tests on both the redirect and proxy sides (variant changing and keeping its format, a tracked `VariantWithRecord`, and processed/unprocessed previews), plus `Preview#filename` tests for the fallback and for not processing the variant when it's read.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.