### PR TITLE
Make Active Storage signed IDs URL-safe

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Make Active Storage signed IDs URL-safe.
+
+    `ActiveStorage.verifier` did not set `url_safe: true`, so signed IDs (and the
+    other tokens it produces) could contain `+` or `/` characters. Because a blob's
+    signed ID is used as a path segment in the Active Storage routes, a `/` in the
+    value broke routing and resulted in a 404. This was most likely to surface with
+    a binary-dense message serializer such as `:message_pack`.
+
+    The verifier is now configured to generate URL-safe messages, mirroring the fix
+    applied to `ActiveRecord::SignedId`. Existing tokens remain valid.
+
+    *Augusto Xavier*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -181,8 +181,10 @@ module ActiveStorage
       end
     end
 
-    initializer "active_storage.verifier" do
-      config.after_initialize do |app|
+    initializer "active_storage.verifier" do |app|
+      app.message_verifiers.prepend { |salt| { url_safe: true } if salt == "ActiveStorage" }
+
+      config.after_initialize do
         ActiveStorage.verifier = app.message_verifier("ActiveStorage")
       end
     end

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -63,6 +63,35 @@ module ApplicationTests
       assert_includes(output, "ActiveStorage::Transformers::NullTransformer")
     end
 
+    def test_signed_ids_are_url_safe_with_message_pack_serializer
+      File.open("#{app_path}/Gemfile", "a") do |f|
+        f.puts 'gem "msgpack"'
+      end
+
+      add_to_config <<~RUBY
+        config.secret_key_base = "secret"
+        config.active_support.message_serializer = :message_pack
+      RUBY
+
+      # A blob's signed ID is used as a path segment in the Active Storage routes,
+      # so a "+" or "/" in its Base64 encoding breaks routing. Pick a blob id whose
+      # non-URL-safe encoding exposes the problem, then assert it is encoded safely.
+      script = <<~RUBY.gsub("\n", " ")
+        secret = Rails.application.key_generator.generate_key('ActiveStorage');
+        unsafe = ActiveSupport::MessageVerifier.new(secret);
+        blob_id = (1..1000).find { |id| s = unsafe.generate(id, purpose: :blob_id); s.include?('+') || s.include?('/') };
+        signed = ActiveStorage.verifier.generate(blob_id, purpose: :blob_id);
+        url_safe = !(signed.include?('+') || signed.include?('/'));
+        round_trips = ActiveStorage.verifier.verified(signed, purpose: :blob_id) == blob_id;
+        puts(url_safe && round_trips ? 'URL_SAFE_OK' : 'URL_SAFE_FAIL');
+      RUBY
+
+      output = run_command(script)
+
+      assert_includes(output, "URL_SAFE_OK")
+      assert_not_includes(output, "URL_SAFE_FAIL")
+    end
+
     private
       def run_command(cmd)
         Dir.chdir(app_path) do


### PR DESCRIPTION
## Summary

`ActiveStorage::Blob#signed_id` could produce Base64 strings containing `+` or `/`. Because a blob's signed ID is used directly as a path segment in the Active Storage redirect route (`/rails/active_storage/blobs/redirect/:signed_id/*filename`), a `/` in the value was interpreted as a path separator, breaking routing and returning a 404.

Fixes #57628.

## Root Cause

`ActiveRecord::SignedId` was already fixed (#49507) to build its `MessageVerifier` with `url_safe: true`. However, `ActiveStorage::Blob` overrides `signed_id_verifier` to return `ActiveStorage.verifier`:

```ruby
def signed_id_verifier # :nodoc:
  @signed_id_verifier ||= ActiveStorage.verifier
end
```

`ActiveStorage.verifier` is set in the engine from `app.message_verifier("ActiveStorage")`, which was **not** configured with `url_safe: true`. So signed IDs (and the disk-service tokens / variation keys that also use `ActiveStorage.verifier` in URLs) could contain non-URL-safe Base64 characters.

This is probabilistic and most likely to surface with a binary-dense serializer such as `:message_pack`, where the whole signed payload — not just an ASCII JSON envelope — is Base64-encoded.

## Solution

Prepend a `url_safe: true` rotation for the `"ActiveStorage"` salt in the engine, mirroring exactly how the `"active_record/signed_id"` salt is configured in the Active Record railtie:

```ruby
initializer "active_storage.verifier" do |app|
  app.message_verifiers.prepend { |salt| { url_safe: true } if salt == "ActiveStorage" }

  config.after_initialize do
    ActiveStorage.verifier = app.message_verifier("ActiveStorage")
  end
end
```

This makes all Active Storage tokens URL-safe regardless of the configured message serializer. `MessageVerifier#decode` accepts both URL-safe and standard Base64 input, so **existing tokens remain valid**.

## Tests

Added a regression test in `railties/test/application/active_storage/engine_integration_test.rb` that boots a real app with the `:message_pack` serializer, finds a blob id whose pre-fix encoding contained `+`/`/`, and asserts the signed ID is now URL-safe and still round-trips.

Verified failing before the fix and passing after:

```
# Without the fix:
ApplicationTests::ActiveStorageEngineTest#test_signed_ids_are_url_safe_with_message_pack_serializer
Expected "...URL_SAFE_FAIL\n" to include "URL_SAFE_OK".

# With the fix:
1 runs, 4 assertions, 0 failures, 0 errors, 0 skips
```

Post-rebase validation on current `main`: `engine_integration_test.rb` passes (**11 runs, 37 assertions, 0 failures, 0 errors**), as does the focused signed-ID test (**1 run, 4 assertions**). RuboCop inspected both changed Ruby files with no offenses. After installing JavaScript dependencies with `yarn install --frozen-lockfile`, the full Active Storage suite passed: **612 runs, 1,868 assertions, 0 failures, 0 errors, 4 skips**. CI is pending.

## QA

The fix changes generated-token formatting only. Before, signed IDs could look like:

```
zICBpl9yYWlsc4KkZGF0Yc4Ae/iko3B1cqdibGxvYl9pZA--b667b9575eebe1bd4510db63cacd5ec37dc7a4c0
```

(note the `/`). After, the same payload encodes without `+`/`/`/`=`, so it is safe to use as a route path segment.

## Risks

- **Backward compatibility:** None expected. URL-safety affects token *generation* only; verification already accepts both encodings, and a fallback rotation preserves the previous options. Existing signed IDs continue to verify.
- No public API changes.

## Checklist
- [x] Contribution guide reviewed and complied with
- [x] No refused-category change (no new generator/locale/feature)
- [x] Requirement confirmed
- [x] Root cause identified
- [x] Small focused diff
- [x] Regression test added (verified failing before fix)
- [x] Existing tests pass (unrelated `libvips` failure noted)
- [x] Documentation reviewed (CHANGELOG entry added)
- [x] No unrelated cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

