### PR TITLE
Memoize ivar when freezing ActiveSupport::TaggedLogging::Formatter

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -65,6 +65,11 @@ module ActiveSupport
       def tags_text
         tag_stack.format_message("")
       end
+
+      def freeze
+        tag_stack
+        super
+      end
     end
 
     class TagStack # :nodoc:

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -258,4 +258,10 @@ class TaggedLoggingWithoutBlockTest < ActiveSupport::TestCase
     @logger.tagged("tag") { @logger.info [1, 2, 3] }
     assert_equal "[tag] [1, 2, 3]\n", @output.string
   end
+
+  test "formatter works when frozen" do
+    @logger.formatter.freeze
+    @logger.info "frozen"
+    assert_equal "frozen\n", @output.string
+  end
 end


### PR DESCRIPTION
This lets us use a `ActiveSupport::TaggedLogging::Formatter` in a Ractor-shareable logger.