### PR TITLE
Support polymorphic associations with custom primary keys through `:inverse_of`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,37 @@
+*   Support polymorphic associations with custom primary keys through `:inverse_of`.
+
+    When using polymorphic associations with `:inverse_of`, ActiveRecord now respects
+    custom `:primary_key` options defined on the inverse association. This allows
+    different associated models to use different primary key columns.
+
+    ```ruby
+    class Post < ActiveRecord::Base
+      has_many :comments, as: :commentable, primary_key: :uuid
+    end
+
+    class Article < ActiveRecord::Base
+      has_many :comments, as: :commentable, primary_key: :slug
+    end
+
+    class Comment < ActiveRecord::Base
+      belongs_to :commentable, polymorphic: true, inverse_of: :comments
+    end
+
+    post = Post.create!(uuid: "post-uuid-123")
+    comment = Comment.new(content: "Great post!")
+    comment.commentable = post  # This now correctly uses :uuid as the foreign key
+    comment.save!
+    comment.commentable_id # => "post-uuid-123" (not the post.id)
+
+    article = Article.create!(slug: "article-slug-456")
+    comment = Comment.new(content: "Nice article!")
+    comment.commentable = article  # This now correctly uses :slug as the foreign key
+    comment.save!
+    comment.commentable_id # => "article-slug-456" (not the article.id)
+    ```
+
+    *Ryuta Kamizono*
+
 *   Make `ActiveRecord::Base.primary_key` inheritable.
 
     Previously setting `primary_key` on a model wouldn't impact child

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -482,7 +482,7 @@ module ActiveRecord
         if autosave && record.marked_for_destruction?
           record.destroy
         elsif autosave != false
-          primary_key = Array(compute_primary_key(reflection, self)).map(&:to_s)
+          primary_key = Array(reflection.active_record_primary_key).map(&:to_s)
           primary_key_value = primary_key.map { |key| _read_attribute(key) }
           return unless (autosave && record.changed_for_autosave?) || _record_changed?(reflection, record, primary_key_value)
 
@@ -557,7 +557,7 @@ module ActiveRecord
             end
 
             if association.updated?
-              primary_key = Array(compute_primary_key(reflection, record)).map(&:to_s)
+              primary_key = Array(reflection.association_primary_key(record.class)).map(&:to_s)
               foreign_key = Array(reflection.foreign_key)
 
               primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
@@ -570,18 +570,6 @@ module ActiveRecord
 
             saved if autosave
           end
-        end
-      end
-
-      def compute_primary_key(reflection, record)
-        if primary_key_options = reflection.options[:primary_key]
-          primary_key_options
-        elsif reflection.options[:query_constraints] && (query_constraints = record.class.query_constraints_list)
-          query_constraints
-        elsif record.class.has_query_constraints? && !reflection.options[:foreign_key]
-          record.class.query_constraints_list
-        else
-          record.class.primary_key_definition.inferred_id || record.class.primary_key
         end
       end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -937,6 +937,13 @@ module ActiveRecord
       def association_primary_key(klass = nil)
         if options[:primary_key]
           @association_primary_key ||= ActiveRecord::Key.for(options[:primary_key]).name
+        elsif polymorphic? && options[:inverse_of] && klass
+          inverse = klass.reflect_on_association(options[:inverse_of])
+          if inverse && inverse.options[:primary_key]
+            ActiveRecord::Key.for(inverse.options[:primary_key]).name
+          else
+            derive_primary_key(klass) { |model| model.composite_query_constraints_list }
+          end
         else
           derive_primary_key(klass || self.klass) { |model| model.composite_query_constraints_list }
         end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -33,7 +33,7 @@ require "models/tree"
 require "models/node"
 require "models/club"
 require "models/cpk"
-require "models/person" # not used by this suite as of this writing, it is a workaround for https://github.com/rails/rails/issues/55133
+require "models/person"
 require "models/car"
 require "models/sharded/blog"
 require "models/sharded/blog_post"
@@ -2109,5 +2109,30 @@ class DeprecatedBelongsToAssociationsTest < ActiveRecord::TestCase
       @bulb.destroy
     end
     assert_predicate @car, :destroyed?
+  end
+end
+
+class BelongsToPolymorphicInversePrimaryKeyTest < ActiveRecord::TestCase
+  def test_polymorphic_with_different_primary_keys_per_type
+    author = Author.create!(name: "Author", author_code: "org_#{SecureRandom.hex(8)}")
+    person = Person.create!(first_name: "Person", external_id: "ext_#{SecureRandom.hex(8)}")
+
+    author_comment = PolymorphicComment.new(body: "Author comment", post_id: 1)
+    author_comment.person = author
+
+    person_comment = PolymorphicComment.new(body: "Person comment", post_id: 1)
+    person_comment.person = person
+
+    assert_equal author.author_code, author_comment.person_id
+    assert_equal person.external_id, person_comment.person_id
+
+    assert_equal "Author", author_comment.person_type
+    assert_equal "Person", person_comment.person_type
+
+    author_comment.save!
+    person_comment.save!
+
+    assert_equal author, author_comment.reload.person
+    assert_equal person, person_comment.reload.person
   end
 end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -17,6 +17,7 @@ require "models/line_item"
 require "models/mouse"
 require "models/order"
 require "models/parrot"
+require "models/person"
 require "models/pirate"
 require "models/project"
 require "models/price_estimate"
@@ -2496,5 +2497,30 @@ class TestAutosaveAssociationWithNestedAttributes < ActiveRecord::TestCase
     end
     assert_includes pirate.errors[:"ships.parts"], "must have at least two parts"
     assert_includes ship.errors[:parts], "must have at least two parts"
+  end
+end
+
+class AutosavePolymorphicInversePrimaryKeyTest < ActiveRecord::TestCase
+  def test_autosave_with_polymorphic_custom_primary_key_from_belongs_to
+    author = Author.new(name: "Author", author_code: "autosave_org_#{SecureRandom.hex(8)}")
+    person = Person.new(first_name: "Person", external_id: "autosave_ext_#{SecureRandom.hex(8)}")
+
+    author_comment = PolymorphicComment.new(body: "Author comment", post_id: 1)
+    author_comment.person = author
+
+    person_comment = PolymorphicComment.new(body: "Person comment", post_id: 1)
+    person_comment.person = person
+
+    author_comment.save!
+    person_comment.save!
+
+    assert_predicate author, :persisted?
+    assert_predicate person, :persisted?
+
+    assert_equal author.author_code, author_comment.person_id
+    assert_equal person.external_id, person_comment.person_id
+
+    assert_equal author, author_comment.reload.person
+    assert_equal person, person_comment.reload.person
   end
 end

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -267,7 +267,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
     set_include_root_in_json(false) do
       authors = [@david, @mary]
       encoded = ActiveSupport::JSON.encode(authors, except: [
-        :name, :author_address_id, :author_address_extra_id,
+        :name, :author_address_id, :author_address_extra_id, :author_code,
         :organization_id, :owned_essay_id, :published_author_id
       ])
       assert_equal %([{"id":1},{"id":2}]), encoded

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -182,6 +182,8 @@ class Author < ActiveRecord::Base
   has_many :subscribers, -> { order("subscribers.nick") }, through: :subscriptions
   has_many :distinct_subscribers, -> { select("DISTINCT subscribers.*").order("subscribers.nick") }, through: :subscriptions, source: :subscriber
 
+  has_many :polymorphic_comments, as: :person, primary_key: :author_code
+
   has_one :essay, primary_key: :name, as: :writer
   has_one :essay_category, through: :essay, source: :category
   has_one :essay_owner, through: :essay, source: :owner

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -105,3 +105,7 @@ class CommentOnPostWithWhereDefaultScope < Comment
 
   belongs_to :post, class_name: "PostWithWhereDefaultScope", foreign_key: :post_id
 end
+
+class PolymorphicComment < Comment
+  belongs_to :person, polymorphic: true, inverse_of: :polymorphic_comments, autosave: true
+end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -39,6 +39,8 @@ class Person < ActiveRecord::Base
   has_many :agents_posts_authors, through: :agents_posts, source: :author
   has_many :essays, primary_key: "first_name", foreign_key: "writer_id"
 
+  has_many :polymorphic_comments, as: :person, primary_key: :external_id
+
   scope :males,   -> { where(gender: "M") }
 
   attr_readonly :born_at

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define do
     t.string :name, null: false
     t.references :author_address
     t.references :author_address_extra
+    t.string :author_code
     t.string :organization_id
     t.string :owned_essay_id
     t.integer :published_author_id
@@ -401,6 +402,8 @@ ActiveRecord::Schema.define do
     t.integer :children_count, default: 0
     t.integer :parent_id
     t.references :author, polymorphic: true
+    t.string :person_id
+    t.string :person_type
     # The type of the attribute is a string to make sure preload work when types don't match.
     # See #14855.
     t.string :resource_id
@@ -965,6 +968,7 @@ ActiveRecord::Schema.define do
     t.integer    :friends_too_count, default: 0
     t.references :best_friend
     t.references :best_friend_of
+    t.string     :external_id
     t.integer    :insures, null: false, default: 0
     t.timestamp :born_at
     t.integer :cars_count, default: 0


### PR DESCRIPTION
## Background

Due to historical reasons, some models use unique identifiers separate from their primary keys, and these unique identifier column names differ across models. While we attempted to unify these names using `alias_attribute`, the current association implementation uses `_read_attribute` for performance optimizations introduced in the past, which doesn't support aliases. To work around this limitation, production applications have had to override `_read_attribute` to resolve aliases.

Polymorphic associations cannot statically determine `inverse_of`, so automatic `inverse_of` detection is disabled. Because of this, support for explicitly specified `:inverse_of` has been incomplete, and the provided inverse association information was not fully utilized. This change improves the implementation to properly respect explicitly defined inverse associations.

## Changes

When using polymorphic associations with `:inverse_of`, ActiveRecord now respects custom `:primary_key` options defined on the inverse association. This allows different associated models to use different primary key columns.

For example:
- Post can use `:uuid` as its primary key for comments
- Article can use `:slug` as its primary key for comments
- Video can use the default `:id`

This is achieved by extending `BelongsToReflection#association_primary_key` to check for inverse associations when dealing with polymorphic relationships. `AutosaveAssociation` has also been simplified to use existing reflection methods instead of duplicating the primary key resolution logic.
