### PR TITLE
Fix typos in generated app config templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Eager load code on boot for better performance and memory savings.
   config.eager_load = true
 
-  # In Rake tasks, the previous assigment is ignored, config.eager_load is set
+  # In Rake tasks, the previous assignment is ignored, config.eager_load is set
   # from config.rake_eager_load.
   config.rake_eager_load = false
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -15,7 +15,7 @@ Rails.application.configure do
   # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
 
-  # In Rake tasks, the previous assigment is ignored, config.eager_load is set
+  # In Rake tasks, the previous assignment is ignored, config.eager_load is set
   # from config.rake_eager_load.
   config.rake_eager_load = ENV["CI"].present?
 

--- a/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
@@ -14,7 +14,7 @@ local:
 #   region: us-east-1
 #   bucket: your_own_bucket-<%%= Rails.env %>
 
-# Remember not to checkin your GCS keyfile to a repository
+# Remember not to check in your GCS keyfile to a repository
 # google:
 #   service: GCS
 #   project: your_project


### PR DESCRIPTION
These comments are generated into every new Rails application's config, so the typos shipped to all generated apps.

- config/environments/production.rb.tt:12  "assigment" -> "assignment"
- config/environments/test.rb.tt:18        "assigment" -> "assignment"
- config/storage.yml.tt:17                 "checkin" -> "check in" (verb)

No tests reference these strings. Not [ci skip] (generator templates).