### PR TITLE
Fix `store_accessor` read mutating a `NULL` structured column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix reading a `store_accessor` on a `NULL` structured column (`json`, `jsonb`,
+    or `hstore`) marking the record as changed and overwriting the `NULL` with an
+    empty hash on the next save.
+
+    *Kenta Ishizaki*
+
 *   Fix `update_all` corrupting the optimistic locking column when it is set
     through an `alias_attribute`.
 

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -246,8 +246,7 @@ module ActiveRecord
         end
 
         def self.read(object, attribute, key)
-          store_object = prepare(object, attribute)
-          store_object[key]
+          get(object.public_send(attribute), key)
         end
 
         def self.write(object, attribute, key, value)
@@ -282,6 +281,12 @@ module ActiveRecord
       end
 
       class IndifferentHashAccessor < ActiveRecord::Store::HashAccessor # :nodoc:
+        def self.get(store_object, key)
+          if store_object
+            IndifferentCoder.as_indifferent_hash(store_object)[key]
+          end
+        end
+
         def self.prepare(object, attribute)
           store_object = object.public_send(attribute)
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -202,6 +202,27 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal true, @john.enable_friend_requests_before_last_save
   end
 
+  test "reading a store accessor on a null structured column does not mutate or persist the store" do
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && ActiveRecord::Base.lease_connection.mariadb?
+      skip "MariaDB doesn't support JSON store_accessor"
+    end
+
+    john = Admin::User.find(@john.id)
+    assert_nil john.json_options
+    assert_not_predicate john, :changed?
+
+    # A pure read of a store accessor must not mutate the record.
+    assert_nil john.enable_friend_requests
+
+    assert_not_predicate john, :changed?
+    assert_nil john.json_options
+
+    # Saving an unrelated change must not overwrite the NULL column with {}.
+    john.name = "John Roe"
+    john.save!
+    assert_nil john.reload.json_options
+  end
+
   test "object initialization with not nullable column" do
     assert_equal true, @john.remember_login
   end


### PR DESCRIPTION
### Summary

Reading a `store_accessor` on a genuinely `NULL` `json` / `jsonb` / `hstore` column marks the record as **changed** and silently overwrites the `NULL` with an empty hash on the next save.

`HashAccessor.read` went through `prepare`, which, when the underlying store column is `nil`, builds an empty `{}` **and assigns it back to the record**:

```ruby
def self.prepare(object, attribute)
  store_object = object.public_send(attribute)

  if store_object.nil?
    store_object = {}
    object.public_send(:"#{attribute}=", store_object) # <- write-back on read
  end

  store_object
end
```

So a *pure read* of an accessor mutates the record. After merely calling `doc.color` on a record whose `data` column is `NULL`:

* `doc.changed?` becomes `true` with `doc.changes == { "data" => [nil, {}] }`,
* the next `save` / `save!` — even for an **unrelated** attribute, or with no real change — persists `{}` over the original `NULL`.

This breaks `save if changed?` guards, fires spurious dirty-based `after_save` / `touch` callbacks, and flips `NULL` → `{}` in the database.

It hits exactly the bare-`store_accessor`-over-a-native-structured-column pattern the documentation recommends:

> NOTE: If you are using structured database data types (e.g. PostgreSQL `hstore`/`json`, MySQL 5.7+ `json`, or SQLite 3.38+ `json`) there is no need for the serialization provided by `.store`. Simply use `.store_accessor` instead [...]

Classic serialized (`coder:`) stores are unaffected, because `IndifferentCoder.load` coerces `NULL` → `{}` at the type layer, so the column is never truly `nil`.

### Reproduction

```ruby
ActiveRecord::Schema.define do
  create_table :docs, force: true do |t|
    t.string :name
    t.json   :data            # genuinely-NULLable structured column
  end
end

class Doc < ActiveRecord::Base
  store_accessor :data, :color
end

doc = Doc.create!(name: "a")  # data left NULL
doc = Doc.find(doc.id)

doc.changed?                  # => false
doc.color                     # a pure read...
doc.changed?                  # => true       (BUG)
doc.changes                   # => {"data" => [nil, {}]}  (BUG)

doc.name = "b"
doc.save!
Doc.connection.select_value("SELECT data FROM docs WHERE id = #{doc.id}")
# => "{}"   (BUG — the NULL column was overwritten)
```

### Fix

Make the read path non-mutating. `read` now reads the current store via the existing `get` primitive (which already nil-guards) instead of the mutating `prepare`; `prepare` stays on the **write** path, so writing a key into a previously-`NULL` column still attaches and persists a hash.

`IndifferentHashAccessor` gains a non-mutating, indifferent `get` so that its inherited `read` keeps indifferent-access semantics (symbol/string keys) without writing an indifferent copy back to the record.

```ruby
# HashAccessor
def self.read(object, attribute, key)
  get(object.public_send(attribute), key)
end

# IndifferentHashAccessor
def self.get(store_object, key)
  if store_object
    IndifferentCoder.as_indifferent_hash(store_object)[key]
  end
end
```

### Test

Added `test "reading a store accessor on a null structured column does not mutate or persist the store"` to `store_test.rb`, using the existing native `json` column `json_options` on `Admin::User` (`store_accessor :json_options, :enable_friend_requests`). It asserts that a pure read leaves `changed?` false and that an unrelated save does not overwrite the `NULL` column. Guarded with the same MariaDB skip the sibling JSON test uses.

Verified fail → pass on **sqlite3**, **postgresql**, and **mysql2**. Surrounding suites green on all three adapters: `store_test`, `serialized_attribute_test`, `json_attribute_test`, `json_serialization_test`, `dirty_test`, and the PostgreSQL `hstore_test` / `json_test`.

### Notes

* No upstream issue/PR found.
* The write-back-on-read dates back to the original hstore support; it was an incidental side effect of `prepare` being shared between read and write, not a designed read behavior. No existing test asserted that a read dirties the record.