### PR TITLE
Fix `kill_connection_from_server` leaving an orphan in `@available`

### DIFF
--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -175,6 +175,6 @@ module AdapterHelper
       skip("kill_connection_from_server unsupported")
     end
 
-    actor_connection.close
+    actor_connection.disconnect!
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to fix #57761.

`ActiveRecord::TestCaseLeakCheckTest#test_check_connection_leaks_does_not_report_connections_held_for_async_reaper_maintenance` hangs deterministically on the `mysql2` and `trilogy` adapters with `--seed=54172` (first observed in Buildkite Rails build #129903, job `activerecord trilogy (3.3)`).

### Detail

The root cause is the `kill_connection_from_server` test helper. d38902f2d9 (part of #54175) added `pool.remove(actor_connection)` so the actor connection used to admin-kill the target would no longer be tracked by the pool. However, the trailing `actor_connection.close` re-adds it to `@available`, because `AbstractAdapter#close` is `pool.checkin self`. The connection then sits in `@available` but not in `@connections` for the rest of the suite. A subsequent `pool.checkout` can return this orphan, so any caller that assumes the leased connection is also in `pool.connections` (such as the target test's `lease_connection`) will misbehave.

This Pull Request replaces `actor_connection.close` with `actor_connection.disconnect!`, which closes the underlying socket without touching the pool, matching the original intent of `pool.remove`.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.