### PR TITLE
Fix increment! with explicit query constraints

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `increment!` / `decrement!` on models with query constraints to include
+    every query constraint column in the counter update.
+
+    *Jean-Samuel Aubry-Guzzi*
+
 *   Fix bug with reloading models with all-queries default scopes. The previous
     implementation allowed non-all-queries on the current scope to leak into
     the scope used for reloading.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -693,7 +693,9 @@ module ActiveRecord
 
       increment(attribute, by)
       change = public_send(attribute) - (public_send(:"#{attribute}_in_database") || 0)
-      self.class.update_counters(id, attribute => change, touch: touch)
+      counters = { attribute => change, touch: touch }
+
+      self.class.unscoped.where!(_query_constraints_hash).update_counters(counters)
       public_send(:"clear_#{attribute}_change")
       self
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1761,6 +1761,28 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_match(/WHERE .*color/, sql)
   end
 
+  def test_increment_and_decrement_use_query_constraints_not_composite_pk
+    topic_class = Class.new(Topic) do
+      self.inheritance_column = :_type_disabled
+      query_constraints :author_name, :id
+    end
+    topic = topic_class.create!(title: "New Topic", author_name: "Not David", replies_count: 0)
+
+    sql = nil
+    assert_difference -> { topic.reload.replies_count }, +1 do
+      sql = capture_sql { topic.increment!(:replies_count) }.first
+    end
+    assert_match(/WHERE .*author_name/, sql)
+    assert_match(/WHERE .*id/, sql)
+
+    sql = nil
+    assert_difference -> { topic.reload.replies_count }, -1 do
+      sql = capture_sql { topic.decrement!(:replies_count) }.first
+    end
+    assert_match(/WHERE .*author_name/, sql)
+    assert_match(/WHERE .*id/, sql)
+  end
+
   def test_it_is_possible_to_update_parts_of_the_query_constraints_config
     clothing_item = clothing_items(:green_t_shirt)
     clothing_item.color = "blue"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `increment!` and `decrement!` on a model with explicit `query_constraints` can update using only the primary key, even when the configured `query_constraints` include additional columns.

Composite-primary-key models already work because `id` contains the full composite key. The bug is for models with a single-column primary key and `query_constraints` that do not match the primary key, for example:

```ruby
class TopicWithConstraints < Topic
  query_constraints :author_name, :id
end

topic.increment!(:replies_count)
# Before: UPDATE topics ... WHERE id = ?
# After:  UPDATE topics ... WHERE author_name = ? AND id = ?
```

### Detail

The cause is in [`ActiveRecord::Persistence#increment!`](https://github.com/rails/rails/blob/9784cde833953dbabf95ae9403d03d30a5feaace/activerecord/lib/active_record/persistence.rb#L690-L699). It persisted the counter change through:

```ruby
self.class.update_counters(id, attribute => change, touch: touch)
```

[`ActiveRecord::CounterCache.update_counters`](https://github.com/rails/rails/blob/9784cde833953dbabf95ae9403d03d30a5feaace/activerecord/lib/active_record/counter_cache.rb#L134-L138) scopes the update by primary key:

```ruby
unscoped.where!(primary_key => id).update_counters(counters)
```

That is correct for regular primary-key updates and for composite-primary-key models, but it bypasses [`_query_constraints_hash`](https://github.com/rails/rails/blob/9784cde833953dbabf95ae9403d03d30a5feaace/activerecord/lib/active_record/persistence.rb#L911-L919) for models whose `query_constraints` are not the same as the primary key.

The fix builds the counter update relation from `_query_constraints_hash` directly:

```ruby
self.class.unscoped.where!(_query_constraints_hash).update_counters(counters)
```

For models without explicit `query_constraints`, `_query_constraints_hash` falls back to the primary key. For models with explicit `query_constraints`, it includes the configured constraint columns. `decrement!` is covered by the same change because it delegates to `increment!` with a negative value.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG files are updated.
