### PR TITLE
Reword allow/let phrasings in guides

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -793,7 +793,7 @@ end
 Action Mailer Callbacks
 -----------------------
 
-Action Mailer allows for you to specify `*_action` callbacks to configure the message, and `*_deliver` callbacks to control the delivery.
+Action Mailer allows you to specify `*_action` callbacks to configure the message, and `*_deliver` callbacks to control the delivery.
 
 Here is a list with all the available Action Mailer callbacks, listed **in the order in which they will get called** when sending an email:
 

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -245,7 +245,7 @@ You might want to ignore the case when querying deterministically encrypted
 data. There are two options for achieving this - `:downcase` and `:ignore_case`.
 
 When you use the `:downcase` option when declaring the encrypted attribute, it
-converts the data to downcase before encryption occurs. This allows to
+converts the data to downcase before encryption occurs. This allows you to
 effectively ignore case when querying data.
 
 ```ruby

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2908,7 +2908,7 @@ def to_checkbox_tag(options = {}, checked_value = "1", unchecked_value = "0")
 end
 ```
 
-The second line can safely access the "type" key, and let the user to pass either `:type` or "type".
+The second line can safely access the "type" key, and let the user pass either `:type` or "type".
 
 There's also the bang variant [`stringify_keys!`][Hash#stringify_keys!] that stringifies keys in place.
 
@@ -2955,7 +2955,7 @@ def rich_textarea_tag(name, value = nil, options = {})
 end
 ```
 
-The third line can safely access the `:input` key, and let the user to pass either `:input` or "input".
+The third line can safely access the `:input` key, and let the user pass either `:input` or "input".
 
 There's also the bang variant [`symbolize_keys!`][Hash#symbolize_keys!] that symbolizes keys in place.
 

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -234,7 +234,7 @@ WARNING: We recommend against using this setting in production environments. It 
 
 ### Verbose Enqueue Logs
 
-Similar to the "Verbose Query Logs" above, allows to print source locations of methods that enqueue background jobs.
+Similar to the "Verbose Query Logs" above, allows printing source locations of methods that enqueue background jobs.
 
 Verbose enqueue logs are [enabled by default](/7_1_release_notes.html#active-job-notable-changes) in the development environment logs.
 


### PR DESCRIPTION
Split out from the grammar PR because these are reword/phrasing changes rather than mechanical fixes. `let` takes a bare infinitive (not a to-infinitive), and `allow` requires an explicit object before the infinitive. 4 files / 5 lines.

- active_support_core_extensions.md:2911  let the user to pass → let the user pass
- active_support_core_extensions.md:2958  let the user to pass → let the user pass
- action_mailer_basics.md:796  allows for you to specify → allows you to specify
- active_record_encryption.md:248  This allows to → This allows you to
- debugging_rails_applications.md:237  allows to print → allows printing

**References**

- Cambridge Grammar — [Verb patterns: verb + infinitive or verb + -ing?](https://dictionary.cambridge.org/grammar/british-grammar/verb-patterns-verb-infinitive-or-verb-ing):
  "*Let* and *make* are followed by an infinitive without *to* in active voice sentences."
- Merriam-Webster — [allow](https://www.merriam-webster.com/dictionary/allow): all listed examples use the *allow + object + to-infinitive* pattern (e.g. "The system allows **you** to transfer data easily").