### PR TITLE
Don't re-deliver captured broadcasts to live subscribers

### DIFF
--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -154,8 +154,9 @@ module ActionCable
         new_messages = broadcasts(stream)
         clear_messages(stream)
 
-        # Restore all sent messages
-        (old_messages + new_messages).each { |m| pubsub_adapter.broadcast(stream, m) }
+        # Restore all recorded messages without re-delivering them to live
+        # subscribers (pubsub_adapter.broadcast would dispatch them again).
+        broadcasts(stream).concat(old_messages + new_messages)
 
         new_messages
       end

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -147,3 +147,28 @@ class TransmittedDataTest < ActionCable::TestCase
     assert_match(/No message found for test/, error.message)
   end
 end
+
+class CaptureBroadcastsRedeliveryTest < ActionCable::TestCase
+  # Runs the test adapter's delivery inline so the live subscriber is invoked
+  # synchronously and the delivery count is deterministic.
+  class InlineExecutor
+    def post
+      yield
+    end
+  end
+
+  def test_capture_does_not_redeliver_to_live_subscribers
+    adapter = ActionCable.server.pubsub
+    adapter.instance_variable_set(:@executor, InlineExecutor.new)
+
+    received = []
+    adapter.subscribe("test", ->(message) { received << message })
+
+    capture_broadcasts("test") do
+      ActionCable.server.broadcast "test", "hello"
+    end
+
+    assert_equal 1, received.size,
+      "the message was re-delivered to live subscribers while restoring captured broadcasts"
+  end
+end


### PR DESCRIPTION
## Summary

`ActionCable::TestHelper`'s block assertions (`assert_broadcasts`, `assert_no_broadcasts`, `capture_broadcasts`, `assert_broadcast_on`) clear the recorded messages, run the block, then restore the messages by re-broadcasting each one:

```ruby
def new_broadcasts_from(current_messages, stream, assertion, &block)
  old_messages = current_messages
  clear_messages(stream)

  _assert_nothing_raised_or_warn(assertion, &block)
  new_messages = broadcasts(stream)
  clear_messages(stream)

  # Restore all sent messages
  (old_messages + new_messages).each { |m| pubsub_adapter.broadcast(stream, m) }

  new_messages
end
```

With the test adapter (`SubscriptionAdapter::Test < Async`), `broadcast` both records the payload **and** calls `super`, which dispatches to live in-process subscribers:

```ruby
def broadcast(channel, payload)
  broadcasts(channel) << payload
  super
end
```

So every message sent inside one of these blocks is delivered a **second** time to live subscribers during the restore step — a duplicate observable side effect in system tests and Async-adapter usage, where a broadcast can trigger a subscriber callback twice. The recorded *count* stays correct (the messages are re-appended), so it is invisible to count-based assertions; it only surfaces as the live subscriber side effect, which is why it has gone unnoticed.

## Fix

Repopulate the recorded array directly instead of broadcasting again:

```ruby
# Restore all recorded messages without re-delivering them to live
# subscribers (pubsub_adapter.broadcast would dispatch them again).
broadcasts(stream).concat(old_messages + new_messages)
```

`broadcasts(stream)` returns the backing array (`channels_data[String(stream)] ||= []`), so this restores the recorded state without invoking the adapter's `broadcast`. `TestHelper` already assumes the test adapter — `broadcasts` / `clear_messages` are delegated to `pubsub_adapter` and only exist on `SubscriptionAdapter::Test`, and the adapter itself records via `broadcasts(channel) << payload` — so mutating the returned array is the established pattern, not new coupling. One production line.

## Testing

`actioncable/test/test_helper_test.rb` subscribes a counting callback, runs the test adapter's delivery inline (a tiny synchronous executor) so the count is deterministic, then `capture_broadcasts` a single broadcast and asserts the subscriber was invoked exactly once. Red before the fix (delivered twice — once in-block, once on restore: `Expected: 1, Actual: 2`), green after; the full `test_helper_test.rb` suite stays green.

No CHANGELOG entry (bug fix).