### PR TITLE
Validate `retry_on` `wait:` argument type at class definition

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -64,6 +64,14 @@ module ActiveJob
       #    end
       #  end
       def retry_on(*exceptions, wait: 3.seconds, attempts: 5, queue: nil, priority: nil, jitter: JITTER_DEFAULT, report: false)
+        case wait
+        when :polynomially_longer, Integer, Float, ActiveSupport::Duration, Proc
+          # Supported wait type, continue.
+        else
+          raise ArgumentError, "Unsupported argument type for :wait, expected an Integer, Float, " \
+            "ActiveSupport::Duration, Proc, or :polynomially_longer, but got #{wait.inspect}"
+        end
+
         rescue_from(*exceptions) do |error|
           executions = executions_for(exceptions)
           if attempts == :unlimited || executions < attempts

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -443,4 +443,25 @@ class ExceptionsTest < ActiveSupport::TestCase
       assert_equal expected_array, JobBuffer.values.last(2)
     end
   end
+
+  test "retry_on raises ArgumentError for an unsupported wait type" do
+    error = assert_raises(ArgumentError) do
+      Class.new(ActiveJob::Base) do
+        retry_on StandardError, wait: "soon"
+      end
+    end
+    assert_match(/Unsupported argument type for :wait/, error.message)
+  end
+
+  test "retry_on accepts all supported wait types" do
+    assert_nothing_raised do
+      Class.new(ActiveJob::Base) do
+        retry_on StandardError, wait: 5
+        retry_on StandardError, wait: 2.5
+        retry_on StandardError, wait: 5.minutes
+        retry_on StandardError, wait: :polynomially_longer
+        retry_on StandardError, wait: ->(executions) { executions * 2 }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #57727, based on @p8's [suggestion](https://github.com/rails/rails/pull/57727#discussion_r3420741025).

### Summary

An unsupported `wait:` type (e.g. `retry_on SomeError, wait: "soon"`) currently raises a `RuntimeError` from `determine_delay` — inside the `rescue_from` handler, after a job has already failed. This replaces the original application exception with a confusing internal error.

This PR moves the type check up to `retry_on` itself, so the `ArgumentError` is raised when the job class is loaded rather than when the retry handler fires.

### Changes

The supported types mirror `determine_delay`'s `case` branches:

- `Integer`, `Float` — seconds
- `ActiveSupport::Duration` — e.g. `1.hour`
- `:polynomially_longer`
- `Proc` — e.g. `->(executions) { executions * 2 }`

The `else` branch in `determine_delay` is kept as a defensive fallback.