### PR TITLE
Fix `number_to_currency` crashing on a negative number with `precision: nil`

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -14,7 +14,7 @@ module ActiveSupport
         if number_d
           if number_d.negative?
             number_d = number_d.abs
-            format = options[:negative_format] if (number_d * 10**options[:precision]) >= 0.5
+            format = options[:negative_format] if options[:precision].nil? || (number_d * 10**options[:precision]) >= 0.5
           end
           number_s = NumberToRoundedConverter.convert(number_d, options)
         else

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -111,6 +111,9 @@ module ActiveSupport
           assert_equal("$0.00", number_helper.number_to_currency(-0.0))
           assert_equal("$0.00", number_helper.number_to_currency("-0.0"))
           assert_equal("$1.23", number_helper.number_to_currency(NumberWithToD.new(1.23)))
+          assert_equal("$1,234.5678", number_helper.number_to_currency(1234.5678, precision: nil))
+          assert_equal("-$1,234.5678", number_helper.number_to_currency(-1234.5678, precision: nil))
+          assert_equal("-$1,234.5678", number_helper.number_to_currency("-1234.5678", precision: nil))
         end
       end
 


### PR DESCRIPTION
### Summary

`number_to_currency` accepts `precision: nil` (meaning "no rounding") for positive numbers, but raises `TypeError: nil can't be coerced into Integer` for **any negative number**:

```ruby
number_to_currency(1234.5678, precision: nil)   # => "$1,234.5678"
number_to_currency(-1234.5678, precision: nil)  # => TypeError: nil can't be coerced into Integer
number_to_currency("-1234.5678", precision: nil) # => TypeError (numeric string too)
```

The sibling converters accept `precision: nil` for negatives just fine:

```ruby
number_to_rounded(-1234.5678, precision: nil)     # => "-1234.5678"
number_to_percentage(-1234.5678, precision: nil)  # => "-1234.5678%"
```

### Cause

`NumberToCurrencyConverter#convert` guards the sign on the negative branch so that a value which *rounds to zero* is not rendered as `-$0`:

```ruby
format = options[:negative_format] if (number_d * 10 ** options[:precision]) >= 0.5
```

When `precision` is `nil`, `10 ** nil` raises. The positive branch never executes this guard, which is why only negatives crash. The guard was added in `ce321c4539` ("handle very large numbers"), which did not consider `precision: nil`.

### Fix

When `precision` is `nil` there is no rounding, so a nonzero negative always keeps its sign. Short-circuit the guard on `options[:precision].nil?` so the `negative_format` is applied, matching the positive path and the sibling converters:

```ruby
format = options[:negative_format] if options[:precision].nil? || (number_d * 10 ** options[:precision]) >= 0.5
```

### Notes

- One-line change in `activesupport/lib/active_support/number_helper/number_to_currency_converter.rb`.
- Adds regression assertions to `test_number_to_currency`; the full number-helper suite is green. Without the fix the new assertions error with the `TypeError`.
- No CHANGELOG entry (simple bug fix, not a feature/deprecation).