### PR TITLE
Reinitialize the thread-safe level key when a logger is copied

### DIFF
--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -12,6 +12,11 @@ module ActiveSupport
       @local_level_key = :"logger_thread_safe_level_#{object_id}"
     end
 
+    def initialize_copy(other)
+      super
+      @local_level_key = :"logger_thread_safe_level_#{object_id}"
+    end
+
     def local_level
       IsolatedExecutionState[local_level_key]
     end

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -384,6 +384,15 @@ class LoggerTest < ActiveSupport::TestCase
     ActiveSupport::IsolatedExecutionState.isolation_level = previous_isolation_level
   end
 
+  def test_copied_logger_has_an_independent_local_level
+    copy = @logger.clone
+
+    copy.log_at(:fatal) do
+      assert_equal Logger::FATAL, copy.level
+      assert_equal Logger::DEBUG, @logger.level
+    end
+  end
+
   def test_logger_freeze
     logger = @logger.clone
     logger.freeze


### PR DESCRIPTION
LoggerThreadSafeLevel stores its per-logger thread-local level under a key derived from object_id. A clone/dup has a new object_id but copies the ivar, so it would share the original's level storage and the two loggers would clobber each other's local level (set via #log_at). Regenerate the key in #initialize_copy, mirroring #initialize.
