### PR TITLE
Add test coverage for HashWithIndifferentAccess key access and except

### DIFF
--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -196,6 +196,39 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_raise(KeyError) { @mixed.fetch_values(:a, :c) }
   end
 
+  def test_indifferent_fetch_with_default_and_block
+    hash = HashWithIndifferentAccess.new
+    hash[:foo] = 1
+
+    assert_equal 0, hash.fetch(:bar, 0)
+    assert_equal 1, hash.fetch(:foo, 99)
+    assert_equal "bar", hash.fetch(:bar) { |key| key }
+  end
+
+  def test_indifferent_values_at_with_missing_key
+    hash = HashWithIndifferentAccess.new
+    hash[:a] = "x"
+    hash[:b] = "y"
+
+    assert_equal ["x", nil, "y"], hash.values_at(:a, :c, "b")
+  end
+
+  def test_indifferent_dig_returns_nil_for_missing_key
+    data = { foo: { bar: 1 } }.with_indifferent_access
+
+    assert_nil data.dig(:zoo)
+    assert_nil data.dig(:foo, :missing)
+  end
+
+  def test_indifferent_except
+    original = { a: "x", b: "y", c: 10 }.with_indifferent_access
+
+    assert_equal({ c: 10 }.with_indifferent_access, original.except(:a, "b"))
+    assert_instance_of HashWithIndifferentAccess, original.except(:a)
+    assert_equal({ a: "x", b: "y", c: 10 }.with_indifferent_access, original)
+    assert_equal({ c: 10 }.with_indifferent_access, original.without(:a, :b))
+  end
+
   def test_indifferent_reading
     hash = HashWithIndifferentAccess.new
     hash["a"] = 1


### PR DESCRIPTION
Adds coverage for several untested branches and a documented-but-entirely-untested method of `ActiveSupport::HashWithIndifferentAccess`. Each is a distinct branch with no conceptually-equivalent existing test. Test-only; no production changes.

- `fetch` with a default value and with a block — the `*extras` passthrough; the block receives the converted (String) key. Existing `fetch` tests only pass a present key with no extras.
- `values_at` with a missing key returns `nil` in that position (distinct from `fetch_values`, which raises). Existing tests only pass present keys.
- `dig` returns `nil` for a missing key — the documented miss path (`counters.dig(:zoo) # => nil`); existing `dig` test only covers the success path.
- `except` / `without` — previously had **no test at all**: returns a new `HashWithIndifferentAccess`, accepts mixed String/Symbol keys, and leaves the receiver unchanged.