### PR TITLE
Iterate a snapshot of the connections in Server#each_connection

### DIFF
--- a/actioncable/lib/action_cable/server/connections.rb
+++ b/actioncable/lib/action_cable/server/connections.rb
@@ -16,7 +16,10 @@ module ActionCable
       def connections = connections_map.values
 
       def each_connection(...)
-        connections_map.each_value(...)
+        # Iterate a snapshot: the heartbeat, #restart and statistics all walk the
+        # live connections while worker threads concurrently add/remove entries,
+        # and mutating a Hash mid-iteration raises a RuntimeError.
+        connections.each(...)
       end
 
       def add_connection(connection)

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -24,6 +24,27 @@ class BaseTest < ActionCable::TestCase
     end
   end
 
+  test "#each_connection iterates a snapshot so connections can be added during iteration" do
+    beating = Class.new do
+      def initialize(server)
+        @server = server
+      end
+
+      def beat
+        @server.add_connection(Object.new)
+      end
+    end.new(@server)
+
+    @server.add_connection(beating)
+
+    # A connection completing its handshake (add_connection) on a worker thread
+    # while the 3s heartbeat iterates the live connections must not raise
+    # "can't add a new key into hash during iteration".
+    assert_nothing_raised do
+      @server.each_connection(&:beat)
+    end
+  end
+
   test "#restart shuts down worker pool" do
     assert_called(@server.worker_pool, :halt) do
       @server.restart


### PR DESCRIPTION
### Problem

`each_connection` walks the live `connections_map` via `connections_map.each_value(...)`. Three callers use it on the event-loop / executor thread while worker threads concurrently `add_connection` / `remove_connection`:

- the 3-second heartbeat — `executor.post { each_connection(&:beat) }`
- `Server::Base#restart` — `each_connection { |c| c.close(...) }`
- `open_connections_statistics` — `each_connection.map(&:statistics)`

This is a regression from `8ed78693c5` which switched the connection store from an Array to a Hash. Appending to an Array during iteration was safe; inserting a Hash key during iteration raises `RuntimeError: can't add a new key into hash during iteration`. On a busy server a new WebSocket handshake (`add_connection`) eventually overlaps the heartbeat and aborts it, so stale connections aren't reaped — or aborts the restart sweep on a code reload.

### Fix

Iterate a snapshot: `each_connection` now delegates to `connections` (which already returns `connections_map.values`, a fresh Array) instead of `connections_map.each_value`. One change fixes all three call sites. The no-block path (`each_connection.map(&:statistics)`) still works because `Array#each` returns an Enumerator over the snapshot.

Added a test where a connection's `#beat` calls `add_connection` mid-iteration and asserts no `RuntimeError` is raised.