### PR TITLE
Make InheritableOptions ractor safe

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -127,6 +127,10 @@ module ActiveSupport
       super || @parent.key?(key)
     end
 
+    def keys
+      @parent.keys | super
+    end
+
     def overridden?(key)
       !!(@parent && @parent.key?(key) && own_key?(key.to_sym))
     end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -100,6 +100,16 @@ module ActiveSupport
       end
     end
 
+    def freeze
+      return self if frozen?
+
+      @own_keys = own_keys.dup.freeze
+      self.default_proc = nil
+      @parent.freeze
+      replace(to_h)
+      super
+    end
+
     def to_h
       @parent.to_h.merge(self)
     end
@@ -120,12 +130,12 @@ module ActiveSupport
       pp.pp_hash(to_h)
     end
 
-    alias_method :own_key?, :key?
-    private :own_key?
-
     def key?(key)
       super || @parent.key?(key)
     end
+
+    alias_method :_own_keys, :keys
+    private :_own_keys
 
     def keys
       @parent.keys | super
@@ -147,5 +157,14 @@ module ActiveSupport
       to_h.each(&block)
       self
     end
+
+    private
+      def own_key?(key)
+        own_keys.include?(key.to_sym)
+      end
+
+      def own_keys
+        @own_keys || _own_keys
+      end
   end
 end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -3,8 +3,11 @@
 require "pp"
 require_relative "abstract_unit"
 require "active_support/ordered_options"
+require "active_support/testing/ractors_assertions"
 
 class OrderedOptionsTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def test_usage
     a = ActiveSupport::OrderedOptions.new
 
@@ -354,5 +357,29 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     io = StringIO.new
     PP.pp(object, io)
     assert_equal({ one: "first value", two: "second value", three: "third value" }.inspect, io.string.strip)
+  end
+
+  def test_inheritable_options_ractor_shareable
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert_ractor_make_shareable(object)
+
+    assert_equal "first value", object[:one]
+    assert_equal "second value", object[:two]
+    assert_equal "third value", object[:three]
+  end
+
+  def test_overridden_works_when_frozen
+    object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    object.freeze
+
+    assert object.overridden?(:two)
+    assert_not object.overridden?(:one)
+    assert_not object.overridden?(:three)
   end
 end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -250,6 +250,14 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_not object.key?(:four)
   end
 
+  def test_inheritable_options_keys
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert_equal [:one, :two, :three], object.keys
+  end
+
   def test_inheritable_options_overridden
     object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value", three: "third value")
     object["one"] = "first value override"


### PR DESCRIPTION
### Motivation / Background

I am working on making it possible to make a Rails application Ractor safe, but some engines contain inheritable options which currently can't be made Ractor safe. This PR fixes that.

### Detail

Inheritable Options have a default proc which accesses the parent hash in case of a key miss. This proc is hard to make ractor safe because it is stored on the options, but needs to reference the options' parent ivar. So we can't make the proc shareable without making the options shareable, and we can't make the options shareable without making the proc shareable. I don't see a good way around that at the moment. One idea I had was to make a new default proc with `self: @parent` but that requires `Ractor.make_shareable`ing the parent, which seems wrong to do in the `freeze` method as it may have unsafe values. We can't raise an isolation error when calling `freeze` directly.

To get around this, we can drop the default proc when freezing and reverse merge the parent hash into the inheritable options. That way it still quacks like an inheritable options but it no longer needs to fallback to the parent.

This also required me to change the way we implement `overriden?` since after freezing the options will have all the keys the parent has, thus making it appear that all keys are overriden. Instead, I decided to keep track of the keys as they're added.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
