### PR TITLE
Clear the connections registry on server restart

### DIFF
--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -76,6 +76,10 @@ module ActionCable
         end
 
         @mutex.synchronize do
+          # Drop the closed connections. remove_connection normally runs on the
+          # worker pool, which we halt below, so the entries would otherwise leak.
+          connections_map.clear
+
           # Shutdown the heartbeat timer
           @heartbeat_timer.shutdown if @heartbeat_timer
           @heartbeat_timer = nil

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -24,6 +24,22 @@ class BaseTest < ActionCable::TestCase
     end
   end
 
+  class ClosableConnection
+    def close(*); end
+  end
+
+  test "#restart clears the connections registry" do
+    @server.add_connection(ClosableConnection.new)
+    assert_equal 1, @server.connections.size
+
+    @server.restart
+
+    # remove_connection normally runs via the worker pool, which restart halts,
+    # so the closed connections must be dropped here or they leak (e.g. on every
+    # dev-mode code reload, which calls restart on the singleton server).
+    assert_empty @server.connections
+  end
+
   test "#each_connection iterates a snapshot so connections can be added during iteration" do
     beating = Class.new do
       def initialize(server)


### PR DESCRIPTION
### Problem

`Server::Base#restart` closes every connection and then tears down the server resources under `@mutex`, but never clears `connections_map`:

```ruby
def restart
  each_connection do |connection|
    connection.close(reason: ...)
  end

  @mutex.synchronize do
    @heartbeat_timer.shutdown if @heartbeat_timer
    @heartbeat_timer = nil
    @worker_pool.halt if @worker_pool
    @worker_pool = nil
    # ...executor, pubsub...
  end
end
```

The only path that removes an entry from `connections_map` is `Socket#handle_close → server.remove_connection`, and `handle_close` is dispatched asynchronously on the worker pool (`send_async :handle_close`). `restart` halts that pool, discarding the queued `remove_connection` callbacks. So the already-closed connection objects stay in `connections_map`, and `#connections` / `open_connections_statistics` over-count and retain dead objects.

The recurring caller is dev-mode reloading — `engine.rb` runs `ActionCable.server.restart` on the persistent singleton in `before_class_unload`, before each class unload — so dead connections accumulate across a dev session.

This is the same class of teardown gap that #57700 just fixed for the heartbeat timer: `restart` resets the worker pool, executor, pub/sub adapter and (now) the heartbeat timer, but left the connections registry behind.

### Fix

Clear the registry during restart, under the mutex alongside the other teardown:

```ruby
@mutex.synchronize do
  # Drop the closed connections. remove_connection normally runs on the
  # worker pool, which we halt below, so the entries would otherwise leak.
  connections_map.clear

  # ...existing resets...
end
```

`connections_map.delete` / `clear` are idempotent, so a `handle_close` that happens to run before the pool halts doesn't conflict with the clear.

### Test

`actioncable/test/server/base_test.rb` adds a connection, calls `restart`, and asserts `connections` is empty. Red before (the closed connection is retained), green after; the existing `base_test.rb` suite stays green.

No CHANGELOG entry (bug fix).