### PR TITLE
Keep composite primary key columns in the default attribute set

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -449,7 +449,7 @@ module ActiveRecord
 
       def attributes_builder # :nodoc:
         @attributes_builder ||= begin
-          defaults = _default_attributes.except(*(column_names - [primary_key]))
+          defaults = _default_attributes.except(*(column_names - Array(primary_key)))
           ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
         end
       end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -423,6 +423,13 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
     Cpk::Book.delete_all
   end
 
+  def test_reading_composite_primary_key_after_partial_select_returns_nil
+    book = Cpk::Book.select(:title).first
+
+    assert_nil book.author_id
+    assert_equal [nil, nil], book.id
+  end
+
   def test_assigning_a_non_array_value_to_model_with_composite_primary_key_raises
     book = Cpk::Book.new
 


### PR DESCRIPTION
### Summary

On a model with a composite primary key, reading a primary key column after a partial `select` that omits it raises `ActiveModel::MissingAttributeError`, whereas a single primary key returns `nil` in the same situation:

```ruby
# Single primary key — returns nil
Topic.select(:title).first.id        # => nil

# Composite primary key — raises
book = Cpk::Book.select(:title).first
book.author_id
# => ActiveModel::MissingAttributeError: missing attribute 'author_id' for Cpk::Book
```

### Cause

`attributes_builder` builds the always-initialized default attribute set by excluding every column **except** the primary key, so the primary key is always present even on a partial select:

```ruby
defaults = _default_attributes.except(*(column_names - [primary_key]))
```

For a composite primary key, `primary_key` is an array (e.g. `["author_id", "id"]`). `column_names - [primary_key]` subtracts nothing, because no column name equals the array, so `except` removes **every** column — including the primary key components — from the defaults. They are therefore not initialized, and reading them after a partial select raises.

### Fix

Use `Array(primary_key)` so the composite key components are kept in the defaults, mirroring the single primary key behavior. `Array("id")` is `["id"]`, so single primary keys are completely unchanged. This also matches the sibling `_returning_columns_for_insert`, which already uses `Array(primary_key)`.

```ruby
defaults = _default_attributes.except(*(column_names - Array(primary_key)))
```

After the fix, `Cpk::Book.select(:title).first.author_id` returns `nil`, just like a single primary key.
