### PR TITLE
Fix `create_or_find_by` scope pollution on the non-transactional retry

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -283,7 +283,7 @@ module ActiveRecord
         if connection.transaction_open?
           rewhere(attributes).lock.take!
         else
-          find_by!(attributes)
+          rewhere(attributes).take!
         end
       end
     end
@@ -303,7 +303,7 @@ module ActiveRecord
         if connection.transaction_open?
           rewhere(attributes).lock.take!
         else
-          find_by!(attributes)
+          rewhere(attributes).take!
         end
       end
     end

--- a/activerecord/test/cases/create_or_find_by_outside_transaction_test.rb
+++ b/activerecord/test/cases/create_or_find_by_outside_transaction_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/subscriber"
+
+# create_or_find_by retries with find_by! only when there is no surrounding
+# transaction. The rest of the suite runs inside a transaction (transactional
+# fixtures), so that branch is never exercised there — these tests run without
+# one to cover the real top-level production path.
+class CreateOrFindByOutsideTransactionTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def setup
+    Subscriber.create!(nick: "cofb_bob", name: "Bob")
+  end
+
+  def teardown
+    Subscriber.where(nick: "cofb_bob").delete_all
+  end
+
+  def test_create_or_find_by_with_polluted_scope_outside_a_transaction
+    existing = Subscriber.find_by!(nick: "cofb_bob")
+
+    found = Subscriber.where(nick: "cofb_alice").create_or_find_by(nick: "cofb_bob")
+
+    assert_equal existing, found
+  end
+
+  def test_create_or_find_by_bang_with_polluted_scope_outside_a_transaction
+    existing = Subscriber.find_by!(nick: "cofb_bob")
+
+    found = Subscriber.where(nick: "cofb_alice").create_or_find_by!(nick: "cofb_bob")
+
+    assert_equal existing, found
+  end
+end


### PR DESCRIPTION
### Summary

This completes the unreleased fix in 2ce7755fa5 (#57192), which removed the duplicate-`WHERE` pollution from `create_or_find_by` / `create_or_find_by!` — but only in the `connection.transaction_open?` branch. The `else` branch (the common top-level call, taken when there is no surrounding transaction) was left calling `find_by!(attributes)` on the scoped relation and still pollutes the lookup.

### Problem

On `RecordNotUnique`, `create_or_find_by` retries the read. After #57192 the rescue looks like this:

```ruby
rescue ActiveRecord::RecordNotUnique
  if connection.transaction_open?
    rewhere(attributes).lock.take!
  else
    find_by!(attributes)   # <- still pollutes
  end
end
```

When the relation carries a scope, the `else` branch builds `WHERE caller_scope AND attributes`. If that scope excludes the just-created row, it raises `RecordNotFound` instead of returning the existing record:

```ruby
Subscriber.create!(nick: "bob")
Subscriber.where(nick: "alice").create_or_find_by(nick: "bob")
# ActiveRecord::RecordNotFound: ... WHERE "subscribers"."nick" = 'alice' AND "subscribers"."nick" = 'bob'
```

This is the same class of bug #57192 set out to fix; it was simply only fixed on one of the two branches.

### Why the existing tests didn't catch it

The suite runs each test inside a transaction (transactional fixtures), so `connection.transaction_open?` is always true and the `else` branch is never exercised. That is exactly the branch real top-level calls take in production.

### Fix

Mirror the transaction-open branch in both `else` branches, dropping `.lock` (which is only meaningful inside a transaction):

```ruby
rewhere(attributes).take!
```

### Test

Adds `test/cases/create_or_find_by_outside_transaction_test.rb` with `self.use_transactional_tests = false` so it runs the real top-level path. A polluted-scope `create_or_find_by` / `create_or_find_by!` is asserted to return the existing record. The test is red before the fix (`RecordNotFound` with the doubled `nick` condition) and green after; the existing `create_or_find_by` tests stay green.