### PR TITLE
Add test coverage for the remaining Type::Date cast branches

### DIFF
--- a/activemodel/test/cases/type/date_test.rb
+++ b/activemodel/test/cases/type/date_test.rb
@@ -30,6 +30,31 @@ module ActiveModel
 
         assert_equal date, type.cast(values_hash_for_multiparameter_assignment)
       end
+
+      def test_type_cast_from_value_responding_to_to_date
+        type = Type::Date.new
+
+        assert_equal ::Date.new(1999, 12, 31), type.cast(::Time.utc(1999, 12, 31, 23, 59, 59))
+        assert_equal ::Date.new(2008, 2, 10), type.cast(::Date.new(2008, 2, 10))
+      end
+
+      def test_type_cast_from_non_iso_string
+        type = Type::Date.new
+
+        assert_equal ::Date.new(2008, 2, 1), type.cast("1 Feb 2008")
+      end
+
+      def test_type_cast_from_invalid_date_string_returns_nil
+        type = Type::Date.new
+
+        assert_nil type.cast("2008-02-31")
+      end
+
+      def test_type_cast_returns_non_date_values_unchanged
+        type = Type::Date.new
+
+        assert_equal 42, type.cast(42)
+      end
     end
   end
 end


### PR DESCRIPTION
`ActiveModel::Type::Date#cast` was only tested for nil/blank/unparseable strings, ISO-format strings, and multiparameter hashes. This completes coverage of the remaining distinct branches of `cast_value` (each a separate code path, not a new input to an already-tested case). Test-only; no production changes.

- a value responding to `#to_date` (e.g. a `Time` or `Date`) is cast via `#to_date` — the documented "Any other values are cast using their `to_date` method" behavior
- a non-ISO but parseable string goes through the fallback parser (`fallback_string_to_date`), distinct from the `ISO_DATE` fast path
- a well-formed but calendar-invalid date string (`"2008-02-31"`) returns `nil` via the `Date.new ... rescue nil` guard — distinct from the unparseable `"ABC"` case, which is caught earlier by the nil-parts guard
- a value that is neither a `String` nor responds to `#to_date` is returned unchanged (the `else` branch)