### PR TITLE
Enable per-pool query log tags prepend config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -69,12 +69,13 @@
 
 *   Allow query log tags to be configured per connection pool.
 
-    A `query_log_tags` key in a `database.yml` entry configures tagging for
-    connections checked out from that pool. Set it to `false` to opt a pool out
-    of tagging even when tags are enabled globally, or to a hash of options:
-    `format` will override the global
-    `config.active_record.query_log_tags_format` so different databases can emit
-    `:legacy` or `:sqlcommenter` formatted comments.
+    Several query log tag settings can be overridden per pool with a `query_log_tags`
+    key in a `database.yml` entry. Its `format` and `prepend_comment` options override
+    the global `config.active_record.query_log_tags_format` and
+    `config.active_record.query_log_tags_prepend_comment`, so different databases can
+    emit `:legacy` or `:sqlcommenter` comments and prepend or append them. Setting
+    `query_log_tags` to `false` instead opts a pool out of tagging entirely, even when
+    tags are enabled globally.
 
     ```yaml
     production:
@@ -84,6 +85,7 @@
         database: analytics
         query_log_tags:
           format: sqlcommenter
+          prepend_comment: false
       replica:
         database: replica
         replica: true

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -67,11 +67,14 @@
 
     *Rosa Gutierrez*
 
-*   Allow the query log tags format to be configured per connection pool.
+*   Allow query log tags to be configured per connection pool.
 
-    A `query_log_tags_format` key in a `database.yml` entry overrides the global
-    `config.active_record.query_log_tags_format` for connections in that pool, so
-    different databases can emit `:legacy` or `:sqlcommenter` formatted comments.
+    A `query_log_tags` key in a `database.yml` entry configures tagging for
+    connections checked out from that pool. Set it to `false` to opt a pool out
+    of tagging even when tags are enabled globally, or to a hash of options:
+    `format` will override the global
+    `config.active_record.query_log_tags_format` so different databases can emit
+    `:legacy` or `:sqlcommenter` formatted comments.
 
     ```yaml
     production:
@@ -79,7 +82,12 @@
         database: primary
       analytics:
         database: analytics
-        query_log_tags_format: sqlcommenter
+        query_log_tags:
+          format: sqlcommenter
+      replica:
+        database: replica
+        replica: true
+        query_log_tags: false
     ```
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -105,10 +105,15 @@ module ActiveRecord
         configuration_hash[:query_cache]
       end
 
+      def query_log_tags_config # :nodoc:
+        configuration_hash[:query_log_tags]
+      end
+
       def query_log_tags_format # :nodoc:
         return @query_log_tags_format if defined? @query_log_tags_format
 
-        @query_log_tags_format = configuration_hash[:query_log_tags_format]&.to_sym
+        config = query_log_tags_config
+        @query_log_tags_format = (config[:format]&.to_sym if config.is_a?(Hash))
       end
 
       def max_queue

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -116,6 +116,13 @@ module ActiveRecord
         @query_log_tags_format = (config[:format]&.to_sym if config.is_a?(Hash))
       end
 
+      def query_log_tags_prepend_comment # :nodoc:
+        return @query_log_tags_prepend_comment if defined? @query_log_tags_prepend_comment
+
+        config = query_log_tags_config
+        @query_log_tags_prepend_comment = (config[:prepend_comment] if config.is_a?(Hash))
+      end
+
       def max_queue
         max_threads * 4
       end

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -85,11 +85,11 @@ module ActiveRecord
   # using the {SQLCommenter}[https://open-telemetry.github.io/opentelemetry-sqlcommenter/] format. This can be changed
   # via {config.active_record.query_log_tags_format}[https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-format]
   #
-  # Query log tags can also be configured per connection pool through a +database.yml+
-  # entry. Setting +query_log_tags+ to +false+ opts a pool out of tagging even when
-  # tags are enabled globally, and a +Hash+ value can override options such as the +format+.
-  # Connections checked out from a pool use its configured options, while pools without
-  # any explicit configuration fall back to the global defaults:
+  # The format can also be overridden per connection pool through the +query_log_tags+
+  # key of a +database.yml+ entry. Connections checked out from that pool use the
+  # configured +format+, while setting +query_log_tags+ to +false+ instead opts the
+  # pool out of tagging entirely. Pools without any explicit configuration fall back
+  # to the global defaults:
   #
   #     production:
   #       primary:
@@ -106,6 +106,19 @@ module ActiveRecord
   # Tag comments can be prepended to the query:
   #
   #     config.active_record.query_log_tags_prepend_comment = true
+  #
+  # Whether the comment is prepended can also be overridden per connection pool with a
+  # +prepend_comment+ key under +query_log_tags+ in a +database.yml+ entry. Connections
+  # checked out from that pool use the configured value, while pools without any explicit
+  # configuration fall back to the global default:
+  #
+  #     production:
+  #       primary:
+  #         database: primary
+  #       analytics:
+  #         database: analytics
+  #         query_log_tags:
+  #           prepend_comment: true
   #
   # For applications where the content will not change during the lifetime of
   # the request or job execution, the tags can be cached for reuse in every query:
@@ -176,7 +189,7 @@ module ActiveRecord
 
         if comment.blank?
           sql
-        elsif prepend_comment
+        elsif resolve_prepend_comment(connection)
           "#{comment} #{sql}"
         else
           "#{sql} #{comment}"
@@ -211,6 +224,11 @@ module ActiveRecord
           else
             @formatter
           end
+        end
+
+        def resolve_prepend_comment(connection)
+          prepend = connection.pool.db_config.query_log_tags_prepend_comment
+          prepend.nil? ? prepend_comment : prepend
         end
 
         def rebuild_handlers

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -85,16 +85,23 @@ module ActiveRecord
   # using the {SQLCommenter}[https://open-telemetry.github.io/opentelemetry-sqlcommenter/] format. This can be changed
   # via {config.active_record.query_log_tags_format}[https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-format]
   #
-  # The format can also be overridden per connection pool by setting +query_log_tags_format+
-  # in a +database.yml+ entry. Connections checked out from that pool use the configured
-  # format, while pools without any explicit configuration fall back to the global default:
+  # Query log tags can also be configured per connection pool through a +database.yml+
+  # entry. Setting +query_log_tags+ to +false+ opts a pool out of tagging even when
+  # tags are enabled globally, and a +Hash+ value can override options such as the +format+.
+  # Connections checked out from a pool use its configured options, while pools without
+  # any explicit configuration fall back to the global defaults:
   #
   #     production:
   #       primary:
   #         database: primary
   #       analytics:
   #         database: analytics
-  #         query_log_tags_format: sqlcommenter
+  #         query_log_tags:
+  #           format: sqlcommenter
+  #       replica:
+  #         database: replica
+  #         replica: true
+  #         query_log_tags: false
   #
   # Tag comments can be prepended to the query:
   #
@@ -163,6 +170,8 @@ module ActiveRecord
       end
 
       def call(sql, connection) # :nodoc:
+        return sql if connection.pool.db_config.query_log_tags_config == false
+
         comment = self.comment(sql: sql, connection: connection)
 
         if comment.blank?

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -204,7 +204,7 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord::QueryLogs.tags_formatter = :legacy
     ActiveRecord::QueryLogs.tags = [ :application ]
 
-    with_db_config(query_log_tags_format: "sqlcommenter") do |connection|
+    with_db_config(query_log_tags: { format: "sqlcommenter" }) do |connection|
       assert_equal "select 1 /*application='active_record'*/",
         ActiveRecord::QueryLogs.call("select 1", connection)
     end
@@ -220,13 +220,22 @@ class QueryLogsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_per_pool_can_be_disabled
+    ActiveRecord::QueryLogs.tags_formatter = :legacy
+    ActiveRecord::QueryLogs.tags = [ :application ]
+
+    with_db_config(query_log_tags: false) do |connection|
+      assert_equal "select 1", ActiveRecord::QueryLogs.call("select 1", connection)
+    end
+  end
+
   def test_cache_is_kept_per_formatter
     ActiveRecord::QueryLogs.cache_query_log_tags = true
     ActiveRecord::QueryLogs.tags_formatter = :legacy
     ActiveRecord::QueryLogs.tags = [ :application ]
 
     with_db_config do |legacy_connection|
-      with_db_config(query_log_tags_format: "sqlcommenter") do |sqlcommenter_connection|
+      with_db_config(query_log_tags: { format: "sqlcommenter" }) do |sqlcommenter_connection|
         # Different formats must not serve each other's cached comment.
         assert_equal "select 1 /*application:active_record*/",
           ActiveRecord::QueryLogs.call("select 1", legacy_connection)

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -204,7 +204,7 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord::QueryLogs.tags_formatter = :legacy
     ActiveRecord::QueryLogs.tags = [ :application ]
 
-    with_query_log_tags_format("sqlcommenter") do |connection|
+    with_db_config(query_log_tags_format: "sqlcommenter") do |connection|
       assert_equal "select 1 /*application='active_record'*/",
         ActiveRecord::QueryLogs.call("select 1", connection)
     end
@@ -214,7 +214,7 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord::QueryLogs.tags_formatter = :sqlcommenter
     ActiveRecord::QueryLogs.tags = [ :application ]
 
-    with_query_log_tags_format(nil) do |connection|
+    with_db_config do |connection|
       assert_equal "select 1 /*application='active_record'*/",
         ActiveRecord::QueryLogs.call("select 1", connection)
     end
@@ -225,8 +225,8 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord::QueryLogs.tags_formatter = :legacy
     ActiveRecord::QueryLogs.tags = [ :application ]
 
-    with_query_log_tags_format(nil) do |legacy_connection|
-      with_query_log_tags_format("sqlcommenter") do |sqlcommenter_connection|
+    with_db_config do |legacy_connection|
+      with_db_config(query_log_tags_format: "sqlcommenter") do |sqlcommenter_connection|
         # Different formats must not serve each other's cached comment.
         assert_equal "select 1 /*application:active_record*/",
           ActiveRecord::QueryLogs.call("select 1", legacy_connection)
@@ -326,10 +326,9 @@ class QueryLogsTest < ActiveRecord::TestCase
   end
 
   private
-    def with_query_log_tags_format(format, &block)
+    def with_db_config(overrides = {}, &block)
       base_config = ActiveRecord::Base.connection_pool.db_config
-      configuration_hash = base_config.configuration_hash
-      configuration_hash = configuration_hash.merge(query_log_tags_format: format) if format
+      configuration_hash = base_config.configuration_hash.merge(overrides)
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(base_config.env_name, base_config.name, configuration_hash)
 
       pool = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :writing, :default).pool

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -245,6 +245,36 @@ class QueryLogsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_per_pool_prepend_comment_overrides_global
+    ActiveRecord::QueryLogs.prepend_comment = false
+    ActiveRecord::QueryLogs.tags = [ :application ]
+
+    with_db_config(query_log_tags: { prepend_comment: true }) do |connection|
+      assert_equal "/*application:active_record*/ select 1",
+        ActiveRecord::QueryLogs.call("select 1", connection)
+    end
+  end
+
+  def test_per_pool_prepend_comment_falls_back_to_global_when_not_set
+    ActiveRecord::QueryLogs.prepend_comment = true
+    ActiveRecord::QueryLogs.tags = [ :application ]
+
+    with_db_config do |connection|
+      assert_equal "/*application:active_record*/ select 1",
+        ActiveRecord::QueryLogs.call("select 1", connection)
+    end
+  end
+
+  def test_per_pool_prepend_comment_can_disable_global
+    ActiveRecord::QueryLogs.prepend_comment = true
+    ActiveRecord::QueryLogs.tags = [ :application ]
+
+    with_db_config(query_log_tags: { prepend_comment: false }) do |connection|
+      assert_equal "select 1 /*application:active_record*/",
+        ActiveRecord::QueryLogs.call("select 1", connection)
+    end
+  end
+
   def test_custom_basic_tags
     ActiveRecord::QueryLogs.tags = [ :application, { custom_string: "test content" } ]
 


### PR DESCRIPTION
[Refactor query_logs test helper to be generic](https://github.com/rails/rails/pull/57641/commits/a3a0668f60177041d80db20b22651f80683b9adf) 

So that it can be used with other keys in the following commits

---

[Allow disabling query_log_tags per pool](https://github.com/rails/rails/pull/57641/commits/5d813755af2a289701d82a21318d6413da7b8f5d) 

A `query_log_tags` key in a `database.yml` entry configures query log
tags for connections checked out from that pool. Set it to `false` to
opt the pool out of tagging even when tags are enabled globally, or to
a hash of options such as `format` to override the global
`config.active_record.query_log_tags_format`. Pools without an explicit
configuration fall back to the global settings.

This supersedes the top-level `query_log_tags_format` key, folding the
per-pool formatter into the same hash and adding the ability to disable
tagging per pool.

```yaml
production:
 primary:
   database: primary
 analytics:
   database: analytics
   query_log_tags:
     format: sqlcommenter
 replica:
   database: replica
   replica: true
   query_log_tags: false
```

---

[Enable per-pool query log tags prepend config](https://github.com/rails/rails/pull/57641/commits/0551469a644b3b51d5d785aad1e57f5177e06e20) 

A `prepend_comment` key under `query_log_tags` in a `database.yml` entry
overrides the global `config.active_record.query_log_tags_prepend_comment`
for connections in that pool, so different databases can prepend or append
the query comment.

```yaml
production:
 primary:
   database: primary
 analytics:
   database: analytics
   query_log_tags:
     prepend_comment: true
```