### PR TITLE
Coerce stream name to String in the test adapter accessors

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/test.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/test.rb
@@ -21,11 +21,11 @@ module ActionCable
       end
 
       def broadcasts(channel)
-        channels_data[channel] ||= []
+        channels_data[String(channel)] ||= []
       end
 
       def clear_messages(channel)
-        channels_data[channel] = []
+        channels_data[String(channel)] = []
       end
 
       def clear

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -56,6 +56,14 @@ class TransmissionsTest < ActionCable::TestCase
     end
   end
 
+  def test_assert_broadcasts_with_symbol_stream
+    assert_nothing_raised do
+      assert_broadcasts(:test, 1) do
+        ActionCable.server.broadcast :test, "message"
+      end
+    end
+  end
+
   def test_assert_broadcasts_message_too_few_sent
     ActionCable.server.broadcast "test", "hello"
     error = assert_raises Minitest::Assertion do


### PR DESCRIPTION
## Summary

The broadcast write path stores messages under `String(broadcasting)` (see `Server::Broadcasting`), but `SubscriptionAdapter::Test#broadcasts` and `#clear_messages` looked the channel up by the raw argument. So a Symbol stream name — idiomatic in tests — caused:

- `assert_broadcasts(:foo, 1) { ... }` to report **0** even though the broadcast was sent, and
- `assert_no_broadcasts(:foo)` to **pass vacuously** even when messages *were* broadcast.

The second case is the dangerous one: it silently masks real regressions.

## Fix

Coerce the key with `String(channel)` in both accessors, mirroring the write side:

```diff
 def broadcasts(channel)
-  channels_data[channel] ||= []
+  channels_data[String(channel)] ||= []
 end

 def clear_messages(channel)
-  channels_data[channel] = []
+  channels_data[String(channel)] = []
 end
```

## Testing

- New `TransmissionsTest` test `test_assert_broadcasts_with_symbol_stream`: **red** = `1 broadcasts to test expected, but 0 were sent`; **green** with the fix. 14 runs.

No CHANGELOG entry (bug fix).