### PR TITLE
Fix `clear_*_change` doc claiming it clears previous changes [ci skip]

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -230,7 +230,7 @@ module ActiveModel
       #
       # This method is generated for each attribute.
       #
-      # Clears all dirty data of the attribute: current changes and previous changes.
+      # Clears the current changes of the attribute.
       #
       #   person = Person.new(name: 'Chris')
       #   person.name = 'Jason'


### PR DESCRIPTION
### Summary

The generated `clear_*_change` method's documentation says it

> Clears all dirty data of the attribute: current changes and previous changes.

But the implementation only clears the current changes:

```ruby
def clear_attribute_change(attr_name)
  mutations_from_database.forget_change(attr_name.to_s)
end
```

`mutations_from_database` backs the *current* changes; `previous_changes` / `saved_changes` are backed by `mutations_before_last_save`, which `clear_attribute_change` never touches. Only `clear_changes_information` clears both trackers. The method's own example demonstrates clearing the current change only.

The "and previous changes" wording was introduced by mistake in `ee58c8e6be`. This drops it so the doc matches the implementation.