### PR TITLE
Ensure `assert_no_changes` isn't given a static value

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   `assert_difference`, `assert_no_difference`, `assert_changes`, and
+    `assert_no_changes` now raise `ArgumentError` when given an expression that
+    is not a callable (like a Proc), String, or Symbol.
+
+    This helps catch issues where you accidentally pass a single static value
+    (like `assert_no_changes(a.size)`). The same value would seen before
+    and after the block, so no change would ever be found, silently passing
+    the assertion even if there *was* an unexpected change.
+
+    To be reevaluated correctly, the expression should wrapped in a lambda like
+    `assert_no_changes(-> { a.size })`, or quoted in a String that can be `eval`-ed.
+
+    *Alexander Momchilov*
+
 *   Add `ActiveSupport::Notifications::NullInstrumenter`, a stateless no-op
     instrumenter that executes blocks without publishing any notifications.
 

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -113,9 +113,7 @@ module ActiveSupport
             Array(expression).index_with(difference)
           end
 
-        exps = expressions.keys.map { |e|
-          e.respond_to?(:call) ? e : lambda { eval(e, block.binding) }
-        }
+        exps = expressions.keys.map { |e| _expression_to_callable(e, block.binding) }
         before = exps.map(&:call)
 
         retval = _assert_nothing_raised_or_warn("assert_difference", &block)
@@ -210,7 +208,7 @@ module ActiveSupport
       #     post :create, params: { status: { incident: true } }
       #   end
       def assert_changes(expression, message = nil, from: UNTRACKED, to: UNTRACKED, &block)
-        exp = expression.respond_to?(:call) ? expression : -> { eval(expression.to_s, block.binding) }
+        exp = _expression_to_callable(expression, block.binding)
 
         before = exp.call
         retval = _assert_nothing_raised_or_warn("assert_changes", &block)
@@ -279,7 +277,7 @@ module ActiveSupport
       #     post :create, params: { status: { ok: false } }
       #   end
       def assert_no_changes(expression, message = nil, from: UNTRACKED, &block)
-        exp = expression.respond_to?(:call) ? expression : -> { eval(expression.to_s, block.binding) }
+        exp = _expression_to_callable(expression, block.binding)
 
         before = exp.call
         retval = _assert_nothing_raised_or_warn("assert_no_changes", &block)
@@ -366,6 +364,17 @@ module ActiveSupport
           end
 
           callable
+        end
+
+        def _expression_to_callable(callable_or_ruby_source, binding)
+          return callable_or_ruby_source if callable_or_ruby_source.respond_to?(:call)
+
+          case callable_or_ruby_source
+          when String, Symbol
+            -> { eval(callable_or_ruby_source.to_s, binding) }
+          else
+            raise ArgumentError, "The expression must be a callable object like a Proc, or a String of Ruby code. Got #{callable_or_ruby_source.inspect}"
+          end
         end
     end
   end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -82,6 +82,15 @@ class AssertionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_no_difference_with_non_callable
+    error = assert_raises ArgumentError do
+      assert_no_difference @object.num do # Should have been `-> { @object.num }`!
+        @object.increment
+      end
+    end
+    assert_match("The expression must be a callable object like a Proc, or a String of Ruby code. Got 0", error.message)
+  end
+
   def test_assert_difference
     assert_difference "@object.num", +1 do
       @object.increment
@@ -178,6 +187,15 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
     assert_equal "Object Changed.\n`@object.num` didn't change by 1, but by 0.\nExpected: 1\n  Actual: 0", error.message
+  end
+
+  def test_assert_difference_with_non_callable
+    error = assert_raises ArgumentError do
+      assert_difference @object.num, +1 do # Should have been `-> { @object.num }`!
+        @object.increment
+      end
+    end
+    assert_match("The expression must be a callable object like a Proc, or a String of Ruby code. Got 0", error.message)
   end
 
   def test_hash_of_lambda_expressions
@@ -315,6 +333,15 @@ class AssertionsTest < ActiveSupport::TestCase
     assert_changes -> { token }, from: /\w{32}/, to: /\w{32}/ do
       token = SecureRandom.hex
     end
+  end
+
+  def test_assert_changes_with_non_callable
+    error = assert_raises ArgumentError do
+      assert_changes @object.num, from: 0, to: 1 do # Should have been `-> { @object.num }`
+        @object.increment
+      end
+    end
+    assert_match("The expression must be a callable object like a Proc, or a String of Ruby code. Got 0", error.message)
   end
 
   def test_assert_changes_with_message
@@ -456,6 +483,15 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
     assert_match(/#<Object:0x.*changed/, error.message)
+  end
+
+  def test_assert_no_changes_message_with_non_callable
+    error = assert_raises ArgumentError do
+      assert_no_changes @object.num do # Should have been `-> { @object.num }`!
+        @object.increment
+      end
+    end
+    assert_match("The expression must be a callable object like a Proc, or a String of Ruby code. Got 0", error.message)
   end
 
   def test_assert_no_changes_with_long_string_wont_output_everything


### PR DESCRIPTION
### Motivation / Background

There's a sharp edge to `assert_no_changes` (and friends): if you accidentally give them a "static" value (like an Integer), they will always pass, even if a change was made. E.g.

```ruby
#!/usr/bin/ruby

require "active_support"
require "active_support/test_case"
require "minitest/autorun"

class AssertNoChangesTest < ActiveSupport::TestCase
  def test_value_changed_but_test_passes
    a = []
    assert_no_changes(a.size) do
      a << "something"
    end
  end
end
```

I should have passed `-> { a.size }` or `"a.size"` (which will be `eval`-ed), but the test silently passes anyway.

Rails should help catch these scenarios.

### Detail

This Pull Request changes `assert_no_changes` to raise `ArgumentError` unless the expression their given is a callable (typically a Proc), String, or Symbol.

### Additional information

#### Correctness

This change isn't totally fool-proof. If the expression you're observing is a `String` (or Symbol), then it'll be treated as Ruby code and evaled. There's no way for us to tell apart a static string expression that should have been wrapped in a proc, from a string that's intended to be evaluated as Ruby source.

That's less likely to fail silently though (your string is mostly likely not semantically valid Ruby), so it's fine. e.g.

```ruby
oncall = "Alice"
assert_no_changes(oncall) do # NameError: uninitialized constant AssertNoChangesTest::Alice
  oncall = "Bob"
end
```

#### Backwards compatibility

This will now raise `ArgumentError` in the rare cases where people were passing a non-String, non-Symbol value that responds to `to_s`, that also happened to eval'ed correctly. This is quite unlikely:

```ruby
class Hmm
  def to_s = "x" # evals correctly in the context below
end

def test_hmm
  x = 1
  assert_no_changes(Hmm.new) do # passes correctly
    # no change
  end
end
```

If it's intended, there's a trivial fix of calling `to_s` on the argument to `assert_no_changes`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
