### PR TITLE
Allow Action Cable server implementation to be configured

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   Allow configuring the Action Cable server implementation.
 
-    `config.action_cable.server` can now be set to a server class or factory.
-    The configured server remains the `ActionCable.server` singleton and Rack
+    `config.action_cable.server_class` can now be set to a server class. The
+    configured server remains the `ActionCable.server` singleton and Rack
     endpoint, allowing alternative server implementations to provide the Action
     Cable runtime boundary without configuring internals of the default server.
 

--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow configuring the Action Cable server implementation.
+
+    `config.action_cable.server` can now be set to a server class or factory.
+    The configured server remains the `ActionCable.server` singleton and Rack
+    endpoint, allowing alternative server implementations to provide the Action
+    Cable runtime boundary without configuring internals of the default server.
+
+    *Samuel Williams*
+
 *   Move `ActionCable::Server::Configuration` to `ActionCable::Configuration`.
 
     The old constant remains available as an alias.

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -78,6 +78,22 @@ module ActionCable
 
   # Singleton instance of the server
   module_function def server
-    @server ||= ActionCable::Server::Base.new
+    @server ||= build_server
+  end
+
+  module_function def server=(server)
+    @server = server
+  end
+
+  module_function def config
+    @config ||= ActionCable::Configuration.new
+  end
+
+  module_function def build_server
+    if config.server.respond_to?(:new)
+      config.server.new
+    else
+      config.server.call
+    end
   end
 end

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -78,22 +78,10 @@ module ActionCable
 
   # Singleton instance of the server
   module_function def server
-    @server ||= build_server
-  end
-
-  module_function def server=(server)
-    @server = server
+    @server ||= config.server_class.new(config: config)
   end
 
   module_function def config
     @config ||= ActionCable::Configuration.new
-  end
-
-  module_function def build_server
-    if config.server.respond_to?(:new)
-      config.server.new
-    else
-      config.server.call
-    end
   end
 end

--- a/actioncable/lib/action_cable/configuration.rb
+++ b/actioncable/lib/action_cable/configuration.rb
@@ -8,10 +8,11 @@ module ActionCable
   # # Action Cable Configuration
   #
   # An instance of this configuration object is available via
-  # ActionCable.server.config, which allows you to tweak Action Cable
-  # configuration in a Rails config initializer.
+  # ActionCable.config and ActionCable.server.config, which allows you to tweak
+  # Action Cable configuration in a Rails config initializer.
   class Configuration
     attr_accessor :logger, :log_tags
+    attr_accessor :server
     attr_accessor :connection_class, :worker_pool_size, :executor_pool_size
     attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host, :filter_parameters
     attr_accessor :cable, :url, :mount_path
@@ -22,6 +23,7 @@ module ActionCable
     def initialize
       @log_tags = []
 
+      @server = -> { ActionCable::Server::Base.new(config: self) }
       @connection_class = -> { ActionCable::Connection::Base }
       @worker_pool_size = 4
       @executor_pool_size = 10

--- a/actioncable/lib/action_cable/configuration.rb
+++ b/actioncable/lib/action_cable/configuration.rb
@@ -7,9 +7,8 @@ require "rack"
 module ActionCable
   # # Action Cable Configuration
   #
-  # An instance of this configuration object is available via
-  # ActionCable.config and ActionCable.server.config, which allows you to tweak
-  # Action Cable configuration in a Rails config initializer.
+  # An instance of this configuration object is available via ActionCable.config,
+  # which allows you to tweak Action Cable configuration in a Rails config initializer.
   class Configuration
     attr_accessor :logger, :log_tags
     attr_accessor :server_class

--- a/actioncable/lib/action_cable/configuration.rb
+++ b/actioncable/lib/action_cable/configuration.rb
@@ -12,7 +12,7 @@ module ActionCable
   # Action Cable configuration in a Rails config initializer.
   class Configuration
     attr_accessor :logger, :log_tags
-    attr_accessor :server
+    attr_accessor :server_class
     attr_accessor :connection_class, :worker_pool_size, :executor_pool_size
     attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host, :filter_parameters
     attr_accessor :cable, :url, :mount_path
@@ -23,7 +23,7 @@ module ActionCable
     def initialize
       @log_tags = []
 
-      @server = -> { ActionCable::Server::Base.new(config: self) }
+      @server_class = ActionCable::Server::Base
       @connection_class = -> { ActionCable::Connection::Base }
       @worker_pool_size = 4
       @executor_pool_size = 10

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -11,7 +11,7 @@ module ActionCable
     config.action_cable = ActiveSupport::OrderedOptions.new
     config.action_cable.mount_path = ActionCable::INTERNAL[:default_mount_path]
     config.action_cable.precompile_assets = true
-    config.action_cable.server = ActionCable::Server::Base
+    config.action_cable.server_class = ActionCable::Server::Base
 
     guard_load_hooks(
       :action_cable_channel, :action_cable_connection,

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -11,6 +11,7 @@ module ActionCable
     config.action_cable = ActiveSupport::OrderedOptions.new
     config.action_cable.mount_path = ActionCable::INTERNAL[:default_mount_path]
     config.action_cable.precompile_assets = true
+    config.action_cable.server = ActionCable::Server::Base
 
     guard_load_hooks(
       :action_cable_channel, :action_cable_connection,

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -42,7 +42,7 @@ module ActionCable
       include ActionCable::Server::Broadcasting
       include ActionCable::Server::Connections
 
-      cattr_accessor :config, instance_accessor: false, default: ActionCable::Server::Configuration.new
+      cattr_accessor :config, instance_accessor: false, default: ActionCable.config
 
       attr_reader :config
 

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -88,4 +88,46 @@ class BaseTest < ActionCable::TestCase
     assert_same ActionCable::Configuration, ActionCable::Server::Configuration
     assert_instance_of ActionCable::Configuration, ActionCable::Server::Base.config
   end
+
+  test "ActionCable.server uses configured server factory class" do
+    server_class = Class.new do
+      attr_reader :config
+
+      def initialize
+        @config = ActionCable::Server::Base.config
+      end
+    end
+
+    with_server_factory(server_class) do
+      assert_instance_of server_class, ActionCable.server
+      assert_same ActionCable::Server::Base.config, ActionCable.server.config
+    end
+  end
+
+  test "ActionCable.server uses configured server factory" do
+    server = Object.new
+
+    with_server_factory(-> { server }) do
+      assert_same server, ActionCable.server
+    end
+  end
+
+  private
+    def with_server_factory(factory)
+      previous_factory = ActionCable.config.server
+      previous_server = ActionCable.instance_variable_get(:@server) if ActionCable.instance_variable_defined?(:@server)
+
+      ActionCable.remove_instance_variable(:@server) if ActionCable.instance_variable_defined?(:@server)
+      ActionCable.config.server = factory
+
+      yield
+    ensure
+      ActionCable.config.server = previous_factory
+
+      if defined?(previous_server)
+        ActionCable.instance_variable_set(:@server, previous_server)
+      elsif ActionCable.instance_variable_defined?(:@server)
+        ActionCable.remove_instance_variable(:@server)
+      end
+    end
 end

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -89,45 +89,37 @@ class BaseTest < ActionCable::TestCase
     assert_instance_of ActionCable::Configuration, ActionCable::Server::Base.config
   end
 
-  test "ActionCable.server uses configured server factory class" do
+  test "ActionCable.server uses configured server class" do
     server_class = Class.new do
       attr_reader :config
 
-      def initialize
-        @config = ActionCable::Server::Base.config
+      def initialize(config:)
+        @config = config
       end
     end
 
-    with_server_factory(server_class) do
+    with_server_class(server_class) do
       assert_instance_of server_class, ActionCable.server
-      assert_same ActionCable::Server::Base.config, ActionCable.server.config
-    end
-  end
-
-  test "ActionCable.server uses configured server factory" do
-    server = Object.new
-
-    with_server_factory(-> { server }) do
-      assert_same server, ActionCable.server
+      assert_same ActionCable.config, ActionCable.server.config
     end
   end
 
   private
-    def with_server_factory(factory)
-      previous_factory = ActionCable.config.server
+    def with_server_class(server_class)
+      previous_server_class = ActionCable.config.server_class
       previous_server = ActionCable.instance_variable_get(:@server) if ActionCable.instance_variable_defined?(:@server)
 
-      ActionCable.remove_instance_variable(:@server) if ActionCable.instance_variable_defined?(:@server)
-      ActionCable.config.server = factory
+      ActionCable.instance_variable_set(:@server, nil)
+      ActionCable.config.server_class = server_class
 
       yield
     ensure
-      ActionCable.config.server = previous_factory
+      ActionCable.config.server_class = previous_server_class
 
       if defined?(previous_server)
         ActionCable.instance_variable_set(:@server, previous_server)
-      elsif ActionCable.instance_variable_defined?(:@server)
-        ActionCable.remove_instance_variable(:@server)
+      else
+        ActionCable.instance_variable_set(:@server, nil)
       end
     end
 end

--- a/actioncable/test/server/health_check_test.rb
+++ b/actioncable/test/server/health_check_test.rb
@@ -7,7 +7,7 @@ class HealthCheckTest < ActionCable::TestCase
   def setup
     @config = ActionCable::Server::Configuration.new
     @config.logger = Logger.new(nil)
-    @server = ActionCable::Server::Base.new config: @config
+    @server = ActionCable::Server::Base.new(config: @config)
     @server.config.cable = { adapter: "async" }.with_indifferent_access
 
     @app = Rack::Lint.new(@server)


### PR DESCRIPTION
### Motivation / Background

[Action Cable modular server refactoring](https://github.com/rails/rails/pull/50979) made a useful distinction between the default Rails Rack hijack server implementation and the lower-level Action Cable runtime pieces used by connections, channels, broadcasting, and pub/sub.

Alternative server integrations, such as Falcon/Async, should be able to replace the server implementation itself rather than configuring internals of `ActionCable::Server::Base` such as its executor. Configuring those internals risks making the default server implementation shape the public extension target.

This PR adds a small server replacement hook instead: `config.action_cable.server_class`.

Follow up to <https://github.com/rails/rails/pull/57801> and builds on <https://github.com/rails/rails/pull/50979> and <https://github.com/rails/rails/pull/57847>.

### Detail

- Expose `ActionCable.config` as the canonical top-level configuration accessor.
- Add `ActionCable.config.server_class`, defaulting to `ActionCable::Server::Base`.
- Build the `ActionCable.server` singleton with `config.server_class.new(config: config)`.
- Keep the existing `ActionCable::Server::Base#initialize(config: ...)` keyword API intact.
- Keep the existing server contract: the configured server is still the `ActionCable.server` singleton and Rack endpoint mounted by Rails, so it must respond to `#call(env)`.

A configured server class can be set with:

```ruby
config.action_cable.server_class = MyCableServer
```

The server class is initialized with the Action Cable configuration object using the existing keyword shape:

```ruby
def initialize(config:)
  @config = config
end
```

This intentionally starts with the existing `Server#call(env)` Rack endpoint shape. A future refinement could split the Rack integration point from the runtime object with something like `ActionCable.server.middleware`, where the default implementation returns `self`; this PR leaves that extra API out until there is a concrete need for a separate mounted object.

### Checklist

- [x] Tests pass: `ruby -Iactioncable/test actioncable/test/server/base_test.rb`
- [x] Tests pass: `ruby -Iactioncable/test actioncable/test/server/health_check_test.rb`
- [x] RuboCop passes for touched Ruby files