### PR TITLE
Match IPv4-mapped IPv6 addresses against IPv4 trusted proxies in RemoteIp

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Match IPv4-mapped IPv6 addresses against IPv4 trusted proxies in
+    `ActionDispatch::RemoteIp`.
+
+    Since Ruby 3.1 (ipaddr 1.2.3), `IPAddr#include?` no longer matches
+    IPv4-mapped IPv6 addresses against IPv4 ranges, so a proxy reporting
+    an address like `::ffff:10.0.0.1` was no longer recognized as trusted
+    and would be returned as the client IP. IPv4-mapped addresses are now
+    converted to their native IPv4 form before being compared.
+
+    Fixes #52862.
+
+    *Nityesh Agarwal*
+
 *   Rate limiting calls `cache_key` on `by:` if the object responds to it.
 
     ```ruby

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -200,6 +200,9 @@ module ActionDispatch
           return unless raw_ip
 
           ip = IPAddr.new(raw_ip)
+          # Match IPv4-mapped IPv6 addresses (e.g. "::ffff:127.0.0.1") against
+          # IPv4 ranges, as the ipaddr gem did before Ruby 3.1.
+          ip = ip.native if ip.ipv4_mapped?
           @proxies.none? do |proxy|
             if proxy.is_a?(IPAddr)
               proxy.include?(ip)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -206,6 +206,25 @@ class RequestIP < BaseRequestTest
     assert_nil request.remote_ip
   end
 
+  test "remote ip v4 mapped v6 addresses are matched against v4 trusted proxies" do
+    request = stub_request "REMOTE_ADDR" => "::ffff:127.0.0.1",
+                           "HTTP_X_FORWARDED_FOR" => "3.4.5.6"
+    assert_equal "3.4.5.6", request.remote_ip
+
+    request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6,::ffff:127.0.0.1"
+    assert_equal "3.4.5.6", request.remote_ip
+
+    request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6,::ffff:10.0.0.1"
+    assert_equal "3.4.5.6", request.remote_ip
+
+    request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6, ::ffff:172.31.4.4, ::ffff:192.168.0.1"
+    assert_equal "3.4.5.6", request.remote_ip
+
+    # An IPv4-mapped address that is not a trusted proxy is still the client.
+    request = stub_request "HTTP_X_FORWARDED_FOR" => "::ffff:3.4.5.6,127.0.0.1"
+    assert_equal "::ffff:3.4.5.6", request.remote_ip
+  end
+
   test "remote ip v6 spoof detection" do
     request = stub_request "HTTP_X_FORWARDED_FOR" => "2001:0db8:85a3:0000:0000:8a2e:0370:7335",
                            "HTTP_CLIENT_IP"       => "2001:0db8:85a3:0000:0000:8a2e:0370:7334"


### PR DESCRIPTION
### Motivation / Background

Fixes #52862.

Since Ruby 3.1 (ipaddr 1.2.3, [ruby/ipaddr@da22ef8](https://github.com/ruby/ipaddr/commit/da22ef8e6c886197f50281f29d61a30e27c0c88e)), `IPAddr#include?` no longer matches IPv4-mapped IPv6 addresses against IPv4 ranges:

```ruby
IPAddr.new("127.0.0.0/8").include?(IPAddr.new("::ffff:127.0.0.1"))
# => true on Ruby 3.0, false on Ruby 3.1+
```

`ActionDispatch::RemoteIp` relies on this comparison to discard trusted proxies when calculating the client IP. A proxy that reports an IPv4-mapped address — common when a proxy or load balancer accepts connections on a dual-stack socket — is therefore no longer recognized as trusted, and the middleware returns the proxy's address as the client IP instead of the real one.

### Detail

This Pull Request converts IPv4-mapped IPv6 addresses to their native IPv4 form (`IPAddr#native`) in `GetIp#first_non_proxy` before comparing against the trusted proxy list, restoring the pre-Ruby 3.1 behavior. This follows the direction discussed in the issue thread.

- `#native` is a no-op for regular IPv4 and IPv6 addresses, so only mapped addresses change behavior.
- Cross-family comparisons (e.g. a native IPv4 address against `fc00::/7`) simply return `false`, as before.
- The address returned as `remote_ip` is untouched — a non-trusted IPv4-mapped client is still reported in its original mapped form.

### Additional information

The conversion is applied only in the trusted-proxy comparison path (`IPAddr` proxies). Custom proxies given as strings, regexps, or other `===`-matchable objects still match against the raw header value, so existing custom configurations are unaffected.

The new test is red without the fix:

```
Expected: "3.4.5.6"
  Actual: "::ffff:127.0.0.1"
```

and the full Action Pack suite passes with it (4216 runs, 19895 assertions, 0 failures).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
