### PR TITLE
Fix `Hash.from_xml` raising `Date::Error` on `type="date"` values surrounded by whitespace

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -66,7 +66,7 @@ module ActiveSupport
     unless defined?(PARSING)
       PARSING = { # rubocop:disable Style/MutableConstant
         "symbol"       => Proc.new { |symbol|  symbol.to_s.to_sym },
-        "date"         => Proc.new { |date|    ::Date.strptime(date, "%Y-%m-%d") },
+        "date"         => Proc.new { |date|    ::Date.strptime(date.to_s.strip, "%Y-%m-%d") },
         "datetime"     => Proc.new { |time|    Time.xmlschema(time).utc rescue ::DateTime.parse(time).utc },
         "duration"     => Proc.new { |duration| Duration.parse(duration) },
         "integer"      => Proc.new { |integer| integer.to_i },

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -880,6 +880,18 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal expected_bacon_hash, Hash.from_xml(bacon_xml)["bacon"]
   end
 
+  def test_date_type_from_xml_with_surrounding_whitespace
+    xml = <<-EOT
+    <event>
+      <starts-on type="date">
+        2020-01-01
+      </starts-on>
+    </event>
+    EOT
+
+    assert_equal({ "starts_on" => Date.new(2020, 1, 1) }, Hash.from_xml(xml)["event"])
+  end
+
   def test_type_trickles_through_when_unknown
     product_xml = <<-EOT
     <product>

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -261,7 +261,7 @@ module XmlMiniTest
     def test_date
       parser = @parsing["date"]
       assert_equal Date.new(2013, 11, 12), parser.call("2013-11-12T0211Z")
-      assert_raises(TypeError) { parser.call(1384190018) }
+      assert_raises(ArgumentError) { parser.call(1384190018) }
       assert_raises(ArgumentError) { parser.call("not really a date") }
     end
 


### PR DESCRIPTION
## Problem

`Hash.from_xml` aborts with `Date::Error: invalid date` whenever a node typed `type="date"` contains surrounding whitespace (leading/trailing newlines or spaces). This is common with indented or pretty-printed XML, where the element content is something like `"\n        2020-01-01\n      "`. The `"date"` typecast in `ActiveSupport::XMLMini::PARSING` calls `::Date.strptime(date, "%Y-%m-%d")` on the raw node content, and `strptime` does not tolerate surrounding whitespace, so it raises and the entire `Hash.from_xml` call fails. Anyone parsing human-readable/pretty-printed XML documents that include date fields hits this. Other typecasts such as `integer` (`to_i`) and `boolean` (which already does `to_s.strip`) tolerate the same whitespace, so dates are inconsistent.

## Reproduction

```ruby
require "active_support/core_ext/hash/conversions"

Hash.from_xml(%(<event><starts-on type="date">\n  2020-01-01\n</starts-on></event>))
# => Date::Error: invalid date  (from Date.strptime in xml_mini.rb)
```

Actual: raises `Date::Error` and the whole parse fails. Expected: `{ "event" => { "starts_on" => Date.new(2020, 1, 1) } }`. The same XML with `type="integer"` and whitespace already parses fine, showing the inconsistency.

## Fix

Coerce and strip the value before passing it to `Date.strptime` in `activesupport/lib/active_support/xml_mini.rb`: `::Date.strptime(date.to_s.strip, "%Y-%m-%d")`. This is a one-line change that matches the existing `boolean` typecast which already does `to_s.strip`.

## Test

Added `test_date_type_from_xml_with_surrounding_whitespace` in `activesupport/test/core_ext/hash_ext_test.rb`. It feeds indented/pretty-printed XML with a `<starts-on type="date">` node whose content is wrapped in newlines and spaces, and asserts `Hash.from_xml(xml)["event"]` equals `{ "starts_on" => Date.new(2020, 1, 1) }`. The test raises `Date::Error` before the fix and passes after. The existing `test_date` assertion in `xml_mini_test.rb` was updated from `TypeError` to `Date::Error` to reflect that non-string inputs are now coerced via `to_s` before reaching `strptime`.
