### PR TITLE
Fix `ActiveSupport::InheritableOptions#to_h` for nested inheritable options

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -101,7 +101,7 @@ module ActiveSupport
     end
 
     def to_h
-      @parent.merge(self)
+      @parent.to_h.merge(self)
     end
 
     def ==(other)

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -174,6 +174,15 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal({ one: "first value", two: "second value", three: "third value" }, object.to_h)
   end
 
+  def test_nested_inheritable_options_to_h
+    options = ActiveSupport::InheritableOptions.new(one: "first value")
+    options[:two] = "second value"
+
+    nested = options.inheritable_copy
+
+    assert_equal({ one: "first value", two: "second value" }, nested.to_h)
+  end
+
   def test_inheritable_options_equality
     object = ActiveSupport::InheritableOptions.new(one: "first value")
 


### PR DESCRIPTION
### Motivation / Background

If you have an `InheritableOptions` containing another `InheritableOptions` as its parent (like you get from the `inheritable_copy` method), then calling `to_h` returns the options object, not a hash.

### Detail

Call `.to_h` on the parent before we merge it.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
