### PR TITLE
Ractor safe readonly attributes

### DIFF
--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -28,7 +28,7 @@ module ActiveRecord
       #   post.title = "a different title" # raises ActiveRecord::ReadonlyAttributeError
       #   post.update(title: "a different title") # raises ActiveRecord::ReadonlyAttributeError
       def attr_readonly(*attributes)
-        self._attr_readonly |= attributes.map(&:to_s)
+        self._attr_readonly = ActiveSupport::Ractors.make_shareable(_attr_readonly | attributes.map(&:to_s))
 
         if ActiveRecord.raise_on_assign_to_attr_readonly
           include(HasReadonlyAttributes)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -32,6 +32,7 @@ require "models/cpk"
 require "concurrent/atomic/count_down_latch"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/kernel/reporting"
+require "active_support/testing/ractors_assertions"
 
 class FirstAbstractClass < ActiveRecord::Base
   self.abstract_class = true
@@ -103,6 +104,8 @@ class LintTest < ActiveRecord::TestCase
 end
 
 class BasicsTest < ActiveRecord::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   fixtures :topics, :companies, :developers, :projects, :computers, :accounts,
     :minimalistics, "warehouse-things", :authors, :author_addresses, :categorizations, :categories,
     :posts, :cpk_books

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -880,6 +880,10 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_readonly_attributes_are_ractor_safe
+    assert_ractor_shareable ReadonlyAuthorPost._attr_readonly
+  end
+
   def test_unicode_column_name
     Weird.reset_column_information
     weird = Weird.create(なまえ: "たこ焼き仮面")

--- a/activesupport/lib/active_support/testing/ractors_assertions.rb
+++ b/activesupport/lib/active_support/testing/ractors_assertions.rb
@@ -5,10 +5,18 @@ module ActiveSupport
     module RactorsAssertions # :nodoc: all
       private
         if RUBY_VERSION >= "4.0"
-          def assert_ractor_shareable(obj)
+          def assert_ractor_make_shareable(obj)
             assert_nothing_raised { Ractor.make_shareable(obj) }
           end
+
+          def assert_ractor_shareable(obj)
+            assert Ractor.shareable?(obj), "Expected #{obj.inspect} to be shareable, but it is not."
+          end
         else
+          def assert_ractor_make_shareable(obj)
+            assert true
+          end
+
           def assert_ractor_shareable(obj)
             assert true
           end

--- a/activesupport/test/backtrace_cleaner_test.rb
+++ b/activesupport/test/backtrace_cleaner_test.rb
@@ -140,8 +140,8 @@ class BacktraceCleanerDefaultFilterAndSilencerTest < ActiveSupport::TestCase
     assert_equal backtrace, @bc.clean(backtrace)
   end
 
-  test "backtrace cleaner is Ractor shareable" do
-    assert_ractor_shareable @bc
+  test "backtrace cleaner can be made Ractor shareable" do
+    assert_ractor_make_shareable @bc
   end
 end
 

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -93,7 +93,7 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     assert_equal "app/views/application/index.html.erb:4", frame
   end
 
-  test "backtrace cleaner is Ractor shareable" do
-    assert_ractor_shareable @cleaner
+  test "backtrace cleaner can be made Ractor shareable" do
+    assert_ractor_make_shareable @cleaner
   end
 end


### PR DESCRIPTION
### Motivation / Background

We are working on making Rails ractor safe. A lot of hashes and arrays are stored in class attributes as configuration, they're mutable so we need to find a way for them to be ractor safe.

This PR focuses on `ActiveRecord::Base._attr_readonly`.

### Detail

Instead of doing the book keeping of freezing all these when we freeze the application, we are going to make them frozen by default. We already did this with exception wrapper configs in https://github.com/rails/rails/pull/57483. The default array is frozen, and then when adding new elements we dup the array, add the new element and freeze it again.

On this PR I also improved the assertion I added in https://github.com/rails/rails/pull/57574. We really need two assertions. `assert_ractor_shareable` for things like this that we expect to be shareable without us needing to make them shareable. And then `assert_ractor_make_shareable` for things like the backtrace cleaner, which we expect to be able to make shareable when freezing the application.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
