### PR TITLE
Reject attribute names that shadow CurrentAttributes methods

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -94,8 +94,6 @@ module ActiveSupport
     include ActiveSupport::Callbacks
     define_callbacks :reset
 
-    INVALID_ATTRIBUTE_NAMES = [:set, :reset, :resets, :instance, :before_reset, :after_reset, :reset_all, :clear_all].freeze # :nodoc:
-
     NOT_SET = Object.new.freeze # :nodoc:
 
     class << self
@@ -239,5 +237,10 @@ module ActiveSupport
           end
         end
       end
+
+      # Declaring an attribute by one of these names would shadow the methods
+      # CurrentAttributes itself relies on. Computed at the very end of the
+      # class body so that all the methods defined above are captured.
+      INVALID_ATTRIBUTE_NAMES = (methods(false) + private_methods(false) + instance_methods(false) + private_instance_methods(false)).uniq.sort.freeze # :nodoc:
   end
 end

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -260,6 +260,22 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     end
   end
 
+  test "CurrentAttributes restricted attribute name :attributes" do
+    assert_raises ArgumentError, match: /Restricted attribute names: attributes/ do
+      class InvalidAttributesAttributeName < ActiveSupport::CurrentAttributes
+        attribute :attributes, :foo
+      end
+    end
+  end
+
+  test "CurrentAttributes restricts attribute names shadowing internal methods" do
+    assert_raises ArgumentError, match: /Restricted attribute names: attribute, defaults/ do
+      class InvalidInternalAttributeNames < ActiveSupport::CurrentAttributes
+        attribute :attribute, :foo, :defaults
+      end
+    end
+  end
+
   test "method_added hook doesn't reach the instance. Fix for #54646" do
     current = Class.new(ActiveSupport::CurrentAttributes) do
       def self.name


### PR DESCRIPTION
## Problem

`ActiveSupport::CurrentAttributes` stores per-request state in an internal `@attributes` Hash, exposed through an `attributes` reader and writer that `reset` relies on. Declaring an attribute whose name collides with one of these internal methods generates accessors that shadow them, silently breaking core behavior. For example, `attribute :attributes` makes `reset` stop clearing state, leaking values across requests — exactly the isolation `CurrentAttributes` is meant to guarantee.

The existing `INVALID_ATTRIBUTE_NAMES` denylist was maintained by hand, so it had drifted from reality: it missed `:attributes` (state leak on reset), `:defaults` (crashes with `NoMethodError` at declaration time), and `:attribute` (silently breaks every subsequent `attribute` declaration), while still listing `:reset_all` — a method that was removed in 475877fc5e.

## Reproduction

```ruby
require "active_support"
require "active_support/current_attributes"

C = Class.new(ActiveSupport::CurrentAttributes) do
  def self.name; "C"; end
  attribute :attributes, :foo
end

C.foo = 99
C.reset
p C.foo
```

Actual: prints `99` (state survived `reset`, leaking across requests). Expected: declaring `attribute :attributes` should raise `ArgumentError`.

## Fix

Replace the handcoded denylist with a dynamically computed constant at the end of the class body, after all method definitions: `methods(false) + singleton_class.private_instance_methods(false) + instance_methods(false) + private_instance_methods(false)`. This captures every method `CurrentAttributes` itself defines — public, private, class, and instance — so the restriction stays in sync with the API automatically. The `(false)` argument excludes inherited methods (`Object`/`Kernel`) to avoid blocking legitimate attribute names.

## Test

Added two regression tests in `activesupport/test/current_attributes_test.rb`:

- `attribute :attributes, :foo` raises `ArgumentError` matching `/Restricted attribute names: attributes/`.
- `attribute :attribute, :foo, :defaults` raises `ArgumentError` matching `/Restricted attribute names: attribute, defaults/`, covering names the old handcoded list missed.

All 27 tests pass (0 failures). The existing "restricted attribute names" test continues to cover the original names (`:set`, `:reset`, etc.).
