### PR TITLE
Fix indefinite article in error messages

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -365,14 +365,14 @@ module ActiveRecord
         def invert_add_unique_constraint(args)
           options = args.dup.extract_options!
 
-          raise ActiveRecord::IrreversibleMigration, "add_unique_constraint is not reversible if given an using_index." if options[:using_index]
+          raise ActiveRecord::IrreversibleMigration, "add_unique_constraint is not reversible if given a using_index." if options[:using_index]
           super
         end
 
         def invert_remove_unique_constraint(args)
           _table, columns = args.dup.tap(&:extract_options!)
 
-          raise ActiveRecord::IrreversibleMigration, "remove_unique_constraint is only reversible if given an column_name." if columns.blank?
+          raise ActiveRecord::IrreversibleMigration, "remove_unique_constraint is only reversible if given a column_name." if columns.blank?
           super
         end
 

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -51,7 +51,7 @@ module ActiveStorage
           {}
         end
       rescue ::Vips::Error => error
-        logger.error "Skipping image analysis due to an Vips error: #{error.message}"
+        logger.error "Skipping image analysis due to a Vips error: #{error.message}"
         {}
       end
 


### PR DESCRIPTION
Use "a" instead of "an" before the consonant-sounded words `using_index`, `column_name`, and `Vips` in user-visible error/log messages.

- `activestorage/.../image_analyzer/vips.rb:54` — `an Vips error` → `a Vips error` (conforms to the sibling rescue at :50 which already says `a Vips error`)
- `activerecord/.../migration/command_recorder.rb:368` — `an using_index` → `a using_index` ("using" = /j/ consonant sound)
- `activerecord/.../migration/command_recorder.rb:375` — `an column_name` → `a column_name` (both conform to the neighbouring `an expression` at :361, correct because vowel sound)
