### PR TITLE
Fix `accepts_nested_attributes_for` docs about `_destroy` and new records [ci skip]

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -103,7 +103,7 @@ module ActiveRecord
     #
     #   class Member < ActiveRecord::Base
     #     has_many :posts
-    #     accepts_nested_attributes_for :posts
+    #     accepts_nested_attributes_for :posts, allow_destroy: true
     #   end
     #
     # You can now set or update attributes on the associated posts through
@@ -112,7 +112,8 @@ module ActiveRecord
     #
     # For each hash that does _not_ have an <tt>id</tt> key a new record will
     # be instantiated, unless the hash also contains a <tt>_destroy</tt> key
-    # that evaluates to +true+.
+    # that evaluates to +true+ and the <tt>:allow_destroy</tt> option is
+    # enabled.
     #
     #   params = { member: {
     #     name: 'joe', posts_attributes: [
@@ -313,8 +314,9 @@ module ActiveRecord
       #   that checks whether a record should be built for a certain attribute
       #   hash. The hash is passed to the supplied Proc or the method
       #   and it should return either +true+ or +false+. When no +:reject_if+
-      #   is specified, a record will be built for all attribute hashes that
-      #   do not have a <tt>_destroy</tt> value that evaluates to true.
+      #   is specified, a record will be built for all attribute hashes, unless
+      #   the <tt>:allow_destroy</tt> option is enabled and the hash has a
+      #   <tt>_destroy</tt> value that evaluates to true.
       #   Passing <tt>:all_blank</tt> instead of a Proc will create a proc
       #   that will reject a record where all the attributes are blank excluding
       #   any value for +_destroy+.


### PR DESCRIPTION
### Summary

The nested attributes documentation claims, unconditionally, that a new record whose hash carries a truthy `_destroy` is ignored. That is only true when the `:allow_destroy` option is enabled. Without it, the new record is still built — deliberate behavior from the CVE-2015-7577 fix:

```ruby
reject_new_record?(association_name, attributes)
  # => will_be_destroyed?(...) || call_reject_if(...)

will_be_destroyed?(association_name, attributes)
  # => allow_destroy?(association_name) && has_destroy_flag?(attributes)
```

Two places were inaccurate:

1. The **One-to-many** example used a plain `accepts_nested_attributes_for :posts` (i.e. `allow_destroy` defaults to `false`), yet annotated `{ title: '', _destroy: '1' }` with `# this will be ignored` and asserted `member.posts.length # => 2`. With `allow_destroy` off, that record is actually built, so the length would be 3 — the example does not hold.
2. The `:reject_if` description stated that, with no `:reject_if`, a record is built "for all attribute hashes that do not have a `_destroy` value that evaluates to true" — again omitting the `:allow_destroy` precondition.

This adds `allow_destroy: true` to the One-to-many example so it behaves as documented, and adds the missing `:allow_destroy` precondition to both passages so the docs match the implementation.

### Other Information

- Documentation only; no behavior change. `[ci skip]`.
- The behavior is covered by the existing test `test_reject_if_is_not_short_circuited_if_allow_destroy_is_false`.