### PR TITLE
Guard the heartbeat timer lazy-init with the server mutex

### DIFF
--- a/actioncable/lib/action_cable/server/connections.rb
+++ b/actioncable/lib/action_cable/server/connections.rb
@@ -36,8 +36,10 @@ module ActionCable
       # second heartbeat runs on all connections. If the beat fails, we automatically
       # disconnect.
       def setup_heartbeat_timer
-        @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
-          executor.post { each_connection(&:beat) }
+        @heartbeat_timer || @mutex.synchronize do
+          @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
+            executor.post { each_connection(&:beat) }
+          end
         end
       end
 

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -88,4 +88,33 @@ class BaseTest < ActionCable::TestCase
     assert_same ActionCable::Configuration, ActionCable::Server::Configuration
     assert_instance_of ActionCable::Configuration, ActionCable::Server::Base.config
   end
+
+  # Records every timer it builds, sleeping to widen the lazy-init race window.
+  class RecordingExecutor
+    attr_reader :built_timers
+
+    def initialize
+      @built_timers = Concurrent::Array.new
+    end
+
+    def timer(interval, &block)
+      sleep 0.05
+      FakeTimer.new.tap { |t| @built_timers << t }
+    end
+
+    class FakeTimer
+      def shutdown; end
+    end
+  end
+
+  test "#setup_heartbeat_timer builds a single timer under concurrent connections" do
+    executor = RecordingExecutor.new
+    @server.instance_variable_set(:@executor, executor)
+
+    threads = 5.times.map { Thread.new { @server.send(:setup_heartbeat_timer) } }
+    threads.each(&:join)
+
+    assert_equal 1, executor.built_timers.size,
+      "concurrent first connections each built a heartbeat timer, leaking all but the last"
+  end
 end


### PR DESCRIPTION
### Problem

`Server::Base#call` runs `setup_heartbeat_timer` on every incoming connection, outside any synchronization. The method (defined in the `Server::Connections` module mixed into `Base`) memoizes with a bare `||=`:

```ruby
def setup_heartbeat_timer
  @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
    executor.post { each_connection(&:beat) }
  end
end
```

`executor.timer` builds a `Concurrent::TimerTask` and immediately `.execute`s it, spawning a live recurring timer thread. Under concurrent first connections, two or more threads can each observe `@heartbeat_timer` as `nil` and each build + execute a timer. `@heartbeat_timer` keeps only the last; the rest leak as orphaned timers that fire `each_connection(&:beat)` forever and are never reached by `restart` / shutdown, which only touch the single referenced timer.

Every other lazy resource on the server — `remote_connections`, `event_loop`, `worker_pool`, `executor`, `pubsub` (all in `base.rb`) — uses the double-checked `@x || @mutex.synchronize { @x ||= ... }` pattern. `setup_heartbeat_timer` is the lone violator, even though it shares the same `@mutex` (the `Monitor` initialized in `Base#initialize`) and `restart` already reads/writes `@heartbeat_timer` under it.

This is the creation-side counterpart to #57700, which just added the `restart`/shutdown teardown for this same timer; guarding the lazy-init here closes the other end of its lifecycle.

### Fix

Conform to the sibling pattern. `@mutex` is a reentrant `Monitor`, so the nested `executor` accessor (which also synchronizes on `@mutex`) is safe:

```ruby
def setup_heartbeat_timer
  @heartbeat_timer || @mutex.synchronize do
    @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
      executor.post { each_connection(&:beat) }
    end
  end
end
```

### Test

`actioncable/test/server/base_test.rb` injects a recording executor whose `timer` sleeps briefly to widen the race window, spawns five threads that each call `setup_heartbeat_timer`, and asserts exactly one timer was built. Red before (`Actual: 5` — four leaked), green after; the existing `base_test.rb` suite stays green.

No CHANGELOG entry (bug fix).