### PR TITLE
Fix `normalizes` casting raw database values on in-place change detection

### DIFF
--- a/activemodel/lib/active_model/attributes/normalization.rb
+++ b/activemodel/lib/active_model/attributes/normalization.rb
@@ -145,7 +145,7 @@ module ActiveModel
         end
 
         def normalized_attribute_changed_in_place?(attribute)
-          attribute.changed_in_place? && attribute.value != attribute.type.cast(attribute.value_before_type_cast)
+          attribute.changed_in_place? && attribute.value != attribute.type_cast(attribute.value_before_type_cast)
         end
 
         class NormalizedValueType < ActiveSupport::Delegation::DelegateClass(ActiveModel::Type::Value) # :nodoc:

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -5,6 +5,16 @@ require "models/aircraft"
 require "active_support/core_ext/string/inflections"
 
 class NormalizedAttributeTest < ActiveRecord::TestCase
+  class NormalizedAdminUser < ActiveRecord::Base
+    self.table_name = "admin_users"
+
+    # MariaDB has no native JSON type (json columns are LONGTEXT), so declare
+    # the attribute type explicitly to get json semantics on all adapters.
+    attribute :json_options, :json
+
+    normalizes :json_options, with: -> options { options.transform_keys(&:downcase) }
+  end
+
   class NormalizedAircraft < Aircraft
     normalizes :name, with: -> name { name.presence&.titlecase }
     normalizes :manufactured_at, with: -> time { time.noon }
@@ -39,6 +49,15 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
 
   test "uses the same query when finding record by nil and normalized nil values" do
     assert_equal NormalizedAircraft.where(name: nil).to_sql, NormalizedAircraft.where(name: "").to_sql
+  end
+
+  test "normalizes json attribute changed in place after loading from database" do
+    admin_user = NormalizedAdminUser.find(NormalizedAdminUser.create!(json_options: { "FOO" => "bar" }).id)
+    admin_user.json_options["BAZ"] = "qux" # change the attribute in place
+
+    admin_user.validate
+
+    assert_equal({ "foo" => "bar", "baz" => "qux" }, admin_user.json_options)
   end
 
   test "minimizes number of times normalization is applied" do


### PR DESCRIPTION
cc @rafaelfranca  @yaroslav 

### Motivation / Background

This Pull Request has been created because #57639 introduced a regression for
attributes built from the database when a `normalizes` attribute is changed in
place.

`normalized_attribute_changed_in_place?` compares the current value against
`attribute.type.cast(attribute.value_before_type_cast)`. For attributes built
from the database, `value_before_type_cast` holds the raw serialized value,
which must be deserialized rather than cast. For example, a json attribute
holds a raw JSON string, and `Type::Json#cast` does not parse strings, so the
raw string was passed straight into the user-supplied normalizer block:

```ruby
class User < ApplicationRecord
  # settings is a json column
  normalizes :settings, with: -> settings { settings.transform_keys(&:downcase) }
end

user = User.find(User.create!(settings: { "foo" => "bar" }).id)
user.settings["BAZ"] = "qux" # change the attribute in place
user.valid?
# => NoMethodError: undefined method 'transform_keys' for an instance of String
```

The same error occurs for new records when the column has a database default
(e.g. a jsonb column with a default of `{}`), since default attributes are
also built from the raw database value.

### Detail

This Pull Request changes `normalized_attribute_changed_in_place?` to use
`Attribute#type_cast` instead of `attribute.type.cast`. `Attribute#type_cast`
dispatches to `type.deserialize` for attributes coming from the database and to
`type.cast` for attributes coming from the user, leaving the existing behavior
for user-assigned values unchanged.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.