### PR TITLE
Avoid mutating params hash passed to ActionDispatch::Http::URL.url_for

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -181,7 +181,7 @@ module ActionDispatch
         private
           def add_params(path, params)
             params = { params: params } unless params.is_a?(Hash)
-            params.reject! { |_, v| v.to_param.nil? }
+            params = params.reject { |_, v| v.to_param.nil? }
             query = params.to_query
             path << "?#{query}" unless query.empty?
           end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -62,6 +62,16 @@ class RequestUrlFor < BaseRequestTest
     assert_equal "http://www.example.com?params=",  url_for(params: "")
     assert_equal "http://www.example.com?params=1", url_for(params: 1)
   end
+
+  test "url_for does not mutate the passed params hash" do
+    params = { a: 1, b: nil }
+    assert_equal "http://www.example.com?a=1", url_for(params: params)
+    assert_equal({ a: 1, b: nil }, params)
+  end
+
+  test "url_for accepts a frozen params hash" do
+    assert_equal "/x?a=1", url_for(only_path: true, path: "/x", params: { a: 1, b: nil }.freeze)
+  end
 end
 
 class RequestIP < BaseRequestTest


### PR DESCRIPTION
### Summary

`ActionDispatch::Http::URL.url_for` mutates the `params:` hash it is given. `add_params` strips valueless keys with the destructive `reject!`:

```ruby
def add_params(path, params)
  params = { params: params } unless params.is_a?(Hash)
  params.reject! { |_, v| v.to_param.nil? }   # <- mutates the caller's hash
  query = params.to_query
  path << "?#{query}" unless query.empty?
end
```

A URL builder should not modify its input. This has two concrete effects.

**1. The memoized `request.query_parameters` gets corrupted.**
`OptionRedirect#path` passes the live, memoized request hash straight through:

```ruby
url_options = {
  protocol: request.protocol,
  host:     request.host,
  port:     request.optional_port,
  path:     request.path,
  params:   request.query_parameters   # memoized, same object every call
}.merge! options
```

`merge!` is shallow, so `url_options[:params]` is still the same object as `request.query_parameters`. A valueless query key (`?foo` → `{"foo" => nil}`) is then `reject!`-ed out of that memoized hash, and every later reader of `request.query_parameters` sees it dropped.

**2. A frozen `params:` hash raises `FrozenError`.**

### Reproduction

```ruby
# Caller's hash is mutated in place
params = { a: 1, b: nil }
ActionDispatch::Http::URL.url_for(params: params)  # => "...?a=1"
params
# actual:   {a: 1}          (b was deleted in place)
# expected: {a: 1, b: nil}

# A frozen params hash raises instead of building the URL
ActionDispatch::Http::URL.url_for(only_path: true, path: "/x", params: { a: 1, b: nil }.freeze)
# actual:   FrozenError: can't modify frozen Hash
# expected: "/x?a=1"
```

### Fix

Replace the in-place `reject!` with the non-destructive `reject`:

```ruby
params = params.reject { |_, v| v.to_param.nil? }
```

The old `reject!` return value was never used (the method read `params` afterwards), so the URL output is unchanged; only the input is now left intact. This also resolves the `FrozenError`.

Adds regression tests covering both the non-mutation and the frozen-hash case.

### Prior art

This is the same class of bug — a Rails internal mutating a memoized per-request hash — as #23103, which fixed
`ActionDispatch::Routing::RouteSet::Generator` mutating `request.path_parameters`.
