### PR TITLE
[ActiveModel] Re-run `normalizes` only when the value changed in place

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `normalizes` re-applying normalizations on every validation of an
+    unpersisted record, and speed up validation of normalized attributes.
+
+    The in-place mutation check re-ran the normalizer on every `valid?` of an
+    unpersisted record: wasteful for idempotent normalizers and compounded the
+    result for non-idempotent ones. Normalizations are now re-applied only on a
+    genuine in-place mutation.
+
+    *Yaroslav Markin*
+
 *   Limit the size of strings `ActiveModel::Type::Integer` will coerce with `to_i`.
 
     Calling `to_i` on very long strings can take a long time and could be used as

--- a/activemodel/lib/active_model/attributes/normalization.rb
+++ b/activemodel/lib/active_model/attributes/normalization.rb
@@ -139,8 +139,13 @@ module ActiveModel
       private
         def normalize_changed_in_place_attributes
           self.class.normalized_attributes.each do |name|
-            normalize_attribute(name) if attribute_changed_in_place?(name)
+            attribute = @attributes[name.to_s]
+            normalize_attribute(name) if normalized_attribute_changed_in_place?(attribute)
           end
+        end
+
+        def normalized_attribute_changed_in_place?(attribute)
+          attribute.changed_in_place? && attribute.value != attribute.type.cast(attribute.value_before_type_cast)
         end
 
         class NormalizedValueType < ActiveSupport::Delegation::DelegateClass(ActiveModel::Type::Value) # :nodoc:

--- a/activemodel/test/cases/attributes/normalization_test.rb
+++ b/activemodel/test/cases/attributes/normalization_test.rb
@@ -88,6 +88,19 @@ class NormalizedAttributeTest < ActiveModel::TestCase
     assert_equal "Only Titlecase", NormalizedAircraft.normalize_value_for(:name, "ONLY titlecase")
   end
 
+  test "does not re-apply normalization on repeated validation" do
+    succ = Class.new(Aircraft) do
+      normalizes :name, with: -> name { name.succ }
+    end
+
+    aircraft = succ.new(name: "a")
+    assert_equal "b", aircraft.name
+
+    aircraft.valid?
+    aircraft.valid?
+    assert_equal "b", aircraft.name
+  end
+
   test "minimizes number of times normalization is applied" do
     count_applied = Class.new(Aircraft) do
       normalizes :name, with: -> name { name.succ }


### PR DESCRIPTION
Extract from [#57619] /cc @rafaelfranca 

`normalize_changed_in_place_attributes` ran the normalizer again on every `valid?` call for a record that is not yet saved. It used `attribute_changed_in_place?` to decide. That check compares the current value with the saved one, but an unsaved record has no saved value (it is `nil`), so any attribute that was just read looked changed. The normalizer then ran again on every validation.

For normalizers that return the same result when run twice, this only wasted work. For the others, the result kept growing: for example, a `succ` normalizer turned "b" into "c", then "d", then "e" on each validation.

Now the normalizer runs again only when the value was really changed in place. We check this by comparing the current value with a fresh normalization of the original value. If the value was only read (not changed), we reset it to the original value, so later validations skip it and a later read normalizes the original value again instead of an already-normalized one.

Create, update, and save run the normalizer the same number of times as before. Validating an already-normalized value again is now faster and makes no extra allocations. Benchmark, three string attributes normalized with strip/downcase, read once then validated many times on an unsaved record (Ruby 4.0, Apple M-series):

    YJIT off:  480k i/s  -> 533k i/s   (~1.1x)
    YJIT on:   1.10M i/s -> 1.13M i/s  (about the same)
    allocations per valid?:  6 -> 6

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
