### PR TITLE
Make `take` respect an existing relation limit

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `take(n)` on a relation with an existing `limit` returning more
+    records than the limit allows.
+
+    *Kenta Ishizaki*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -588,6 +588,10 @@ module ActiveRecord
         if loaded?
           records.take(limit)
         else
+          if limit_value
+            limit = [limit_value, limit].min
+          end
+
           limit(limit).to_a
         end
       end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1082,6 +1082,15 @@ class FinderTest < ActiveRecord::TestCase
     assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.last(5).entries }
   end
 
+  def test_take_and_first_and_last_with_integer_should_respect_an_existing_limit
+    count = Topic.count
+    assert_operator count, :>, 2
+
+    assert_equal 2, Topic.limit(2).take(count).size
+    assert_equal 2, Topic.limit(2).first(count).size
+    assert_equal 2, Topic.limit(2).last(count).size
+  end
+
   def test_last_with_integer_and_order_should_keep_the_order
     assert_equal Topic.order("title").to_a.last(2), Topic.order("title").last(2)
   end


### PR DESCRIPTION
### Detail

Calling `take(n)` on an unloaded relation that already has a `limit` overwrites the existing limit instead of capping at it:

```ruby
Post.limit(2).first(5).size      # => 2
Post.limit(2).last(5).size       # => 2
Post.limit(2).load.take(5).size  # => 2
Post.limit(2).take(5).size       # => 5  (now 2)
```

`take(n)` with `n` at or below the existing limit is unaffected, and a relation without a limit behaves exactly as before.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
