### PR TITLE
8-1-stable: Clear Postgres warnings as they get handled

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -568,8 +568,20 @@ module ActiveRecord
           type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds, async: async, allow_retry: allow_retry) do |notification_payload|
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-              result = perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
-              handle_warnings(result, sql)
+              begin
+                result = perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
+                query_completed = true
+              ensure
+                begin
+                  handle_warnings(result, sql)
+                rescue
+                  raise if query_completed
+
+                  # The query failed, so we need to swallow this exception
+                  # from handle_warnings to avoid masking the original.
+                end
+              end
+
               result
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -27,21 +27,6 @@ module ActiveRecord
           !READ_QUERY.match?(sql.b)
         end
 
-        # Executes an SQL statement, returning a PG::Result object on success
-        # or raising a PG::Error exception otherwise.
-        #
-        # Setting +allow_retry+ to true causes the db to reconnect and retry
-        # executing the SQL statement in case of a connection-related exception.
-        # This option should only be enabled for known idempotent queries.
-        #
-        # Note: the PG::Result object is manually memory managed; if you don't
-        # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
-        def execute(...) # :nodoc:
-          super
-        ensure
-          @notice_receiver_sql_warnings = []
-        end
-
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
           if use_insert_returning? || pk == false
             super
@@ -223,7 +208,9 @@ module ActiveRecord
           end
 
           def handle_warnings(result, sql)
-            @notice_receiver_sql_warnings.each do |warning|
+            warnings, @notice_receiver_sql_warnings = @notice_receiver_sql_warnings, []
+
+            warnings.each do |warning|
               next if warning_ignored?(warning)
 
               warning.sql = sql

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -763,6 +763,60 @@ module ActiveRecord
         end
       end
 
+      def test_clears_warnings_after_handling_non_execute_query
+        warning_sql = "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$"
+        warnings = []
+        warning_action = ->(warning) { warnings << [warning.message, warning.sql] }
+
+        with_db_warnings_action(warning_action) do
+          @connection.exec_query(warning_sql)
+          @connection.exec_query("SELECT 1")
+        end
+
+        assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+      end
+
+      def test_clears_warnings_after_non_execute_warning_action_raises
+        with_db_warnings_action(:raise) do
+          assert_raises(ActiveRecord::SQLWarning) do
+            @connection.exec_query("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")
+          end
+
+          assert_nothing_raised do
+            @connection.exec_query("SELECT 1")
+          end
+        end
+      end
+
+      def test_handles_warnings_after_non_execute_query_raises
+        warning_sql = "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; RAISE EXCEPTION 'PostgreSQL SQL error'; END; $$"
+        warnings = []
+        warning_action = ->(warning) { warnings << [warning.message, warning.sql] }
+
+        with_db_warnings_action(warning_action) do
+          assert_raises(ActiveRecord::StatementInvalid) do
+            @connection.exec_query(warning_sql)
+          end
+
+          @connection.exec_query("SELECT 1")
+        end
+
+        assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+      end
+
+      def test_warning_action_does_not_hide_non_execute_query_error
+        with_db_warnings_action(:raise) do
+          error = assert_raises(ActiveRecord::StatementInvalid) do
+            @connection.exec_query("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; RAISE EXCEPTION 'PostgreSQL SQL error'; END; $$")
+          end
+          assert_match(/PostgreSQL SQL error/, error.message)
+
+          assert_nothing_raised do
+            @connection.exec_query("SELECT 1")
+          end
+        end
+      end
+
       def test_allowlist_of_warnings_to_ignore
         with_db_warnings_action(:raise, [/PostgreSQL SQL warning/]) do
           result = @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")


### PR DESCRIPTION
Backport of #57584

The code blocks are very similar between `main` and `8-1-stable`, but there's enough that differs overall that this seems worth a separate PR instead of a direct commit.