### PR TITLE
Fix `number_to_delimited` corrupting numbers with a leading sign

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
@@ -22,6 +22,7 @@ module ActiveSupport
             end
           else
             left_parts = []
+            sign = left.slice!(0) if left.start_with?("-", "+")
             offset = left.size % 3
             if offset > 0
               left_parts << left[0, offset]
@@ -31,7 +32,7 @@ module ActiveSupport
               left_parts << left[offset + (i * 3), 3]
             end
 
-            left = left_parts.join(options[:delimiter])
+            left = "#{sign}#{left_parts.join(options[:delimiter])}"
           end
 
           [left, right].compact

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -158,6 +158,28 @@ module ActiveSupport
         end
       end
 
+      def test_to_delimited_with_negative_numbers
+        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+          assert_equal("-1", number_helper.number_to_delimited(-1))
+          assert_equal("-12", number_helper.number_to_delimited(-12))
+          assert_equal("-123", number_helper.number_to_delimited(-123))
+          assert_equal("-1,234", number_helper.number_to_delimited(-1234))
+          assert_equal("-123,456", number_helper.number_to_delimited(-123456))
+          assert_equal("-123,456,789", number_helper.number_to_delimited(-123456789))
+          assert_equal("-123,456.78", number_helper.number_to_delimited(-123456.78))
+          assert_equal("-123,456", number_helper.number_to_delimited("-123456"))
+        end
+      end
+
+      def test_to_delimited_with_leading_plus_sign
+        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+          assert_equal("+123", number_helper.number_to_delimited("+123"))
+          assert_equal("+1,234", number_helper.number_to_delimited("+1234"))
+          assert_equal("+123,456", number_helper.number_to_delimited("+123456"))
+          assert_equal("+123,456.78", number_helper.number_to_delimited("+123456.78"))
+        end
+      end
+
       def test_to_delimited_with_non_finite_floats
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal "Infinity", number_helper.number_to_delimited(Float::INFINITY)


### PR DESCRIPTION
### Summary

`number_to_delimited` inserts a spurious delimiter immediately after the sign of a signed number whenever the digit count is a multiple of three:

```ruby
number_to_delimited(-123456)      # => "-,123,456"   (expected "-123,456")
number_to_delimited(-123)         # => "-,123"       (expected "-123")
number_to_delimited(-123456789)   # => "-,123,456,789"
number_to_delimited(-123456.78)   # => "-,123,456.78"
number_to_delimited("+123456")    # => "+,123,456"   (expected "+123,456")
number_to_delimited("+123")       # => "+,123"       (expected "+123")
```

Because `number_to_rounded` and `number_to_human` route their integer part through the same converter, they are corrupted too when a `delimiter:` is used:

```ruby
number_to_rounded(-123456, delimiter: ",", precision: 0) # => "-,123,456"
number_to_human(-123456, delimiter: ",")                 # => "-,123 Thousand"
```

The output is silently wrong — no exception is raised — so corrupted negative figures can flow straight into invoices, balances, and reports.

### Cause

`NumberToDelimitedConverter#parts` groups the integer part into threes using `offset = left.size % 3`. For a signed value the leading `-`/`+` is part of `left`, so it is treated as one of the leading "digits" and a delimiter is emitted right after it. A signed number whose digit count is a multiple of three (`-123`, `-123456`, `"+123456"`, …) lands the sign alone in the first group, e.g. `["-", "123", "456"].join(",")` → `"-,123,456"`. (`-1234` happens to look correct only because the `-` gets bundled with a digit.)

This fast `% 3` path became the **default** in 33fbedb1b1 ("Make fast behavior the default for NumberToDelimitedConverter"). The previous default `delimiter_pattern` regex `/(\d)(?=(\d\d\d)+(?!\d))/` only ever matched digits, so it handled the sign correctly — making this a regression. The same regression for non-finite floats (`Float::INFINITY` → `"In,fin,ity"`) was fixed in 150e4c0443; this addresses the signed-number case of the same path.

A leading `+` only reaches the converter via string input (numeric `to_s` never emits one), but it is corrupted identically and was likewise handled correctly by the old regex path, so it is fixed here as well.

### Fix

Strip a leading sign from the integer part before grouping and re-prepend it afterwards, mirroring how `NumberToCurrencyConverter` already formats the absolute value and re-applies the sign. The change is confined to `#parts` and does not affect the `delimiter_pattern` (regex) path.

```ruby
sign = left.slice!(0) if left.start_with?("-", "+")
# ... existing grouping ...
left = "#{sign}#{left_parts.join(options[:delimiter])}"
```

### Changes

- `activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb` — preserve a leading sign (`-`/`+`) across delimiter grouping.
- `activesupport/test/number_helper_test.rb` — `test_to_delimited_with_negative_numbers` covering `-1`, `-12`, `-123`, `-1234`, `-123456`, `-123456789`, `-123456.78`, and the string form; plus `test_to_delimited_with_leading_plus_sign` covering `"+123"`, `"+1234"`, `"+123456"`, `"+123456.78"`. (There were previously no signed-number cases for `number_to_delimited`, which is how the regression slipped through.)
### Testing

Verified red → green (the new tests fail before the fix, pass after) and the full `number_helper_test.rb` suite passes (26 runs, 888 assertions, 0 failures). Ripple checks confirmed: `number_to_rounded`/`number_to_human` with `delimiter:`, `number_to_currency`, positive numbers, zero, floats, and the custom `delimiter_pattern` path are all unaffected.