### PR TITLE
Fix `Array#to_query` to skip empty Array elements, mirroring the empty-Hash case

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -60,8 +60,8 @@ class Array
       nil.to_query(prefix)
     else
       filter_map { |value|
-        q = value.to_query(prefix)
-        q unless q.empty?
+        next if (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
+        value.to_query(prefix)
       }.join "&"
     end
   end
@@ -83,9 +83,8 @@ class Hash
   # are sorted lexicographically in ascending order.
   def to_query(namespace = nil)
     query = filter_map do |key, value|
-      unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
-        value.to_query(namespace ? "#{namespace}[#{key}]" : key)
-      end
+      next if (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
+      value.to_query(namespace ? "#{namespace}[#{key}]" : key)
     end
 
     query.sort! unless namespace.to_s.include?("[]")

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -56,6 +56,10 @@ class ToQueryTest < ActiveSupport::TestCase
     assert_query_equal "a%5B%5D=1&a%5B%5D=2", a: [1, {}, 2]
   end
 
+  def test_array_with_empty_array
+    assert_query_equal "a%5B%5D=1&a%5B%5D=2", a: [1, [], 2]
+  end
+
   def test_nested_empty_hash
     assert_equal "",
       {}.to_query


### PR DESCRIPTION
## Problem

`Array#to_query` was recently updated (68160c4417) to drop nested elements whose serialization is empty, so that an empty Hash element is omitted from the query string. That filtering relies on the resulting string being empty (`q unless q.empty?`). An empty *Array* element, however, does not produce an empty string: `[].to_query(prefix)` falls through to `nil.to_query(prefix)`, which returns the bare escaped key (non-empty). As a result an empty Array element leaks a stray valueless `a[][]` segment (no `=`), inconsistent with how an empty Hash element is handled. Anyone serializing params that contain a nested empty array (e.g. `{ a: [1, [], 2] }.to_query` from form/URL helpers) hits this.

## Reproduction

```ruby
require "active_support/core_ext/object/to_query"

[1, [], 2].to_query("a")
# actual:   "a%5B%5D=1&a%5B%5D%5B%5D&a%5B%5D=2"   (stray "a%5B%5D%5B%5D")
# expected: "a%5B%5D=1&a%5B%5D=2"

{ a: [1, {}, 2] }.to_query  # => "a%5B%5D=1&a%5B%5D=2"  (empty Hash already dropped)
{ a: [1, [], 2] }.to_query  # => stray segment, before the fix
```

The empty-Hash element is already elided; the empty-Array element should behave the same way.

## Fix

`Array#to_query` now applies the same guard that `Hash#to_query` already uses for nested empty collections: skip an element when it is an empty Hash or Array before delegating to its `to_query`. This is a 3-line change that makes the Array path consistent with the Hash path. The top-level empty-array case is unchanged: `[].to_query("a")` still returns `"a%5B%5D"`, because that case is handled by the separate `if empty?` branch.

## Test

Added `test_array_with_empty_array` in `activesupport/test/core_ext/object/to_query_test.rb`, paralleling the existing `test_array_with_empty_hash`: it asserts `{ a: [1, [], 2] }.to_query == "a%5B%5D=1&a%5B%5D=2"`. The test fails before the change (the stray `a%5B%5D%5B%5D` segment appears) and passes after.