### PR TITLE
Make ActiveRecord::Base.primary_key a class attribute

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Make `ActiveRecord::Base.primary_key` inheritable.
+
+    Previously setting `primary_key` on a model wouldn't impact child
+    classes. Now the property is inherited by subclasses as well.
+
+    ``` ruby
+    class AbstractShardedModel < ApplicationRecord
+        self.abstract_class = true
+        self.primary_key = ["tenant_id", "id"]
+    end
+
+    class Invoice < AbstractShardedModel
+    end
+
+    Invoice.primary_key # => ["tenant_id", "id"]
+    ```
+
+    *Iliana Hadzhiatanasova*
+
 *   Fix `has_many` and `has_one` associations on a new record returning an empty
     result when the owner has a composite primary key, even when every primary
     key column is populated.

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -77,8 +77,7 @@ module ActiveRecord
           # Overwriting will negate any effect of the +primary_key_prefix_type+
           # setting, though.
           def primary_key
-            reset_primary_key unless @primary_key_definition
-            @primary_key_definition.name
+            primary_key_definition.name
           end
 
           def composite_primary_key? # :nodoc:
@@ -86,8 +85,8 @@ module ActiveRecord
           end
 
           def primary_key_definition # :nodoc:
-            reset_primary_key unless @primary_key_definition
-            @primary_key_definition
+            reset_primary_key unless _primary_key_definition
+            _primary_key_definition
           end
 
           # Returns a quoted version of the primary key name.
@@ -121,9 +120,9 @@ module ActiveRecord
           #     self.primary_key = 'sysid'
           #   end
           def primary_key=(value)
-            @primary_key_definition = ActiveRecord::Key.for(value)
+            self._primary_key_definition = ActiveRecord::Key.for(value)
 
-            include CompositePrimaryKey if @primary_key_definition.composite?
+            include CompositePrimaryKey if primary_key_definition.composite?
 
             @attributes_builder = nil
           end
@@ -132,7 +131,7 @@ module ActiveRecord
             def inherited(base)
               super
               base.class_eval do
-                @primary_key_definition = nil
+                class_attribute :_primary_key_definition, instance_accessor: false
                 @attributes_builder = nil
               end
             end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -226,6 +226,14 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal k.lease_connection.quote_column_name("foo"), k.quoted_primary_key
   end
 
+  def test_primary_key_inherited
+    k = Class.new(ActiveRecord::Base)
+    subclass = Class.new(k)
+    k.primary_key = "foo"
+    assert_equal "foo", k.primary_key
+    assert_equal "foo", subclass.primary_key
+  end
+
   def test_auto_detect_primary_key_from_schema
     MixedCaseMonkey.reset_primary_key
     assert_equal "monkeyID", MixedCaseMonkey.primary_key


### PR DESCRIPTION
Similar to table_name, if you are overriding primary_key you'd likely expect that all subclasses will inherit the override This is useful for abstract classes as well as STI