### PR TITLE
Don't remap `write_attribute("id")` to a composite primary key

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         name = attr_name.to_s
         name = self.class.attribute_aliases[name] || name
 
-        name = @primary_key if name == "id" && @primary_key
+        name = @primary_key if name == "id" && @primary_key.is_a?(String)
         @attributes.write_from_user(name, value)
       end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -167,6 +167,14 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "nick", pk.name, "nick should be primary key"
   end
 
+  def test_write_attribute_with_id_on_composite_primary_key_model
+    # write_attribute("id") must hit the literal "id" column, symmetric with
+    # read_attribute, not remap to the composite primary key Array.
+    book = Cpk::Book.new
+    book.write_attribute("id", 5)
+    assert_equal 5, book.read_attribute("id")
+  end
+
   def test_primary_key_with_no_id
     assert_nil Edge.primary_key
   end


### PR DESCRIPTION
### Summary

For composite primary key models, `write_attribute("id", value)` (and `record["id"] = value`) raises a confusing `ActiveModel::MissingAttributeError: can't write unknown attribute ["author_id", "id"]`, even though `read_attribute("id")` / `record["id"]` work fine and read the literal `id` column. This restores read/write symmetry by only remapping `"id"` to the primary key when the primary key is a scalar.

### Problem

`write_attribute` remaps `"id"` to `@primary_key` so that `record.id =` / `write_attribute("id", v)` target a custom single-column primary key:

```ruby
name = @primary_key if name == "id" && @primary_key
```

For a composite primary key, `@primary_key` is an Array, so the remap feeds an Array key into `write_from_user`:

```ruby
# Cpk::Book has primary_key [:author_id, :id] and a literal "id" column
book = Cpk::Book.new
book.write_attribute("id", 5)
# => ActiveModel::MissingAttributeError: can't write unknown attribute ["author_id", "id"]
book["id"] = 5
# => same error ([]= delegates to write_attribute)
```

This is asymmetric with reads. `read_attribute` does no such remap — it reads the literal `"id"` column — so on the same model the read path works while the write path crashes:

```ruby
book.read_attribute("id")  # => reads the literal "id" column, no error
book["id"]                 # => reads the literal "id" column, no error
```

The composite-PK semantics of `id` / `id=` are handled separately by `ActiveRecord::AttributeMethods::CompositePrimaryKey` (which maps/zips over `@primary_key`), so the generic low-level `write_attribute("id")` path treating `"id"` as the literal column does not conflict with the high-level API.

### Fix

Only remap when the primary key is a scalar; for a composite PK, `write_attribute("id")` now writes the literal `"id"` column, symmetric with `read_attribute`:

```ruby
name = @primary_key if name == "id" && @primary_key.is_a?(String)
```

`write_attribute` is a hot path, but the added `is_a?(String)` check only runs when `name == "id"`, so the cost is negligible. The check also preserves all existing behavior:

- scalar custom PK (e.g. `self.primary_key = "nick"`): `@primary_key` is a String → remap still applies, unchanged.
- no primary key (e.g. `Edge`, `primary_key == nil`): `nil.is_a?(String)` is false → no remap, same as the previous `&& @primary_key` truthiness guard.
- composite PK: `@primary_key` is an Array → no remap, writes the literal `"id"` column.

### Test

`test/cases/base_test.rb` asserts `Cpk::Book.new.write_attribute("id", 5)` followed by `read_attribute("id") == 5`. Red before the fix (`MissingAttributeError` with the Array key), green after. The `primary_keys` and `attribute_methods` suites stay green (the scalar custom-PK `id` remap is preserved).