### PR TITLE
Remove unordered baseline assertions from test_default_order

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -659,10 +659,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_default_order
     post = posts(:welcome)
 
-    comments = post.comments
-    assert_equal [1, 2], comments.pluck(:id)
-    assert_equal 1, comments.first.id
-
     comments = post.comments.order(:body)
     assert_equal [2, 1], comments.pluck(:id)
     assert_equal 2, comments.first.id

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2025,11 +2025,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_default_order
-    comments = posts(:welcome).comments
-    assert_equal [1, 2], comments.pluck(:id)
-    assert_equal 1, comments.first.id
-
-    comments = comments.default_order(:body)
+    comments = posts(:welcome).comments.default_order(:body)
     assert_equal [2, 1], comments.pluck(:id)
     assert_equal 2, comments.first.id
 


### PR DESCRIPTION
### Motivation / Background

`HasManyAssociationsTest#test_default_order` failed on the rails-nightly build #4408:

https://buildkite.com/rails/rails-nightly/builds/4408#019ea909-5baa-430c-91a2-66d4fe1f65ee/L11949

```
15) Failure:
HasManyAssociationsTest#test_default_order [test/cases/associations/has_many_associations_test.rb:663]:
Expected: [1, 2]
  Actual: [2, 1]
```

### Detail

The failing assertion is a baseline on `posts(:welcome).comments`, a plain association with no order:

```ruby
assert_equal [1, 2], comments.pluck(:id)
```

`comments.pluck(:id)` builds SQL with no `ORDER BY` clause. On PostgreSQL it produced:

```sql
SELECT "comments"."id" FROM "comments" WHERE "comments"."post_id" = $1
```

so the result order is undefined and the `[1, 2]` expectation is unreliable; it had only been passing because the rows happened to come back in that order.

Both `test_default_order` tests were added in #39525 (`default_order` query method and association option). Investigating this failure surfaced the same unordered baseline in `RelationTest#test_default_order`, which carried the same latent problem.

This Pull Request removes the unordered baseline assertions from both tests:

- `HasManyAssociationsTest#test_default_order` — `test/cases/associations/has_many_associations_test.rb`
- `RelationTest#test_default_order` — `test/cases/relations_test.rb`

The baseline lines query a plain association with no order and do not exercise `default_order`. `.sort` would make them deterministic, but they would then only assert that the association returns comments 1 and 2 (already covered by other tests), so they are removed rather than kept as set-only assertions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
