### PR TITLE
Make ExecutionContext.after_change ractor safe

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -10,7 +10,7 @@ module AbstractController
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_helper_methods, default: Array.new.freeze
+      class_attribute :_helper_methods, default: [].freeze
 
       # This is here so that it is always higher in the inheritance chain than the
       # definition in lib/action_view/rendering.rb
@@ -127,7 +127,7 @@ module AbstractController
       #     made available on the view.
       def helper_method(*methods)
         methods.flatten!
-        self._helper_methods = (_helper_methods | methods).freeze
+        self._helper_methods = (_helper_methods + methods).freeze
 
         location = caller_locations(1, 1).first
         file, line = location.path, location.lineno

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -204,7 +204,7 @@ module ActiveRecord
         LogSubscriber.backtrace_cleaner.first_clean_frame
       end
 
-      ActiveSupport::ExecutionContext.after_change { ActiveRecord::QueryLogs.clear_cache }
+      ActiveSupport::ExecutionContext.after_change(&ActiveSupport::Ractors.shareable_proc { ActiveRecord::QueryLogs.clear_cache })
 
       private
         def formatter_for(format)

--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -32,7 +32,7 @@ module ActiveSupport
       end
     end
 
-    @after_change_callbacks = []
+    @after_change_callbacks = [].freeze
 
     # Execution context nesting should only legitimately happen during test
     # because the test case itself is wrapped in an executor, and it might call
@@ -42,10 +42,10 @@ module ActiveSupport
     @nestable = false
 
     class << self
-      attr_accessor :nestable
+      attr_accessor :nestable, :after_change_callbacks
 
       def after_change(&block)
-        @after_change_callbacks << block
+        @after_change_callbacks = [*@after_change_callbacks, block].freeze
       end
 
       # Updates the execution context. If a block is given, it resets the provided keys to their

--- a/activesupport/test/execution_context_test.rb
+++ b/activesupport/test/execution_context_test.rb
@@ -3,11 +3,13 @@
 require_relative "abstract_unit"
 require "active_support/execution_context/test_helper"
 require "active_support/core_ext/object/with"
+require "active_support/testing/ractors_assertions"
 
 class ExecutionContextTest < ActiveSupport::TestCase
   # ExecutionContext is automatically reset in Rails app via executor hooks set in railtie
   # But not in Active Support's own test suite.
   include ActiveSupport::ExecutionContext::TestHelper
+  include ActiveSupport::Testing::RactorsAssertions
 
   test "#set restore the modified keys when the block exits" do
     assert_nil ActiveSupport::ExecutionContext.to_h[:foo]
@@ -64,5 +66,13 @@ class ExecutionContextTest < ActiveSupport::TestCase
     context = ActiveSupport::ExecutionContext.to_h
     context[:foo] = 43
     assert_equal 42, ActiveSupport::ExecutionContext.to_h[:foo]
+  end
+
+  test "callbacks are ractor safe" do
+    ActiveSupport::ExecutionContext.with(after_change_callbacks: [].freeze) do
+      ActiveSupport::ExecutionContext.after_change(&ActiveSupport::Ractors.shareable_proc { })
+
+      assert_ractor_shareable ActiveSupport::ExecutionContext.after_change_callbacks
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Working on making the framework Ractor safe. `ActiveSupport::ExecutionContext.after_change_callbacks` are just an array of procs and thus not Ractor safe.

### Detail

This is not widely used (it is no-doced). The procs are just `called` not `instanced_execed`, so the caller that creates the proc needs to be responsible for making it Ractor shareable. Then we just dup, add, freeze and reassign the array when adding a new one.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
