### PR TITLE
Add ActiveSupport::Ractors.on_main to proxy work to the main Ractor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ PATH
       logger (>= 1.4.2)
       minitest (>= 5.1)
       psych (>= 4)
+      ractor-dispatch (>= 0.2.0)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
@@ -431,6 +432,7 @@ GEM
       rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
+    ractor-dispatch (0.2.0)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -923,6 +925,7 @@ CHECKSUMS
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.2.1) sha256=f737191fd5c5b348b7f0a4412a3b86383f88c43e13b8217b63d4c8d90b9e798d
+  ractor-dispatch (0.2.0) sha256=5fe3eb85c202ac33910b0ada80a15f7a2e9504a057cf91d90ce80a73608492b2
   rails (8.2.0.alpha)
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -406,7 +406,9 @@ module ActiveRecord
       end
 
       def predicate_builder # :nodoc:
-        @predicate_builder ||= PredicateBuilder.new(TableMetadata.new(self, arel_table))
+        @predicate_builder || ActiveSupport::Ractors.on_main(self) do
+          @predicate_builder ||= PredicateBuilder.new(TableMetadata.new(self, arel_table))
+        end
       end
 
       def type_caster # :nodoc:

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |s|
   s.add_dependency "logger", ">= 1.4.2"
   s.add_dependency "securerandom", ">= 0.3"
   s.add_dependency "uri", ">= 0.13.1"
+  s.add_dependency "ractor-dispatch", ">= 0.2.0"
 end

--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -68,6 +68,20 @@ module ActiveSupport
       end
 
       if defined?(Ractor) && RUBY_VERSION >= "4.0"
+        def on_main(obj = nil, &block)
+          if Ractor.main?
+            obj.instance_eval(&block)
+          else
+            require "ractor/dispatch"
+            shareable_block = Ractor.shareable_proc(&block)
+            Ractor::Dispatch.main.run { obj.instance_eval(&shareable_block) }
+          end
+        end
+
+        def main?
+          Ractor.main?
+        end
+
         # Makes +obj+ Ractor-shareable by delegating to +Ractor.make_shareable+.
         #
         # The +copy:+ option is forwarded unchanged. On Ruby versions without
@@ -104,6 +118,14 @@ module ActiveSupport
           Ractor.shareable_lambda(...)
         end
       else
+        def main?
+          Ractor.current == Ractor.main
+        end
+
+        def on_main(obj = nil, &block)
+          obj.instance_eval(&block)
+        end
+
         def make_shareable(obj, copy: false)
           obj
         end

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -2,8 +2,45 @@
 
 require_relative "abstract_unit"
 
-class KernelRactorShareabilityTest < ActiveSupport::TestCase
+class RactorsTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  def test_main_is_true_on_the_main_ractor
+    assert ActiveSupport::Ractors.main?
+  end
+
+  def test_main_is_false_on_a_non_main_ractor
+    ractor = Ractor.new do
+      ActiveSupport::Ractors.main?
+    end
+    value = ractor.respond_to?(:value) ? ractor.value : ractor.take
+
+    assert_not value
+  end
+
   if RUBY_VERSION >= "4.0"
+    def test_on_main_runs_block_on_main_ractor
+      value = Ractor.new do
+        ActiveSupport::Ractors.on_main { Ractor.main? }
+      end.value
+
+      assert value
+    rescue RailsStrictWarnings::WarningError
+    end
+
+    def test_on_main_evaluates_block_against_object
+      object = Class.new do
+        self.singleton_class.attr_accessor :foo
+        self.foo = :foo
+      end
+      Ractor.new(object) do |obj|
+        ActiveSupport::Ractors.on_main(obj) { @foo = :bar }
+      end.join
+
+      assert_equal :bar, object.foo
+    rescue RailsStrictWarnings::WarningError
+    end
+
     def test_ractor_make_shareable_returns_a_shareable_object
       string = +"hello"
       assert_not ActiveSupport::Ractors.shareable?(string)

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -25,7 +25,6 @@ class RactorsTest < ActiveSupport::TestCase
       end.value
 
       assert value
-    rescue RailsStrictWarnings::WarningError
     end
 
     def test_on_main_evaluates_block_against_object
@@ -38,7 +37,6 @@ class RactorsTest < ActiveSupport::TestCase
       end.join
 
       assert_equal :bar, object.foo
-    rescue RailsStrictWarnings::WarningError
     end
 
     def test_ractor_make_shareable_returns_a_shareable_object


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because non-main Ractors need a way to delegate assignment of variables to the main Ractor. API usage will refactor something like:
```rb
class Something
  def self.something
     @ivar ||= :a
  end
end
```
To this:
```rb
class Something
  def self.something
     @ivar || ActiveSupport::Ractors.on_main { @ivar ||= :a }
  end
end
```
So that non-main Ractors may be lazily load values when it is necessary. I'm trying to remove some class level memoization in Active Record in https://github.com/rails/rails/pull/57642, but sometimes memos are needed, and we can memoize safely with this Ractor proxying API.

Alternatively, we discussed implementing a autoloader hook that would call a method like:

```rb
def ractorize!
  some_memo_method
  other_memo_method
end
```

which would use eager-load semantics to prepare an object for non-main Ractor use. This was dismissed as we didn't want an approach that coupled us to the autoloader.

### Detail

This Pull Request adds `.on_main` to `ActiveSupport::Ractors` which uses https://github.com/jhawthorn/ractor-dispatch to do the proxying. We may want to look at upstreaming this feature in Active Support in the future, if this patch is accepted.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
