### PR TITLE
Clean up the subscription slot when subscribe_to_channel raises

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -76,7 +76,18 @@ module ActionCable
 
         if subscription
           subscriptions[id_key] = subscription
-          subscription.subscribe_to_channel
+
+          successfully_subscribed = false
+          begin
+            subscription.subscribe_to_channel
+            successfully_subscribed = true
+          ensure
+            # Don't leave a half-initialized subscription occupying the
+            # identifier's slot if subscribe_to_channel raised: it would reject
+            # every later subscribe for that identifier with AlreadySubscribedError
+            # until the connection is torn down.
+            subscriptions.delete(id_key) unless successfully_subscribed
+          end
         else
           id_options = ActiveSupport::JSON.decode(id_key).with_indifferent_access
           raise ChannelNotFound, id_options[:channel]

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -37,6 +37,12 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     end
   end
 
+  class FailToSubscribeChannel < ActionCable::Channel::Base
+    def subscribed
+      raise ChatChannelError.new("Uh Oh")
+    end
+  end
+
   setup do
     @server = TestServer.new
     @chat_identifier = ActiveSupport::JSON.encode(id: 1, channel: "ActionCable::Connection::SubscriptionsTest::ChatChannel")
@@ -94,6 +100,24 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     end
 
     assert_equal 1, @subscriptions.identifiers.size
+  end
+
+  test "subscribe command does not leave a slot when subscribe_to_channel raises" do
+    setup_connection
+
+    identifier = ActiveSupport::JSON.encode(id: 1, channel: "ActionCable::Connection::SubscriptionsTest::FailToSubscribeChannel")
+    subscribe = -> { @subscriptions.execute_command "command" => "subscribe", "identifier" => identifier }
+
+    # `add` inserts the slot, then `subscribe_to_channel` runs `subscribed`,
+    # which raises. The half-initialized subscription must not be left behind...
+    assert_raises(ChatChannelError) { subscribe.call }
+    assert_empty @subscriptions.identifiers
+
+    # ...otherwise the slot stays "poisoned": the same identifier could never be
+    # subscribed again, every retry being rejected with AlreadySubscribedError.
+    # Here the retry instead reaches the channel again (raising ChatChannelError),
+    # proving the slot was freed.
+    assert_raises(ChatChannelError) { subscribe.call }
   end
 
   test "unsubscribe command" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because a failed `subscribe_to_channel` leaves a half-initialized subscription stranded in the connection's `subscriptions` hash, permanently poisoning that identifier's slot.

`Connection::Subscriptions#add` inserts the subscription into the hash before calling `subscribe_to_channel`:

```ruby
subscriptions[id_key] = subscription
subscription.subscribe_to_channel
```

If `subscribe_to_channel` raises (e.g. an exception in the channel's `subscribed` or a `before_subscribe` callback), the entry is never removed. Since `add` raises `AlreadySubscribedError` when the key is already present, every later subscribe for that identifier is rejected for the lifetime of the connection, and the client's `SubscriptionGuarantor` retries it forever.

### Detail

This Pull Request changes `add` to remove the entry when `subscribe_to_channel` does not complete successfully.

Reordering (subscribe first, insert after) is **not** an option: the insert-before-subscribe order is intentional, because `subscribe_to_channel` may call `reject_subscription`, which removes the entry via `connection.subscriptions.remove_subscription`. So the fix wraps `subscribe_to_channel` and deletes the entry only on a non-successful subscribe, leaving the rejection and success paths untouched:

```ruby
subscriptions[id_key] = subscription

successfully_subscribed = false
begin
  subscription.subscribe_to_channel
  successfully_subscribed = true
ensure
  subscriptions.delete(id_key) unless successfully_subscribed
end
```

A test subscribes a channel whose `subscribed` raises, then asserts the identifier is not left in `identifiers` and that the same identifier can be subscribed again (reaching the channel instead of being rejected with `AlreadySubscribedError`).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
