### PR TITLE
Raise a typed error for a `message` command without a data payload

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -97,6 +97,8 @@ module ActionCable
       end
 
       def perform_action(data)
+        raise MalformedCommandError, data unless data["data"].present?
+
         subscription = find(data)
         raise UnknownSubscription.new(data["identifier"]) unless subscription
         subscription.perform_action ActiveSupport::JSON.decode(data["data"])

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -152,6 +152,15 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     assert_equal [ data ], channel.lines
   end
 
+  test "message command without a data key" do
+    setup_connection
+    subscribe_to_chat_channel
+
+    assert_raises ActionCable::Connection::Subscriptions::MalformedCommandError do
+      @subscriptions.execute_command "command" => "message", "identifier" => @chat_identifier
+    end
+  end
+
   test "accessing exceptions thrown during command execution" do
     setup_connection
     subscribe_to_chat_channel


### PR DESCRIPTION
### Summary

`Connection::Subscriptions#execute_command` routes incoming `subscribe` / `unsubscribe` / `message` commands. In 7a8f26dcff ("Improve exceptions in Action Cable subscriptions") the subscribe and unsubscribe paths were given typed `Subscriptions::Error` subclasses for malformed input — `add` raises `MalformedCommandError` on a missing identifier, `remove` raises `MissingIdentifier`. The `message` path (`perform_action`) was the one route left out: it decodes the payload with no presence check, so malformed input still escapes as a bare, untyped error.

```ruby
def perform_action(data)
  subscription = find(data)
  raise UnknownSubscription.new(data["identifier"]) unless subscription
  subscription.perform_action ActiveSupport::JSON.decode(data["data"])
end
```

A `message` command that carries a valid identifier but no `"data"` key makes `data["data"]` `nil`, so `ActiveSupport::JSON.decode(nil)` raises a bare `TypeError` ("no implicit conversion of nil into String") — an error class outside the `Subscriptions::Error` hierarchy that the surrounding `rescue_from` handlers and command-error logging don't expect, unlike the typed errors its two sibling handlers raise for the equivalent malformed input.

### Fix

Guard with `.present?` and raise `MalformedCommandError`, mirroring `add`'s identifier guard, so the third command path conforms to the typed-error effort started in 7a8f26dcff:

```ruby
def perform_action(data)
  raise MalformedCommandError, data unless data["data"].present?

  subscription = find(data)
  raise UnknownSubscription.new(data["identifier"]) unless subscription
  subscription.perform_action ActiveSupport::JSON.decode(data["data"])
end
```

The guard is precise — it only intercepts the inputs that currently fail to produce a typed error, and leaves every legitimate payload untouched:

| `data["data"]` | before | after |
| --- | --- | --- |
| `nil` (key absent) | `TypeError` | `MalformedCommandError` |
| `""` | `JSON::ParserError` | `MalformedCommandError` |
| `"false"` | `false` | `false` (`present?` → still decoded) |
| `"0"` | `0` | `0` (`present?` → still decoded) |

Falsy-but-legitimate JSON payloads (`"false"`, `"0"`) are non-blank strings and still decode exactly as before. Only `nil` and `""` — both of which already raised an untyped error — are now reported as malformed.

### Test

`actioncable/test/connection/subscriptions_test.rb` subscribes a channel and executes a `message` command with no `"data"` key, asserting it raises `MalformedCommandError`. Red before the change (bare `TypeError`), green after; the full Action Cable suite stays green.