### PR TITLE
Fix `counter_cache_column` crash when no column is given on the has_many side

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -250,7 +250,7 @@ module ActiveRecord
               counter_cache[:column] || -"#{active_record.name.demodulize.underscore.pluralize}_count"
             end
           else
-            -((counter_cache && -counter_cache[:column]) || "#{name}_count")
+            -((counter_cache && counter_cache[:column]) || "#{name}_count")
           end
         end
       end

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -734,6 +734,26 @@ class ReflectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_counter_cache_column_defaults_when_counter_cache_is_true
+    model = Class.new(ActiveRecord::Base) do
+      def self.name = "CounterCacheTrueAuthor"
+      self.table_name = "authors"
+      has_many :books, foreign_key: "author_id", counter_cache: true
+    end
+
+    assert_equal "books_count", model.reflect_on_association(:books).counter_cache_column
+  end
+
+  def test_counter_cache_column_defaults_when_counter_cache_hash_omits_column
+    model = Class.new(ActiveRecord::Base) do
+      def self.name = "CounterCacheActiveFalseAuthor"
+      self.table_name = "authors"
+      has_many :books, foreign_key: "author_id", counter_cache: { active: false }
+    end
+
+    assert_equal "books_count", model.reflect_on_association(:books).counter_cache_column
+  end
+
   private
     def assert_reflection(klass, association, options)
       assert reflection = klass.reflect_on_association(association)


### PR DESCRIPTION
### Summary

Declaring a counter cache on the has_many / has_one side without an explicit column — `counter_cache: true` or the documented backfill form `counter_cache: { active: false }` — crashes with `NoMethodError: undefined method '-@' for nil` before the default column name can be derived. This is a regression introduced in e79455f3d4 ("Add the ability to ignore counter cache columns while they are backfilling", *fatkodima*) and shipped since v7.2.0.

### Problem

On the has_many / has_one side, `counter_cache_column` computes:

```ruby
-((counter_cache && -counter_cache[:column]) || "#{name}_count")
```

`normalize_options` always rewrites `options[:counter_cache]` into a Hash `{ active:, column: }`, and its `:column` is `nil` both for `counter_cache: true` and for `counter_cache: { active: false }`:

```ruby
# reflection.rb#normalize_options
when Hash
  active = counter_cache.fetch(:active, true)
  column = counter_cache[:column]&.to_s   # nil when no column given
end
options[:counter_cache] = { active: active, column: column }
```

Since the Hash is always truthy, `counter_cache && -counter_cache[:column]` evaluates the inner `-counter_cache[:column]` as `-nil`, which raises **before** the `|| "#{name}_count"` fallback can apply.

The belongs_to branch does it correctly — it does not put a unary minus in front of the column lookup:

```ruby
counter_cache[:column] || -"#{active_record.name.demodulize.underscore.pluralize}_count"
```

### Real-world impact

The crash is reached through ordinary usage, e.g. `author.books.create!` (via `HasManyAssociation#update_counter_in_memory` → `counter_cache_column`) and `author.books.size`. All three documented has_many forms are affected: `counter_cache: true`, `counter_cache: :custom_name` falls through fine but `counter_cache: { active: false }` (the recommended safe-backfill form) crashes.

### Fix

Drop the stray inner minus so a nil column falls through to the default. The outer `-@` still freezes the resulting string, matching the belongs_to branch:

```ruby
-((counter_cache && counter_cache[:column]) || "#{name}_count")
```

### Test

`test/cases/reflection_test.rb` asserts `counter_cache_column` returns `"books_count"` for a has_many declared with `counter_cache: true` and with `counter_cache: { active: false }`. Both are red before the fix (`NoMethodError: undefined method '-@' for nil`) and green after; the existing reflection and belongs_to counter_cache tests stay green.