### PR TITLE
Remove some memoization in Active Record and Active Model

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -68,6 +68,7 @@ module ActiveModel
     CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
 
     included do
+      @attribute_method_patterns_cache = Concurrent::Map.new(initial_capacity: 4)
       class_attribute :attribute_aliases, instance_writer: false, default: {}
       class_attribute :attribute_method_patterns, instance_writer: false, default: [ ClassMethods::AttributeMethodPattern.new ]
     end
@@ -219,7 +220,7 @@ module ActiveModel
           attribute_method_patterns.each do |pattern|
             alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
           end
-          attribute_method_patterns_cache.clear
+          @attribute_method_patterns_cache.clear
         end
       end
 
@@ -313,7 +314,7 @@ module ActiveModel
           attribute_method_patterns.each do |pattern|
             define_attribute_method_pattern(pattern, attr_name, owner: owner, as: as)
           end
-          attribute_method_patterns_cache.clear
+          @attribute_method_patterns_cache.clear
         end
       end
 
@@ -376,7 +377,7 @@ module ActiveModel
         @generated_attribute_methods&.module_eval do
           undef_method(*instance_methods)
         end
-        attribute_method_patterns_cache.clear
+        @attribute_method_patterns_cache.clear
       end
 
       def aliases_by_attribute_name # :nodoc:
@@ -387,7 +388,7 @@ module ActiveModel
         def inherited(base) # :nodoc:
           super
           base.class_eval do
-            @attribute_method_patterns_cache = nil
+            @attribute_method_patterns_cache = Concurrent::Map.new(initial_capacity: 4)
             @aliases_by_attribute_name = nil
             @generated_attribute_methods = nil
           end
@@ -405,21 +406,8 @@ module ActiveModel
           @generated_attribute_methods&.method_defined?(method_name)
         end
 
-        # The methods +method_missing+ and +respond_to?+ of this module are
-        # invoked often in a typical rails, both of which invoke the method
-        # +matched_attribute_method+. The latter method iterates through an
-        # array doing regular expression matches, which results in a lot of
-        # object creations. Most of the time it returns a +nil+ match. As the
-        # match result is always the same given a +method_name+, this cache is
-        # used to alleviate the GC, which ultimately also speeds up the app
-        # significantly (in our case our test suite finishes 10% faster with
-        # this cache).
-        def attribute_method_patterns_cache
-          @attribute_method_patterns_cache ||= Concurrent::Map.new(initial_capacity: 4)
-        end
-
         def attribute_method_patterns_matching(method_name)
-          attribute_method_patterns_cache.compute_if_absent(method_name) do
+          @attribute_method_patterns_cache.compute_if_absent(method_name) do
             attribute_method_patterns.filter_map { |pattern| pattern.match(method_name) }
           end
         end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -81,7 +81,7 @@ module ActiveRecord
         attribute_method_patterns.each do |pattern|
           alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
         end
-        attribute_method_patterns_cache.clear
+        @attribute_method_patterns_cache.clear
       end
 
       def alias_attribute_method_definition(code_generator, pattern, new_name, old_name) # :nodoc:

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -127,16 +127,11 @@ module ActiveRecord
             self._primary_key_definition = ActiveRecord::Key.for(value)
 
             include CompositePrimaryKey if primary_key_definition.composite?
-
-            @attributes_builder = nil
           end
 
           private
             def inherited(base)
               super
-              base.class_eval do
-                @attributes_builder = nil
-              end
             end
         end
     end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -11,6 +11,8 @@ module ActiveRecord
     include ActiveModel::Access
 
     included do
+      @arel_table = Arel::Table.new(klass: self)
+
       ##
       # :singleton-method:
       #
@@ -400,7 +402,7 @@ module ActiveRecord
 
       # Returns an instance of +Arel::Table+ loaded with the current table name.
       def arel_table # :nodoc:
-        @arel_table ||= Arel::Table.new(table_name, klass: self)
+        @arel_table
       end
 
       def predicate_builder # :nodoc:
@@ -431,7 +433,7 @@ module ActiveRecord
           end
 
           subclass.class_eval do
-            @arel_table = nil
+            @arel_table = Arel::Table.new(klass: self)
             @predicate_builder = nil
             @inspection_filter = nil
             @filter_attributes ||= nil

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -277,7 +277,7 @@ module ActiveRecord
         end
 
         @table_name        = value
-        @arel_table        = nil
+        @arel_table        = Arel::Table.new(klass: self)
         @sequence_name     = nil unless @explicit_sequence_name
         @predicate_builder = nil
       end
@@ -448,10 +448,8 @@ module ActiveRecord
       end
 
       def attributes_builder # :nodoc:
-        @attributes_builder ||= begin
-          defaults = _default_attributes.except(*(column_names - Array(primary_key)))
-          ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
-        end
+        defaults = _default_attributes.except(*(column_names - Array(primary_key)))
+        ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
       end
 
       def columns_hash # :nodoc:
@@ -508,7 +506,7 @@ module ActiveRecord
 
       # Returns an array of column names as strings.
       def column_names
-        @column_names ||= columns.map(&:name).freeze
+        columns.map(&:name).freeze
       end
 
       def symbol_column_to_string(name_symbol) # :nodoc:
@@ -585,12 +583,10 @@ module ActiveRecord
         def reload_schema_from_cache(recursive = true)
           @_returning_columns_for_insert = nil
           @_returning_columns_for_update = nil
-          @arel_table = nil
-          @column_names = nil
+          @arel_table = Arel::Table.new(klass: self)
           @symbol_column_to_string_name_hash = nil
           @content_columns = nil
           @column_defaults = nil
-          @attributes_builder = nil
           @columns = nil
           @columns_hash = nil
           @schema_loaded = false

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -17,7 +17,6 @@ module ActiveRecord
       included do
         # Stores the default scope for the class.
         class_attribute :default_scopes, instance_writer: false, instance_predicate: false, default: []
-        class_attribute :default_scope_override, instance_writer: false, instance_predicate: false, default: nil
       end
 
       module ClassMethods
@@ -145,11 +144,7 @@ module ActiveRecord
           def build_default_scope(relation = relation(), all_queries: nil)
             return if abstract_class?
 
-            if default_scope_override.nil?
-              self.default_scope_override = !Base.is_a?(method(:default_scope).owner)
-            end
-
-            if default_scope_override
+            if !Base.is_a?(method(:default_scope).owner)
               # The user has defined their own default scope method, so call that
               evaluate_default_scope do
                 relation.scoping { default_scope }

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -8,10 +8,11 @@ module Arel # :nodoc: all
     @engine = nil
     class << self; attr_accessor :engine; end
 
-    attr_accessor :name
+    attr_writer :name
     attr_reader :table_alias, :klass
 
-    def initialize(name, as: nil, klass: nil, type_caster: klass&.type_caster)
+    def initialize(name = nil, as: nil, klass: nil, type_caster: klass&.type_caster)
+      raise ArgumentError, "A name or klass is required." unless klass || name
       name = name.name if name.is_a?(Symbol)
 
       @name = name
@@ -25,6 +26,10 @@ module Arel # :nodoc: all
         as = nil
       end
       @table_alias = as
+    end
+
+    def name
+      @name || @klass&.table_name
     end
 
     def alias(name = "#{self.name}_2")
@@ -89,7 +94,7 @@ module Arel # :nodoc: all
       # Perf note: aliases and table alias is excluded from the hash
       #  aliases can have a loop back to this table breaking hashes in parent
       #  relations, for the vast majority of cases @name is unique to a query
-      @name.hash
+      name.hash
     end
 
     def eql?(other)

--- a/activerecord/test/cases/arel/support/fake_record.rb
+++ b/activerecord/test/cases/arel/support/fake_record.rb
@@ -124,6 +124,13 @@ module FakeRecord
 
   class Base
     attr_accessor :connection_pool
+    singleton_class.attr_accessor :table_name
+
+    class << self
+      def type_caster
+        nil
+      end
+    end
 
     def initialize
       @connection_pool = ConnectionPool.new

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -4,6 +4,10 @@ require_relative "helper"
 
 module Arel
   class TableTest < Arel::Test
+    class User < FakeRecord::Base
+      self.table_name = "users"
+    end
+
     setup do
       @relation = Table.new(:users)
     end
@@ -171,6 +175,17 @@ module Arel
       relation2 = Table.new(:users, as: "zomg2")
       array = [relation1, relation2]
       assert_equal 2, array.uniq.size
+    end
+
+    test "works with only klass" do
+      table = Table.new(klass: User)
+      assert_equal "users", table.name
+    end
+
+    test "raises without klass or name" do
+      assert_raises(ArgumentError) do
+        Table.new
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Active Records have a lot of memoized values. This makes it difficult to use them in non-main Ractors. We can remove some of the unnecessary memorization with minimal performance impact. Here's a benchmark:

<details>
  <summary>Benchmark Source</summary>

  ```ruby
# frozen_string_literal: true

require "bundler/inline"

RAILS_ROOT = File.expand_path("../..", __dir__)
LABEL = ENV["BRANCH"] || "main"

gemfile(true) do
  source "https://rubygems.org"

  gem "activesupport", path: RAILS_ROOT
  gem "activemodel", path: RAILS_ROOT
  gem "activerecord", path: RAILS_ROOT

  gem "sqlite3"
  gem "benchmark-ips"
end

require "active_record"
require "benchmark/ips"
require "tmpdir"

ENV["DATABASE_URL"] = "sqlite3::memory:"
ActiveRecord::Base.establish_connection(ENV["DATABASE_URL"])
ActiveRecord::Base.logger = nil

ActiveRecord::Schema.verbose = false
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :title
  end
end

class Post < ActiveRecord::Base
end

class DefaultScopedPost < ActiveRecord::Base
  self.table_name = "posts"
  default_scope { where.not(title: nil) }
end

Post.create!(title: "hello")

post = Post.first
title = post.title

SCENARIOS = {
  "Post#title"                  => -> { post.title },
  "Post#method_missing(:title)" => -> { post.public_send(:title) },
  "Post.arel_table"             => -> { Post.arel_table },
  "Post.column_names"           => -> { Post.column_names },
  "Post#to_partial_path"        => -> { post.to_partial_path },
  "Post.new"                    => -> { Post.new },
  "Post#respond_to?(:title)"    => -> { post.respond_to?(:title) },
  "DefaultScopedPost.all"       => -> { DefaultScopedPost.all.to_a },
  "Post.where(title:).load"     => -> { Post.where(title: title).load },
}

SCENARIOS.each do |name, callable|
  # A stable, filesystem-safe hold file per scenario so both runs line up.
  hold_file = File.join(Dir.tmpdir, "ar_bench_#{name.gsub(/\W+/, '_')}.json")

  puts
  puts " #{name} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.config(time: 3, warmup: 1)
    x.report("#{name} (#{LABEL})", &callable)
    x.save!(hold_file)
    x.compare!
  end
end
  ```
</details>

Main
```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [arm64-darwin23]
Warming up --------------------------------------
                 Post#title   760.612k i/100ms
Post#method_missing(:title)   262.269k i/100ms
            Post.arel_table     2.823M i/100ms
          Post.column_names     3.391M i/100ms
       Post#to_partial_path     2.166M i/100ms
                   Post.new    30.420k i/100ms
   Post#respond_to?(:title)   487.990k i/100ms
         Post.where(title:)    18.058k i/100ms
      DefaultScopedPost.all    12.463k i/100ms
    Post.where(title:).load     1.257k i/100ms
Calculating -------------------------------------
                 Post#title      7.494M (± 3.5%) i/s  (133.43 ns/i) -     38.031M in   5.074489s
Post#method_missing(:title)      2.667M (± 8.2%) i/s  (374.93 ns/i) -     13.376M in   5.014897s
            Post.arel_table     26.707M (± 2.5%) i/s   (37.44 ns/i) -    135.494M in   5.073355s
          Post.column_names     30.449M (± 5.1%) i/s   (32.84 ns/i) -    152.590M in   5.011309s
       Post#to_partial_path     19.918M (± 4.7%) i/s   (50.21 ns/i) -     99.643M in   5.002704s
                   Post.new    293.933k (± 6.9%) i/s    (3.40 μs/i) -      1.491M in   5.071158s
   Post#respond_to?(:title)      4.749M (± 2.0%) i/s  (210.57 ns/i) -     23.912M in   5.035120s
         Post.where(title:)    175.377k (± 9.2%) i/s    (5.70 μs/i) -    884.842k in   5.045363s
      DefaultScopedPost.all    124.386k (± 7.3%) i/s    (8.04 μs/i) -    623.150k in   5.009799s
    Post.where(title:).load     12.434k (± 7.5%) i/s   (80.42 μs/i) -     62.850k in   5.054511s
```
This branch (ed35c9e8126b1618b5f6a7d88e8b66534a13ff5c)
```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [arm64-darwin23]
Warming up --------------------------------------
                 Post#title   741.100k i/100ms
Post#method_missing(:title)   260.044k i/100ms
            Post.arel_table   507.494k i/100ms
          Post.column_names   383.205k i/100ms
       Post#to_partial_path   646.323k i/100ms
                   Post.new    25.564k i/100ms
   Post#respond_to?(:title)   483.966k i/100ms
         Post.where(title:)    14.240k i/100ms
      DefaultScopedPost.all    10.621k i/100ms
    Post.where(title:).load     1.105k i/100ms
Calculating -------------------------------------
                 Post#title      7.369M (± 2.8%) i/s  (135.71 ns/i) -     37.055M in   5.028737s
Post#method_missing(:title)      2.628M (± 5.4%) i/s  (380.55 ns/i) -     13.262M in   5.046969s
            Post.arel_table      5.215M (± 5.9%) i/s  (191.76 ns/i) -     26.390M in   5.060544s
          Post.column_names      4.029M (± 5.1%) i/s  (248.21 ns/i) -     20.310M in   5.041067s
       Post#to_partial_path      6.164M (± 6.6%) i/s  (162.24 ns/i) -     31.024M in   5.033123s
                   Post.new    255.921k (± 4.2%) i/s    (3.91 μs/i) -      1.304M in   5.094409s
   Post#respond_to?(:title)      4.798M (± 2.0%) i/s  (208.40 ns/i) -     24.198M in   5.043027s
         Post.where(title:)    143.167k (± 6.9%) i/s    (6.98 μs/i) -    726.240k in   5.072694s
      DefaultScopedPost.all    108.206k (± 5.7%) i/s    (9.24 μs/i) -    541.671k in   5.005915s
    Post.where(title:).load     11.534k (± 6.1%) i/s   (86.70 μs/i) -     58.565k in   5.077673s
```

### Detail

This Pull Request changes Active Record and Active Model by removing the following memoization:
- `arel_table`
- `attribute_method_patterns_cache`
- `attributes_builder`
- `columns_names`
- `default_scope_override`

We're doing this to make Active Record classes more Ractor-friendly. It is possible some of these ivars need to be restored or usage needs to be refactored if the performance impact is too costly. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
