### PR TITLE
Add a Ractor-shareable ActiveSupport::TaggedLogging.shareable_logger

### DIFF
--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -4,6 +4,9 @@ module ActiveSupport
   # Shims for +Ractor+ shareability methods so framework code can call them
   # unconditionally regardless of the Ruby version.
   module Ractors # :nodoc:
+    extend ActiveSupport::Autoload
+    autoload :Logger
+
     class << self
       attr_accessor :unshareable_proc_action
 

--- a/activesupport/lib/active_support/ractors/logger.rb
+++ b/activesupport/lib/active_support/ractors/logger.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/module/delegation"
+
+module ActiveSupport
+  module Ractors # :nodoc:
+    # A Ractor-shareable +ActiveSupport::Logger+.
+    #
+    # +flush+ honors the Rails per-request contract: Rails::Rack::Logger calls ActiveSupport::LogSubscriber.flush_all!,
+    # which calls +#flush+ on the logger to drain a request's logs before the next request is processed.
+    class Logger < ActiveSupport::Logger # :nodoc:
+      def initialize(*args, level: ::Logger::DEBUG, progname: nil, formatter: nil, datetime_format: nil, **logdev_options)
+        super(nil, level: level, progname: progname, formatter: formatter, datetime_format: datetime_format)
+        @logdev = DeviceProxy.new(*args, **logdev_options)
+      end
+
+      delegate :flush, to: :@logdev
+
+      extend ActiveSupport::Autoload
+      autoload :DeviceProxy
+      autoload :Writer
+    end
+  end
+end

--- a/activesupport/lib/active_support/ractors/logger/device_proxy.rb
+++ b/activesupport/lib/active_support/ractors/logger/device_proxy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Ractors # :nodoc:
+    class Logger # :nodoc:
+      class DeviceProxy # :nodoc:
+        def initialize(*args, **logdev_options)
+          @writer = Writer.spawn(*args, **logdev_options)
+          @closed = false
+        end
+
+        def write(message)
+          return if @closed
+
+          @writer.async(message)
+          message.bytesize
+        end
+
+        def flush
+          @writer.flush unless @closed
+          true
+        end
+
+        def close
+          return true if @closed
+
+          @writer.shutdown
+          @closed = true unless frozen?
+          true
+        end
+
+        def reopen(log = nil, **options)
+          @writer.reopen(log, options) unless @closed
+          self
+        end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/ractors/logger/writer.rb
+++ b/activesupport/lib/active_support/ractors/logger/writer.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Ractors # :nodoc:
+    class Logger # :nodoc:
+      class Writer # :nodoc:
+        def self.spawn(...)
+          new.spawn(...)
+        end
+
+        def initialize
+          unless defined?(::Ractor::Port)
+            raise NotImplementedError, "ActiveSupport::Ractors::Logger requires Ractor::Port support"
+          end
+
+          @port = ::Ractor::Port.new
+        end
+
+        def spawn(logdev = nil, shift_age = 0, shift_size = 1048576, binmode: false, shift_period_suffix: "%Y%m%d")
+          device = build_logdev(logdev, shift_age, shift_size, binmode, shift_period_suffix)
+          start_consumer(@port, device)
+          ::Ractor.make_shareable(self)
+        end
+
+        def async(message)
+          @port << [:write, message]
+        rescue ::Ractor::ClosedError
+          # Consumer is gone; drop the line rather than raising in the caller.
+          nil
+        end
+
+        def call(operation, *args)
+          reply = reply_port
+          @port << [:call, reply, operation, args]
+          status, value = reply.receive
+          raise RuntimeError, value if status == :error
+          value
+        rescue ::Ractor::ClosedError
+          # Consumer is gone; degrade to a no-op rather than raising in the caller.
+          nil
+        end
+
+        def flush
+          call(:flush)
+        end
+
+        def reopen(log, options)
+          call(:reopen, log, options)
+        end
+
+        def shutdown
+          call(:shutdown) unless @port.closed?
+        ensure
+          @port.close
+        end
+
+        private
+          # Reuse one reply port per calling thread instead of allocating one per call. A thread blocks on its own reply,
+          # so its calls are serial and the port is safe to reuse.
+          def reply_port
+            ::Thread.current.thread_variable_get(:active_support_shareable_logger_reply_port) ||
+              ::Thread.current.thread_variable_set(:active_support_shareable_logger_reply_port, ::Ractor::Port.new)
+          end
+
+          def build_logdev(logdev, shift_age, shift_size, binmode, shift_period_suffix)
+            return NullDevice.new if logdev.nil?
+
+            ::Logger::LogDevice.new(logdev,
+              shift_age: shift_age,
+              shift_size: shift_size,
+              shift_period_suffix: shift_period_suffix,
+              binmode: binmode)
+          end
+
+          # The consumer must survive a failing log device the same way the stock Logger does: a write error is swallowed
+          # and reported to stderr, and the logger keeps working.
+          def start_consumer(port, logdev)
+            Thread.new do
+              closed = false
+              until closed
+                begin
+                  message = port.receive
+                rescue ::Ractor::ClosedError
+                  # Port closed; nothing left to consume.
+                  break
+                end
+                case message[0]
+                when :write
+                  begin
+                    logdev.write(message[1])
+                  rescue StandardError => error
+                    warn_failure(error)
+                  end
+                when :call
+                  _, reply, operation, args = message
+                  begin
+                    case operation
+                    when :flush
+                      flush_device(logdev)
+                    when :reopen
+                      logdev.reopen(args[0], **args[1])
+                    when :shutdown
+                      flush_device(logdev)
+                      logdev.close
+                      closed = true
+                    end
+                  rescue StandardError => error
+                    warn_failure(error)
+                  ensure
+                    reply << [:ok, operation == :shutdown ? true : :ok]
+                  end
+                end
+              end
+            ensure
+              # On an unexpected exit close the port too, so producers get a ClosedError instead of blocking forever on a
+              # dead consumer.
+              unless closed
+                logdev.close
+                port.close
+              end
+            end
+          end
+
+          def warn_failure(error)
+            warn "[ActiveSupport::Ractors::Logger::Writer] #{error.class}: #{error.message}"
+          end
+
+          def flush_device(logdev)
+            dev = logdev.respond_to?(:dev) ? logdev.dev : logdev
+            dev.flush if dev.respond_to?(:flush)
+          end
+
+          class NullDevice # :nodoc:
+            def write(_message); end
+            def reopen(*); end
+            def close; end
+          end
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -123,6 +123,15 @@ module ActiveSupport
       new ActiveSupport::Logger.new(*args, **kwargs)
     end
 
+    # Returns a logger that can be used from Ractors. Accepts the same arguments
+    # as Logger.new. The returned logger is an ActiveSupport::Ractors::Logger
+    # (a ::Logger subclass whose device proxies writes to a background Writer)
+    # wrapped with tagged logging, so it can be made shareable and used from any
+    # Ractor.
+    def self.ractor_logger(*args, **kwargs) # :nodoc:
+      new(ActiveSupport::Ractors::Logger.new(*args, **kwargs))
+    end
+
     def self.new(logger)
       logger = logger.clone
 

--- a/activesupport/test/ractor_logger_test.rb
+++ b/activesupport/test/ractor_logger_test.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "fileutils"
+require "timeout"
+
+class RactorLoggerTest < ActiveSupport::TestCase
+  if RUBY_VERSION >= "4.0"
+    include ActiveSupport::Testing::Isolation
+
+    test ".ractor_logger writes through a writer" do
+      path = log_path("basic.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+
+      logger.info("hello")
+      logger.flush
+
+      assert_includes File.read(path), "hello"
+    ensure
+      logger&.close
+    end
+
+    test ".ractor_logger returns a ::Logger subclass wrapped with tagged logging" do
+      path = log_path("subclass.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+
+      assert_kind_of ActiveSupport::Ractors::Logger, logger
+      assert_kind_of ::Logger, logger
+    ensure
+      logger&.close
+    end
+
+    test "consumer preserves Logger::LogDevice rotation" do
+      path = log_path("rotation.log")
+      # Rotate after a tiny size so a few writes trigger a roll-over.
+      logger = ActiveSupport::Ractors::Logger.new(path, 5, 64)
+
+      20.times { |i| logger.info("rotation-message-#{i}") }
+      logger.flush
+
+      assert_not_empty Dir["#{path}.*"], "expected Logger::LogDevice to rotate the log file"
+    ensure
+      logger&.close
+    end
+
+    test "reopen refreshes the device after the file is rotated externally" do
+      path = log_path("reopen.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+
+      logger.info("before")
+      logger.flush
+
+      rotated = "#{path}.1"
+      File.rename(path, rotated) # an external tool moves the file, like logrotate
+
+      logger.reopen # reopen the same path -> a fresh file
+      logger.info("after")
+      logger.flush
+
+      assert_includes File.read(rotated), "before"
+      assert_includes File.read(path), "after"
+      assert_not_includes File.read(path), "before"
+    ensure
+      logger&.close
+    end
+
+    test "uses Active Support tagged logging formatter for tags" do
+      path = log_path("tags.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+
+      logger.tagged("request-id") { logger.info("hello") }
+      logger.flush
+
+      assert_includes File.read(path), "[request-id] hello"
+    ensure
+      logger&.close
+    end
+
+    test "uses LocalTagStorage for tagged logger without block" do
+      path = log_path("local_tag_storage.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+
+      tagged_logger = logger.tagged("job")
+      tagged_logger.info("performed")
+      logger.info("plain")
+      logger.flush
+
+      contents = File.read(path)
+      assert_includes contents, "[job] performed"
+      assert_includes contents, "plain"
+      assert_not_includes contents, "[job] plain"
+    ensure
+      logger&.close
+    end
+
+    test "log_at uses logger-local level storage" do
+      path = log_path("log_at.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+      logger.level = Logger::INFO
+
+      logger.debug("outside")
+      logger.log_at(:debug) { logger.debug("inside") }
+      logger.debug("outside-again")
+      logger.flush
+
+      contents = File.read(path)
+      assert_includes contents, "inside"
+      assert_not_includes contents, "outside"
+      assert_not_includes contents, "outside-again"
+    ensure
+      logger&.close
+    end
+
+    test "log_at works through BroadcastLogger" do
+      path = log_path("broadcast_log_at.log")
+      ractor_logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+      logger = ActiveSupport::BroadcastLogger.new(ractor_logger)
+      logger.level = Logger::INFO
+
+      logger.debug("outside")
+      logger.log_at(:debug) { logger.debug("inside") }
+      logger.debug("outside-again")
+      ractor_logger.flush
+
+      contents = File.read(path)
+      assert_includes contents, "inside"
+      assert_not_includes contents, "outside"
+      assert_not_includes contents, "outside-again"
+    ensure
+      ractor_logger&.close
+    end
+
+    test "silence uses logger-local level storage" do
+      path = log_path("silence.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+      logger.level = Logger::DEBUG
+
+      logger.silence(Logger::ERROR) { logger.info("quiet-line") }
+      logger.info("loud-line")
+      logger.flush
+
+      contents = File.read(path)
+      assert_includes contents, "loud-line"
+      assert_not_includes contents, "quiet-line"
+    ensure
+      logger&.close
+    end
+
+    test "shareable logger writer is shareable" do
+      path = log_path("shareable_writer.log")
+      writer = ActiveSupport::Ractors::Logger::Writer.spawn(path)
+
+      assert Ractor.shareable?(writer)
+
+      writer.async("hello\n")
+      writer.flush
+
+      assert_includes File.read(path), "hello"
+    ensure
+      writer&.shutdown
+    end
+
+    test "shareable logger can be made shareable" do
+      path = log_path("shareable.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+
+      Ractor.make_shareable(logger)
+
+      assert Ractor.shareable?(logger)
+      logger.tagged("shareable") { logger.info("hello") }
+      logger.flush
+
+      assert_includes File.read(path), "[shareable] hello"
+    ensure
+      logger&.close
+    end
+
+    test "a shareable logger logs from a non-main Ractor" do
+      path = log_path("from_ractor.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+      Ractor.make_shareable(logger)
+
+      Ractor.new(logger) do |lg|
+        lg.tagged("request-id") { lg.info("from ractor") }
+        :done
+      end.value
+
+      logger.flush
+
+      assert_includes File.read(path), "[request-id] from ractor"
+    ensure
+      logger&.close
+    end
+
+    test "a failing log device does not kill the consumer or raise in the caller" do
+      device = FailingDevice.new(fail_writes: true, fail_flush: true)
+      logger = ActiveSupport::TaggedLogging.ractor_logger(device)
+
+      capture_io do
+        Timeout.timeout(5) do
+          assert_equal true, logger.info("swallowed")  # write error swallowed
+          assert_equal true, logger.flush              # flush error swallowed, no hang/raise
+
+          device.recover!
+          logger.info("after recovery")
+          logger.flush
+        end
+      end
+
+      assert_includes device.written.join, "after recovery"
+    ensure
+      logger&.close
+    end
+
+    test "a dead consumer degrades to a no-op instead of hanging" do
+      null_device = ActiveSupport::Ractors::Logger::Writer::NullDevice.new
+      writer = ActiveSupport::Ractors::Logger::Writer.spawn(null_device)
+      writer.instance_variable_get(:@port).close # simulate a consumer that has gone away
+
+      Timeout.timeout(5) do
+        assert_nil writer.async("dropped\n")
+        assert_nil writer.flush
+      end
+    end
+  end
+
+  class FailingDevice
+    attr_reader :written
+
+    def initialize(fail_writes:, fail_flush:)
+      @fail_writes = fail_writes
+      @fail_flush = fail_flush
+      @written = []
+    end
+
+    def recover!
+      @fail_writes = false
+      @fail_flush = false
+    end
+
+    def write(message)
+      raise IOError, "write boom" if @fail_writes
+      @written << message
+    end
+
+    def flush
+      raise IOError, "flush boom" if @fail_flush
+    end
+
+    def close; end
+  end
+
+  private
+    def log_path(name)
+      tmp_dir = File.join(__dir__, "tmp", "ractor_logger_test")
+      FileUtils.mkdir_p(tmp_dir)
+      path = File.join(tmp_dir, name)
+      File.delete(path) if File.exist?(path)
+      path
+    end
+end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2043,6 +2043,26 @@ module ApplicationTests
       assert_includes(Rails.logger.broadcasts, logger)
     end
 
+    if RUBY_VERSION >= "4.0"
+      test "config.logger can be a tagged shareable logger" do
+        add_to_config <<~RUBY
+          config.logger = ActiveSupport::TaggedLogging.ractor_logger(Rails.root.join("log/ractor.log"))
+        RUBY
+
+        app "development"
+
+        ractor_logger = Rails.logger.broadcasts.first
+        assert_instance_of ActiveSupport::Ractors::Logger, ractor_logger
+        assert_kind_of ::Logger, ractor_logger
+        assert_equal Rails.logger, Rails.application.config.action_controller.logger
+
+        Rails.logger.tagged("request-id") { Rails.logger.info("hello") }
+        Rails.logger.flush
+
+        assert_includes File.read(app_path("log/ractor.log")), "[request-id] hello"
+      end
+    end
+
     test "respond_to? accepts include_private" do
       make_basic_app
 


### PR DESCRIPTION
This mirrors `ActiveSupport::TaggedLogging.logger`, but returns a logger that can be made shareable and used from multiple Ractors.

The logger is an ActiveSupport::ShareableLogger (a ::Logger subclass whose device proxies writes to a background ShareableLogger::Writer), wrapped with tagged logging.

It reproduces the logger's behavior if there's a failure while writing: writes to stderr, and doesn't cause an error in the caller. (I looked into using the error reporter, but since it itself falls back to the logger, it was a bit too circular).

There's some risk about unbounded queue growth from the Ractor port, but it's mostly mitigated by enforcing the contract that at the end of the request, the logger should be flushed. An endpoint logging a lot could end up using more memory than without the ractor logger still. Still, I have a [follow-up branch](https://github.com/Shopify/rails/compare/activesupport-shareable-logger...shareable-logger-backpressure?expand=1) with an optional threshold that, once reached, causes the logger to become synchronous, but it requires the `ractor_safe` gem, so I feel like it's better to keep it optional.

For now, it's undocumented, but it should be usable from normal threaded Rails applications, albeit with unclear performance gains, if any. But once we have this, we should be able to disable the mutex in `Logger::LogDevice` for example, since only the Writer thread writes to the logdev.