### PR TITLE
Add regression tests for `counter_cache` with composite FK and unloaded target

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -111,13 +111,25 @@ module ActiveRecord
             if target && !stale_target?
               target.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
             else
-              update_counters_via_scope(klass, owner._read_attribute(reflection.foreign_key), by)
+              foreign_key = reflection.foreign_key
+              value = if foreign_key.is_a?(Array)
+                foreign_key.map { |fk| owner._read_attribute(fk) }
+              else
+                owner._read_attribute(foreign_key)
+              end
+              update_counters_via_scope(klass, value, by)
             end
           end
         end
 
         def update_counters_via_scope(klass, foreign_key, by)
-          scope = klass.unscoped.where!(primary_key(klass) => foreign_key)
+          primary_key = primary_key(klass)
+          where_constraints = if primary_key.is_a?(Array)
+            primary_key.zip(foreign_key).to_h
+          else
+            { primary_key => foreign_key }
+          end
+          scope = klass.unscoped.where!(where_constraints)
           scope.update_counters(reflection.counter_cache_column => by, touch: reflection.options[:touch])
         end
 

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -64,6 +64,13 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "increment counter via the association when the composite foreign key is set directly" do
+    order = Cpk::Order.create!(id: [1, 100], status: "paid")
+    assert_difference -> { order.reload.books_count }, +1 do
+      Cpk::Book.create!(id: [1, 100], shop_id: order.shop_id, order_id: order.id_value, title: "New Book", revision: 1)
+    end
+  end
+
   test "decrement counter" do
     assert_difference "@topic.reload.replies_count", -1 do
       Topic.decrement_counter(:replies_count, @topic.id)
@@ -80,6 +87,16 @@ class CounterCacheTest < ActiveRecord::TestCase
     order = Cpk::Order.first
     assert_difference -> { order.reload.books_count }, -1 do
       Cpk::Order.decrement_counter(:books_count, order.id)
+    end
+  end
+
+  test "decrement counter via the association when destroying a record with a composite foreign key" do
+    order = Cpk::Order.create!(id: [1, 100], status: "paid")
+    Cpk::Book.create!(id: [1, 100], shop_id: order.shop_id, order_id: order.id_value, title: "New Book", revision: 1)
+    book = Cpk::Book.find([1, 100])
+
+    assert_difference -> { order.reload.books_count }, -1 do
+      book.destroy
     end
   end
 

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -88,6 +88,13 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "increment counter via the association when the composite foreign key is set directly" do
+    order = Cpk::Order.create!(id: [1, 100], status: "paid")
+    assert_difference -> { order.reload.books_count }, +1 do
+      Cpk::Book.create!(id: [1, 100], shop_id: order.shop_id, order_id: order.id_value, title: "New Book", revision: 1)
+    end
+  end
+
   test "decrement counter" do
     assert_difference "@topic.reload.replies_count", -1 do
       Topic.decrement_counter(:replies_count, @topic.id)
@@ -104,6 +111,16 @@ class CounterCacheTest < ActiveRecord::TestCase
     order = Cpk::Order.first
     assert_difference -> { order.reload.books_count }, -1 do
       Cpk::Order.decrement_counter(:books_count, order.id)
+    end
+  end
+
+  test "decrement counter via the association when destroying a record with a composite foreign key" do
+    order = Cpk::Order.create!(id: [1, 100], status: "paid")
+    Cpk::Book.create!(id: [1, 100], shop_id: order.shop_id, order_id: order.id_value, title: "New Book", revision: 1)
+    book = Cpk::Book.find([1, 100])
+
+    assert_difference -> { order.reload.books_count }, -1 do
+      book.destroy
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This PR originally fixed `BelongsToAssociation#update_counters` reading a composite
`reflection.foreign_key` (`["shop_id", "order_id"]`) as a single attribute name,
which collapsed the counter scope to an empty `WHERE ()` and raised
`ActiveRecord::StatementInvalid`.

The underlying bug has since been fixed on main by 94d106955bdf07be74dcdcabe9ece26d2ba570aa
("Honor composite FKs in belongs_to counter cache, autosave, and has_many :through nullify"),
and the code was later refactored to use `ActiveRecord::Key`
(`foreign_key.value_of(owner)` / `primary_key.where_hash(values)`).

### Detail

Rebased on current main. The code change is gone — superseded by the upstream fix.
What remains are two regression tests for the **unloaded-target** path, which the
cpk counter cache tests added in 94d10695 don't exercise directly (they always
assign the association, so the target is loaded and the counter goes through
`target.increment!`):

* increment on create when the composite FK columns are set directly
  (`create!(shop_id:, order_id:)`) and the association target was never loaded
* decrement on destroy of a freshly-found record

Both go through `update_counters_via_scope` with the composite FK read off the owner.

### Additional information

`activerecord/test/cases/counter_cache_test.rb` on current main: 66 runs, 0 failures (sqlite3).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
