### PR TITLE
Return an empty array from `find([])` on a composite primary key

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -492,15 +492,16 @@ module ActiveRecord
       def find_with_ids(*ids)
         raise UnknownPrimaryKey.new(model) if primary_key.nil?
 
+        first_item = ids.first
+        return [] if first_item.is_a?(Array) && first_item.empty?
+
         expects_array = if model.composite_primary_key?
-          ids.first.first.is_a?(Array)
+          first_item.first.is_a?(Array)
         else
-          ids.first.is_a?(Array)
+          first_item.is_a?(Array)
         end
 
-        return [] if expects_array && ids.first.empty?
-
-        ids = ids.first if expects_array
+        ids = first_item if expects_array
 
         ids = ids.compact.uniq
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -2073,6 +2073,13 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [book], Cpk::Book.find([book.id])
   end
 
+  test "find with an empty array on a composite primary key" do
+    empty_array = []
+    result = Cpk::Book.find(empty_array)
+    assert_equal [], result
+    assert_not_same empty_array, result
+  end
+
   test "find with a multiple sets of composite primary key" do
     books = [cpk_books(:cpk_great_author_first_book), cpk_books(:cpk_great_author_second_book)]
     ids = books.map(&:id)


### PR DESCRIPTION
### Summary

`Model.find([])` returns `[]` for a model with a single primary key, but on a model with a composite primary key the same call raises `RecordNotFound`:

```ruby
# Single primary key — returns []
Topic.find([])          # => []

# Composite primary key — raises
Cpk::Book.find([])
# => ActiveRecord::RecordNotFound: Couldn't find all Cpk::Books with
#    '["author_id", "id"]': () (found 0 results, but was looking for 1)
```

Passing an empty array is the natural result of `find(ids)` where `ids` came from a previous query that returned nothing, so the composite-key path should mirror the single-key path and return `[]`.

### Cause

`find_with_ids` decides whether the caller expects an array of records by inspecting the shape of the ids. For a composite primary key it used:

```ruby
expects_array = ids.first.first.is_a?(Array)
```

For `find([])`, `ids.first` is `[]`, so `ids.first.first` is `nil`, not an `Array`. The empty array is therefore misclassified as a *single* composite id and the method tries to look up one record, raising `RecordNotFound`.

### Fix

Treat an empty `ids.first` as the expects-array case:

```ruby
expects_array = ids.first.is_a?(Array) && (ids.first.empty? || ids.first.first.is_a?(Array))
```

This restores parity with the single primary key behavior — `find([])` returns a new empty array. Non-empty composite-id forms (`find([1, 2])`, `find([[1, 2], [3, 4]])`) are unchanged.
