### PR TITLE
Raise ChannelNotFound for a subscribe command without a channel

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -120,7 +120,7 @@ module ActionCable
 
         def subscription_from_identifier(id_key)
           id_options = ActiveSupport::JSON.decode(id_key).with_indifferent_access
-          subscription_klass = id_options[:channel].safe_constantize
+          subscription_klass = id_options[:channel]&.safe_constantize
 
           if subscription_klass && ActionCable::Channel::Base > subscription_klass
             subscription_klass.new(connection, id_key, id_options)

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -72,6 +72,18 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     assert_empty @subscriptions.identifiers
   end
 
+  test "subscribe command without a channel" do
+    setup_connection
+
+    identifier = ActiveSupport::JSON.encode(id: 1)
+
+    assert_raises ActionCable::Connection::Subscriptions::ChannelNotFound do
+      @subscriptions.execute_command "command" => "subscribe", "identifier" => identifier
+    end
+
+    assert_empty @subscriptions.identifiers
+  end
+
   test "double subscribe command" do
     setup_connection
 


### PR DESCRIPTION
## Summary

A `subscribe` command whose identifier omits the `channel` key (e.g. a malformed client sending `{"id":1}`) made `Connection::Subscriptions#subscription_from_identifier` call `nil.safe_constantize`, raising a bare `NoMethodError` instead of the structured `ChannelNotFound` error that the `add` path already raises for an unresolvable channel.

## Fix

Guard the lookup with safe navigation so a missing channel flows into the existing `else` branch (which raises `ChannelNotFound`):

```diff
-subscription_klass = id_options[:channel].safe_constantize
+subscription_klass = id_options[:channel]&.safe_constantize
```

## Testing

- New `SubscriptionsTest` test "subscribe command without a channel", next to the existing "subscribe command with Base channel": **red** = `undefined method 'safe_constantize' for nil`; **green** raises `ChannelNotFound`. 12 runs.

No CHANGELOG entry (bug fix).