### PR TITLE
Treat `remove_column` with options but no type as irreversible

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -239,7 +239,9 @@ module ActiveRecord
         end
 
         def invert_remove_column(args)
-          raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type." if args.size <= 2
+          if args.size <= 2 || args[2].is_a?(Hash)
+            raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type."
+          end
           super
         end
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -295,6 +295,12 @@ module ActiveRecord
         end
       end
 
+      def test_invert_remove_column_with_options_but_no_type
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :remove_column, [:table, :column, { null: false }]
+        end
+      end
+
       def test_invert_rename_column
         rename = @recorder.inverse_of :rename_column, [:table, :old, :new]
         assert_equal [:rename_column, [:table, :new, :old]], rename


### PR DESCRIPTION
### Summary

`remove_column :users, :name, null: false` (options given, but no column type) passes `CommandRecorder`'s reversibility guard and produces a broken `add_column` inverse. Rolling such a migration back crashes with a cryptic error instead of raising the clear `IrreversibleMigration` the guard was meant to produce.

### Problem

```ruby
def invert_remove_column(args)
  raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type." if args.size <= 2
  super
end
```

The `args.size <= 2` check intends to require a column type, but `remove_column :users, :name, null: false` records its args as `[:users, :name, { null: false }]` — size 3 — so the guard passes. `super` then builds the inverse `[:add_column, [:users, :name, { null: false }], block]`, placing the **options Hash in the type position**.

On rollback the resulting `add_column` crashes:

- through a real migration's `change`/rollback: `ArgumentError: wrong number of arguments (given 2, expected 3)` (the recorded `null: false` is treated as keyword args, leaving `add_column` with only two positionals);
- with the Hash kept positional: `NoMethodError: undefined method 'to_sym' for an instance of Hash`.

Either way the user gets a confusing failure deep in schema code instead of the actionable "remove_column is only reversible if given a type." message.

### Why this is a bug, not a fluke

- The class documents the contract explicitly: `command_recorder.rb` lists "remove_column (must supply a type)".
- The sibling `invert_remove_columns` already enforces it correctly by checking for a real type: `args[-1].is_a?(Hash) && args[-1].has_key?(:type)`. `invert_remove_column` simply never got the equivalent check.

### Fix

Mirror the sibling: also treat a Hash in the type slot as "no type given".

```ruby
def invert_remove_column(args)
  if args.size <= 2 || args[2].is_a?(Hash)
    raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type."
  end
  super
end
```

A genuine type still passes (`remove_column :users, :name, :string, null: false` → `[:users, :name, :string, { null: false }]`, where `args[2]` is `:string`).

### Test

`test/cases/migration/command_recorder_test.rb` asserts `inverse_of(:remove_column, [:table, :column, { null: false }])` raises `IrreversibleMigration`. Red before the fix (nothing raised — a crashing `add_column` was produced), green after; the existing reversible case (`[:table, :column, :type, {}]`) and the existing no-type case (`[:table, :column]`) stay green.