### PR TITLE
Don't mutate the names array passed to `Cache::Store#delete_multi`

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -702,7 +702,7 @@ module ActiveSupport
         return 0 if names.empty?
 
         options = merged_options(options)
-        names.map! { |key| normalize_key(key, options) }
+        names = names.map { |key| normalize_key(key, options) }
 
         instrument_multi(:delete_multi, names, options) do
           delete_multi_entries(names, **options)

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -453,6 +453,23 @@ module CacheStoreBehavior
     assert_equal(0, @cache.delete_multi([]))
   end
 
+  def test_delete_multi_does_not_mutate_names
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+    names = [key, other_key].freeze
+
+    @cache.write(key, "bar")
+    @cache.write(other_key, "world")
+    assert_equal 2, @cache.delete_multi(names)
+    assert_equal [key, other_key], names
+
+    @cache.write(key, "bar")
+    @cache.write(other_key, "world")
+    assert_equal 2, @cache.delete_multi(names)
+    assert_not @cache.exist?(key)
+    assert_not @cache.exist?(other_key)
+  end
+
   def test_original_store_objects_should_not_be_immutable
     bar = +"bar"
     key = SecureRandom.alphanumeric


### PR DESCRIPTION
### Summary

`delete_multi` destructively mutates the caller's array via `names.map!`, replacing the original keys with namespaced internal cache keys. This is inconsistent with every sibling multi-key method (`read_multi`, `write_multi`, `fetch_multi`), which all build new collections.

```ruby
cache = ActiveSupport::Cache::MemoryStore.new(namespace: "ns")

names = ["foo", "bar"]
cache.write("foo", 1)
cache.write("bar", 2)
cache.delete_multi(names)
names  # => ["ns:foo", "ns:bar"]  (expected ["foo", "bar"])

# Reusing the same array double-namespaces the keys — second call silently deletes nothing:
cache.write("foo", 1)
cache.write("bar", 2)
cache.delete_multi(names)  # => 0  (looks for "ns:ns:foo", "ns:ns:bar")
cache.exist?("foo")        # => true  (stale!)

# A frozen array raises:
cache.delete_multi(["foo", "bar"].freeze)
# => FrozenError: can't modify frozen Array: ["foo", "bar"]
```

### Cause

`delete_multi` uses `names.map!` to normalize keys in place, while the other multi-key methods (`read_multi` uses `flat_map`, `write_multi` uses `each_with_object`, `fetch_multi` goes through `read_multi_entries`) all create new collections. `delete_multi` is the only one that writes normalized internal keys back into the caller's object.

### Fix

Use a non-destructive `map` and rebind the local variable, matching the siblings:

```ruby
names = names.map { |key| normalize_key(key, options) }
```

Nothing downstream relies on the mutation — `delete_multi_entries` (base implementation and the `RedisCacheStore` override) only iterates over the array it receives, and `instrument_multi` only reads it for the event payload.
