### PR TITLE
Add 2-day cooldown to default Gemfile templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 <% gemfile_entries.each do |gemfile_entry| -%>
 <%= gemfile_entry %>

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,4 +1,4 @@
-source "https://rubygems.org", cooldown: 7
+source "https://rubygems.org", cooldown: 2
 
 <% gemfile_entries.each do |gemfile_entry| -%>
 <%= gemfile_entry %>

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -1,4 +1,4 @@
-source "https://rubygems.org", cooldown: 7
+source "https://rubygems.org", cooldown: 2
 <% unless options[:skip_gemspec] -%>
 
 # Specify your gem's dependencies in <%= name %>.gemspec.

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 <% unless options[:skip_gemspec] -%>
 
 # Specify your gem's dependencies in <%= name %>.gemspec.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to protect new Rails applications from supply-chain attacks. Bundler 4.0.13 introduced a `cooldown` feature.

Reference: https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html

### Detail

This Pull Request changes the default `Gemfile` template in `railties`. It adds `cooldown: 7` to the default `https://rubygems.org` source.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.