### PR TITLE
Clear `enqueue_error` when re-enqueuing a job

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -82,6 +82,7 @@ module ActiveJob
     def enqueue(options = {})
       set(options)
       self.successfully_enqueued = false
+      self.enqueue_error = nil
 
       raw_enqueue
 

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -66,6 +66,20 @@ class QueuingTest < ActiveSupport::TestCase
     end
   end
 
+  test "enqueue_error is cleared when the same job is successfully re-enqueued" do
+    EnqueueErrorJob::EnqueueErrorAdapter.should_raise_sequence = [ true, false ]
+    job = EnqueueErrorJob.new
+
+    assert_equal false, job.enqueue
+    assert_equal ActiveJob::EnqueueError, job.enqueue_error.class
+
+    assert_equal job, job.enqueue
+    assert job.successfully_enqueued?
+    assert_nil job.enqueue_error
+  ensure
+    EnqueueErrorJob::EnqueueErrorAdapter.should_raise_sequence = []
+  end
+
   test "run multiple queued jobs" do
     ActiveJob.perform_all_later(HelloJob.new("Jamie"), HelloJob.new("John"))
     assert_equal ["Jamie says hello", "John says hello"], JobBuffer.values.sort


### PR DESCRIPTION
### Summary

`ActiveJob::Enqueuing#enqueue` resets `successfully_enqueued` at the start of every enqueue, but leaves a stale `enqueue_error` from a previous failed attempt in place:

```ruby
def enqueue(options = {})
  set(options)
  self.successfully_enqueued = false
  # enqueue_error is not reset

  raw_enqueue
  ...
```

If the same job instance is enqueued again after a transient `EnqueueError` (e.g. retrying a flaky adapter), a successful second enqueue leaves the job in a contradictory state:

```ruby
job.enqueue                 # adapter raises EnqueueError -> returns false
job.enqueue                 # succeeds -> returns the job
job.successfully_enqueued?  # => true
job.enqueue_error           # => #<ActiveJob::EnqueueError ...>   (stale, should be nil)
```

This isn't only cosmetic: `ActiveJob::StructuredEventSubscriber#enqueue` computes `exception = event.payload[:exception_object] || job.enqueue_error`. On the successful re-enqueue there is no `:exception_object`, so it falls through to the stale `enqueue_error` and emits `exception_class`/`exception_message` for a job that actually enqueued successfully.

### Fix

Reset `enqueue_error` alongside `successfully_enqueued`:

```ruby
self.successfully_enqueued = false
self.enqueue_error = nil
```

### Tests

Added a test that fails the first enqueue and succeeds the second on the same instance, asserting `successfully_enqueued? == true` and `enqueue_error == nil`.