### PR TITLE
[RF Docs] Multiple Databases

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -882,7 +882,7 @@ end
 Use `ActiveRecord::Base.connected_to` when you want to switch all abstract
 connection classes globally.
 
-### Handling Associations with Joins across Databases
+## Handling Associations Across Databases
 
 Active Record has an option for handling associations that would perform a join across multiple
 databases. If you have a has many through or a has one through association that you want to disable
@@ -947,7 +947,7 @@ There are some important things to be aware of with this option:
    Rails can't guess this for you because association loading is lazy, to load `treats` in `@dog.treats`
    Rails already needs to know what SQL should be generated.
 
-### Schema Caching
+## Schema Caching
 
 If you want to load a schema cache for each database you must set
 `schema_cache_path` in each database configuration and set

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -339,53 +339,41 @@ After changing the role names, use those names in `connects_to`:
 connects_to database: { default: :primary, readonly: :primary_replica }
 ```
 
-
 #### Running Database Tasks
 
-Now that we have `config/database.yml` and the model classes set up, it's time
-to create the databases. Rails ships with all the commands you need to use
-multiple databases.
-
-You can run `bin/rails --help` to see all the commands you're able to run. You
-should see the following:
+Rails creates database tasks for each managed database configuration. Running a
+task without a database name applies it to all managed databases, for example:
 
 ```bash
-$ bin/rails --help
-...
-db:create                          # Create the database from DATABASE_URL or config/database.yml for the ...
-db:create:animals                  # Create animals database for current environment
-db:create:primary                  # Create primary database for current environment
-db:drop                            # Drop the database from DATABASE_URL or config/database.yml for the cu...
-db:drop:animals                    # Drop animals database for current environment
-db:drop:primary                    # Drop primary database for current environment
-db:migrate                         # Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)
-db:migrate:animals                 # Migrate animals database for current environment
-db:migrate:primary                 # Migrate primary database for current environment
-db:migrate:status                  # Display status of migrations
-db:migrate:status:animals          # Display status of migrations for animals database
-db:migrate:status:primary          # Display status of migrations for primary database
-db:reset                           # Drop and recreates all databases from their schema for the current environment and loads the seeds
-db:reset:animals                   # Drop and recreates the animals database from its schema for the current environment and loads the seeds
-db:reset:primary                   # Drop and recreates the primary database from its schema for the current environment and loads the seeds
-db:rollback                        # Roll the schema back to the previous version (specify steps w/ STEP=n)
-db:rollback:animals                # Rollback animals database for current environment (specify steps w/ STEP=n)
-db:rollback:primary                # Rollback primary database for current environment (specify steps w/ STEP=n)
-db:schema:dump                     # Create a database schema file (either db/schema.rb or db/structure.sql  ...
-db:schema:dump:animals             # Create a database schema file (either db/schema.rb or db/structure.sql  ...
-db:schema:dump:primary             # Create a db/schema.rb file that is portable against any DB supported  ...
-db:schema:load                     # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-db:schema:load:animals             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-db:schema:load:primary             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-db:setup                           # Create all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)
-db:setup:animals                   # Create the animals database, loads the schema, and initializes with the seed data (use db:reset:animals to also drop the database first)
-db:setup:primary                   # Create the primary database, loads the schema, and initializes with the seed data (use db:reset:primary to also drop the database first)
-...
+$ bin/rails db:create
+$ bin/rails db:migrate
+$ bin/rails db:schema:dump
 ```
 
-Running a command like `bin/rails db:create` will create both the primary and animals databases.
-Note that there is no command for creating the database users, and you'll need to do that manually
-to support the read-only users for your replicas. If you want to create just the animals
-database you can run `bin/rails db:create:animals`.
+To run a task for one database, append the database configuration name:
+
+```bash
+$ bin/rails db:create:animals
+$ bin/rails db:migrate:animals
+$ bin/rails db:schema:dump:animals
+```
+
+The same pattern applies to the primary database:
+
+```bash
+$ bin/rails db:migrate:primary
+```
+
+Rails does not create database tasks for replicas. For example,
+`primary_replica` and `animals_replica` do not get migration tasks because they
+are marked with `replica: true`.
+
+Running `bin/rails db:create` will create both the primary and animals
+databases. Rails does not create database users; create writer and read-only
+replica users in your database system.
+
+For the full list of Rails database commands, see the
+[Command Line guide](command_line.html#managing-the-database).
 
 ### Connecting to Databases without Managing Schema and Migrations
 
@@ -462,10 +450,10 @@ $ bin/rails generate scaffold Dog name:string --database animals --parent Animal
 This will skip generating `AnimalsRecord` since you've indicated to Rails that you want to
 use a different parent class.
 
-### Activating Automatic Role Switching
-
 Finally, in order to use the read-only replica in your application, you'll need to activate
 the middleware for automatic switching.
+
+### Activating Automatic Role Switching
 
 Automatic switching allows the application to switch from the writer to the replica or the replica
 to the writer based on the HTTP verb and whether there was a recent write by the requesting user.
@@ -630,7 +618,7 @@ class ShardRecord < ApplicationRecord
   }
 end
 
-class Person < ShardRecord
+class Customer < ShardRecord
 end
 ```
 
@@ -716,7 +704,6 @@ Options may be set in the application configuration. For example, this configura
 ``` ruby
 config.active_record.shard_selector = { lock: true, class_name: "AnimalsRecord" }
 ```
-
 
 ## Granular Database Connection Switching
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -308,7 +308,13 @@ end
 `Dog` now uses the `animals` database for writes and the `animals_replica`
 database for reads when Rails is switched to the reading role.
 
-##### Custom Role Names
+WARNING. It's important to connect to each database from a single abstract class and
+then inherit from that class for the models stored in that database. Connecting
+multiple individual models to the same database multiplies the number of
+connections, because Rails uses the model class name for the connection
+specification name.
+
+#### Custom Role Names
 
 By default, Rails expects the database roles to be `writing` for the writer and
 `reading` for the replica. If you have a legacy system, you may already have

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -487,24 +487,37 @@ In this example, Rails will still connect to the `reporting` database when a
 model uses that configuration, but commands such as `bin/rails db:create`,
 `bin/rails db:migrate`, and `bin/rails db:schema:dump` will skip it.
 
-### Activating Automatic Role Switching
+### Automatic Role Switching
 
-Automatic switching allows the application to switch from the writer to the replica or the replica
-to the writer based on the HTTP verb and whether there was a recent write by the requesting user.
+Automatic role switching lets Rails choose between the writer and replica for
+each request. You may want automatic role switching when your application uses replicas to
+reduce read traffic on the writer, but still needs users to see their own
+changes immediately after they write. It is implemented as middleware, so it applies to web requests.
 
-If the application receives a POST, PUT, DELETE, or PATCH request, the application will
-automatically write to the writer database. If the request is not one of those methods,
-but the application recently made a write, the writer database will also be used. All
-other requests will use the replica database.
+For scripts, console sessions, background jobs, or places where you need
+explicit control, use manual connection switching instead.
 
-To activate the automatic connection switching middleware you can run the automatic swapping
-generator:
+The middleware chooses a role based on the HTTP verb and whether the same
+requesting user recently wrote to the database:
+
+* `POST`, `PUT`, `PATCH`, and `DELETE` requests use the writer database.
+* `GET` and `HEAD` requests use the replica, unless the user recently wrote to
+  the database.
+* `GET` and `HEAD` requests from a user who recently wrote to the database use
+  the writer until the configured delay has passed.
+
+This helps the application provide "read your own write" behavior. For example,
+after a user submits a form, a redirect back to a `GET` request can still read
+from the writer for a short time so the user can see their own change.
+
+To activate the automatic connection switching middleware, run the automatic
+swapping generator:
 
 ```bash
 $ bin/rails g active_record:multi_db
 ```
 
-And then uncomment the following lines:
+Then uncomment the following lines in the generated initializer:
 
 ```ruby
 Rails.application.configure do
@@ -514,19 +527,22 @@ Rails.application.configure do
 end
 ```
 
-Rails guarantees "read your own write" and will send your GET or HEAD request to the
-writer if it's within the `delay` window. By default the delay is set to 2 seconds. You
-should change this based on your database infrastructure. Rails doesn't guarantee "read
-a recent write" for other users within the delay window and will send GET and HEAD requests
-to the replicas unless they wrote recently.
+The `delay` controls how long Rails keeps sending a user's reads to the writer
+after that user writes. By default, the delay is set to 2 seconds. Change this
+based on your database infrastructure and expected replication lag.
 
-The automatic connection switching in Rails is relatively primitive and deliberately doesn't
-do a whole lot. The goal is a system that demonstrates how to do automatic connection
-switching that is flexible enough to be customizable by app developers.
+Rails does not guarantee that other users will immediately see a recent write.
+For users who did not perform the write, `GET` and `HEAD` requests can still go
+to the replica and may be affected by replication lag.
 
-The setup in Rails allows you to easily change how the switching is done and what
-parameters it's based on. Let's say you want to use a cookie instead of a session to
-decide when to swap connections. You can write your own class:
+Automatic role switching is intentionally simple. It does not inspect actual
+replication lag, load balance across multiple replicas, or decide per query
+which database should be used. The default behavior is designed to be a small,
+customizable starting point for applications.
+
+You can change how Rails tracks the last write. By default, Rails stores the
+last write timestamp in the session. If you want to use a cookie instead, you
+can write your own resolver context:
 
 ```ruby
 class MyCookieResolver < ActiveRecord::Middleware::DatabaseSelector::Resolver

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -17,24 +17,25 @@ After reading this guide you will know:
 ## Overview
 
 As your application grows, you may need to split data across more than one
-database. You might move a group of tables to its own database cluster, send
-read traffic to replicas, or partition the same set of tables across multiple
+database. You might send read traffic to replicas, move a group of tables to
+its own database cluster, or partition the same set of tables across multiple
 shards.
 
 Rails supports these common multiple database patterns:
 
+* Read replicas for each writer database, so reads can be sent to a replica
+  while writes continue to use the writer.
 * Multiple writer databases, where each database stores a different part of
   your application's data. For example, `User` records might live in the
   `primary` database, while `Dog` records live in the `animals` database. This is
   also called vertical partitioning.
-* Read replicas for each writer database, so reads can be sent to a replica
-  while writes continue to use the writer.
 * Automatic role switching between writers and replicas based on the HTTP verb
-  and whether the request recently performed a write.
+  and whether the request performed a write within the configured delay.
 * Horizontal sharding, where each database has the same schema but stores a
   different subset of the records.
-* Rails tasks for creating, dropping, migrating, loading schemas, dumping
-  schemas, and interacting with each database.
+
+Rails provides tasks for creating, dropping, and migrating tables, as well as
+loading and dumping schemas and interacting with each database.
 
 The right setup depends on what you are trying to accomplish:
 
@@ -62,31 +63,49 @@ names a database configuration that Rails can connect to, and Rails uses those
 configuration names later when you connect models, run database tasks, and
 switch between writers, replicas, or shards.
 
-Rails supports two layouts for `config/database.yml`. A two-tier configuration
-has the environment, such as `development`, point directly to one database
-configuration. A three-tier configuration has the environment point to multiple
-named database configurations, such as `primary`, `primary_replica`, `animals`,
-and `animals_replica`.
+Rails supports two layouts for `config/database.yml`. If an environment has one
+database configuration, the database settings can live directly under the
+environment:
 
-INFO: Three-tier configuration refers to the YAML nesting: environment, database configuration name, and then database settings.<br><br><code class="yaml">production:          # tier 1: environment
-  primary:           # tier 2: database configuration name
-    database: ...    # tier 3: adapter/database/credentials/settings
-</code>
-<br>
+```yaml
+production:
+  database: my_primary_database
+  adapter: mysql2
+```
+
+This is called a two-tier configuration because the YAML has two levels: the
+environment, and then the database settings.
+
+When an environment has multiple database configurations, add another level
+under the environment. This third level names each database configuration:
+
+```yaml
+production:
+  primary: # database configuration name
+    database: my_primary_database
+  animals: # database configuration name
+    database: my_animals_database
+```
+
+This is called a three-tier configuration because the YAML has three levels: the
+environment, the database configuration name, and then the database settings.
+The database configuration names, such as `primary`, `primary_replica`,
+`animals`, and `animals_replica`, are used later when you connect models, run
+database tasks, and switch between writers and replicas.
+
 In a default Rails application, `development` and `test` often use a two-tier
 configuration, while `production` may already use a three-tier configuration
 for `primary`, `cache`, `queue`, and `cable`.
 
-The examples in this guide start with a three-tier production configuration
-that has one primary database. The application then adds a second database
-named `animals`. Models such as `User` will continue to use the primary
-database, while models such as `Dog` will use the animals database. Later
-sections build on this example by adding replicas and showing how Rails
-switches between them.
+The examples in this guide start with one primary production database. The
+application then adds a second database named `animals`. Models such as `User`
+will continue to use the primary database, while models such as `Dog` will use
+the animals database. Later sections build on this example by adding replicas
+and showing how Rails switches between them.
 
 ### Database Configurations
 
-Suppose you have an application with a single primary database configuration:
+Consider the following database configuration with a single primary database:
 
 ```yaml
 production:
@@ -97,15 +116,19 @@ production:
     password: <%= ENV['ROOT_PASSWORD'] %>
 ```
 
-To add the `animals` database and replicas for both databases, add new named
-database configurations under `production`.
-
 If a `primary` configuration key is provided, it will be used as the default
 configuration. If there is no configuration named `primary`, Rails will use the
-first configuration as the default for each environment. The default
-configuration uses the default Rails filenames. For example, a `primary`
-configuration will use `db/schema.rb` for the schema file, whereas other entries
-will use `db/[CONFIGURATION_NAMESPACE]_schema.rb`.
+first configuration as the default for each environment.
+
+The default configuration uses the default Rails filenames for schema and
+schema cache files. For example, a `primary` configuration will use
+`db/schema.rb` for the schema file and `db/schema_cache.yml` for the schema
+cache file. Other entries use names based on the database configuration name,
+such as `db/[CONFIGURATION_NAMESPACE]_schema.rb` and
+`db/[CONFIGURATION_NAMESPACE]_schema_cache.yml`.
+
+Let's now add an `animals` database and replicas for the `production`
+environment:
 
 ```yaml
 production:
@@ -140,6 +163,12 @@ and deletes. Each writer also has a replica: `primary_replica` copies data from
 `primary`, and `animals_replica` copies data from `animals`, so Rails can send
 read queries to a replica when appropriate.
 
+INFO: Read replicas are database servers that keep a copy of a writer database's data
+and structure. The database system, not Rails, handles replication from the
+writer to the replica. Replication can be delayed, so applications need to
+account for the possibility that a replica has not received the latest write
+yet.
+
 #### Database Connection URLs
 
 A database connection URL is a single string that contains the adapter,
@@ -154,7 +183,7 @@ Rails looks for an environment variable named `ANIMALS_DATABASE_URL`:
 ANIMALS_DATABASE_URL="mysql2://animals_root:password@localhost/my_animals_database"
 ```
 
-Rails combines the matching environment variable with the matching
+Rails matches the environment variable with the corresponding
 `database.yml` entry. The URL supplies the connection details, while
 `database.yml` can keep Rails-specific options such as `migrations_paths`.
 
@@ -173,7 +202,7 @@ When Rails loads the `animals` configuration, it uses
 `migrations_paths` from `database.yml`.
 
 See [Configuring a Database](configuring.html#configuring-a-database) for
-details about how the merging works.
+details about how the configurations are merged.
 
 #### Configuration Settings
 
@@ -181,8 +210,7 @@ When using multiple databases, there are a few important settings.
 
 First, the database name for a writer and its replica should be the same because
 they contain the same data. This means `primary` and `primary_replica` should
-point to the same database, and `animals` and `animals_replica` should point to
-the same database.
+have the same name, as should `animals` and `animals_replica`.
 
 ```yaml#3,5
 production:
@@ -192,8 +220,8 @@ production:
     database: my_primary_database
 ```
 
-Second, the username for the writers and replicas should be different, and the
-replica user's database permissions should be set to only read and not write.
+Second, a different username can be used for each replica, and set
+the replica user's database permissions to only read and not write.
 
 ```yaml#3,5
 production:
@@ -206,7 +234,9 @@ production:
 When using a replica database, you need to add `replica: true` to the replica
 configuration in `config/database.yml`. Rails otherwise has no way of knowing
 which configuration is the replica and which one is the writer. Rails will not
-run certain tasks, such as migrations, against replicas.
+run certain tasks, such as migrations, against configurations marked as
+replicas. If you forget `replica: true`, Rails will treat the replica as
+another writer database and may run database tasks against it.
 
 ```yaml#3
 production:
@@ -216,7 +246,7 @@ production:
 
 Lastly, for new writer databases, you need to set the `migrations_paths` key to
 the directory where you will store migrations for that database. We'll look more
-at `migrations_paths` later on in this guide.
+at `migrations_paths` later in [Generating Migrations](#generating-migrations).
 
 ```yaml#3
 production:
@@ -225,7 +255,9 @@ production:
 ```
 
 You can also configure the schema dump file by setting `schema_dump` to a
-custom schema file name. For example:
+custom schema file name. By default, the primary configuration uses
+`db/schema.rb`, and other configurations use
+`db/[CONFIGURATION_NAMESPACE]_schema.rb`. For example:
 
 ```yaml#5
 production:
@@ -255,8 +287,26 @@ Each abstract class owns the connection for one database, or for one writer and
 replica pair. Concrete models then inherit from the abstract class for the
 database where their table lives.
 
-In `connects_to`, `writing` and `reading` are role names. The `writing` role
-points to the writer database, and the `reading` role points to the replica:
+For example, an application with `primary` and `animals` databases might have
+one abstract class for each database:
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+
+  connects_to database: { writing: :primary, reading: :primary_replica }
+end
+
+class AnimalsRecord < ApplicationRecord
+  self.abstract_class = true
+
+  connects_to database: { writing: :animals, reading: :animals_replica }
+end
+```
+
+In [`connects_to`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionHandling.html#method-i-connects_to),
+`writing` and `reading` are role names. The `writing` role points to the writer
+database, and the `reading` role points to the replica:
 
 ```ruby
 connects_to database: { writing: :primary, reading: :primary_replica }
@@ -295,9 +345,9 @@ Models that inherit from `ApplicationRecord` will use the `primary` database for
 writes and the `primary_replica` database for reads when Rails is switched to
 the reading role.
 
-If you use a differently named class for your application record, set
-`primary_abstract_class` so that Rails knows which class `ActiveRecord::Base`
-should share a connection with:
+If you're using a custom name for the base class of your database-backed
+models, set `primary_abstract_class` on that class. This marks it as the primary
+abstract class that shares a connection with `ActiveRecord::Base`:
 
 ```ruby
 class PrimaryApplicationRecord < ActiveRecord::Base
@@ -346,16 +396,21 @@ Connecting multiple individual models to the same database multiplies the
 number of connections, because Rails uses the model class name for the
 connection specification name.
 
-If you create models and migrations with Rails generators, pass the database
-name so Rails can place files in the right migration path and use the right
-abstract class.
-
 #### Generating Migrations
 
 Each managed writer database needs a migration path. Keeping migrations
 separate lets Rails migrate one database without running migrations intended for
 another database. Replicas do not need migration paths because Rails does not
 run migrations against configurations marked with `replica: true`.
+
+For example, a migration that creates a table in the primary database belongs in
+`db/migrate`, while a migration that creates a table in the `animals` database
+belongs in `db/animals_migrate`:
+
+```text
+db/migrate/20240501000000_create_users.rb
+db/animals_migrate/20240501000000_create_dogs.rb
+```
 
 Migrations for multiple databases should live in their own folders prefixed
 with the name of the database key in the configuration. You also need to set
@@ -379,8 +434,9 @@ are placed in the correct directory:
 $ bin/rails generate migration CreateDogs name:string --database animals
 ```
 
-This creates the migration in `db/animals_migrate`. Without `--database
-animals`, the migration would be generated in the default migration path.
+This creates the migration in `db/animals_migrate`. Without
+`--database animals`, the migration would be generated in the default migration
+path.
 
 #### Generating Models and Scaffolds
 
@@ -429,8 +485,8 @@ should inherit from:
 $ bin/rails generate scaffold Dog name:string --database animals --parent Animals::Record
 ```
 
-This will skip generating `AnimalsRecord` since you've indicated to Rails that you want to
-use a different parent class.
+This will skip generating `AnimalsRecord` since you've indicated to Rails that
+you want to use a different parent class.
 
 ### Database Tasks
 
@@ -523,6 +579,9 @@ requesting user recently wrote to the database:
   the database.
 * `GET` and `HEAD` requests from a user who recently wrote to the database use
   the writer until the configured delay has passed.
+
+By default, the delay is 2 seconds. You can configure it in the generated
+initializer, as shown below.
 
 This helps the application provide "read your own write" behavior. For example,
 after a user submits a form, a redirect back to a `GET` request can still read

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -375,23 +375,32 @@ replica users in your database system.
 For the full list of Rails database commands, see the
 [Command Line guide](command_line.html#managing-the-database).
 
-### Connecting to Databases without Managing Schema and Migrations
+### Connecting to Databases Managed Outside Rails
 
-If you would like to connect to an external database without any database
-management tasks such as schema management, migrations, seeds, etc., you can set
-the per database config option `database_tasks: false`. By default it is
-set to true.
+Some applications connect to databases that Rails should use but not manage.
+For example, you might connect to a legacy database, a reporting database, or a
+database owned by another application.
+
+In those cases, Rails needs the database configuration so models can connect to
+the database, but Rails should not run database management tasks such as
+creating, dropping, migrating, seeding, or dumping the schema for that database.
+Set `database_tasks: false` on the database configuration to opt out of those
+tasks. By default, `database_tasks` is `true`.
 
 ```yaml
 production:
   primary:
     database: my_database
     adapter: mysql2
-  animals:
-    database: my_animals_database
+  reporting:
+    database: my_reporting_database
     adapter: mysql2
     database_tasks: false
 ```
+
+In this example, Rails will still connect to the `reporting` database when a
+model uses that configuration, but commands such as `bin/rails db:create`,
+`bin/rails db:migrate`, and `bin/rails db:schema:dump` will skip it.
 
 ### Generators and Migrations
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -402,31 +402,54 @@ In this example, Rails will still connect to the `reporting` database when a
 model uses that configuration, but commands such as `bin/rails db:create`,
 `bin/rails db:migrate`, and `bin/rails db:schema:dump` will skip it.
 
-### Generators and Migrations
+### Generating Migrations and Models
 
-Migrations for multiple databases should live in their own folders prefixed with the
-name of the database key in the configuration.
+Each managed writer database needs a migration path. Keeping migrations
+separate lets Rails migrate one database without running migrations intended for
+another database. Replicas do not need migration paths because Rails does not
+run migrations against configurations marked with `replica: true`.
 
-You also need to set `migrations_paths` in the database configurations to tell
-Rails where to find the migrations.
+#### Migration Paths
 
-For example the `animals` database would look for migrations in the `db/animals_migrate` directory and
-`primary` would look in `db/migrate`. Rails generators now take a `--database` option
-so that the file is generated in the correct directory. The command can be run like so:
+Migrations for multiple databases should live in their own folders prefixed
+with the name of the database key in the configuration. You also need to set
+`migrations_paths` in the database configuration to tell Rails where to find
+those migrations.
+
+The `primary` database uses the default `db/migrate` path, so you usually only
+need to set `migrations_paths` for additional writer databases. In the example
+configuration, the `animals` database uses `db/animals_migrate`:
+
+```yaml
+production:
+  animals:
+    migrations_paths: db/animals_migrate
+```
+
+#### Generating Migrations
+
+Rails generators take a `--database` option so that generated migration files
+are placed in the correct directory:
 
 ```bash
 $ bin/rails generate migration CreateDogs name:string --database animals
 ```
 
-If you are using Rails generators, the scaffold and model generators will create the abstract
-class for you. Simply pass the database key to the command line.
+This creates the migration in `db/animals_migrate`. Without `--database
+animals`, the migration would be generated in the default migration path.
+
+#### Generating Models and Scaffolds
+
+The model and scaffold generators also take the `--database` option:
 
 ```bash
 $ bin/rails generate scaffold Dog name:string --database animals
 ```
 
-A class with the camelized database name and `Record` will be created. In this
-example the database is "animals" so we end up with `AnimalsRecord`:
+When you pass `--database`, Rails generates an abstract class for that database
+unless one already exists. The class name is the camelized database name
+followed by `Record`. In this example, the database is `animals`, so Rails
+generates `AnimalsRecord`:
 
 ```ruby
 class AnimalsRecord < ApplicationRecord
@@ -443,14 +466,17 @@ class Dog < AnimalsRecord
 end
 ```
 
-NOTE: Since Rails doesn't know which database is the replica for your writer you will need to
-add this to the abstract class after you're done.
+NOTE: Since Rails doesn't know which database is the replica for your writer you will need to add this to the abstract class after you're done: `connects_to database: { writing: :animals, reading: :animals_replica }`.
 
 Rails will only generate `AnimalsRecord` once. It will not be overwritten by new
-scaffolds or deleted if the scaffold is deleted.
+scaffolds or deleted if the scaffold is deleted, so your changes to the
+abstract class are preserved.
 
-If you already have an abstract class and its name differs from `AnimalsRecord`, you can pass
-the `--parent` option to indicate you want a different abstract class:
+#### Using a Custom Abstract Class
+
+If you already have an abstract class and its name differs from
+`AnimalsRecord`, pass the `--parent` option to tell Rails which class the model
+should inherit from:
 
 ```bash
 $ bin/rails generate scaffold Dog name:string --database animals --parent Animals::Record
@@ -458,9 +484,6 @@ $ bin/rails generate scaffold Dog name:string --database animals --parent Animal
 
 This will skip generating `AnimalsRecord` since you've indicated to Rails that you want to
 use a different parent class.
-
-Finally, in order to use the read-only replica in your application, you'll need to activate
-the middleware for automatic switching.
 
 ### Activating Automatic Role Switching
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -235,6 +235,12 @@ production:
 If you want to skip dumping the schema for a database entirely, set
 `schema_dump: false`.
 
+### Models and Migrations
+
+Once the database configurations are in place, the next step is to connect
+models to those configurations and make sure migrations are generated in the
+right directories.
+
 #### Connecting Models to Databases
 
 Adding a database configuration tells Rails how to connect to the database, but
@@ -339,70 +345,11 @@ After changing the role names, use those names in `connects_to`:
 connects_to database: { default: :primary, readonly: :primary_replica }
 ```
 
-#### Running Database Tasks
+#### Using Generators
 
-Rails creates database tasks for each managed database configuration. Running a
-task without a database name applies it to all managed databases, for example:
-
-```bash
-$ bin/rails db:create
-$ bin/rails db:migrate
-$ bin/rails db:schema:dump
-```
-
-To run a task for one database, append the database configuration name:
-
-```bash
-$ bin/rails db:create:animals
-$ bin/rails db:migrate:animals
-$ bin/rails db:schema:dump:animals
-```
-
-The same pattern applies to the primary database:
-
-```bash
-$ bin/rails db:migrate:primary
-```
-
-Rails does not create database tasks for replicas. For example,
-`primary_replica` and `animals_replica` do not get migration tasks because they
-are marked with `replica: true`.
-
-Running `bin/rails db:create` will create both the primary and animals
-databases. Rails does not create database users; create writer and read-only
-replica users in your database system.
-
-For the full list of Rails database commands, see the
-[Command Line guide](command_line.html#managing-the-database).
-
-### Connecting to Databases Managed Outside Rails
-
-Some applications connect to databases that Rails should use but not manage.
-For example, you might connect to a legacy database, a reporting database, or a
-database owned by another application.
-
-In those cases, Rails needs the database configuration so models can connect to
-the database, but Rails should not run database management tasks such as
-creating, dropping, migrating, seeding, or dumping the schema for that database.
-Set `database_tasks: false` on the database configuration to opt out of those
-tasks. By default, `database_tasks` is `true`.
-
-```yaml
-production:
-  primary:
-    database: my_database
-    adapter: mysql2
-  reporting:
-    database: my_reporting_database
-    adapter: mysql2
-    database_tasks: false
-```
-
-In this example, Rails will still connect to the `reporting` database when a
-model uses that configuration, but commands such as `bin/rails db:create`,
-`bin/rails db:migrate`, and `bin/rails db:schema:dump` will skip it.
-
-### Generating Migrations and Models
+If you create models and migrations with Rails generators, pass the database
+name so Rails can place files in the right migration path and use the right
+abstract class.
 
 Each managed writer database needs a migration path. Keeping migrations
 separate lets Rails migrate one database without running migrations intended for
@@ -484,6 +431,69 @@ $ bin/rails generate scaffold Dog name:string --database animals --parent Animal
 
 This will skip generating `AnimalsRecord` since you've indicated to Rails that you want to
 use a different parent class.
+
+### Running Database Tasks
+
+Rails creates database tasks for each managed database configuration. Running a
+task without a database name applies it to all managed databases, for example:
+
+```bash
+$ bin/rails db:create
+$ bin/rails db:migrate
+$ bin/rails db:schema:dump
+```
+
+To run a task for one database, append the database configuration name:
+
+```bash
+$ bin/rails db:create:animals
+$ bin/rails db:migrate:animals
+$ bin/rails db:schema:dump:animals
+```
+
+The same pattern applies to the primary database:
+
+```bash
+$ bin/rails db:migrate:primary
+```
+
+Rails does not create database tasks for replicas. For example,
+`primary_replica` and `animals_replica` do not get migration tasks because they
+are marked with `replica: true`.
+
+Running `bin/rails db:create` will create both the primary and animals
+databases. Rails does not create database users; create writer and read-only
+replica users in your database system.
+
+For the full list of Rails database commands, see the
+[Command Line guide](command_line.html#managing-the-database).
+
+### Connecting to Databases Managed Outside Rails
+
+Some applications connect to databases that Rails should use but not manage.
+For example, you might connect to a legacy database, a reporting database, or a
+database owned by another application.
+
+In those cases, Rails needs the database configuration so models can connect to
+the database, but Rails should not run database management tasks such as
+creating, dropping, migrating, seeding, or dumping the schema for that database.
+Set `database_tasks: false` on the database configuration to opt out of those
+tasks. By default, `database_tasks` is `true`.
+
+```yaml
+production:
+  primary:
+    database: my_database
+    adapter: mysql2
+  reporting:
+    database: my_reporting_database
+    adapter: mysql2
+    database_tasks: false
+```
+
+In this example, Rails will still connect to the `reporting` database when a
+model uses that configuration, but commands such as `bin/rails db:create`,
+`bin/rails db:migrate`, and `bin/rails db:schema:dump` will skip it.
 
 ### Activating Automatic Role Switching
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -246,6 +246,15 @@ Each abstract class owns the connection for one database, or for one writer and
 replica pair. Concrete models then inherit from the abstract class for the
 database where their table lives.
 
+In `connects_to`, `writing` and `reading` are role names. The `writing` role
+points to the writer database, and the `reading` role points to the replica:
+
+```ruby
+connects_to database: { writing: :primary, reading: :primary_replica }
+```
+
+By default, Rails expects these role names to be `writing` and `reading`.
+
 ##### Connecting the Primary Model and Database
 
 The primary database and its replica can be configured in `ApplicationRecord`
@@ -316,21 +325,20 @@ specification name.
 
 #### Custom Role Names
 
-By default, Rails expects the database roles to be `writing` for the writer and
-`reading` for the replica. If you have a legacy system, you may already have
-roles set up that you don't want to change. In that case, you can set new role
-names in your application config:
+If your application already uses different role names, you can configure Rails
+to use those names instead:
 
 ```ruby
 config.active_record.writing_role = :default
 config.active_record.reading_role = :readonly
 ```
 
-WARNING. It's important to connect to each database from a single abstract class and
-then inherit from that class for the models stored in that database. Connecting
-multiple individual models to the same database multiplies the number of
-connections, because Rails uses the model class name for the connection
-specification name.
+After changing the role names, use those names in `connects_to`:
+
+```ruby
+connects_to database: { default: :primary, readonly: :primary_replica }
+```
+
 
 #### Running Database Tasks
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -47,7 +47,10 @@ The right setup depends on what you are trying to accomplish:
 
 Rails handles the application-side plumbing for these configurations: connection
 definitions, abstract connection classes, role and shard switching, and database
-tasks. It does not provision database servers, create database users, manage
+tasks.
+
+
+NOTE: Rails does not provision database servers, create database users, manage
 replication, balance traffic across replicas, or provide distributed
 transactions across database clusters. Those responsibilities remain with your
 database infrastructure and application architecture.
@@ -969,23 +972,40 @@ There are some tradeoffs to be aware of with this option:
 
 ## Schema Caching
 
-If you want to load a schema cache for each database you must set
-`schema_cache_path` in each database configuration and set
+Schema caching stores a snapshot of database table and column metadata. Rails
+uses this information for features like attribute type casting, query generation,
+and dynamically defining model attributes. Without schema caching, Rails may
+need to query the database for schema information each time a connection is
+established. By loading this metadata from the cache instead, applications can
+reduce unnecessary database queries and improve boot and connection performance.
+
+In a multiple database application, each database should use its own schema
+cache file. By default, the primary database uses `db/schema_cache.yml`, and
+other databases use `db/[DATABASE_CONFIGURATION_NAME]_schema_cache.yml`. For
+example, the `animals` database uses `db/animals_schema_cache.yml`.
+
+You can configure the schema cache path explicitly with `schema_cache_path`:
+
+```yaml#4,7
+production:
+  primary:
+    database: my_primary_database
+    schema_cache_path: db/schema_cache.yml
+  animals:
+    database: my_animals_database
+    schema_cache_path: db/animals_schema_cache.yml
+```
+
+To load schema cache files lazily as database connections are established, set
 `config.active_record.lazily_load_schema_cache = true` in your application
-configuration.
+configuration:
 
-Schema caching stores a snapshot of the database table and column metadata so Rails
-does not have to query the database for that information every time a connection is
-established.
+```ruby
+config.active_record.lazily_load_schema_cache = true
+```
 
+You can generate schema cache files with:
 
-NOTE: With these settings the cache is loaded lazily when the database connections are established.
-
-## Caveats
-
-### Load Balancing Replicas
-
-Rails doesn't support automatic load balancing of replicas. This is very
-dependent on your infrastructure. We may implement basic, primitive load
-balancing in the future, but for an application at scale this should be
-something your application handles outside of Rails.
+```bash
+$ bin/rails db:schema:cache:dump
+```

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -639,14 +639,22 @@ also configure replica users as read-only in your database.
 
 ## Horizontal Sharding
 
-Horizontal sharding is when you split up your database to reduce the number of rows on each
-database server, but maintain the same schema across "shards". This is commonly called "multi-tenant"
-sharding.
+Horizontal sharding splits records across multiple databases that share the
+same schema. Each database is called a shard. For example, one shard might store
+customers 1 through 100, while another shard stores customers 101 through 200.
 
-The API for supporting horizontal sharding in Rails is similar to the multiple database / vertical
-sharding API.
+Sharding is different from replication. A replica copies the same data from its
+writer. A shard stores a different subset of records. Applications commonly use
+sharding when one database has too much data or traffic, or when tenant or
+account data should be distributed across database servers.
 
-Shards are declared in the three-tier config like this:
+The API for supporting horizontal sharding in Rails is similar to the multiple
+database, or vertical partitioning, API.
+
+### Configuring Shards
+
+Shards are declared as database configurations in `config/database.yml`. Each
+shard needs a writer configuration, and can also have a replica configuration:
 
 ```yaml
 production:
@@ -675,7 +683,21 @@ production:
     replica: true
 ```
 
-Models are then connected with the `connects_to` API via the `shards` key:
+In this example, `primary_shard_one` and `primary_shard_two` are database
+configuration names. Later, [the model connection maps those configurations to
+Rails shard names](#connecting-models-to-shards), such as `shard_one` and `shard_two`.
+
+Each shard can also have its own replica. `primary_shard_one` stores one subset
+of records, and `primary_shard_one_replica` is a read replica of that same
+shard. `primary_shard_two` stores a different subset of records, and
+`primary_shard_two_replica` is a read replica of that second shard. Shards split
+records across databases; replicas copy one shard's data so reads for that shard
+can be sent away from its writer.
+
+### Connecting Models to Shards
+
+Models are connected to shards with the `connects_to` API using the `shards`
+key:
 
 ```ruby
 class ApplicationRecord < ActiveRecord::Base
@@ -697,17 +719,41 @@ class Customer < ShardRecord
 end
 ```
 
-If you're using shards, make sure both `migrations_paths` and `schema_dump` remain unchanged for
-all the shards. When generating a migration you can pass the `--database` option and
-use one of the shard names. Since they all set the same path, it doesn't matter which
-one you choose.
+In this example, `Customer` inherits from `ShardRecord`, so `Customer` records
+can be stored on either `shard_one` or `shard_two`. The `shard_one` name maps to
+the `primary_shard_one` writer and `primary_shard_one_replica` replica. The
+`shard_two` name maps to the `primary_shard_two` writer and
+`primary_shard_two_replica` replica.
 
-```
-$ bin/rails g scaffold Dog name:string --database primary_shard_one
+### Generating Migrations for Shards
+
+Shards usually share a schema, so shard migrations should use the same
+`migrations_paths` and `schema_dump` settings across all shards.
+
+When generating a migration, pass `--database` with one of the shard database
+configuration names. Since both shards use the same migration path, it does not
+matter which shard configuration you choose.
+
+```bash
+$ bin/rails g scaffold Customer name:string --database primary_shard_one
 ```
 
-Then models can swap shards manually via the `connected_to` API. If
-using sharding, both a `role` and a `shard` must be passed:
+This command generates the scaffold and places the migration in the shared
+`db/migrate_shards` path.
+
+### Shard Switching
+
+Rails needs to know which shard to use for each operation. You can choose the
+shard manually with `connected_to`, or configure middleware to choose the shard
+for each request.
+
+#### Manual Shard Switching
+
+Use manual shard switching when you need to run a block of code against a
+specific shard. This is common in background jobs, data migrations, scripts, or
+service objects where there is no request middleware to choose the shard.
+
+To switch shards manually, use `connected_to` with both a `role` and a `shard`:
 
 ```ruby
 ShardRecord.connected_to(role: :writing, shard: :shard_one) do
@@ -720,8 +766,11 @@ ShardRecord.connected_to(role: :writing, shard: :shard_two) do
 end
 ```
 
-The horizontal sharding API also supports read replicas. You can swap the
-role and the shard with the `connected_to` API.
+The shard name must match one of the shard keys passed to `connects_to`, such
+as `shard_one` or `shard_two`.
+
+The horizontal sharding API also supports read replicas. To read from a shard's
+replica, use the `reading` role with the shard:
 
 ```ruby
 ShardRecord.connected_to(role: :reading, shard: :shard_one) do
@@ -729,20 +778,22 @@ ShardRecord.connected_to(role: :reading, shard: :shard_one) do
 end
 ```
 
-### Activating Automatic Shard Switching
+#### Automatic Shard Switching
 
-Applications are able to automatically switch shards per request using the `ShardSelector`
-middleware, which allows an application to provide custom logic for determining the appropriate
-shard for each request.
+Applications can automatically switch shards per request using the
+`ShardSelector` middleware. This is useful for tenant-based applications where
+each request can be mapped to a shard, for example from a subdomain or current
+account.
 
-The same generator used for the database selector above can be used to generate an initializer file
-for automatic shard swapping:
+The same generator used for the database selector above can be used to generate
+an initializer file for automatic shard swapping:
 
 ```bash
 $ bin/rails g active_record:multi_db
 ```
 
-Then in the generated `config/initializers/multi_db.rb` uncomment and modify the following code:
+Then in the generated `config/initializers/multi_db.rb`, uncomment and modify
+the following code:
 
 ```ruby
 Rails.application.configure do
@@ -751,7 +802,8 @@ Rails.application.configure do
 end
 ```
 
-Applications must provide a resolver to provide application-specific logic. An example resolver that
+Applications must provide a resolver because Rails cannot know how your
+application assigns tenants or accounts to shards. An example resolver that
 uses a subdomain to determine the shard might look like this:
 
 ```ruby
@@ -762,21 +814,24 @@ config.active_record.shard_resolver = ->(request) {
 }
 ```
 
-The behavior of `ShardSelector` can be altered through some configuration options.
+The behavior of `ShardSelector` can be altered through some configuration
+options.
 
-`lock` is true by default and will prohibit the request from switching shards during the request. If
-`lock` is false, then shard swapping will be allowed. For tenant-based sharding, `lock` should
-always be true to prevent application code from mistakenly switching between tenants.
+- `lock` is true by default and prevents the request from switching shards after
+the resolver chooses one. If `lock` is false, shard swapping is allowed during
+the request. For tenant-based sharding, `lock` should usually be true to
+prevent application code from accidentally switching between tenants.
 
-`class_name` is the name of the abstract connection class to switch. By default, the `ShardSelector`
-will use `ActiveRecord::Base`, but if the application has multiple databases, then this option
-should be set to the name of the sharded database's abstract connection class.
+- `class_name` is the name of the abstract connection class to switch. By
+default, the `ShardSelector` uses `ActiveRecord::Base`. If the application has
+multiple abstract connection classes, set `class_name` to the sharded
+database's abstract connection class.
 
-Options may be set in the application configuration. For example, this configuration tells
-`ShardSelector` to switch shards using `AnimalsRecord.connected_to`:
+Options may be set in the application configuration. For example, this
+configuration tells `ShardSelector` to switch shards using
+`AnimalsRecord.connected_to`:
 
-
-``` ruby
+```ruby
 config.active_record.shard_selector = { lock: true, class_name: "AnimalsRecord" }
 ```
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -7,49 +7,45 @@ This guide covers using multiple databases with your Rails application.
 
 After reading this guide you will know:
 
-* How to set up your application for multiple databases.
-* How automatic connection switching works.
-* How to use horizontal sharding for multiple databases.
-
+* How to configure multiple databases and connect models to them.
+* How to run database tasks for multiple databases.
+* How to use read replicas and how automatic connection switching works.
+* How to use horizontal sharding.
 
 --------------------------------------------------------------------------------
 
 ## Overview
 
-As your application grows, you may need to split data across more than one
-database. You might send read traffic to replicas, move a group of tables to
-its own database cluster, or partition the same set of tables across multiple
-shards.
+As your application grows, a single database may no longer be sufficient for all of its data and traffic. High read volumes, large datasets, reporting workloads, or the need to isolate different parts of an application can all place pressure on a single database server. Rails supports connecting to multiple databases so different models, reads, writes, or groups of records can use separate database connections when needed.
 
-Rails supports these common multiple database patterns:
+### General Terminology
 
-* Read replicas for each writer database, so reads can be sent to a replica
-  while writes continue to use the writer.
-* Multiple writer databases, where each database stores a different part of
-  your application's data. For example, `User` records might live in the
-  `primary` database, while `Dog` records live in the `animals` database. This is
-  also called vertical partitioning.
-* Automatic role switching between writers and replicas based on the HTTP verb
-  and whether the request performed a write within the configured delay.
-* Horizontal sharding, where each database has the same schema but stores a
-  different subset of the records.
+| Term                   | Meaning                                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| Writer                 | A database that handles inserts, updates, and deletes.                                                |
+| Replica                | A copy of a writer database that can serve read queries.                                              |
+| Role                   | A connection type, such as `writing` or `reading`, that Rails uses to choose a database connection.   |
+| Database cluster       | A group of database servers that work together, such as a writer and its replicas.                    |
+| Shard                  | One of several databases with the same schema, where each shard stores a different subset of records. |
+| Database configuration | A named entry in `config/database.yml` that tells Rails how to connect to a database.                 |
+| Managed database       | A database configuration that Rails creates, drops, migrates, and dumps schemas for.                  |
+| Vertical partitioning  | Splitting different tables or models across different databases.                                      |
+| Horizontal sharding    | Splitting records from the same tables across different databases with the same schema.               |
 
-Rails provides tasks for creating, dropping, and migrating tables, as well as
-loading and dumping schemas and interacting with each database.
+### Choosing a Setup
 
 The right setup depends on what you are trying to accomplish:
 
 | If you need to...                                              | Use...                                                |
 | -------------------------------------------------------------- | ----------------------------------------------------- |
 | Move some models to a separate database                        | Multiple writer databases                             |
-| Send read traffic away from the writer                         | Read replicas and automatic role switching            |
+| Send read queries to replicas                                  | Read replicas and automatic role switching            |
 | Split records across databases that share the same schema      | Horizontal sharding                                   |
 | Connect to a legacy, reporting, or externally managed database | A database configuration with `database_tasks: false` |
 
 Rails handles the application-side plumbing for these configurations: connection
 definitions, abstract connection classes, role and shard switching, and database
 tasks.
-
 
 NOTE: Rails does not provision database servers, create database users, manage
 replication, balance traffic across replicas, or provide distributed
@@ -167,7 +163,7 @@ INFO: Read replicas are database servers that keep a copy of a writer database's
 and structure. The database system, not Rails, handles replication from the
 writer to the replica. Replication can be delayed, so applications need to
 account for the possibility that a replica has not received the latest write
-yet.
+yet. Refer to your database documentation for replication setup and behavior.
 
 #### Database Connection URLs
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -10,25 +10,47 @@ After reading this guide you will know:
 * How to set up your application for multiple databases.
 * How automatic connection switching works.
 * How to use horizontal sharding for multiple databases.
-* What features are supported and what's still a work in progress.
+
 
 --------------------------------------------------------------------------------
 
-As an application grows in popularity and usage, you'll need to scale the application
-to support your new users and their data. One way in which your application may need
-to scale is on the database level. Rails supports using multiple databases, so you don't
-have to store your data all in one place.
+## Overview
 
-At this time the following features are supported:
+As your application grows, you may need to split data across more than one
+database. You might move a group of tables to its own database cluster, send
+read traffic to replicas, or partition the same set of tables across multiple
+shards.
 
-* Multiple writer databases and a replica for each
-* Automatic connection switching for the model you're working with
-* Automatic swapping between the writer and replica depending on the HTTP verb and recent writes
-* Rails tasks for creating, dropping, migrating, and interacting with the multiple databases
+Rails supports these common multiple database patterns:
 
-The following features are not supported:
+* Multiple writer databases, where each database stores a different part of
+  your application's data. For example, `User` records might live in the
+  `primary` database, while `Dog` records live in the `animals` database. This is
+  also called vertical partitioning.
+* Read replicas for each writer database, so reads can be sent to a replica
+  while writes continue to use the writer.
+* Automatic role switching between writers and replicas based on the HTTP verb
+  and whether the request recently performed a write.
+* Horizontal sharding, where each database has the same schema but stores a
+  different subset of the records.
+* Rails tasks for creating, dropping, migrating, loading schemas, dumping
+  schemas, and interacting with each database.
 
-* Load balancing replicas
+The right setup depends on what you are trying to accomplish:
+
+| If you need to...                                              | Use...                                                |
+| -------------------------------------------------------------- | ----------------------------------------------------- |
+| Move some models to a separate database                        | Multiple writer databases                             |
+| Send read traffic away from the writer                         | Read replicas and automatic role switching            |
+| Split records across databases that share the same schema      | Horizontal sharding                                   |
+| Connect to a legacy, reporting, or externally managed database | A database configuration with `database_tasks: false` |
+
+Rails handles the application-side plumbing for these configurations: connection
+definitions, abstract connection classes, role and shard switching, and database
+tasks. It does not provision database servers, create database users, manage
+replication, balance traffic across replicas, or provide distributed
+transactions across database clusters. Those responsibilities remain with your
+database infrastructure and application architecture.
 
 ## Setting up Your Application
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -465,6 +465,11 @@ Running `bin/rails db:create` will create both the primary and animals
 databases. Rails does not create database users; create writer and read-only
 replica users in your database system.
 
+Other Rails commands can also target a database configuration by name. For
+example, `bin/rails dbconsole --database=animals` opens a database console for
+the `animals` database, and `bin/rails query "Dog.count" --database animals`
+runs a read-only query against that database configuration.
+
 For the full list of Rails database commands, see the
 [Command Line guide](command_line.html#managing-the-database).
 
@@ -1009,3 +1014,42 @@ You can generate schema cache files with:
 ```bash
 $ bin/rails db:schema:cache:dump
 ```
+
+For multiple databases, this command dumps a schema cache for each managed
+database configuration. Each database needs its own cache file because each
+database can have different tables, columns, and metadata.
+
+You can read more about schema management in the
+[Command Line guide](command_line.html#schema-management).
+
+## Caveats and Operational Considerations
+
+Multiple database applications have a few important limitations and production
+considerations.
+
+### Connection Pools
+
+Each database configuration can have its own connection pool. Roles, replicas,
+and shards can increase the total number of database connections your
+application may open. Make sure the pool sizes in `config/database.yml` match
+your web server and job worker concurrency, and that your database servers can
+handle the total number of connections.
+
+### Load Balancing Replicas
+
+Rails does not automatically load balance reads across multiple replicas. If
+your application needs replica load balancing, handle it in your database
+infrastructure or with application-specific connection logic.
+
+### Transactions Across Databases
+
+Rails does not provide distributed transactions across database clusters. A
+transaction is scoped to one database connection. If a workflow writes to
+multiple databases, design it so it can tolerate partial failure, retry safely,
+or reconcile data later.
+
+### Foreign Keys Across Databases
+
+Database-level foreign keys generally cannot span separate database clusters.
+Keep data that requires strict database-level integrity in the same database
+when possible, or enforce cross-database consistency in your application.

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -857,11 +857,11 @@ Inside the block, only models that inherit from `AnimalsRecord` switch to the
 `reading` role. Models that inherit from `ApplicationRecord` keep using their
 current role.
 
-You can also switch one abstract class to a specific shard:
+You can also switch one sharded abstract class to a specific shard:
 
 ```ruby
-AnimalsRecord.connected_to(role: :reading, shard: :shard_one) do
-  Dog.first # Reads from shard_one_replica.
+ShardRecord.connected_to(role: :reading, shard: :shard_one) do
+  Customer.first # Reads from primary_shard_one_replica.
   Person.first  # Reads from primary writer.
 end
 ```
@@ -873,9 +873,9 @@ To switch only the primary database cluster, call `connected_to` on
 `ApplicationRecord`:
 
 ```ruby
-ApplicationRecord.connected_to(role: :reading, shard: :shard_one) do
-  Person.first # Reads from primary_shard_one_replica.
-  Dog.first # Reads from animals_primary.
+ApplicationRecord.connected_to(role: :reading) do
+  Person.first # Reads from primary_replica.
+  Dog.first # Reads from animals writer.
 end
 ```
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -26,7 +26,7 @@ At this time the following features are supported:
 * Automatic swapping between the writer and replica depending on the HTTP verb and recent writes
 * Rails tasks for creating, dropping, migrating, and interacting with the multiple databases
 
-The following features are not (yet) supported:
+The following features are not supported:
 
 * Load balancing replicas
 
@@ -34,6 +34,10 @@ The following features are not (yet) supported:
 
 While Rails tries to do most of the work for you, there are still some steps you'll
 need to do to get your application ready for multiple databases.
+
+New Rails applications generate a 3-tier production `config/database.yml` by default,
+and this same multiple database support is used by Solid Cache, queueing, and Action
+Cable.
 
 Let's say we have an application with a single writer database, and we need to add a
 new database for some new tables we're adding. The name of the new database will be
@@ -87,9 +91,14 @@ production:
 ```
 
 Connection URLs for databases can also be configured using environment variables. The variable
-name is formed by concatenating the connection name with `_DATABASE_URL`. For example, setting
-`ANIMALS_DATABASE_URL="mysql2://username:password@host/database"` is merged into the `animals`
-configuration in `database.yml` in the `production` environment. See
+name is formed by concatenating the connection name with `_DATABASE_URL`. For example:
+
+```bash
+ANIMALS_DATABASE_URL="mysql2://username:password@host/database"
+```
+
+This value is merged into the `animals` configuration in `database.yml` for the `production`
+environment. See
 [Configuring a Database](configuring.html#configuring-a-database) for details about how the
 merging works.
 
@@ -109,8 +118,18 @@ Lastly, for new writer databases, you need to set the `migrations_paths` key to 
 where you will store migrations for that database. We'll look more at `migrations_paths`
 later on in this guide.
 
-You can also configure the schema dump file by setting `schema_dump` to a custom schema file name
-or completely skip the schema dumping by setting `schema_dump: false`.
+You can also configure the schema dump file by setting `schema_dump` to a custom schema file name.
+For example:
+
+```yaml
+production:
+  animals:
+    database: my_animals_database
+    adapter: mysql2
+    schema_dump: db/animals_schema.rb
+```
+
+If you want to skip dumping the schema for a database entirely, set `schema_dump: false`.
 
 Now that we have a new database, let's set up the connection model.
 
@@ -222,7 +241,7 @@ Note that there is no command for creating the database users, and you'll need t
 to support the read-only users for your replicas. If you want to create just the animals
 database you can run `bin/rails db:create:animals`.
 
-## Connecting to Databases without Managing Schema and Migrations
+### Connecting to Databases without Managing Schema and Migrations
 
 If you would like to connect to an external database without any database
 management tasks such as schema management, migrations, seeds, etc., you can set
@@ -240,7 +259,7 @@ production:
     database_tasks: false
 ```
 
-## Generators and Migrations
+### Generators and Migrations
 
 Migrations for multiple databases should live in their own folders prefixed with the
 name of the database key in the configuration.
@@ -297,7 +316,7 @@ $ bin/rails generate scaffold Dog name:string --database animals --parent Animal
 This will skip generating `AnimalsRecord` since you've indicated to Rails that you want to
 use a different parent class.
 
-## Activating Automatic Role Switching
+### Activating Automatic Role Switching
 
 Finally, in order to use the read-only replica in your application, you'll need to activate
 the middleware for automatic switching.
@@ -374,7 +393,7 @@ config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelec
 config.active_record.database_resolver_context = MyCookieResolver
 ```
 
-## Using Manual Connection Switching
+### Using Manual Connection Switching
 
 There are some cases where you may want your application to connect to a writer or a replica
 and the automatic connection switching isn't adequate. For example, you may know that for a
@@ -416,7 +435,7 @@ database server, but maintain the same schema across "shards". This is commonly 
 sharding.
 
 The API for supporting horizontal sharding in Rails is similar to the multiple database / vertical
-sharding API that's existed since Rails 6.0.
+sharding API.
 
 Shards are declared in the three-tier config like this:
 
@@ -483,11 +502,11 @@ using sharding, both a `role` and a `shard` must be passed:
 
 ```ruby
 ShardRecord.connected_to(role: :writing, shard: :shard_one) do
-  @person = Person.create! # Creates a record in shard shard_one
+  @customer = Customer.create! # Creates a record in shard shard_one
 end
 
 ShardRecord.connected_to(role: :writing, shard: :shard_two) do
-  Person.find(@person.id) # Can't find record, doesn't exist because it was created
+  Customer.find(@customer.id) # Can't find record, doesn't exist because it was created
                    # in the shard named ":shard_one".
 end
 ```
@@ -497,11 +516,11 @@ role and the shard with the `connected_to` API.
 
 ```ruby
 ShardRecord.connected_to(role: :reading, shard: :shard_one) do
-  Person.first # Lookup record from read replica of shard one.
+  Customer.first # Lookup record from read replica of shard one.
 end
 ```
 
-## Activating Automatic Shard Switching
+### Activating Automatic Shard Switching
 
 Applications are able to automatically switch shards per request using the `ShardSelector`
 middleware, which allows an application to provide custom logic for determining the appropriate
@@ -555,8 +574,7 @@ config.active_record.shard_selector = { lock: true, class_name: "AnimalsRecord" 
 
 ## Granular Database Connection Switching
 
-Starting from Rails 6.1, it's possible to switch connections for one database
-instead of all databases globally.
+It's possible to switch connections for one database instead of all databases globally.
 
 With granular database connection switching, any abstract connection class
 will be able to switch connections without affecting other connections. This
@@ -597,27 +615,36 @@ connections globally.
 
 ### Handling Associations with Joins across Databases
 
-As of Rails 7.0+, Active Record has an option for handling associations that would perform
-a join across multiple databases. If you have a has many through or a has one through association
-that you want to disable joining and perform 2 or more queries, pass the `disable_joins: true` option.
+Active Record has an option for handling associations that would perform a join across multiple
+databases. If you have a has many through or a has one through association that you want to disable
+joining and perform 2 or more queries, pass the `disable_joins: true` option.
 
 For example:
 
 ```ruby
 class Dog < AnimalsRecord
+  has_many :humans, disable_joins: true
   has_many :treats, through: :humans, disable_joins: true
-  has_many :humans
 
   has_one :home
   has_one :yard, through: :home, disable_joins: true
 end
 
-class Home
+class Human < ApplicationRecord
+  belongs_to :dog
+  has_many :treats
+end
+
+class Treat < ApplicationRecord
+  belongs_to :human
+end
+
+class Home < ApplicationRecord
   belongs_to :dog
   has_one :yard
 end
 
-class Yard
+class Yard < ApplicationRecord
   belongs_to :home
 end
 ```
@@ -656,8 +683,14 @@ There are some important things to be aware of with this option:
 If you want to load a schema cache for each database you must set
 `schema_cache_path` in each database configuration and set
 `config.active_record.lazily_load_schema_cache = true` in your application
-configuration. Note that this will lazily load the cache when the database
-connections are established.
+configuration.
+
+Schema caching stores a snapshot of the database table and column metadata so Rails
+does not have to query the database for that information every time a connection is
+established.
+
+
+NOTE: With these settings the cache is loaded lazily when the database connections are established.
 
 ## Caveats
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -834,14 +834,17 @@ configuration tells `ShardSelector` to switch shards using
 config.active_record.shard_selector = { lock: true, class_name: "ShardRecord" }
 ```
 
-## Granular Database Connection Switching
+## Granular Role and Shard Switching
 
-It's possible to switch connections for one database instead of all databases globally.
+By default, calling `connected_to` on `ActiveRecord::Base` switches the role or
+shard for all abstract connection classes. In a multiple database application,
+you may only want to switch one database connection while leaving the others
+unchanged.
 
-With granular database connection switching, any abstract connection class
-will be able to switch connections without affecting other connections. This
-is useful for switching your `AnimalsRecord` queries to read from the replica
-while ensuring your `ApplicationRecord` queries go to the primary.
+Granular role and shard switching lets you call `connected_to` on a specific
+abstract class. This is useful when you want `AnimalsRecord` queries to read
+from the replica while `ApplicationRecord` queries continue using the primary
+writer.
 
 ```ruby
 AnimalsRecord.connected_to(role: :reading) do
@@ -850,20 +853,24 @@ AnimalsRecord.connected_to(role: :reading) do
 end
 ```
 
-It's also possible to swap connections granularly for shards.
+Inside the block, only models that inherit from `AnimalsRecord` switch to the
+`reading` role. Models that inherit from `ApplicationRecord` keep using their
+current role.
+
+You can also switch one abstract class to a specific shard:
 
 ```ruby
 AnimalsRecord.connected_to(role: :reading, shard: :shard_one) do
-  # Will read from shard_one_replica. If no connection exists for shard_one_replica,
-  # a ConnectionNotEstablished error will be raised.
-  Dog.first
-
-  # Will read from primary writer.
-  Person.first
+  Dog.first # Reads from shard_one_replica.
+  Person.first  # Reads from primary writer.
 end
 ```
 
-To switch only the primary database cluster use `ApplicationRecord`:
+If no connection exists for the requested role and shard, Rails raises
+`ActiveRecord::ConnectionNotEstablished`.
+
+To switch only the primary database cluster, call `connected_to` on
+`ApplicationRecord`:
 
 ```ruby
 ApplicationRecord.connected_to(role: :reading, shard: :shard_one) do
@@ -872,8 +879,8 @@ ApplicationRecord.connected_to(role: :reading, shard: :shard_one) do
 end
 ```
 
-`ActiveRecord::Base.connected_to` maintains the ability to switch
-connections globally.
+Use `ActiveRecord::Base.connected_to` when you want to switch all abstract
+connection classes globally.
 
 ### Handling Associations with Joins across Databases
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -884,11 +884,16 @@ connection classes globally.
 
 ## Handling Associations Across Databases
 
-Active Record has an option for handling associations that would perform a join across multiple
-databases. If you have a has many through or a has one through association that you want to disable
-joining and perform 2 or more queries, pass the `disable_joins: true` option.
+Databases cannot perform SQL joins across separate database clusters. If an
+association would require Rails to join tables that live in different databases,
+the query cannot be sent as a single SQL join.
 
-For example:
+For `has_many :through` and `has_one :through` associations, you can pass
+`disable_joins: true` to tell Rails to load the association with separate
+queries instead of a join.
+
+In this example, `Dog` is stored in the `animals` database, while `Human`,
+`Treat`, `Home`, and `Yard` are stored in the primary database:
 
 ```ruby
 class Dog < AnimalsRecord
@@ -918,34 +923,49 @@ class Yard < ApplicationRecord
 end
 ```
 
-Previously calling `@dog.treats` without `disable_joins` or `@dog.yard` without `disable_joins`
-would raise an error because databases are unable to handle joins across clusters. With the
-`disable_joins` option, Rails will generate multiple select queries
-to avoid attempting joining across clusters. For the above association, `@dog.treats` would generate the
-following SQL:
+Notice that `disable_joins: true` is added to the associations in the `Dog`
+model. If these models used the same database connection, Rails would normally
+load the association with a SQL join. Since the associated models are backed by
+different database connections, Rails needs to avoid that join. Without
+`disable_joins: true`, calling `@dog.treats` or `@dog.yard` would raise an
+error because databases are unable to handle joins across clusters.
+
+The `disable_joins: true` option tells Rails to skip the SQL join for that
+association and load the records with two or more queries instead.
+
+Instead of building one query that joins the tables, Rails queries the
+intermediate association first, collects the IDs it needs, and then uses those
+IDs in a second query for the associated records.
+
+In the example below, to get `@dog.treats`, Rails first loads the associated
+`humans` IDs, and then uses those IDs to load `treats`:
 
 ```sql
 SELECT "humans"."id" FROM "humans" WHERE "humans"."dog_id" = ?  [["dog_id", 1]]
 SELECT "treats".* FROM "treats" WHERE "treats"."human_id" IN (?, ?, ?)  [["human_id", 1], ["human_id", 2], ["human_id", 3]]
 ```
 
-While `@dog.yard` would generate the following SQL:
+For `@dog.yard`, Rails first loads the associated `home` ID, and then uses
+that ID to load `yards`:
 
 ```sql
 SELECT "home"."id" FROM "homes" WHERE "homes"."dog_id" = ? [["dog_id", 1]]
 SELECT "yards".* FROM "yards" WHERE "yards"."home_id" = ? [["home_id", 1]]
 ```
 
-There are some important things to be aware of with this option:
+There are some tradeoffs to be aware of with this option:
 
-1. There may be performance implications since now two or more queries will be performed (depending
-   on the association) rather than a join. If the select for `humans` returned a high number of IDs
-   the select for `treats` may send too many IDs.
-2. Since we are no longer performing joins, a query with an order or limit is now sorted in-memory since
-   order from one table cannot be applied to another table.
-3. This setting must be added to all associations where you want joining to be disabled.
-   Rails can't guess this for you because association loading is lazy, to load `treats` in `@dog.treats`
-   Rails already needs to know what SQL should be generated.
+1. There may be performance implications because Rails performs two or more
+   queries, depending on the association, rather than one join. If the query for
+   `humans` returns many IDs, the query for `treats` may send a large `IN`
+   list.
+2. Since Rails is no longer performing a join, a query with an order or limit
+   is sorted in-memory because an order from one table cannot be applied to
+   another table.
+3. This setting must be added to all associations where you want joining to be
+   disabled. Rails can't guess this for you because association loading is
+   lazy. To load `treats` in `@dog.treats`, Rails already needs to know what
+   SQL should be generated.
 
 ## Schema Caching
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -52,38 +52,57 @@ replication, balance traffic across replicas, or provide distributed
 transactions across database clusters. Those responsibilities remain with your
 database infrastructure and application architecture.
 
-## Setting up Your Application
+## Setting Up Multiple Databases
 
-While Rails tries to do most of the work for you, there are still some steps you'll
-need to do to get your application ready for multiple databases.
+Setting up multiple databases starts with `config/database.yml`. Each entry
+names a database configuration that Rails can connect to, and Rails uses those
+configuration names later when you connect models, run database tasks, and
+switch between writers, replicas, or shards.
 
-New Rails applications generate a 3-tier production `config/database.yml` by default,
-and this same multiple database support is used by Solid Cache, queueing, and Action
-Cable.
+Rails supports two layouts for `config/database.yml`. A two-tier configuration
+has the environment, such as `development`, point directly to one database
+configuration. A three-tier configuration has the environment point to multiple
+named database configurations, such as `primary`, `primary_replica`, `animals`,
+and `animals_replica`.
 
-Let's say we have an application with a single writer database, and we need to add a
-new database for some new tables we're adding. The name of the new database will be
-"animals".
+INFO: Three-tier configuration refers to the YAML nesting: environment, database configuration name, and then database settings.<br><br><code class="yaml">production:          # tier 1: environment
+  primary:           # tier 2: database configuration name
+    database: ...    # tier 3: adapter/database/credentials/settings
+</code>
+<br>
+In a default Rails application, `development` and `test` often use a two-tier
+configuration, while `production` may already use a three-tier configuration
+for `primary`, `cache`, `queue`, and `cable`.
 
-`config/database.yml` looks like this:
+The examples in this guide start with a three-tier production configuration
+that has one primary database. The application then adds a second database
+named `animals`. Models such as `User` will continue to use the primary
+database, while models such as `Dog` will use the animals database. Later
+sections build on this example by adding replicas and showing how Rails
+switches between them.
+
+### Database Configurations
+
+Suppose you have an application with a single primary database configuration:
 
 ```yaml
 production:
-  database: my_primary_database
-  adapter: mysql2
-  username: root
-  password: <%= ENV['ROOT_PASSWORD'] %>
+  primary:
+    database: my_primary_database
+    adapter: mysql2
+    username: root
+    password: <%= ENV['ROOT_PASSWORD'] %>
 ```
 
-Let's add a second database called "animals" and replicas for both databases as
-well. To do this, we need to change our `config/database.yml` from a 2-tier to a
-3-tier config.
+To add the `animals` database and replicas for both databases, add new named
+database configurations under `production`.
 
-If a `primary` configuration key is provided, it will be used as the "default" configuration. If
-there is no configuration named `primary`, Rails will use the first configuration as default
-for each environment. The default configurations will use the default Rails filenames. For example,
-primary configurations will use `db/schema.rb` for the schema file, whereas all the other entries
-will use `db/[CONFIGURATION_NAMESPACE]_schema.rb` for the filename.
+If a `primary` configuration key is provided, it will be used as the default
+configuration. If there is no configuration named `primary`, Rails will use the
+first configuration as the default for each environment. The default
+configuration uses the default Rails filenames. For example, a `primary`
+configuration will use `db/schema.rb` for the schema file, whereas other entries
+will use `db/[CONFIGURATION_NAMESPACE]_schema.rb`.
 
 ```yaml
 production:
@@ -112,38 +131,100 @@ production:
     replica: true
 ```
 
-Connection URLs for databases can also be configured using environment variables. The variable
-name is formed by concatenating the connection name with `_DATABASE_URL`. For example:
+The updated configuration defines two writer databases, `primary` and
+`animals`. A writer database is the database Rails uses for inserts, updates,
+and deletes. Each writer also has a replica: `primary_replica` copies data from
+`primary`, and `animals_replica` copies data from `animals`, so Rails can send
+read queries to a replica when appropriate.
+
+#### Database Connection URLs
+
+A database connection URL is a single string that contains the adapter,
+username, password, host, and database name for a database connection.
+Connection URLs can also be configured using environment variables.
+
+The variable name is formed by concatenating the database configuration name
+with `_DATABASE_URL`. For example, because the configuration name is `animals`,
+Rails looks for an environment variable named `ANIMALS_DATABASE_URL`:
 
 ```bash
-ANIMALS_DATABASE_URL="mysql2://username:password@host/database"
+ANIMALS_DATABASE_URL="mysql2://animals_root:password@localhost/my_animals_database"
 ```
 
-This value is merged into the `animals` configuration in `database.yml` for the `production`
-environment. See
-[Configuring a Database](configuring.html#configuring-a-database) for details about how the
-merging works.
+Rails combines the matching environment variable with the matching
+`database.yml` entry. The URL supplies the connection details, while
+`database.yml` can keep Rails-specific options such as `migrations_paths`.
+
+For example, `database.yml` does not need to include the username, password,
+host, or database name if those details are provided by the connection URL:
+
+```yaml
+production:
+  animals:
+    adapter: mysql2
+    migrations_paths: db/animals_migrate
+```
+
+When Rails loads the `animals` configuration, it uses
+`ANIMALS_DATABASE_URL` for the connection details and keeps
+`migrations_paths` from `database.yml`.
+
+See [Configuring a Database](configuring.html#configuring-a-database) for
+details about how the merging works.
+
+#### Configuration Settings
 
 When using multiple databases, there are a few important settings.
 
-First, the database name for `primary` and `primary_replica` should be the same because they contain
-the same data. This is also the case for `animals` and `animals_replica`.
+First, the database name for a writer and its replica should be the same because
+they contain the same data. This means `primary` and `primary_replica` should
+point to the same database, and `animals` and `animals_replica` should point to
+the same database.
+
+```yaml#3,5
+production:
+  primary:
+    database: my_primary_database
+  primary_replica:
+    database: my_primary_database
+```
 
 Second, the username for the writers and replicas should be different, and the
 replica user's database permissions should be set to only read and not write.
 
-When using a replica database, you need to add a `replica: true` entry to the replica in
-`config/database.yml`. This is because Rails otherwise has no way of knowing which one is a replica
-and which one is the writer. Rails will not run certain tasks, such as migrations, against replicas.
+```yaml#3,5
+production:
+  primary:
+    username: root
+  primary_replica:
+    username: root_readonly
+```
 
-Lastly, for new writer databases, you need to set the `migrations_paths` key to the directory
-where you will store migrations for that database. We'll look more at `migrations_paths`
-later on in this guide.
+When using a replica database, you need to add `replica: true` to the replica
+configuration in `config/database.yml`. Rails otherwise has no way of knowing
+which configuration is the replica and which one is the writer. Rails will not
+run certain tasks, such as migrations, against replicas.
 
-You can also configure the schema dump file by setting `schema_dump` to a custom schema file name.
-For example:
+```yaml#3
+production:
+  primary_replica:
+    replica: true
+```
 
-```yaml
+Lastly, for new writer databases, you need to set the `migrations_paths` key to
+the directory where you will store migrations for that database. We'll look more
+at `migrations_paths` later on in this guide.
+
+```yaml#3
+production:
+  animals:
+    migrations_paths: db/animals_migrate
+```
+
+You can also configure the schema dump file by setting `schema_dump` to a
+custom schema file name. For example:
+
+```yaml#5
 production:
   animals:
     database: my_animals_database
@@ -151,11 +232,24 @@ production:
     schema_dump: db/animals_schema.rb
 ```
 
-If you want to skip dumping the schema for a database entirely, set `schema_dump: false`.
+If you want to skip dumping the schema for a database entirely, set
+`schema_dump: false`.
 
-Now that we have a new database, let's set up the connection model.
+#### Connecting Models to Databases
 
-The primary database replica may be configured in `ApplicationRecord` this way:
+Adding a database configuration tells Rails how to connect to the database, but
+Rails also needs to know which models should use that connection. To do that,
+define an abstract class for each database and have the models for that database
+inherit from it.
+
+Each abstract class owns the connection for one database, or for one writer and
+replica pair. Concrete models then inherit from the abstract class for the
+database where their table lives.
+
+##### Connecting the Primary Model and Database
+
+The primary database and its replica can be configured in `ApplicationRecord`
+this way:
 
 ```ruby
 class ApplicationRecord < ActiveRecord::Base
@@ -165,9 +259,13 @@ class ApplicationRecord < ActiveRecord::Base
 end
 ```
 
-If you use a differently named class for your application record you need to
-set `primary_abstract_class` instead, so that Rails knows which class `ActiveRecord::Base`
-should share a connection with.
+Models that inherit from `ApplicationRecord` will use the `primary` database for
+writes and the `primary_replica` database for reads when Rails is switched to
+the reading role.
+
+If you use a differently named class for your application record, set
+`primary_abstract_class` so that Rails knows which class `ActiveRecord::Base`
+should share a connection with:
 
 ```ruby
 class PrimaryApplicationRecord < ActiveRecord::Base
@@ -186,7 +284,9 @@ class Person < PrimaryApplicationRecord
 end
 ```
 
-On the other hand, we need to set up our models persisted in the "animals" database:
+##### Connecting the Animals Model and Database
+
+Next, set up an abstract class for models stored in the `animals` database:
 
 ```ruby
 class AnimalsRecord < ApplicationRecord
@@ -196,7 +296,8 @@ class AnimalsRecord < ApplicationRecord
 end
 ```
 
-Those models should inherit from that common abstract class:
+Models stored in the `animals` database should inherit from that common
+abstract class:
 
 ```ruby
 class Dog < AnimalsRecord
@@ -204,26 +305,35 @@ class Dog < AnimalsRecord
 end
 ```
 
-By default, Rails expects the database roles to be `writing` and `reading` for the primary
-and replica respectively. If you have a legacy system you may already have roles set up that
-you don't want to change. In that case you can set a new role name in your application config.
+`Dog` now uses the `animals` database for writes and the `animals_replica`
+database for reads when Rails is switched to the reading role.
+
+##### Custom Role Names
+
+By default, Rails expects the database roles to be `writing` for the writer and
+`reading` for the replica. If you have a legacy system, you may already have
+roles set up that you don't want to change. In that case, you can set new role
+names in your application config:
 
 ```ruby
 config.active_record.writing_role = :default
 config.active_record.reading_role = :readonly
 ```
 
-It's important to connect to your database in a single model and then inherit from that model
-for the tables rather than connect multiple individual models to the same database. Database
-clients have a limit to the number of open connections there can be, and if you do this, it will
-multiply the number of connections you have since Rails uses the model class name for the
-connection specification name.
+WARNING. It's important to connect to each database from a single abstract class and
+then inherit from that class for the models stored in that database. Connecting
+multiple individual models to the same database multiplies the number of
+connections, because Rails uses the model class name for the connection
+specification name.
 
-Now that we have the `config/database.yml` and the new model set up, it's time
+#### Running Database Tasks
+
+Now that we have `config/database.yml` and the model classes set up, it's time
 to create the databases. Rails ships with all the commands you need to use
 multiple databases.
 
-You can run `bin/rails --help` to see all the commands you're able to run. You should see the following:
+You can run `bin/rails --help` to see all the commands you're able to run. You
+should see the following:
 
 ```bash
 $ bin/rails --help

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -323,13 +323,11 @@ end
 `Dog` now uses the `animals` database for writes and the `animals_replica`
 database for reads when Rails is switched to the reading role.
 
-WARNING. It's important to connect to each database from a single abstract class and
-then inherit from that class for the models stored in that database. Connecting
+WARNING: It's important to connect to each database from a single abstract class
+and then inherit from that class for the models stored in that database. Connecting
 multiple individual models to the same database multiplies the number of
 connections, because Rails uses the model class name for the connection
 specification name.
-
-#### Custom Role Names
 
 If your application already uses different role names, you can configure Rails
 to use those names instead:
@@ -345,18 +343,16 @@ After changing the role names, use those names in `connects_to`:
 connects_to database: { default: :primary, readonly: :primary_replica }
 ```
 
-#### Using Generators
-
 If you create models and migrations with Rails generators, pass the database
 name so Rails can place files in the right migration path and use the right
 abstract class.
+
+#### Generating Migrations
 
 Each managed writer database needs a migration path. Keeping migrations
 separate lets Rails migrate one database without running migrations intended for
 another database. Replicas do not need migration paths because Rails does not
 run migrations against configurations marked with `replica: true`.
-
-#### Migration Paths
 
 Migrations for multiple databases should live in their own folders prefixed
 with the name of the database key in the configuration. You also need to set
@@ -372,8 +368,6 @@ production:
   animals:
     migrations_paths: db/animals_migrate
 ```
-
-#### Generating Migrations
 
 Rails generators take a `--database` option so that generated migration files
 are placed in the correct directory:
@@ -419,8 +413,6 @@ Rails will only generate `AnimalsRecord` once. It will not be overwritten by new
 scaffolds or deleted if the scaffold is deleted, so your changes to the
 abstract class are preserved.
 
-#### Using a Custom Abstract Class
-
 If you already have an abstract class and its name differs from
 `AnimalsRecord`, pass the `--parent` option to tell Rails which class the model
 should inherit from:
@@ -432,7 +424,7 @@ $ bin/rails generate scaffold Dog name:string --database animals --parent Animal
 This will skip generating `AnimalsRecord` since you've indicated to Rails that you want to
 use a different parent class.
 
-### Running Database Tasks
+### Database Tasks
 
 Rails creates database tasks for each managed database configuration. Running a
 task without a database name applies it to all managed databases, for example:

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -261,6 +261,20 @@ connects_to database: { writing: :primary, reading: :primary_replica }
 
 By default, Rails expects these role names to be `writing` and `reading`.
 
+If your application already uses different role names, you can configure Rails
+to use those names instead:
+
+```ruby
+config.active_record.writing_role = :default
+config.active_record.reading_role = :readonly
+```
+
+After changing the role names, use those names in `connects_to`:
+
+```ruby
+connects_to database: { default: :primary, readonly: :primary_replica }
+```
+
 ##### Connecting the Primary Model and Database
 
 The primary database and its replica can be configured in `ApplicationRecord`
@@ -324,24 +338,10 @@ end
 database for reads when Rails is switched to the reading role.
 
 WARNING: It's important to connect to each database from a single abstract class
-and then inherit from that class for the models stored in that database. Connecting
-multiple individual models to the same database multiplies the number of
-connections, because Rails uses the model class name for the connection
-specification name.
-
-If your application already uses different role names, you can configure Rails
-to use those names instead:
-
-```ruby
-config.active_record.writing_role = :default
-config.active_record.reading_role = :readonly
-```
-
-After changing the role names, use those names in `connects_to`:
-
-```ruby
-connects_to database: { default: :primary, readonly: :primary_replica }
-```
+and then inherit from that class for the models stored in that database.
+Connecting multiple individual models to the same database multiplies the
+number of connections, because Rails uses the model class name for the
+connection specification name.
 
 If you create models and migrations with Rails generators, pass the database
 name so Rails can place files in the right migration path and use the right
@@ -407,7 +407,12 @@ class Dog < AnimalsRecord
 end
 ```
 
-NOTE: Since Rails doesn't know which database is the replica for your writer you will need to add this to the abstract class after you're done: `connects_to database: { writing: :animals, reading: :animals_replica }`.
+Since Rails doesn't know which database is the replica for your writer, add the
+replica to the abstract class after it's generated:
+
+```ruby
+connects_to database: { writing: :animals, reading: :animals_replica }
+```
 
 Rails will only generate `AnimalsRecord` once. It will not be overwritten by new
 scaffolds or deleted if the scaffold is deleted, so your changes to the
@@ -460,7 +465,7 @@ replica users in your database system.
 For the full list of Rails database commands, see the
 [Command Line guide](command_line.html#managing-the-database).
 
-### Connecting to Databases Managed Outside Rails
+### External Databases
 
 Some applications connect to databases that Rails should use but not manage.
 For example, you might connect to a legacy database, a reporting database, or a
@@ -494,13 +499,13 @@ These roles usually point to a writer database and its replica.
 
 #### Automatic Role Switching
 
-Automatic role switching, sometimes called automatic connection switching, lets
-Rails choose between the writer and replica for each request. You may want
-automatic role switching when your application uses replicas to reduce read
-traffic on the writer, but still needs users to see their own changes
-immediately after they write. It is implemented as middleware, so it applies to
-web requests.
+Automatic role switching lets Rails choose between the writer and replica for
+each request. This is sometimes called automatic connection switching.
 
+You may want automatic role switching when your application uses replicas to
+reduce read traffic on the writer, but still needs users to see their own
+changes immediately after they write. It is implemented as middleware, so it
+applies to web requests.
 
 The middleware chooses a role based on the HTTP verb and whether the same
 requesting user recently wrote to the database:

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -648,8 +648,7 @@ writer. A shard stores a different subset of records. Applications commonly use
 sharding when one database has too much data or traffic, or when tenant or
 account data should be distributed across database servers.
 
-The API for supporting horizontal sharding in Rails is similar to the multiple
-database, or vertical partitioning, API.
+Rails uses the same `connects_to` and `connected_to` APIs for sharding.
 
 ### Configuring Shards
 
@@ -730,9 +729,9 @@ the `primary_shard_one` writer and `primary_shard_one_replica` replica. The
 Shards usually share a schema, so shard migrations should use the same
 `migrations_paths` and `schema_dump` settings across all shards.
 
-When generating a migration, pass `--database` with one of the shard database
-configuration names. Since both shards use the same migration path, it does not
-matter which shard configuration you choose.
+When generating a migration or scaffold, pass `--database` with one of the
+shard database configuration names. Since both shards use the same migration
+path, it does not matter which shard configuration you choose.
 
 ```bash
 $ bin/rails g scaffold Customer name:string --database primary_shard_one
@@ -818,21 +817,21 @@ The behavior of `ShardSelector` can be altered through some configuration
 options.
 
 - `lock` is true by default and prevents the request from switching shards after
-the resolver chooses one. If `lock` is false, shard swapping is allowed during
-the request. For tenant-based sharding, `lock` should usually be true to
-prevent application code from accidentally switching between tenants.
+  the resolver chooses one. If `lock` is false, shard swapping is allowed
+  during the request. For tenant-based sharding, `lock` should usually be true
+  to prevent application code from accidentally switching between tenants.
 
 - `class_name` is the name of the abstract connection class to switch. By
-default, the `ShardSelector` uses `ActiveRecord::Base`. If the application has
-multiple abstract connection classes, set `class_name` to the sharded
-database's abstract connection class.
+  default, the `ShardSelector` uses `ActiveRecord::Base`. If the application
+  has multiple abstract connection classes, set `class_name` to the sharded
+  database's abstract connection class.
 
 Options may be set in the application configuration. For example, this
 configuration tells `ShardSelector` to switch shards using
-`AnimalsRecord.connected_to`:
+`ShardRecord.connected_to`:
 
 ```ruby
-config.active_record.shard_selector = { lock: true, class_name: "AnimalsRecord" }
+config.active_record.shard_selector = { lock: true, class_name: "ShardRecord" }
 ```
 
 ## Granular Database Connection Switching

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -487,15 +487,20 @@ In this example, Rails will still connect to the `reporting` database when a
 model uses that configuration, but commands such as `bin/rails db:create`,
 `bin/rails db:migrate`, and `bin/rails db:schema:dump` will skip it.
 
-### Automatic Role Switching
+### Role Switching
 
-Automatic role switching lets Rails choose between the writer and replica for
-each request. You may want automatic role switching when your application uses replicas to
-reduce read traffic on the writer, but still needs users to see their own
-changes immediately after they write. It is implemented as middleware, so it applies to web requests.
+Role switching lets Rails choose between the `writing` and `reading` roles.
+These roles usually point to a writer database and its replica.
 
-For scripts, console sessions, background jobs, or places where you need
-explicit control, use manual connection switching instead.
+#### Automatic Role Switching
+
+Automatic role switching, sometimes called automatic connection switching, lets
+Rails choose between the writer and replica for each request. You may want
+automatic role switching when your application uses replicas to reduce read
+traffic on the writer, but still needs users to see their own changes
+immediately after they write. It is implemented as middleware, so it applies to
+web requests.
+
 
 The middleware chooses a role based on the HTTP verb and whether the same
 requesting user recently wrote to the database:
@@ -577,40 +582,55 @@ config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelec
 config.active_record.database_resolver_context = MyCookieResolver
 ```
 
-### Using Manual Connection Switching
+#### Manual Role Switching
 
-There are some cases where you may want your application to connect to a writer or a replica
-and the automatic connection switching isn't adequate. For example, you may know that for a
-particular request you always want to send the request to a replica, even when you are in a
-POST request path.
+Manual role switching lets you choose the database role for a block of code.
+Use it when automatic role switching would choose the wrong role for a specific
+case, or when automatic role switching does not apply, such as in scripts,
+console sessions, and background jobs.
 
-To do this Rails provides a `connected_to` method that will switch to the connection you
-need.
+For example, automatic role switching sends `POST` requests to the writer, but
+you may have a `POST` request that only reads data and should use a replica.
+
+To switch roles manually, wrap the code in `connected_to`:
 
 ```ruby
 ActiveRecord::Base.connected_to(role: :reading) do
-  # All code in this block will be connected to the reading role.
+  # All code in this block uses the reading role.
 end
 ```
 
-The "role" in the `connected_to` call looks up the connections that are connected on that
-connection handler (or role). The `reading` connection handler will hold all the connections
-that were connected via `connects_to` with the role name of `reading`.
+The role passed to `connected_to` must match a role defined by `connects_to`.
+In the examples above, the `reading` role points to the replica configuration:
 
-Note that `connected_to` with a role will look up an existing connection and switch
-using the connection specification name. This means that if you pass an unknown role
-like `connected_to(role: :nonexistent)` you will get an error that says
+```ruby
+connects_to database: { writing: :primary, reading: :primary_replica }
+```
+
+If you pass an unknown role, Rails raises an error:
+
+```ruby
+ActiveRecord::Base.connected_to(role: :nonexistent) do
+  # ...
+end
+```
+
+The error will look like:
+
 `ActiveRecord::ConnectionNotEstablished (No connection pool for 'ActiveRecord::Base' found for the 'nonexistent' role.)`
 
-If you want Rails to ensure any queries performed are read-only, pass `prevent_writes: true`.
-This just prevents queries that look like writes from being sent to the database.
-You should also configure your replica database to run in read-only mode.
+If you want Rails to prevent write queries while using a role, pass
+`prevent_writes: true`. This prevents queries that look like writes from being
+sent to the database:
 
 ```ruby
 ActiveRecord::Base.connected_to(role: :reading, prevent_writes: true) do
   # Rails will check each query to ensure it's a read query.
 end
 ```
+
+This Rails-level check is not a substitute for database permissions. You should
+also configure replica users as read-only in your database.
 
 ## Horizontal Sharding
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Detail

We update the guides with the following details:

- Any new Rails applications also uses multiple database support for SolidCache/Queue/Cable, maybe we should mention that as well?
- "Load balancing replicas" is still not supported. Maybe we should remove the "yet"?
- A newly generated Rails application already has a 3-tier database configuration for production. For older applications changing to a 3-tier makes sense, but maybe we should mention the new default?
-  I personally find examples like `ANIMALS_DATABASE_URL="mysql2://username:password@host/database"` more readable in an example code block.
- The schema_dump options could use an example code block I think.
- This relates to the database tasks, so I think it can be a part of the previous section.
-  "Finally, in order to use the read-only replica in your application, you'll need to activate the middleware for automatic switching." It seems this is still part of the "Setting up your Application" section. The same thing applies to "Using Manual Connection Switching".
- There is an `class Person` example that inherits from `ShardRecord`, while a previous example inherited from `PrimaryApplicationRecord`. This makes some examples further on a bit confusing. Maybe we could use `Home` as an example of a shared class? Or maybe we should make a clearer distinction as just use different examples of sharding.
- This should probably be a subsection of "Horizontal Sharding"
- `class Home` and `class Yard` should both at least inherit from `ApplicationRecord` I think, or Maybe a ShardRecord. Also `has_many :treats` assumes a `Treats` class.  
- `Schema Caching` is mentioned, but I have no idea what that is.
- I think we can remove all the references to older Rails versions: "existed since Rails 6.0", "Starting from Rails 6.1", "As of Rails 7.0+"....
- Reworked the overview to introduce multiple database concepts earlier, including writers, replicas, vertical partitioning, horizontal sharding, and external databases.
- Reorganized “Setting Up Multiple Databases” into clearer sections for database configuration, models and migrations, database tasks, external databases, and role switching.
- Expanded the database configuration examples to explain three-tier YAML nesting, connection URLs, replicas, `migrations_paths`, and `schema_dump`.
- Clarified how models connect to databases through abstract classes, including primary models, secondary database models, custom role names, and generator behavior.
- Improved database task documentation by explaining per-database tasks, replica task behavior, dbconsole/query targeting, and external databases managed outside Rails.
- Split role switching into automatic and manual role switching, with clearer guidance on when each applies.
- Expanded the horizontal sharding section with more context on shards vs replicas, shard configuration names, shared migration paths, and manual/automatic shard switching.
- Added a dedicated “Granular Role and Shard Switching” section.
- Clarified cross-database associations and `disable_joins: true`, including how Rails avoids SQL joins by issuing multiple queries.
- Expanded schema caching documentation for multiple databases.
- Added a concise caveats section covering connection pools, replica load balancing, transactions across databases, and foreign keys across databases.


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
