### PR TITLE
Fix StructuredEventSubscriber.debug_only leaking across subscriber subclasses

### DIFF
--- a/activesupport/lib/active_support/structured_event_subscriber.rb
+++ b/activesupport/lib/active_support/structured_event_subscriber.rb
@@ -48,7 +48,7 @@ module ActiveSupport
         end
 
         def debug_only(method)
-          self.debug_methods << method
+          self.debug_methods += [method]
           set_silenced_events
         end
     end

--- a/activesupport/test/structured_event_subscriber_test.rb
+++ b/activesupport/test/structured_event_subscriber_test.rb
@@ -33,6 +33,8 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
 
   teardown do
     ActiveSupport.event_reporter.debug_mode = @old_debug_mode
+    TestSubscriber.detach_from :test
+    ActiveSupport::StructuredEventSubscriber.detach_from :test
   end
 
   def test_emit_event_calls_event_reporter_notify
@@ -85,7 +87,7 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_debug_only_methods
-    ActiveSupport::StructuredEventSubscriber.attach_to :test, @subscriber
+    TestSubscriber.attach_to :test, @subscriber
 
     event_reporter_subscriber = TestEventReporterSubscriber.new
     ActiveSupport.event_reporter.subscribe(event_reporter_subscriber)
@@ -101,6 +103,24 @@ class StructuredEventSubscriberTest < ActiveSupport::TestCase
     end
   ensure
     ActiveSupport.event_reporter.unsubscribe(event_reporter_subscriber)
+  end
+
+  def test_debug_only_does_not_leak_across_subclasses
+    base_methods = ActiveSupport::StructuredEventSubscriber.debug_methods.dup
+
+    subscriber_a = Class.new(ActiveSupport::StructuredEventSubscriber) do
+      def foo(event); end
+      debug_only :foo
+    end
+
+    subscriber_b = Class.new(ActiveSupport::StructuredEventSubscriber) do
+      def bar(event); end
+      debug_only :bar
+    end
+
+    assert_equal [:foo], subscriber_a.debug_methods
+    assert_equal [:bar], subscriber_b.debug_methods
+    assert_equal base_methods, ActiveSupport::StructuredEventSubscriber.debug_methods
   end
 
   def test_no_event_reporter_subscribers


### PR DESCRIPTION
## Problem

`ActiveSupport::StructuredEventSubscriber` declares `debug_methods` as a `class_attribute` with a single mutable default array (`default: []`). The private `debug_only` helper appends to it in place with `self.debug_methods << method`. Because the default array object is shared by the base class and every subclass, mutating it in place pollutes all of them: every subscriber subclass ends up seeing every other subclass's `debug_only` methods, and the base class is polluted too.

The practical consequence: a user-defined `StructuredEventSubscriber` whose method name happens to collide with a framework `debug_only` name (e.g. `:sql`, `:render_template`) can get that event silenced in production even though it never called `debug_only` itself, because the framework subscriber's `debug_only` leaked into the shared array.

## Reproduction

```ruby
sx = Class.new(ActiveSupport::StructuredEventSubscriber) { def foo(e); end; debug_only :foo }
sy = Class.new(ActiveSupport::StructuredEventSubscriber) { def bar(e); end; debug_only :bar }

sx.debug_methods                          # => [:foo, :bar]   (expected [:foo])
sy.debug_methods                          # => [:foo, :bar]   (expected [:bar])
sx.debug_methods.equal?(sy.debug_methods) # => true           (expected false)
ActiveSupport::StructuredEventSubscriber.debug_methods # => [:foo, :bar] (base polluted; expected [])
```

Actual: both subclasses (and the base class) share one array containing every method. Expected: each subclass holds only its own `debug_only` methods, leaving the base class untouched.

## Fix

Replace the in-place `self.debug_methods << method` with a non-mutating reassignment `self.debug_methods += [method]`. This builds a fresh per-class array via the `class_attribute` writer instead of mutating the shared default, so each subclass gets its own copy and the base class stays clean. This mirrors the sibling `LogSubscriber.subscribe_log_level`, which likewise reassigns (`self.log_levels = log_levels.merge(...)`) rather than mutating in place. One-line change.

## Test

Added `test_debug_only_does_not_leak_across_subclasses` asserting that two distinct subclasses each calling `debug_only` with a different method name end up with only their OWN method in `debug_methods`, and that the base class's `debug_methods` is unchanged. The test fails before the fix (`[:debug_only_event, :foo, :bar]`) and passes after.

The existing `test_debug_only_methods` was updated to attach the `TestSubscriber` subclass (which actually declares the `debug_only` method) instead of the base class; previously it only worked because the leak pushed the subclass's method onto the base class's array. A `detach_from :test` was added to the teardown so each test cleans up its `Notifications` subscriptions, keeping the suite order-independent.