### PR TITLE
Document max_connections/min_connections in Database Pooling guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -4482,15 +4482,28 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 Database Pooling
 ----------------
 
-Active Record database connections are managed by [`ActiveRecord::ConnectionAdapters::ConnectionPool`][] which ensures that a connection pool synchronizes the amount of thread access to a limited number of database connections. This limit defaults to 5 and can be configured in `database.yml`.
+Active Record database connections are managed by [`ActiveRecord::ConnectionAdapters::ConnectionPool`][] which ensures that a connection pool synchronizes the amount of thread access to a limited number of database connections. This limit defaults to 5 and can be configured in `database.yml` with the `max_connections` option.
 
 ```yaml
 development:
   adapter: sqlite3
   database: storage/development.sqlite3
-  pool: 5
+  max_connections: 5
   timeout: 5000
 ```
+
+You can also set `min_connections` to tell the pool how many connections to open up front and keep available even while idle (it defaults to `0`, meaning connections are only opened on demand):
+
+```yaml
+development:
+  adapter: sqlite3
+  database: storage/development.sqlite3
+  max_connections: 5
+  min_connections: 1
+  timeout: 5000
+```
+
+NOTE: The `max_connections` option was previously named `pool`. The `pool` option is still supported and is treated as an alias for `max_connections`, but `max_connections` is now preferred. Setting both `pool` and `max_connections` to different values, or combining `pool` with `min_connections`, raises an error.
 
 Since the connection pooling is handled inside of Active Record by default, all application servers (Thin, Puma, Unicorn, etc.) should behave the same. The database connection pool is initially empty. As demand for connections increases it will create them until it reaches the connection pool limit.
 
@@ -4505,7 +4518,7 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
 ```
 
 If you get the above error, you might want to increase the size of the
-connection pool by incrementing the `pool` option in `database.yml`
+connection pool by incrementing the `max_connections` option in `database.yml`
 
 NOTE. If you are running in a multi-threaded environment, there could be a chance that several threads may be accessing multiple connections simultaneously. So depending on your current request load, you could very well have multiple threads contending for a limited number of connections.
 


### PR DESCRIPTION
### Summary

The database pooling configuration options were renamed in #54175: `max_connections` is now the preferred name for the connection limit (previously `pool`), and `min_connections` was added to pre-open and maintain a minimum number of connections.

The generated `database.yml` templates already use `max_connections`, but the [Database Pooling](https://guides.rubyonrails.org/configuring.html#database-pooling) section of the configuration guide still documented the legacy `pool` option.

### Changes

- Use `max_connections` in the Database Pooling example and prose.
- Document `min_connections` with an example.
- Add a note explaining that `pool` remains supported as an alias for `max_connections`, that `max_connections` is now preferred, and that setting conflicting `pool`/`max_connections` values (or combining `pool` with `min_connections`) raises an error — matching the validation in `HashConfig`.

Scope is intentionally limited to the Database Pooling section. The `pool` examples in the DATABASE_URL merging section illustrate URL/hash merge mechanics where `pool` still works, so they're left unchanged to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)