### PR TITLE
Shut down the heartbeat timer on server restart

### DIFF
--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -54,7 +54,7 @@ module ActionCable
       def initialize(config: self.class.config)
         @config = config
         @mutex = Monitor.new
-        @remote_connections = @event_loop = @worker_pool = @executor = @pubsub = nil
+        @remote_connections = @event_loop = @worker_pool = @executor = @pubsub = @heartbeat_timer = nil
       end
 
       # Called by Rack to set up the server.
@@ -76,6 +76,10 @@ module ActionCable
         end
 
         @mutex.synchronize do
+          # Shutdown the heartbeat timer
+          @heartbeat_timer.shutdown if @heartbeat_timer
+          @heartbeat_timer = nil
+
           # Shutdown the worker pool
           @worker_pool.halt if @worker_pool
           @worker_pool = nil

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -35,4 +35,15 @@ class BaseTest < ActionCable::TestCase
       @server.restart
     end
   end
+
+  test "#restart shuts down the heartbeat timer" do
+    @server.send(:setup_heartbeat_timer)
+    timer = @server.instance_variable_get(:@heartbeat_timer)
+    assert_predicate timer, :running?
+
+    @server.restart
+
+    assert_not timer.running?
+    assert_nil @server.instance_variable_get(:@heartbeat_timer)
+  end
 end


### PR DESCRIPTION
## Summary

`ActionCable::Server::Base#restart` tears down `@worker_pool`, `@executor`, and `@pubsub`, but left `@heartbeat_timer` running. The orphaned `Concurrent::TimerTask` keeps firing every `BEAT_INTERVAL` seconds, and because its block calls `executor` (re-resolved lazily), it recreates a fresh executor thread pool right after `restart` shut the old one down — defeating the executor teardown and leaking the timer itself.

`restart` runs on every development code reload (via the engine's `before_class_unload`), so this leaks/churns a thread pool each reload and keeps a heartbeat beating against a server that was just torn down.

## Fix

Shut down and clear `@heartbeat_timer` alongside the other resources, mirroring the existing teardown pattern, so `setup_heartbeat_timer` lazily recreates it on the next request. `@heartbeat_timer` is also added to the `initialize` nil-assignment list for consistency with the other lazily-created resources.

```diff
 @mutex.synchronize do
+  # Shutdown the heartbeat timer
+  @heartbeat_timer.shutdown if @heartbeat_timer
+  @heartbeat_timer = nil
+
   # Shutdown the worker pool
   @worker_pool.halt if @worker_pool
   @worker_pool = nil
   ...
```

## Testing

- New `BaseTest` test "#restart shuts down the heartbeat timer", alongside the existing `#restart shuts down …` siblings: **red** = the timer is still `running?` after `restart`; **green** with the fix (timer shut down and `@heartbeat_timer` nil). 4 runs.

No CHANGELOG entry (bug fix).