### PR TITLE
Apply the deprecated `scope` hash `:except` option to except, not only

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -989,7 +989,7 @@ module ActionDispatch
         def scope(*args, only: nil, except: nil, **options)
           if args.grep(Hash).any? && (deprecated_options = args.extract_options!)
             only ||= assign_deprecated_option(deprecated_options, :only, :scope)
-            only ||= assign_deprecated_option(deprecated_options, :except, :scope)
+            except ||= assign_deprecated_option(deprecated_options, :except, :scope)
             assign_deprecated_options(deprecated_options, options, :scope)
           end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -886,6 +886,22 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "replies#unmark_as_answer", @response.body
   end
 
+  def test_scope_with_deprecated_except_hash_option
+    assert_deprecated(ActionDispatch.deprecator) do
+      draw do
+        scope({ except: :destroy }) do
+          resources :posts
+        end
+      end
+    end
+
+    get "/posts"
+    assert_equal "posts#index", @response.body
+
+    delete "/posts/1"
+    assert_equal "pass", @response.headers["x-cascade"]
+  end
+
   def test_resource_routes_with_only_and_except
     draw do
       resources :posts, only: [:index, :show] do


### PR DESCRIPTION
## Summary

When `scope` is given the deprecated positional-hash form, the deprecated `:except` value is assigned to the `only` local variable instead of `except`:

```ruby
# actionpack/lib/action_dispatch/routing/mapper.rb
only ||= assign_deprecated_option(deprecated_options, :only, :scope)
only ||= assign_deprecated_option(deprecated_options, :except, :scope) # <- should be `except`
```

The `except` keyword local therefore never receives the value, so

```ruby
scope({ except: :destroy }) do
  resources :posts
end
```

is treated as if `only: :destroy` had been passed — the **opposite** of the request. The deprecated hash form silently generates only the `:destroy` route and drops every other action.

The keyword form `scope(except: :destroy)` is unaffected, so the two supported spellings of the same call disagree.

The bug was introduced in 3b4255e180 ("Use keywords in routing mapper"), which converted these methods from positional hashes to keyword arguments. A sibling issue in `namespace` (`:path` / `:shallow_path` / `:shallow_prefix` silently ignored) is addressed in #57740. 

## Fix

Assign the deprecated `:except` value to the `except` local, matching the keyword form and every other deprecated option in this file, which all map to the local of the same name.

```ruby
only   ||= assign_deprecated_option(deprecated_options, :only, :scope)
except ||= assign_deprecated_option(deprecated_options, :except, :scope)
```

## Why it matters

The deprecated positional-hash form is still supported, so apps mid-migration hit this. The failure is silent and inverts route generation, which is a behavior change rather than a crash — easy to ship to production unnoticed. One-token fix that conforms to the sibling keyword path.

## Test

Adds `test_scope_with_deprecated_except_hash_option` to `actionpack/test/dispatch/routing_test.rb`, exercising the deprecated hash form and asserting the `index` route survives while `destroy` is excluded. The test fails before the fix (`/posts` returns "Not Found", proving the `only: :destroy` inversion) and passes after.

```
2 runs, 13 assertions, 0 failures, 0 errors, 0 skips
```

(Run together with the existing `test_resource_routes_with_only_and_except`.)