### PR TITLE
Re-raise suppressed RedisClient errors in all RedisCacheStoreTests classes

### DIFF
--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -151,7 +151,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
 
     def lookup_store(options = {})
-      ActiveSupport::Cache.lookup_store(:redis_cache_store, { url: REDIS_URL, timeout: 0.1, namespace: @namespace, pool: false }.merge(options))
+      ActiveSupport::Cache.lookup_store(:redis_cache_store, { url: REDIS_URL, timeout: 0.1, namespace: @namespace, pool: false, error_handler: ->(method:, returning:, exception:) { raise exception } }.merge(options))
     end
 
     teardown do
@@ -325,10 +325,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     def capture_redis_commands(&block)
       capture_notifications("redis_query.active_support_test", &block).flat_map { |e| e.payload.fetch(:commands) }
-    end
-
-    def lookup_store(options = {})
-      super(options.merge(error_handler: ->(method:, returning:, exception:) { raise exception }))
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Make the failure message of
`ActiveSupport::Cache::RedisCacheStoreTests::FailureRaisingFromMaxClientsReachedErrorTest#test_fetch_with_block_read_failure_raises`
easier to diagnose. In a
[rails-nightly (master-debug) activesupport run](https://buildkite.com/rails/rails-nightly/builds/4426#019eb87c-96a1-49cf-a581-6e8ca348864f/L8294)
it failed with output that gives no hint of the cause:

```ruby
Failure:
ActiveSupport::Cache::RedisCacheStoreTests::FailureRaisingFromMaxClientsReachedErrorTest#test_fetch_with_block_read_failure_raises [test/cache/behaviors/failure_raising_behavior.rb:26]:
--- expected
+++ actual
@@ -1,3 +1 @@
-# encoding: US-ASCII
-#    valid: true
-"ix70bwHXFsZAhUKh"
+nil
```

### Detail

With this change, the same intermittent timeout will surface as:

```ruby
Error:
ActiveSupport::Cache::RedisCacheStoreTests::FailureRaisingFromMaxClientsReachedErrorTest#test_fetch_with_block_read_failure_raises:
RedisClient::CannotConnectError: user specified timeout for redis:6379 (redis://redis:6379/1)
    /usr/local/lib/ruby/4.1.0+3/socket.rb:922:in 'block in Socket.tcp_with_fast_fallback'
    ...
    lib/active_support/cache.rb:678:in 'ActiveSupport::Cache::Store#write'
    test/cache/behaviors/failure_raising_behavior.rb:18:in 'FailureRaisingBehavior#test_fetch_with_block_read_failure_raises'
```

### Additional information

This is a follow-up to https://github.com/rails/rails/pull/57571, which added
the re-raising `error_handler` to `RedisCacheStoreCommonBehaviorTest`. This
Pull Request extends its coverage to all `RedisCacheStoreTests` classes by
moving the `error_handler` into the `StoreTest#lookup_store` defaults.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.