### PR TITLE
Make ActionController::Flash.add_flash_types ractor safe

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -7,7 +7,7 @@ module ActionController # :nodoc:
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_flash_types, instance_accessor: false, default: []
+      class_attribute :_flash_types, instance_accessor: false, default: [].freeze
 
       delegate :flash, to: :request
       add_flash_types(:alert, :notice)
@@ -41,7 +41,7 @@ module ActionController # :nodoc:
           private type
           helper_method(type) if respond_to?(:helper_method)
 
-          self._flash_types += [type]
+          self._flash_types = (_flash_types | [type]).freeze
         end
       end
     end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "active_support/messages/rotation_configuration"
+require "active_support/testing/ractors_assertions"
 
 class FlashTest < ActionController::TestCase
   class TestController < ActionController::Base
@@ -100,6 +101,8 @@ class FlashTest < ActionController::TestCase
   end
 
   tests TestController
+
+  include ActiveSupport::Testing::RactorsAssertions
 
   def test_flash
     get :set_flash
@@ -244,6 +247,10 @@ class FlashTest < ActionController::TestCase
       add_flash_types :bar
     end
     assert_not TestController._flash_types.include?(:bar)
+  end
+
+  def test_flash_types_are_ractor_safe
+    assert_ractor_shareable TestController._flash_types
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Make `ActionController::Flash.add_flash_types` ractor safe

### Detail

When adding a new flash type we dup, add, freeze and reassign the array. Following pattern in https://github.com/rails/rails/pull/57743

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
