### PR TITLE
Make AbstractController::Helper.helper_method ractor safe

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -10,7 +10,7 @@ module AbstractController
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_helper_methods, default: Array.new
+      class_attribute :_helper_methods, default: Array.new.freeze
 
       # This is here so that it is always higher in the inheritance chain than the
       # definition in lib/action_view/rendering.rb
@@ -127,7 +127,7 @@ module AbstractController
       #     made available on the view.
       def helper_method(*methods)
         methods.flatten!
-        self._helper_methods += methods
+        self._helper_methods = (_helper_methods | methods).freeze
 
         location = caller_locations(1, 1).first
         file, line = location.path, location.lineno

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 ActionController::Base.helpers_path = File.expand_path("../fixtures/helpers", __dir__)
 
@@ -93,6 +94,8 @@ class HelpersTypoControllerTest < ActiveSupport::TestCase
 end
 
 class HelperTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   class TestController < ActionController::Base
     attr_accessor :delegate_attr
     def delegate_method() end
@@ -258,6 +261,14 @@ class HelperTest < ActiveSupport::TestCase
     AllHelpersController.config.my_var = "smth"
 
     assert_equal "smth", AllHelpersController.helpers.config.my_var
+  end
+
+  def test_helper_methods_are_ractor_safe
+    controller = Class.new(ActionController::Base) do
+      helper_method :foo
+    end
+
+    assert_ractor_shareable controller._helper_methods
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

Make `AbstractController::Helper.helper_method` ractor safe

### Detail

When adding a new helper method we dup, add, freeze and reassign the array. Following pattern in https://github.com/rails/rails/pull/57743

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
