### PR TITLE
Fix `has_many_attached` `attach` deleting files attached concurrently

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix `has_many_attached` `attach` deleting files attached concurrently.
+
+    On a persisted record, `attach` read the current set of blobs and reassigned
+    the whole collection, so two concurrent `attach` calls working from the same
+    snapshot would each replace the collection and delete the other's file. The
+    Guides document that `attach` always appends and never replaces, so `attach`
+    now inserts only the new attachments instead of reassigning the collection.
+
+    Fixes #42941.
+
+    *Willian Tenfen Wazilewski*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/lib/active_storage/attached/changes/create_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_many.rb
@@ -4,9 +4,11 @@ module ActiveStorage
   class Attached::Changes::CreateMany # :nodoc:
     attr_reader :name, :attachables, :pending_uploads
     attr_accessor :record
+    attr_writer :append
 
     def initialize(name, record, attachables, pending_uploads: [])
       @name, @record, @attachables = name, record, Array(attachables)
+      @append = false
       blobs.each(&:identify_without_saving)
       @pending_uploads = Array(pending_uploads) + subchanges_without_blobs
       attachments
@@ -28,6 +30,10 @@ module ActiveStorage
       pending_uploads.each(&:upload)
     end
 
+    def append?
+      @append
+    end
+
     def save
       assign_associated_attachments
       reset_associated_blobs
@@ -47,11 +53,19 @@ module ActiveStorage
       end
 
       def assign_associated_attachments
-        record.public_send("#{name}_attachments=", persisted_or_new_attachments)
+        if append?
+          record.public_send("#{name}_attachments").concat(new_attachments)
+        else
+          record.public_send("#{name}_attachments=", persisted_or_new_attachments)
+        end
       end
 
       def reset_associated_blobs
         record.public_send("#{name}_blobs").reset
+      end
+
+      def new_attachments
+        attachments.select(&:new_record?)
       end
 
       def persisted_or_new_attachments

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -49,10 +49,22 @@ module ActiveStorage
     #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpeg")
     #   document.images.attach([ first_blob, second_blob ])
     def attach(*attachables)
+      append =
+        case change = record.attachment_changes[name]
+        when ActiveStorage::Attached::Changes::CreateMany then change.append?
+        when ActiveStorage::Attached::Changes::DeleteMany then false
+        else true
+        end
+
       record.public_send("#{name}=", blobs + attachables.flatten)
+
+      change = record.attachment_changes[name]
+      change.append = append if change.is_a?(ActiveStorage::Attached::Changes::CreateMany)
+
       if record.persisted? && !record.changed?
         return if !record.save
       end
+
       record.public_send("#{name}")
     end
 

--- a/activestorage/test/database/create_groups_migration.rb
+++ b/activestorage/test/database/create_groups_migration.rb
@@ -3,6 +3,7 @@
 class ActiveStorageCreateGroups < ActiveRecord::Migration[6.0]
   def change
     create_table :groups do |t|
+      t.string :name
     end
   end
 end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -989,4 +989,47 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     special_user = user.becomes(SpecialUser)
     assert_predicate special_user.highlights, :attached?
   end
+
+  test "attaching does not delete attachments added concurrently" do
+    group = Group.create!
+    group.files.attach create_blob(filename: "a.txt")
+
+    one = Group.find(group.id)
+    two = Group.find(group.id)
+    one.files_blobs.to_a
+    two.files_blobs.to_a
+
+    one.files.attach create_blob(filename: "b.txt")
+    two.files.attach create_blob(filename: "c.txt")
+
+    assert_equal %w[ a.txt b.txt c.txt ], group.reload.files_blobs.map { |blob| blob.filename.to_s }.sort
+  end
+
+  test "attaching after changing another attribute does not delete attachments added concurrently" do
+    group = Group.create!
+    group.files.attach create_blob(filename: "a.txt")
+
+    one = Group.find(group.id)
+    two = Group.find(group.id)
+    one.files_blobs.to_a
+    two.files_blobs.to_a
+
+    one.files.attach create_blob(filename: "b.txt")
+
+    two.name = "Renamed"
+    two.files.attach create_blob(filename: "c.txt")
+    two.save!
+
+    assert_equal %w[ a.txt b.txt c.txt ], group.reload.files_blobs.map { |blob| blob.filename.to_s }.sort
+  end
+
+  test "assigning then attaching on an existing record replaces and then appends" do
+    group = Group.create!
+    group.files.attach create_blob(filename: "old.txt")
+
+    group.files = [ create_blob(filename: "new.txt") ]
+    group.files.attach create_blob(filename: "added.txt")
+
+    assert_equal %w[ added.txt new.txt ], group.reload.files_blobs.map { |blob| blob.filename.to_s }.sort
+  end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -214,6 +214,7 @@ class SpecialUser < User; end
 
 class Group < ActiveRecord::Base
   has_one_attached :avatar
+  has_many_attached :files
   has_many :users, autosave: true
 
   accepts_nested_attributes_for :users


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #42941

On a persisted record, `attach` read the current set of blobs and reassigned the whole collection, so two concurrent `attach` calls working from the same snapshot would each replace the collection and delete the other's file.

The Guides document that `attach` always appends and never replaces, so `attach` now inserts only the new attachments instead of reassigning the collection. The staged change tracks whether it should append or replace, which lets `attach` fold new files into a pending change while preserving assignment (`record.files = [...]`) semantics.


### Detail

`ActiveStorage::Attached::Many#attach` was implemented as a read-modify-**replace** of the entire collection:
```ruby
def attach(*attachables)
  record.public_send("#{name}=", blobs + attachables.flatten)
  # ...
end
```


It read blobs (the current set), appended the new attachables, and reassigned #{name}=. On save, CreateMany#assign_associated_attachments does record.#{name}_attachments = ..., and a has_many collection assignment destroys members not in the assigned set. So when two requests both load [A] and one attaches B while the other attaches C, the second save reassigns the collection from its stale [A] snapshot and deletes the first request's B. The added file (B or C) is silently lost.

This conflicts with the documented contract in the Active Storage guide:

 <b>Calling .attach always appends new files</b>. It never replaces existing attachments

This PR makes attach:

- ActiveStorage::Attached::Changes::CreateMany gains an append flag (default false, preserving the existing replace behavior used by record.files = [...]). When set, save inserts only the newly built attachments via concat instead of reassigning the whole collection, leaving existing rows — including ones added concurrently — untouched.
- ActiveStorage::Attached::Many#attach now stages an append-mode change. It folds the new files into any change that's already pending and preserves that change's mode, so:
 -- a bare attach (nothing pending) appends;
 -- record.files = [...] then attach stays a replace (assignment wins);
 -- record.files = [] then attach replaces;
 -- repeated attach calls (including on a dirty/unsaved record, before a single save) stay an append.

Because the existing-vs-new determination is already by blob_id (plus the index_active_storage_attachments_uniqueness unique index), the insert-only path is order-independent and behavior-preserving for the non-concurrent cases: attaching an already-attached blob remains a no-op, and attaching the same file bytes twice still produces two blobs/attachments as before.



### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

The new regression tests use the Group model rather than User. User's table has a lock_version column, and its optimistic locking masks the bug by raising ActiveRecord::StaleObjectError instead of silently losing data — most application models that hit this have no lock_version, so they get the silent data loss. Group has no optimistic locking, which lets two stale instances reproduce the race deterministically.

Tests added (they fail on main, pass with this change):
- attaching does not delete attachments added concurrently
- attaching after changing another attribute does not delete attachments added concurrently (covers the deferred/dirty-record save path)
- assigning then attaching on an existing record replaces and then appends (guards that = replace semantics are preserved)

The full ActiveStorage::ManyAttachedTest and ActiveStorage::OneAttachedTest suites pass with no new failures.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
