### PR TITLE
Make callbacks ractor-safe

### DIFF
--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -83,6 +83,7 @@ class ValidatesWithTest < ActiveModel::TestCase
     validator.expect(:new, validator, [{ foo: :bar, if: :condition_is_true, class: Topic }])
     validator.expect(:validate, nil, [topic])
     validator.expect(:is_a?, false, [String]) # Call run by ActiveSupport::Callbacks::Callback.build
+    validator.expect(:is_a?, false, [Proc])   # Call run by ActiveSupport::Callbacks::Callback#try_shareable_proc
 
     Topic.validates_with(validator, if: :condition_is_true, foo: :bar)
     assert_predicate topic, :valid?

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -67,7 +67,7 @@ module ActiveSupport
 
     included do
       extend ActiveSupport::DescendantsTracker
-      class_attribute :__callbacks, instance_writer: false, instance_predicate: false, default: {}
+      class_attribute :__callbacks, instance_writer: false, instance_predicate: false, default: {}.freeze
     end
 
     CALLBACK_FILTER_TYPES = [:before, :after, :around].freeze
@@ -153,7 +153,8 @@ module ActiveSupport
       module Conditionals # :nodoc: all
         class Value
           def initialize(&block)
-            @block = block
+            @block = Ractors.shareable_proc(&block)
+            freeze
           end
           def call(target, value); @block.call(value); end
         end
@@ -245,11 +246,12 @@ module ActiveSupport
 
         def initialize(name, filter, kind, options, chain_config)
           @chain_config = chain_config
-          @name    = name
-          @kind    = kind
-          @filter  = filter
-          @if      = check_conditionals(options[:if])
-          @unless  = check_conditionals(options[:unless])
+          @name            = name
+          @kind            = kind
+          @original_filter = filter
+          @filter          = try_shareable_proc(filter)
+          @if              = check_conditionals(options[:if])
+          @unless          = check_conditionals(options[:unless])
 
           compiled
         end
@@ -267,7 +269,7 @@ module ActiveSupport
         end
 
         def matches?(_kind, _filter)
-          @kind == _kind && filter == _filter
+          @kind == _kind && (filter == _filter || (@original_filter  == _filter.object_id))
         end
 
         def duplicates?(other)
@@ -296,6 +298,19 @@ module ActiveSupport
             end
         end
 
+        def freeze # :nodoc:
+          return self if frozen?
+
+          @filter = Ractors.make_shareable(@filter)
+          @if = make_conditionals_ractor_shareable(@if)
+          @unless = make_conditionals_ractor_shareable(@unless)
+          @compiled = nil
+
+          compiled
+          super
+          self
+        end
+
         # Wraps code with filter
         def apply(callback_sequence)
           compiled.apply(callback_sequence)
@@ -321,14 +336,24 @@ module ActiveSupport
               MSG
             end
 
-            conditionals.freeze
+            conditionals.map! { |conditional| try_shareable_proc(conditional) }
           end
 
           def conditions_lambdas
             conditions =
               @if.map { |c| CallTemplate.build(c, self).make_lambda } +
               @unless.map { |c| CallTemplate.build(c, self).inverted_lambda }
-            conditions.empty? ? EMPTY_ARRAY : conditions
+            conditions.empty? ? EMPTY_ARRAY : conditions.freeze
+          end
+
+          def try_shareable_proc(object)
+            object.is_a?(Proc) ? Ractors.try_shareable_proc(object) : object
+          end
+
+          def make_conditionals_ractor_shareable(conditionals)
+            return conditionals if conditionals.empty?
+
+            Ractors.make_shareable(conditionals)
           end
       end
 
@@ -358,14 +383,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              target.send(@method_name, &block)
+            method_name = @method_name
+            Ractors.shareable_proc do |target, value, &block|
+              target.send(method_name, &block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !target.send(@method_name, &block)
+            method_name = @method_name
+            Ractors.shareable_proc do |target, value, &block|
+              !target.send(method_name, &block)
             end
           end
         end
@@ -381,14 +408,18 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              (@override_target || target).send(@method_name, target, &block)
+            override_target = @override_target
+            method_name = @method_name
+            Ractors.try_shareable_proc do |target, value, &block|
+              (override_target || target).send(method_name, target, &block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !(@override_target || target).send(@method_name, target, &block)
+            override_target = @override_target
+            method_name = @method_name
+            Ractors.try_shareable_proc do |target, value, &block|
+              !(override_target || target).send(method_name, target, &block)
             end
           end
         end
@@ -403,14 +434,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              target.instance_exec(&@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              target.instance_exec(&override_block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !target.instance_exec(&@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              !target.instance_exec(&override_block)
             end
           end
         end
@@ -425,14 +458,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              target.instance_exec(target, &@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              target.instance_exec(target, &override_block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !target.instance_exec(target, &@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              !target.instance_exec(target, &override_block)
             end
           end
         end
@@ -448,16 +483,18 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
               raise ArgumentError unless block
-              target.instance_exec(target, block, &@override_block)
+              target.instance_exec(target, block, &override_block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
               raise ArgumentError unless block
-              !target.instance_exec(target, block, &@override_block)
+              !target.instance_exec(target, block, &override_block)
             end
           end
         end
@@ -472,14 +509,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              (@override_target || target).call(target, value, &block)
+            override_target = @override_target
+            Ractors.shareable_proc do |target, value, &block|
+              (override_target || target).call(target, value, &block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !(@override_target || target).call(target, value, &block)
+            override_target = @override_target
+            Ractors.shareable_proc do |target, value, &block|
+              !(override_target || target).call(target, value, &block)
             end
           end
         end
@@ -563,6 +602,12 @@ module ActiveSupport
         def invoke_after(arg)
           @after&.each { |a| a.call(arg) }
         end
+
+        def freeze
+          @before&.freeze
+          @after&.freeze
+          super
+        end
       end
 
       class CallbackChain # :nodoc:
@@ -576,6 +621,7 @@ module ActiveSupport
             scope: [:kind],
             terminator: DEFAULT_TERMINATOR
           }.merge!(config)
+          @config[:terminator] = Ractors.try_shareable_proc(@config[:terminator]) if @config[:terminator].is_a?(Proc)
           @chain = []
           @all_callbacks = nil
           @single_callbacks = {}
@@ -613,19 +659,15 @@ module ActiveSupport
         end
 
         def compile(type)
-          if type.nil?
+          if frozen?
+            type.nil? ? (@all_callbacks || compile_sequence(nil)) : (@single_callbacks[type] || compile_sequence(type))
+          elsif type.nil?
             @all_callbacks || @mutex.synchronize do
-              final_sequence = CallbackSequence.new
-              @all_callbacks ||= @chain.reverse.inject(final_sequence) do |callback_sequence, callback|
-                callback.apply(callback_sequence)
-              end
+              @all_callbacks ||= compile_sequence(nil)
             end
           else
             @single_callbacks[type] || @mutex.synchronize do
-              final_sequence = CallbackSequence.new
-              @single_callbacks[type] ||= @chain.reverse.inject(final_sequence) do |callback_sequence, callback|
-                type == callback.kind ? callback.apply(callback_sequence) : callback_sequence
-              end
+              @single_callbacks[type] ||= compile_sequence(type)
             end
           end
         end
@@ -638,10 +680,30 @@ module ActiveSupport
           callbacks.each { |c| prepend_one(c) }
         end
 
+        def freeze
+          return self if frozen?
+
+          @chain.each(&:freeze)
+          compile(nil)
+          CALLBACK_FILTER_TYPES.each { |type| compile(type) }
+          @chain.freeze
+          @config.freeze
+          @single_callbacks.freeze
+          @mutex = nil
+          super
+        end
+
         protected
           attr_reader :chain
 
         private
+          def compile_sequence(type)
+            final_sequence = CallbackSequence.new
+            @chain.reverse.inject(final_sequence) do |callback_sequence, callback|
+              type.nil? || type == callback.kind ? callback.apply(callback_sequence) : callback_sequence
+            end
+          end
+
           def append_one(callback)
             @all_callbacks = nil
             @single_callbacks.clear
@@ -940,20 +1002,27 @@ module ActiveSupport
             __callbacks[name.to_sym]
           end
 
-          def set_callbacks(name, callbacks) # :nodoc:
-            # HACK: We're making assumption on how `class_attribute` is implemented
-            # to save constantly duping the callback hash. If this desync with class_attribute
-            # we'll lose the optimization, but won't cause an actual behavior bug.
-            unless singleton_class.private_method_defined?(:__class_attr__callbacks_owner, false)
-              self.__callbacks = __callbacks.dup
+          def freeze # :nodoc:
+            descendants.prepend(self).each do |target|
+              target.__callbacks = Ractors.make_shareable(target.__callbacks)
             end
+          end
+
+          def set_callbacks(name, callbacks) # :nodoc:
             name = name.to_sym
-            callbacks_was = self.__callbacks[name.to_sym]
+            callback_sets = __callbacks.dup
+            callbacks_was = callback_sets[name]
             if (callbacks_was.nil? || callbacks_was.empty?) && !callbacks.empty?
               alias_method("_run_#{name}_callbacks", "_run_#{name}_callbacks!")
             end
-            self.__callbacks[name.to_sym] = callbacks
-            self.__callbacks
+            callback_sets[name] = callbacks
+            ractor_shareable = Ractors.unshareable_proc_action == :raise ||
+              (!__callbacks.empty? && Ractors.shareable?(__callbacks))
+            self.__callbacks = if ractor_shareable
+              Ractors.make_shareable(callback_sets)
+            else
+              callback_sets
+            end
           end
       end
   end

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -295,12 +295,13 @@ module ActiveSupport
             begin
               user_conditions = conditions_lambdas
               user_callback = CallTemplate.build(@filter, self)
+              lambda = Ractors.try_shareable_lambda(user_callback, &user_callback.make_lambda)
 
               case kind
               when :before
-                Filters::Before.new(user_callback.make_lambda, user_conditions, chain_config, @filter, name)
+                Filters::Before.new(lambda, user_conditions, chain_config, @filter, name)
               when :after
-                Filters::After.new(user_callback.make_lambda, user_conditions, chain_config)
+                Filters::After.new(lambda, user_conditions, chain_config)
               when :around
                 Filters::Around.new(user_callback, user_conditions)
               end
@@ -396,16 +397,14 @@ module ActiveSupport
           end
 
           def make_lambda
-            method_name = @method_name
-            Ractors.shareable_proc do |target, value, &block|
-              target.send(method_name, &block)
+            lambda do |target, value, &block|
+              target.send(@method_name, &block)
             end
           end
 
           def inverted_lambda
-            method_name = @method_name
-            Ractors.shareable_proc do |target, value, &block|
-              !target.send(method_name, &block)
+            lambda do |target, value, &block|
+              !target.send(@method_name, &block)
             end
           end
         end
@@ -421,18 +420,14 @@ module ActiveSupport
           end
 
           def make_lambda
-            override_target = @override_target
-            method_name = @method_name
-            Ractors.try_shareable_proc do |target, value, &block|
-              (override_target || target).send(method_name, target, &block)
+            lambda do |target, value, &block|
+              (@override_target || target).send(@method_name, target, &block)
             end
           end
 
           def inverted_lambda
-            override_target = @override_target
-            method_name = @method_name
-            Ractors.try_shareable_proc do |target, value, &block|
-              !(override_target || target).send(method_name, target, &block)
+            lambda do |target, value, &block|
+              !(@override_target || target).send(@method_name, target, &block)
             end
           end
         end
@@ -447,16 +442,14 @@ module ActiveSupport
           end
 
           def make_lambda
-            override_block = @override_block
-            Ractors.try_shareable_proc do |target, value, &block|
-              target.instance_exec(&override_block)
+            lambda do |target, value, &block|
+              target.instance_exec(&@override_block)
             end
           end
 
           def inverted_lambda
-            override_block = @override_block
-            Ractors.try_shareable_proc do |target, value, &block|
-              !target.instance_exec(&override_block)
+            lambda do |target, value, &block|
+              !target.instance_exec(&@override_block)
             end
           end
         end
@@ -471,16 +464,14 @@ module ActiveSupport
           end
 
           def make_lambda
-            override_block = @override_block
-            Ractors.try_shareable_proc do |target, value, &block|
-              target.instance_exec(target, &override_block)
+            lambda do |target, value, &block|
+              target.instance_exec(target, &@override_block)
             end
           end
 
           def inverted_lambda
-            override_block = @override_block
-            Ractors.try_shareable_proc do |target, value, &block|
-              !target.instance_exec(target, &override_block)
+            lambda do |target, value, &block|
+              !target.instance_exec(target, &@override_block)
             end
           end
         end
@@ -496,18 +487,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            override_block = @override_block
-            Ractors.try_shareable_proc do |target, value, &block|
+            lambda do |target, value, &block|
               raise ArgumentError unless block
-              target.instance_exec(target, block, &override_block)
+              target.instance_exec(target, block, &@override_block)
             end
           end
 
           def inverted_lambda
-            override_block = @override_block
-            Ractors.try_shareable_proc do |target, value, &block|
+            lambda do |target, value, &block|
               raise ArgumentError unless block
-              !target.instance_exec(target, block, &override_block)
+              !target.instance_exec(target, block, &@override_block)
             end
           end
         end
@@ -522,16 +511,14 @@ module ActiveSupport
           end
 
           def make_lambda
-            override_target = @override_target
-            Ractors.shareable_proc do |target, value, &block|
-              (override_target || target).call(target, value, &block)
+            lambda do |target, value, &block|
+              (@override_target || target).call(target, value, &block)
             end
           end
 
           def inverted_lambda
-            override_target = @override_target
-            Ractors.shareable_proc do |target, value, &block|
-              !(override_target || target).call(target, value, &block)
+            lambda do |target, value, &block|
+              !(@override_target || target).call(target, value, &block)
             end
           end
         end
@@ -547,7 +534,7 @@ module ActiveSupport
         # All of these objects are converted into a CallTemplate and handled
         # the same after this point.
         def self.build(filter, callback)
-          case filter
+          type = case filter
           when Symbol
             MethodCall.new(filter)
           when Conditionals::Value
@@ -564,6 +551,8 @@ module ActiveSupport
           else
             ObjectCall.new(filter, callback.current_scopes.join("_").to_sym)
           end
+
+          Ractors.try_make_shareable(type)
         end
       end
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -74,7 +74,7 @@ module ActiveSupport
 
     included do
       extend ActiveSupport::DescendantsTracker
-      class_attribute :__callbacks, instance_writer: false, instance_predicate: false, default: {}
+      class_attribute :__callbacks, instance_writer: false, instance_predicate: false, default: {}.freeze
     end
 
     CALLBACK_FILTER_TYPES = [:before, :after, :around].freeze
@@ -162,7 +162,8 @@ module ActiveSupport
       module Conditionals # :nodoc: all
         class Value
           def initialize(&block)
-            @block = block
+            @block = Ractors.shareable_proc(&block)
+            freeze
           end
           def call(target, value); @block.call(value); end
         end
@@ -254,11 +255,12 @@ module ActiveSupport
 
         def initialize(name, filter, kind, options, chain_config)
           @chain_config = chain_config
-          @name    = name
-          @kind    = kind
-          @filter  = filter
-          @if      = check_conditionals(options[:if])
-          @unless  = check_conditionals(options[:unless])
+          @name            = name
+          @kind            = kind
+          @original_filter = filter.object_id
+          @filter          = try_shareable_proc(filter)
+          @if              = check_conditionals(options[:if])
+          @unless          = check_conditionals(options[:unless])
 
           compiled
         end
@@ -276,7 +278,7 @@ module ActiveSupport
         end
 
         def matches?(_kind, _filter)
-          @kind == _kind && filter == _filter
+          @kind == _kind && (filter == _filter || (@original_filter == _filter.object_id))
         end
 
         def duplicates?(other)
@@ -305,6 +307,19 @@ module ActiveSupport
             end
         end
 
+        def freeze # :nodoc:
+          return self if frozen?
+
+          @filter = Ractors.make_shareable(@filter)
+          @if = make_conditionals_ractor_shareable(@if)
+          @unless = make_conditionals_ractor_shareable(@unless)
+          @compiled = nil
+
+          compiled
+          super
+          self
+        end
+
         # Wraps code with filter
         def apply(callback_sequence)
           compiled.apply(callback_sequence)
@@ -330,14 +345,24 @@ module ActiveSupport
               MSG
             end
 
-            conditionals.freeze
+            conditionals.map! { |conditional| try_shareable_proc(conditional) }
           end
 
           def conditions_lambdas
             conditions =
               @if.map { |c| CallTemplate.build(c, self).make_lambda } +
               @unless.map { |c| CallTemplate.build(c, self).inverted_lambda }
-            conditions.empty? ? EMPTY_ARRAY : conditions
+            conditions.empty? ? EMPTY_ARRAY : conditions.freeze
+          end
+
+          def try_shareable_proc(object)
+            object.is_a?(Proc) ? Ractors.try_shareable_proc(object) : object
+          end
+
+          def make_conditionals_ractor_shareable(conditionals)
+            return conditionals if conditionals.empty?
+
+            Ractors.make_shareable(conditionals)
           end
       end
 
@@ -371,14 +396,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              target.send(@method_name, &block)
+            method_name = @method_name
+            Ractors.shareable_proc do |target, value, &block|
+              target.send(method_name, &block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !target.send(@method_name, &block)
+            method_name = @method_name
+            Ractors.shareable_proc do |target, value, &block|
+              !target.send(method_name, &block)
             end
           end
         end
@@ -394,14 +421,18 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              (@override_target || target).send(@method_name, target, &block)
+            override_target = @override_target
+            method_name = @method_name
+            Ractors.try_shareable_proc do |target, value, &block|
+              (override_target || target).send(method_name, target, &block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !(@override_target || target).send(@method_name, target, &block)
+            override_target = @override_target
+            method_name = @method_name
+            Ractors.try_shareable_proc do |target, value, &block|
+              !(override_target || target).send(method_name, target, &block)
             end
           end
         end
@@ -416,14 +447,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              target.instance_exec(&@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              target.instance_exec(&override_block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !target.instance_exec(&@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              !target.instance_exec(&override_block)
             end
           end
         end
@@ -438,14 +471,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              target.instance_exec(target, &@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              target.instance_exec(target, &override_block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !target.instance_exec(target, &@override_block)
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
+              !target.instance_exec(target, &override_block)
             end
           end
         end
@@ -461,16 +496,18 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
               raise ArgumentError unless block
-              target.instance_exec(target, block, &@override_block)
+              target.instance_exec(target, block, &override_block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
+            override_block = @override_block
+            Ractors.try_shareable_proc do |target, value, &block|
               raise ArgumentError unless block
-              !target.instance_exec(target, block, &@override_block)
+              !target.instance_exec(target, block, &override_block)
             end
           end
         end
@@ -485,14 +522,16 @@ module ActiveSupport
           end
 
           def make_lambda
-            lambda do |target, value, &block|
-              (@override_target || target).call(target, value, &block)
+            override_target = @override_target
+            Ractors.shareable_proc do |target, value, &block|
+              (override_target || target).call(target, value, &block)
             end
           end
 
           def inverted_lambda
-            lambda do |target, value, &block|
-              !(@override_target || target).call(target, value, &block)
+            override_target = @override_target
+            Ractors.shareable_proc do |target, value, &block|
+              !(override_target || target).call(target, value, &block)
             end
           end
         end
@@ -578,6 +617,12 @@ module ActiveSupport
         def invoke_after(arg)
           @after&.each { |a| a.call(arg) }
         end
+
+        def freeze
+          @before&.freeze
+          @after&.freeze
+          super
+        end
       end
 
       class CallbackChain # :nodoc:
@@ -591,6 +636,7 @@ module ActiveSupport
             scope: [:kind],
             terminator: DEFAULT_TERMINATOR
           }.merge!(config)
+          @config[:terminator] = Ractors.try_shareable_proc(@config[:terminator]) if @config[:terminator].is_a?(Proc)
           @chain = []
           @all_callbacks = nil
           @single_callbacks = {}
@@ -628,19 +674,15 @@ module ActiveSupport
         end
 
         def compile(type)
-          if type.nil?
+          if frozen?
+            type.nil? ? (@all_callbacks || compile_sequence(nil)) : (@single_callbacks[type] || compile_sequence(type))
+          elsif type.nil?
             @all_callbacks || @mutex.synchronize do
-              final_sequence = CallbackSequence.new
-              @all_callbacks ||= @chain.reverse.inject(final_sequence) do |callback_sequence, callback|
-                callback.apply(callback_sequence)
-              end
+              @all_callbacks ||= compile_sequence(nil)
             end
           else
             @single_callbacks[type] || @mutex.synchronize do
-              final_sequence = CallbackSequence.new
-              @single_callbacks[type] ||= @chain.reverse.inject(final_sequence) do |callback_sequence, callback|
-                type == callback.kind ? callback.apply(callback_sequence) : callback_sequence
-              end
+              @single_callbacks[type] ||= compile_sequence(type)
             end
           end
         end
@@ -653,10 +695,30 @@ module ActiveSupport
           callbacks.each { |c| prepend_one(c) }
         end
 
+        def freeze
+          return self if frozen?
+
+          @chain.each(&:freeze)
+          compile(nil)
+          CALLBACK_FILTER_TYPES.each { |type| compile(type) }
+          @chain.freeze
+          @config.freeze
+          @single_callbacks.freeze
+          @mutex = nil
+          super
+        end
+
         protected
           attr_reader :chain
 
         private
+          def compile_sequence(type)
+            final_sequence = CallbackSequence.new
+            @chain.reverse.inject(final_sequence) do |callback_sequence, callback|
+              type.nil? || type == callback.kind ? callback.apply(callback_sequence) : callback_sequence
+            end
+          end
+
           def append_one(callback)
             @all_callbacks = nil
             @single_callbacks.clear
@@ -973,20 +1035,28 @@ module ActiveSupport
             __callbacks[name.to_sym]
           end
 
-          def set_callbacks(name, callbacks) # :nodoc:
-            # HACK: We're making assumption on how `class_attribute` is implemented
-            # to save constantly duping the callback hash. If this desync with class_attribute
-            # we'll lose the optimization, but won't cause an actual behavior bug.
-            unless singleton_class.private_method_defined?(:__class_attr__callbacks_owner, false)
-              self.__callbacks = __callbacks.dup
+          def freeze # :nodoc:
+            descendants.prepend(self).each do |target|
+              target.__callbacks =
+                Ractors.make_shareable(target.__callbacks)
             end
+          end
+
+          def set_callbacks(name, callbacks) # :nodoc:
             name = name.to_sym
-            callbacks_was = self.__callbacks[name.to_sym]
+            callback_sets = __callbacks.dup
+            callbacks_was = callback_sets[name]
             if (callbacks_was.nil? || callbacks_was.empty?) && !callbacks.empty?
               alias_method("_run_#{name}_callbacks", "_run_#{name}_callbacks!")
             end
-            self.__callbacks[name.to_sym] = callbacks
-            self.__callbacks
+            callback_sets[name] = callbacks
+            ractor_shareable = Ractors.unshareable_proc_action == :raise ||
+              (!__callbacks.empty? && Ractors.shareable?(__callbacks))
+            self.__callbacks = if ractor_shareable
+              Ractors.make_shareable(callback_sets)
+            else
+              callback_sets
+            end
           end
       end
   end

--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -40,6 +40,33 @@ module ActiveSupport
         end
       end
 
+      # Attempt to make a lambda shareable, bound to +receiver+ as its +self+.
+      # If successful, a shareable lambda is returned. If a Ractor::IsolationError
+      # is raised, the outcome will depend on the user's application configuration:
+      #
+      # :raise - The error is raised
+      # :warn  - A deprecation warning is triggered and the original unshareable lambda is returned.
+      def try_shareable_lambda(receiver, &block)
+        return block unless unshareable_proc_action
+
+        shareable_lambda(self: receiver, &block)
+      rescue Ractor::IsolationError
+        case unshareable_proc_action
+        when :raise
+          raise
+        when :warn
+          ActiveSupport.deprecator.warn(<<~MSG)
+            Rails attempted to make a lambda from your application Ractor shareable but a Ractor
+            Isolation error was raised. The lambda being returned is not Ractor safe and a runtime
+            error may occur anytime during the request lifecycle.
+
+            #{block.inspect}
+          MSG
+
+          block
+        end
+      end
+
       # Attempt to make an object shareable. If successful, a shareable object is returned.
       # If a Ractor::IsolationError is raised, the outcome will depend on how
       # the user's application configuration:

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -2,6 +2,8 @@
 
 require_relative "abstract_unit"
 require "active_support/core_ext/kernel/singleton_class"
+require "active_support/core_ext/object/with"
+require "active_support/testing/ractors_assertions"
 
 module CallbacksTest
   class Record
@@ -581,6 +583,8 @@ module CallbacksTest
   end
 
   class CallbacksTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
     def test_save_person
       person = Person.new
       assert_equal [], person.history
@@ -597,6 +601,85 @@ module CallbacksTest
         [:after_save, :proc],
         [:after_save, :symbol]
       ], person.history
+    end
+
+    if RUBY_VERSION >= "4.0"
+      def test_callbacks_are_ractor_shareable
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          klass = Class.new do
+            include ActiveSupport::Callbacks
+
+            define_callbacks :save, terminator: ->(_target, result_lambda) { result_lambda.call == false }
+
+            set_callback :save, :before, -> { events << :before }, if: -> { true }
+            set_callback :save, :around, ->(_record, block) {
+              events << :around_before
+              block.call
+              events << :around_after
+            }
+            set_callback :save, :after, ->(record) { record.events << :after }, unless: -> { false }
+
+            attr_reader :events
+
+            def initialize
+              @events = []
+            end
+
+            def save
+              run_callbacks(:save) { events << :save }
+            end
+          end
+
+          assert_ractor_shareable klass
+
+          assert_equal [:before, :around_before, :save, :after, :around_after], Ractor.new(klass) { |callback_class|
+            record = callback_class.new
+            record.save
+            record.events
+          }.value
+        end
+      end
+
+      def test_user_supplied_callback_procs_use_unshareable_proc_action
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          object = Object.new
+
+          assert_raises(Ractor::IsolationError) do
+            Class.new do
+              include ActiveSupport::Callbacks
+              define_callbacks :save
+              set_callback :save, :before, -> { object }
+            end
+          end
+        end
+      end
+
+      def test_user_supplied_callback_condition_procs_use_unshareable_proc_action
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          object = Object.new
+
+          assert_raises(Ractor::IsolationError) do
+            Class.new do
+              include ActiveSupport::Callbacks
+              define_callbacks :save
+              set_callback :save, :before, :save, if: -> { object }
+            end
+          end
+        end
+      end
+
+      def test_user_supplied_callback_terminator_procs_use_unshareable_proc_action
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          object = Object.new
+
+          assert_raises(Ractor::IsolationError) do
+            Class.new do
+              include ActiveSupport::Callbacks
+              define_callbacks :save, terminator: ->(_target, _result_lambda) { object }
+            end
+          end
+        end
+      end
     end
   end
 

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -2,6 +2,8 @@
 
 require_relative "abstract_unit"
 require "active_support/core_ext/kernel/singleton_class"
+require "active_support/core_ext/object/with"
+require "active_support/testing/ractors_assertions"
 
 module CallbacksTest
   class Record
@@ -579,6 +581,8 @@ module CallbacksTest
   end
 
   class CallbacksTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
     def test_save_person
       person = Person.new
       assert_equal [], person.history
@@ -595,6 +599,110 @@ module CallbacksTest
         [:after_save, :proc],
         [:after_save, :symbol]
       ], person.history
+    end
+
+    if RUBY_VERSION >= "4.0"
+      def test_callbacks_are_ractor_shareable
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          klass = Class.new do
+            include ActiveSupport::Callbacks
+
+            define_callbacks :save, terminator: ->(_target, result_lambda) { result_lambda.call == false }
+
+            set_callback :save, :before, -> { events << :before }, if: -> { true }
+            set_callback :save, :around, ->(_record, block) {
+              events << :around_before
+              block.call
+              events << :around_after
+            }
+            set_callback :save, :after, ->(record) { record.events << :after }, unless: -> { false }
+
+            attr_reader :events
+
+            def initialize
+              @events = []
+            end
+
+            def save
+              run_callbacks(:save) { events << :save }
+            end
+          end
+
+          assert_ractor_shareable klass
+
+          assert_equal [:before, :around_before, :save, :after, :around_after], Ractor.new(klass) { |callback_class|
+            record = callback_class.new
+            record.save
+            record.events
+          }.value
+        end
+      end
+
+      def test_user_supplied_callback_procs_use_unshareable_proc_action
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          object = Object.new
+
+          assert_raises(Ractor::IsolationError) do
+            Class.new do
+              include ActiveSupport::Callbacks
+              define_callbacks :save
+              set_callback :save, :before, -> { object }
+            end
+          end
+        end
+      end
+
+      def test_user_supplied_callback_condition_procs_use_unshareable_proc_action
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          object = Object.new
+
+          assert_raises(Ractor::IsolationError) do
+            Class.new do
+              include ActiveSupport::Callbacks
+              define_callbacks :save
+              set_callback :save, :before, :save, if: -> { object }
+            end
+          end
+        end
+      end
+
+      def test_user_supplied_callback_terminator_procs_use_unshareable_proc_action
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          object = Object.new
+
+          assert_raises(Ractor::IsolationError) do
+            Class.new do
+              include ActiveSupport::Callbacks
+              define_callbacks :save, terminator: ->(_target, _result_lambda) { object }
+            end
+          end
+        end
+      end
+
+      def test_skip_callback_with_proc_filter_when_ractor_shareable
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          filter_proc = ->(record) { record.events << :before_proc }
+
+          klass = Class.new do
+            include ActiveSupport::Callbacks
+            define_callbacks :save
+            set_callback :save, :before, filter_proc
+            attr_accessor :events
+            def initialize; @events = []; end
+            def save; run_callbacks(:save) { @events << :save }; end
+          end
+
+          assert_ractor_shareable klass
+
+          klass.skip_callback(:save, :before, filter_proc)
+
+          assert_equal [:save], Ractor.new(klass) { |k|
+            record = k.new
+            record.save
+            record.events
+          }.value
+        end
+      end
     end
   end
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -205,7 +205,7 @@ module ApplicationTests
 
     if RUBY_VERSION >= "4.0"
       test "notification subscriptions are recorded" do
-        add_to_config "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+        add_to_config "ActiveSupport::Ractors.unshareable_proc_action = :warn"
 
         app_file "config/initializers/subscriptions.rb", <<-RUBY
           WitnessError = Class.new(StandardError)
@@ -236,7 +236,7 @@ module ApplicationTests
       end
 
       test "Notification subscriptions can be added after boot" do
-        add_to_config "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+        add_to_config "ActiveSupport::Ractors.unshareable_proc_action = :warn"
 
         app_file "config/initializers/subscriptions.rb", <<-RUBY
           WitnessError = Class.new(StandardError)

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -12,7 +12,7 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
       def setup
         build_app
 
-        add_to_env_config "production", "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+        add_to_env_config "production", "ActiveSupport::Ractors.unshareable_proc_action = :warn"
 
         # Remove defaults that are not compatible
         add_to_env_config "production", "config.logger = ActiveSupport::Ractors::Logger.new"


### PR DESCRIPTION
### Motivation / Background

This Pull Request makes `ActiveSupport::Callbacks` ractor-safe.

### Detail

This Pull Request changes `ActiveSupport::Callbacks` to do the following:
- Makes user-supplied procs Ractor-shareable when configured
- Makes `__callbacks` / `CallbackChain` shareable
- Makes `set_callbacks` build a new chain instead of mutating the existing one

Ractor shareable behaviour switch taken from https://github.com/rails/rails/pull/57626, which will merge before this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
