### PR TITLE
Fix `find` with an explicit `order` + `offset` past the ids raising a spurious `RecordNotFound`

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -542,10 +542,6 @@ module ActiveRecord
       def find_some(ids)
         return find_some_ordered(ids) unless order_values.present?
 
-        relation = where(primary_key => ids)
-        relation = relation.select(table[primary_key]) unless select_values.empty?
-        result = relation.to_a
-
         expected_size =
           if limit_value && ids.size > limit_value
             limit_value
@@ -554,9 +550,17 @@ module ActiveRecord
           end
 
         # 11 ids with limit 3, offset 9 should give 2 results.
-        if offset_value && (ids.size - offset_value < expected_size)
-          expected_size = ids.size - offset_value
+        if offset_value
+          if ids.size <= offset_value
+            return []
+          elsif ids.size - offset_value < expected_size
+            expected_size = ids.size - offset_value
+          end
         end
+
+        relation = where(primary_key => ids)
+        relation = relation.select(table[primary_key]) unless select_values.empty?
+        result = relation.to_a
 
         if result.size == expected_size
           result
@@ -567,6 +571,7 @@ module ActiveRecord
 
       def find_some_ordered(ids)
         ids = ids.slice(offset_value || 0, limit_value || ids.size) || []
+        return [] if ids.empty?
 
         relation = except(:limit, :offset)
         relation = relation.where(primary_key => ids)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -656,6 +656,41 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal "Jamis", last_devs[1].name
   end
 
+  def test_find_with_order_and_offset_past_the_ids_returns_empty
+    ids = Developer.order(:id).limit(3).ids
+    assert_equal 3, ids.size
+
+    # unordered, offset greater than the number of ids
+    assert_equal [], Developer.offset(9999).find(ids)
+
+    # ordered, offset greater than the number of ids
+    assert_equal [], Developer.order(:id).offset(9999).find(ids)
+
+    # ordered, offset equal to the number of ids
+    assert_equal [], Developer.order(:id).offset(3).find(ids)
+  end
+
+  def test_find_with_order_limit_and_offset_matches_unordered_path
+    ids = Developer.order(:id).ids
+    assert_equal 11, ids.size
+
+    # For every limit/offset combination, the ordered path must return
+    # the same records as the unordered path: the ids sliced by offset then limit.
+    # Covers offsets within range, limits that run past the end, the boundary
+    # offset == ids.size, and offsets past the end.
+    [[3, 2], [4, 7], [3, 9], [5, 9], [2, 11], [3, 15], [11, 0]].each do |limit, offset|
+      expected = ids.slice(offset, limit) || []
+
+      ordered = Developer.order(:id).limit(limit).offset(offset).find(ids)
+      assert_equal expected, ordered.map(&:id),
+        "ordered find with limit #{limit}, offset #{offset}"
+
+      unordered = Developer.limit(limit).offset(offset).find(ids)
+      assert_equal expected.sort, unordered.map(&:id).sort,
+        "unordered find with limit #{limit}, offset #{offset}"
+    end
+  end
+
   def test_find_with_large_number
     assert_queries_count(0) do
       assert_raises(ActiveRecord::RecordNotFound) { Topic.find("9999999999999999999999999999999") }


### PR DESCRIPTION
### Summary

`find` with an array of ids, an explicit `order`, and an `offset` greater than the number of ids raises a spurious `RecordNotFound` with a nonsensical negative count:

```ruby
Model.order(:id).offset(10).find([1, 2, 3])
# => ActiveRecord::RecordNotFound: Couldn't find all Models with 'id':
#    (1, 2, 3) (found 0 results, but was looking for -7).
```

The same query **without** an `order` correctly returns `[]`.

### Cause

An explicit `order` routes `find` through `find_some` (no order goes through `find_some_ordered`). `find_some` computes the expected number of results and adjusts it for the offset:

```ruby
# 11 ids with limit 3, offset 9 should give 2 results.
if offset_value && (ids.size - offset_value < expected_size)
  expected_size = ids.size - offset_value
end
```

When `offset_value` is greater than `ids.size`, `ids.size - offset_value` is negative, so `expected_size` becomes negative. `result.size` (`0`) then never equals the negative `expected_size`, and `find` raises `RecordNotFound`.

The semantically-equivalent no-order path slices the ids by offset/limit and returns `[]` for the same input, so the ordered path is an inconsistent outlier that crashes on ordinary pagination-past-the-end input. The boundary case `offset == ids.size` already returns `[]` on both paths.

### Fix

Clamp the offset-adjusted expected size at zero:

```ruby
expected_size = [ids.size - offset_value, 0].max
```

With this, `result.size` (`0`) `== 0` and `find` returns `[]`, matching the no-order path. The existing offset edge case (11 ids, limit 3, offset 9 → 2 results: `max(2, 0) == 2`) is unaffected.

### Test

Added two regression tests to `finder_test.rb`:

- `test_find_with_order_and_offset_past_the_ids_returns_empty` asserts that an offset past the number of ids returns `[]` on both the ordered (`find_some`) and unordered (`find_some_ordered`) paths, and covers the `offset == ids.size` boundary.
- `test_find_with_order_limit_and_offset_matches_unordered_path` exercises seven `limit`/`offset` combinations against all 11 Developer fixture ids, verifying that the ordered path (`find_some`) returns the same records as the unordered path (`find_some_ordered`) — including offsets within range, limits past the end, the boundary `offset == ids.size`, and offsets past the end (which used to raise).

Verified fail → pass on **sqlite3**, **postgresql**, and **mysql2**; the full `finder_test` suite is green on all three adapters.

### Notes

* No upstream issue/PR found.
* Behaviour change is limited to a previously-raising edge case (offset strictly greater than the number of ids passed to `find`, with an explicit order); it now returns `[]` instead of raising.