### PR TITLE
Make `ActiveRecord::Base.with` call `Object#with` when passed a block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActiveRecord::Base.with` now calls `Object#with` when given a block.
+
+    The class-level `with` delegates to the relation's CTE query method, which
+    does not accept a block. When a block is passed, it now delegates to
+    `Object#with` instead, so it can be used to temporarily set attributes on
+    the class for the duration of the block.
+
+    *Janko Marohnić*
+
 *   Fix `increment!` / `decrement!` on models with query constraints to include
     every query constraint column in the counter update.
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -17,11 +17,23 @@ module ActiveRecord
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
-      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with, :with_recursive,
+      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with_recursive,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
       :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)
+
+    # Add a Common Table Expression (CTE) that you can then reference within another SELECT statement.
+    #
+    # See ActiveRecord::QueryMethods#with for more information.
+    #
+    # When given a block, and the Object#with core extension is loaded, this
+    # delegates to it instead, temporarily setting the given attributes on the
+    # class for the duration of the block and restoring them afterwards.
+    def with(...)
+      return super if block_given? && defined?(super)
+      all.with(...)
+    end
 
     # Executes a custom SQL query against your database and returns all the results. The results will
     # be returned as an array, with the requested columns encapsulated as attributes of the model you call

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       ActiveRecord::SpawnMethods.public_instance_methods(false) - [:spawn, :merge!] +
       ActiveRecord::QueryMethods.public_instance_methods(false).reject { |method|
         method.end_with?("=", "!", "?", "value", "values", "clause")
-      } - [:all, :reverse_order, :arel, :extensions, :construct_join_dependency] + [
+      } - [:all, :reverse_order, :arel, :extensions, :construct_join_dependency, :with] + [
         :any?, :many?, :none?, :one?,
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/core_ext/object/with"
 require "models/comment"
 require "models/post"
 require "models/company"
@@ -136,10 +137,24 @@ module ActiveRecord
         assert_equal POSTS_WITH_COMMENTS, records.filter_map { _1.id if _1.has_comments }
       end
 
-      def test_raises_when_using_block
+      def test_relation_with_raises_when_using_block
         assert_raises(ArgumentError, match: "does not accept a block") do
-          Post.with(attributes_for_inspect: :id) { }
+          Post.all.with(attributes_for_inspect: :id) { }
         end
+      end
+
+      def test_class_with_calls_object_with_when_given_a_block
+        original = Post.attributes_for_inspect
+
+        captured = nil
+        result = Post.with(attributes_for_inspect: [:id]) do
+          captured = Post.attributes_for_inspect
+          :block_value
+        end
+
+        assert_equal [:id], captured
+        assert_equal :block_value, result
+        assert_equal original, Post.attributes_for_inspect
       end
 
       def test_unscoping


### PR DESCRIPTION
### Motivation / Background

I have custom class accessors on my Active Record models, which I wanted to temporarily set to a value for the duration of a block. I naturally reached for the `Object#with` method, but was surprised it didn't work.

### Detail

`ActiveRecord::Base.with` currently delegates to
`ActiveRecord::Relation#with` for building CTEs, which rejects blocks. We use that to call `Object#with` when a block was passed, provided that the core extension was loaded. This is consistent with how `Enumerable#find` and `Enumerable#select` are called instead of query methods when a block is passed in.

A common use case would be temporarily enabling Active Record logging in tests:

```rb
ActiveRecord::Base.with(logger: Logger.new($stdout)) do
  # ...
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
