### PR TITLE
Make `test_assign_ids_with_cpk_for_two_models` order-independent

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1005,7 +1005,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     order.save
     order.reload
 
-    assert_equal book_ids, order.book_ids
+    assert_equal book_ids.sort, order.book_ids.sort
     assert_equal 2, order.books.length
     assert_includes order.books, cpk_books(:cpk_great_author_first_book)
     assert_includes order.books, cpk_books(:cpk_great_author_second_book)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `TestDefaultAutosaveAssociationOnAHasManyAssociation#test_assign_ids_with_cpk_for_two_models` is flaky against PostgreSQL. The assertion at `activerecord/test/cases/autosave_association_test.rb:1008` compares the assigned `book_ids` array to `order.book_ids` by ordered equality, but the `has_many :books` association on `Cpk::Order` has no `order:` clause, so the SQL emitted by `order.book_ids` carries no `ORDER BY` and the returned row order is undefined.

Recently observed in Buildkite build 129895 (`activerecord postgresql (3.4)`), seed 16372:
https://buildkite.com/rails/rails/builds/129895#019ed1d0-262a-462b-9478-28d2108d4c76

```
4) Failure:
TestDefaultAutosaveAssociationOnAHasManyAssociation#test_assign_ids_with_cpk_for_two_models
[activerecord/test/cases/autosave_association_test.rb:1008]:
--- expected
+++ actual
@@ -1 +1 @@
-[[550090038, 342015473], [550090038, 385957113]]
+[[550090038, 385957113], [550090038, 342015473]]
```

### Detail

This Pull Request changes the assertion to sort both sides so the comparison is order-independent. The two subsequent `assert_includes` calls and `assert_equal 2, order.books.length` already verify that the same id set is round-tripped.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.