### PR TITLE
Fix `InheritableOptions#==` raising `NoMethodError` on non-Hash comparison

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -105,7 +105,7 @@ module ActiveSupport
     end
 
     def ==(other)
-      to_h == other.to_h
+      other.is_a?(Hash) && to_h == other.to_h
     end
 
     def inspect

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -174,6 +174,23 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal({ one: "first value", two: "second value", three: "third value" }, object.to_h)
   end
 
+  def test_inheritable_options_equality
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+
+    assert object == ActiveSupport::InheritableOptions.new(one: "first value")
+    assert object == { one: "first value" }
+    assert_not object == { one: "other value" }
+  end
+
+  def test_inheritable_options_equality_with_non_hash_returns_false
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    empty  = ActiveSupport::InheritableOptions.new
+
+    assert_not object == "first value"
+    assert_not object == nil
+    assert_not empty == nil
+  end
+
   def test_ordered_options_dup
     object = ActiveSupport::OrderedOptions.new
     object.one = "first value"


### PR DESCRIPTION
### Summary

`ActiveSupport::InheritableOptions#==` is implemented as:

```ruby
def ==(other)
  to_h == other.to_h
end
```

This `#==` was added in 81d0a29 ("Improve `InheritableOptions` hash-like behaviour") to compare merged parent contents and did not account for non-Hash arguments.

It calls `#to_h` on the argument unconditionally. Comparing an `InheritableOptions` to anything that does not respond to `#to_h` — a `String`, `Integer`, `Symbol`, or any plain object — raises `NoMethodError` instead of returning a boolean. This violates the universal contract of `#==`, which is expected to return `true`/`false` and never raise.

```ruby
options = ActiveSupport::InheritableOptions.new(one: "first value")

options == "first value"   # => NoMethodError: undefined method 'to_h' for an instance of String
[options].include?("x")    # => NoMethodError (Array#include? compares with #==)
```

Because so many core operations lean on `#==` implicitly (`Array#include?`, `Array#uniq`, `case`/`when`, test assertions, etc.), the crash surfaces far from the comparison itself, as an opaque `NoMethodError`.

Additionally, because `nil.to_h` returns `{}`, an empty `InheritableOptions` currently compares equal to `nil`:

```ruby
ActiveSupport::InheritableOptions.new == nil   # => true (expected false)
```

`InheritableOptions` is a public class used to back things like Rails credentials, `AbstractController` config, Active Record `protocol_adapters`, and Action Text editors, so any code that compares one of those against a non-Hash value hits this.

### Why this fix

The sibling class `OrderedOptions` is a `Hash` subclass and inherits `Hash#==`, which correctly returns `false` for non-Hash arguments:

```ruby
ActiveSupport::OrderedOptions.new == "x"   # => false
```

This patch makes `InheritableOptions#==` honor the same contract by only performing the content comparison when the other object is `Hash`-like, and returning `false` otherwise:

```ruby
def ==(other)
  other.is_a?(Hash) && to_h == other.to_h
end
```

`is_a?(Hash)` (rather than `respond_to?(:to_h)`) is used deliberately to match `Hash#==` exactly: `nil` responds to `#to_h` (`nil.to_h == {}`), so a `respond_to?`-based guard would make an empty `InheritableOptions` compare equal to `nil`. The `is_a?(Hash)` guard still covers comparisons against plain `Hash`, `OrderedOptions`, and other `InheritableOptions` (their merged parent contents are compared via `#to_h`), while returning `false` for every non-Hash value.

### Behavior after the fix

```ruby
options = ActiveSupport::InheritableOptions.new(one: "first value")

options == { one: "first value" }                                     # => true
options == ActiveSupport::InheritableOptions.new(one: "first value")  # => true
options == { one: "other value" }                                     # => false
options == "first value"                                              # => false
options == 42                                                         # => false
options == nil                                                        # => false
[options].include?("x")                                               # => false
```

### Testing

Added `test_inheritable_options_equality` and `test_inheritable_options_equality_with_non_hash_returns_false` to `activesupport/test/ordered_options_test.rb`.

- Without the fix the non-Hash test errors with `NoMethodError: undefined method 'to_h' for an instance of String`.
- With the fix the full `ordered_options_test.rb` is green (30 runs, 99 assertions, 0 failures).

No CHANGELOG entry — this is a small bug fix, not a new feature or deprecation.