### PR TITLE
Allow `insert!` to accept the `:unique_by` option

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `insert!` now accepts the `:unique_by` option, consistent with `insert`.
+
+    *Kenta Ishizaki*
+
 *   Fix reading a `store_accessor` on a `NULL` structured column (`json`, `jsonb`,
     or `hstore`) marking the record as changed and overwriting the `NULL` with an
     empty hash on the next save.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -754,8 +754,8 @@ module ActiveRecord
     # go through Active Record's type casting and serialization.
     #
     # See #insert_all! for more.
-    def insert!(attributes, returning: nil, record_timestamps: nil)
-      insert_all!([ attributes ], returning: returning, record_timestamps: record_timestamps)
+    def insert!(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
+      insert_all!([ attributes ], returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
     end
 
     # Inserts multiple records into the database in a single SQL INSERT

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -120,6 +120,14 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_bang_accepts_unique_by
+    skip unless supports_insert_conflict_target?
+
+    assert_difference "Book.count", +1 do
+      Book.insert!({ name: "UniqueBy", author_id: 1, isbn: "unique-by-insert-bang" }, unique_by: :isbn)
+    end
+  end
+
   def test_insert_all_bang_with_unique_by_raises_on_duplicate
     skip unless supports_insert_conflict_target?
 


### PR DESCRIPTION
### Summary

`ActiveRecord::Persistence::ClassMethods#insert` accepts `:unique_by`, and so does `#insert_all!`, to which `#insert!` delegates. But `#insert!`'s own signature omitted the keyword:

```ruby
def insert!(attributes, returning: nil, record_timestamps: nil)
  insert_all!([ attributes ], returning: returning, record_timestamps: record_timestamps)
end
```

So passing `unique_by:` to `insert!` raised `ArgumentError: unknown keyword: :unique_by`, even though `insert!`'s documentation already points readers to `#insert_all!` for the available options.

```ruby
Book.insert({ id: 1, name: "X", author_id: 1 }, unique_by: :index_books_on_isbn)   # works
Book.insert!({ id: 2, name: "X", author_id: 1 }, unique_by: :index_books_on_isbn)  # ArgumentError (before)
```

This adds `unique_by:` to `#insert!` and forwards it to `#insert_all!`, matching its sibling `#insert`.

### Other Information

- Added `test_insert_bang_accepts_unique_by`, mirroring the existing `test_insert_all_bang_accepts_unique_by` and guarded with `skip unless supports_insert_conflict_target?` (PostgreSQL/SQLite).
- Verified red → green: with the signature change reverted the new test errors with `ArgumentError: unknown keyword: :unique_by`; with the fix the full `insert_all_test.rb` suite is green.
- CHANGELOG entry added (user-facing).