### PR TITLE
Honor the deprecated `namespace` hash path options

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1097,9 +1097,9 @@ module ActionDispatch
         def namespace(name, deprecated_options = nil, as: DEFAULT, path: DEFAULT, shallow_path: DEFAULT, shallow_prefix: DEFAULT, **options, &block)
           if deprecated_options.is_a?(Hash)
             as = assign_deprecated_option(deprecated_options, :as, :namespace) if deprecated_options.key?(:as)
-            path ||= assign_deprecated_option(deprecated_options, :path, :namespace)  if deprecated_options.key?(:path)
-            shallow_path ||= assign_deprecated_option(deprecated_options, :shallow_path, :namespace) if deprecated_options.key?(:shallow_path)
-            shallow_prefix ||= assign_deprecated_option(deprecated_options, :shallow_prefix, :namespace)  if deprecated_options.key?(:shallow_prefix)
+            path = assign_deprecated_option(deprecated_options, :path, :namespace) if deprecated_options.key?(:path)
+            shallow_path = assign_deprecated_option(deprecated_options, :shallow_path, :namespace) if deprecated_options.key?(:shallow_path)
+            shallow_prefix = assign_deprecated_option(deprecated_options, :shallow_prefix, :namespace) if deprecated_options.key?(:shallow_prefix)
             assign_deprecated_options(deprecated_options, options, :namespace)
           end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1184,6 +1184,52 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "users/home#index", @response.body
   end
 
+  def test_namespace_with_deprecated_path_hash_option
+    assert_deprecated(ActionDispatch.deprecator) do
+      draw do
+        namespace :users, { path: "usuarios" } do
+          root to: "home#index"
+        end
+      end
+    end
+
+    get "/usuarios"
+    assert_equal "/usuarios", users_root_path
+    assert_equal "users/home#index", @response.body
+  end
+
+  def test_namespace_with_deprecated_shallow_path_hash_option
+    assert_deprecated(ActionDispatch.deprecator) do
+      draw do
+        namespace :foo, { shallow_path: "bar" } do
+          resources :posts, only: [:index, :show] do
+            resources :comments, only: [:index, :show], shallow: true
+          end
+        end
+      end
+    end
+
+    get "/bar/comments/2"
+    assert_equal "/bar/comments/2", foo_comment_path("2")
+    assert_equal "foo/comments#show", @response.body
+  end
+
+  def test_namespace_with_deprecated_shallow_prefix_hash_option
+    assert_deprecated(ActionDispatch.deprecator) do
+      draw do
+        namespace :foo, { shallow_prefix: "bar" } do
+          resources :posts, only: [:index, :show] do
+            resources :comments, only: [:index, :show], shallow: true
+          end
+        end
+      end
+    end
+
+    get "/foo/comments/2"
+    assert_equal "/foo/comments/2", bar_comment_path("2")
+    assert_equal "foo/comments#show", @response.body
+  end
+
   def test_namespaced_shallow_routes_with_module_option
     draw do
       namespace :foo, module: "bar" do


### PR DESCRIPTION
## Summary

`namespace` defaults its `:path`, `:shallow_path` and `:shallow_prefix` keywords to a **truthy** sentinel:

```ruby
DEFAULT = Object.new.freeze

def namespace(name, deprecated_options = nil, as: DEFAULT, path: DEFAULT,
              shallow_path: DEFAULT, shallow_prefix: DEFAULT, **options, &block)
  if deprecated_options.is_a?(Hash)
    as = assign_deprecated_option(deprecated_options, :as, :namespace) if deprecated_options.key?(:as)
    path ||= assign_deprecated_option(deprecated_options, :path, :namespace) if deprecated_options.key?(:path)
    shallow_path ||= ...
    shallow_prefix ||= ...
```

Because `path` (etc.) already hold the truthy `DEFAULT`, the `||=` never fires, so the deprecated hash values are dropped. Worse, with the value never read, `path` falls through to `path = name if path == DEFAULT` and the leftover key is re-injected into `**options`, producing a **doubled** path.

```ruby
namespace :admin, { path: "adm" } do  # deprecated hash form
  resources :posts
end
# routes generated at /admin/adm/...  (expected /adm/...)

namespace :foo, { shallow_path: "bar" } do ... end   # shallow_path ignored
namespace :foo, { shallow_prefix: "bar" } do ... end # shallow_prefix ignored
```

The keyword forms (`namespace :admin, path: "adm"`) work correctly, so the two supported spellings disagree. Note the adjacent `:as` handler already uses plain `=` with a `key?` guard — it is the one option that behaves correctly and shows the intended pattern.

The bug was introduced in 3b4255e180 ("Use keywords in routing mapper"), which converted these methods from positional hashes to keyword arguments. A sibling issue in `scope` (`:except` silently assigned to `only`, inverting route filtering) is addressed in #57739.

## Fix

Assign the three options with `=` guarded by `key?`, matching the `:as` sibling one line above:

```ruby
path = assign_deprecated_option(deprecated_options, :path, :namespace) if deprecated_options.key?(:path)
shallow_path = assign_deprecated_option(deprecated_options, :shallow_path, :namespace) if deprecated_options.key?(:shallow_path)
shallow_prefix = assign_deprecated_option(deprecated_options, :shallow_prefix, :namespace) if deprecated_options.key?(:shallow_prefix)
```

## Why it matters

The deprecated positional-hash form is still supported, so apps mid-migration silently get wrong/doubled paths and broken shallow nesting with no error. Mechanical `||=` → `=` change matching the adjacent correct handler.

## Test

Adds `test_namespace_with_deprecated_path_hash_option`, `test_namespace_with_deprecated_shallow_path_hash_option`, and `test_namespace_with_deprecated_shallow_prefix_hash_option` to `actionpack/test/dispatch/routing_test.rb`, mirroring the existing keyword tests in hash form. Before the fix all three fail (doubled `/users/usuarios`, `shallow_path`/`shallow_prefix` ignored / helper undefined); after the fix they pass alongside the existing keyword siblings.

```
6 runs, 27 assertions, 0 failures, 0 errors, 0 skips
```
