### PR TITLE
Resolve attribute aliases for the locking column in `update_all`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `update_all` corrupting the optimistic locking column when it is set
+    through an `alias_attribute`.
+
+    *Kenta Ishizaki*
+
 *   Fix `serialize` with `coder: ActiveRecord::Coders::JSON` silently double-encoding
     a native `json`/`jsonb` column.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -619,8 +619,7 @@ module ActiveRecord
 
       if updates.is_a?(Hash)
         if model.locking_enabled? &&
-            !updates.key?(model.locking_column) &&
-            !updates.key?(model.locking_column.to_sym)
+            updates.keys.none? { |key| (model.attribute_alias(key) || key.to_s) == model.locking_column }
           attr = table[model.locking_column]
           updates[attr.name] = _increment_attribute(attr)
         end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -28,6 +28,11 @@ class ReadonlyNameShip < Ship
   attr_readonly :name
 end
 
+class PersonWithAliasedLockVersion < ActiveRecord::Base
+  self.table_name = :people
+  alias_attribute :aliased_lock_version, :lock_version
+end
+
 class OptimisticLockingTest < ActiveRecord::TestCase
   fixtures :people, :legacy_things, :references, :string_key_objects, :peoples_treasures
 
@@ -39,6 +44,19 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     p1.save!
 
     assert_equal 1, p1.lock_version
+  end
+
+  def test_update_all_with_lock_column_set_through_an_alias
+    person = PersonWithAliasedLockVersion.create!(first_name: "aliased")
+    assert_equal 0, person.lock_version
+
+    # Setting the locking column through an alias must not also auto-increment
+    # it: two assignments to the same column would silently drop the value on
+    # SQLite/MySQL and raise on PostgreSQL.
+    affected = PersonWithAliasedLockVersion.where(id: person.id).update_all(aliased_lock_version: 10)
+
+    assert_equal 1, affected
+    assert_equal 10, person.reload.lock_version
   end
 
   def test_non_integer_lock_existing


### PR DESCRIPTION
### Summary

`update_all` corrupts the optimistic-locking column when it is set through an `alias_attribute`: the value is silently dropped on SQLite/MySQL, and on PostgreSQL the statement raises.

```ruby
class Widget < ActiveRecord::Base
  alias_attribute :v, :lock_version
end

Widget.where(id: id).update_all(v: 10)
# SQLite/MySQL: lock_version ends up 1, not 10  (value silently lost)
# PostgreSQL:   PG::SyntaxError: multiple assignments to same column "lock_version"
```

The canonical name works correctly:

```ruby
Widget.where(id: id).update_all(lock_version: 10) # => lock_version is 10
```

### Cause

`update_all` auto-increments the locking column unless the caller already sets it, but the guard recognizes the column only by its canonical name:

```ruby
if model.locking_enabled? &&
    !updates.key?(model.locking_column) &&
    !updates.key?(model.locking_column.to_sym)
  attr = table[model.locking_column]
  updates[attr.name] = _increment_attribute(attr)
end
values = _substitute_values(updates)
```

An aliased key (`v`) is not equal to `"lock_version"` / `:lock_version`, so the guard fires and appends the auto-increment. `_substitute_values` then resolves **both** `v` and the appended key to the same physical column, producing two assignments to `lock_version`:

```sql
UPDATE "widgets" SET "lock_version" = 10, "lock_version" = COALESCE("widgets"."lock_version", 0) + 1 ...
```

SQLite/MySQL take the last assignment (the auto-increment), dropping the user's value; PostgreSQL rejects the duplicate column assignment.

### Fix

Resolve each update key through `model.attribute_alias` before comparing it to the locking column, so an aliased lock column is recognized just like the canonical name — `insert_all` already resolves aliases this way:

```ruby
if model.locking_enabled? &&
    updates.keys.none? { |key| (model.attribute_alias(key) || key.to_s) == model.locking_column }
  ...
end
```

The auto-increment still fires when no update key maps to the locking column, and the canonical-name path is unchanged.

### Test

Added `test_update_all_with_lock_column_set_through_an_alias` to `OptimisticLockingTest` (a model on the `people` table with `alias_attribute :aliased_lock_version, :lock_version`). It asserts `update_all(aliased_lock_version: 10)` sets the column to `10` and affects one row.

Verified fail → pass on **sqlite3** (`10` → `1` lost write on `main`), **postgresql** (crash on `main`), and **mysql2**. `locking_test` and `relation/update_all_test` are green on all three adapters.