### PR TITLE
Fix grammar in Model.inspect schema-not-loaded message

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -389,7 +389,7 @@ module ActiveRecord
         elsif abstract_class?
           "#{super}(abstract)"
         elsif !schema_loaded? && !connected?
-          "#{super} (call '#{super}.load_schema' to load schema informations)"
+          "#{super} (call '#{super}.load_schema' to load schema information)"
         elsif table_exists?
           attr_list = attribute_types.map { |name, type| "#{name}: #{type.type}" } * ", "
           "#{super}(#{attr_list})"

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -20,7 +20,7 @@ class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
     end
 
     test "inspect on Model class does not raise" do
-      assert_equal "#{Bird.name} (call '#{Bird.name}.load_schema' to load schema informations)", Bird.inspect
+      assert_equal "#{Bird.name} (call '#{Bird.name}.load_schema' to load schema information)", Bird.inspect
     end
   end
 end


### PR DESCRIPTION
When a model class is inspected before its schema has been loaded, `inspect` returns a hint message. That message used "informations", but "information" is an uncountable noun in English and does not take a plural form, so the word should be "information".

The same "schema information" phrasing is already used in the singular elsewhere; this was the only occurrence of "informations" in the codebase.

>[!NOTE]
> - Not a `[ci skip]` change: it touches a user-facing string in production code plus its test, so CI should run.
> - No CHANGELOG (simple grammar fix, not user-facing in the feature sense).
> - Why "information" is correct: (1) uncountable noun, no plural `-s`; (2) Merriam-Webster / Oxford list it as noncount; (3) only outlier occurrence in the repo, same phrase used singular elsewhere.