### PR TITLE
Fix `serialize coder: ActiveRecord::Coders::JSON` double-encoding a JSON column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `serialize` with `coder: ActiveRecord::Coders::JSON` silently double-encoding
+    a native `json`/`jsonb` column.
+
+    *Kenta Ishizaki*
+
 *   Fix `update_all` / `delete_all` ignoring `group` and `having`, updating or
     deleting every row in the table instead of only the rows that satisfy the
     `HAVING` clause.

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -236,7 +236,7 @@ module ActiveRecord
           end
 
           def type_incompatible_with_serialize?(cast_type, coder, type)
-            cast_type.is_a?(ActiveRecord::Type::Json) && coder == ::JSON ||
+            cast_type.is_a?(ActiveRecord::Type::Json) && (coder == ::JSON || coder == Coders::JSON) ||
               cast_type.respond_to?(:type_cast_array, true) && type == ::Array
           end
       end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -227,6 +227,15 @@ module JSONSharedTestCases
     end
   end
 
+  def test_not_compatible_with_serialize_active_record_coders_json
+    new_klass = Class.new(klass) do
+      serialize :payload, coder: ActiveRecord::Coders::JSON
+    end
+    assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
+      new_klass.new
+    end
+  end
+
   class MySettings
     def initialize(hash); @hash = hash end
     def to_hash; @hash end


### PR DESCRIPTION
### Summary

Declaring `serialize` with `coder: JSON` on a column whose type is already a native `json`/`jsonb` raises `ColumnNotSerializableError`, but the equivalent `coder: ActiveRecord::Coders::JSON` slips past the same guard and silently double-encodes the value:

```ruby
class Post < ActiveRecord::Base
  # `data` is a native json/jsonb column
  serialize :data, coder: JSON                          # => raises ColumnNotSerializableError (good)
end

class Post < ActiveRecord::Base
  serialize :data, coder: ActiveRecord::Coders::JSON    # => silently accepted (bug)
end

Post.create!(data: { "a" => 1 })
# raw DB value: "\"{\\\"a\\\":1}\""   (a JSON string of a JSON string)
# a model reading the column without the serializer sees a String, not a Hash
```

The two spellings are meant to be equivalent, so one protecting the user while the other corrupts data is surprising.

### Cause

`build_column_serializer` already treats both spellings as the same JSON coder:

```ruby
if coder == ::JSON || coder == Coders::JSON
  coder = Coders::JSON.new
end
```

But the compatibility guard only checks the bare `::JSON` constant:

```ruby
def type_incompatible_with_serialize?(cast_type, coder, type)
  cast_type.is_a?(ActiveRecord::Type::Json) && coder == ::JSON ||
    cast_type.respond_to?(:type_cast_array, true) && type == ::Array
end
```

So for a `Type::Json` column, `coder: JSON` is correctly rejected, while `coder: ActiveRecord::Coders::JSON` is not — it wraps the JSON type in a `Type::Serialized`, and the value is JSON-encoded twice (once by the serializer, once by the JSON type underneath).

### Fix

Broaden the guard to recognize both spellings, mirroring `build_column_serializer`:

```ruby
def type_incompatible_with_serialize?(cast_type, coder, type)
  cast_type.is_a?(ActiveRecord::Type::Json) && (coder == ::JSON || coder == Coders::JSON) ||
    cast_type.respond_to?(:type_cast_array, true) && type == ::Array
end
```

`ColumnNotSerializableError` is now raised consistently for both forms.

### Test

Added `test_not_compatible_with_serialize_active_record_coders_json` to the shared `JSONSharedTestCases`, alongside the existing `coder: JSON` test, asserting that declaring `coder: ActiveRecord::Coders::JSON` on a native JSON column raises `ColumnNotSerializableError`.

Verified fail → pass on **sqlite3** ("nothing was raised" → raises), **postgresql**, and **mysql2**. The adapter JSON suites and `json_attribute_test` / `serialized_attribute_test` are green on all three adapters.