### PR TITLE
Fix inverse matching for association composite primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix inverse association matching for `has_many` and `has_one` associations
+    with association-specific composite primary keys.
+
+    *Hugo Vacher*
+
 *   Support polymorphic associations with custom primary keys through `:inverse_of`.
 
     When using polymorphic associations with `:inverse_of`, ActiveRecord now respects

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -416,18 +416,22 @@ module ActiveRecord
         end
 
         def record_foreign_key_matches_owner?(record)
-          foreign_key_values(record) == primary_key_values(owner)
+          foreign_key_values(record) == active_record_primary_key_values(owner)
         end
 
         def owner_foreign_key_matches_record?(record)
-          foreign_key_values(owner) == primary_key_values(record)
+          foreign_key_values(owner) == association_primary_key_values(record)
         end
 
         def foreign_key_values(record)
           Array(reflection.foreign_key).map { |key| record.read_attribute(key) }
         end
 
-        def primary_key_values(record)
+        def active_record_primary_key_values(record)
+          Array(reflection.active_record_primary_key).map { |key| record.read_attribute(key) }
+        end
+
+        def association_primary_key_values(record)
           Array(reflection.association_primary_key(record.class)).map { |key| record.read_attribute(key) }
         end
     end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -163,6 +163,18 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_same book.order, book.order.books.first.order
   end
 
+  def test_belongs_to_a_model_with_composite_association_primary_key_sets_inverse_of
+    cpk_order = cpk_orders(:cpk_groceries_order_1)
+    store_id, order_id = cpk_order.id
+    order = Cpk::NonCpkOrder.find(order_id)
+    book = order.books_with_composite_primary_key.create!(id: [store_id, 4], title: "Book")
+    book = Cpk::BookWithNonCpkOrder.find(book.id)
+    associated_order = book.non_cpk_order
+    associated_book = associated_order.books_with_composite_primary_key.to_a.find { |record| record.id == book.id }
+
+    assert_same associated_order, associated_book.non_cpk_order
+  end
+
   def test_belongs_to_a_cpk_model_by_id_attribute
     order = cpk_orders(:cpk_groceries_order_1)
     _order_shop_id, order_id = order.id

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -39,6 +39,13 @@ module Cpk
     belongs_to :non_cpk_order, foreign_key: [:order_id]
   end
 
+  class BookWithNonCpkOrder < ActiveRecord::Base
+    self.table_name = :cpk_books
+
+    belongs_to :non_cpk_order, class_name: "Cpk::NonCpkOrder",
+      foreign_key: [:shop_id, :order_id], primary_key: [:shop_id, :id], inverse_of: :books_with_composite_primary_key
+  end
+
   class NullifiedBook < Book
     has_one :chapter, foreign_key: [:author_id, :book_id], dependent: :nullify
   end

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -39,6 +39,9 @@ module Cpk
 
   class NonCpkOrder < Order
     self.primary_key = :id
+
+    has_many :books_with_composite_primary_key, class_name: "Cpk::BookWithNonCpkOrder",
+      foreign_key: [:shop_id, :order_id], primary_key: [:shop_id, :id], inverse_of: :non_cpk_order
   end
 
   class OrderWithPrimaryKeyAssociatedBook < Order


### PR DESCRIPTION
[rails/rails#56664](https://github.com/rails/rails/pull/56664) fixed array-vs-array inverse matching, but this still missed associations that declare a composite `primary_key` while the owner class itself keeps scalar `id`. In that shape, the owner-side comparison in [`Association#matches_foreign_key?`](https://github.com/Korri/rails/blob/51c5ec91f978e4322fc9ff0604e6b6c123fc1ab1/activerecord/lib/active_record/associations/association.rb#L413-L431) needs the association's `active_record_primary_key`.

The regression is modeled in [`AssociationsTest#test_belongs_to_a_model_with_composite_association_primary_key_sets_inverse_of`](https://github.com/Korri/rails/blob/51c5ec91f978e4322fc9ff0604e6b6c123fc1ab1/activerecord/test/cases/associations_test.rb#L166-L175), mirroring the failure shape: child FK values like `[shop_id, order_id]` should match owner values `[shop_id, id]`.
