### PR TITLE
Don't autovivify the PostgreSQL listener on shutdown

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -32,7 +32,7 @@ module ActionCable
       end
 
       def shutdown
-        listener.shutdown
+        @listener.shutdown if @listener
       end
 
       def with_subscriptions_connection(&block) # :nodoc:


### PR DESCRIPTION
### Problem

`ActionCable::SubscriptionAdapter::PostgreSQL#shutdown` calls the memoizing private `listener` accessor:

```ruby
def shutdown
  listener.shutdown
end

def listener
  @listener || @mutex.synchronize { @listener ||= Listener.new(self, executor) }
end
```

`Listener.new` immediately spawns a background thread that calls `with_subscriptions_connection`, opening a brand-new database connection and entering the `LISTEN` loop. So shutting down an adapter that was **never subscribed to** — a broadcast-only process, an idle worker, or simply a `@tx_adapter`-style transmit-only adapter — lazily builds a Listener (thread + throwaway DB connection) purely to tear it back down. The spawned thread runs with `abort_on_exception = true`, so a connection failure there can surface in an unexpected place.

The Redis adapter does not have this problem because its `shutdown` touches the raw ivar:

```ruby
def shutdown
  @listener.shutdown if @listener
end
```

Both adapters nil-initialize `@listener` in `initialize`, so the ivar is always defined.

### Fix

Conform to the Redis sibling — guard on `@listener` so an unused adapter shuts down as a no-op:

```ruby
def shutdown
  @listener.shutdown if @listener
end
```

One production line.

### Test

`actioncable/test/subscription_adapter/postgresql_shutdown_test.rb` builds a PostgreSQL adapter, never subscribes, then calls `shutdown` and asserts `@listener` is still `nil`. It stubs `with_subscriptions_connection` so the (buggy) autovivified thread can't touch a real database; the fixed code never spawns it. Red before the fix (`@listener` is a `Listener`), green after.