### PR TITLE
Return an empty string from `word_wrap` when the text is nil

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -325,7 +325,7 @@ module ActionView
       #   word_wrap('Once upon a time', line_width: 1, break_sequence: "\r\n")
       #   # => "Once\r\nupon\r\na\r\ntime"
       def word_wrap(text, line_width: 80, break_sequence: "\n")
-        return +"" if text.empty?
+        return +"" if text.nil? || text.empty?
 
         # Match up to `line_width` characters, followed by one of
         #   (1) non-newline whitespace plus an optional newline

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -401,6 +401,11 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "", word_wrap("", line_width: 3)
   end
 
+  test "word_wrap with nil" do
+    assert_equal "", word_wrap(nil)
+    assert_equal "", word_wrap(nil, line_width: 3)
+  end
+
   def test_pluralization
     assert_equal("1 count", pluralize(1, "count"))
     assert_equal("2 counts", pluralize(2, "count"))


### PR DESCRIPTION
## Summary

`word_wrap` guards the empty-string case but crashes on `nil`:

```ruby
def word_wrap(text, line_width: 80, break_sequence: "\n")
  return +"" if text.empty?   # NoMethodError: undefined method 'empty?' for nil
```

```ruby
word_wrap(nil)   # => NoMethodError
word_wrap("")    # => ""  (handled)
```

Every sibling text helper tolerates `nil`:

- `truncate(nil)` → `nil`
- `highlight(nil, ...)` → `""`
- `simple_format(nil)` → `"<p></p>"`
- `excerpt(nil, ...)` → `nil`

`word_wrap` is the lone outlier that raises.

## Fix

Guard `nil` as well and return an empty string, matching the existing empty-string result:

```ruby
return +"" if text.nil? || text.empty?
```

(Deliberately scoped to `nil` rather than switching to `blank?`, so the behavior of whitespace-only strings is left untouched.)

## Why it matters

Passing a nullable model attribute or optional param straight into `word_wrap` in a view is common (`<%= word_wrap(@post.summary, line_width: 60) %>` with a NULL summary). The empty-string case is already handled and tested; `nil` should be too. One-line, conform-to-sibling.

## Test

Adds a `"word_wrap with nil"` test to `actionview/test/template/text_helper_test.rb`. It fails before the fix (`NoMethodError`) and passes after.

```
7 runs, 14 assertions, 0 failures, 0 errors, 0 skips