### PR TITLE
Carry `has_many` `default_order:` into the cached association SQL

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -27,6 +27,7 @@ module ActiveRecord
 
         scope.extending! reflection.extensions
         scope = add_constraints(scope, owner, chain)
+        scope.default_order!(reflection.options[:default_order]) if reflection.options[:default_order].present?
         scope.limit!(1) unless reflection.collection?
         scope
       end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -676,6 +676,27 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, comments.first.id
   end
 
+  def test_default_order_is_applied_when_the_target_is_loaded
+    author = authors(:david)
+
+    # The generated SQL (used by pluck/count/to_sql) honors default_order.
+    assert_equal [6, 5, 4, 2, 1], author.posts_with_default_order.pluck(:id)
+
+    # The materialized collection must honor it too, not come back in
+    # arbitrary database order.
+    assert_equal [6, 5, 4, 2, 1], author.posts_with_default_order.to_a.map(&:id)
+    assert_equal [6, 5, 4, 2, 1], author.posts_with_default_order.reload.map(&:id)
+  end
+
+  def test_default_order_keeps_using_the_statement_cache
+    author = authors(:david)
+    association = author.association(:posts_with_default_order)
+
+    # The ORDER BY is baked into the cached SQL, so the statement cache must
+    # not be bypassed.
+    assert_not association.send(:skip_statement_cache?, association.scope)
+  end
+
   def test_finding
     assert_equal 3, Firm.first.clients.length
   end

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -10,6 +10,7 @@ class Author < ActiveRecord::Base
   has_many :posts_with_comments_sorted_by_comment_id, -> { includes(:comments).order("comments.id") }, class_name: "Post"
   has_many :posts_sorted_by_id, -> { order(:id) }, class_name: "Post"
   has_many :posts_sorted_by_id_limited, -> { order("posts.id").limit(1) }, class_name: "Post"
+  has_many :posts_with_default_order, class_name: "Post", default_order: "posts.id DESC"
   has_many :posts_with_categories, -> { includes(:categories) }, class_name: "Post"
   has_many :posts_with_comments_and_categories, -> { includes(:comments, :categories).order("posts.id") }, class_name: "Post"
   has_many :posts_with_special_categorizations, class_name: "PostWithSpecialCategorization"


### PR DESCRIPTION
### Summary

This is the alternative approach @rafaelfranca asked for in https://github.com/rails/rails/pull/57538#issuecomment-4655646072 — it keeps the statement cache instead of opting `default_order:` associations out of it. Supersedes #57538.

The `default_order:` association option (added by aa76590371, merged 2026-05-28 and not yet in a released version) is silently ignored when the association target itself is loaded:

```ruby
class Author < ApplicationRecord
  has_many :posts, default_order: "posts.id DESC"
end

author = Author.first

author.posts.to_sql          # => "... ORDER BY posts.id DESC"   ✅
author.posts.pluck(:id)      # => [6, 5, 4, 2, 1]                ✅
author.posts.to_a.map(&:id)  # => [1, 2, 4, 5, 6]   ❌  arbitrary DB order
author.posts.map(&:id)       # => [1, 2, 4, 5, 6]   ❌
```

So the generated SQL advertises an `ORDER BY` while the materialized collection comes back in arbitrary database order — a silent wrong-result.

### Cause

`CollectionAssociation#scope` applies the option (`scope.default_order!(options[:default_order])`, `collection_association.rb:305`), so building a relation via `pluck`/`count`/`to_sql` does emit the `ORDER BY`.

But `Association#find_target` only uses `self.scope` on the slow path guarded by `skip_statement_cache?`. On the default fast path it builds SQL from the cached statement via `AssociationScope#scope`, which never read `options[:default_order]`. A plain `has_many ..., default_order: ...` has no scope block and no `default_scope`, so `skip_statement_cache?` returns `false` and the cached, `ORDER BY`-less SQL loads the target.

### Fix

Rather than opt the association out of the statement cache (the approach in #57538), build the `ORDER BY` into `AssociationScope#scope` itself so it becomes part of the cached SQL:

```ruby
scope.default_order!(reflection.options[:default_order]) if reflection.options[:default_order].present?
```

`default_order` is a `NORMAL_VALUES` merge key, so the order is carried through `target_scope.merge!` on the cached path, and `default_order!` *assigns* (not appends) its value, so the existing `CollectionAssociation#scope` call stays idempotent. The association keeps using the statement cache.

### Test

`has_many_associations_test.rb` adds a plain `has_many :posts_with_default_order, ..., default_order: "posts.id DESC"` on `Author` (no `default_scope`) and asserts:

- `test_default_order_is_applied_when_the_target_is_loaded` — the loaded target (`to_a` / `reload`) matches the SQL order, not just `pluck`.
- `test_default_order_keeps_using_the_statement_cache` — `skip_statement_cache?` stays `false`, i.e. the order is baked into the cached SQL rather than the cache being bypassed.

Verified **red on `main` / green with the fix**. Full `has_many_associations_test` green on **sqlite3, postgresql, mysql2, and trilogy**.
