### PR TITLE
Fix `Relation#cache_key` crashing on a loaded collection with a `NULL` timestamp

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `ActiveRecord::Relation#cache_key` / `cache_version` for a loaded collection
+    containing a record without a timestamp.
+
+    *Kenta Ishizaki*
+
 *   Fix `ActiveRecord::MessagePack` serialization raising `NoMethodError`
     for any record with a populated `time` column, which made such records
     uncacheable through the MessagePack cache serializer.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -486,7 +486,7 @@ module ActiveRecord
       if loaded?
         size = records.size
         if size > 0
-          timestamp = records.map { |record| record.read_attribute(timestamp_column) }.max
+          timestamp = records.filter_map { |record| record.read_attribute(timestamp_column) }.max
         end
       else
         collection = eager_loading? ? apply_join_dependency : self

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -70,6 +70,16 @@ module ActiveRecord
       assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), $3
     end
 
+    test "cache_key for a loaded relation with a NULL timestamp matches the unloaded key" do
+      with_timestamp = Topic.create!(title: "with timestamp")
+      without_timestamp = Topic.create!(title: "without timestamp")
+      Topic.where(id: without_timestamp.id).update_all(updated_at: nil)
+
+      relation = -> { Topic.where(id: [with_timestamp.id, without_timestamp.id]) }
+
+      assert_equal relation.call.cache_key, relation.call.load.cache_key
+    end
+
     test "cache_key for relation with table alias" do
       table_alias = Developer.arel_table.alias("omg_developers")
 


### PR DESCRIPTION
### Summary

`Relation#cache_key` / `cache_version` raises `ArgumentError: comparison of Time with nil failed` for a **loaded** collection that contains a record with a `NULL` timestamp — but only once the relation has been loaded. The same call on a fresh (unloaded) relation succeeds.

```ruby
# topics: one row with updated_at = <time>, one row with updated_at = NULL
scope = Topic.where(id: [a.id, b.id])

scope.cache_key        # => "topics/query-...-2-2026..."   (OK, unloaded)
scope.load.cache_key   # => ArgumentError: comparison of Time with nil failed
```

### Cause

`Relation#compute_cache_version` computes the collection timestamp two different ways depending on whether the relation is loaded:

```ruby
if loaded?
  size = records.size
  if size > 0
    timestamp = records.map { |record| record.read_attribute(timestamp_column) }.max
  end
else
  # ... SQL: MAX(timestamp_column) ...
end
```

* **Unloaded:** runs SQL `MAX(updated_at)`, which **skips `NULL`s**.
* **Loaded:** `records.map { ... }.max`, i.e. `Array#max` over `[Time, nil, ...]`, which raises `ArgumentError: comparison of Time with nil failed`.

So the two paths disagree on `NULL` timestamps, and the public `cache_key` / `cache_version` API crashes in a **load-state-dependent** way: a collection that was iterated in a view (and is therefore already loaded) before being cached with `cache @collection` blows up, while the same code on an unloaded relation does not. It reproduces under the default `collection_cache_versioning = false`.

### Fix

Use `filter_map` in the loaded path so it skips `NULL` timestamps, matching the SQL `MAX` the unloaded path already uses:

```ruby
timestamp = records.filter_map { |record| record.read_attribute(timestamp_column) }.max
```

Both paths now produce the same key (the max of the non-`NULL` timestamps), and the all-`NULL` case yields `nil` on both paths as before.

### Test

Added `test "cache_key for a loaded relation with a NULL timestamp matches the unloaded key"` to `collection_cache_key_test.rb`, using `Topic` (which has a nullable `updated_at`). One record's `updated_at` is set to `NULL` via `update_all` (bypassing the timestamp callbacks — a plain `create!(updated_at: nil)` would be overwritten by the timestamp callback, so it would not exercise the bug), then the loaded and unloaded `cache_key` are asserted equal.

Verified fail → pass on **sqlite3**, **postgresql**, and **mysql2**; the full `collection_cache_key_test`, `cache_key_test`, and `integration_test` suites are green.