### PR TITLE
Return an Enumerator from `Parameters#select` / `#reject` when no block is given

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -1001,6 +1001,7 @@ module ActionController
     # Returns a new `ActionController::Parameters` instance with only items that the
     # block evaluates to true.
     def select(&block)
+      return to_enum(:select) unless block_given?
       new_instance_with_inherited_permitted_status(@parameters.select(&block))
     end
 
@@ -1014,6 +1015,7 @@ module ActionController
     # Returns a new `ActionController::Parameters` instance with items that the
     # block evaluates to true removed.
     def reject(&block)
+      return to_enum(:reject) unless block_given?
       new_instance_with_inherited_permitted_status(@parameters.reject(&block))
     end
 

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -288,6 +288,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_predicate @params.reject { |k| k == "person" }, :permitted?
   end
 
+  test "reject without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.reject
+    assert_kind_of ActionController::Parameters, @params.reject.each { |k, v| false }
+  end
+
   test "select retains permitted status" do
     @params.permit!
     assert_predicate @params.select { |k| k == "person" }, :permitted?
@@ -295,6 +300,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "select retains unpermitted status" do
     assert_not_predicate @params.select { |k| k == "person" }, :permitted?
+  end
+
+  test "select without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.select
+    assert_kind_of ActionController::Parameters, @params.select.each { |k, v| true }
   end
 
   test "slice retains permitted status" do


### PR DESCRIPTION
### Problem

`ActionController::Parameters` mirrors `Hash` and guards the no-block case of its Enumerable wrappers with `return to_enum(...) unless block_given?` — `each_pair`, `each_value`, `transform_values`, `transform_values!`, `transform_keys`, `transform_keys!` all do. The paired `#select` and `#reject` were missing that guard:

```ruby
def select(&block)
  new_instance_with_inherited_permitted_status(@parameters.select(&block))
end
```

Called without a block, `@parameters.select(&nil)` returns a bare `Enumerator`, which is passed into `new_instance_with_inherited_permitted_status` → `each_key` → `NoMethodError: undefined method 'each_key' for an instance of Enumerator`. `Hash#select` / `#reject` return an Enumerator block-less (supporting `select.with_index { }`).

### Fix

Add the same guard as the sibling wrappers (verbatim mirror of `transform_values`):

```ruby
def select(&block)
  return to_enum(:select) unless block_given?
  ...
end
```

2 production lines.

### Test

`actionpack/test/controller/parameters/accessors_test.rb` adds `select` / `reject` twins of the existing "transform_values without a block returns an enumerator" test. Red before (NoMethodError), green after; full accessors suite stays green.