### PR TITLE
Preserve falsy default value when building `HashWithIndifferentAccess`

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -75,7 +75,7 @@ module ActiveSupport
         update(constructor)
 
         hash = constructor.is_a?(Hash) ? constructor : constructor.to_hash
-        self.default = hash.default if hash.default
+        self.default = hash.default unless hash.default.nil?
         self.default_proc = hash.default_proc if hash.default_proc
       else
         super(constructor)

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -224,6 +224,16 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal 1, hash[:e]
   end
 
+  def test_indifferent_preserves_falsy_default_from_source_hash
+    source = Hash.new(false)
+    source["a"] = 1
+    hash = HashWithIndifferentAccess.new(source)
+
+    assert_equal false, hash.default
+    assert_equal false, hash[:missing]
+    assert_equal 1, hash[:a]
+  end
+
   def test_indifferent_writing
     hash = HashWithIndifferentAccess.new
     hash[:a] = 1


### PR DESCRIPTION
### Summary

`HashWithIndifferentAccess.new` copies the source hash's default value so that reads for missing keys behave consistently after conversion (introduced in 6e574e8a11 to make `.new` match `.new_from_hash_copying_default`). The copy is guarded by `if hash.default`:

```ruby
self.default = hash.default if hash.default
```

Because `false` (and `nil`) are falsy in Ruby, a source hash built with a deliberately-falsy default — e.g. `Hash.new(false)`, a common pattern for "unknown keys are off" flag maps — silently loses its default. Reads for missing keys then return `nil` instead of `false`.

```ruby
source = Hash.new(false)
source["a"] = 1
hwia = ActiveSupport::HashWithIndifferentAccess.new(source)

hwia.default     # => nil   (expected: false)
hwia["missing"]  # => nil   (expected: false)
```

### Fix

Guard on `unless hash.default.nil?` so a falsy-but-present default is preserved. A plain hash's default is `nil`, so the common case is a no-op.

```ruby
self.default = hash.default unless hash.default.nil?
```

### Notes

- One-line change in `activesupport/lib/active_support/hash_with_indifferent_access.rb`.
- Adds a regression test; full HWIA suite (96 runs) is green.
- No CHANGELOG entry (simple bug fix, not a feature/deprecation).