### PR TITLE
Fix `update_all` / `delete_all` ignoring `group`/`having` (updates/deletes every row)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `update_all` / `delete_all` ignoring `group` and `having`, updating or
+    deleting every row in the table instead of only the rows that satisfy the
+    `HAVING` clause.
+
+    *Kenta Ishizaki*
+
 *   Fix `ActiveRecord::Relation#cache_key` / `cache_version` for a loaded collection
     containing a record without a timestamp.
 

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -939,7 +939,7 @@ module Arel # :nodoc: all
         # on MySQL (even when aliasing the tables), but MySQL allows using JOIN directly in
         # an UPDATE statement, so in the MySQL visitor we redefine this to do that.
         def prepare_update_statement(o)
-          if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o))
+          if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o) || has_group_by_and_having?(o))
             stmt = o.clone
             stmt.limit = nil
             stmt.offset = nil

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -80,6 +80,22 @@ class DeleteAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_delete_all_with_group_by_and_having_without_joins
+    posts = [
+      Post.create!(title: "low", body: "x", legacy_comments_count: 0),
+      Post.create!(title: "mid", body: "x", legacy_comments_count: 3),
+      Post.create!(title: "high", body: "x", legacy_comments_count: 9),
+    ]
+    relation = Post.where(id: posts).group("posts.id").having("MAX(legacy_comments_count) >= 3")
+
+    # Only the rows that survive the HAVING filter must be deleted, not every row.
+    assert_equal 2, relation.delete_all
+
+    assert Post.exists?(posts[0].id)
+    assert_not Post.exists?(posts[1].id)
+    assert_not Post.exists?(posts[2].id)
+  end
+
   def test_delete_all_with_unpermitted_relation_raises_error
     assert_raises(ActiveRecord::ActiveRecordError) { Author.distinct.delete_all }
     assert_raises(ActiveRecord::ActiveRecordError) { Author.with(limited: Author.limit(2)).delete_all }

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -67,6 +67,22 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_not_equal "ig", post.title
   end
 
+  def test_update_all_with_group_by_and_having_without_joins
+    posts = [
+      Post.create!(title: "low", body: "x", legacy_comments_count: 0),
+      Post.create!(title: "mid", body: "x", legacy_comments_count: 3),
+      Post.create!(title: "high", body: "x", legacy_comments_count: 9),
+    ]
+    relation = Post.where(id: posts).group("posts.id").having("MAX(legacy_comments_count) >= 3")
+
+    # Only the rows that survive the HAVING filter must be updated, not every row.
+    assert_equal 2, relation.update_all(title: "updated")
+
+    assert_equal "low", posts[0].reload.title
+    assert_equal "updated", posts[1].reload.title
+    assert_equal "updated", posts[2].reload.title
+  end
+
   def test_update_all_with_joins_and_limit
     pets = Pet.joins(:toys).where(toys: { name: "Bone" }).limit(2)
 


### PR DESCRIPTION
### Summary

`update_all` / `delete_all` on a relation that carries `group`/`having` but **no** `joins`, `limit`, `offset`, or `order` silently affects **every row in the table** on every adapter, instead of only the rows that survive the `HAVING` clause. No error and no deprecation is raised.

```ruby
# posts: (low, 0), (mid, 3), (high, 9)
Post.where(id: posts)
    .group("posts.id")
    .having("MAX(legacy_comments_count) >= 3")
    .update_all(title: "updated")
# emitted on all adapters (main):  UPDATE "posts" SET "title" = ? WHERE "id" IN (...)
#   -> all three rows updated, including the row that fails HAVING
```

### Cause

`update_all`/`delete_all` build an Arel `UpdateManager`/`DeleteManager`, and the base `Arel::Visitors::ToSql#prepare_update_statement` decides whether to wrap the statement in a primary-key subquery:

```ruby
def prepare_update_statement(o)
  if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o))
    # ... build `WHERE pk IN (SELECT pk ... GROUP BY ... HAVING ...)`
```

The trigger checks `has_limit_or_offset_or_orders?` and `has_join_sources?` but **not** `has_group_by_and_having?` — even though that helper is defined right above (`to_sql.rb:934`). A relation with only `group`/`having` therefore falls to the `else` branch and emits a bare `UPDATE`/`DELETE` with the `GROUP BY`/`HAVING` dropped.

Why it stayed hidden:

* The **`joins` + `group` + `having`** case (e.g. the `most_commented` scope used by the existing `test_update_all_with_group_by` and `test_delete_all_with_group_by_and_having`) is caught by `has_join_sources?`, so the subquery rewrite already fires on every adapter and correctly copies the groups/havings into the subselect. The pure-group (no-join) path had no test on any adapter, so it was never exercised.
* All three adapters reach the buggy base for the pure-group case. SQLite (`sqlite.rb`) and PostgreSQL (`postgresql.rb`) only special-case the join transform and otherwise delegate to the base `super`. **MySQL** (`mysql.rb`) has its own override too, but it routes `group`/`having` to `super` as well — its dedicated branch only handles the JOIN-in-`UPDATE` form, not the pure-group one — so it hits the same buggy base. The bug is **not** SQLite/PostgreSQL-specific.

### Fix

Add `has_group_by_and_having?(o)` to the base trigger so the pure-group case routes through the same primary-key subquery as the join case (the subquery machinery, `build_subselect`, already copies `groups`/`havings`):

```ruby
if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o) || has_group_by_and_having?(o))
```

Resulting SQL:

```sql
UPDATE "posts" SET "title" = ?
WHERE ("posts"."id") IN (
  SELECT "posts"."id" FROM "posts" WHERE "id" IN (...) GROUP BY "posts"."id"
  HAVING (MAX(legacy_comments_count) >= 3)
)
```

This fixes all three adapters at once: SQLite and PostgreSQL hit the base directly, and MySQL's override already delegates the `group`/`having` case to `super`.

### Semantics

This matches the behavior already documented and tested for the `joins` + `group` case: the rows that survive `GROUP BY ... HAVING` are identified by primary key and only those are updated/deleted. It is well-defined when grouping by the primary key (or a superkey), as in the `most_commented` scope. Grouping by a column that does not functionally determine the primary key remains DB-dependent (one arbitrary row per group on SQLite / loose MySQL, an error under PostgreSQL/MySQL `ONLY_FULL_GROUP_BY`) — but that is pre-existing behavior of the `joins` + `group` path and is unchanged here; the fix only removes the catastrophic "every row" footgun.

### Tests

Added `test_update_all_with_group_by_and_having_without_joins` and `test_delete_all_with_group_by_and_having_without_joins` — pure `group`/`having` (no joins) that asserts only the rows passing `HAVING` are affected and the failing row is untouched.

Verified fail → pass on **sqlite3**, **postgresql**, and **mysql2** (all three reproduce the "every row" bug before the fix and pass after). Surrounding suites green on all three adapters: `relation/update_all_test`, `relation/delete_all_test`, `arel/visitors/{to_sql,sqlite,postgres,mysql}_test`, `arel/{update,delete}_manager_test`, `persistence_test`.

### Notes

* This completes the work started in #43465 (which fixed #38155): that PR taught `update_all` / `delete_all` to honor `group`/`having` via the primary-key subquery, but only for the **joins** path (caught by `has_join_sources?`). The no-join `group`/`having` case was never routed through the rewrite, so it kept silently dropping the clause. This PR closes that remaining gap by extending the same base trigger to `has_group_by_and_having?`.
* The `group`/`having` subquery support (and the `has_group_by_and_having?` helper itself) was introduced in `4acb6660e2`, part of #43465; the base trigger was simply never extended to the no-join group case. Until now, only the `has_join_sources?` / limit-offset-order paths ever reached the rewrite, so every adapter (SQLite and PostgreSQL directly, MySQL via its own `super`) dropped a pure `group`/`having`.