### PR TITLE
Forward blocks to `DelegateClass` methods that yield implicitly

### DIFF
--- a/activesupport/lib/active_support/delegation.rb
+++ b/activesupport/lib/active_support/delegation.rb
@@ -232,6 +232,15 @@ module ActiveSupport
               "..."
             end
 
+            # Methods that yield to an implicit block do not list a `:block`
+            # parameter, so forward an anonymous block to them too. The `...`
+            # signature already forwards the block.
+            forwards_implicit_block = signature != "..." && parameters.none? { |type, _name| type == :block }
+
+            if forwards_implicit_block
+              signature = signature.empty? ? "&" : "#{signature}, &"
+            end
+
             method_def <<
               "def #{method_name}(#{signature})" <<
               "  __getobj__.#{method_name}(#{signature})" <<

--- a/activesupport/test/delegation_test.rb
+++ b/activesupport/test/delegation_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/core_ext/module/delegation"
+
+class DelegationTest < ActiveSupport::TestCase
+  # A class whose methods yield to an implicit block (no explicit `&block`
+  # parameter), plus a few other arities to guard against regressions.
+  class Target
+    def each_doubled
+      yield 1
+      yield 2
+    end
+
+    def maybe_yield
+      yield :yielded if block_given?
+      :returned
+    end
+
+    def with_required(arg)
+      yield arg
+    end
+
+    def with_keyword(value:)
+      yield value
+    end
+  end
+
+  DelegatingWrapper = ActiveSupport::Delegation.DelegateClass(Target)
+
+  setup do
+    @wrapper = DelegatingWrapper.new(Target.new)
+  end
+
+  test "forwards a block to a delegated method that yields implicitly" do
+    collected = []
+    @wrapper.each_doubled { |value| collected << value }
+    assert_equal [1, 2], collected
+  end
+
+  test "block_given? is true in the delegated method when a block is passed" do
+    assert_equal :yielded, (@wrapper.maybe_yield { |v| break v })
+  end
+
+  test "no block is forwarded when none is given" do
+    assert_equal :returned, @wrapper.maybe_yield
+  end
+
+  test "forwards a block alongside a required positional argument" do
+    assert_equal 42, (@wrapper.with_required(42) { |arg| break arg })
+  end
+
+  test "forwards a block alongside a required keyword argument" do
+    assert_equal :ok, (@wrapper.with_keyword(value: :ok) { |v| break v })
+  end
+
+  test "forwards a block to a yielding method inherited from the delegated class" do
+    wrapper = ActiveSupport::Delegation.DelegateClass(Array).new([1, 2, 3])
+    assert_equal [2, 4, 6], wrapper.map { |n| n * 2 }
+    assert_equal [1, 3], wrapper.select(&:odd?)
+  end
+end


### PR DESCRIPTION
### Summary

`ActiveSupport::Delegation.DelegateClass` builds a delegator method for each public method of the wrapped class, generating each method's signature from its `parameters` (introduced in dc17084b7b, "Faster class delegator", which replaced unconditional `...` forwarding with per-method signatures).

Methods that yield to an **implicit** block — i.e. they call `yield` internally rather than declaring an explicit `&block` parameter — do not list a `:block` entry in `parameters`. As a result the generated signature forwards no block, and the wrapped method is invoked without one. The block is **silently dropped**, turning block-taking methods into no-ops with no error.

```ruby
wrapper = ActiveSupport::Delegation.DelegateClass(String).new("a1b2c3")
res = []
wrapper.scan(/\d/) { |m| res << m }
res # => []   (Ruby's stdlib DelegateClass returns ["1", "2", "3"])

ActiveSupport::Delegation.DelegateClass(Array).new([1, 2, 3]).map { |n| n * 2 }
# => [1, 2, 3]   (expected [2, 4, 6])
```

Ruby's stdlib `DelegateClass` forwards the block correctly in both cases, so the Rails delegator diverges from the semantics it is meant to mirror. Because `Delegation.DelegateClass` underpins a number of decorators across the codebase (e.g. ActiveRecord type metadata and optimistic locking), this is an easy-to-miss correctness regression for any wrapped method that takes a block.

### Fix

Forward an anonymous block to delegated methods that do not already declare a block parameter. The `...` signature (used for methods with optional/rest parameters) already forwards the block, so only the explicit-signature branches need it.

### Notes

- ~5 lines changed in `activesupport/lib/active_support/delegation.rb`.
- Adds `activesupport/test/delegation_test.rb` (no dedicated test existed); without the fix 5 of the 6 new tests fail/error, all green with it.
- Calls without a block are unaffected (anonymous `&` forwards a `nil` block).
- CHANGELOG entry included — this is a user-facing behavior regression.