### PR TITLE
Fix `where.missing` and `where.associated` with colliding names

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `where.missing` and `where.associated` generating a where clause on the
+    wrong table when an association with an explicit `:class_name` has the same
+    name as the model's table.
+
+    *Sampo Kuokkanen*
+
 *   Fix bug with reloading models with all-queries default scopes. The previous
     implementation allowed non-all-queries on the current scope to leak into
     the scope used for reloading.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -93,11 +93,7 @@ module ActiveRecord
           end
 
           association_conditions = Array(reflection.association_primary_key).index_with(nil)
-          if reflection.options[:class_name]
-            self.not(association => association_conditions)
-          else
-            self.not(reflection.table_name => association_conditions)
-          end
+          self.not(association_where_key(reflection, association) => association_conditions)
         end
 
         @scope
@@ -126,11 +122,7 @@ module ActiveRecord
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
           association_conditions = Array(reflection.association_primary_key).index_with(nil)
-          if reflection.options[:class_name]
-            @scope.where!(association => association_conditions)
-          else
-            @scope.where!(reflection.table_name => association_conditions)
-          end
+          @scope.where!(association_where_key(reflection, association) => association_conditions)
         end
 
         @scope
@@ -144,6 +136,17 @@ module ActiveRecord
             raise ArgumentError.new("An association named `:#{association}` does not exist on the model `#{model.name}`.")
           end
           reflection
+        end
+
+        # Associations with a custom :class_name are joined under an alias named
+        # after the association, unless that name conflicts with the model's own
+        # table name, in which case the join uses the association's table name.
+        def association_where_key(reflection, association)
+          if reflection.options[:class_name] && association.to_s != @scope.table.name
+            association
+          else
+            reflection.table_name
+          end
         end
     end
 

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -14,6 +14,12 @@ module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
     fixtures :posts, :comments, :authors, :humans, :essays, :author_addresses, :books
 
+    class AuthorWithTableNameMatchingAssociation < ActiveRecord::Base
+      self.table_name = "authors"
+
+      has_many :authors, class_name: "::Post", foreign_key: :author_id
+    end
+
     def test_associated_with_association
       Post.where.associated(:author).tap do |relation|
         assert_includes     relation, posts(:welcome)
@@ -121,9 +127,25 @@ module ActiveRecord
       assert_predicate Cpk::Author.where.associated(:books), :any?
     end
 
+    def test_associated_with_association_matching_the_model_table_name
+      author_without_posts = AuthorWithTableNameMatchingAssociation.create!(name: "Shy")
+
+      relation = AuthorWithTableNameMatchingAssociation.left_joins(:authors).where.associated(:authors)
+      assert_includes     relation.ids, authors(:david).id
+      assert_not_includes relation.ids, author_without_posts.id
+    end
+
     def test_missing_with_association
       assert_predicate posts(:authorless).author, :blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
+    end
+
+    def test_missing_with_association_matching_the_model_table_name
+      author_without_posts = AuthorWithTableNameMatchingAssociation.create!(name: "Shy")
+
+      relation = AuthorWithTableNameMatchingAssociation.where.missing(:authors)
+      assert_includes     relation.ids, author_without_posts.id
+      assert_not_includes relation.ids, authors(:david).id
     end
 
     def test_missing_with_child_association


### PR DESCRIPTION
### Motivation / Background

This PR is created to fix #57631.

### Detail

When an association with an explicit `:class_name` has the same name as the model's own table, the `IS NULL` / `IS NOT NULL` condition targeted the model's table instead of the joined association's.

`where.missing` and `where.associated` use the association name as the where clause key so that the join dependency aliases the join to that name. But when the name is already taken by the model's own table, the join dependency picks a different alias, leaving the condition pointing at the model's table.

Fall back to the association's table name in that case, which leaves the join unaliased and lets the condition resolve to the correct table.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
