### PR TITLE
Introduce a new mechanism for applications to prepare for ractor safety

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -685,7 +685,7 @@ module ActionDispatch
         def initialize(name, defaults, &block)
           @name = name
           @defaults = defaults
-          @block = block
+          @block = ActiveSupport::Ractors.try_shareable_proc(block)
         end
 
         def call(t, args, only_path = false)

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/core_ext/object/with"
 
 module ActionDispatch
   module Routing
@@ -185,6 +186,44 @@ module ActionDispatch
         route = @set.from_requirements(controller: "baz", action: "index")
 
         assert_nil route
+      end
+
+      if RUBY_VERSION >= "4.0"
+        test "#resolve raises an error when a proc is not shareable and unshareable_proc_action is :raise" do
+          assert_raise(Ractor::IsolationError) do
+            ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+              draw do
+                to_resolve = [:basket, anchor: "items"]
+
+                resolve("Cart") { to_resolve }
+              end
+            end
+          end
+        end
+
+        test "#resolve trigger a deprecation when a proc is not shareable and unshareable_proc_action is :warn" do
+          assert_deprecated(/Rails attempted to make a Proc .* Ractor shareable/, ActiveSupport.deprecator) do
+            ActiveSupport::Ractors.with(unshareable_proc_action: :warn) do
+              draw do
+                to_resolve = [:basket, anchor: "items"]
+
+                resolve("Cart") { to_resolve }
+              end
+            end
+          end
+        end
+
+        test "#resolve does not attempt to make a proc shareable when unshareable_proc_action is nil" do
+          assert_nothing_raised do
+            ActiveSupport::Ractors.with(unshareable_proc_action: nil) do
+              draw do
+                to_resolve = [:basket, anchor: "items"]
+
+                resolve("Cart") { to_resolve }
+              end
+            end
+          end
+        end
       end
 
       private

--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -5,6 +5,36 @@ module ActiveSupport
   # unconditionally regardless of the Ruby version.
   module Ractors # :nodoc:
     class << self
+      attr_accessor :unshareable_proc_action
+
+      # Attempt to make a proc shareable. If successful, a shareable proc is returned.
+      # If a Ractor::IsolationError is raised, the outcome will depend on how
+      # the user's application configuration:
+      #
+      # :raise - The error is raised
+      # :warn  - A deprecation warning is triggered and the original unshareable proc is returned.
+      def try_shareable_proc(proc = nil, &block)
+        proc ||= block
+        return proc unless unshareable_proc_action
+
+        shareable_proc(&proc)
+      rescue Ractor::IsolationError
+        case unshareable_proc_action
+        when :raise
+          raise
+        when :warn
+          ActiveSupport.deprecator.warn(<<~MSG)
+            Rails attempted to make a Proc from your application Ractor shareable but a Ractor
+            Isolation error was raised. The proc being returned is not Ractor safe and a runtime
+            error may occur anytime during the request lifecycle.
+
+            #{proc.inspect}
+          MSG
+
+          proc
+        end
+      end
+
       if defined?(Ractor) && RUBY_VERSION >= "4.0"
         # Makes +obj+ Ractor-shareable by delegating to +Ractor.make_shareable+.
         #

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -44,5 +44,59 @@ class KernelRactorShareabilityTest < ActiveSupport::TestCase
       assert ActiveSupport::Ractors.shareable?(lambda)
       assert_equal "2", lambda.call
     end
+
+    def test_try_shareable_proc_when_action_is_nil
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = nil
+
+      proc = -> { }
+      attempted = ActiveSupport::Ractors.try_shareable_proc(proc)
+
+      assert_same(proc, attempted)
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_try_shareable_proc_creates_a_shareable_proc
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+
+      proc = -> { }
+      attempted = ActiveSupport::Ractors.try_shareable_proc(proc)
+
+      assert_not_same(proc, attempted)
+      assert ActiveSupport::Ractors.shareable?(attempted)
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_try_shareable_proc_raises
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+
+      outer = []
+      proc = -> { outer }
+
+      assert_raises(Ractor::IsolationError) do
+        ActiveSupport::Ractors.try_shareable_proc(proc)
+      end
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_try_shareable_proc_warns
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :warn
+
+      outer = []
+      proc = -> { outer }
+
+      assert_deprecated(/Rails attempted to make a Proc .* Ractor shareable/, ActiveSupport.deprecator) do
+        attempted = ActiveSupport::Ractors.try_shareable_proc(proc)
+        assert_same(proc, attempted)
+      end
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

We'd like to make Rails applications be Ractor safe. One of the issue is about procs passed to some Rails API. We'd like those application procs to be made shareable, however, specific (and admittedly edge case) application code may prevent us from making the proc shareable.

For example, this snippet will raise a Ractor::IsolationError.

```ruby
  Rails.application.routes.draw do
    to_resolve = [:basket, anchor: "items"]

    resolve("Cart") { to_resolve }
  end
```

This is one example in the rails codebase where we'd hit this problem but there are few others.

### Detail

This PR introduces a way for applications to know whether all procs passed to Rails API are ractors safe. It's opt-in by default and include 3 modes:

* `:raise` -> Rails attempt to make the proc shareable. It it's not, a loud `Ractor::IsolationError` will be raised.
* `:warn` -> We attempt to make the proc shareable. If it's not, we rescue `Ractor::IsolationError` and output a warning.
* `nil` -> We *do not* attempt to make the proc shareable.

This PR introduces this new feature and one codepath (the RouteSet) uses it. We'd be using this mechanism in other part of Rails in future PRs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @matthewd @etiennebarrie @gmcgibbon @andrewn617 