### PR TITLE
Support a single composite primary key id in `update`/`update!`

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -130,7 +130,7 @@ module ActiveRecord
       # it is preferred to use {update_all}[rdoc-ref:Relation#update_all]
       # for updating all records in a single query.
       def update(id = :all, attributes)
-        if id.is_a?(Array)
+        if update_multiple_ids?(id)
           if id.any?(ActiveRecord::Base)
             raise ArgumentError,
               "You are passing an array of ActiveRecord::Base instances to `update`. " \
@@ -156,7 +156,7 @@ module ActiveRecord
       # Updates the object (or multiple objects) just like #update but calls #update! instead
       # of +update+, so an exception is raised if the record is invalid and saving will fail.
       def update!(id = :all, attributes)
-        if id.is_a?(Array)
+        if update_multiple_ids?(id)
           if id.any?(ActiveRecord::Base)
             raise ArgumentError,
               "You are passing an array of ActiveRecord::Base instances to `update!`. " \
@@ -300,6 +300,18 @@ module ActiveRecord
           subclass.class_eval do
             @_query_constraints_list = nil
             @has_query_constraints = false
+          end
+        end
+
+        # +update+/+update!+ accept either a single id or an array of ids. For a
+        # composite primary key a single id is itself an array, so an array of
+        # ids is an array of arrays, mirroring how +Relation#destroy+ tells the
+        # two apart.
+        def update_multiple_ids?(id)
+          if composite_primary_key?
+            id.is_a?(Array) && id.first.is_a?(Array)
+          else
+            id.is_a?(Array)
           end
         end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -195,6 +195,34 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not_equal "updated", Topic.second.content
   end
 
+  def test_update_with_single_composite_primary_key
+    book = cpk_books(:cpk_great_author_first_book)
+
+    updated = Cpk::Book.update(book.id, title: "updated")
+
+    assert_equal book.id, updated.id
+    assert_equal "updated", book.reload.title
+  end
+
+  def test_update_bang_with_single_composite_primary_key
+    book = cpk_books(:cpk_great_author_first_book)
+
+    updated = Cpk::Book.update!(book.id, title: "updated")
+
+    assert_equal book.id, updated.id
+    assert_equal "updated", book.reload.title
+  end
+
+  def test_update_many_with_composite_primary_keys
+    first = cpk_books(:cpk_great_author_first_book)
+    second = cpk_books(:cpk_great_author_second_book)
+
+    Cpk::Book.update([first.id, second.id], [{ title: "first updated" }, { title: "second updated" }])
+
+    assert_equal "first updated", first.reload.title
+    assert_equal "second updated", second.reload.title
+  end
+
   def test_class_level_update_without_ids
     topics = Topic.all
     assert_equal 5, topics.length


### PR DESCRIPTION
### Summary

The class-level `update`/`update!` raise `ActiveRecord::RecordNotFound` when given a single id of a composite primary key model, whereas a single primary key works:

```ruby
# Single primary key — works
Topic.update(1, title: "updated")

# Composite primary key — raises
book = Cpk::Book.first
Cpk::Book.update(book.id, title: "updated")
# => ActiveRecord::RecordNotFound: Couldn't find Cpk::Book with '["author_id", "id"]'=...
```

### Cause

`update`/`update!` decide between a batch of ids and a single id with `id.is_a?(Array)`. For a composite primary key a single record's id is itself an array (e.g. `["author_id", "id"]`), so it is mistaken for a batch and each component is passed to `find`, which then fails.

### Fix

Decide whether multiple ids were given the same way `Relation#destroy` already does: for a composite primary key, an array of ids is an array of arrays. This is extracted into a small private `update_multiple_ids?` helper used by both `update` and `update!`. The `:all` (no-ids) form is checked first so the default argument keeps working, and the single primary key path is unchanged.

After the fix, `Model.update(record.id, attributes)` updates a single composite-key record, matching the single primary key behavior, while the batch form `Model.update([id1, id2], [attrs1, attrs2])` keeps working.