### PR TITLE
Touch has_many :through owner when records removed via delete_all

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Touch the owner of a `has_many :through` association when associated records are
+    removed via collection assignment (`tags = []`, `tag_ids = []`), `delete`, or
+    `clear`. The owner is now touched on the `delete_all` path too, mirroring the
+    existing `counter_cache` handling.
+
+    Fixes #29078.
+
+    *Willian Tenfen Wazilewski*
+
 *   Fix `increment!` / `decrement!` on models with query constraints to include
     every query constraint column in the counter update.
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -122,6 +122,23 @@ module ActiveRecord
           !(through_reflection.belongs_to? && Array(through_reflection.foreign_key).all? { |foreign_key_column| owner[foreign_key_column].blank? })
         end
 
+        # Returns the +:touch+ option of the join model's +belongs_to+ that points
+        # back to the owner, or +nil+ when none is configured.
+        def through_belongs_to_touch
+          candidates = if (inverse = through_reflection.inverse_of)
+            [inverse]
+          else
+            through_reflection.klass.reflect_on_all_associations(:belongs_to)
+          end
+
+          reflection = candidates.find do |candidate|
+            candidate.options[:touch] &&
+              (candidate.polymorphic? || candidate.klass == through_reflection.active_record)
+          end
+
+          reflection && reflection.options[:touch]
+        end
+
         def update_through_counter?(method)
           case method
           when :destroy
@@ -163,6 +180,10 @@ module ActiveRecord
           if source_reflection.options[:counter_cache] && method != :destroy
             counter = source_reflection.counter_cache_column
             klass.decrement_counter counter, records.map(&:id)
+          end
+
+          if count > 0 && method != :destroy && owner.persisted? && (touch = through_belongs_to_touch)
+            touch == true ? owner.touch : owner.touch(touch)
           end
 
           if through_reflection.collection? && update_through_counter?(method)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -47,6 +47,22 @@ require "models/interest"
 require "models/human"
 require "models/dats"
 
+class TouchableThroughOwner < ActiveRecord::Base
+  self.table_name = "pets"
+  self.primary_key = :pet_id
+
+  has_many :touch_through_links, foreign_key: :pet_id, class_name: "TouchThroughLink"
+  has_many :treasures, through: :touch_through_links, source: :treasure
+  has_many :destroyable_treasures, through: :touch_through_links, source: :treasure, dependent: :destroy
+end
+
+class TouchThroughLink < ActiveRecord::Base
+  self.table_name = "pets_treasures"
+
+  belongs_to :touchable_through_owner, foreign_key: :pet_id, touch: true
+  belongs_to :treasure
+end
+
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
            :owners, :pets, :toys, :jobs, :references, :companies, :members, :author_addresses,
@@ -664,6 +680,53 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_no_difference "post.reload.indestructible_tags_count" do
       posts(:welcome).indestructible_tags.destroy(tag)
     end
+  end
+
+  def test_touch_owner_when_removing_through_record_via_collection_assignment
+    owner = TouchableThroughOwner.create!(name: "owner")
+    owner.treasures = [Treasure.create!, Treasure.create!]
+
+    assert_touches(owner) { owner.treasures = [] }
+  end
+
+  def test_touch_owner_when_removing_through_record_via_ids_writer
+    owner = TouchableThroughOwner.create!(name: "owner")
+    owner.treasures = [Treasure.create!, Treasure.create!]
+
+    assert_touches(owner) { owner.treasure_ids = [] }
+  end
+
+  def test_touch_owner_when_removing_through_record_via_delete
+    owner = TouchableThroughOwner.create!(name: "owner")
+    treasure = Treasure.create!
+    owner.treasures = [treasure, Treasure.create!]
+
+    assert_touches(owner) { owner.treasures.delete(treasure) }
+  end
+
+  def test_touch_owner_when_removing_through_record_via_clear
+    owner = TouchableThroughOwner.create!(name: "owner")
+    owner.treasures = [Treasure.create!, Treasure.create!]
+
+    assert_touches(owner) { owner.treasures.clear }
+  end
+
+  def test_touch_owner_only_once_when_removing_through_record_with_dependent_destroy
+    owner = TouchableThroughOwner.create!(name: "owner")
+    owner.destroyable_treasures = [Treasure.create!]
+
+    assert_touches(owner) { owner.destroyable_treasures = [] }
+  end
+
+  def test_does_not_touch_owner_when_no_through_record_is_removed
+    owner = TouchableThroughOwner.create!(name: "owner")
+    owner.treasures = [Treasure.create!]
+    owner.update_column(:updated_at, 1.day.ago)
+    previous = owner.reload.updated_at
+
+    owner.treasures.delete(Treasure.create!) # not a member, nothing removed
+
+    assert_equal previous, owner.reload.updated_at
   end
 
   def test_replace_association
@@ -1755,6 +1818,15 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       lesson.has_many :lesson_students, anonymous_class: lesson_student
       lesson.has_many :students, through: :lesson_students, anonymous_class: student
       [lesson, lesson_student, student]
+    end
+
+    def assert_touches(owner)
+      owner.update_column(:updated_at, 1.day.ago)
+      previous = owner.reload.updated_at
+
+      yield
+
+      assert_operator owner.reload.updated_at, :>, previous
     end
 end
 


### PR DESCRIPTION
Removing records from a has_many :through via collection assignment (`tags = []`, `tag_ids = []`), `delete`, or `clear` deletes the join records with `delete_all`, which does not run the join model's callbacks. As a result a `belongs_to ..., touch: true` on the join model never fired and the owner's `updated_at` was left stale, even though removing the same records through `destroy` / `dependent: :destroy` touched the owner.

Touch the owner on the `delete_all` path too, mirroring the existing `counter_cache` handling in `delete_records`.

Fixes #29078.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because removing records from a has_many :through association does not touch the owner, even when the join model declares belongs_to ..., touch: true.

Removing records via collection assignment (tags = [], tag_ids = []), delete, or clear deletes the join records with delete_all, which does not run the join model's callbacks. As a result a belongs_to ..., touch: true on the join model never fired and the owner's updated_at was left stale, even though removing the same records through destroy / dependent: :destroy touched the owner.

This is an undocumented and surprising asymmetry: the owner is touched only when records are removed via the destroy variants, but not via the assignment/delete/clear variants — which are exactly the ones the guides recommend for editing a has_many :through from a form (e.g. collection_check_boxes :tag_ids → params[:post][:tag_ids] → post.update(tag_ids: [...])). The result is stale cache keys / updated_at on the owner after a perfectly ordinary "edit the tags on this record" action.

Fixes #29078 (open since 2017, confirmed still present on main).

### Detail

This Pull Request changes HasManyThroughAssociation#delete_records so that, when join records are removed via delete_all (i.e. method != :destroy), the owner is touched if the join model's belongs_to pointing back to the owner declares a :touch option.

The fix mirrors the counter_cache handling already present a few lines above in the same method, which manually re-applies a side effect precisely because delete_all bypasses callbacks.
The custom touch column form (touch: :some_column) is honored, and ActiveRecord::Base.no_touching is respected (since it routes through #touch).
The destroy / dependent: :destroy path is intentionally left untouched (guarded by method != :destroy) so the owner is still touched exactly once via the join model's callbacks — no double-touch.

### Additional information

This only affects associations that actually declare touch: on the join model's belongs_to; other associations are unchanged.

Cost: the fix issues one additional UPDATE owners SET updated_at = ... per removal (not per record). This is the same query the destroy / dependent: :destroy path already emits today, and is consistent with the immediate counter_cache writes in the same method — so it does not introduce a new query pattern, it just makes the delete_all path consistent with the destroy path.

Tests cover every removal idiom (tags = [], tag_ids = [], delete, clear), plus a guard that the dependent: :destroy path still touches exactly once, and a negative case asserting the owner is not touched when nothing is actually removed.

No documentation change is needed: the :touch section of the Association Basics guide already describes the intended behavior; this change makes the implementation match it.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
