### PR TITLE
Fix :singleton-method: directive typo for protected_environments [ci skip]

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -193,7 +193,7 @@ module ActiveRecord
   self.lazily_load_schema_cache = false
 
   ##
-  # :singlton-method: protected_environments
+  # :singleton-method: protected_environments
   # The array of names of environments where destructive actions should be
   # prohibited. By default, the value is <tt>["production"]</tt>.
   singleton_class.attr_reader :protected_environments


### PR DESCRIPTION
`ActiveRecord.protected_environments` is defined through `singleton_class.attr_reader`, which RDoc can't pick up on its own, so it's documented via the `# :singleton-method:` directive above the accessor. That directive was misspelled `:singlton-method:` — RDoc doesn't recognize it, drops it, and the method ends up missing from the API docs with its description left as stray text in the source listing.

Correcting the spelling restores the documented method. The accessors on either side of it, `lazily_load_schema_cache` and `schema_cache_ignored_tables`, already use the correct directive.

You can see the breakage in the current edge API docs: https://edgeapi.rubyonrails.org/classes/ActiveRecord.html lists the setter [`protected_environments=`](https://edgeapi.rubyonrails.org/classes/ActiveRecord.html#method-c-protected_environments-3D) and both sibling accessors, but not `protected_environments` itself.
