### PR TITLE
Fix `ActiveModel::Type::Decimal` doc for a non-numeric cast [ci skip]

### DIFF
--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -32,7 +32,7 @@ module ActiveModel
     #   bag.weight # => nil
     #
     #   bag.weight = :arbitrary
-    #   bag.weight # => nil (the result of `.to_s.to_d`)
+    #   bag.weight # => 0.0 (the result of `.to_s.to_d`)
     #
     # Decimal precision defaults to 18, and can be customized when declaring an
     # attribute:


### PR DESCRIPTION
### Summary

The `ActiveModel::Type::Decimal` documentation example claims that casting a non-numeric value returns `nil`:

```ruby
bag.weight = :arbitrary
bag.weight # => nil (the result of `.to_s.to_d`)
```

But `:arbitrary.to_s.to_d` is `"arbitrary".to_d`, and `BigDecimal` returns `0.0` for a non-numeric string rather than `nil`. The actual type confirms it:

```ruby
ActiveModel::Type::Decimal.new.cast(:arbitrary)  # => 0.0
ActiveModel::Type::Decimal.new.cast("")          # => nil  (only blank strings)
```

The parenthetical "(the result of `.to_s.to_d`)" is correct — it just resolves to `0.0`, not `nil`. Only blank strings cast to `nil`, as the immediately preceding example already shows. This updates the expected value to `0.0`.