### PR TITLE
Fix cross-database schema cache for PostgreSQL extension types

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Fix PostgreSQL extension columns (`hstore`, `citext`, ...) raising or casting
+    incorrectly when loaded from a schema cache dumped against another database.
+
+    Extension types are assigned a different OID in every database, so a schema
+    cache dumped in one database (e.g. development) records an OID that doesn't
+    exist in another (e.g. test loaded from `structure.sql`). The cached column
+    then failed to resolve its type, surfacing as `TypeError: can't cast Hash` or
+    `NoMethodError: undefined method 'type' for nil` on the first write.
+
+    The column type is now re-resolved from the portable SQL type name when the
+    cached cast type is missing, and `PostgreSQLAdapter#lookup_cast_type` loads
+    the type's OID on demand instead of falling back to a string. Array columns
+    (e.g. `hstore[]`) keep their array wrapper through the fallback.
+
+    Fixes #52944.
+
+    *Islam Gagiev*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Fix PostgreSQL extension columns (`hstore`, `citext`, ...) raising or casting
+    incorrectly when loaded from a schema cache dumped against another database.
+
+    Extension types are assigned a different OID in every database, so a schema
+    cache dumped in one database (e.g. development) records an OID that doesn't
+    exist in another (e.g. test loaded from `structure.sql`). The cached column
+    then failed to resolve its type, surfacing as `TypeError: can't cast Hash` or
+    `NoMethodError: undefined method 'type' for nil` on the first write.
+
+    The column type is now re-resolved from the portable SQL type name when the
+    cached cast type is missing, and `PostgreSQLAdapter#lookup_cast_type` loads
+    the type's OID on demand instead of falling back to a string. Array columns
+    (e.g. `hstore[]`) keep their array wrapper through the fallback.
+
+    Fixes #52944.
+
+    *Islam Gagiev*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -188,7 +188,11 @@ module ActiveRecord
 
         # TODO: Make this method private after we release 8.1.
         def lookup_cast_type(sql_type) # :nodoc:
-          super(query_value("SELECT #{quote(sql_type)}::regtype::oid").to_i)
+          oid = query_value("SELECT #{quote(sql_type)}::regtype::oid").to_i
+          # get_oid_type, not a bare type_map lookup, so an OID not yet loaded --
+          # e.g. an extension type from a stale schema cache -- is fetched on
+          # demand instead of degrading to the default string type.
+          get_oid_type(oid, -1, sql_type, sql_type)
         end
 
         def type_casted_binds(binds) # :nodoc:

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -655,6 +655,16 @@ module ActiveRecord
         def type_for_column(column)
           type = column.cast_type
 
+          # Extension type OIDs (hstore, citext, ...) differ per database, so a
+          # schema cache dumped elsewhere can carry an OID this database lacks; the
+          # cached cast type then comes back nil. Re-resolve from the portable SQL
+          # type name, re-adding "[]" for arrays since Column#sql_type strips it.
+          if type.nil? && column.respond_to?(:sql_type)
+            sql_type = column.sql_type
+            sql_type = "#{sql_type}[]" if column.try(:array?)
+            type = with_connection { |c| c.lookup_cast_type(sql_type) }
+          end
+
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
             type = type.to_immutable_string
           end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -643,6 +643,16 @@ module ActiveRecord
         def type_for_column(column)
           type = column.cast_type
 
+          # Extension type OIDs (hstore, citext, ...) differ per database, so a
+          # schema cache dumped elsewhere can carry an OID this database lacks; the
+          # cached cast type then comes back nil. Re-resolve from the portable SQL
+          # type name, re-adding "[]" for arrays since Column#sql_type strips it.
+          if type.nil? && column.respond_to?(:sql_type)
+            sql_type = column.sql_type
+            sql_type = "#{sql_type}[]" if column.try(:array?)
+            type = with_connection { |c| c.lookup_cast_type(sql_type) }
+          end
+
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
             type = type.to_immutable_string
           end

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -38,6 +38,23 @@ class PostgresqlCitextTest < ActiveRecord::PostgreSQLTestCase
     assert_not_predicate type, :binary?
   end
 
+  def test_type_for_column_resolves_extension_type_when_cast_type_is_missing
+    # Like hstore, a citext column from a cross-database schema cache resolves its
+    # stale OID to nil, and must re-resolve by the portable SQL type name.
+    column = @connection.columns("citexts").find { |c| c.name == "cival" }
+    without_cast_type = ActiveRecord::ConnectionAdapters::PostgreSQL::Column.new(
+      "cival", nil, nil, column.sql_type_metadata, column.null
+    )
+    assert_nil without_cast_type.cast_type
+
+    # Drop citext (a base type, not bulk-loaded) so the fallback fetches the OID on demand.
+    @connection.reload_type_map
+
+    type = Citext.send(:type_for_column, without_cast_type)
+    assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::SpecializedString, type
+    assert_equal :citext, type.type
+  end
+
   def test_change_table_supports_json
     @connection.transaction do
       @connection.change_table("citexts") do |t|

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -46,6 +46,19 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     assert_not_predicate type, :binary?
   end
 
+  def test_type_for_column_resolves_enum_when_cast_type_is_missing
+    # The OID fallback must not mask other nil cast types: an enum should
+    # re-resolve to its enum type by name, not degrade to a string.
+    column = @connection.columns("postgresql_enums").find { |c| c.name == "current_mood" }
+    without_cast_type = ActiveRecord::ConnectionAdapters::PostgreSQL::Column.new(
+      "current_mood", nil, nil, column.sql_type_metadata, column.null
+    )
+    assert_nil without_cast_type.cast_type
+
+    type = PostgresqlEnum.send(:type_for_column, without_cast_type)
+    assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum, type
+  end
+
   def test_enum_defaults
     @connection.add_column "postgresql_enums", "good_mood", :mood, default: "happy"
     PostgresqlEnum.reset_column_information

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -50,6 +50,76 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
     load_schema
   end
 
+  def test_type_for_column_resolves_extension_type_when_cast_type_is_missing
+    # A schema cache dumped against another database carries an hstore OID this
+    # one lacks, so the cached cast type comes back nil. It must still resolve via
+    # the portable SQL type name -- for scalar and array columns alike.
+    @connection.create_table("hstore_oid_cache_test", force: true) do |t|
+      t.hstore "data"
+      t.hstore "labels", array: true
+    end
+    klass = Class.new(ActiveRecord::Base) { self.table_name = "hstore_oid_cache_test" }
+    columns = @connection.columns("hstore_oid_cache_test").index_by(&:name)
+
+    scalar = ActiveRecord::ConnectionAdapters::PostgreSQL::Column.new(
+      "data", nil, nil, columns["data"].sql_type_metadata, columns["data"].null
+    )
+    array = ActiveRecord::ConnectionAdapters::PostgreSQL::Column.new(
+      "labels", nil, nil, columns["labels"].sql_type_metadata, columns["labels"].null
+    )
+    assert_nil scalar.cast_type
+    assert_nil array.cast_type
+
+    # Drop hstore (a base type, not bulk-loaded) from the type map so the fallback
+    # fetches the OID on demand -- the state an unknown local OID produces.
+    @connection.reload_type_map
+
+    assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore,
+      klass.send(:type_for_column, scalar)
+
+    array_type = klass.send(:type_for_column, array)
+    assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array, array_type
+    assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore, array_type.subtype
+  ensure
+    @connection.drop_table("hstore_oid_cache_test", if_exists: true)
+  end
+
+  def test_standard_columns_do_not_trigger_a_type_lookup
+    # The fallback fires only for nil cached cast types; standard types resolve
+    # from the static map and must never emit a `::regtype` lookup.
+    @connection.create_table("hstore_plain", force: true) do |t|
+      t.string :name
+      t.integer :count
+      t.boolean :flag
+    end
+    klass = Class.new(ActiveRecord::Base) { self.table_name = "hstore_plain" }
+    klass.create!(name: "x", count: 1, flag: true) # warm the schema
+
+    type_lookups = 0
+    counter = ->(*, payload) { type_lookups += 1 if payload[:sql] =~ /::regtype/ }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      klass.reset_column_information
+      record = klass.create!(name: "y", count: 2, flag: false)
+      assert_equal [2, false], [record.reload.count, record.flag]
+    end
+
+    assert_equal 0, type_lookups
+  ensure
+    @connection.drop_table("hstore_plain", if_exists: true)
+  end
+
+  def test_lookup_cast_type_raises_a_clean_error_for_a_missing_type
+    # A cache so stale the type no longer exists must surface the database error,
+    # not loop or raise an opaque Ruby error.
+    assert_raises(ActiveRecord::StatementInvalid) do
+      # Wrapped in a savepoint so the deliberately failing lookup doesn't abort
+      # the surrounding test transaction.
+      @connection.transaction(requires_new: true) do
+        @connection.lookup_cast_type("a_type_that_does_not_exist")
+      end
+    end
+  end
+
   def test_column
     assert_equal :hstore, @column.type
     assert_equal "hstore", @column.sql_type


### PR DESCRIPTION
### Motivation / Background

Fixes #52944.

PostgreSQL assigns extension types (`hstore`, `citext`, ...) a different OID in
every database. A schema cache dumped in one database (e.g. development) records
that OID; loaded in another (e.g. a test database populated from `structure.sql`),
the OID doesn't exist there, so the cached column can't resolve its cast type and
it comes back `nil`. The first write then fails — `NoMethodError: undefined method
'type' for nil` on `main` (and `TypeError: can't cast Hash` on earlier versions).

This became reachable after #45450 stopped re-establishing same-config
connections, which removed the reset that previously masked it (per @fatkodima's
bisect on the issue).

### Detail

This Pull Request makes two read-side changes:

- `ActiveRecord::ModelSchema#type_for_column`: when a column's cached cast type is
  `nil`, re-resolve it from the portable SQL type name, re-adding `[]` for array
  columns (which `Column#sql_type` strips). This runs with a connection through
  `with_connection`; the deserialization path (`Column#init_with`) can't, because
  the schema cache may be loaded without one.
- `PostgreSQLAdapter#lookup_cast_type`: resolve through `get_oid_type`, so an OID
  not yet in the type map is loaded on demand, instead of `type_map.lookup`
  returning the default string type for an unknown OID.

OIDs are still written to the schema cache (they're needed for normal resolution);
the type name is only a fallback for the cross-database mismatch, not a
replacement.

### Additional information

Tests (each red without the patch unless marked as a guard):

- `hstore_test`, `citext_test`, `enum_test`: a column whose cached cast type is
  `nil` (the state a cross-database schema cache produces) re-resolves to the
  correct type by name — scalar and array, and without degrading enum/citext to a
  plain string.
- Guards (green with and without the patch, by design): standard columns never
  emit a `::regtype` lookup (no regression on the hot path); a type that no longer
  exists raises a clean `ActiveRecord::StatementInvalid`, not an opaque error.

Not covered by a dedicated test: the end-to-end write through a stale
cross-database cache, and the two-database scenario itself — there's no public API
to seed a schema cache with a specific (foreign) OID, and a real dump/load
re-resolves the cast type. The resolution point that fails is covered directly
above. The fix relies on `with_connection` resolving against the model's own
pool/role.
