### PR TITLE
Remove primary_key class ivar

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -64,7 +64,6 @@ module ActiveRecord
 
         module ClassMethods
           ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database id_for_database).to_set.freeze
-          PRIMARY_KEY_NOT_SET = Object.new.freeze
 
           def instance_method_already_implemented?(method_name)
             super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)
@@ -78,8 +77,8 @@ module ActiveRecord
           # Overwriting will negate any effect of the +primary_key_prefix_type+
           # setting, though.
           def primary_key
-            reset_primary_key if PRIMARY_KEY_NOT_SET.equal?(@primary_key)
-            @primary_key
+            reset_primary_key unless @primary_key_definition
+            @primary_key_definition.name
           end
 
           def composite_primary_key? # :nodoc:
@@ -87,7 +86,7 @@ module ActiveRecord
           end
 
           def primary_key_definition # :nodoc:
-            reset_primary_key if PRIMARY_KEY_NOT_SET.equal?(@primary_key)
+            reset_primary_key unless @primary_key_definition
             @primary_key_definition
           end
 
@@ -133,7 +132,6 @@ module ActiveRecord
           #   Project.primary_key # => "foo_id"
           def primary_key=(value)
             @primary_key_definition = ActiveRecord::Key.for(value)
-            @primary_key = @primary_key_definition.name
 
             include CompositePrimaryKey if @primary_key_definition.composite?
 
@@ -144,7 +142,6 @@ module ActiveRecord
             def inherited(base)
               super
               base.class_eval do
-                @primary_key = PRIMARY_KEY_NOT_SET
                 @primary_key_definition = nil
                 @attributes_builder = nil
               end


### PR DESCRIPTION
Make it easier to keep primary_key and primary_key_definition in sync by removing the @primary_key alias after https://github.com/rails/rails/pull/57638