### PR TITLE
Make some more constants ractor safe

### DIFF
--- a/actionpack/lib/action_dispatch/http/param_builder.rb
+++ b/actionpack/lib/action_dispatch/http/param_builder.rb
@@ -17,7 +17,7 @@ module ActionDispatch
     end
 
     cattr_accessor :default
-    self.default = make_default(100)
+    self.default = make_default(100).freeze
 
     class << self
       delegate :from_query_string, :from_pairs, :from_hash, to: :default

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -135,12 +135,10 @@ module ActionDispatch
 
     HTTP_METHODS = RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789
 
-    HTTP_METHOD_LOOKUP = {} # rubocop:disable Style/MutableConstant
-
     # Populate the HTTP method lookup cache.
-    HTTP_METHODS.each { |method|
-      HTTP_METHOD_LOOKUP[method] = method.downcase.tap { |m| m.tr!("-", "_") }.to_sym
-    }
+    HTTP_METHOD_LOOKUP = HTTP_METHODS.each.with_object({}) { |method, hash|
+      hash[method] = method.downcase.tap { |m| m.tr!("-", "_") }.to_sym
+    }.freeze
 
     alias raw_request_method request_method # :nodoc:
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -483,7 +483,7 @@ module ActionDispatch # :nodoc:
 
   private
     ContentTypeHeader = Struct.new :mime_type, :charset
-    NullContentTypeHeader = ContentTypeHeader.new nil, nil
+    NullContentTypeHeader = ContentTypeHeader.new(nil, nil).freeze
 
     CONTENT_TYPE_PARSER = /
       \A

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -43,7 +43,7 @@ module ActionDispatch
           US_ASCII = Encoding::US_ASCII
           UTF_8    = Encoding::UTF_8
           EMPTY    = (+"").force_encoding(US_ASCII).freeze
-          DEC2HEX  = (0..255).map { |i| (ENCODE % i).force_encoding(US_ASCII) }
+          DEC2HEX  = (0..255).map { |i| (ENCODE % i).force_encoding(US_ASCII).freeze }.freeze
 
           ALPHA = "a-zA-Z"
           DIGIT = "0-9"
@@ -80,7 +80,7 @@ module ActionDispatch
             end
         end
 
-        ENCODER = UriEncoder.new
+        ENCODER = UriEncoder.new.freeze
 
         def self.escape_path(path)
           ENCODER.escape_path(path.to_s)


### PR DESCRIPTION
### Motivation / Background

We already made most constants containing literals ractor safe. This freezes a few things that missed the first pass because they aren't literals or contain non-shareable values.

FYI I am working on running a new app with scaffolded routes in a ractor, and these are constants that get hit during the request path.

### Detail

Freezes some constants (and one cattr).

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
