### PR TITLE
Fix Active Storage variants re-processed when format is a Symbol

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix variants being re-processed on every request when a `format` is given as a Symbol.
+
+    A variation's digest is derived from its transformations via `Marshal.dump`,
+    which encodes a Symbol (e.g. `format: :webp`, as kept in memory for named
+    variants) differently from the String the message serializer produces when
+    decoding a signed variation key. The variant was therefore stored under one
+    digest but looked up under another, silently missing the cache and
+    re-processing the image on every request. The `format` is now normalized to a
+    UTF-8 String so both forms resolve to the same variant.
+
+    Fixes #57302.
+
+    *Hans Canonico*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -45,6 +45,16 @@ class ActiveStorage::Variation
 
   def initialize(transformations)
     @transformations = transformations.deep_symbolize_keys
+
+    if @transformations.key?(:format)
+      # Normalize the format to a UTF-8 String so that a variation referenced
+      # with a Symbol (e.g. +format: :webp+, as kept in memory for named
+      # variants) and the same variation decoded from a signed key (where the
+      # JSON message serializer turns it into a String) produce the same
+      # #digest. Otherwise the variant is stored under one digest but looked up
+      # under another, causing it to be re-processed on every request.
+      @transformations[:format] = @transformations[:format].to_s.encode(Encoding::UTF_8)
+    end
   end
 
   def default_to(defaults)

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -54,6 +54,24 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     assert_equal 67, image.height
   end
 
+  test "serving a variant processed with a Symbol format when looked up with a String format" do
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    # Variants defined in the model keep their format as a Symbol in memory.
+    assert_difference -> { blob.variant_records.count }, +1 do
+      blob.variant(resize_to_limit: [100, 100], format: :webp).processed
+    end
+
+    # When a variant is requested from a signed key, the message serializer can
+    # turn the format into a String (e.g. the JSON serializer). The String form
+    # must resolve to the same record instead of being re-processed.
+    variant = blob.variant(resize_to_limit: [100, 100], format: "webp")
+
+    assert_no_difference -> { blob.variant_records.count } do
+      variant.processed
+    end
+  end
+
   test "variant of a blob is on the same service" do
     blob = create_file_blob(filename: "racecar.jpg", service_name: "local_public")
     variant = blob.variant(resize_to_limit: [100, 100]).processed

--- a/activestorage/test/models/variation_test.rb
+++ b/activestorage/test/models/variation_test.rb
@@ -61,14 +61,28 @@ class ActiveStorage::VariationTest < ActiveSupport::TestCase
     variation = ActiveStorage::Variation.new(resize_to_limit: [100, 100])
       .default_to(format: :png)
 
-    assert_equal({ resize_to_limit: [100, 100], format: :png }, variation.transformations)
+    assert_equal({ resize_to_limit: [100, 100], format: "png" }, variation.transformations)
   end
 
   test "default_to does not override existing transformations" do
     variation = ActiveStorage::Variation.new(format: :jpg, resize_to_limit: [100, 100])
       .default_to(format: :png)
 
-    assert_equal({ format: :jpg, resize_to_limit: [100, 100] }, variation.transformations)
+    assert_equal({ format: "jpg", resize_to_limit: [100, 100] }, variation.transformations)
+  end
+
+  test "format is normalized to a UTF-8 string" do
+    variation = ActiveStorage::Variation.new(format: :webp, resize_to_limit: [100, 100])
+
+    assert_equal "webp", variation.transformations[:format]
+    assert_equal Encoding::UTF_8, variation.transformations[:format].encoding
+  end
+
+  test "variations have the same digest whether the format is a Symbol or a String" do
+    symbol_variation = ActiveStorage::Variation.new(format: :webp, resize_to_limit: [100, 100])
+    string_variation = ActiveStorage::Variation.new(format: "webp", resize_to_limit: [100, 100])
+
+    assert_equal symbol_variation.digest, string_variation.digest
   end
 
   test "format defaults to png" do
@@ -80,7 +94,7 @@ class ActiveStorage::VariationTest < ActiveSupport::TestCase
   test "format accepts valid extensions" do
     variation = ActiveStorage::Variation.new(resize_to_limit: [100, 100], format: :jpg)
 
-    assert_equal :jpg, variation.format
+    assert_equal "jpg", variation.format
   end
 
   test "format accepts uppercase string extensions" do


### PR DESCRIPTION
### Motivation / Background

Fixes #57302.

When an Active Storage variant is defined with a Symbol `format` (e.g. `format: :webp`), the variant is re-processed on every request instead of being served from the cache, causing severe, silent performance degradation. Changing `format: :webp` to `format: "webp"` works around it.

```ruby
has_one_attached :image do |attachable|
  attachable.variant :medium, format: :webp, resize_to_limit: [800, 800]
end

photo.image.variant(:medium).processed.url # re-processes every time
```

### Detail

A variation's `digest` (used as the lookup key for `ActiveStorage::VariantRecord`) is derived from its transformations via `Marshal.dump`. `Marshal` encodes the Symbol `:webp` differently from the String `"webp"` — and even `:webp.to_s` (US-ASCII) differs from a UTF-8 `"webp"`.

Named variants keep `format: :webp` as a **Symbol** in memory, so the variant is stored under the Symbol-based digest. But when the variant is later requested through its signed `variation_key`, the message verifier decodes it with the configured serializer — JSON since `load_defaults 7.1` (`config.active_support.message_serializer = :json_allow_marshal`) — which turns the format into a **String**. The lookup digest no longer matches the stored one, the cache silently misses, and the image is re-processed.

This is the same underlying inconsistency discussed in #54300.

**Fix:** normalize the `:format` transformation to a UTF-8 String in `ActiveStorage::Variation#initialize`, so the Symbol form and the String form produce the same `digest`. Variants already stored with a String format keep the same digest and are not invalidated; only the previously-broken Symbol case changes (it processes once more, then caches correctly).

### Additional information

- New unit tests in `variation_test.rb`: the `:format` is normalized to a UTF-8 String, Symbol vs String formats produce the same digest, and a variation decoded from its own signed `key` has the same digest as the in-memory one (this last test reproduces the actual bug and fails on `main`).
- New end-to-end test in `variant_with_record_test.rb`: a variant stored via the in-memory Symbol form is reused (not re-processed) when looked up via the decoded String form. Confirmed it fails before the fix (a second `VariantRecord` is created) and passes after.
- Applications still on the Marshal message serializer (`load_defaults` below 7.1) were internally consistent on the Symbol digest, so they never hit the bug; after this change they reprocess variants with an explicit `format:` once. Noted in the CHANGELOG.
- Only `format` is normalized. Other Symbol-valued transformations (e.g. `saver: { subsample_mode: :on }`) also change type through the JSON serializer, but a general normalization would change the digest of every existing variant that uses one, a much wider blast radius. `format` is the common case since Active Storage's own `default_variant_transformations` injects it. Complementary to #58473, which keeps transformation key order stable at enqueue time.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.

