### PR TITLE
Avoid mutating the override options passed to `ActiveModel::Errors#import`

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -150,6 +150,7 @@ module ActiveModel
     # * +:attribute+ - Override the attribute the error belongs to.
     # * +:type+ - Override type of the error.
     def import(error, override_options = {})
+      override_options = override_options.dup
       [:attribute, :type].each do |key|
         if override_options.key?(key)
           override_options[key] = override_options[key].to_sym

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -817,6 +817,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal :blank, imported.type
   end
 
+  test "import does not mutate the override options passed in" do
+    person = Person.new
+    original_error = ActiveModel::Error.new(Person.new, :name, :invalid)
+
+    options = { attribute: "age", type: "blank" }
+    person.errors.import(original_error, options)
+
+    assert_equal({ attribute: "age", type: "blank" }, options)
+  end
+
   test "merge errors" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)


### PR DESCRIPTION
### Summary

`ActiveModel::Errors#import` normalizes the `:attribute` and `:type` overrides by writing the symbolized values straight back into the `override_options` hash it was handed:

```ruby
def import(error, override_options = {})
  [:attribute, :type].each do |key|
    if override_options.key?(key)
      override_options[key] = override_options[key].to_sym   # mutates the caller's hash
    end
  end
  @errors.append(NestedError.new(@base, error, override_options))
end
```

`override_options` belongs to the caller, so `import` should not modify it. `import` is public, documented API (the doc block lists `:attribute`/`:type` as override options) and is the supported way to copy an error from one model onto another. This has two concrete effects.

**1. The caller's hash is corrupted in place.**

```ruby
options = { attribute: "age", type: "blank" }
errors.import(error, options)
options
# actual:   {attribute: :age, type: :blank}
# expected: {attribute: "age", type: "blank"}
```

A caller that reuses one options hash across several `import` calls — or reads it afterwards — sees its string values silently rewritten to symbols.

**2. A frozen options hash raises `FrozenError`.**

```ruby
errors.import(error, { attribute: "age" }.freeze)
# actual:   FrozenError: can't modify frozen Hash
# expected: imports the error with attribute :age
```

The internal caller (`merge!` → `import(error)`) always passes a fresh `{}`, so existing tests never exercise a shared or frozen hash and the issue goes unnoticed.

### Fix

Duplicate the options before symbolizing, leaving the caller's hash untouched:

```ruby
def import(error, override_options = {})
  override_options = override_options.dup
  ...
end
```

A shallow `dup` is sufficient: only the top-level `:attribute`/`:type` keys are reassigned, no nested object is touched. This also resolves the `FrozenError`, since `dup` returns an unfrozen copy.

Adds regression tests covering both the non-mutation and the frozen-hash case.

### Prior art

Same class of bug as #57782 (`ActionDispatch::Http::URL.url_for` mutating the `params:` hash it is given) and #23103 — a Rails internal destructively modifying a hash it does not own.