### PR TITLE
Add load hooks for all Active Storage job classes

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add load hooks for all Active Storage job classes.
+
+    Applications can now use the lazy load hook system to extend Active Storage
+    jobs without eager loading them, e.g. to register additional retry or
+    discard handlers:
+
+    ```ruby
+    ActiveSupport.on_load(:active_storage_create_variants_job) do
+      discard_on Vips::Error
+    end
+    ```
+
+    The following hooks are available: `active_storage_base_job`,
+    `active_storage_analyze_job`, `active_storage_create_variants_job`,
+    `active_storage_mirror_job`, `active_storage_preview_image_job`,
+    `active_storage_purge_job`, `active_storage_sync_metadata_job`, and
+    `active_storage_transform_job`.
+
+    *Chedli Bourguiba*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/app/jobs/active_storage/analyze_job.rb
+++ b/activestorage/app/jobs/active_storage/analyze_job.rb
@@ -11,3 +11,5 @@ class ActiveStorage::AnalyzeJob < ActiveStorage::BaseJob
     blob.analyze
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_analyze_job, ActiveStorage::AnalyzeJob

--- a/activestorage/app/jobs/active_storage/base_job.rb
+++ b/activestorage/app/jobs/active_storage/base_job.rb
@@ -2,3 +2,5 @@
 
 class ActiveStorage::BaseJob < ActiveJob::Base
 end
+
+ActiveSupport.run_load_hooks :active_storage_base_job, ActiveStorage::BaseJob

--- a/activestorage/app/jobs/active_storage/create_variants_job.rb
+++ b/activestorage/app/jobs/active_storage/create_variants_job.rb
@@ -30,3 +30,5 @@ class ActiveStorage::CreateVariantsJob < ActiveStorage::BaseJob
       (@process == :immediately) ? :perform_now : :perform_later
     end
 end
+
+ActiveSupport.run_load_hooks :active_storage_create_variants_job, ActiveStorage::CreateVariantsJob

--- a/activestorage/app/jobs/active_storage/mirror_job.rb
+++ b/activestorage/app/jobs/active_storage/mirror_job.rb
@@ -13,3 +13,5 @@ class ActiveStorage::MirrorJob < ActiveStorage::BaseJob
     ActiveStorage::Blob.service.try(:mirror, key, checksum: checksum)
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_mirror_job, ActiveStorage::MirrorJob

--- a/activestorage/app/jobs/active_storage/preview_image_job.rb
+++ b/activestorage/app/jobs/active_storage/preview_image_job.rb
@@ -23,3 +23,5 @@ class ActiveStorage::PreviewImageJob < ActiveStorage::BaseJob
     end
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_preview_image_job, ActiveStorage::PreviewImageJob

--- a/activestorage/app/jobs/active_storage/purge_job.rb
+++ b/activestorage/app/jobs/active_storage/purge_job.rb
@@ -11,3 +11,5 @@ class ActiveStorage::PurgeJob < ActiveStorage::BaseJob
     blob.purge
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_purge_job, ActiveStorage::PurgeJob

--- a/activestorage/app/jobs/active_storage/sync_metadata_job.rb
+++ b/activestorage/app/jobs/active_storage/sync_metadata_job.rb
@@ -10,3 +10,5 @@ class ActiveStorage::SyncMetadataJob < ActiveStorage::BaseJob
     blob.sync_metadata
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_sync_metadata_job, ActiveStorage::SyncMetadataJob

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -10,3 +10,5 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
     blob.representation(transformations).processed
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_transform_job, ActiveStorage::TransformJob

--- a/activestorage/test/jobs/load_hooks_test.rb
+++ b/activestorage/test/jobs/load_hooks_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::LoadHooksTest < ActiveSupport::TestCase
+  {
+    active_storage_base_job: "ActiveStorage::BaseJob",
+    active_storage_analyze_job: "ActiveStorage::AnalyzeJob",
+    active_storage_create_variants_job: "ActiveStorage::CreateVariantsJob",
+    active_storage_mirror_job: "ActiveStorage::MirrorJob",
+    active_storage_preview_image_job: "ActiveStorage::PreviewImageJob",
+    active_storage_purge_job: "ActiveStorage::PurgeJob",
+    active_storage_sync_metadata_job: "ActiveStorage::SyncMetadataJob",
+    active_storage_transform_job: "ActiveStorage::TransformJob"
+  }.each do |hook, job_class_name|
+    test "#{hook} load hook runs with #{job_class_name}" do
+      job_class = nil
+      ActiveSupport.on_load(hook) { job_class = self }
+
+      assert_equal job_class_name.constantize, job_class
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -4306,6 +4306,14 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveStorage::VariantRecord`       | `active_storage_variant_record`      |
 | `ActiveStorage::Blob`                | `active_storage_blob`                |
 | `ActiveStorage::Record`              | `active_storage_record`              |
+| `ActiveStorage::BaseJob`             | `active_storage_base_job`            |
+| `ActiveStorage::AnalyzeJob`          | `active_storage_analyze_job`         |
+| `ActiveStorage::CreateVariantsJob`   | `active_storage_create_variants_job` |
+| `ActiveStorage::MirrorJob`           | `active_storage_mirror_job`          |
+| `ActiveStorage::PreviewImageJob`     | `active_storage_preview_image_job`   |
+| `ActiveStorage::PurgeJob`            | `active_storage_purge_job`           |
+| `ActiveStorage::SyncMetadataJob`     | `active_storage_sync_metadata_job`   |
+| `ActiveStorage::TransformJob`        | `active_storage_transform_job`       |
 | `ActiveSupport::TestCase`            | `active_support_test_case`           |
 | `i18n`                               | `i18n`                               |
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because applications currently have no way to extend Active Storage job classes through the lazy load hook system, unlike the Active Storage models (`ActiveStorage::Blob`, `ActiveStorage::Attachment`, `ActiveStorage::VariantRecord`, and `ActiveStorage::Record`) which already provide load hooks.

This was suggested in https://github.com/rails/rails/pull/57060#discussion_r3384565872, where an application needed to register an additional discard handler on `ActiveStorage::CreateVariantsJob` and had to piggyback on the `:active_storage_blob` hook to do so:

```ruby
ActiveSupport.on_load(:active_storage_blob) do
  next unless defined?(Vips::Error)

  ActiveStorage::CreateVariantsJob.discard_on(Vips::Error)
end
```

### Detail

This Pull Request adds a load hook to every Active Storage job class,
following the same pattern as the existing Active Storage model hooks:

| Class                                | Hook                                 |
| ------------------------------------ | ------------------------------------ |
| `ActiveStorage::BaseJob`             | `active_storage_base_job`            |
| `ActiveStorage::AnalyzeJob`          | `active_storage_analyze_job`         |
| `ActiveStorage::CreateVariantsJob`   | `active_storage_create_variants_job` |
| `ActiveStorage::MirrorJob`           | `active_storage_mirror_job`          |
| `ActiveStorage::PreviewImageJob`     | `active_storage_preview_image_job`   |
| `ActiveStorage::PurgeJob`            | `active_storage_purge_job`           |
| `ActiveStorage::SyncMetadataJob`     | `active_storage_sync_metadata_job`   |
| `ActiveStorage::TransformJob`        | `active_storage_transform_job`       |

Applications can now extend a job without eager loading it:

```ruby
ActiveSupport.on_load(:active_storage_create_variants_job) do
  discard_on Vips::Error
end
```

A hook is also provided for `ActiveStorage::BaseJob`: since the base class is
loaded (and its hook run) before any subclass body is executed, handlers
registered there propagate correctly to all Active Storage jobs.

The "Available Load Hooks" table in the configuring guide is updated
accordingly.

### Additional information

Suggested by @rafaelfranca in https://github.com/rails/rails/pull/57060#discussion_r3384610522.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.