### PR TITLE
Support a single composite primary key id in `delete`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1093,6 +1093,10 @@ module ActiveRecord
     def delete(id_or_array)
       return 0 if id_or_array.nil? || (id_or_array.is_a?(Array) && id_or_array.empty?)
 
+      if model.composite_primary_key? && !id_or_array.first.is_a?(Array)
+        id_or_array = [id_or_array]
+      end
+
       where(model.primary_key => id_or_array).delete_all
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -462,6 +462,25 @@ class PersistenceTest < ActiveRecord::TestCase
     end
   end
 
+  def test_delete_with_single_composite_primary_key
+    book = cpk_books(:cpk_great_author_first_book)
+
+    assert_difference("Cpk::Book.count", -1) do
+      assert_equal 1, Cpk::Book.delete(book.id)
+    end
+  end
+
+  def test_delete_with_multiple_composite_primary_keys
+    books = [
+      cpk_books(:cpk_great_author_first_book),
+      cpk_books(:cpk_great_author_second_book),
+    ]
+
+    assert_difference("Cpk::Book.count", -2) do
+      assert_equal 2, Cpk::Book.delete(books.map(&:id))
+    end
+  end
+
   def test_becomes
     assert_kind_of Reply, topics(:first).becomes(Reply)
     assert_equal "The First Topic", topics(:first).becomes(Reply).title


### PR DESCRIPTION
### Summary

The class-level `delete` raises an `ArgumentError` when given a single id of a composite primary key model, whereas its documented twin `destroy` accepts one:

```ruby
book = Cpk::Book.first

# destroy — works (and is already tested)
Cpk::Book.destroy(book.id)

# delete — raises
Cpk::Book.delete(book.id)
# => ArgumentError: Expected corresponding value for ["author_id", "id"] to be an Array
```

`delete` and `destroy` are documented as a pair (the same id arguments, one running callbacks and one issuing a direct `DELETE`), and `destroy` already supports a single composite id with an explicit test, so this is a composite-key parity gap rather than a missing feature.

### Cause

`delete` passes its argument straight to `where(model.primary_key => id_or_array)`. For a composite primary key a single id is itself an array (e.g. `["author_id", "id"]`), so it is zipped against the key columns and rejected as a malformed tuple value instead of being treated as one tuple.

### Fix

Wrap a single composite id in an array before building the predicate, the same way `destroy` already tells a single id from a batch: for a composite primary key an array of ids is an array of arrays. The single primary key path is unchanged, and the batch form `delete([id1, id2])` keeps working because its first element is already an array.

After the fix, `Model.delete(record.id)` deletes a single composite-key record (matching `destroy` and the single primary key behavior), while `Model.delete([id1, id2])` still deletes multiple records.