### PR TITLE
Don't mutate the caller's string in `Inflector#transliterate`

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -66,7 +66,10 @@ module ActiveSupport
       raise ArgumentError, "Cannot transliterate strings with #{string.encoding} encoding" unless ALLOWED_ENCODINGS_FOR_TRANSLITERATE.include?(string.encoding)
 
       return string.dup if string.ascii_only?
-      string = string.dup if string.frozen?
+
+      # Operate on a copy so the in-place force_encoding/encode! below never
+      # mutate the caller's (possibly non-frozen) string.
+      string = string.dup
 
       input_encoding = string.encoding
 

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -113,4 +113,32 @@ class TransliterateTest < ActiveSupport::TestCase
     assert_predicate string, :ascii_only?
     assert_not_equal string.object_id, ActiveSupport::Inflector.transliterate(string).object_id
   end
+
+  def test_transliterate_does_not_mutate_a_non_frozen_gb18030_argument
+    string = "中文".encode(Encoding::GB18030)
+    assert_not string.frozen?
+    original_encoding = string.encoding
+    original_bytes = string.bytes
+    ActiveSupport::Inflector.transliterate(string)
+    assert_equal original_encoding, string.encoding
+    assert_equal original_bytes, string.bytes
+  end
+
+  def test_transliterate_does_not_mutate_a_non_frozen_us_ascii_argument
+    string = String.new("caf\xC3\xA9", encoding: Encoding::US_ASCII)
+    assert_not string.frozen?
+    original_encoding = string.encoding
+    original_bytes = string.bytes
+    ActiveSupport::Inflector.transliterate(string)
+    assert_equal original_encoding, string.encoding
+    assert_equal original_bytes, string.bytes
+  end
+
+  def test_parameterize_does_not_mutate_a_non_frozen_gb18030_argument
+    string = "中文".encode(Encoding::GB18030)
+    assert_not string.frozen?
+    original_encoding = string.encoding
+    ActiveSupport::Inflector.parameterize(string)
+    assert_equal original_encoding, string.encoding
+  end
 end


### PR DESCRIPTION
## Problem

`ActiveSupport::Inflector.transliterate` mutates the string argument in place when the argument is **non-frozen and not UTF-8** (e.g. a GB18030 string, or a US-ASCII string carrying non-ASCII bytes). The method only duplicates the input when it is frozen, but it then calls `force_encoding` / `encode!` on that same object, so a non-frozen caller string has its encoding (and bytes, for GB18030) rewritten underneath the caller. `parameterize`, which delegates to `transliterate`, inherits the same surprise mutation. A prior commit (5623f7f1a3) guarded the frozen + ascii_only case but missed the non-frozen non-UTF-8 branch.

## Reproduction

```ruby
s = "中文".encode(Encoding::GB18030)
s.frozen? # => false
ActiveSupport::Inflector.transliterate(s)
s.encoding # expected: GB18030, actual: UTF-8  (s was mutated in place)
```

The same happens through `parameterize(s)`, and for a US-ASCII string with non-ASCII bytes (its encoding flips to UTF-8 in place).

Expected: `transliterate` returns the approximated value without ever modifying the argument the caller passed in. Actual: the caller's own string object is mutated.

## Fix

Always operate on a duplicate of the input before the in-place `force_encoding` / `encode!` calls, instead of duplicating only when the input is frozen. This broadens the existing frozen-only `dup` to an unconditional `dup`, so the caller's string is never touched regardless of frozen-ness. One-line behavioral change; the early `return string.dup if string.ascii_only?` fast path is unchanged.

## Test

Added three regression tests to `activesupport/test/transliterate_test.rb`:

- `transliterate` does not change a non-frozen GB18030 argument's encoding or bytes.
- `transliterate` does not change a non-frozen US-ASCII (with non-ASCII bytes) argument's encoding or bytes.
- `parameterize` does not change a non-frozen GB18030 argument's encoding.

All three fail before the fix (encoding rewritten to UTF-8) and pass after. The full `transliterate_test.rb` and `inflector_test.rb` suites remain green.