### PR TITLE
Fix Time#advance and DateTime#advance mutating the caller's options hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -80,6 +80,7 @@ class DateTime
   # largest to smallest. This order can affect the result around the end of a
   # month.
   def advance(options)
+    options = options.dup
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
       options[:days] = options.fetch(:days, 0) + 7 * partial_weeks

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -192,6 +192,7 @@ class Time
   # largest to smallest. This order can affect the result around the end of a
   # month.
   def advance(options)
+    options = options.dup
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
       options[:days] = options.fetch(:days, 0) + 7 * partial_weeks

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -202,6 +202,18 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(2012, 10, 29, 13, 15, 10), DateTime.civil(2012, 9, 28, 1, 15, 10).advance(days: 1.5, months: 1)
   end
 
+  def test_advance_does_not_mutate_options
+    options = { weeks: 1, days: 2 }
+    DateTime.civil(2024, 1, 1).advance(options)
+    assert_equal({ weeks: 1, days: 2 }, options)
+  end
+
+  def test_advance_with_frozen_options
+    assert_nothing_raised do
+      DateTime.civil(2024, 1, 1).advance({ weeks: 1, days: 2 }.freeze)
+    end
+  end
+
   def test_advanced_processes_first_the_date_deltas_and_then_the_time_deltas
     # If the time deltas were processed first, the following datetimes would be advanced to 2010/04/01 instead.
     assert_equal DateTime.civil(2010, 3, 29), DateTime.civil(2010, 2, 28, 23, 59, 59).advance(months: 1, seconds: 1)

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -664,6 +664,18 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal t, t.advance(months: 0)
   end
 
+  def test_advance_does_not_mutate_options
+    options = { weeks: 1, days: 2 }
+    Time.new(2024, 1, 1).advance(options)
+    assert_equal({ weeks: 1, days: 2 }, options)
+  end
+
+  def test_advance_with_frozen_options
+    assert_nothing_raised do
+      Time.new(2024, 1, 1).advance({ weeks: 1, days: 2 }.freeze)
+    end
+  end
+
   def test_advance_gregorian_proleptic
     assert_equal Time.local(1582, 10, 14, 15, 15, 10), Time.local(1582, 10, 15, 15, 15, 10).advance(days: -1)
     assert_equal Time.local(1582, 10, 15, 15, 15, 10), Time.local(1582, 10, 14, 15, 15, 10).advance(days: 1)


### PR DESCRIPTION
## Problem

`Time#advance` and `DateTime#advance` reassign keys on the `options` hash they receive (folding `:weeks` into `:days` and `:days` into `:hours`) in place. This mutates the caller's hash: a spurious `hours: 0` (and rewritten `:weeks`/`:days`) leaks back into the variable the caller passed in. Worse, if the caller passes a frozen or shared options hash, `advance` raises `FrozenError` instead of computing the result. `Date#advance` reads its options without mutating them, so the three siblings behave inconsistently. Anyone who reuses an options hash across calls, or passes a frozen constant of advance options, hits this.

## Reproduction

```ruby
require "active_support/all"

options = { weeks: 1, days: 2 }
Time.new(2024, 1, 1).advance(options)
p options
# actual:   {weeks: 1, days: 2, hours: 0}   <- caller's hash mutated
# expected: {weeks: 1, days: 2}

Time.new(2024, 1, 1).advance({ weeks: 1, days: 2 }.freeze)
# actual:   FrozenError: can't modify frozen Hash
# expected: returns the advanced Time without raising
```

The same happens with `DateTime.civil(2024, 1, 1).advance(...)`.

## Fix

Add `options = options.dup` as the first line of both `Time#advance` and `DateTime#advance`, so the in-place reassignments operate on a private copy instead of the caller's hash. This is a one-line change per method, it makes both methods non-mutating (matching `Date#advance`), and it fixes the `FrozenError` since the dup is always mutable. No behavior change for callers that did not reuse or freeze their options hash.

## Test

Added regression tests to `activesupport/test/core_ext/time_ext_test.rb` and `activesupport/test/core_ext/date_time_ext_test.rb`. Each asserts that the caller's options hash is unchanged after `advance` (`{ weeks: 1, days: 2 }` stays equal), and that calling `advance` with a frozen options hash does not raise. All four tests fail before the fix (one mutation failure and one `FrozenError` per class) and pass after; the full `time_ext_test.rb`, `date_time_ext_test.rb`, and `time_with_zone_test.rb` suites stay green.