### PR TITLE
Make some lambdas in constants shareable

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -37,9 +37,9 @@ module ActionController
     end
 
     private
-      INCLUDE = ->(list, action) { list.include? action }
-      EXCLUDE = ->(list, action) { !list.include? action }
-      NULL    = ->(list, action) { true }
+      INCLUDE = ActiveSupport::Ractors.shareable_lambda(&->(list, action) { list.include? action })
+      EXCLUDE = ActiveSupport::Ractors.shareable_lambda(&->(list, action) { !list.include? action })
+      NULL    = ActiveSupport::Ractors.shareable_lambda(&->(list, action) { true })
 
       def build_middleware(klass, args, block)
         options = args.extract_options!

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -10,10 +10,10 @@ module ActionDispatch
       PARAMETERS_KEY = "action_dispatch.request.path_parameters"
 
       DEFAULT_PARSERS = {
-        Mime[:json].symbol => -> (raw_post) {
+        Mime[:json].symbol => ActiveSupport::Ractors.shareable_lambda(&-> (raw_post) {
           data = ActiveSupport::JSON.decode(raw_post)
           data.is_a?(Hash) ? data : { _json: data }
-        }
+        })
       }.freeze
 
       # Raised when raw data from the request cannot be parsed by the parser defined

--- a/actionpack/lib/action_dispatch/journey/visitors.rb
+++ b/actionpack/lib/action_dispatch/journey/visitors.rb
@@ -6,8 +6,8 @@ module ActionDispatch
   # :stopdoc:
   module Journey
     class Format
-      ESCAPE_PATH    = ->(value) { Router::Utils.escape_path(value) }
-      ESCAPE_SEGMENT = ->(value) { Router::Utils.escape_segment(value) }
+      ESCAPE_PATH    = ActiveSupport::Ractors.shareable_lambda(&->(value) { Router::Utils.escape_path(value) })
+      ESCAPE_SEGMENT = ActiveSupport::Ractors.shareable_lambda(&->(value) { Router::Utils.escape_segment(value) })
 
       Parameter = Struct.new(:name, :escaper) do
         def escape(value); escaper.call value; end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -29,8 +29,8 @@ module ActionDispatch
       class Constraints < Routing::Endpoint # :nodoc:
         attr_reader :app, :constraints
 
-        SERVE = ->(app, req) { app.serve req }
-        CALL  = ->(app, req) { app.call req.env }
+        SERVE = ActiveSupport::Ractors.shareable_lambda(&->(app, req) { app.serve req })
+        CALL  = ActiveSupport::Ractors.shareable_lambda(&->(app, req) { app.call req.env })
 
         def initialize(app, constraints, strategy)
           # Unwrap Constraints objects. I don't actually think it's possible to pass a

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -346,8 +346,8 @@ module ActionDispatch
       end
 
       # strategy for building URLs to send to the client
-      PATH    = ->(options) { ActionDispatch::Http::URL.path_for(options) }
-      UNKNOWN = ->(options) { ActionDispatch::Http::URL.url_for(options) }
+      PATH    = ActiveSupport::Ractors.shareable_lambda(&->(options) { ActionDispatch::Http::URL.path_for(options) })
+      UNKNOWN = ActiveSupport::Ractors.shareable_lambda(&->(options) { ActionDispatch::Http::URL.url_for(options) })
 
       attr_accessor :formatter, :set, :named_routes, :router
       attr_accessor :disable_clear_and_finalize, :resources_path_names


### PR DESCRIPTION
### Motivation / Background

We are experimenting with serving requests in a ractor. Some lambdas stored in constants need to be made shareable

### Detail

Use the shareability shim to make these shareable on ruby 4.0+

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
