### PR TITLE
Return an Enumerator from Parameters#deep_transform_values/#deep_transform_values! when no block is given

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -977,6 +977,7 @@ module ActionController
     #     params.deep_transform_values { |v| v.is_a?(String) ? v.strip.downcase : v }
     #     # => #<ActionController::Parameters {"user"=>#<ActionController::Parameters {"email"=>"alice@example.com", "profile"=>#<ActionController::Parameters {"bio"=>"hello world"} permitted: false>} permitted: false>} permitted: false>
     def deep_transform_values(&block)
+      return to_enum(:deep_transform_values) unless block_given?
       new_instance_with_inherited_permitted_status(
         _deep_transform_values_in_object(@parameters, &block)
       )
@@ -986,6 +987,7 @@ module ActionController
     # values. This includes the values from the root hash and from all nested
     # hashes and arrays. The keys are unchanged.
     def deep_transform_values!(&block)
+      return to_enum(:deep_transform_values!) unless block_given?
       @parameters = _deep_transform_values_in_object!(@parameters, &block)
       self
     end

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -372,6 +372,16 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_same @params, result
   end
 
+  test "deep_transform_values returns an enumerator when no block is given" do
+    params = ActionController::Parameters.new(person: { name: " Francesco " })
+
+    assert_instance_of Enumerator, params.deep_transform_values
+
+    transformed = params.deep_transform_values.each(&:strip)
+    assert_equal({ "person" => { "name" => "Francesco" } }, transformed.to_unsafe_h)
+    assert_not_predicate transformed, :permitted?
+  end
+
   test "transform_values retains permitted status" do
     @params.permit!
     assert_predicate @params.transform_values { |v| v }, :permitted?

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -164,6 +164,15 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_equal expected_hash, @params.to_hash
   end
 
+  test "deep_transform_values! returns an enumerator when no block is given" do
+    params = ActionController::Parameters.new(person: { name: " Francesco " })
+
+    assert_instance_of Enumerator, params.deep_transform_values!
+
+    params.deep_transform_values!.each(&:strip)
+    assert_equal({ "person" => { "name" => "Francesco" } }, params.to_unsafe_h)
+  end
+
   test "deep_transform_values transforms nested values" do
     original_hash = @params.to_unsafe_h
     @params.permit!


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
Follows up to https://github.com/rails/rails/pull/57721
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `deep_transform_values` and `deep_transform_values!` on `ActionController::Parameters` should similarly return an `Enumerator` if called without a block.

### Detail

Currently, running `deep_transform_values` without passing a block raises a `LocalJumpError: no block given (yield)`, because the underlying loop relies on a `yield` call without checking `block_given?`.

We have run the following failing test case against `rails/rails` main branch :

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "activesupport", github: "rails/rails", branch: "main"
  gem "actionpack", github: "rails/rails", branch: "main"
  
  gem "minitest"
end

require "action_controller"
require "active_support/test_case"
require "minitest/autorun"

class BugTest < ActiveSupport::TestCase
  setup do
    @params = ActionController::Parameters.new(
      person: {
        name: " Francesco ",
        address: { city: " Rome " }
      },
      tags: [" rails ", " coding "]
    )
  end

  test "deep_transform_values returns an Enumerator when no block is given" do
    assert_instance_of Enumerator, @params.deep_transform_values
    
    enumerator = @params.deep_transform_values
    transformed = enumerator.each { |v| v.is_a?(String) ? v.strip : v }
    
    expected = {
      "person" => { "name" => "Francesco", "address" => { "city" => "Rome" } },
      "tags" => ["rails", "coding"]
    }

    assert_equal expected, transformed.to_unsafe_h
    assert_not_predicate transformed, :permitted?
  end

  test "deep_transform_values! returns an Enumerator when no block is given" do
    assert_instance_of Enumerator, @params.deep_transform_values!
    
    enumerator = @params.deep_transform_values!
    enumerator.each { |v| v.is_a?(String) ? v.strip : v }
    
    expected = {
      "person" => { "name" => "Francesco", "address" => { "city" => "Rome" } },
      "tags" => ["rails", "coding"]
    }

    assert_equal expected, @params.to_unsafe_h
  end

  test "deep_transform_values keeps permitted flag in returning Enumerator context" do
    @params.permit!
    
    enumerator = @params.deep_transform_values
    transformed = enumerator.each { |v| v.is_a?(String) ? v.strip : v }
    
    assert_equal "Francesco", transformed[:person][:name]
    assert_predicate transformed, :permitted?
  end
end
```

To resolve this issue cleanly, we follow the exact patterns established in PR #57721. We check `block_given?` at the entry point of both `deep_transform_values` and `deep_transform_values!`. If no block is present, we return `to_enum`.

We have add two test cases.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
