### PR TITLE
Keep pending subscribe confirmations across a Redis reconnect

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -206,7 +206,6 @@ module ActionCable
             def reset
               @subscription_lock.synchronize do
                 @subscribed_client = nil
-                @subscribe_callbacks.clear
                 @when_connected.clear
               end
             end

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -160,3 +160,76 @@ class RedisAdapterTest::SentinelConfigAsHash < ActionCable::TestCase
     assert_kind_of RedisClient::SentinelConfig, redis_client.config
   end
 end
+
+class RedisAdapterTest::ListenerReconnection < ActionCable::TestCase
+  # Drives the real Listener#listen/reset/resubscribe path with a fake pub/sub
+  # connection so we can deterministically simulate a connection drop while a
+  # subscription confirmation is still in flight. The blocking event queue is the
+  # only point at which the listener loop advances, so the test fully controls the
+  # ordering of the drop and the acknowledgements; no real Redis is involved.
+  class FakePubSub
+    def initialize(events)
+      @events = events
+    end
+
+    def call(*)
+    end
+
+    def next_event(_timeout)
+      event = @events.pop
+      raise RedisClient::ConnectionError, "connection dropped" if event == :drop
+      event
+    end
+  end
+
+  class FakeConnection
+    def initialize(pubsub)
+      @pubsub = pubsub
+    end
+
+    attr_reader :pubsub
+  end
+
+  class FakeAdapter
+    def initialize(connection)
+      @connection = connection
+    end
+
+    def redis_connection_for_subscriptions
+      @connection
+    end
+
+    def logger
+      nil
+    end
+  end
+
+  # Runs posted work inline so the test stays single-threaded apart from the
+  # listener loop itself.
+  class InlineExecutor
+    def post(task = nil, &block)
+      (task || block).call
+    end
+  end
+
+  test "an in-flight subscription confirmation is delivered after a reconnect" do
+    events = Queue.new
+    listener = ActionCable::SubscriptionAdapter::Redis::Listener.new(
+      FakeAdapter.new(FakeConnection.new(FakePubSub.new(events))), {}, InlineExecutor.new
+    )
+
+    confirmed = Concurrent::Event.new
+    listener.add_subscriber("channel", ->(_message) { }, -> { confirmed.set })
+
+    # The "subscribe" acknowledgement never arrives before the connection drops,
+    # so the confirmation is still pending when the listener resets...
+    events << :drop
+    # ...and after it reconnects and re-subscribes, the acknowledgement for the
+    # still-pending subscription must fire its confirmation callback.
+    events << ["subscribe", "channel", 1]
+
+    assert confirmed.wait(2), "expected the in-flight subscription confirmation to be delivered after reconnect"
+  ensure
+    listener.instance_variable_get(:@thread)&.kill
+  end
+end


### PR DESCRIPTION
### Problem

When the Redis pub/sub connection drops, `ActionCable::SubscriptionAdapter::Redis::Listener` resets, reconnects, and resubscribes to every channel in `@subscribers`. But `reset` also cleared `@subscribe_callbacks`, discarding the `on_success` confirmation of any subscription whose `subscribe` acknowledgement had not yet arrived when the connection dropped.

The resubscribe re-issues the `SUBSCRIBE`, but with no callback armed its acknowledgement fires nothing — so the client never receives its subscription confirmation even though the channel is live again. The subscription appears permanently stuck on the client side (the channel's `confirm_subscription` / `subscribed` never resolves) until the connection is torn down and rebuilt.

This is a regression from the redis-client rewrite (`ef812c2652`). It is independent of #57690 ("Keep the Redis listener alive when the last channel is unsubscribed"), which fixes a different bug from the same rewrite: that one lives in the listen loop's unsubscribe handling, this one in `reset`. The two fixes touch different lines and do not overlap.

### Fix

Drop the `@subscribe_callbacks.clear` from `reset` so a pending confirmation survives the reconnect and is delivered by the resubscribe acknowledgement. Already-confirmed channels delete their own key once their callback fires, so nothing stale is retained, and a re-subscribed channel whose callback array is now empty simply fires nothing on its acknowledgement.

```diff
 def reset
   @subscription_lock.synchronize do
     @subscribed_client = nil
-    @subscribe_callbacks.clear
     @when_connected.clear
   end
 end
```

### Testing

The bug only manifests when a `subscribe` is in flight at the exact moment the connection drops. That race can't be hit deterministically against a real Redis: acknowledgements come back sub-millisecond, so you can't reliably wedge a drop in between issuing the `SUBSCRIBE` and receiving its ack.

The new test instead drives the **real** `Listener#listen`/`reset`/`resubscribe`/retry path with a fake pub/sub connection whose `next_event` blocks on a Ruby `Queue`. That queue is the only point at which the listener loop advances, so the test fully controls the ordering: it pushes `:drop` (→ `next_event` raises `RedisClient::ConnectionError` → `reset` → `resubscribe` → retry), then the reconnect's `["subscribe", "channel", 1]` acknowledgement. An inline executor runs posted work synchronously so the confirmation is observable via a `Concurrent::Event`. No real Redis, no timing dependence.

- New `RedisAdapterTest::ListenerReconnection` test: **red** = 2s timeout, confirmation never delivered; **green** with the fix (~30ms).
- Full `actioncable/test/subscription_adapter/redis_test.rb`: **26 runs, 0 failures** (includes the real-Redis reconnection integration tests).

### Note / trade-off

A subscription that goes in flight and is then *fully* unsubscribed before the reconnect would leak its (tiny) callback proc — the channel is no longer in `@subscribers`, so the resubscribe skips it and the callback is never fired nor cleared. This is a rare edge case; a follow-up could retain only callbacks for channels still present in `@subscribers` if desired.

No CHANGELOG entry (bug fix).