### PR TITLE
Honor falsy values in routing's deprecated positional-hash options

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -665,11 +665,11 @@ module ActionDispatch
 
         private
           def assign_deprecated_option(deprecated_options, key, method_name)
-            if (deprecated_value = deprecated_options.delete(key))
+            if deprecated_options.key?(key)
               ActionDispatch.deprecator.warn(<<~MSG.squish)
                 #{method_name} received a hash argument #{key}. Please use a keyword instead. Support to hash argument will be removed in Rails 8.2.
               MSG
-              deprecated_value
+              deprecated_options.delete(key)
             end
           end
 

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -222,6 +222,17 @@ module ActionDispatch
         end
       end
 
+      def test_deprecated_hash_honors_format_false
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+
+        assert_deprecated(ActionDispatch.deprecator) do
+          mapper.get "/*path", { to: "pages#show", format: false }
+        end
+
+        assert_equal "/*path", fakeset.asts.first.to_s
+      end
+
       def test_deprecated_hash
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset


### PR DESCRIPTION
## Summary

During the keyword migration period, the deprecated positional-hash form and the keyword form of the routing DSL are meant to be equivalent. But boolean options like `format: false` and `anchor: false` are silently dropped in the positional-hash form, producing a different route — and no deprecation warning fires for the dropped key, so users have no way to notice the discrepancy.

```ruby
# keyword form — correct: disables the format segment
get "/*path", to: "pages#show", format: false
#=> "/*path"

# deprecated positional-hash form — wrong: format: false silently ignored
get "/*path", { to: "pages#show", format: false }
#=> "/*path(.:format)"
```

Users following the deprecation warning to migrate from hash to keyword form may find their routes change behavior in the process, making the migration itself a source of subtle breakage.

## Cause

`assign_deprecated_option` extracted the value with a truthiness test:

```ruby
def assign_deprecated_option(deprecated_options, key, method_name)
  if (deprecated_value = deprecated_options.delete(key))
    ActionDispatch.deprecator.warn(...)
    deprecated_value
  end
end
```

The boolean-capable options `:format` and `:anchor` are wired through this helper behind an outer `if deprecated_options.key?(key)` guard — that guard exists precisely so a deliberately-passed `false` survives. But the helper's inner truthiness check returns `nil` for a stored value of `false`, so the value is swallowed and the deprecation warning never fires either.

## Fix

Check key presence with `key?` before deleting, then return the deleted value (including falsy ones):

```ruby
def assign_deprecated_option(deprecated_options, key, method_name)
  if deprecated_options.key?(key)
    ActionDispatch.deprecator.warn(...)
    deprecated_options.delete(key)
  end
end
```

This honors `false` (and warns about it) while leaving every other call site unchanged — the `||=` callers still no-op when the key is absent.

## Provenance

Introduced by the keyword migration in `3b4255e180` ("Use keywords in routing mapper", v8.1.0). This is the same fix family as the recently-merged deprecated-hash fixes for `scope`'s `:except` / `namespace`'s `:path` — those addressed non-boolean options; this addresses the boolean `:format` / `:anchor` options that flow through the shared helper.

## Tests

Added `test_deprecated_hash_honors_format_false` to `actionpack/test/dispatch/mapper_test.rb`, mirroring the existing `test_map_wildcard_with_format_false` keyword test.

- Before fix: `Expected: "/*path"  Actual: "/*path(.:format)"` (red)
- After fix: green

Full local run, all green:
- `mapper_test.rb`: 23 runs, 48 assertions, 0 failures
- `routing_test.rb`: 326 runs, 1181 assertions, 0 failures
- `routing/route_set_test.rb`: 18 runs, 34 assertions, 0 failures