### PR TITLE
Fix `Range#include?` / `Range#===` raising on exclusive non-integer sub-ranges

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/compare_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/compare_range.rb
@@ -15,13 +15,7 @@ module ActiveSupport
     # The given range must be fully bounded, with both start and end.
     def ===(value)
       if value.is_a?(::Range)
-        is_backwards_op = value.exclude_end? ? :>= : :>
-        return false if value.begin && value.end && value.begin.public_send(is_backwards_op, value.end)
-        # 1...10 includes 1..9 but it does not include 1..10.
-        # 1..10 includes 1...11 but it does not include 1...12.
-        operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
-        super(value.first) && (self.end.nil? || value_max.public_send(operator, last))
+        cover?(value)
       else
         super
       end
@@ -40,13 +34,7 @@ module ActiveSupport
     # The given range must be fully bounded, with both start and end.
     def include?(value)
       if value.is_a?(::Range)
-        is_backwards_op = value.exclude_end? ? :>= : :>
-        return false if value.begin && value.end && value.begin.public_send(is_backwards_op, value.end)
-        # 1...10 includes 1..9 but it does not include 1..10.
-        # 1..10 includes 1...11 but it does not include 1...12.
-        operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
-        super(value.first) && (self.end.nil? || value_max.public_send(operator, last))
+        cover?(value)
       else
         super
       end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -131,6 +131,13 @@ class RangeTest < ActiveSupport::TestCase
     assert_not_operator((...3), :overlap?, (3..))
   end
 
+  def test_include_uses_ruby_include
+    assert((1..3).include?(1.5))
+    assert(("a".."d").include?("c"))
+
+    assert_not(("a".."d").include?("cc")) # As opposed to `=== 'cc'` => `true`
+  end
+
   def test_should_include_identical_inclusive
     assert((1..10).include?(1..10))
   end
@@ -145,6 +152,8 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_include_returns_false_for_backwards
     assert_not((1..10).include?(5..3))
+    assert_not((10..1).include?(3..5))
+    assert_not((10..1).include?(5..3))
   end
 
   # Match quirky plain-Ruby behavior
@@ -158,10 +167,12 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_include_range_with_endless_range
     assert((1..).include?(2..4))
+    assert_not((2..4).include?(1..))
   end
 
   def test_should_not_include_range_with_endless_range
     assert_not((1..).include?(0..4))
+    assert_not((0..4).include?(1..))
   end
 
   def test_include_with_beginless_range
@@ -170,10 +181,20 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_include_range_with_beginless_range
     assert((..2).include?(-1..1))
+    assert((..2).include?(..1))
   end
 
   def test_should_not_include_range_with_beginless_range
     assert_not((..2).include?(-1..3))
+    assert_not((..1).include?(..2))
+    assert_not((-1..1).include?(..2))
+  end
+
+  def test_case_equality_uses_ruby_case_equality
+    assert((1..3) === 1.5)
+    assert(("a".."d") === "c")
+
+    assert(("a".."d") === "cc") # As opposed to `.include?('cc')` => `false`
   end
 
   def test_should_compare_identical_inclusive
@@ -199,18 +220,25 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_compare_range_with_endless_range
     assert((1..) === (2..4))
+    assert((1..) === (1..))
+    assert((1..) === (2..))
   end
 
   def test_should_not_compare_range_with_endless_range
     assert_not((1..) === (0..4))
+    assert_not((0..4) === (1..))
+    assert_not((2..) === (1..))
   end
 
   def test_should_compare_range_with_beginless_range
     assert((..2) === (-1..1))
+    assert((..2) === (..1))
   end
 
   def test_should_not_compare_range_with_beginless_range
     assert_not((..2) === (-1..3))
+    assert_not((..1) === (..2))
+    assert_not((-1..3) === (..2))
   end
 
   def test_exclusive_end_should_not_include_identical_with_inclusive_end
@@ -227,6 +255,22 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_include_identical_exclusive_with_floats
     assert((1.0...10.0).include?(1.0...10.0))
+  end
+
+  def test_should_include_exclusive_end_float_range
+    assert((1.0..10.0).include?(2.0...5.0))
+    assert((1.0..10.0) === (2.0...5.0))
+  end
+
+  def test_should_not_include_exclusive_end_float_range_past_end
+    assert_not((1.0..10.0).include?(2.0...10.5))
+    assert_not((1.0..10.0) === (2.0...10.5))
+  end
+
+  def test_should_include_exclusive_end_time_range
+    range = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
+    assert(range.include?(Time.utc(2005, 12, 10, 16, 0)...Time.utc(2005, 12, 10, 17, 0)))
+    assert(range === (Time.utc(2005, 12, 10, 16, 0)...Time.utc(2005, 12, 10, 17, 0)))
   end
 
   def test_cover_is_not_override


### PR DESCRIPTION
### Summary

ActiveSupport extends `Range#include?` and `Range#===` to support comparing a range against another range. When the argument is a range, the override computed the other range's maximum element like this (`activesupport/lib/active_support/core_ext/range/compare_range.rb`):

```ruby
value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
```

`Range#max` enumerates the range, so for an **exclusive-end range whose endpoint is not an `Integer`** it raises instead of returning a boolean:

```ruby
(1.0..10.0).include?(2.0...5.0)
# => TypeError: cannot exclude non Integer end value

t = Time.now
(t..(t + 1.hour)).include?(t...(t + 10.minutes))
# => TypeError: can't iterate from Time
```

This affects exclusive `Float`, `Time`, `DateTime`, `TimeWithZone`, and `BigDecimal` sub-ranges — exactly the kinds of ranges used for time windows and tolerance bands — turning an ordinary membership check into a hard crash. The `value.max` call exists only so that an integer case such as `(1..10).include?(1...11)` resolves to `true`; for every non-discrete element type it simply blows up.

### Why this fix

The hand-rolled range-vs-range comparison predates `Range#cover?` accepting a range argument (added in Ruby 2.6). Since Rails requires a newer Ruby, the range branch can delegate straight to `Range#cover?`, which is the canonical "is this range fully contained" check and returns the correct boolean for every combination of inclusive/exclusive ends and element type — including the backwards and empty-range edge cases the override handled specially:

```ruby
def ===(value)
  if value.is_a?(::Range)
    cover?(value)
  else
    super
  end
end

def include?(value)
  if value.is_a?(::Range)
    cover?(value)
  else
    super
  end
end
```

The scalar (`else super`) branch is left untouched, so native `Range#include?` / `Range#===` behavior for non-range arguments (e.g. `('a'..'f').include?('c')`) is unchanged.

`Range#cover?` was verified to produce the **same result as every existing assertion** in `range_ext_test.rb` — identical inclusive/exclusive ranges, exclusive-end integer ranges (`1..10` vs `1...11`), backwards ranges (`5..3` → false), empty exclusive ranges (`3...3` → false), endless/beginless ranges, and the overlap cases — while also returning the correct boolean for the previously-crashing Float/Time/BigDecimal cases.

### Behavior after the fix

```ruby
(1.0..10.0).include?(2.0...5.0)    # => true  (was: TypeError)
(1.0..10.0).include?(2.0...10.5)   # => false (was: TypeError)

t = Time.utc(2005, 12, 10, 15, 30)
(t..(t + 2.hours)).include?((t + 30.minutes)...(t + 90.minutes))  # => true (was: TypeError)
```

### Testing

Added to `activesupport/test/core_ext/range_ext_test.rb`:

- `test_should_include_exclusive_end_float_range`
- `test_should_not_include_exclusive_end_float_range_past_end`
- `test_should_include_exclusive_end_time_range`

Without the fix these error with `TypeError: cannot exclude non Integer end value` / `can't iterate from Time`. With the fix:

- `range_ext_test.rb`: 51 runs, 164 assertions, 0 failures, 0 errors
- `time_ext_test.rb`, `date_ext_test.rb`, `date_time_ext_test.rb`, `time_zone_test.rb`, `time_with_zone_test.rb`: all green (no regressions)

No CHANGELOG entry — small bug fix, not a feature or deprecation.