### PR TITLE
Stop documenting the removed `args:` Hash form of `assert_enqueued_email_with`

### DIFF
--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -102,7 +102,7 @@ module ActionMailer
     #
     #   def test_email_with_parameters
     #     ContactMailer.with(greeting: "Hello").welcome.deliver_later
-    #     assert_enqueued_email_with ContactMailer, :welcome, args: { greeting: "Hello" }
+    #     assert_enqueued_email_with ContactMailer, :welcome, params: { greeting: "Hello" }
     #   end
     #
     #   def test_email_with_arguments
@@ -143,15 +143,6 @@ module ActionMailer
     #   def test_email_in_block
     #     assert_enqueued_email_with ContactMailer, :welcome do
     #       ContactMailer.welcome.deliver_later
-    #     end
-    #   end
-    #
-    # If +args+ is provided as a Hash, a parameterized email is matched.
-    #
-    #   def test_parameterized_email
-    #     assert_enqueued_email_with ContactMailer, :welcome,
-    #       args: {email: 'user@example.com'} do
-    #       ContactMailer.with(email: 'user@example.com').welcome.deliver_later
     #     end
     #   end
     def assert_enqueued_email_with(mailer, method, params: nil, args: nil, queue: nil, &block)


### PR DESCRIPTION
## Summary

The RDoc for `assert_enqueued_email_with` still teaches that passing a Hash to `:args` matches a parameterized email:

```ruby
# If +args+ is provided as a Hash, a parameterized email is matched.
#
#   def test_parameterized_email
#     assert_enqueued_email_with ContactMailer, :welcome,
#       args: {email: 'user@example.com'} do
#       ContactMailer.with(email: 'user@example.com').welcome.deliver_later
#     end
#   end
```

and the `test_email_with_parameters` example does the same with `args: { greeting: "Hello" }`.

That behavior was removed. The method now does:

```ruby
args = Array(args) unless args.is_a?(Proc)
...
params === job_kwargs[:params] && args === job_kwargs[:args]
```

so a Hash passed to `:args` becomes `[[:email, "user@example.com"]]` while `params` stays `nil`. The documented examples therefore **silently fail to match** a parameterized email (`nil === {email: ...}` is false). Anyone copying the docs gets a confusing assertion failure even though the email was enqueued correctly.

## Fix

Doc-only. Point the parameterized examples at `params:` (the supported form, already shown elsewhere in the same docstring) and remove the stale "If +args+ is provided as a Hash…" paragraph and its example.

## Why it matters

`assert_enqueued_email_with` is a commonly used test helper; the published RDoc actively teaches an idiom that was intentionally removed and now produces failing assertions — a classic doc-vs-code drift. Zero-risk `[ci skip]` change.

## Verification

The supported `params:` usage is already covered by the existing helper tests:

```
19 runs, 60 assertions, 0 failures, 0 errors, 0 skips
```

(`actionmailer/test/test_helper_test.rb`, `enqueued_email_with` filter.) No code change, so no new test is added.