### PR TITLE
Reset the memoized `finder_needs_type_condition?` flag on `reset_column_information`

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -244,6 +244,7 @@ module ActiveRecord
         end
 
         def reload_schema_from_cache(*) # :nodoc:
+          @finder_needs_type_condition = nil
           if @_new_optimized
             singleton_class.remove_method(:new)
             @_new_optimized = false

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -565,6 +565,18 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
     ActiveRecord::Base.lease_connection.change_column_default :companies, :type, original_type
     Company.reset_column_information
   end
+
+  def test_inheritance_new_with_subclass_after_adding_type_column_and_resetting_schema_cache
+    ActiveRecord::Base.lease_connection.rename_column :companies, :type, :old_type
+    Company.reset_column_information
+    _firm = Firm.new # populate the cache
+
+    ActiveRecord::Base.lease_connection.rename_column :companies, :old_type, :type
+    Company.reset_column_information
+
+    firm = Firm.new
+    assert_equal "Firm", firm.type
+  end
 end
 
 class InheritanceAttributeTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

`finder_needs_type_condition?` decides whether an STI `type` condition is added to queries. It memoizes `@finder_needs_type_condition`, but that memo is only cleared when a subclass is defined (`.inherited`) — **not** on `reset_column_information` / `reload_schema_from_cache`, even though that method already resets ~12 sibling schema memos. So changing the inheritance column at runtime and resetting leaves the flag stale, in two opposite and equally broken ways:

```ruby
# (1) add the type column, then reset -> STI silently NOT applied
Cat.finder_needs_type_condition?         # memoized false (no type column yet)
connection.add_column :animals, :type, :string
Animal.reset_column_information
Cat.finder_needs_type_condition?         # still false  (BUG)
Cat.create!(name: "felix").type          # => nil       (BUG: type not stored)
Cat.count                                # counts ALL animals — no WHERE type

# (2) remove the type column, then reset -> stale condition crashes
Lion.count                               # memoized true (STI active)
connection.remove_column :zoos, :type
Zoo.reset_column_information
Lion.count                               # ActiveRecord::StatementInvalid:
                                         #   no such column: zoos.type   (BUG)
```

Direction (1) is silent data corruption (a subclass scope widens to every row, and `create` writes a `nil` discriminator); direction (2) is an outright crash. Both are reachable through `reset_column_information`, whose own rdoc documents the in-migration usage that triggers it.

### Cause

`ModelSchema#reload_schema_from_cache` nils `@columns_hash`, `@content_columns`, and ~10 other memos, and `Inheritance#reload_schema_from_cache` additionally undoes the `new`-allocation optimization — but neither resets `@finder_needs_type_condition`. It therefore keeps a value derived from the schema as it was at first call.

### Fix

Reset the memo in `Inheritance#reload_schema_from_cache`, alongside the existing resets, so it is recomputed from the current schema:

```ruby
def reload_schema_from_cache(*)
  @finder_needs_type_condition = nil
  # ...
  super
end
```

### Test

Added `InheritanceFinderNeedsTypeConditionTest` (self-contained STI models on a temporary table; `use_transactional_tests = false` because it alters the schema, which implicitly commits on MySQL). It memoizes `finder_needs_type_condition?` while there is no inheritance column, adds the column, resets, and asserts STI is now applied (the flag flips, `create` stores the type, and a subclass scope is filtered).

Verified fail → pass on **sqlite3**, **postgresql**, and **mysql2**; `inheritance_test`, `reload_models_test`, and `base_test` are green.

### Notes

* Related to the long-known stale-memo family on `inheritance_column=`; cf. #31475 (attribute methods). This fixes the broader `reset_column_information` / `reload_schema_from_cache` path for `finder_needs_type_condition?` (and both the add-column and remove-column directions).