### PR TITLE
Include adapter in Active Job `perform_start` event payload

### DIFF
--- a/activejob/lib/active_job/structured_event_subscriber.rb
+++ b/activejob/lib/active_job/structured_event_subscriber.rb
@@ -72,10 +72,12 @@ module ActiveJob
 
     def perform_start(event)
       job = event.payload[:job]
+      adapter = event.payload[:adapter]
       payload = {
         job_class: job.class.name,
         job_id: job.job_id,
         queue: job.queue_name,
+        adapter: ActiveJob.adapter_name(adapter),
         enqueued_at: job.enqueued_at&.utc&.iso8601(9),
       }
       if job.class.log_arguments?

--- a/activejob/test/cases/structured_event_subscriber_test.rb
+++ b/activejob/test/cases/structured_event_subscriber_test.rb
@@ -129,7 +129,8 @@ module ActiveJob
     def test_perform_start_job
       event = assert_event_reported("active_job.started", payload: {
         job_class: TestJob.name,
-        queue: "default"
+        queue: "default",
+        adapter: ActiveJob.adapter_name(ActiveJob::Base.queue_adapter)
       }) do
         TestJob.perform_now
       end


### PR DESCRIPTION
## Summary

`ActiveJob::StructuredEventSubscriber#perform_start` builds its event payload without an `:adapter` key, unlike every other event in the same subscriber (`enqueue`, `enqueue_at`, `enqueue_all`, `perform`), each of which includes `adapter: ActiveJob.adapter_name(adapter)`.

`ActiveJob::LogSubscriber#started` renders the queue through the private `queue_name` helper, which reads `:adapter` and `:queue` from the event payload and formats them as `adapter(queue)`. Because `:adapter` is missing from the `started` payload, the "Performing ... from" log line drops the adapter name.

## Behavior

For a job run on, say, the async adapter, the two log lines for a single job disagree:

```
Performing TestJob (Job ID: ...) from (default)            # started  -> adapter missing
Performed  TestJob (Job ID: ...) from Async(default) in 0.3ms   # completed -> adapter present
```

Expected: both lines read `from Async(default)`.

Structured-event consumers of `active_job.started` likewise lose the adapter dimension that every sibling event carries.

## Root cause

The adapter is already present on the notification payload — `Instrumentation#instrument` sets `payload[:adapter] = queue_adapter` for every operation, including `perform_start`. The subscriber simply did not forward it into the emitted event for this one event.

## Fix

Forward the adapter exactly like the sibling events do (2 production lines):

```ruby
def perform_start(event)
  job = event.payload[:job]
  adapter = event.payload[:adapter]
  payload = {
    job_class: job.class.name,
    job_id: job.job_id,
    queue: job.queue_name,
    adapter: ActiveJob.adapter_name(adapter),
    enqueued_at: job.enqueued_at&.utc&.iso8601(9),
  }
  ...
```

## Tests

`test_perform_start_job` previously asserted only `job_class` and `queue`, so the missing adapter was invisible. It now asserts `adapter:` like the sibling `test_enqueue_job` / `test_enqueue_at_job`.

- Before fix: RED — `active_job.started` payload has no `:adapter`, while the `active_job.completed` payload from the same job reports `adapter: "Inline"`.
- After fix: GREEN.

```
activejob/test/cases/structured_event_subscriber_test.rb  -> 11 runs, 24 assertions, 0 failures
activejob/test/cases/logging_test.rb                      -> 39 runs, 186 assertions, 0 failures
```

## Notes

- No CHANGELOG entry (simple bug fix, no behavior change beyond restoring the dropped adapter).
- The new structured-event/`EventReporter` log subscriber path is not part of any released tag, so this is not a user-facing regression in a shipped release.