### PR TITLE
Make Messages::Metadata serializer arrays frozen by default.

### DIFF
--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -7,23 +7,23 @@ require_relative "serializer_with_fallback"
 module ActiveSupport
   module Messages # :nodoc:
     module Metadata # :nodoc:
-      singleton_class.attr_accessor :use_message_serializer_for_metadata
+      singleton_class.attr_accessor :use_message_serializer_for_metadata, :envelope_serializers, :timestamp_serializers
 
-      ENVELOPE_SERIALIZERS = [ # rubocop:disable Style/MutableConstant
+      self.envelope_serializers = [
         *SerializerWithFallback::SERIALIZERS.values,
         ActiveSupport::JSON,
         ::JSON,
         Marshal,
-      ]
+      ].freeze
 
-      TIMESTAMP_SERIALIZERS = [ # rubocop:disable Style/MutableConstant
+      self.timestamp_serializers = [
         SerializerWithFallback::SERIALIZERS.fetch(:message_pack),
         SerializerWithFallback::SERIALIZERS.fetch(:message_pack_allow_marshal),
-      ]
+      ].freeze
 
       ActiveSupport.on_load(:message_pack) do
-        ENVELOPE_SERIALIZERS << ActiveSupport::MessagePack
-        TIMESTAMP_SERIALIZERS << ActiveSupport::MessagePack
+        ActiveSupport::Messages::Metadata.envelope_serializers = (ActiveSupport::Messages::Metadata.envelope_serializers | [ActiveSupport::MessagePack]).freeze
+        ActiveSupport::Messages::Metadata.timestamp_serializers = (ActiveSupport::Messages::Metadata.timestamp_serializers | [ActiveSupport::MessagePack]).freeze
       end
 
       private
@@ -58,7 +58,7 @@ module ActiveSupport
         end
 
         def use_message_serializer_for_metadata?
-          Metadata.use_message_serializer_for_metadata && Metadata::ENVELOPE_SERIALIZERS.include?(serializer)
+          Metadata.use_message_serializer_for_metadata && Metadata.envelope_serializers.include?(serializer)
         end
 
         def wrap_in_metadata_envelope(hash, expires_at: nil, expires_in: nil, purpose: nil)
@@ -104,7 +104,7 @@ module ActiveSupport
             Time.now.utc.advance(seconds: expires_in)
           end
 
-          unless Metadata::TIMESTAMP_SERIALIZERS.include?(serializer)
+          unless Metadata.timestamp_serializers.include?(serializer)
             expiry = expiry&.iso8601(3)
           end
 


### PR DESCRIPTION
### Motivation / Background

We are working on making the Rails' global state Ractor safe. This PR makes Messages::Metadata envelope and timestamp serializer arrays Ractor-shareable by default.

### Detail

These are currently held in constants, but we mutate the array in a load hook when loading message pack. So we can't do the normal dup, add, freeze, reassign pattern we have done in other PRs. So, I turned the constants into attrs on the module. This thing is no-doced so I believe its ok.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
