### PR TITLE
Fail direct uploads on unparseable blob creation responses

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix direct uploads hanging when the blob creation request returns a 2xx
+    response without a parseable JSON body.
+
+    On flaky connections the response body can fail to parse even though the
+    request loaded with a 2xx status, leaving `xhr.response` null. `BlobRecord`
+    then threw inside its own load handler and the `DirectUpload` callback was
+    never invoked, so callers could not surface an error or retry. Such
+    responses now fail through the error callback like any other failed
+    request.
+
+    *Daniel Steele*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -1009,7 +1009,7 @@ class BlobRecord {
     }));
   }
   requestDidLoad(event) {
-    if (this.status >= 200 && this.status < 300) {
+    if (this.status >= 200 && this.status < 300 && this.response) {
       const {response: response} = this;
       const {direct_upload: direct_upload} = response;
       delete response.direct_upload;

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -997,7 +997,7 @@
       }));
     }
     requestDidLoad(event) {
-      if (this.status >= 200 && this.status < 300) {
+      if (this.status >= 200 && this.status < 300 && this.response) {
         const {response: response} = this;
         const {direct_upload: direct_upload} = response;
         delete response.direct_upload;

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -50,7 +50,7 @@ export class BlobRecord {
   }
 
   requestDidLoad(event) {
-    if (this.status >= 200 && this.status < 300) {
+    if (this.status >= 200 && this.status < 300 && this.response) {
       const { response } = this
       const { direct_upload } = response
       delete response.direct_upload


### PR DESCRIPTION
### Motivation / Background

`DirectUpload` silently hangs when the blob creation request returns a 2xx status without a parseable JSON body. On flaky connections (observed in production from a Mobile Safari user) the request can load with HTTP 200 while the body fails to parse, so `xhr.response` is `null` (the request uses `responseType = "json"`). `BlobRecord#requestDidLoad` then throws

```
TypeError: Cannot destructure property 'direct_upload' from null or undefined value
```

inside its own XHR load listener, before the `DirectUpload` create callback is invoked. Applications receive neither a success nor an error callback: upload UIs spin forever and delegates have no way to surface an error or offer a retry.

### Detail

This Pull Request changes `BlobRecord#requestDidLoad` to treat a 2xx response without a parseable body as a failed request, routing it through `requestDidError` so the failure reaches the caller via the normal error callback. The compiled bundles are rebuilt (`yarn build`) and an Active Storage CHANGELOG entry is included.

### Additional information

Real-world occurrence: an iPhone user retried a photo upload after a network failure; the retry returned HTTP 200 with a truncated body and the upload hung with no error surfaced to our UI, while Sentry recorded the unhandled TypeError above.

The activestorage package has no JavaScript unit test harness (`test/javascript_package_test.rb` only asserts the compiled bundles are in sync with the source; the build is idempotent after this change). Happy to add a test if there is a preferred place for one.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (No JS unit test harness exists for this package; see additional information.)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.