### PR TITLE
Fix `max_resumptions` attribute name in `ResumeLimitError` docs

### DIFF
--- a/activejob/lib/active_job/continuation.rb
+++ b/activejob/lib/active_job/continuation.rb
@@ -223,7 +223,7 @@ module ActiveJob
     class UnadvanceableCursorError < Error; end
 
     # Raised when a job has reached its limit of the number of resumes.
-    # The limit is defined by the +max_resumes+ class attribute.
+    # The limit is defined by the +max_resumptions+ class attribute.
     class ResumeLimitError < Error; end
 
     include Validation


### PR DESCRIPTION
### Summary

The RDoc for `ActiveJob::Continuation::ResumeLimitError` refers to a `max_resumes` class attribute:

```ruby
# Raised when a job has reached its limit of the number of resumes.
# The limit is defined by the +max_resumes+ class attribute.
class ResumeLimitError < Error; end
```

There is no `max_resumes` attribute. The class attribute is named `max_resumptions` — defined in `ActiveJob::Continuable` and documented correctly everywhere else in the same file (the configuration list and the `Example` block both use `max_resumptions`).

A reader copying `self.max_resumes = 3` from this comment would get `NoMethodError: undefined method 'max_resumes='`.

### Fix

One-word documentation correction: `+max_resumes+` → `+max_resumptions+`.

Documentation only — tagged `[ci skip]`.