### PR TITLE
Coerce broadcasting to String in Channel#stop_stream_from

### DIFF
--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -119,6 +119,8 @@ module ActionCable
 
       # Unsubscribes streams from the named `broadcasting`.
       def stop_stream_from(broadcasting)
+        broadcasting = String(broadcasting)
+
         callback = streams.delete(broadcasting)
         if callback
           pubsub.unsubscribe(broadcasting, callback)

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -219,6 +219,21 @@ module ActionCable::StreamTests
       assert_equal 1, subscribers["room_two"].size
     end
 
+    test "stop_stream_from with a non-string broadcasting matches stream_from" do
+      connection = Connection.new(server, socket)
+
+      channel = ChatChannel.new connection, "{id: 3}"
+      channel.subscribe_to_channel
+
+      channel.stream_from :room_one
+
+      assert_equal 1, subscribers_of(connection).size
+
+      channel.stop_stream_from :room_one
+
+      assert_equal 0, subscribers_of(connection).size
+    end
+
     test "stop_stream_for" do
       connection = Connection.new(server, socket)
 


### PR DESCRIPTION
### Problem

`stream_from` coerces its argument with `broadcasting = String(broadcasting)` before using it as the `streams` hash key, so `stream_from :chat` registers the stream under the `"chat"` String key. `stop_stream_from` deletes with the raw argument: `streams.delete(broadcasting)`.

Passing the same Symbol to both — a tested input (`SymbolChannel` in `stream_test.rb` does `stream_from :channel`) — looks up the wrong key, finds nothing, and never calls `pubsub.unsubscribe`. The stream stays registered for the life of the connection.

### Fix

Mirror the sibling: coerce `broadcasting = String(broadcasting)` as the first line of `stop_stream_from`.

Added a test: `stream_from :room_one` then `stop_stream_from :room_one` must leave zero subscribers.