### PR TITLE
Don't cap `max_threads` at 5 for finite pools larger than 5

### DIFF
--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -89,7 +89,7 @@ module ActiveRecord
       end
 
       def max_threads
-        (configuration_hash[:max_threads] || (max_connections || 5).clamp(0, 5)).to_i
+        (configuration_hash[:max_threads] || max_connections || 5).to_i
       end
 
       def max_age

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -141,6 +141,12 @@ module ActiveRecord
         assert_equal 1, config.max_threads
       end
 
+      def test_max_threads_not_capped_for_large_finite_pool
+        config = HashConfig.new("default_env", "primary", max_connections: 20, adapter: "abstract")
+        assert_equal 20, config.max_connections
+        assert_equal 20, config.max_threads
+      end
+
       def test_max_queue_is_max_threads_multiplied_by_4
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
         assert_equal 5, config.max_threads


### PR DESCRIPTION
### Summary

`HashConfig#max_threads` silently caps at 5 for any finite `max_connections` greater than 5. Apps that configure a connection pool larger than 5 and use `async_query_executor = :multi_thread_pool` get a 5-thread executor (and a correspondingly shrunken `max_queue = max_threads * 4`) instead of one sized to the pool. This is a regression shipped in v8.1.0 (from fed08be767); before that release `max_threads` followed `max_connections`.

### Problem

```ruby
def max_threads
  (configuration_hash[:max_threads] || (max_connections || 5).clamp(0, 5)).to_i
end
```

The `.clamp(0, 5)` was meant only to bound the unlimited case (`max_connections == nil`, i.e. an explicitly unlimited pool), but it also caps every finite `max_connections` above 5:

```ruby
HashConfig.new(env, "primary", max_connections: 20, adapter: "abstract").max_threads
# => 5   (expected 20)
```

The `|| 5` already handles the nil case on its own, so the clamp is both unnecessary for nil and harmful for finite pools larger than 5.

### Pre-regression behavior

Before v8.1.0, `max_threads` was simply `(configuration_hash[:max_threads] || max_connections).to_i`, so it tracked `max_connections` directly (which defaulted to 5 via `pool`). The existing test `test_max_threads_uses_max_connections_when_set` documents this intent — but it only checks `max_connections: 1`, a value below the clamp ceiling, so the regression for larger pools went unnoticed.

### Fix

`max_connections` already returns `nil` when the pool is unlimited, so fall back to 5 on nil and otherwise use it directly:

```ruby
def max_threads
  (configuration_hash[:max_threads] || max_connections || 5).to_i
end
```

This restores the pre-v8.1.0 follow-`max_connections` behavior while keeping the default of 5 (unset) and the unlimited fallback of 5 (`max_connections: nil` / `-1`).

### Test

`test/cases/database_configurations/hash_config_test.rb` asserts `max_connections: 20` yields `max_threads == 20`. Red before the fix (`Expected: 20, Actual: 5`), green after; the unlimited-fallback tests (`nil` / `-1` → 5) and the default-5 tests stay green.