### PR TITLE
Fix `in_order_of` surfacing `NULL` rows for an unknown enum key or out-of-range integer

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -736,16 +736,8 @@ module ActiveRecord
       else
         arel_column = order_column(column.to_s)
 
-        caster = arel_column.type_caster
-        values = values.map do |value|
-          if value.is_a?(Array)
-            value.map do |current_value|
-              caster.serialize(current_value) if caster.serializable?(current_value)
-            end
-          else
-            caster.serialize(value) if caster.serializable?(value)
-          end
-        end
+        values = cast_values_for_in_order_of(values, arel_column.type_caster)
+        return spawn.none! if values.empty?
       end
 
       scope = spawn.order!(build_case_for_value_position(arel_column, values, filter: filter))
@@ -2333,6 +2325,28 @@ module ActiveRecord
             field
           end
         end
+      end
+
+      def cast_values_for_in_order_of(values, type_caster)
+        bad_value = Symbol # use some object that can not be a valid value
+
+        values = values.map do |value|
+          if value.is_a?(Array)
+            cast_values_for_in_order_of(value, type_caster).without(bad_value)
+          else
+            serialized = type_caster.serialize(value) if type_caster.serializable?(value)
+
+            if value.nil?
+              nil
+            elsif !serialized.nil?
+              serialized
+            else
+              bad_value
+            end
+          end
+        end
+
+        values.reject { |v| v == bad_value || (v.is_a?(Array) && v.empty?) }
       end
 
       def arel_column_aliases_from_hash(fields)

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -126,6 +126,41 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
     assert_equal([1], posts.map(&:id))
   end
 
+  def test_in_order_of_with_out_of_bound_integer_does_not_match_nulls
+    Book.destroy_all
+    in_range = Book.create!(format_record_id: 5)
+    Book.create!(format_record_id: nil)
+    max_integer = Book.type_for_attribute(:format_record_id).send(:max_value)
+
+    books = Book.in_order_of(:format_record_id, [max_integer + 1, 5])
+
+    # The out-of-range value is ignored, not turned into an IS NULL match that
+    # would return the row with a nil format_record_id.
+    assert_equal([in_range.id], books.ids)
+  end
+
+  def test_in_order_of_with_unknown_enum_key_does_not_match_nulls
+    Book.destroy_all
+    single = Book.create!(nullable_status: :single)
+    married = Book.create!(nullable_status: :married)
+    Book.create!(nullable_status: nil)
+
+    books = Book.in_order_of(:nullable_status, [:married, :bogus, :single])
+
+    # The unknown enum key is ignored, not turned into an IS NULL match that
+    # would return the nil-status row.
+    assert_equal([married.id, single.id], books.ids)
+  end
+
+  def test_in_order_of_with_only_unrepresentable_values_does_not_build_empty_case
+    Book.destroy_all
+    Book.create!(nullable_status: :single)
+    Book.create!(nullable_status: nil)
+
+    assert_empty(Book.in_order_of(:nullable_status, [:bogus], filter: false).ids)
+    assert_empty(Book.in_order_of(:nullable_status, [:bogus]).ids)
+  end
+
   def test_in_order_of_with_array_values
     order = [3, [5, 2], [4, 7], 1]
     posts = Post.in_order_of(:id, order).order(id: :asc)


### PR DESCRIPTION
### Summary

`in_order_of` silently pulls in rows with a `NULL` value when the order list contains an unknown enum key or an out-of-range integer:

```ruby
# books: one :proposed, one :written, one with a NULL status
Book.in_order_of(:status, [:written, :bogus, :proposed]).pluck(:id)
# => [2, 3, 1]   the NULL-status row (id 3) appears at :bogus's position
#    expected [2, 1]
```

`Enumerable#in_order_of` ignores values not present in the collection, so this contradicts the documented parity (and the CHANGELOG for the commit that added out-of-range handling, which says such values should be *ignored*).

### Cause

Each value is serialized with:

```ruby
caster.serialize(value) if caster.serializable?(value)
```

A value that can't be represented in the column becomes `nil`:

* an **out-of-range integer** fails `serializable?` → the `if` yields `nil`;
* an **unknown enum key** passes `serializable?` but `serialize` returns `nil`.

That `nil` is then indistinguishable from a caller-supplied `nil`, which `in_order_of` intentionally treats as "match `NULL`". So it injects `... OR column IS NULL` into both the `WHERE` filter and the `ORDER BY CASE`, surfacing rows with a `NULL` value and sorting them to the bad value's position.

The existing `test_in_order_of_with_out_of_bound_integer` used `Post.id` (a non-null primary key), so no row matched the spurious `IS NULL` and the bug was masked.

### Fix

Distinguish a caller-supplied `nil` from a value that serialized to `nil`: keep an explicit `nil` (still matches `NULL`), but drop a non-nil value that is not serializable or serializes to `nil` — mirroring `Enumerable#in_order_of`. Applied to both the scalar and grouped-array branches, so a dropped value contributes neither a `WHERE` term nor an `ORDER BY` branch.

Dropping values means the list can become empty (e.g. every listed value is unrepresentable). An empty list would build an empty `CASE` expression — `CASE END`, or `CASE ELSE 1 END` with `filter: false` — which is invalid SQL and raises `StatementInvalid`. This was previously unreachable because nothing shrank the list; now that values can be dropped, an empty result is treated like an empty `values` list and returns `none!`, the same as when the caller passes `[]`.

### Tests

Added to `field_ordered_values_test.rb`:

* `test_in_order_of_with_unknown_enum_key_does_not_match_nulls` — a nullable enum column (`Book#nullable_status`) with a `nil`-status row; an unknown key is ignored and the `nil` row is not surfaced.
* `test_in_order_of_with_out_of_bound_integer_does_not_match_nulls` — a nullable integer column (`Book#format_record_id`) with a `nil` row; the out-of-range value is ignored and the `nil` row is not surfaced (the gap the PK-based existing test missed).
* `test_in_order_of_with_only_unrepresentable_values_does_not_build_empty_case` — every listed value is dropped; asserts no `StatementInvalid` is raised and the result is empty, for both `filter: true` and `filter: false` (the latter is what surfaces the invalid `CASE ELSE 1 END`).

A caller-supplied `nil` still matches `NULL` (covered by the existing `test_in_order_of_with_nil` and verified manually).

Verified fail → pass on **sqlite3** (`[2, 3, 1]` → `[2, 1]`; `[2, 1]` → `[1]`; and the empty-`CASE` `StatementInvalid` → empty result), **postgresql**, and **mysql2**. `field_ordered_values_test`, `enum_test`, and `relations_test` are green.

### Notes

* The out-of-range handling added in #44746 documents that such values should be *ignored*, but the implementation turned them into `NULL` matches instead. This restores that intent.
* No upstream issue/PR found.