### PR TITLE
Coerce the broadcasting in assert_has_stream / assert_has_no_stream

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -286,6 +286,7 @@ module ActionCable
         #
         def assert_has_stream(stream)
           check_subscribed!
+          stream = String(stream)
           assert subscription.stream_names.include?(stream), "Stream #{stream} has not been started"
         end
 
@@ -309,6 +310,7 @@ module ActionCable
         #
         def assert_has_no_stream(stream)
           check_subscribed!
+          stream = String(stream)
           assert subscription.stream_names.exclude?(stream), "Stream #{stream} has been started"
         end
 

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -140,6 +140,31 @@ class StreamsTestChannelTest < ActionCable::Channel::TestCase
   end
 end
 
+class SymbolStreamsTestChannel < ActionCable::Channel::Base
+  def subscribed
+    stream_from :my_room
+  end
+end
+
+class SymbolStreamsTestChannelTest < ActionCable::Channel::TestCase
+  def test_assert_has_stream_with_symbol_broadcasting
+    subscribe
+
+    # stream_from coerces the broadcasting with String(), so it is stored as a
+    # String; the assertion must coerce its argument the same way to match.
+    assert_equal ["my_room"], subscription.stream_names
+    assert_has_stream :my_room
+  end
+
+  def test_assert_has_no_stream_with_symbol_broadcasting
+    subscribe
+
+    # The stream is active, so asserting its absence must fail loudly rather
+    # than silently passing because the raw Symbol never matched the String key.
+    assert_raises(Minitest::Assertion) { assert_has_no_stream :my_room }
+  end
+end
+
 class StreamsForTestChannel < ActionCable::Channel::Base
   def subscribed
     stream_for User.new(params[:id])


### PR DESCRIPTION
## Summary

Same family of Symbol-vs-String asymmetry as #57698 (which coerced the stream key in the test adapter accessors `SubscriptionAdapter::Test#broadcasts` / `#clear_messages`) and #57703 (which coerces it in the channel `TestCase#broadcasting_for` used by `assert_broadcasts` / `assert_broadcast_on`). This one closes the remaining gap: `assert_has_stream` / `assert_has_no_stream` compare the raw argument directly against `subscription.stream_names`, so they never go through `broadcasting_for` and were not reached by either of those fixes.

`stream_from` and `stop_stream_from` coerce their broadcasting with `String()` (`streams.rb`), so a stream started with a Symbol is stored under a String key:

```ruby
stream_from :my_room   # stored as "my_room"
```

But the channel test assertions compare the raw argument against `subscription.stream_names` (always String keys):

```ruby
def assert_has_stream(stream)
  check_subscribed!
  assert subscription.stream_names.include?(stream), "Stream #{stream} has not been started"
end
```

So a Symbol never matches:

- `assert_has_stream(:my_room)` **fails** even though the stream is active (`Stream my_room has not been started`).
- `assert_has_no_stream(:my_room)` **passes silently** even though the stream *was* started — a false-green where the assertion verifies nothing. This is the dangerous case: it silently masks real regressions, exactly the failure mode #57698 flagged for `assert_no_broadcasts`.

Non-String broadcastings are explicitly supported by the streaming API (`stream_test.rb` covers "stream from non-string channel"), so this is a divergence between the assertions and the API, not the spec.

## Fix

Coerce the argument with `String()` at the top of both assertions, matching `stream_from` / `stop_stream_from` (and the coercions added in #57698 / #57703):

```ruby
def assert_has_stream(stream)
  check_subscribed!
  stream = String(stream)
  assert subscription.stream_names.include?(stream), "Stream #{stream} has not been started"
end

def assert_has_no_stream(stream)
  check_subscribed!
  stream = String(stream)
  assert subscription.stream_names.exclude?(stream), "Stream #{stream} has been started"
end
```

Two production lines. `String("foo")` is a no-op, so the String case is unchanged; this only fixes the Symbol (and other coercible broadcasting) case.

## Testing

`actioncable/test/channel/test_case_test.rb` adds a channel that does `stream_from :my_room` and asserts both that `assert_has_stream :my_room` succeeds and that `assert_has_no_stream :my_room` now fails loudly (via `assert_raises(Minitest::Assertion)`) instead of passing silently. Red before the fix (`Stream my_room has not been started`, and `Minitest::Assertion expected but nothing was raised` for the false-green), green after; the full `test_case_test.rb` suite stays green.

No CHANGELOG entry (bug fix).