### PR TITLE
Restart the Redis listener thread when it dies

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -166,6 +166,17 @@ module ActionCable
 
           private
             def ensure_listener_running
+              # The internal sentinel subscription keeps the listener alive in
+              # normal operation, but the thread can still die for other reasons
+              # (e.g. exhausting the Redis reconnect attempts). Since this method
+              # memoizes with `||=`, a dead thread would never be replaced and
+              # every later subscribe would queue forever. Drop a dead thread so
+              # the next subscribe spawns a fresh listener.
+              if @thread && !@thread.alive?
+                @thread = nil
+                @reconnect_attempt = 0
+              end
+
               @thread ||= Thread.new do
                 Thread.current.abort_on_exception = true
 

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -33,6 +33,49 @@ class RedisAdapterTest < ActionCable::TestCase
     end
   end
 
+  def test_listener_thread_is_restarted_after_it_dies
+    # A dedicated rx adapter that gives up reconnecting immediately, so a dropped
+    # pubsub connection kills the listener thread (exhausted retries) instead of
+    # recovering it. The sentinel only prevents the count-to-zero death; this
+    # exercises ensure_listener_running reviving a thread that died otherwise.
+    server = ActionCable::Server::Base.new
+    server.config.cable = cable_config.merge(reconnect_attempts: 0).with_indifferent_access
+    rx_adapter = server.config.pubsub_adapter.new(server)
+
+    before_queue = Queue.new
+    subscription_confirmed = Concurrent::Event.new
+    rx_adapter.subscribe("channel", ->(data) { before_queue << data }, -> { subscription_confirmed.set })
+    assert subscription_confirmed.wait(WAIT_WHEN_EXPECTING_EVENT)
+
+    @tx_adapter.broadcast("channel", "before")
+    assert_equal "before", before_queue.pop
+
+    listener = rx_adapter.send(:listener)
+    original_listener_thread = listener.instance_variable_get(:@thread)
+    assert original_listener_thread.alive?
+
+    drop_pubsub_connections
+    wait_for(message: "the listener thread did not die after the connection drop") do
+      !original_listener_thread.alive?
+    end
+
+    # Subscribing to a *new* channel goes through add_channel (a re-subscribe to
+    # an existing channel would not), which must restart the dead listener.
+    after_queue = Queue.new
+    resubscription_confirmed = Concurrent::Event.new
+    rx_adapter.subscribe("other channel", ->(data) { after_queue << data }, -> { resubscription_confirmed.set })
+    assert resubscription_confirmed.wait(WAIT_WHEN_EXPECTING_EVENT)
+
+    restarted_listener_thread = listener.instance_variable_get(:@thread)
+    assert_not_same original_listener_thread, restarted_listener_thread
+    assert restarted_listener_thread.alive?
+
+    @tx_adapter.broadcast("other channel", "after")
+    assert_equal "after", after_queue.pop
+  ensure
+    rx_adapter&.shutdown
+  end
+
   def test_reconnections
     subscribe_as_queue("channel") do |queue|
       subscribe_as_queue("other channel") do |queue_2|

--- a/actioncable/test/test_helper.rb
+++ b/actioncable/test/test_helper.rb
@@ -36,6 +36,17 @@ class ActionCable::TestCase < ActiveSupport::TestCase
       raise "Executor could not complete all tasks in 2 seconds" unless timeout > 0
     end
   end
+
+  def wait_for(message: "condition not met", timeout: 5, interval: 0.01)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      return if yield
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        raise Timeout::Error, "#{message} after #{timeout} seconds"
+      end
+      sleep interval
+    end
+  end
 end
 
 require_relative "../../tools/test_common"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the Action Cable Redis listener
thread can die and never be restarted, silently dropping all broadcasts on
the affected process until it is restarted.

#57690 fixed the most common death — an unsubscribe driving the Redis
subscription count to zero — by keeping an internal sentinel subscription
alive. But the listener thread can still die for other reasons. The main one
is exhausting the Redis reconnect attempts: in `ensure_listener_running`'s
rescue, once `retry_connecting?` returns false the block simply ends and the
thread exits.

Because `ensure_listener_running` memoizes with `@thread ||= Thread.new`, a
dead (but non-nil) thread is never replaced. Every later `subscribe` then
queues into `@when_connected` forever, `@subscribed_client` stays `nil`, and
all broadcasts are silently dropped until the process restarts.

### Detail

This Pull Request changes `ensure_listener_running` to reset a dead thread
(and its reconnect counter) before the `||=` memoization, so the next
`subscribe` spawns a fresh listener instead of reusing the dead one.

It also adds a regression test driving the real reconnect-exhaustion path:
with `reconnect_attempts: 0`, dropping the pub/sub connection kills the
listener thread, and a subsequent subscription to a new channel must restart
it and receive broadcasts again. A small `wait_for` test helper (mirroring
the one in Active Record's test suite) is added to `ActionCable::TestCase`
to poll for the thread's death without a fixed sleep.

### Additional information

Follow-up to #57690, as suggested there. The two changes are complementary:
the sentinel prevents the normal-operation death, while this restart recovers
from the remaining causes (e.g. exhausted reconnects).

cc @byroot @55728 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.