### PR TITLE
Make `rails new` work again on systems that do not have vips

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -38,7 +38,7 @@ gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 2.0"
-gem "ruby-vips", "~> 2.3"
+gem "ruby-vips", "~> 2.3", require: false
 <% end -%>
 <%- if options.api? -%>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1874,6 +1874,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     def assert_gem_for_active_storage
       assert_gem "image_processing"
+      assert_gem "ruby-vips", /.*require: false/
     end
 
     def assert_frameworks_are_not_required_when_active_storage_is_skipped
@@ -1890,6 +1891,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     def assert_gems_when_active_storage_is_skipped
       assert_no_gem "image_processing"
+      assert_no_gem "ruby-vips"
     end
 
     def assert_gitattributes_does_not_have_schema_file


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/57403.
Fixes https://github.com/rails/rails/issues/57612.

### Motivation / Background

This Pull Request has been created because `rails new` currently breaks on Rails `main` if you do not have vips. I believe this is a regression as I don't think developers running `rails new` are expected to have vips installed, especially if they are not using ActiveStorage.

### Detail

This Pull Request changes `Gemfile.tt`'s `gem "ruby-vips"` entry to use `require: false`. This way it doesn't error out on rails boot, but only when/if Active Storage loads vips on demand, and at this stage you are expected to have vips or ImageMagick installed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
