### PR TITLE
Fix `Rails.app.dotenvs` to honor an explicit path argument

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -586,7 +586,8 @@ module Rails
     #
     # In development mode, this configuration backend is automatically part of `Rails.app.creds`.
     def dotenvs(path = Rails.root.join(".env"))
-      @dotenvs ||= ActiveSupport::DotEnvConfiguration.new(path)
+      @dotenvs ||= {}
+      @dotenvs[path] ||= ActiveSupport::DotEnvConfiguration.new(path)
     end
 
     # Returns an ActiveSupport::EncryptedConfiguration instance for the

--- a/railties/test/application/creds_test.rb
+++ b/railties/test/application/creds_test.rb
@@ -46,6 +46,16 @@ class Rails::CredsTest < ActiveSupport::TestCase
     ENV.delete("MYSTERY")
   end
 
+  test "dotenvs honors an explicit path even after the default has been accessed" do
+    File.write("#{app_path}/.env", "MYSTERY=default_env")
+    File.write("#{app_path}/.env.custom", "MYSTERY=custom_env")
+
+    app("development")
+
+    assert_equal "default_env", Rails.app.dotenvs.require(:mystery)
+    assert_equal "custom_env", Rails.app.dotenvs("#{app_path}/.env.custom").require(:mystery)
+  end
+
   test "dotenvs are available only in development mode" do
     write_credentials_override(:development)
     write_credentials_override(:production)


### PR DESCRIPTION
## Summary

`Rails.application#dotenvs` accepts a `path` argument so callers can point it at a non-default `.env` file, but the result was memoized with a bare `@dotenvs ||=`. As a result only the path from the **first** call ever took effect; every later call returned that same instance and silently ignored its `path` argument.

This is easy to trigger because `creds` itself calls `dotenvs` (with the default path) in development:

```ruby
# railties/lib/rails/application.rb
@creds ||= ActiveSupport::CombinedConfiguration.new(envs, dotenvs, credentials)
```

So after any access to `Rails.app.creds` (dev) or `Rails.app.dotenvs`, a later `Rails.app.dotenvs("/path/to/.env.custom")` returns the **default** `.env` configuration rather than the requested one — a silent wrong result.

## Conform-to-sibling rationale

The three configuration accessors form a clear pattern:

| accessor | takes `path`? | memoized? | honors path? |
|---|---|---|---|
| `encrypted(path, …)` | yes | no (fresh each call) | yes |
| `credentials` | no (derived internally) | yes | n/a |
| `dotenvs(path = …)` | **yes** | **yes (bare `\|\|=`)** | **no — this patch** |

`dotenvs` is the only hybrid: it both takes a `path` and memoizes, but with a memo key of *nothing*. The fix keys the memo on `path`, giving the path-honoring behavior of `encrypted` while keeping the file-parse memoization that `credentials` also relies on.

## The fix

```ruby
def dotenvs(path = Rails.root.join(".env"))
  (@dotenvs ||= {})[path] ||= ActiveSupport::DotEnvConfiguration.new(path)
end
```

One line. `@dotenvs` is read nowhere else in the codebase (only inside this method; `creds` goes through `dotenvs` with the default path), so switching it from a single instance to a per-path hash is safe.