### PR TITLE
Fix `instance_variable_names` RDoc to show declaration order

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -25,7 +25,7 @@ class Object
   #     end
   #   end
   #
-  #   C.new(0, 1).instance_variable_names # => ["@y", "@x"]
+  #   C.new(0, 1).instance_variable_names # => ["@x", "@y"]
   def instance_variable_names
     instance_variables.map(&:name)
   end


### PR DESCRIPTION
## Summary

The RDoc example for `Object#instance_variable_names` shows the return value in reversed order.

```ruby
class C
  def initialize(x, y)
    @x, @y = x, y
  end
end

C.new(0, 1).instance_variable_names # => ["@x", "@y"]   (actual)
                                    # => ["@y", "@x"]    (what the doc claimed)
```

`instance_variables` returns names in definition order, so a class that assigns `@x` first then `@y` yields `["@x", "@y"]`.

## Cause

The reversed order dates back to `ca9413674e` (2008), when Ruby 1.8 did not guarantee instance-variable order. Since Ruby 1.9 the order is deterministic (definition order), so the example has been wrong for years; a later optimization commit copied the stale example forward verbatim.

The sibling `instance_values` example right above it already shows `@x`-first order (`{"x" => 0, "y" => 1}`), and the Active Support Core Extensions guide (`guides/source/active_support_core_extensions.md`) already shows the correct `["@x", "@y"]` — so this RDoc was the lone outlier.

## Fix

One-line doc change: `["@y", "@x"]` → `["@x", "@y"]`. Documentation only, no behavior change → `[ci skip]`.

## Verification

```
$ ruby -Ilib -e 'require "active_support/core_ext/object/instance_variables"; \
    class C; def initialize(x,y); @x,@y=x,y; end; end; \
    p C.new(0,1).instance_variable_names'
["@x", "@y"]
```
