### PR TITLE
Fix visibility of ActiveRecord::Coders [ci skip]

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -123,7 +123,7 @@ module ActiveRecord
     end
   end
 
-  module Coders
+  module Coders # :nodoc:
     autoload :ColumnSerializer, "active_record/coders/column_serializer"
     autoload :JSON, "active_record/coders/json"
     autoload :YAMLColumn, "active_record/coders/yaml_column"

--- a/activerecord/lib/active_record/coders/column_serializer.rb
+++ b/activerecord/lib/active_record/coders/column_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module Coders # :nodoc:
+  module Coders
     class ColumnSerializer # :nodoc:
       attr_reader :object_class
       attr_reader :coder

--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -3,7 +3,7 @@
 require "active_support/json"
 
 module ActiveRecord
-  module Coders # :nodoc:
+  module Coders
     class JSON # :nodoc:
       DEFAULT_OPTIONS = { escape: false }.freeze
 

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -3,9 +3,9 @@
 require "yaml"
 
 module ActiveRecord
-  module Coders # :nodoc:
+  module Coders
     class YAMLColumn < ColumnSerializer # :nodoc:
-      class SafeCoder
+      class SafeCoder # :nodoc:
         def initialize(permitted_classes: [], unsafe_load: nil)
           @permitted_classes = permitted_classes
           @unsafe_load = unsafe_load


### PR DESCRIPTION
Coders was inconsistently documented: the module defining the autoloads
was documented but these nested classes had it nodoc. I think inverting
it makes more sense.

SafeCoder is an implementation detail, it shouldn't be documented.