### PR TITLE
Use Hash default instead of default proc

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -41,7 +41,7 @@ module ActionView
       TAG_TYPES.merge! CLASS_PREFIXES.index_with(:class)
       TAG_TYPES.freeze
 
-      PRE_CONTENT_STRINGS             = Hash.new(&ActiveSupport::Ractors.shareable_proc { "" })
+      PRE_CONTENT_STRINGS             = Hash.new("")
       PRE_CONTENT_STRINGS[:textarea]  = "\n"
       PRE_CONTENT_STRINGS["textarea"] = "\n"
       PRE_CONTENT_STRINGS.freeze


### PR DESCRIPTION
Since the string is frozen and always returned on missing keys, and since the default_proc doesn't mutate the Hash, we can use a value default instead of a default proc.

Follow-up to #57752