### PR TITLE
Remove outdated documentation for overriding primary_key

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -121,16 +121,6 @@ module ActiveRecord
           #   class Project < ActiveRecord::Base
           #     self.primary_key = 'sysid'
           #   end
-          #
-          # You can also define the #primary_key method yourself:
-          #
-          #   class Project < ActiveRecord::Base
-          #     def self.primary_key
-          #       'foo_' + super
-          #     end
-          #   end
-          #
-          #   Project.primary_key # => "foo_id"
           def primary_key=(value)
             @primary_key_definition = ActiveRecord::Key.for(value)
             @primary_key = @primary_key_definition.name


### PR DESCRIPTION
After https://github.com/rails/rails/pull/57638 we can no longer simply override primary_key value as it needs to be in sync with primary_key_definition.