### PR TITLE
Extract Template.validate_formats and Template.normalized_formats

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -67,9 +67,9 @@ module ActionView
       def self.details_cache_key(details)
         @details_keys.fetch(details) do
           if formats = details[:formats]
-            unless Template::Types.valid_symbols?(formats)
+            if normalized = Template.normalized_formats(formats)
               details = details.dup
-              details[:formats] &= Template::Types.symbols
+              details[:formats] = normalized
             end
           end
           @details_keys[details] ||= TemplateDetails::Requested.new(**details)
@@ -268,10 +268,7 @@ module ActionView
         values.concat(default_formats) if values.delete "*/*"
         values.uniq!
 
-        unless Template::Types.valid_symbols?(values)
-          invalid_values = values - Template::Types.symbols
-          raise ArgumentError, "Invalid formats: #{invalid_values.map(&:inspect).join(", ")}"
-        end
+        Template.validate_formats(values)
 
         if (values.length == 1) && (values[0] == :js)
           values << :html

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -164,12 +164,11 @@ module ActionView
 
     eager_autoload do
       autoload :Error
+      autoload :HTML
+      autoload :Handlers
+      autoload :Inline
       autoload :RawFile
       autoload :Renderable
-      autoload :Handlers
-      autoload :HTML
-      autoload :Inline
-      autoload :Types
       autoload :Sources
       autoload :Text
       autoload :Types
@@ -188,6 +187,16 @@ module ActionView
           remove_const(:Types)
           const_set(:Types, implementation)
         end
+      end
+
+      def validate_formats(formats)
+        return if Types.valid_symbols?(formats)
+        invalid = formats - Types.symbols
+        raise ArgumentError, "Invalid formats: #{invalid.map(&:inspect).join(", ")}"
+      end
+
+      def normalized_formats(formats)
+        formats & Types.symbols unless Types.valid_symbols?(formats)
       end
     end
 


### PR DESCRIPTION
Instead of reaching in Template::Types, define a couple of helper methods to handle validating/normalizing request formats.

They had to be defined on Template because Template::Types has a different implementation if Action Dispatch is loaded.

Also remove a duplicated autoload (and sort them to help avoid this mistake).
