### PR TITLE
Introduce `ActiveJob::DeserializationError::RecordNotFound`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ PATH
       rails-html-sanitizer (~> 1.7)
     activejob (8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
-      globalid (>= 0.3.6)
+      globalid (>= 1.4.0)
     activemodel (8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
     activerecord (8.2.0.alpha)
@@ -221,7 +221,7 @@ GEM
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
-    globalid (1.2.1)
+    globalid (1.4.0)
       activesupport (>= 6.1)
     google-apis-core (0.15.1)
       addressable (~> 2.5, >= 2.5.1)
@@ -830,7 +830,7 @@ CHECKSUMS
   ffi (1.17.1-x86_64-linux-gnu) sha256=8c0ade2a5d19f3672bccfe3b58e016ae5f159e3e2e741c856db87fcf07c903d0
   ffi-compiler (1.3.2) sha256=a94f3d81d12caf5c5d4ecf13980a70d0aeaa72268f3b9cc13358bcc6509184a0
   fugit (1.11.1) sha256=e89485e7be22226d8e9c6da411664d0660284b4b1c08cacb540f505907869868
-  globalid (1.2.1) sha256=70bf76711871f843dbba72beb8613229a49429d1866828476f9c9d6ccc327ce9
+  globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   google-apis-core (0.15.1) sha256=91484122791af5b2f3d3f4297912748febe2b5d704d04ad54cbf5df87339a71a
   google-apis-iamcredentials_v1 (0.22.0) sha256=38c1de913d541802398841a124bb5592f1bae71119b5aede5369647eee7a3dad
   google-apis-storage_v1 (0.49.0) sha256=48b45e448fbfb6dda538be4a77ec955009ab7aaaf77aa660459e4691a7187ca2

--- a/actionmailbox/app/jobs/action_mailbox/incineration_job.rb
+++ b/actionmailbox/app/jobs/action_mailbox/incineration_job.rb
@@ -12,7 +12,7 @@ module ActionMailbox
   class IncinerationJob < ActiveJob::Base
     queue_as { ActionMailbox.queues[:incineration] }
 
-    discard_on ActiveRecord::RecordNotFound
+    discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound
 
     def self.schedule(inbound_email)
       set(wait: ActionMailbox.incinerate_after).perform_later(inbound_email)

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -238,6 +238,12 @@ class MessageDeliveryTest < ActiveSupport::TestCase
       raise "boom, missing find"
     end
 
+    # GlobalID::Locator.fetch, used during argument deserialization, looks
+    # records up through a non-raising finder, so blow up here too.
+    def self.where(id:)
+      raise "boom, missing find"
+    end
+
     attr_reader :id
     def initialize(id = 1)
       @id = id
@@ -256,7 +262,8 @@ class MessageDeliveryTest < ActiveSupport::TestCase
     # on the mailer class.
     assert_nothing_raised { message.deliver_later }
     assert_equal DelayedMailer, DelayedMailer.last_rescue_from_instance
-    assert_equal "Error while trying to deserialize arguments: boom, missing find", DelayedMailer.last_error.message
+    assert_match "Error while trying to deserialize arguments:", DelayedMailer.last_error.message
+    assert_match "boom, missing find", DelayedMailer.last_error.message
   end
 
   test "allows for keyword arguments" do

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add `ActiveJob::DeserializationError::RecordNotFound`, raised when argument
+    deserialization fails because a referenced record could not be found, and not
+    for any other reason.
+
+    Its parent class, `ActiveJob::DeserializationError` is raised when any error
+    happens during argument deserialization, including transient database errors,
+    and discarding a job based only on this exception might lead to losing
+    relevant, perfectly fine jobs.
+
+    Instead, `ActiveJob::DeserializationError::RecordNotFound` is raised only when
+    a record referenced by the arguments through a Global ID no longer exists, so
+    jobs can discard on missing records specifically:
+
+    ```ruby
+    discard_on ActiveJob::DeserializationError::RecordNotFound
+    ```
+
+    Existing handlers for the parent class continue to work as before.
+
+    Note that a record that is missing when arguments are deserialized is no
+    longer reported as `ActiveRecord::RecordNotFound`, so jobs that relied on
+    `discard_on ActiveRecord::RecordNotFound` to discard it should discard
+    `ActiveJob::DeserializationError::RecordNotFound` instead. `ActiveRecord::RecordNotFound`
+    still applies to records that go missing while the job runs.
+
+    *Rosa Gutiérrez*
+
 *   Allow `retry_on` to accept a Float for `:wait`.
 
     Similar to `ActiveJob.set(wait: 1.5)`, allow a Float to be passed.

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
-  s.add_dependency "globalid", ">= 0.3.6"
+  s.add_dependency "globalid", ">= 1.4.0"
 end

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -12,6 +12,24 @@ module ActiveJob
       super("Error while trying to deserialize arguments: #{$!.message}")
       set_backtrace $!.backtrace
     end
+
+    # Raised when arguments couldn't be deserialized because a record they
+    # reference through a Global ID no longer exists, most likely because it
+    # was deleted after the job was enqueued.
+    #
+    # Jobs whose arguments may legitimately reference deleted records can
+    # discard this error:
+    #
+    #   class SearchIndexingJob < ApplicationJob
+    #     discard_on ActiveJob::DeserializationError::RecordNotFound
+    #   end
+    #
+    # Unlike its parent class, it isn't raised for other errors that may occur
+    # while deserializing arguments, such as transient database connectivity
+    # failures, where the referenced record may still exist and a retry could
+    # succeed.
+    class RecordNotFound < DeserializationError
+    end
   end
 
   # Raised when an unsupported argument type is set as a job argument. We
@@ -81,6 +99,8 @@ module ActiveJob
     # GlobalID.
     def deserialize(arguments)
       arguments.map { |argument| deserialize_argument(argument) }
+    rescue GlobalID::Locator::RecordNotFound
+      raise DeserializationError::RecordNotFound
     rescue
       raise DeserializationError
     end
@@ -130,7 +150,7 @@ module ActiveJob
       end
 
       def deserialize_global_id(hash)
-        GlobalID::Locator.locate hash[GLOBALID_KEY]
+        GlobalID::Locator.fetch hash[GLOBALID_KEY]
       end
 
       def custom_serialized?(hash)

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -105,14 +105,14 @@ module ActiveJob
       # ==== Example
       #
       #  class SearchIndexingJob < ActiveJob::Base
-      #    discard_on ActiveJob::DeserializationError
+      #    discard_on ActiveJob::DeserializationError::RecordNotFound
       #    discard_on CustomAppException, report: true
       #    discard_on(AnotherCustomAppException) do |job, error|
       #      CustomErrorHandlingCode.handle(job, error)
       #    end
       #
       #    def perform(record)
-      #      # Will raise ActiveJob::DeserializationError if the record can't be deserialized
+      #      # Will raise ActiveJob::DeserializationError::RecordNotFound if the record can't be found
       #      # Might raise CustomAppException for something domain specific
       #    end
       #  end

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -266,6 +266,26 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_match "Unable to serialize Person without an id.", err.message
   end
 
+  test "wraps a missing record referenced by a Global ID in a DeserializationError::RecordNotFound" do
+    serialized = ActiveJob::Arguments.serialize [Person.new(404)]
+
+    error = assert_raises ActiveJob::DeserializationError::RecordNotFound do
+      ActiveJob::Arguments.deserialize serialized
+    end
+    assert_kind_of ActiveJob::DeserializationError, error
+    assert_instance_of GlobalID::Locator::RecordNotFound, error.cause
+  end
+
+  test "wraps other errors raised during deserialization in a plain DeserializationError" do
+    serialized = ActiveJob::Arguments.serialize [Person.new(500)]
+
+    error = assert_raises ActiveJob::DeserializationError do
+      ActiveJob::Arguments.deserialize serialized
+    end
+    assert_instance_of ActiveJob::DeserializationError, error
+    assert_instance_of GlobalID::Locator::RecordUnavailable, error.cause
+  end
+
   private
     def assert_arguments_unchanged(*args)
       assert_arguments_roundtrip args

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -350,7 +350,7 @@ class ExceptionsTest < ActiveSupport::TestCase
     end
 
     test "successfully retry job throwing DeserializationError" do
-      RetryJob.perform_later Person.new(404), 5
+      RetryJob.perform_later Person.new(500), 5
       assert_equal ["Raised ActiveJob::DeserializationError for the 5 time"], JobBuffer.values
     end
 

--- a/activejob/test/cases/rescue_test.rb
+++ b/activejob/test/cases/rescue_test.rb
@@ -25,13 +25,13 @@ class RescueTest < ActiveSupport::TestCase
   test "rescue from deserialization errors" do
     RescueJob.perform_later Person.new(404)
     assert_includes JobBuffer.values, "rescued from DeserializationError"
-    assert_includes JobBuffer.values, "DeserializationError original exception was Person::RecordNotFound"
+    assert_includes JobBuffer.values, "DeserializationError original exception was GlobalID::Locator::RecordNotFound"
     assert_not_includes JobBuffer.values, "performed beautifully"
   end
 
   test "should not wrap DeserializationError in DeserializationError" do
     RescueJob.perform_later [Person.new(404)]
-    assert_includes JobBuffer.values, "DeserializationError original exception was Person::RecordNotFound"
+    assert_includes JobBuffer.values, "DeserializationError original exception was GlobalID::Locator::RecordNotFound"
   end
 
   test "rescue from exceptions that don't inherit from StandardError" do

--- a/activejob/test/models/person.rb
+++ b/activejob/test/models/person.rb
@@ -7,9 +7,19 @@ class Person
 
   attr_reader :id
 
-  def self.find(id)
-    raise RecordNotFound.new("Cannot find person with ID=404") if id.to_i == 404
-    new(id)
+  class << self
+    def find(id)
+      raise RecordNotFound.new("Cannot find person with ID=404") if id.to_i == 404
+      raise "Connection error" if id.to_i == 500
+
+      new(id)
+    end
+
+    def where(id:)
+      ids = Array(id)
+      raise "Connection error" if ids.any? { |value| value.to_i == 500 }
+      ids.filter_map { |value| new(value) unless value.to_i == 404 }
+    end
   end
 
   def initialize(id)

--- a/activestorage/app/jobs/active_storage/analyze_job.rb
+++ b/activestorage/app/jobs/active_storage/analyze_job.rb
@@ -4,7 +4,7 @@
 class ActiveStorage::AnalyzeJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:analysis] }
 
-  discard_on ActiveRecord::RecordNotFound
+  discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob)

--- a/activestorage/app/jobs/active_storage/create_variants_job.rb
+++ b/activestorage/app/jobs/active_storage/create_variants_job.rb
@@ -3,7 +3,7 @@
 class ActiveStorage::CreateVariantsJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:transform] }
 
-  discard_on ActiveRecord::RecordNotFound
+  discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, variants:, process:)

--- a/activestorage/app/jobs/active_storage/preview_image_job.rb
+++ b/activestorage/app/jobs/active_storage/preview_image_job.rb
@@ -3,7 +3,7 @@
 class ActiveStorage::PreviewImageJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:preview_image] }
 
-  discard_on ActiveRecord::RecordNotFound, ActiveStorage::UnrepresentableError
+  discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound, ActiveStorage::UnrepresentableError
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def initialize(*arguments)

--- a/activestorage/app/jobs/active_storage/purge_job.rb
+++ b/activestorage/app/jobs/active_storage/purge_job.rb
@@ -4,7 +4,7 @@
 class ActiveStorage::PurgeJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:purge] }
 
-  discard_on ActiveRecord::RecordNotFound
+  discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound
   retry_on ActiveRecord::Deadlocked, attempts: 10, wait: :polynomially_longer
 
   def perform(blob)

--- a/activestorage/app/jobs/active_storage/sync_metadata_job.rb
+++ b/activestorage/app/jobs/active_storage/sync_metadata_job.rb
@@ -3,7 +3,7 @@
 class ActiveStorage::SyncMetadataJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:sync_metadata] }
 
-  discard_on ActiveRecord::RecordNotFound
+  discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound
   retry_on ActiveRecord::Deadlocked, attempts: 10, wait: :polynomially_longer
 
   def perform(blob)

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -3,7 +3,7 @@
 class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:transform] }
 
-  discard_on ActiveRecord::RecordNotFound
+  discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, transformations)

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -1399,6 +1399,20 @@ when calling `#perform`.
 
 If a passed record is deleted after the job is enqueued but before the
 `#perform` method is called Active Job will raise an
-[`ActiveJob::DeserializationError`](https://api.rubyonrails.org/classes/ActiveJob/DeserializationError.html)
-exception.
+[`ActiveJob::DeserializationError::RecordNotFound`](https://api.rubyonrails.org/classes/ActiveJob/DeserializationError/RecordNotFound.html)
+exception. Jobs whose arguments may legitimately reference deleted records can
+discard it:
+
+```ruby
+class SearchIndexingJob < ApplicationJob
+  discard_on ActiveJob::DeserializationError::RecordNotFound
+end
+```
+
+Other errors raised while deserializing arguments, including database errors
+raised while locating a record, are wrapped in the more general
+[`ActiveJob::DeserializationError`](https://api.rubyonrails.org/classes/ActiveJob/DeserializationError.html),
+its parent class. Prefer discarding `RecordNotFound`: discarding the parent
+class would also discard jobs that failed due to a transient database error,
+even though the record may still exist.
 

--- a/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/jobs/application_job.rb.tt
@@ -3,5 +3,5 @@ class ApplicationJob < ActiveJob::Base
   # retry_on ActiveRecord::Deadlocked
 
   # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  # discard_on ActiveJob::DeserializationError::RecordNotFound
 end


### PR DESCRIPTION
### Motivation / Background

We've run into a problem with one of our email delivery jobs for our HEY email service a couple of times, where the job is discarded due to a transient networking issue when connecting to our DB.
```
Discarded Entry::DelayedDeliveryJob (Job ID: c690f56a-1bb9-412f-be1a-f1dbc37b801c) 
due to a ActiveJob::DeserializationError (Error while trying to deserialize arguments: 
Trilogy::QueryError: trilogy_read_row: TRILOGY_TRUNCATED_PACKET).
```

We have alerts for pending deliveries, so we've located those, and re-enqueued a new job for the record that failed to be deserialised due to the `TRILOGY_TRUNCATED_PACKET` error. 

For this job in particular, we use 
```ruby
  discard_on ActiveJob::DeserializationError
```
because the underlying record is often deleted before the job is executed, as this powers the _Undo send_ feature in HEY, so that's a legit case. We don't want to discard the job when a transient networking error happens, though; we just want to retry normally. However, `ActiveJob::DeserializationError` wraps _any_ error that happens during deserialization, not just missing records, even though the `ApplicationJob` template suggests this is the only reason and encourages you to discard on that exception with this comment: 

```ruby
# Most jobs are safe to ignore if the underlying records are no longer available
# discard_on ActiveJob::DeserializationError
```

Searching online about previous discussions on this, I came across this post by @gravitystorm in the Ruby on Rails forums: [Is `discard_on ActiveJob::DeserializationError` a footgun?](https://discuss.rubyonrails.org/t/is-discard-on-activejob-deserializationerror-a-footgun/88442), where he describes the situation perfectly:

> So if you enable `discard_on ActiveJob::DeserializationError` and you have a short network outage, all your legitimate pending jobs could be instantly and silently discarded. Which is probably not what you want?

This PR is a possible solution to this, backwards-compatible and without breaking changes. 

### Detail

This PR introduces a new  `ActiveJob::DeserializationError::RecordNotFound` exception. This new exception extends `ActiveJob::DeserializationError`  but is raised only when deserialization fails because a record is missing. It uses the new `GlobalID::Locator.fetch` introduced in https://github.com/rails/globalid/pull/206. 

In this way, existing handlers for `ActiveJob::DeserializationError` will continue to work in the same way, but jobs can now instead handle `ActiveJob::DeserializationError::RecordNotFound` to ensure any other kind of issue while deserialising jobs doesn't result in the job being discarded:

```ruby
discard_on ActiveJob::DeserializationError::RecordNotFound
```

**Note**: jobs that set `discard_on ActiveRecord::RecordNotFound`, which could be raised both during deserialization or within `perform`, would now get  `ActiveJob::DeserializationError::RecordNotFound` for missing records during deserialization, so they would need to discard both errors if that's what they actually need: 
```ruby
discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError::RecordNotFound
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
