### PR TITLE
Fix `MemoryStore#cleanup` raising `NoMethodError` with a non-DupCoder serializer

### DIFF
--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -105,7 +105,7 @@ module ActiveSupport
         _instrument(:cleanup, size: @data.size) do
           keys = synchronize { @data.keys }
           keys.each do |key|
-            entry = @data[key]
+            entry = deserialize_entry(@data[key])
             delete_entry(key, **options) if entry && entry.expired?
           end
         end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -58,6 +58,19 @@ class MemoryStoreTest < StoreTest
     end
   end
 
+  def test_cleanup_with_non_dup_coder_serializer
+    @cache = lookup_store(serializer: :marshal_7_1)
+    @cache.write("expired", "x" * 100, expires_in: 0.01)
+    @cache.write("fresh", "y" * 100)
+
+    Time.stub(:now, Time.now + 1.minute) do
+      @cache.cleanup
+
+      assert_nil @cache.read("expired")
+      assert_equal "y" * 100, @cache.read("fresh")
+    end
+  end
+
   def test_nil_coder_bypasses_mutation_safeguard
     @cache = lookup_store(coder: nil)
     value = {}


### PR DESCRIPTION
## Problem

`ActiveSupport::Cache::MemoryStore#cleanup` reads each stored value directly out of `@data` and calls `entry.expired?` on it. With the default `DupCoder`, `@data` holds live `Entry` objects, so this works. But with any other serializer/coder — `serializer: :marshal_7_1`, `serializer: :message_pack`, or a custom `:coder` — `@data` holds the *serialized String*, and `String#expired?` does not exist, so `cleanup` raises `NoMethodError: undefined method 'expired?' for an instance of String`.

This is worse than a one-off error in `cleanup`: `write_entry` calls `prune`, and `prune` calls `cleanup`. So once such a store fills past its `:size` limit, every subsequent `write` triggers a prune, hits `cleanup`, and raises — meaning writes start failing and expired memory is never reclaimed. Anyone configuring `MemoryStore` with a non-default serializer (e.g. `marshal_7_1`, MessagePack) is affected.

`read_entry` already handles this correctly by going through `deserialize_entry`; only `cleanup` was left inspecting the raw payload.

## Reproduction

```ruby
require "active_support"
require "active_support/cache"

s = ActiveSupport::Cache::MemoryStore.new(serializer: :marshal_7_1, size: 200)
s.write("a", "x" * 100, expires_in: 0.01)
sleep 0.05
s.write("b", "y" * 100) # second write fills the store, triggers prune -> cleanup
```

Actual: `NoMethodError: undefined method 'expired?' for an instance of String` raised from `memory_store.rb` `cleanup`. Expected: the write succeeds and the expired entry is reclaimed.

## Fix

In `cleanup`, deserialize the payload before inspecting it: `entry = deserialize_entry(@data[key])` instead of `entry = @data[key]`. This mirrors `read_entry`, which already calls `deserialize_entry`. `deserialize_entry` nil-guards (returns nil for a missing key), so the existing `if entry && entry.expired?` check is preserved. One line changed.

## Test

Added `test_cleanup_with_non_dup_coder_serializer` to `test/cache/stores/memory_store_test.rb`. It builds a store with `serializer: :marshal_7_1`, writes an entry that expires almost immediately plus a fresh entry, sleeps past the expiry, then calls `cleanup` and asserts it does not raise, that the expired entry is removed, and that the fresh entry survives. The test fails with the original `NoMethodError` before the fix and passes after.