### PR TITLE
Make Action Cable executor configurable

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `config.action_cable.executor` for configuring the Action Cable executor.
+
+    The configured object is called with the server instance and must return an
+    executor responding to `#post`, `#timer`, and `#shutdown`. This allows
+    applications and adapters to provide executor implementations that match
+    their concurrency model.
+
+    *Samuel Williams*
+
 *   Respect calls to `#reject` in `before_subscribe` callbacks.
 
     It doesn't call `#subscribed` if a `before_subscribe` callback calls `#reject`.

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -8,6 +8,10 @@ module ActionCable
   module Server
     # A wrapper over ConcurrentRuby::ThreadPoolExecutor and Concurrent::TimerTask
     class ThreadedExecutor # :nodoc:
+      def self.call(server)
+        new(max_size: server.config.executor_pool_size, name: "streamer")
+      end
+
       def initialize(max_size: 10, name: "server")
         @executor = Concurrent::ThreadPoolExecutor.new(
           name: "ActionCable-#{name}",
@@ -129,7 +133,7 @@ module ActionCable
 
       # Executor is used by various actions within Action Cable (e.g., pub/sub operations) to run code asynchronously.
       def executor
-        @executor || @mutex.synchronize { @executor ||= ThreadedExecutor.new(max_size: config.executor_pool_size, name: "streamer") }
+        @executor || @mutex.synchronize { @executor ||= config.executor.call(self) }
       end
 
       # Adapter used for all streams/broadcasting.

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -13,7 +13,7 @@ module ActionCable
     # configuration in a Rails config initializer.
     class Configuration
       attr_accessor :logger, :log_tags
-      attr_accessor :connection_class, :worker_pool_size, :executor_pool_size
+      attr_accessor :connection_class, :worker_pool_size, :executor_pool_size, :executor
       attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host, :filter_parameters
       attr_accessor :cable, :url, :mount_path
       attr_accessor :precompile_assets
@@ -26,6 +26,7 @@ module ActionCable
         @connection_class = -> { ActionCable::Connection::Base }
         @worker_pool_size = 4
         @executor_pool_size = 10
+        @executor = ActionCable::Server::ThreadedExecutor
 
         @disable_request_forgery_protection = false
         @allow_same_origin_as_host = true

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -6,12 +6,27 @@ require "active_support/core_ext/hash/indifferent_access"
 
 class BaseTest < ActionCable::TestCase
   def setup
-    @server = ActionCable::Server::Base.new
+    @server = ActionCable::Server::Base.new(config: ActionCable::Server::Configuration.new)
     @server.config.cable = { adapter: "async" }.with_indifferent_access
   end
 
   class FakeConnection
     def close
+    end
+  end
+
+  class CustomExecutor
+    attr_reader :server
+
+    def self.call(server)
+      new(server)
+    end
+
+    def initialize(server)
+      @server = server
+    end
+
+    def shutdown
     end
   end
 
@@ -63,6 +78,23 @@ class BaseTest < ActionCable::TestCase
 
   test "#restart shuts down worker pool" do
     assert_called(@server.worker_pool, :halt) do
+      @server.restart
+    end
+  end
+
+  test "#executor uses the configured executor factory" do
+    @server.config.executor = CustomExecutor
+
+    assert_instance_of CustomExecutor, @server.executor
+    assert_same @server, @server.executor.server
+  end
+
+  test "#executor uses ThreadedExecutor by default" do
+    assert_instance_of ActionCable::Server::ThreadedExecutor, @server.executor
+  end
+
+  test "#restart shuts down executor" do
+    assert_called(@server.executor, :shutdown) do
       @server.restart
     end
   end


### PR DESCRIPTION
### Motivation / Background

Action Cable currently memoizes `ActionCable::Server::ThreadedExecutor` directly inside `ActionCable::Server::Base#executor`. That makes it difficult for servers or adapters with a different concurrency model to provide an executor that still satisfies Action Cable's small executor contract.

This adds a public configuration hook so applications can provide an executor factory instead of patching `@executor` directly.

### Detail

- Add `config.action_cable.executor`, defaulting to `ActionCable::Server::ThreadedExecutor`.
- Add `ActionCable::Server::ThreadedExecutor.call(server)` so the default executor can be used as a factory.
- Instantiate the memoized server executor via `config.executor.call(self)`.
- Cover the default executor and a custom executor factory in `ActionCable::Server::Base` tests.

The expected executor surface remains the existing small interface Action Cable already uses: `#post`, `#timer`, and `#shutdown`.

### Checklist

- [x] Tests pass: `ruby -Iactioncable/test actioncable/test/server/base_test.rb`
- [x] RuboCop passes for touched Ruby files