### PR TITLE
Don't fire remove_channel for an unknown channel

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
@@ -26,7 +26,8 @@ module ActionCable
 
       def remove_subscriber(channel, subscriber)
         @sync.synchronize do
-          @subscribers[channel].delete(subscriber)
+          return if !@subscribers.key?(channel)
+          return unless @subscribers[channel].delete(subscriber)
 
           if @subscribers[channel].empty?
             @subscribers.delete channel

--- a/actioncable/test/subscription_adapter/subscriber_map_test.rb
+++ b/actioncable/test/subscription_adapter/subscriber_map_test.rb
@@ -12,6 +12,29 @@ class SubscriberMapTest < ActionCable::TestCase
     assert_equal origin, @subscription_map.instance_variable_get(:@subscribers)
   end
 
+  test "remove_subscriber from an unknown channel does not trigger remove_channel" do
+    setup_subscription_map
+    origin = @subscription_map.instance_variable_get(:@subscribers).dup
+
+    assert_not_called(@subscription_map, :remove_channel) do
+      @subscription_map.remove_subscriber("not_exist_channel", "subscriber")
+    end
+
+    assert_equal origin, @subscription_map.instance_variable_get(:@subscribers)
+  end
+
+  test "remove_subscriber for an absent subscriber on a known channel does not trigger remove_channel" do
+    setup_subscription_map
+    @subscription_map.add_subscriber("channel", "subscriber", nil)
+    origin = @subscription_map.instance_variable_get(:@subscribers).dup
+
+    assert_not_called(@subscription_map, :remove_channel) do
+      @subscription_map.remove_subscriber("channel", "other_subscriber")
+    end
+
+    assert_equal origin, @subscription_map.instance_variable_get(:@subscribers)
+  end
+
   private
     def setup_subscription_map
       @subscription_map = ActionCable::SubscriptionAdapter::SubscriberMap.new


### PR DESCRIPTION
### Problem

`SubscriberMap`'s `@subscribers` uses a key-inserting default proc (`Hash.new { |h, k| h[k] = [] }`). `#remove_subscriber` read `@subscribers[channel]` unguarded, so removing a subscriber for a channel that was never subscribed (or was already removed) autovivified an empty array, found it empty, and called `remove_channel` — issuing a real `UNLISTEN` / Redis `unsubscribe` for a channel the server isn't even tracking.

This is the odd one out among the three accessors: the sibling `broadcast` already bails with `return if !@subscribers.key?(channel)`, and `add_subscriber` keys off the same `key?` check to decide whether a channel is new. Only `remove_subscriber` autovivifies.

While the channel-level `stop_stream_from` guards its `pubsub.unsubscribe` call behind `streams.delete(broadcasting)`, the server-wide `SubscriberMap` is still reachable with an unknown channel through the async adapters: `SubscriberMap::Async` posts `add_subscriber` and `remove_subscriber` onto the executor as separate tasks, so a subscribe immediately followed by an unsubscribe can run the remove before the add has registered the channel — autovivifying it and emitting a spurious `UNLISTEN` for a channel that was never `LISTEN`ed.

### Fix

Bail out early when the channel is absent, matching the `key?` guard the sibling `broadcast` already uses:

```diff
 def remove_subscriber(channel, subscriber)
   @sync.synchronize do
+    return if !@subscribers.key?(channel)
+
     @subscribers[channel].delete(subscriber)

     if @subscribers[channel].empty?
       @subscribers.delete channel
       remove_channel channel
     end
   end
 end
```

The early `return` value is unused — every caller (`redis`, `postgresql`, `inline`) just invokes it for effect.

### Testing

- New `SubscriberMapTest` test "remove_subscriber from an unknown channel does not trigger remove_channel", next to the existing "broadcast should not change subscribers": **red** = `remove_channel` called 1 time; **green** = 0 times.
- Full `actioncable/test/subscription_adapter/subscriber_map_test.rb`: **2 runs, 0 failures**.

No CHANGELOG entry (bug fix).