### PR TITLE
Make config.rake_eager_load more explicit

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -413,7 +413,9 @@ Eager Loading
 
 In production-like environments it is generally better to load all the application code when the application boots. Eager loading puts everything in memory ready to serve requests right away, and it is also [CoW](https://en.wikipedia.org/wiki/Copy-on-write)-friendly.
 
-Eager loading is controlled by the flag [`config.eager_load`][], which is disabled by default in all environments except `production`. When a Rake task gets executed, `config.eager_load` is overridden by [`config.rake_eager_load`][], which is `false` by default. So, by default, in production environments Rake tasks do not eager load the application.
+Eager loading is controlled by the flag [`config.eager_load`][]. By default, `development` does not eager load, `test` eager loads if the environment variable `CI` is present, and `production` eager loads.
+
+For Rake task, however, the value assigned to `config.eager_load` is replaced with [`config.rake_eager_load`][]. By default, this one is `false` in `development` and `production`, and matches `config.eager_load` in `test`.
 
 The order in which files are eager-loaded is undefined.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -6,8 +6,12 @@ Rails.application.configure do
   # Code is not reloaded between requests.
   config.enable_reloading = false
 
-  # Eager load code on boot for better performance and memory savings (ignored by Rake tasks).
+  # Eager load code on boot for better performance and memory savings.
   config.eager_load = true
+
+  # In Rake tasks, the previous assigment is ignored, config.eager_load is set
+  # from config.rake_eager_load.
+  config.rake_eager_load = false
 
   # Full error reports are disabled.
   config.consider_all_requests_local = false

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -14,6 +14,9 @@ Rails.application.configure do
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
+
+  # In Rake tasks, the previous assigment is ignored, config.eager_load is set
+  # from config.rake_eager_load.
   config.rake_eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with cache-control for performance.


### PR DESCRIPTION
The generated code comment in `config/environments/production.rb` says that `config.eager_load` is _ignored_:

```ruby
# Eager load code on boot for better performance and memory savings (ignored by Rake tasks).
```

This is kind of true, but incomplete. The setting is indeed _overwritten_. In a default setup, `config.eager_load` is set to `true` by the user in `production`, and during boot it _becomes_ `false` for Rake tasks.

 I really do not like this interface. In general, I think user settings should not be flipped behind the scenes. They should be preserved as is. If you need richer logic and API, you do that. However, this is this way for historical reasons and it would be hard to not mutate `config.eager_load` for backwards compatibility.

Additionally `config.rake_eager_load` is responsible for all this and it does not have enough visibility for how important it is, in my view. I am pretty sure you ask Rails programmers if production eager loads by default and many will just say "yes". No, it depends.

We cannot address these pain points easily, but at least we can word things a bit differently and make this contract more explicit.