### PR TITLE
Fix ArgumentError when using authenticate_with_http_token with malformed input

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -507,7 +507,10 @@ module ActionController
 
       # Takes `raw_params` and turns it into an array of parameters.
       def params_array_from(raw_params)
-        raw_params.map { |param| param.split %r/=(.+)?/ }
+        raw_params.filter_map do |param|
+          pieces = param.split %r/=(.+)?/
+          pieces unless pieces.empty?
+        end
       end
 
       # This removes the `"` characters wrapping the value.

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -192,6 +192,26 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal expected_options, actual.last
   end
 
+  test "token_and_options ignores a missing key and value pair element in header value" do
+    token = "foo,,bar,  ,  ""="" , baz=qux"
+    expected_token = "foo"
+    expected_options = { "bar" => nil, "baz" => "qux" }
+
+    actual = ActionController::HttpAuthentication::Token.token_and_options(sample_request(token, {}))
+    assert_equal expected_token, actual.first
+    assert_equal expected_options, actual.last
+  end
+
+  test "token_and_options does not ignore a missing key element in header value" do
+    token = "foo,,bar,  ,  =bad , baz=qux"
+    expected_token = "foo"
+    expected_options = { "" => "bad", "bar" => nil, "baz" => "qux" }
+
+    actual = ActionController::HttpAuthentication::Token.token_and_options(sample_request(token, {}))
+    assert_equal expected_token, actual.first
+    assert_equal expected_options, actual.last
+  end
+
   test "raw_params returns a tuple of two key value pair strings" do
     auth = sample_request("rcHu+HzSFw89Ypyhn/896A=").authorization.to_s
     actual = ActionController::HttpAuthentication::Token.raw_params(auth)


### PR DESCRIPTION
If a client supplies a key-value pair without a key or value, the call to the Hash initializer would raise an ArgumentError because one of the arrays in the array was empty.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
