### PR TITLE
Fix double encode for Coders::JSON and JSON column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `serialize` with `coder: ActiveRecord::Coders::JSON` silently double-encoding
+    a native `json`/`jsonb` column.
+
+    *Kenta Ishizaki*
+
 *   Fix `update_all` / `delete_all` ignoring `group` and `having`, updating or
     deleting every row in the table instead of only the rows that satisfy the
     `HAVING` clause.

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -205,7 +205,7 @@ module ActiveRecord
           attribute(attr_name, **options)
 
           decorate_attributes([attr_name]) do |attr_name, cast_type|
-            if type_incompatible_with_serialize?(cast_type, coder, type)
+            if type_incompatible_with_serialize?(cast_type, column_serializer, type)
               raise ColumnNotSerializableError.new(attr_name, cast_type)
             end
 
@@ -236,7 +236,7 @@ module ActiveRecord
           end
 
           def type_incompatible_with_serialize?(cast_type, coder, type)
-            cast_type.is_a?(ActiveRecord::Type::Json) && coder == ::JSON ||
+            cast_type.is_a?(ActiveRecord::Type::Json) && Coders::JSON === coder ||
               cast_type.respond_to?(:type_cast_array, true) && type == ::Array
           end
       end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -227,6 +227,15 @@ module JSONSharedTestCases
     end
   end
 
+  def test_not_compatible_with_serialize_active_record_coders_json
+    new_klass = Class.new(klass) do
+      serialize :payload, coder: ActiveRecord::Coders::JSON
+    end
+    assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
+      new_klass.new
+    end
+  end
+
   class MySettings
     def initialize(hash); @hash = hash end
     def to_hash; @hash end


### PR DESCRIPTION
(re-opening #57609)

`build_column_serializer` treats `coder: JSON` and `coder: ActiveRecord::Coders::JSON` as the same JSON coder, but the compatibility guard `type_incompatible_with_serialize?` only matched the bare `::JSON` constant. As a result, declaring `serialize :col, coder: JSON` on a native `json`/`jsonb` column correctly raised `ColumnNotSerializableError`, while the equivalent `coder: ActiveRecord::Coders::JSON` silently wrapped the JSON type in a serializer and encoded the value twice, storing corrupted JSON that other readers see as a string.

This commit fixes the issue by changing the check to always look at the normalized coder, so that it catches any JSON coder variation

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
