### PR TITLE
Simplify PRE_CONTENT_STRING hash

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -41,10 +41,10 @@ module ActionView
       TAG_TYPES.merge! CLASS_PREFIXES.index_with(:class)
       TAG_TYPES.freeze
 
-      PRE_CONTENT_STRINGS             = Hash.new(&ActiveSupport::Ractors.shareable_proc { "" })
-      PRE_CONTENT_STRINGS[:textarea]  = "\n"
-      PRE_CONTENT_STRINGS["textarea"] = "\n"
-      PRE_CONTENT_STRINGS.freeze
+      PRE_CONTENT_STRINGS = {
+        textarea: "\n",
+        "textarea" => "\n",
+      }.freeze
 
       # = Action View Tag Builder
       #


### PR DESCRIPTION
Followup #57752

The default value was [added][1] because `"#{nil}"` would allocate a new string for `nil.to_s`. However, `nil` inside string interpolation was optimized to not allocate a new String in [Ruby 3.1][2].

Therefore, this commit simplifies `PRE_CONTENT_STRING` by removing the default value since it not longer provides a reduction in allocations.

```
❯ irb

⢀⡴⠊⢉⡟⢿  IRB v1.18.0 - Ruby 4.0.1
⣎⣀⣴⡋⡟⣻  "ls [object] -g pattern" to filter methods and properties
⣟⣼⣱⣽⣟⣾  ~/src/github.com/skipkayhil/rails

irb(main):001* def allocations
irb(main):002*   x = GC.stat(:total_allocated_objects)
irb(main):003*   yield
irb(main):004*   GC.stat(:total_allocated_objects) - x
irb(main):005> end
=> :allocations
irb(main):006> a = "".freeze
=> ""
irb(main):007> allocations { "#{a}" }
=> 2
irb(main):008> allocations { "#{a}" }
=> 1
irb(main):009> allocations { "#{nil}" }
=> 1
irb(main):010> allocations { "#{nil}" }
=> 1
```

cc @andrewn617 

[1]: https://github.com/rails/rails/commit/2a4d4301d405dbc4a6bce85b4632a78099c8d1c6
[2]: ruby/ruby@b08dacfea39ad8da3f1fd7fdd0e4538cc892ec44