### PR TITLE
Fix associations on a new record when the owner has a composite primary key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `has_many` and `has_one` associations on a new record returning an empty
+    result when the owner has a composite primary key, even when every primary
+    key column is populated.
+
+    *Jean-Samuel Aubry-Guzzi*
+
 *   Fix `increment!` / `decrement!` on models with query constraints to include
     every query constraint column in the counter update.
 

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -4,7 +4,9 @@ module ActiveRecord::Associations
   module ForeignAssociation # :nodoc:
     def foreign_key_present?
       if reflection.klass.primary_key
-        owner.attribute_present?(reflection.active_record_primary_key)
+        Array(reflection.active_record_primary_key).all? do |key|
+          owner.attribute_present?(key)
+        end
       else
         false
       end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2073,6 +2073,27 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert great_author.books.include?(book)
   end
 
+  def test_collection_for_new_record_owner_with_composite_primary_key_present
+    book = Cpk::Book.create!(id: [1, 10], title: "Some book")
+    chapter = book.chapters.create!(id: [1, 100], title: "Some chapter")
+
+    new_book = Cpk::Book.new(id: [1, 10])
+    assert_predicate new_book, :new_record?
+
+    assert_equal [chapter], new_book.chapters.to_a
+  end
+
+  def test_collection_for_new_record_owner_with_composite_primary_key_missing
+    book = Cpk::Book.create!(id: [1, 10], title: "Some book")
+    book.chapters.create!(id: [1, 100], title: "Some chapter")
+
+    new_book = Cpk::Book.new(author_id: 1)
+    assert_predicate new_book, :new_record?
+    assert_not new_book.attribute_present?(:id)
+
+    assert_empty new_book.chapters
+  end
+
   def test_included_in_collection_for_new_records
     client = Client.create(name: "Persisted")
     assert_nil client.client_of

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -183,6 +183,27 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_nil book.shop_id
   end
 
+  def test_has_one_for_new_record_owner_with_composite_primary_key_present
+    order = Cpk::Order.create!(id: [1, 10])
+    book = order.create_book!(id: [1, 100], title: "Some book")
+
+    new_order = Cpk::Order.new(id: [1, 10])
+    assert_predicate new_order, :new_record?
+
+    assert_equal book, new_order.book
+  end
+
+  def test_has_one_for_new_record_owner_with_composite_primary_key_missing
+    order = Cpk::Order.create!(id: [1, 10])
+    order.create_book!(id: [1, 100], title: "Some book")
+
+    new_order = Cpk::Order.new(shop_id: 1)
+    assert_predicate new_order, :new_record?
+    assert_not new_order.attribute_present?(:id)
+
+    assert_nil new_order.book
+  end
+
   def test_natural_assignment_to_nil_after_destroy
     firm = companies(:rails_core)
     old_account_id = firm.account.id


### PR DESCRIPTION
 ### Motivation / Background

This Pull Request has been created because a `has_many` or `has_one` association on a new (unsaved) record returns an empty result when the owner has a composite primary key, even when every key column is populated and matching rows exist. The association is never queried — it just resolves to `[]/nil` without raising.

A single-key owner in the same situation queries correctly, so this is a composite-key parity break. Using the existing `Cpk::Book model (primary key [:author_id, :id], has_many :chapters, foreign_key: [:author_id, :book_id])`:

 ```ruby
   book = Cpk::Book.new(id: [1, 10])   # new_record?, but author_id + id are populated
   book.chapters.to_a
   # Before: []                     ← never queried
   # After:  [#<Cpk::Chapter ...>]  ← queries on (author_id, id)
 ```

 ### Detail

The cause is in `ActiveRecord::Associations::ForeignAssociation#foreign_key_present?`. It passed the composite `active_record_primary_key array` (e.g. `["author_id", "id"]`) to `attribute_present?`, which stringified the array, found no column by that name, and always returned false. That made `null_scope?` (`new_record? && !foreign_key_present?`) always true for an unsaved owner, short-circuiting the query.

 The fix checks each key column individually; single-column keys are unchanged:

 ```ruby
   Array(reflection.active_record_primary_key).all? do |key|
     owner.attribute_present?(key)
   end
 ```

`foreign_key_present?` is shared by `has_many` and `has_one` via `ForeignAssociation` (feeding `CollectionAssociation#null_scope?` and `Association#find_target?` respectively), so both are covered.

 ### Additional information

Same family as other recent composite-key fixes (#57534, #57158), but a distinct mechanism: the key array is misused as an attribute name when checking for presence. Tests were added to both `has_many_associations_test.rb` (`Cpk::Book → chapters`) and `has_one_associations_test.rb` (`Cpk::Order → book`), each covering the all-keys-present and a-key-missing cases — red on main, green with the fix.

 ### Checklist

 - [x] This Pull Request is related to one change.
 - [x] Commit message has a detailed description of what changed and why.
 - [x] Tests are added or updated.
 - [x] CHANGELOG files are updated.
