### PR TITLE
Exclude all composite primary key components from `content_columns`

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -520,7 +520,7 @@ module ActiveRecord
       # and columns used for single table inheritance have been removed.
       def content_columns
         @content_columns ||= columns.reject do |c|
-          c.name == primary_key ||
+          Array(primary_key).include?(c.name) ||
           c.name == inheritance_column ||
           c.name.end_with?("_id", "_count")
         end.freeze

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -34,6 +34,7 @@ require "models/admin"
 require "models/admin/user"
 require "models/user"
 require "models/dats"
+require "models/cpk/book"
 
 class ReflectionTest < ActiveRecord::TestCase
   include ActiveRecord::Reflection
@@ -70,6 +71,10 @@ class ReflectionTest < ActiveRecord::TestCase
     content_column_names   = content_columns.map(&:name)
     assert_equal 14, content_columns.length
     assert_equal %w(title author_name author_email_address written_on bonus_time last_read content important binary_content group approved parent_title created_at updated_at).sort, content_column_names.sort
+  end
+
+  def test_content_columns_excludes_all_composite_primary_key_components
+    assert_equal %w(title revision), Cpk::Book.content_columns.map(&:name)
   end
 
   def test_column_string_type_and_limit


### PR DESCRIPTION
### Summary

`content_columns` does not exclude composite primary key (CPK) components. The bare `"id"` component of a CPK leaks into the result, contradicting both the documented behavior ("the primary id ... removed") and the single-primary-key behavior.

### Problem

```ruby
def content_columns
  @content_columns ||= columns.reject do |c|
    c.name == primary_key ||
    c.name == inheritance_column ||
    c.name.end_with?("_id", "_count")
  end.freeze
end
```

For a composite primary key, `primary_key` returns an Array (e.g. `["author_id", "id"]`), so `c.name == primary_key` compares a String against an Array and is always false — no PK component is rejected by that clause. The other components happen to be dropped only incidentally: `author_id` ends with `_id`, but the bare `"id"` matches none of the rules and leaks through:

```ruby
Cpk::Book.primary_key            # => ["author_id", "id"]
Cpk::Book.content_columns.map(&:name)
# => ["id", "title", "revision"]   # expected ["title", "revision"]
```

### Fix

Use `Array(primary_key)`, the established CPK idiom already used throughout the codebase (`model_schema.rb`, `persistence.rb`, `relation/batches.rb`, `relation/calculations.rb`):

```ruby
Array(primary_key).include?(c.name) ||
```

This excludes every PK component regardless of its name (not just the ones that happen to end in `_id`), and is safe for both the single-key case (`Array("id").include?(c.name)`) and the no-primary-key case (`Array(nil)` is `[]`, matching the previous `c.name == nil` which was likewise always false).

### Test

`test/cases/base_test.rb` asserts that `Cpk::Book` (primary key `[:author_id, :id]`) yields `content_columns == %w(title revision)`. Red before the fix (`["id", "title", "revision"]` — the bare `id` leaks), green after; the existing single-primary-key `content_columns` test (`Topic`) stays green.