### PR TITLE
Strip inline comments from unquoted `.env` values

### DIFF
--- a/activesupport/lib/active_support/dot_env_configuration.rb
+++ b/activesupport/lib/active_support/dot_env_configuration.rb
@@ -55,7 +55,7 @@ module ActiveSupport
             # Match KEY=value pattern
             if line =~ /\A([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\z/
               key, value = $1, $2
-              envs[key] = interpolate(execute_commands(unquote(value)), envs)
+              envs[key] = interpolate(execute_commands(unquote(strip_inline_comment(value))), envs)
             end
           end
 
@@ -63,6 +63,16 @@ module ActiveSupport
         else
           {}
         end
+      end
+
+      # Strip a trailing " # comment" from an unquoted value, matching the
+      # common .env convention. Quoted values are left untouched so that a
+      # "#" inside quotes (e.g. PASS="a # b") is preserved, and a "#" that is
+      # not preceded by whitespace (e.g. URL=http://host#frag) stays part of
+      # the value.
+      def strip_inline_comment(value)
+        return value if value.start_with?('"', "'")
+        value.sub(/\s+#.*\z/, "")
       end
 
       def unquote(value)

--- a/activesupport/test/dot_env_configuration_test.rb
+++ b/activesupport/test/dot_env_configuration_test.rb
@@ -105,6 +105,26 @@ class DotEnvConfigurationTest < ActiveSupport::TestCase
     assert_equal "1", @config.require(:one)
   end
 
+  test "strips inline comments from unquoted values" do
+    write_env_file_raw("ONE=1 # this is one")
+    assert_equal "1", @config.require(:one)
+  end
+
+  test "strips inline comment after a command substitution" do
+    write_env_file_raw("SECRET=$(echo hello) # inline note")
+    assert_equal "hello", @config.require(:secret)
+  end
+
+  test "keeps a # without preceding whitespace as part of an unquoted value" do
+    write_env_file_raw("URL=http://example.com#section")
+    assert_equal "http://example.com#section", @config.require(:url)
+  end
+
+  test "keeps # inside quoted values" do
+    write_env_file_raw('PASS="a # b"')
+    assert_equal "a # b", @config.require(:pass)
+  end
+
   test "ignores empty lines" do
     write_env_file_raw("ONE=1\n\nTWO=2")
     assert_equal "1", @config.require(:one)


### PR DESCRIPTION
## Summary

`DotEnvConfiguration` only strips **full-line** comments (`next if line.start_with?("#")`). The `KEY=value` regex `\A([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\z` captures the rest of the line into the value, so a **trailing** comment is stored verbatim:

```
PORT=5432 # primary   →  option(:port) == "5432 # primary"   (expected "5432")
SECRET=$(echo hi) # x →  require(:secret) == "hi # x"          (expected "hi")
```

Trailing comments on unquoted values are a near-universal `.env` authoring convention (the dotenv gem, foreman, and docker-compose all strip them), and the failure here is **silent** configuration corruption — no error, just a wrong value.

## The fix (intentionally narrow)

Strip a whitespace-preceded `# ...` from **unquoted** values before unquoting, interpolation, and command execution:

```ruby
def strip_inline_comment(value)
  return value if value.start_with?('"', "'")
  value.sub(/\s+#.*\z/, "")
end
```

Wired in as `unquote(strip_inline_comment(value))`.

Design choices, all covered by tests:

| input | result | why |
|---|---|---|
| `PORT=5432 # primary` | `5432` | trailing comment stripped |
| `DB=$(op read x) # note` | runs `op read x` | comment after `$(…)` stripped, command intact |
| `URL=http://host#frag` | `http://host#frag` | no whitespace before `#` → part of value |
| `PASS="a # b"` | `a # b` | quoted value untouched |

## Scope note

This deliberately covers the **unquoted** case only — exactly the convention the ecosystem tools implement. A trailing comment on a *quoted* value (`TWO="2" # two`) is still retained, because stripping it correctly requires a quote-aware scan (finding the closing quote, honoring `\"` escapes) — a larger parser change. Since the subsystem is unreleased there's no back-compat pressure; the quoted-comment case can be a follow-up if maintainers want it. Flagged here so the limitation is explicit rather than hidden.

Also a known residual: ` #` *inside* an unquoted `$(...)` (e.g. `X=$(echo "a # b")`) would be stripped — same limitation the dotenv gem has; rare, and documented here.