### PR TITLE
Fix `retry_on` `wait:` proc with an optional argument

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -185,7 +185,7 @@ module ActiveJob
           delay + delay_jitter
         when Proc
           algorithm = seconds_or_duration_or_algorithm
-          algorithm.arity == 1 ? algorithm.call(executions) : algorithm.call(executions, error)
+          algorithm.arity == 2 || algorithm.arity < -1 ? algorithm.call(executions, error) : algorithm.call(executions)
         else
           raise "Couldn't determine a delay based on #{seconds_or_duration_or_algorithm.inspect}"
         end

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -266,6 +266,20 @@ class ExceptionsTest < ActiveSupport::TestCase
       ], JobBuffer.values
     end
 
+    test "custom wait proc with an optional argument" do
+      travel_to Time.now
+
+      RetryJob.perform_later "OptionalArgWaitError", 3, :log_scheduled_at
+
+      assert_equal [
+        "Raised OptionalArgWaitError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 2.seconds).to_f}",
+        "Raised OptionalArgWaitError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 4.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+
     test "custom wait proc can use the error" do
       travel_to Time.now
 

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -12,6 +12,7 @@ class LongWaitError < StandardError; end
 class ShortWaitTenAttemptsError < StandardError; end
 class PolynomialWaitTenAttemptsError < StandardError; end
 class CustomWaitTenAttemptsError < StandardError; end
+class OptionalArgWaitError < StandardError; end
 class RetryWaitIncludedInError < StandardError
   def retry_after
     10
@@ -35,6 +36,7 @@ class RetryJob < ActiveJob::Base
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10
   retry_on PolynomialWaitTenAttemptsError, wait: :polynomially_longer, attempts: 10
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10
+  retry_on OptionalArgWaitError, wait: ->(executions = 0) { executions * 2 }, attempts: 10
   retry_on RetryWaitIncludedInError, wait: ->(executions, error) { error.retry_after + executions }
   retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
   retry_on(ActiveJob::DeserializationError) { |job, error| JobBuffer.add("Raised #{error.class} for the #{job.executions} time") }


### PR DESCRIPTION
### Problem

The two-argument `wait:` proc feature dispatched on strict `arity == 1`:

```ruby
algorithm.arity == 1 ? algorithm.call(executions) : algorithm.call(executions, error)
```

A proc declared with an optional parameter — `->(executions = 0) { ... }` — has arity `-1`, so it fell into the `else` branch and was called with two arguments, raising `ArgumentError`. The two-argument feature was designed to be backward compatible with existing single-argument procs, but this edge case was not covered.

### Fix

Decide by whether the callable actually accepts a second argument:

```ruby
algorithm.arity == 2 || algorithm.arity < -1 ? algorithm.call(executions, error) : algorithm.call(executions)
```

- `->(executions)` (1) and `->(executions = 0)` (-1) → one argument
- `->(executions, error)` (2) and `->(executions, *rest)` (-2) → both arguments

1 production line.

### Test

`activejob/test/jobs/retry_job.rb` gains a `retry_on ..., wait: ->(executions = 0) { executions * 2 }` declaration and `activejob/test/cases/exceptions_test.rb` a test that the job retries on the expected schedule (run with `AJ_ADAPTER=test`). Red before (`ArgumentError` during retry), green after; the existing 1-arg and 2-arg `wait:` proc tests stay green.