### PR TITLE
Accept a Float wait in `retry_on`

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -179,7 +179,7 @@ module ActiveJob
           delay = executions**4
           delay_jitter = determine_jitter_for_delay(delay, jitter)
           delay + delay_jitter + 2
-        when ActiveSupport::Duration, Integer
+        when ActiveSupport::Duration, Integer, Float
           delay = seconds_or_duration_or_algorithm.to_i
           delay_jitter = determine_jitter_for_delay(delay, jitter)
           delay + delay_jitter

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -119,6 +119,21 @@ class ExceptionsTest < ActiveSupport::TestCase
       end
     end
 
+    test "float wait job" do
+      travel_to Time.now
+      random_amount = 1
+      delay_for_jitter = random_amount * 2 * ActiveJob::Base.retry_jitter
+
+      Kernel.stub(:rand, random_amount) do
+        RetryJob.perform_later "FloatWaitError", 2, :log_scheduled_at
+        assert_equal [
+          "Raised FloatWaitError for the 1st time",
+          "Next execution scheduled at #{(Time.now + 2.seconds + delay_for_jitter).to_f}",
+          "Successfully completed job"
+        ], JobBuffer.values
+      end
+    end
+
     test "polynomially retrying job includes jitter" do
       travel_to Time.now
 

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -9,6 +9,7 @@ class ZeroJitterError < StandardError; end
 class FirstRetryableErrorOfTwo < StandardError; end
 class SecondRetryableErrorOfTwo < StandardError; end
 class LongWaitError < StandardError; end
+class FloatWaitError < StandardError; end
 class ShortWaitTenAttemptsError < StandardError; end
 class PolynomialWaitTenAttemptsError < StandardError; end
 class CustomWaitTenAttemptsError < StandardError; end
@@ -33,6 +34,7 @@ class RetryJob < ActiveJob::Base
   retry_on ZeroJitterError, jitter: 0.0
   retry_on FirstRetryableErrorOfTwo, SecondRetryableErrorOfTwo, attempts: 4
   retry_on LongWaitError, wait: 1.hour, attempts: 10
+  retry_on FloatWaitError, wait: 2.5, attempts: 10
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10
   retry_on PolynomialWaitTenAttemptsError, wait: :polynomially_longer, attempts: 10
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10


### PR DESCRIPTION
### Summary

`retry_on` documents `:wait` as "a delay specified either in seconds (default: 3 seconds)". An Integer wait works, and the public `set(wait: 2.5)` API already accepts a bare Float, but `retry_on ..., wait: 2.5` crashes:

```ruby
class FloatWaitJob < ActiveJob::Base
  retry_on SomeError, wait: 2.5, attempts: 3
  def perform; raise SomeError; end
end

FloatWaitJob.perform_now
# => RuntimeError: Couldn't determine a delay based on 2.5
```

`determine_delay` matches `ActiveSupport::Duration, Integer` but not a bare `Float`, so a Float falls through to the `else` branch and raises. Because this happens inside the `rescue_from` handler, it **replaces the original application exception** with a confusing internal error and the job is never re-enqueued.

```ruby
when ActiveSupport::Duration, Integer
  delay = seconds_or_duration_or_algorithm.to_i
  ...
else
  raise "Couldn't determine a delay based on #{seconds_or_duration_or_algorithm.inspect}"
```

### Fix

Match `Numeric` so a Float is handled like an Integer:

```ruby
when ActiveSupport::Duration, Numeric
  delay = seconds_or_duration_or_algorithm.to_i
```

`.to_i` is kept, so a Float wait truncates to whole seconds exactly as an `ActiveSupport::Duration` wait already does (`2.5.seconds` → 2). This keeps the change minimal and avoids altering the long-standing delay granularity; enabling genuine sub-second delays would be a separate decision (it depends on adapter support).

### Tests

Added `FloatWaitError` to the retry test job (`wait: 2.5`) and a test asserting the retry is scheduled at the expected delay, mirroring the existing "long wait job" test.