### PR TITLE
Keep the Redis listener alive when the last channel is unsubscribed

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -76,6 +76,13 @@ module ActionCable
         class Listener < SubscriberMap::Async
           delegate :logger, to: :@adapter
 
+          # A permanent internal subscription keeps the Redis subscription count
+          # above zero while any user channel comes and goes, so removing the
+          # last user channel doesn't end the listen loop. Only an explicit
+          # shutdown (which unsubscribes from everything) drives the count to
+          # zero and stops the listener.
+          INTERNAL_CHANNEL = "_action_cable_internal"
+
           def initialize(adapter, config_options, executor)
             super(executor)
 
@@ -101,6 +108,8 @@ module ActionCable
 
             @reconnect_attempt = 0
             @subscribed_client = pubsub_client
+
+            pubsub_client.call("subscribe", INTERNAL_CHANNEL)
 
             until @when_connected.empty?
               @when_connected.shift.call

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -16,6 +16,23 @@ class RedisAdapterTest < ActionCable::TestCase
     end
   end
 
+  def test_resubscribe_after_removing_the_last_channel
+    subscribe_as_queue("channel") do |queue|
+      @tx_adapter.broadcast("channel", "hello world")
+
+      assert_equal "hello world", queue.pop
+    end
+
+    # The block above unsubscribed from the only channel, driving the Redis
+    # subscription count to zero. The listener must stay alive so a brand-new
+    # subscription on the same adapter still receives broadcasts.
+    subscribe_as_queue("channel") do |queue|
+      @tx_adapter.broadcast("channel", "hallo welt")
+
+      assert_equal "hallo welt", queue.pop
+    end
+  end
+
   def test_reconnections
     subscribe_as_queue("channel") do |queue|
       subscribe_as_queue("other channel") do |queue_2|


### PR DESCRIPTION
### Problem

The redis-client rewrite (`ef812c2652`) drives the listen loop to `break` (and nils `@subscribed_client`) whenever an unsubscribe brings the Redis subscription count to zero — a silent production outage.

The previous redis-gem implementation held a permanent subscription to `_action_cable_internal`, so the count only reached zero on an explicit shutdown. The rewrite dropped that sentinel, so removing the last user channel now kills the listener thread — on any process where every channel is transiently unsubscribed (low traffic, single-channel apps, nodes draining during deploys).

`ensure_listener_running` guards with `@thread ||= Thread.new ...`, so the dead thread is never replaced. Every later `subscribe` queues into `@when_connected` forever, `@subscribed_client` stays nil, and all broadcasts are silently dropped. Reconnecting clients are accepted but never wired to Redis.

### Fix

Restore the sentinel: subscribe to `_action_cable_internal` in `listen`, right after `@subscribed_client` is set. Normal channel removal leaves the count at 1; only an explicit shutdown (which unsubscribes from everything) drives it to 0 and ends the loop. The sentinel has no subscribers in the `SubscriberMap`, so messages on it are a no-op.

Added a regression test with two sequential subscriptions on the same adapter — the first unsubscription drives the count to 0, and the second verifies the listener is still alive. Full adapter suite passes (27 runs, 0 failures).