### PR TITLE
Coerce `seeds` and `use_metadata_table` booleans in `UrlConfig`

### DIFF
--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -52,6 +52,8 @@ module ActiveRecord
 
         to_boolean!(@configuration_hash, :replica)
         to_boolean!(@configuration_hash, :database_tasks)
+        to_boolean!(@configuration_hash, :seeds)
+        to_boolean!(@configuration_hash, :use_metadata_table)
 
         @configuration_hash.freeze
       end

--- a/activerecord/test/cases/database_configurations/url_config_test.rb
+++ b/activerecord/test/cases/database_configurations/url_config_test.rb
@@ -51,6 +51,16 @@ module ActiveRecord
         config = UrlConfig.new("default_env", "primary", "postgres://localhost/foo?database_tasks=false", {})
         assert_equal false, config.database_tasks?
       end
+
+      def test_seeds_parsing
+        config = UrlConfig.new("default_env", "primary", "postgres://localhost/foo?seeds=false", {})
+        assert_equal false, config.seeds?
+      end
+
+      def test_use_metadata_table_parsing
+        config = UrlConfig.new("default_env", "primary", "postgres://localhost/foo?use_metadata_table=false", {})
+        assert_equal false, config.use_metadata_table?
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

`UrlConfig` runs `to_boolean!` on `:replica` and `:database_tasks` so that `?replica=false` / `?database_tasks=false` in a `DATABASE_URL` actually disable those flags. A query string value always arrives as a String, so `"false"` is truthy unless it is coerced. But `:seeds` and `:use_metadata_table` were left as the raw query string.

This was an oversight in 63631e2d5b ("Make `schema_dump`, `query_cache`, `replica` and `database_tasks` configurable via `DATABASE_URL`"), whose stated intent was to handle *all* the boolean configs:

> I went a bit farther and handled all the boolean configs, not just `schema_cache`.

`seeds` and `use_metadata_table` are boolean configs that were missed, so they don't yet honor a `DATABASE_URL` query string.

### Problem

```ruby
to_boolean!(@configuration_hash, :replica)
to_boolean!(@configuration_hash, :database_tasks)
# :seeds and :use_metadata_table missing
```

`seeds?` is defined as `configuration_hash.fetch(:seeds, primary?)` and `use_metadata_table?` as `configuration_hash.fetch(:use_metadata_table, true)`, both returning the stored value as-is.

So `postgres://host/db?seeds=false` leaves `configuration_hash[:seeds] == "false"` (truthy) and `seeds?` still returns a truthy value — the `db:prepare` seeding is not disabled. The same applies to `use_metadata_table?`.

### Fix

Coerce both the same way, conforming to the existing `:replica` / `:database_tasks` handling:

```ruby
to_boolean!(@configuration_hash, :seeds)
to_boolean!(@configuration_hash, :use_metadata_table)
```

### Test

`test/cases/database_configurations/url_config_test.rb` asserts `?seeds=false` → `seeds? == false` and `?use_metadata_table=false` → `use_metadata_table? == false`, mirroring the existing `database_tasks` parsing test. Red before the fix (`"false"` String), green after.