### PR TITLE
Fix `in_order_of` raising on CTEs

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -736,7 +736,9 @@ module ActiveRecord
       else
         arel_column = order_column(column.to_s)
 
-        values = cast_values_for_in_order_of(values, arel_column.type_caster)
+        unless arel_column.is_a?(Arel::Nodes::SqlLiteral)
+          values = cast_values_for_in_order_of(values, arel_column.type_caster)
+        end
         return spawn.none! if values.empty?
       end
 

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -180,4 +180,24 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
     books = Book.in_order_of(:format, order).order(Book.arel_table[:format].desc.nulls_last)
     assert_equal(["ebook", "paperback", "digital", nil, "letter"], books.map(&:format))
   end
+
+  if ActiveRecord::Base.lease_connection.supports_common_table_expressions?
+    def test_in_order_of_with_column_from_cte
+      Book.destroy_all
+      Book.create!(format: "paperback")
+      Book.create!(format: "ebook")
+      Book.create!(format: "hardcover")
+
+      cte = Book.select(:id, format: :book_format)
+      order = ["hardcover", "paperback", "ebook"]
+
+      books = Book
+        .with(cte_books: cte)
+        .from("cte_books")
+        .select(:id, :book_format)
+        .in_order_of(:book_format, order)
+
+      assert_equal(order, books.map(&:book_format))
+    end
+  end
 end


### PR DESCRIPTION


### Motivation / Background
If the provided column name cant be resolved, `order_column` returns an instance of `Arel::Nodes::SqlLiteral` -- since it doesn't respond to `type_caster`, `in_order_of` ends up raising a `NoMethodError`.

For columns coming from a CTE there's no type information available anyway, so skipping type casting in this case seems reasonable.

related: https://github.com/rails/rails/pull/44746

MRE:

```ruby

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new(File::NULL)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :books, force: true do |t|
    t.string :format
  end
end

class Book < ActiveRecord::Base
end

class BugTest < Minitest::Test
  def test_in_order_of_with_cte_column
    Book.delete_all
    Book.create!(format: "paperback")
    Book.create!(format: "ebook")
    Book.create!(format: "hardcover")

    cte = Book.select(:id, Arel.sql("format AS book_format"))

    order = %w[hardcover paperback ebook]
    books = Book
      .with(cte_books: cte)
      .from("cte_books")
      .select(Arel.sql("id, book_format"))
      .in_order_of("book_format", order)

    assert_equal order, books.map { |b| b["book_format"] }
  end
end
```

output:

```
BugTest#test_in_order_of_with_cte_column:
NoMethodError: undefined method 'type_caster' for an instance of Arel::Nodes::SqlLiteral
    lib/active_record/relation/query_methods.rb:739:in 'ActiveRecord::QueryMethods#in_order_of'
    mre.rb:56:in 'BugTest#test_in_order_of_with_cte_column'
```


### Detail

Skipping type casting in case of unreasonable columns.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
