### PR TITLE
Make AbstractController::Caching.view_cache_dependency ractor safe

### DIFF
--- a/actionpack/lib/abstract_controller/caching.rb
+++ b/actionpack/lib/abstract_controller/caching.rb
@@ -44,13 +44,15 @@ module AbstractController
       delegate :enable_fragment_cache_logging, :enable_fragment_cache_logging=, to: :config
       self.enable_fragment_cache_logging = false
 
-      class_attribute :_view_cache_dependencies, default: []
+      class_attribute :_view_cache_dependencies, default: [].freeze
       helper_method :view_cache_dependencies if respond_to?(:helper_method)
     end
 
     module ClassMethods
       def view_cache_dependency(&dependency)
-        self._view_cache_dependencies += [dependency]
+        self._view_cache_dependencies = [
+          *_view_cache_dependencies, ActiveSupport::Ractors.try_shareable_proc(dependency)
+        ].freeze
       end
     end
 

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -3,6 +3,8 @@
 require "fileutils"
 require "abstract_unit"
 require "lib/controller/fake_models"
+require "active_support/testing/ractors_assertions"
+require "active_support/core_ext/object/with"
 
 CACHE_DIR = "test_cache"
 # Don't change '/../temp/' cavalierly or you might hose something you don't want hosed
@@ -343,6 +345,8 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
 end
 
 class ViewCacheDependencyTest < ActionController::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   class NoDependenciesController < ActionController::Base
   end
 
@@ -357,6 +361,16 @@ class ViewCacheDependencyTest < ActionController::TestCase
 
   def test_view_cache_dependencies_are_listed_in_declaration_order
     assert_equal %w(trombone flute), HasDependenciesController.new.view_cache_dependencies
+  end
+
+  def test_view_cache_dependencies_are_ractor_safe
+    ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+      controller = Class.new(ActionController::Base) do
+        view_cache_dependency { "foo" }
+      end
+
+      assert_ractor_shareable controller._view_cache_dependencies
+    end
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Make `AbstraceController::Caching.view_cache_dependency` ractor safe

### Detail

When adding a new dependency, we dup, add, freeze and reassign the underlying `_view_cache_dependencies` array. Following pattern in https://github.com/rails/rails/pull/57743

These a procs, but they are instance execed, so we can call `ActiveSupport::Ractors.try_shareable_proc` on them to make them Ractor shareable for apps opting in to Ractors.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
