### PR TITLE
Remove unused private `EnvConfiguration#lookup`

### DIFF
--- a/activesupport/lib/active_support/env_configuration.rb
+++ b/activesupport/lib/active_support/env_configuration.rb
@@ -80,10 +80,6 @@ module ActiveSupport
     end
 
     private
-      def lookup(env_key)
-        @envs[env_key]
-      end
-
       def envify(*key)
         key.collect { |part| part.to_s.upcase }.join("__")
       end


### PR DESCRIPTION
## Summary

`ActiveSupport::EnvConfiguration` defines a private `#lookup(env_key)` that is never called:

- `#require`, `#option`, and `#keys` all read through `@envs.fetch(envify(*key))` / `@envs[...]` directly.
- The `DotEnvConfiguration` subclass never calls it (its `parse_env_file`/`reload` build `@envs` and read nothing through `lookup`).
- A repo-wide grep finds the sole definition site and zero call sites (no `send(:lookup)` / `:lookup` dynamic dispatch either).
