### PR TITLE
More shareable constants

### DIFF
--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -72,7 +72,7 @@ module ActionController # :nodoc:
 
       class BrowserBlocker # :nodoc:
         SETS = {
-          modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, ie: false }
+          modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, ie: false }.freeze
         }.freeze
 
         attr_reader :request, :versions

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -41,7 +41,7 @@ module ActionView
       TAG_TYPES.merge! CLASS_PREFIXES.index_with(:class)
       TAG_TYPES.freeze
 
-      PRE_CONTENT_STRINGS             = Hash.new { "" }
+      PRE_CONTENT_STRINGS             = Hash.new(&ActiveSupport::Ractors.shareable_proc { "" })
       PRE_CONTENT_STRINGS[:textarea]  = "\n"
       PRE_CONTENT_STRINGS["textarea"] = "\n"
       PRE_CONTENT_STRINGS.freeze

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -67,9 +67,9 @@ module ActiveSupport
     class_attribute :log_levels, instance_accessor: false, default: {} # :nodoc:
 
     LEVEL_CHECKS = {
-      debug: -> (logger) { !logger.debug? },
-      info: -> (logger) { !logger.info? },
-      error: -> (logger) { !logger.error? },
+      debug: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { !logger.debug? }),
+      info: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { !logger.info? }),
+      error: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { !logger.error? }),
     }.freeze
 
     class << self


### PR DESCRIPTION
### Motivation / Background

Working on making the framework Ractor-safe. We need to freeze the values in constants. These are just a few more that I encountered while working with a test app.

### Detail

These are hashes with have mutable values / default procs that we need to freeze with `freeze` / `Ractor.shareable_`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
