### PR TITLE
Assortment of CI/test fixes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -521,9 +521,15 @@ module ActiveRecord
               @connections.each do |conn|
                 if conn.in_use?
                   conn.steal!
-                  checkin conn
+
+                  ActiveSupport.error_reporter.handle(source: "active_record.connection_pool") do
+                    checkin conn
+                  end
                 end
-                conn.disconnect!
+
+                ActiveSupport.error_reporter.handle(source: "active_record.connection_pool") do
+                  conn.disconnect!
+                end
               end
               @connections = @pinned_connection ? [@pinned_connection] : []
               @leases.clear

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1247,11 +1247,15 @@ module ActiveRecord
         pg_type_scan_nodes = plan_nodes(plan).select { |node| node["Relation Name"] == "pg_type" }
         # Keep anti-OR behavior from #40876 visible: OID lookups should stay index-driven,
         # and only the typtype='d' branch may seq-scan.
-        scan_summary = pg_type_scan_nodes.map { |node| [node["Index Name"], node["Filter"]] }.sort_by { |(index_name, filter)| [index_name.to_s, filter.to_s] }
+        scan_summary = pg_type_scan_nodes.map do |node|
+          index_name = plan_nodes(node).pluck("Index Name").compact.first
+          [index_name, node["Filter"]]
+        end.sort_by { |(index_name, filter)| [index_name.to_s, filter.to_s] }
+
         assert_equal 2, scan_summary.length
         assert_includes scan_summary, ["pg_type_oid_index", nil]
 
-        seq_scan_filter = scan_summary.find { |index_name, _| index_name.nil? }.last
+        seq_scan_filter = scan_summary.find { |index_name, filter| index_name.nil? && filter }.last
         assert_includes seq_scan_filter, "typtype = ANY ('{r,e,d}'::\"char\"[])"
       ensure
         @connection.execute "DROP DOMAIN IF EXISTS postgresql_domain_nested"

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -7,6 +7,10 @@ require "models/post"
 require "timeout"
 
 class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
+  uses_transaction :test_timeout_in_transaction_doesnt_query_closed_connection,
+    :test_timeout_in_fixture_set_insertion_doesnt_query_closed_connection,
+    :test_timeout_without_referential_integrity_doesnt_query_closed_connection
+
   setup do
     @conn = ActiveRecord::Base.lease_connection
   end
@@ -19,11 +23,9 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   end
 
   test "timeout in transaction doesnt query closed connection" do
-    assert_raises(Timeout::Error) do
-      Timeout.timeout(0.1) do
-        @conn.transaction do
-          @conn.execute("SELECT SLEEP(1)")
-        end
+    assert_timeout_and_remove_connection do
+      @conn.transaction do
+        @conn.execute("SELECT SLEEP(1)")
       end
     end
   end
@@ -35,19 +37,15 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
       ]]
     ] * 2000
 
-    assert_raises(Timeout::Error) do
-      Timeout.timeout(0.1) do
-        @conn.insert_fixtures_set(fixtures)
-      end
+    assert_timeout_and_remove_connection do
+      @conn.insert_fixtures_set(fixtures)
     end
   end
 
   test "timeout without referential integrity doesnt query closed connection" do
-    assert_raises(Timeout::Error) do
-      Timeout.timeout(0.1) do
-        @conn.disable_referential_integrity do
-          @conn.execute("SELECT SLEEP(1)")
-        end
+    assert_timeout_and_remove_connection do
+      @conn.disable_referential_integrity do
+        @conn.execute("SELECT SLEEP(1)")
       end
     end
   end
@@ -401,4 +399,14 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
       ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(prepared_statements: true).connect!
     end
   end
+
+  private
+    def assert_timeout_and_remove_connection(&block)
+      assert_raises(Timeout::Error) do
+        Timeout.timeout(0.1, &block)
+      end
+    ensure
+      ActiveRecord::Base.connection_pool.remove(@conn) if @conn
+      @conn = nil
+    end
 end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1450,6 +1450,7 @@ module ActiveRecord
       # available connections slowly, ensuring the wakeup order is
       # correct in this case.
       def test_checkout_fairness
+        @pool.checkout_timeout = 5
         @pool.instance_variable_set(:@max_connections, 10)
         expected = (1..@pool.size).to_a.freeze
         # check out all connections so our threads start out waiting
@@ -1495,6 +1496,8 @@ module ActiveRecord
       # group1 threads, and the fact that only group1 and no group2
       # threads acquired a connection is enforced.
       def test_checkout_fairness_by_group
+        group_wait_timeout = 5
+        @pool.checkout_timeout = group_wait_timeout + 1
         @pool.instance_variable_set(:@max_connections, 10)
         # take all the connections
         conns = (1..10).map { @pool.checkout }
@@ -1532,7 +1535,7 @@ module ActiveRecord
 
         checkin.call(group1.size)         # should wake up all group1
 
-        wait_for(message: "group1 threads did not finish", interval: 0.1) do
+        wait_for(message: "group1 threads did not finish", timeout: group_wait_timeout, interval: 0.1) do
           mutex.synchronize { (successes.size + errors.size) == group1.size }
         end
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -641,44 +641,50 @@ module ActiveRecord
       end
 
       def test_idle_through_keepalive
-        pool = new_pool_with_options(keepalive: 0.1, pool_jitter: 0, idle_timeout: 0.5, async: false, reaping_frequency: 30)
-        conn = pool.checkout
-        conn.connect!
-        pool.checkin conn
+        monotonic_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        real_clock_gettime = Process.method(:clock_gettime)
 
-        assert_predicate conn, :connected?
-        assert_operator conn.seconds_since_last_activity, :<, 0.1
-        assert_operator conn.seconds_idle, :<, 0.1
+        Process.stub(:clock_gettime, ->(clock_id, *args) {
+          if clock_id == Process::CLOCK_MONOTONIC
+            monotonic_time
+          else
+            real_clock_gettime.call(clock_id, *args)
+          end
+        }) do
+          pool = new_pool_with_options(keepalive: 0.1, pool_jitter: 0, idle_timeout: 0.5, async: false, reaping_frequency: nil)
+          conn = pool.checkout
+          conn.connect!
+          pool.checkin conn
 
-        # This test is about the interaction between multiple "last use"
-        # timers, so manual fudging is a bit too intimate / relies on
-        # knowledge of the implementation. So instead, we have to live
-        # with a bit of sleeping (and hope we don't lose any races).
+          assert_predicate conn, :connected?
+          assert_operator conn.seconds_since_last_activity, :<, 0.1
+          assert_operator conn.seconds_idle, :<, 0.1
 
-        sleep 0.2
+          monotonic_time += 0.2
 
-        assert_operator conn.seconds_since_last_activity, :>, 0.1
-        assert_operator conn.seconds_idle, :>, 0.1
-        assert_operator conn.seconds_idle, :<, 0.5
+          assert_operator conn.seconds_since_last_activity, :>, 0.1
+          assert_operator conn.seconds_idle, :>, 0.1
+          assert_operator conn.seconds_idle, :<, 0.5
 
-        pool.keep_alive # sends a keep-alive query
-        pool.flush # no-op
+          pool.keep_alive # sends a keep-alive query
+          pool.flush # no-op
 
-        assert_predicate conn, :connected?
-        assert_operator conn.seconds_since_last_activity, :<, 0.1
-        assert_operator conn.seconds_idle, :>, 0.1
-        assert_operator conn.seconds_idle, :<, 0.5
+          assert_predicate conn, :connected?
+          assert_operator conn.seconds_since_last_activity, :<, 0.1
+          assert_operator conn.seconds_idle, :>, 0.1
+          assert_operator conn.seconds_idle, :<, 0.5
 
-        sleep 0.4
+          monotonic_time += 0.4
 
-        assert_predicate conn, :connected?
-        assert_operator conn.seconds_since_last_activity, :>, 0.1
-        assert_operator conn.seconds_idle, :>, 0.5
+          assert_predicate conn, :connected?
+          assert_operator conn.seconds_since_last_activity, :>, 0.1
+          assert_operator conn.seconds_idle, :>, 0.5
 
-        pool.keep_alive # sends another query, though it doesn't matter
-        pool.flush # drops the idle connection
+          pool.keep_alive # sends another query, though it doesn't matter
+          pool.flush # drops the idle connection
 
-        assert_not_predicate conn, :connected?
+          assert_not_predicate conn, :connected?
+        end
       end
 
       def test_remove_connection

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/error_reporter/test_helper"
 require "concurrent/atomic/count_down_latch"
 
 module ActiveRecord
@@ -771,6 +772,60 @@ module ActiveRecord
         end
       ensure
         pool&.disconnect!
+      end
+
+      def test_disconnect_closes_in_use_connections_when_checkin_fails
+        connection = @pool.lease_connection
+        connection.connect!
+
+        checkin_error = StandardError.new("error during checkin")
+        proc_to_raise = -> { raise checkin_error }
+        subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
+        ActiveSupport.error_reporter.subscribe(subscriber)
+        ActiveRecord::ConnectionAdapters::AbstractAdapter.set_callback(:checkin, :before, proc_to_raise)
+
+        assert_nothing_raised do
+          @pool.disconnect!
+        end
+
+        assert_not_predicate connection, :connected?
+        assert_empty @pool.connections
+        assert_equal [[checkin_error, true, :warning, "active_record.connection_pool", {}]], subscriber.events
+      ensure
+        ActiveRecord::ConnectionAdapters::AbstractAdapter.skip_callback(:checkin, :before, proc_to_raise) if proc_to_raise
+        ActiveSupport.error_reporter.unsubscribe(subscriber) if subscriber
+        connection&.disconnect! rescue nil
+      end
+
+      def test_disconnect_continues_when_connection_disconnect_fails
+        first_connection = @pool.checkout
+        second_connection = @pool.checkout
+        disconnect_error = StandardError.new("error during disconnect")
+        disconnected = []
+        subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
+        ActiveSupport.error_reporter.subscribe(subscriber)
+
+        first_connection.define_singleton_method(:disconnect!) do
+          disconnected << self
+          raise disconnect_error
+        end
+        second_connection.define_singleton_method(:disconnect!) do
+          disconnected << self
+        end
+
+        assert_nothing_raised do
+          @pool.disconnect!
+        end
+
+        assert_equal [first_connection, second_connection], disconnected
+        assert_empty @pool.connections
+        assert_equal [[disconnect_error, true, :warning, "active_record.connection_pool", {}]], subscriber.events
+      ensure
+        ActiveSupport.error_reporter.unsubscribe(subscriber) if subscriber
+        first_connection&.singleton_class&.remove_method(:disconnect!) rescue nil
+        second_connection&.singleton_class&.remove_method(:disconnect!) rescue nil
+        first_connection&.disconnect! rescue nil
+        second_connection&.disconnect! rescue nil
       end
 
       def test_pool_sets_connection_visitor

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1390,8 +1390,8 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   end
 
   def test_preserves_existing_fixture_data
-    assert_equal(2.weeks.ago.to_date, pirates(:redbeard).created_on.to_date)
-    assert_equal(2.weeks.ago.to_date, pirates(:redbeard).updated_on.to_date)
+    assert_equal(Date.new(2004, 1, 1), pirates(:redbeard).created_on.to_date)
+    assert_equal(Date.new(2004, 1, 1), pirates(:redbeard).updated_on.to_date)
   end
 
   def test_generates_unique_ids

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -79,15 +79,15 @@ module ActiveRecord
     end
 
     def test_or_with_unscope_where
-      expected = Post.where("id = 1 or id = 2")
+      expected = Post.where("id = 1 or id = 2").sort_by(&:id)
       partial = Post.where("id = 1 and id != 2")
-      assert_equal expected, partial.or(partial.unscope(:where).where("id = 2")).to_a
+      assert_equal expected, partial.or(partial.unscope(:where).where("id = 2")).sort_by(&:id)
     end
 
     def test_or_with_unscope_where_column
-      expected = Post.where("id = 1 or id = 2")
+      expected = Post.where("id = 1 or id = 2").sort_by(&:id)
       partial = Post.where(id: 1).where.not(id: 2)
-      assert_equal expected, partial.or(partial.unscope(where: :id).where("id = 2")).to_a
+      assert_equal expected, partial.or(partial.unscope(where: :id).where("id = 2")).sort_by(&:id)
     end
 
     def test_or_with_unscope_order

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -56,7 +56,8 @@ class StrictLoadingTest < ActiveRecord::TestCase
   def test_strict_loading_n_plus_one_only_mode_with_has_many
     developer = Developer.first
     firm = Firm.create!(name: "NASA")
-    developer.projects << Project.create!(name: "Apollo", firm: firm)
+    project = Project.create!(name: "Apollo", firm: firm)
+    developer.projects << project
 
     developer.reload
 
@@ -71,7 +72,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
     # strict_loading is enabled for has_many associations
     assert developer.projects.all?(&:strict_loading?)
     assert_raises ActiveRecord::StrictLoadingViolationError do
-      developer.projects.last.firm
+      developer.projects.detect { |record| record.id == project.id }.firm
     end
 
     assert_nothing_raised do
@@ -80,7 +81,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
 
     assert developer.projects_extended_by_name.all?(&:strict_loading?)
     assert_raises ActiveRecord::StrictLoadingViolationError do
-      developer.projects_extended_by_name.last.firm
+      developer.projects_extended_by_name.detect { |record| record.id == project.id }.firm
     end
   end
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -235,16 +235,11 @@ class TransactionTest < ActiveRecord::TestCase
 
       connection = Topic.lease_connection
 
-      Topic.lease_connection.class_eval do
-        alias :real_exec_rollback_db_transaction :exec_rollback_db_transaction
-        define_method(:exec_rollback_db_transaction) do
-          raise
+      connection.stub(:exec_rollback_db_transaction, -> (*) { raise }) do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "Rails is broken")
+          raise ActiveRecord::Rollback
         end
-      end
-
-      ActiveRecord::Base.transaction do
-        topic.update(title: "Rails is broken")
-        raise ActiveRecord::Rollback
       end
 
       assert_not connection.active?
@@ -255,17 +250,13 @@ class TransactionTest < ActiveRecord::TestCase
 
     def test_rollback_dirty_changes_even_with_raise_during_rollback_doesnt_commit_transaction
       topic = topics(:fifth)
+      connection = Topic.lease_connection
 
-      Topic.lease_connection.class_eval do
-        alias :real_exec_rollback_db_transaction :exec_rollback_db_transaction
-        define_method(:exec_rollback_db_transaction) do
-          raise
+      connection.stub(:exec_rollback_db_transaction, -> (*) { raise }) do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "Rails is broken")
+          raise ActiveRecord::Rollback
         end
-      end
-
-      ActiveRecord::Base.transaction do
-        topic.update(title: "Rails is broken")
-        raise ActiveRecord::Rollback
       end
 
       topic.reload
@@ -281,28 +272,17 @@ class TransactionTest < ActiveRecord::TestCase
 
     def test_connection_removed_from_pool_when_commit_raises_and_rollback_raises
       connection = Topic.lease_connection
-
-      # Update commit_transaction to raise the first time it is called.
-      Topic.lease_connection.transaction_manager.class_eval do
-        alias :real_commit_transaction :commit_transaction
-        define_method(:commit_transaction) do
-          raise "commit failed"
-        end
-      end
-
-      # Update rollback_transaction to raise.
-      Topic.lease_connection.transaction_manager.class_eval do
-        alias :real_rollback_transaction :rollback_transaction
-        define_method(:rollback_transaction) do |*_args|
-          raise "rollback failed"
-        end
-      end
+      transaction_manager = connection.transaction_manager
 
       # Start a transaction and update a record. The commit and rollback will fail.
       topic = topics(:fifth)
       exception = assert_raises(RuntimeError) do
-        ActiveRecord::Base.transaction do
-          topic.update(title: "Updated title")
+        transaction_manager.stub(:commit_transaction, -> { raise "commit failed" }) do
+          transaction_manager.stub(:rollback_transaction, -> (*) { raise "rollback failed" }) do
+            ActiveRecord::Base.transaction do
+              topic.update(title: "Updated title")
+            end
+          end
         end
       end
       assert_equal "rollback failed", exception.message
@@ -318,17 +298,11 @@ class TransactionTest < ActiveRecord::TestCase
       # Disable lazy transactions so that we will begin a transaction before attempting to write.
       connection.disable_lazy_transactions!
 
-      # Update begin_db_transaction to successfully begin a transaction, then raise.
-      Topic.lease_connection.class_eval do
-        alias :real_begin_db_transaction :begin_db_transaction
-        define_method(:begin_db_transaction) do |*_args|
-          raise "begin failed"
-        end
-      end
-
       # Attempt to begin a transaction. This will raise, causing a rollback.
       exception = assert_raises(RuntimeError) do
-        ActiveRecord::Base.transaction { }
+        connection.stub(:begin_db_transaction, -> (*) { raise "begin failed" }) do
+          ActiveRecord::Base.transaction { }
+        end
       end
       assert_equal "begin failed", exception.message
       assert_not connection.active?
@@ -347,15 +321,9 @@ class TransactionTest < ActiveRecord::TestCase
         connection.disable_lazy_transactions!
 
         # Update begin_db_transaction to block.
-        connection.class_eval do
-          alias :real_begin_db_transaction :begin_db_transaction
-          define_method(:begin_db_transaction) do |*_args|
-            queue.push nil
-            sleep
-          end
+        connection.stub(:begin_db_transaction, -> (*) { queue.push nil; sleep }) do
+          ActiveRecord::Base.transaction { }
         end
-
-        ActiveRecord::Base.transaction { }
       end
       queue.pop
       thread.kill

--- a/activerecord/test/fixtures/pirates.yml
+++ b/activerecord/test/fixtures/pirates.yml
@@ -5,8 +5,8 @@ blackbeard:
 redbeard:
   catchphrase: "Avast!"
   parrot: louis
-  created_on: "<%= 2.weeks.ago.to_fs(:db) %>"
-  updated_on: "<%= 2.weeks.ago.to_fs(:db) %>"
+  created_on: "2004-01-01 00:00:00"
+  updated_on: "2004-01-01 00:00:00"
 
 mark:
   catchphrase: "X $LABELs the spot!"

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -140,7 +140,7 @@ module AdapterHelper
         connection.instance_variable_get(:@raw_connection).async_exec("begin")
       end
       connection.instance_variable_get(:@raw_connection).async_exec("set idle_in_transaction_session_timeout = '10ms'")
-      sleep 0.05
+      sleep 0.2
     elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
       connection.query_command("set @@wait_timeout=1", materialize_transactions: false)
       sleep 1.2

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -72,6 +72,11 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
       # has been touched.
       IO.select([touch_reader])
 
+      10.times do
+        break if checker.updated?
+        wait
+      end
+
       assert_predicate checker, :updated?
     rescue Exception => ex
       result_writer.write("#{ex.class.name}: #{ex.message}")

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -110,8 +110,10 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
       [WeakRef.new(checker), Thread.list - threads_before_checker]
     end.value
 
-    GC.start
-    listener_threads.each { |t| t.join(1) }
+    5.times do
+      GC.start
+      listener_threads.each { |thread| thread.join(0.4) }
+    end
 
     assert_not checker_ref.weakref_alive?, "EventedFileUpdateChecker was not garbage collected"
     assert_empty Thread.list & listener_threads

--- a/guides/test/epub_test.rb
+++ b/guides/test/epub_test.rb
@@ -5,8 +5,6 @@ require "test_helper"
 class EpubTest < ActiveSupport::TestCase
   setup do
     @path = Dir.mktmpdir
-    @old_path = Dir.pwd
-    Dir.chdir(@path)
     @html_file = File.join(@path, "test.html")
     @alternate_png_file = "images/sample.png"
     File.write(@html_file, <<~HTML)
@@ -19,7 +17,6 @@ class EpubTest < ActiveSupport::TestCase
   end
 
   teardown do
-    Dir.chdir(@old_path)
     FileUtils.remove_entry(@path)
   end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -47,7 +47,11 @@ module TestHelpers
     end
 
     def tmp_path(*args)
-      @tmp_path ||= File.realpath(Dir.mktmpdir(nil, File.join(RAILS_FRAMEWORK_ROOT, "tmp")))
+      @tmp_path = nil if @tmp_path && !File.directory?(@tmp_path)
+      @tmp_path ||= begin
+        FileUtils.mkdir_p(File.join(RAILS_FRAMEWORK_ROOT, "tmp"))
+        File.realpath(Dir.mktmpdir(nil, File.join(RAILS_FRAMEWORK_ROOT, "tmp")))
+      end
       File.join(@tmp_path, *args)
     end
 
@@ -162,7 +166,8 @@ module TestHelpers
       end
       Rails.app_class = @prev_rails_app_class if @prev_rails_app_class
       Rails.application = @prev_rails_application if @prev_rails_application
-      FileUtils.rm_rf(tmp_path)
+      FileUtils.rm_rf(@tmp_path) if @tmp_path
+      @tmp_path = nil
     end
 
     def with_test_database_cleanup(adapter)

--- a/railties/test/isolation/test_helpers_test.rb
+++ b/railties/test/isolation/test_helpers_test.rb
@@ -22,6 +22,28 @@ module TestHelpersTests
       assert_not File.exist?(app_path)
     end
 
+    def test_build_app_after_teardown_app
+      build_app
+      previous_app_path = app_path
+      teardown_app
+
+      build_app
+
+      assert_not_equal previous_app_path, app_path
+      assert File.exist?("#{app_path}/config/database.yml")
+    end
+
+    def test_build_app_after_tmp_path_is_removed
+      build_app
+      previous_app_path = app_path
+      FileUtils.rm_rf(tmp_path)
+
+      build_app
+
+      assert_not_equal previous_app_path, app_path
+      assert File.exist?("#{app_path}/config/database.yml")
+    end
+
     def test_add_to_config
       build_app
 


### PR DESCRIPTION
One `lib` change, to `report`-and-continue for exceptions that occur while disconnecting an AR pool -- which _is_ supported framework behaviour/API, but I think our own test suite is likely one of the biggest callers.