### PR TITLE
Don't share the actions Hash across `ActionableError` subclasses

### DIFF
--- a/activesupport/lib/active_support/actionable_error.rb
+++ b/activesupport/lib/active_support/actionable_error.rb
@@ -43,7 +43,7 @@ module ActiveSupport
       #     end
       #   end
       def action(name, &block)
-        _actions[name] = block
+        self._actions = _actions.merge(name => block)
       end
     end
   end

--- a/activesupport/test/actionable_error_test.rb
+++ b/activesupport/test/actionable_error_test.rb
@@ -26,6 +26,16 @@ class ActionableErrorTest < ActiveSupport::TestCase
     assert_equal ["Flip 1", "Flip 2"], ActiveSupport::ActionableError.actions(DispatchableError.new).keys
   end
 
+  test "subclass actions are not leaked to the parent or sibling subclasses" do
+    base = Class.new(StandardError) { include ActiveSupport::ActionableError }
+    sub_a = Class.new(base) { action("A") { } }
+    sub_b = Class.new(base) { action("B") { } }
+
+    assert_equal [], ActiveSupport::ActionableError.actions(base).keys
+    assert_equal ["A"], ActiveSupport::ActionableError.actions(sub_a).keys
+    assert_equal ["B"], ActiveSupport::ActionableError.actions(sub_b).keys
+  end
+
   test "returns no actions for non-actionable errors" do
     assert_predicate ActiveSupport::ActionableError.actions(Exception), :empty?
     assert_predicate ActiveSupport::ActionableError.actions(Exception.new), :empty?


### PR DESCRIPTION
### Problem

`ActionableError.action` mutated the Hash that the `_actions` `class_attribute` defaults to:

```ruby
class_attribute :_actions, default: {}
# ...
def action(name, &block)
  _actions[name] = block
end
```

Subclasses inherit that default object until they assign their own, so an `action` defined in one subclass mutated the shared Hash and leaked into the parent and sibling subclasses. `ActionableError.actions(error)` / `dispatch` could then find actions never declared on that class.

### Fix

Reassign via copy-on-write, matching the other reassigning `class_attribute` writers (and the recent `StructuredEventSubscriber#debug_only` fix, #57676):

```ruby
def action(name, &block)
  self._actions = _actions.merge(name => block)
end
```

Inheritance is preserved because the merge starts from the inherited Hash. 1 production line.

### Test

`activesupport/test/actionable_error_test.rb` defines a base `ActionableError` and two subclasses each with one action, and asserts each class sees only its own action (and the base none). Red before (`["A", "B"]` leaked onto the base), green after; the existing actions/inheritance tests stay green.