### PR TITLE
Strip whitespace from string URLs passed to redirect_to

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Strip leading and trailing whitespace from string URLs passed to `redirect_to`.
+
+    Browsers ignore surrounding whitespace when navigating, so `redirect_to " https://example.com"`
+    now redirects to `https://example.com` instead of being misclassified as a path relative
+    redirect and producing a broken `Location`. Trimming happens before the redirect protections
+    run, so genuinely path relative and cross-host URLs are still flagged as before.
+
+    *Dominic Baratta*
+
 *   Rate limiting calls `cache_key` on `by:` if the object responds to it.
 
     ```ruby

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -204,6 +204,12 @@ module ActionController
     end
 
     def _compute_redirect_to_location(request, options) # :nodoc:
+      # Browsers strip leading and trailing whitespace from URLs before
+      # navigating, so do the same here. Otherwise an otherwise valid URL like
+      # " https://example.com" would be misclassified as a path relative
+      # redirect because of the leading space.
+      options = options.strip if options.is_a?(String)
+
       case options
       # The scheme name consist of a letter followed by any combination of letters,
       # digits, and the plus ("+"), period ("."), or hyphen ("-") characters; and is

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -38,7 +38,7 @@ class ACLogSubscriberTest < ActionController::TestCase
       end
 
       def filterable_redirector_bad_uri
-        redirect_to " s:/invalid-string0uri"
+        redirect_to "s:/invalid string0uri"
       end
 
       def data_sender

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -147,6 +147,10 @@ class RedirectController < ActionController::Base
     redirect_to "http://example.com/query?status=new"
   end
 
+  def redirect_to_url_with_leading_and_trailing_whitespace
+    redirect_to "  http://www.rubyonrails.org/  "
+  end
+
   def redirect_to_url_with_complex_scheme
     redirect_to "x-test+scheme.complex:redirect"
   end
@@ -161,6 +165,10 @@ class RedirectController < ActionController::Base
 
   def redirect_to_path_relative_url_starting_with_an_at
     redirect_to "@example.com"
+  end
+
+  def redirect_to_path_relative_url_with_surrounding_whitespace
+    redirect_to "  example.com  "
   end
 
   def redirect_to_query_string_url
@@ -340,6 +348,12 @@ class RedirectTest < ActionController::TestCase
     get :redirect_to_url_with_unescaped_query_string
     assert_response :redirect
     assert_redirected_to "http://example.com/query?status=new"
+  end
+
+  def test_redirect_to_url_strips_leading_and_trailing_whitespace
+    get :redirect_to_url_with_leading_and_trailing_whitespace
+    assert_response :redirect
+    assert_redirected_to "http://www.rubyonrails.org/"
   end
 
   def test_redirect_to_url_with_complex_scheme
@@ -729,6 +743,22 @@ class RedirectTest < ActionController::TestCase
     end
   end
 
+  def test_redirect_to_path_relative_url_with_surrounding_whitespace_is_still_host_prefixed
+    get :redirect_to_path_relative_url_with_surrounding_whitespace
+    assert_response :redirect
+    assert_equal "http://test.hostexample.com", redirect_to_url
+  end
+
+  def test_redirect_to_path_relative_url_with_surrounding_whitespace_with_raise
+    with_path_relative_redirect(:raise) do
+      error = assert_raise(ActionController::Redirecting::UnsafeRedirectError) do
+        get :redirect_to_path_relative_url_with_surrounding_whitespace
+      end
+
+      assert_equal 'Path relative URL redirect detected: "example.com"', error.message
+    end
+  end
+
   def test_redirect_to_absolute_url_does_not_log
     with_path_relative_redirect(:log) do
       with_logger do |logger|
@@ -776,6 +806,14 @@ class RedirectTest < ActionController::TestCase
       get :redirect_to_url_with_network_path_reference
       assert_response :redirect
       assert_equal "//www.rubyonrails.org/", redirect_to_url
+    end
+  end
+
+  def test_redirect_to_whitespace_padded_absolute_url_does_not_raise_path_relative
+    with_path_relative_redirect(:raise) do
+      get :redirect_to_url_with_leading_and_trailing_whitespace
+      assert_response :redirect
+      assert_equal "http://www.rubyonrails.org/", redirect_to_url
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Fixes #57035.

`redirect_to " https://www.example.com"` (note the leading space) raises `ActionController::Redirecting::PathRelativeRedirectError`, or with the default `:log` setting produces a broken `Location` such as `http://yourhost https://www.example.com`. The scheme check in `_compute_redirect_to_location` is anchored with `\A`, so a single leading space stops `" https://..."` from being recognized as an absolute URL and it gets classified as a path relative redirect instead.

Browsers ignore leading and trailing whitespace when they navigate (per the WHATWG URL spec), so a stray space pasted in front of an otherwise valid URL shouldn't break the redirect.

### Detail

`_compute_redirect_to_location` now strips leading and trailing whitespace from string targets before classifying them:

```ruby
options = options.strip if options.is_a?(String)
```

The strip runs before the existing redirect protections, so behavior for genuinely unsafe input is unchanged:

* `"  example.com  "` still strips to `"example.com"` and is flagged as a path relative redirect (the warning/raise message shows the trimmed value).
* A whitespace padded cross-host URL is now recognized as cross-host and goes through the same open redirect protection it would without the whitespace, instead of becoming a broken same-host `Location`.

One existing test action in `log_subscriber_test.rb` relied on a leading space making `" s:/invalid-string0uri"` unparseable after host prefixing. Since that input is no longer host prefixed, I changed it to `"s:/invalid string0uri"`, which is still unparseable by `URI.parse` regardless of trimming, so it keeps exercising the `[FILTERED]` rescue path it was written for.

### Additional information

Added coverage in `redirect_test.rb` for a whitespace padded absolute URL redirecting to the trimmed URL, that same URL not raising under `action_on_path_relative_redirect = :raise`, and a whitespace padded path relative URL still being host prefixed and still raising. RuboCop and the Action Pack controller redirect and log subscriber tests pass.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
