### PR TITLE
Don't log a dangling "with arguments:" for jobs with no arguments

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -199,7 +199,7 @@ module ActiveJob
       end
 
       def args_info(event)
-        if (arguments = event[:payload][:arguments])
+        if (arguments = event[:payload][:arguments]) && arguments.any?
           " with arguments: " +
             arguments.map { |arg| format(arg).inspect }.join(", ")
         else

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -8,6 +8,7 @@ require "jobs/hello_job"
 require "jobs/logging_job"
 require "jobs/overridden_logging_job"
 require "jobs/nested_job"
+require "jobs/configuration_job"
 require "jobs/rescue_job"
 require "jobs/retry_job"
 require "jobs/disable_log_job"
@@ -84,6 +85,13 @@ class LoggingTest < ActiveSupport::TestCase
     end
 
     assert_match(/Enqueued HelloJob \(Job ID: .*?\) to .*?:.*Cristian/, @logger.messages)
+  end
+
+  def test_enqueue_job_with_no_arguments_omits_the_arguments_suffix
+    ConfigurationJob.perform_later
+
+    assert_match(/Enqueued ConfigurationJob/, @logger.messages)
+    assert_no_match(/with arguments:/, @logger.messages)
   end
 
   def test_enqueue_job_log_error_when_callback_chain_is_halted


### PR DESCRIPTION
### Problem

The structured-event rewrite of `ActiveJob::LogSubscriber#args_info` dropped the empty-arguments guard:

```ruby
# before: if job.class.log_arguments? && job.arguments.any?
def args_info(event)
  if (arguments = event[:payload][:arguments])
    " with arguments: " + arguments.map { ... }.join(", ")
  else
    ""
  end
end
```

`event[:payload][:arguments]` is an empty array `[]` for an argument-less job, which is truthy, so every no-arg job's Enqueued/Performing lines now end with a dangling `with arguments: ` (suffix present, nothing after).

### Fix

Restore the prior `.any?` check:

```ruby
if (arguments = event[:payload][:arguments]) && arguments.any?
```

1 production line.

### Test

`activejob/test/cases/logging_test.rb` enqueues a no-argument job (`ConfigurationJob`) and asserts the log has no `with arguments:`. Red before (dangling suffix on both Enqueued and Performing lines), green after; full logging suite stays green.