### PR TITLE
Split template lookup into raising and non-raising

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -48,7 +48,7 @@ module ActionController
       # digest from the ETag.
       def pick_template_for_etag(options)
         unless options[:template] == false
-          options[:template] || lookup_context.find_all(action_name, _prefixes).first&.virtual_path
+          options[:template] || lookup_context.find(action_name, _prefixes)&.virtual_path
         end
       end
 

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -70,7 +70,7 @@ module ActionView
       private
         def find_template(finder, name, prefixes, partial, keys)
           finder.disable_cache do
-            finder.find_all(name, prefixes, partial, keys).first
+            finder.find(name, prefixes, partial, keys)
           end
         end
     end

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -284,7 +284,7 @@ module ActionView
         silence_redefinition_of_method(:_layout)
 
         prefixes = /\blayouts/.match?(_implied_layout_name) ? [] : ["layouts"]
-        default_behavior = "lookup_context.find_all('#{_implied_layout_name}', #{prefixes.inspect}, false, keys, { formats: formats }).first || super"
+        default_behavior = "lookup_context.find('#{_implied_layout_name}', #{prefixes.inspect}, false, keys, { formats: formats }) || super"
         name_clause = if name
           default_behavior
         else

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -132,7 +132,12 @@ module ActionView
         details, details_key = detail_args_for(options)
         @view_paths.find(name, prefixes, partial, details, details_key, keys)
       end
-      alias :find_template :find
+
+      def find!(name, prefixes = [], partial = false, keys = [], options = {})
+        name, prefixes = normalize_name(name, prefixes)
+        details, details_key = detail_args_for(options)
+        @view_paths.find!(name, prefixes, partial, details, details_key, keys)
+      end
 
       def find_all(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
@@ -153,6 +158,10 @@ module ActionView
         @view_paths.exists?(name, prefixes, partial, details, details_key, [])
       end
       alias :any_templates? :any?
+
+      def any_formats?(name, prefixes = [], partial = false, keys = [], options = {})
+        exists?(name, prefixes, partial, keys, **options, formats: default_formats)
+      end
 
       def append_view_paths(paths)
         @view_paths = build_view_paths(@view_paths.to_a + paths)

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -38,7 +38,11 @@ module ActionView # :nodoc:
     end
 
     def find(path, prefixes, partial, details, details_key, locals)
-      find_all(path, prefixes, partial, details, details_key, locals).first ||
+      find_all(path, prefixes, partial, details, details_key, locals).first
+    end
+
+    def find!(path, prefixes, partial, details, details_key, locals)
+      find(path, prefixes, partial, details, details_key, locals) ||
         raise(MissingTemplate.new(self, path, prefixes, partial, details, details_key, locals))
     end
 

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -277,7 +277,7 @@ module ActionView
 
       def find_template(path, locals)
         prefixes = path.include?(?/) ? [] : @lookup_context.prefixes
-        @lookup_context.find_template(path, prefixes, true, locals, @details)
+        @lookup_context.find!(path, prefixes, true, locals, @details)
       end
   end
 end

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -46,7 +46,7 @@ module ActionView
           if options[:template].respond_to?(:render)
             options[:template]
           else
-            @lookup_context.find_template(options[:template], options[:prefixes], false, keys, @details)
+            @lookup_context.find!(options[:template], options[:prefixes], false, keys, @details)
           end
         else
           raise ArgumentError, "You invoked render but did not give any of :body, :file, :html, :inline, :partial, :plain, :renderable, or :template option."
@@ -90,21 +90,17 @@ module ActionView
       end
 
       def resolve_layout(layout, keys, formats)
-        details = @details.dup
-        details[:formats] = formats
-
         case layout
         when String
-          begin
-            if layout.start_with?("/")
-              raise ArgumentError, "Rendering layouts from an absolute path is not supported."
-            else
-              @lookup_context.find_template(layout, nil, false, keys, details)
-            end
-          rescue ActionView::MissingTemplate
-            all_details = @details.merge(formats: @lookup_context.default_formats)
-            raise unless template_exists?(layout, nil, false, keys, **all_details)
+          if layout.start_with?("/")
+            raise ArgumentError, "Rendering layouts from an absolute path is not supported."
           end
+
+          template = @lookup_context.find(layout, nil, false, keys, @details.merge(formats: formats))
+          return template if template
+
+          return if @lookup_context.any_formats?(layout, nil, false, keys, @details)
+          @lookup_context.find!(layout, nil, false, keys, @details)
         when Proc
           resolve_layout(layout.call(@lookup_context, formats, keys), keys, formats)
         else

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -206,14 +206,14 @@ class TestMissingTemplate < ActiveSupport::TestCase
 
   test "if no template was found we get a helpful error message including the inheritance chain" do
     e = assert_raise ActionView::MissingTemplate do
-      @lookup_context.find("foo", %w(parent child))
+      @lookup_context.find!("foo", %w(parent child))
     end
     assert_match %r{Missing template parent/foo, child/foo with .*\n\nSearched in:\n  \* "/Path/to/views"\n}, e.message
   end
 
   test "if no partial was found we get a helpful error message including the inheritance chain" do
     e = assert_raise ActionView::MissingTemplate do
-      @lookup_context.find("foo", %w(parent child), true)
+      @lookup_context.find!("foo", %w(parent child), true)
     end
     assert_match %r{Missing partial parent/_foo, child/_foo with .*\n\nSearched in:\n  \* "/Path/to/views"\n}, e.message
   end
@@ -221,7 +221,7 @@ class TestMissingTemplate < ActiveSupport::TestCase
   test "if a single prefix is passed as a string and the lookup fails, MissingTemplate accepts it" do
     e = assert_raise ActionView::MissingTemplate do
       details = { handlers: [], formats: [], variants: [], locale: [] }
-      @lookup_context.view_paths.find("foo", "parent", true, details, nil, [])
+      @lookup_context.view_paths.find!("foo", "parent", true, details, nil, [])
     end
     assert_match %r{Missing partial parent/_foo with .*\n\nSearched in:\n  \* "/Path/to/views"\n}, e.message
   end


### PR DESCRIPTION
Use the non-raising #find in places where we had to use find_all(...).first to avoid exceptions or where we had to rescue.

This opens up the possibility of implementing a better #find which does not return all templates sorted but just the best match.

Also introduce an #any_formats? finder to keep the template lookup in LookupContext, similarly to [ImplicitRender using any?/any_templates?](https://github.com/rails/rails/blob/8817776b7864df906542ef14cf7f12db5e4d48ae/actionpack/lib/action_controller/metal/implicit_render.rb#L40).

