### PR TITLE
Respect an explicit `id: nil` in the Redis cable config

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -17,7 +17,7 @@ module ActionCable
       # using Makara proxies for distributed Redis.
       cattr_accessor :redis_connector, default: ->(config) do
         config = config.except(:adapter, :channel_prefix)
-        config[:id] ||= "ActionCable-PID-#{$$}"
+        config[:id] = "ActionCable-PID-#{$$}" unless config.key?(:id)
 
         redis_config = if config.key?(:sentinels)
           ::RedisClient.sentinel(**config)

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -98,7 +98,7 @@ class RedisAdapterTest::ConnectorDefaultID < ActionCable::TestCase
   test "sets connection id for connection" do
     client = @adapter.send(:redis_connection)
     if connection_id.nil?
-      assert_nil connection_id
+      assert_nil client.id
     else
       assert_equal connection_id, client.id
     end


### PR DESCRIPTION
## Summary

`ActionCable::SubscriptionAdapter::Redis.redis_connector` defaulted the connection id with:

```ruby
config[:id] ||= "ActionCable-PID-#{$$}"
```

`||=` treats an explicit `id: nil` as "unset" and clobbers it with the PID-based name. Setting `id: nil` is the documented way to skip `CLIENT SETNAME` (e.g. when naming is delegated to a proxy), so this silently overrode the user's intent.

`SubscriptionAdapter::Base#identifier` already preserves an explicit nil via an `unless key?(:id)` guard, so the two id-setting sites disagreed — and the connector, applied last, won.

## Fix

Use the same key-presence guard so an explicit `id: nil` survives, while a genuinely absent id still gets the default:

```diff
-config[:id] ||= "ActionCable-PID-#{$$}"
+config[:id] = "ActionCable-PID-#{$$}" unless config.key?(:id)
```

## Testing

The existing `RedisAdapterTest::ConnectorCustomIDNil` test passed vacuously: in the nil branch it asserted on the test's own `connection_id` helper (`assert_nil connection_id`) rather than the actual `client.id`, so it never checked that `id: nil` was honored. The test now asserts `client.id`.

- `RedisAdapterTest::Connector*` "sets connection id for connection": **red** = `Expected "ActionCable-PID-NNNN" to be nil`; **green** with the fix (4 runs).

No CHANGELOG entry (bug fix).