### PR TITLE
Treat a Symbol stream name as a literal stream in channel broadcast assertions

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -329,7 +329,7 @@ module ActionCable
           end
 
           def broadcasting_for(stream_or_object)
-            return stream_or_object if stream_or_object.is_a?(String)
+            return String(stream_or_object) if stream_or_object.is_a?(String) || stream_or_object.is_a?(Symbol)
 
             self.class.channel_class.broadcasting_for(stream_or_object)
           end

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -223,6 +223,26 @@ class PerformUnsubscribedTestChannelTest < ActionCable::Channel::TestCase
   end
 end
 
+class SymbolBroadcastTestChannel < ActionCable::Channel::Base
+end
+
+class SymbolBroadcastTestChannelTest < ActionCable::Channel::TestCase
+  def test_assert_broadcasts_with_string_stream_name
+    # Control: a String stream name already works.
+    assert_broadcasts("my_room", 1) do
+      ActionCable.server.broadcast("my_room", { text: "hi" })
+    end
+  end
+
+  def test_assert_broadcasts_with_symbol_stream_name
+    # A Symbol naming a literal stream must be treated as that stream, like
+    # stream_from(:my_room) does, not scoped to the channel as a broadcastable.
+    assert_broadcasts(:my_room, 1) do
+      ActionCable.server.broadcast("my_room", { text: "hi" })
+    end
+  end
+end
+
 class BroadcastsTestChannel < ActionCable::Channel::Base
   def broadcast(data)
     ActionCable.server.broadcast(


### PR DESCRIPTION
## Summary

Follow-up to #57698, which coerced the stream key with `String(channel)` in the test adapter accessors (`SubscriptionAdapter::Test#broadcasts` / `#clear_messages`) so that the plain `ActionCable::TestHelper#assert_broadcasts(:foo)` handles a Symbol stream name. That fix lives at the adapter layer. The channel `TestCase` overrides sit one layer above it and have the same Symbol asymmetry that #57698 did not reach.

`ActionCable::Channel::TestCase` overrides `assert_broadcasts` / `assert_broadcast_on` and routes the stream argument through the private `broadcasting_for`, which returned the argument unchanged only for a `String`:

```ruby
def broadcasting_for(stream_or_object)
  return stream_or_object if stream_or_object.is_a?(String)

  self.class.channel_class.broadcasting_for(stream_or_object)
end
```

A Symbol naming a literal stream therefore falls through to `channel_class.broadcasting_for`, which scopes it to the channel, so the assertion counts the wrong broadcasting and reports zero:

```ruby
assert_broadcasts(:my_room, 1) { ActionCable.server.broadcast("my_room", { text: "hi" }) }
# counts "my_channel:my_room", finds 0, fails with:
# 1 broadcasts to my_channel:my_room expected, but 0 were sent.
```

The String form already works, and after #57698 the plain `ActionCable::TestHelper#assert_broadcasts(:my_room)` works too, so only the channel override still introduces this asymmetry. `stream_from(:my_room)` already coerces the Symbol to the literal stream `"my_room"` via `String(broadcasting)`, so a Symbol naturally names a literal stream in production — the assertion should agree.

## Fix

Treat a Symbol like a String in `broadcasting_for`, mirroring the streaming API's `String()` coercion (and the adapter coercion from #57698):

```ruby
def broadcasting_for(stream_or_object)
  return String(stream_or_object) if stream_or_object.is_a?(String) || stream_or_object.is_a?(Symbol)

  self.class.channel_class.broadcasting_for(stream_or_object)
end
```

This leaves model/object broadcastings (passed by `assert_has_stream_for` etc.) on the existing `channel_class.broadcasting_for` path. `String("foo")` is a no-op, so the String case is unchanged.

## Testing

`actioncable/test/channel/test_case_test.rb` adds a control test (`assert_broadcasts("my_room", 1)`) and the Symbol case (`assert_broadcasts(:my_room, 1)`) against a literal-stream broadcast. With #57698 already on main, the Symbol case is still **red** before this fix (counts the channel-scoped broadcasting, `1 broadcasts to symbol_broadcast_test:my_room expected, but 0 were sent`) and **green** after; the full Action Cable suite stays green.

No CHANGELOG entry (bug fix).