### PR TITLE
Fix `add_index` example in Active Record Schema docs

### DIFF
--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -15,7 +15,7 @@ module ActiveRecord
   #       t.string :name, null: false
   #     end
   #
-  #     add_index :authors, :name, :unique
+  #     add_index :authors, :name, unique: true
   #
   #     create_table :posts do |t|
   #       t.integer :author_id, null: false


### PR DESCRIPTION
### Summary

The usage example in the `ActiveRecord::Schema` documentation (`activerecord/lib/active_record/schema.rb`) passes `:unique` as a bare third **positional** argument to `add_index`:

```ruby
ActiveRecord::Schema[7.0].define do
  create_table :authors do |t|
    t.string :name, null: false
  end

  add_index :authors, :name, :unique
end
```

`add_index` is defined as `add_index(table_name, column_name, **options)` (`activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb`), and every override/compatibility shim uses the same keyword-only `**options` form. A bare `:unique` symbol is not a keyword argument, so the documented call raises `ArgumentError` before any SQL is generated.

### Evidence

```ruby
def add_index(table_name, column_name, **options)
  [table_name, column_name, options]
end

add_index(:authors, :name, :unique)
# => ArgumentError: wrong number of arguments (given 3, expected 2)

add_index(:authors, :name, unique: true)
# => [:authors, :name, {unique: true}]   # correct form
```

Running the documented `Schema.define` block (`add_index :authors, :name, :unique`) against any adapter raises `ArgumentError`. Copying the documented example does not work.