### PR TITLE
Pass the exception positionally when resuming a continuation after an error

### DIFF
--- a/activejob/lib/active_job/continuable.rb
+++ b/activejob/lib/active_job/continuable.rb
@@ -86,7 +86,7 @@ module ActiveJob
         raise
       rescue StandardError => e
         if resume_errors_after_advancing? && continuation.advanced?
-          resume_job(exception: e)
+          resume_job(e)
         else
           raise
         end

--- a/activejob/test/cases/continuation_test.rb
+++ b/activejob/test/cases/continuation_test.rb
@@ -251,6 +251,19 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
     end
   end
 
+  test "records the exception message as the exception_executions key when resuming after an error" do
+    IteratingRecord.records = [ 123, 432, 6565, 3243, 234, 13, 22 ].map { |i| IteratingRecord.new(i, "item_#{i}") }
+
+    IteratingJob.perform_later(raise_when_cursor: 433)
+
+    assert_enqueued_jobs 1, only: IteratingJob do
+      perform_enqueued_jobs
+    end
+
+    job = queue_adapter.enqueued_jobs.first
+    assert_equal({ "Cursor error" => 1 }, job["exception_executions"])
+  end
+
   test "passes the job to the queue adapter stopping predicate" do
     LinearJob.items = []
     LinearJob.perform_later


### PR DESCRIPTION
### Summary

When a continuable job raises a recoverable error after making progress, `ActiveJob::Continuable#continue` resumes it. The two resume branches disagree on how they call `resume_job`:

```ruby
rescue Continuation::Interrupt => e
  resume_job(e)            # positional
rescue Continuation::Error
  raise
rescue StandardError => e
  if resume_errors_after_advancing? && continuation.advanced?
    resume_job(exception: e)   # keyword-style
  else
    raise
  end
end
```

`resume_job` is defined with a single **positional** parameter and no keyword parameter:

```ruby
def resume_job(exception)
  executions_for(exception)
  ...
```

So `resume_job(exception: e)` binds the literal hash `{ exception: e }` to `exception`. `executions_for` then records the per-error counter under `{ exception: e }.to_s`, e.g.:

```ruby
# exception_executions
{ "{exception: #<StandardError: Cursor error>}" => 1 }   # before
{ "Cursor error" => 1 }                                  # after
```

The malformed key is serialized into the job's `exception_executions` on every error-triggered resume, and the two resume paths key the same data differently.

### Fix

Pass the exception positionally — matching the sibling Interrupt branch, which already does `resume_job(e)`. The parameter is literally named `exception`, so the intent is unambiguous.

### Tests

Added a test asserting that resuming after an error records `exception_executions` keyed by the exception message, consistent with the interrupt path.