### PR TITLE
Raise RecordNotFound for `find(nil)` on a composite primary key model

### DIFF
--- a/activerecord/lib/active_record/key.rb
+++ b/activerecord/lib/active_record/key.rb
@@ -148,7 +148,7 @@ module ActiveRecord
       # A single composite id is itself an Array, so several ids are an Array of
       # Arrays.
       def expects_multiple_ids?(value)
-        value.first.is_a?(Array)
+        value.is_a?(Array) && value.first.is_a?(Array)
       end
 
       # When a composite key has the conventional [tenant_key, "id"] shape,

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -154,6 +154,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal "id", exception.primary_key
   end
 
+  def test_find_with_no_id_passed_on_composite_primary_key_model
+    assert_raises(ActiveRecord::RecordNotFound) { Cpk::Book.find }
+    assert_raises(ActiveRecord::RecordNotFound) { Cpk::Book.find(nil) }
+  end
+
   def test_find_with_ids_with_id_out_of_range
     exception = assert_raises(ActiveRecord::RecordNotFound) do
       Topic.find("9999999999999999999999999999999")


### PR DESCRIPTION
### Problem

On a composite primary key model, `Model.find(nil)` and `Model.find` (no args) raise `NoMethodError: undefined method 'first' for nil` instead of the documented `ActiveRecord::RecordNotFound`. `Key::Composite#expects_multiple_ids?` lacks the nil guard its single-key sibling has:

```ruby
# Key::Single
def expects_multiple_ids?(value)
  value.is_a?(Array)            # nil-safe
end

# Key::Composite
def expects_multiple_ids?(value)
  value.first.is_a?(Array)      # nil.first => NoMethodError
end
```

The single-key path correctly surfaces `RecordNotFound: Couldn't find <Model> without an ID` (and tests it).

### Fix

Guard the composite check the same way:

```ruby
def expects_multiple_ids?(value)
  value.is_a?(Array) && value.first.is_a?(Array)
end
```

`nil` returns false → falls through to the proper `RecordNotFound`. 1 production line.

### Test

`activerecord/test/cases/finder_test.rb` (beside `test_find_with_ids_with_no_id_passed`) asserts `Cpk::Book.find` and `Cpk::Book.find(nil)` raise `RecordNotFound`. Red before (`NoMethodError`), green after; finder and primary_keys suites stay green.