### PR TITLE
Preserve the sub-second fraction in `TimeZone#strptime` with `%s`

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -594,7 +594,7 @@ module ActiveSupport
         return if parts.empty?
 
         if parts[:seconds]
-          time = Time.at(parts[:seconds])
+          time = Time.at(parts[:seconds] + parts.fetch(:sec_fraction, 0))
         else
           time = Time.new(
             parts.fetch(:year, now.year),

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -699,6 +699,15 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
   end
 
+  def test_strptime_with_timestamp_seconds_and_fractional_seconds
+    with_env_tz "US/Eastern" do
+      zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+      time = zone.strptime("1470272280.123456789", "%s.%N")
+      assert_equal 123456789, time.nsec
+      assert_equal Time.strptime("1470272280.123456789", "%s.%N"), time
+    end
+  end
+
   def test_strptime_with_ambiguous_time
     zone = ActiveSupport::TimeZone["Moscow"]
     assert_equal Time.utc(2014, 10, 25, 22, 0, 0), zone.strptime("2014-10-26 01:00:00", "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
### Summary

`ActiveSupport::TimeZone#strptime` silently drops the sub-second fraction when parsing an epoch-seconds format that carries one (`"%s.%N"` / `"%s.%L"`):

```ruby
zone = ActiveSupport::TimeZone["UTC"]

zone.strptime("1577836800.123456789", "%s.%N").nsec   # => 0          (fraction lost)
Time.strptime("1577836800.123456789", "%s.%N").nsec   # => 123456789  (Ruby stdlib)
```

The fraction is lost regardless of the time zone — it is purely a matter of the `:sec_fraction` key being ignored in the `:seconds` branch.

### Cause

`DateTime._strptime("1577836800.123456789", "%s.%N")` returns **both** `{ seconds: 1577836800, sec_fraction: (123456789/1000000000) }`, but the private `parts_to_time` helper's `:seconds` branch only used `parts[:seconds]`:

```ruby
if parts[:seconds]
  time = Time.at(parts[:seconds])          # sec_fraction ignored
else
  time = Time.new(..., parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0), ...)  # added here
end
```

The sibling non-`:seconds` branch already adds `sec_fraction`, and the `iso8601`/`rfc3339`/`parse` code paths all preserve nanoseconds — so this is an oversight, not a deliberate choice. The rdoc states `strptime` mirrors Ruby's `Time.strptime`, which keeps the fraction. The integer `"%s"` case worked only because no `:sec_fraction` is present, and `"%Q"` (milliseconds) worked only because `_strptime` folds everything into a `Rational` `:seconds`.

### Fix

Add the fraction to the seconds, mirroring the other branch:

```ruby
time = Time.at(parts[:seconds] + parts.fetch(:sec_fraction, 0))
```

### Notes

- One-line change in `activesupport/lib/active_support/values/time_zone.rb`.
- Adds `test_strptime_with_timestamp_seconds_and_fractional_seconds`. Without the fix it fails (`nsec` is `0`); with it the full `time_zone_test.rb` suite (566 runs) is green. The existing integer `%s` and `%Q` tests are unaffected.
- No CHANGELOG entry (simple bug fix, not a feature/deprecation).