### PR TITLE
Match composite primary key ids in one-to-one nested attributes

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -438,7 +438,7 @@ module ActiveRecord
         existing_record = send(association_name)
 
         if (options[:update_only] || !attributes["id"].blank?) && existing_record &&
-            (options[:update_only] || existing_record.id.to_s == attributes["id"].to_s)
+            (options[:update_only] || ids_match?(existing_record, attributes["id"]))
           assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 
         elsif attributes["id"].present?
@@ -626,8 +626,15 @@ module ActiveRecord
       end
 
       def find_record_by_id(records, id)
-        id = Array(id).map(&:to_s)
-        records.find { |record| Array(record.id).map(&:to_s) == id }
+        records.find { |record| ids_match?(record, id) }
+      end
+
+      def ids_match?(record, id)
+        if record.class.composite_primary_key?
+          Array(record.id).map(&:to_s) == Array(id).map(&:to_s)
+        else
+          record.id.to_s == id.to_s
+        end
       end
   end
 end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -247,6 +247,16 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_equal 1, book.reload.chapters.count
     assert_equal "New title", book.chapters.first.title
   end
+
+  def test_updating_one_to_one_association_with_cpk_provided_as_strings
+    order = Cpk::OrderWithNestedBook.create!(shop_id: 2)
+    book = order.create_book!(id: [1, 3], title: "Title")
+
+    order.update!(book_attributes: { id: ["1", "3"], title: "New title" })
+
+    assert_equal book.id, order.book.id
+    assert_equal "New title", order.book.reload.title
+  end
 end
 
 class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -16,6 +16,10 @@ module Cpk
     has_many :tags, through: :order_tags
   end
 
+  class OrderWithNestedBook < Order
+    accepts_nested_attributes_for :book
+  end
+
   class BrokenOrder < Order
     self.primary_key = [:shop_id, :status]
 


### PR DESCRIPTION
### Summary

Updating a one-to-one association (`has_one`/`belongs_to`) through nested attributes raises `RecordNotFound` for an existing record when the association target has a composite primary key and the id is supplied component-wise (the shape form params take, and the shape the collection path already accepts):

```ruby
order = Cpk::OrderWithNestedBook.create!(shop_id: 2)
book  = order.create_book!(id: [1, 3], title: "Title")

order.update!(book_attributes: { id: ["1", "3"], title: "New title" })
# => ActiveRecord::RecordNotFound: Couldn't find Cpk::Book with ID=["1", "3"] ...
```

The collection form of the same update already works:

```ruby
book.update!(chapters_attributes: { id: ["1", "3"], title: "New title" }) # OK
```

### Cause

`assign_nested_attributes_for_one_to_one_association` matches the existing record with a plain string comparison:

```ruby
existing_record.id.to_s == attributes["id"].to_s
```

For a composite primary key, `existing_record.id` is an array, so `"[1, 3]"` is compared against the submitted `'["1", "3"]'`. They never match, the record is treated as not found, and `update` raises.

The collection path does not have this problem because `find_record_by_id` already compares composite ids component-wise.

### Fix

Extract the existing `find_record_by_id` comparison into an `ids_match?` helper and use it on the one-to-one path as well, so both paths compare composite primary keys component-wise:

```ruby
def ids_match?(record, id)
  if record.class.composite_primary_key?
    Array(record.id).map(&:to_s) == Array(id).map(&:to_s)
  else
    record.id.to_s == id.to_s
  end
end
```

Single primary keys are unchanged.
