### PR TITLE
Add backticks to `execute` method name in Active Record Migrations guide [ci skip]

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1623,7 +1623,7 @@ key constraints][] in the database.
 In practice, foreign key constraints and unique indexes are generally considered
 safer when enforced at the database level. Although Active Record does not
 provide direct support for working with these database-level features, you can
-still use the execute method to run arbitrary SQL commands.
+still use the `execute` method to run arbitrary SQL commands.
 
 It's worth emphasizing that while the Active Record pattern emphasizes keeping
 intelligence within models, neglecting to implement foreign keys and unique


### PR DESCRIPTION
I fixed the Markdown file for the Active Record Migrations guide to display the `execute` method in code font. This is consistent with the rest of the guide and with other guides.