### PR TITLE
Route Action Cable work scheduling through server

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Route Action Cable internal work scheduling through the server.
+
+    Servers now expose `#perform_work`, `#post`, `#timer`, and `#schedule`
+    as the scheduling surface used by sockets, channels, and subscription
+    adapters. The default server keeps the existing threaded behavior, while
+    alternative server implementations can own work dispatch without exposing
+    the default server's executor or worker pool internals.
+
+    *Samuel Williams*
+
 *   Allow configuring the Action Cable server implementation.
 
     `config.action_cable.server_class` can now be set to a server class. The

--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow configuring the Action Cable server implementation.
+
+    `config.action_cable.server_class` can now be set to a server class. The
+    configured server remains the `ActionCable.server` singleton and Rack
+    endpoint, allowing alternative server implementations to provide the Action
+    Cable runtime boundary without configuring internals of the default server.
+
+    *Samuel Williams*
+
 *   Move `ActionCable::Server::Configuration` to `ActionCable::Configuration`.
 
     The old constant remains available as an alias.

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -78,6 +78,10 @@ module ActionCable
 
   # Singleton instance of the server
   module_function def server
-    @server ||= ActionCable::Server::Base.new
+    @server ||= config.server_class.new(config: config)
+  end
+
+  module_function def config
+    @config ||= ActionCable::Configuration.new
   end
 end

--- a/actioncable/lib/action_cable/channel/periodic_timers.rb
+++ b/actioncable/lib/action_cable/channel/periodic_timers.rb
@@ -67,7 +67,7 @@ module ActionCable
           # A callback must be executed within the channel context
           callback = -> { instance_exec(&timer_callback) }
 
-          connection.executor.timer(every) do
+          connection.timer(every) do
             connection.perform_work callback, :call
           end
         end

--- a/actioncable/lib/action_cable/configuration.rb
+++ b/actioncable/lib/action_cable/configuration.rb
@@ -7,11 +7,11 @@ require "rack"
 module ActionCable
   # # Action Cable Configuration
   #
-  # An instance of this configuration object is available via
-  # ActionCable.server.config, which allows you to tweak Action Cable
-  # configuration in a Rails config initializer.
+  # An instance of this configuration object is available via ActionCable.config,
+  # which allows you to tweak Action Cable configuration in a Rails config initializer.
   class Configuration
     attr_accessor :logger, :log_tags
+    attr_accessor :server_class
     attr_accessor :connection_class, :worker_pool_size, :executor_pool_size
     attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host, :filter_parameters
     attr_accessor :cable, :url, :mount_path
@@ -22,6 +22,7 @@ module ActionCable
     def initialize
       @log_tags = []
 
+      @server_class = ActionCable::Server::Base
       @connection_class = -> { ActionCable::Connection::Base }
       @worker_pool_size = 4
       @executor_pool_size = 10

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -62,7 +62,7 @@ module ActionCable
 
       attr_reader :subscriptions, :logger
 
-      delegate :pubsub, :executor, :config, :broadcast, to: :server
+      delegate :pubsub, :config, :broadcast, :post, :timer, :schedule, to: :server
       delegate :env, :request, :protocol, :perform_work, to: :socket, allow_nil: true
 
       def initialize(server, socket)

--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -130,7 +130,7 @@ module ActionCable
       end
     end
 
-    # TestServer provides test pub/sub and executor implementations
+    # TestServer provides test pub/sub and scheduling implementations
     class TestServer
       attr_reader :streams, :config, :timers
 
@@ -141,9 +141,8 @@ module ActionCable
       end
 
       alias_method :pubsub, :itself
-      alias_method :executor, :itself
 
-      #== Executor interface ==
+      #== Server scheduling interface ==
 
       # Inline async calls
       def post(&work) = work.call
@@ -151,6 +150,8 @@ module ActionCable
       def timer(every, &block)
         TestTimer.new(every, &block).tap { |t| @timers << t }
       end
+
+      def schedule(&block) = block.call
 
       def advance_time(seconds)
         @timers.each { |timer| timer.advance(seconds) }

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -11,6 +11,7 @@ module ActionCable
     config.action_cable = ActiveSupport::OrderedOptions.new
     config.action_cable.mount_path = ActionCable::INTERNAL[:default_mount_path]
     config.action_cable.precompile_assets = true
+    config.action_cable.server_class = ActionCable::Server::Base
 
     guard_load_hooks(
       :action_cable_channel, :action_cable_connection,

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -107,34 +107,28 @@ module ActionCable
         @event_loop || @mutex.synchronize { @event_loop ||= StreamEventLoop.new }
       end
 
-      # The worker pool is where we run connection callbacks and channel actions. We
-      # do as little as possible on the server's main thread. The worker pool is an
-      # executor service that's backed by a pool of threads working from a task queue.
-      # The thread pool size maxes out at 4 worker threads by default. Tune the size
-      # yourself with `config.action_cable.worker_pool_size`.
-      #
-      # Using Active Record, Redis, etc within your channel actions means you'll get a
-      # separate connection from each thread in the worker pool. Plan your deployment
-      # accordingly: 5 servers each running 5 Puma workers each running an 8-thread
-      # worker pool means at least 200 database connections.
-      #
-      # Also, ensure that your database connection pool size is as least as large as
-      # your worker pool size. Otherwise, workers may oversubscribe the database
-      # connection pool and block while they wait for other workers to release their
-      # connections. Use a smaller worker pool or a larger database connection pool
-      # instead.
-      def worker_pool
-        @worker_pool || @mutex.synchronize { @worker_pool ||= ActionCable::Server::Worker.new(max_size: config.worker_pool_size) }
+      def perform_work(connection, receiver, method, *args, &block)
+        worker_pool.async_invoke(receiver, method, *args, connection: connection, &block)
       end
 
-      # Executor is used by various actions within Action Cable (e.g., pub/sub operations) to run code asynchronously.
-      def executor
-        @executor || @mutex.synchronize { @executor ||= ThreadedExecutor.new(max_size: config.executor_pool_size, name: "streamer") }
+      def post(task = nil, &block)
+        executor.post(task, &block)
+      end
+
+      def timer(interval, &block)
+        executor.timer(interval, &block)
+      end
+
+      def schedule(&block)
+        Thread.new do
+          Thread.current.abort_on_exception = true
+          block.call
+        end
       end
 
       # Adapter used for all streams/broadcasting.
       def pubsub
-        @pubsub || (executor && @mutex.synchronize { @pubsub ||= config.pubsub_adapter.new(self) })
+        @pubsub || @mutex.synchronize { @pubsub ||= config.pubsub_adapter.new(self) }
       end
 
       # All of the identifiers applied to the connection class associated with this
@@ -165,6 +159,32 @@ module ActionCable
           false
         end
       end
+
+      private
+        # The worker pool is where we run connection callbacks and channel actions. We
+        # do as little as possible on the server's main thread. The worker pool is an
+        # executor service that's backed by a pool of threads working from a task queue.
+        # The thread pool size maxes out at 4 worker threads by default. Tune the size
+        # yourself with `config.action_cable.worker_pool_size`.
+        #
+        # Using Active Record, Redis, etc within your channel actions means you'll get a
+        # separate connection from each thread in the worker pool. Plan your deployment
+        # accordingly: 5 servers each running 5 Puma workers each running an 8-thread
+        # worker pool means at least 200 database connections.
+        #
+        # Also, ensure that your database connection pool size is as least as large as
+        # your worker pool size. Otherwise, workers may oversubscribe the database
+        # connection pool and block while they wait for other workers to release their
+        # connections. Use a smaller worker pool or a larger database connection pool
+        # instead.
+        def worker_pool
+          @worker_pool || @mutex.synchronize { @worker_pool ||= ActionCable::Server::Worker.new(max_size: config.worker_pool_size) }
+        end
+
+        # Executor is used by various actions within Action Cable (e.g., pub/sub operations) to run code asynchronously.
+        def executor
+          @executor || @mutex.synchronize { @executor ||= ThreadedExecutor.new(max_size: config.executor_pool_size, name: "streamer") }
+        end
     end
 
     ActiveSupport.run_load_hooks(:action_cable, Base.config)

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -42,7 +42,7 @@ module ActionCable
       include ActionCable::Server::Broadcasting
       include ActionCable::Server::Connections
 
-      cattr_accessor :config, instance_accessor: false, default: ActionCable::Server::Configuration.new
+      cattr_accessor :config, instance_accessor: false, default: ActionCable.config
 
       attr_reader :config
 

--- a/actioncable/lib/action_cable/server/connections.rb
+++ b/actioncable/lib/action_cable/server/connections.rb
@@ -36,8 +36,8 @@ module ActionCable
       # second heartbeat runs on all connections. If the beat fails, we automatically
       # disconnect.
       def setup_heartbeat_timer
-        @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
-          executor.post { each_connection(&:beat) }
+        @heartbeat_timer ||= timer(BEAT_INTERVAL) do
+          post { each_connection(&:beat) }
         end
       end
 

--- a/actioncable/lib/action_cable/server/socket.rb
+++ b/actioncable/lib/action_cable/server/socket.rb
@@ -11,14 +11,11 @@ module ActionCable
     # connection object shouldn't know about such details.
     class Socket
       attr_reader :server, :env, :protocol, :logger, :connection
-      private attr_reader :worker_pool
-
       delegate :event_loop, :pubsub, :config, to: :server
 
       def initialize(server, env, coder: ActiveSupport::JSON)
         @server, @env, @coder = server, env, coder
 
-        @worker_pool = server.worker_pool
         @logger = server.new_tagged_logger { request }
 
         @websocket      = WebSocket.new(env, self, event_loop)
@@ -55,11 +52,11 @@ module ActionCable
 
       # Invoke a method on the connection asynchronously through the pool of thread workers.
       def perform_work(receiver, method, *args)
-        worker_pool.async_invoke(receiver, method, *args, connection: self)
+        server.perform_work(self, receiver, method, *args)
       end
 
       def send_async(method, *arguments)
-        worker_pool.async_invoke(self, method, *arguments)
+        server.perform_work(self, self, method, *arguments)
       end
 
       # The request that initiated the WebSocket connection is available here. This gives access to the environment, cookies, etc.

--- a/actioncable/lib/action_cable/subscription_adapter/async.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/async.rb
@@ -7,7 +7,7 @@ module ActionCable
     class Async < Inline # :nodoc:
       private
         def new_subscriber_map
-          SubscriberMap::Async.new(executor)
+          SubscriberMap::Async.new(server)
         end
     end
   end

--- a/actioncable/lib/action_cable/subscription_adapter/base.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/base.rb
@@ -8,7 +8,7 @@ module ActionCable
       delegate :logger, to: :config
 
       def initialize(server)
-        @executor = server.executor
+        @server = server
         @config = server.config
       end
 
@@ -34,7 +34,7 @@ module ActionCable
       end
 
       private
-        attr_reader :executor, :config
+        attr_reader :server, :config
     end
   end
 end

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -69,7 +69,7 @@ module ActionCable
         end
 
         def listener
-          @listener || @mutex.synchronize { @listener ||= Listener.new(self, executor) }
+          @listener || @mutex.synchronize { @listener ||= Listener.new(self, server) }
         end
 
         def verify!(pg_conn)
@@ -79,14 +79,13 @@ module ActionCable
         end
 
         class Listener < SubscriberMap::Async
-          def initialize(adapter, executor)
-            super(executor)
+          def initialize(adapter, server)
+            super(server)
 
             @adapter = adapter
             @queue = Queue.new
 
-            @thread = Thread.new do
-              Thread.current.abort_on_exception = true
+            @thread = server.schedule do
               listen
             end
           end
@@ -101,7 +100,7 @@ module ActionCable
                     case action
                     when :listen
                       pg_conn.exec("LISTEN #{pg_conn.escape_identifier channel}")
-                      @executor.post(&callback) if callback
+                      @server.post(&callback) if callback
                     when :unlisten
                       pg_conn.exec("UNLISTEN #{pg_conn.escape_identifier channel}")
                     when :shutdown

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -56,7 +56,7 @@ module ActionCable
 
       private
         def listener
-          @listener || @mutex.synchronize { @listener ||= Listener.new(self, config_options, executor) }
+          @listener || @mutex.synchronize { @listener ||= Listener.new(self, config_options, server) }
         end
 
         def redis_connection_for_broadcasts
@@ -83,8 +83,8 @@ module ActionCable
           # zero and stops the listener.
           INTERNAL_CHANNEL = "_action_cable_internal"
 
-          def initialize(adapter, config_options, executor)
-            super(executor)
+          def initialize(adapter, config_options, server)
+            super(server)
 
             @adapter = adapter
 
@@ -121,7 +121,7 @@ module ActionCable
               when "subscribe", "psubscribe"
                 if callbacks = @subscribe_callbacks[chan]
                   next_callback = callbacks.shift
-                  @executor.post(&next_callback) if next_callback
+                  @server.post(&next_callback) if next_callback
                   @subscribe_callbacks.delete(chan) if callbacks.empty?
                 end
               when "message", "pmessage"
@@ -177,21 +177,17 @@ module ActionCable
                 @reconnect_attempt = 0
               end
 
-              @thread ||= Thread.new do
-                Thread.current.abort_on_exception = true
-
-                begin
-                  conn = @adapter.redis_connection_for_subscriptions
-                  listen conn
-                rescue RedisClient::ConnectionError => e
-                  reset
-                  if retry_connecting?
-                    logger&.warn "Redis connection failed: #{e.message}. Trying to reconnect..."
-                    when_connected { resubscribe }
-                    retry
-                  else
-                    logger&.error "Failed to reconnect to Redis after #{@reconnect_attempt} attempts."
-                  end
+              @thread ||= @server.schedule do
+                conn = @adapter.redis_connection_for_subscriptions
+                listen conn
+              rescue RedisClient::ConnectionError => e
+                reset
+                if retry_connecting?
+                  logger&.warn "Redis connection failed: #{e.message}. Trying to reconnect..."
+                  when_connected { resubscribe }
+                  retry
+                else
+                  logger&.error "Failed to reconnect to Redis after #{@reconnect_attempt} attempts."
                 end
               end
             end

--- a/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
@@ -59,21 +59,21 @@ module ActionCable
       end
 
       class Async < self
-        def initialize(executor)
-          @executor = executor
+        def initialize(server)
+          @server = server
           super()
         end
 
         def add_subscriber(*)
-          @executor.post { super }
+          @server.post { super }
         end
 
         def remove_subscriber(*)
-          @executor.post { super }
+          @server.post { super }
         end
 
         def invoke_callback(*)
-          @executor.post { super }
+          @server.post { super }
         end
       end
     end

--- a/actioncable/test/channel/periodic_timers_test.rb
+++ b/actioncable/test/channel/periodic_timers_test.rb
@@ -68,7 +68,7 @@ class ActionCable::Channel::PeriodicTimersTest < ActionCable::TestCase
     3.times { mock.expect(:shutdown, nil) }
 
     assert_called(
-      @connection.server.executor,
+      @connection.server,
       :timer,
       times: 3,
       returns: mock

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -88,4 +88,38 @@ class BaseTest < ActionCable::TestCase
     assert_same ActionCable::Configuration, ActionCable::Server::Configuration
     assert_instance_of ActionCable::Configuration, ActionCable::Server::Base.config
   end
+
+  test "ActionCable.server uses configured server class" do
+    server_class = Class.new do
+      attr_reader :config
+
+      def initialize(config:)
+        @config = config
+      end
+    end
+
+    with_server_class(server_class) do
+      assert_instance_of server_class, ActionCable.server
+      assert_same ActionCable.config, ActionCable.server.config
+    end
+  end
+
+  private
+    def with_server_class(server_class)
+      previous_server_class = ActionCable.config.server_class
+      previous_server = ActionCable.instance_variable_get(:@server) if ActionCable.instance_variable_defined?(:@server)
+
+      ActionCable.instance_variable_set(:@server, nil)
+      ActionCable.config.server_class = server_class
+
+      yield
+    ensure
+      ActionCable.config.server_class = previous_server_class
+
+      if defined?(previous_server)
+        ActionCable.instance_variable_set(:@server, previous_server)
+      else
+        ActionCable.instance_variable_set(:@server, nil)
+      end
+    end
 end

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -62,7 +62,9 @@ class BaseTest < ActionCable::TestCase
   end
 
   test "#restart shuts down worker pool" do
-    assert_called(@server.worker_pool, :halt) do
+    worker_pool = @server.send(:worker_pool)
+
+    assert_called(worker_pool, :halt) do
       @server.restart
     end
   end
@@ -87,6 +89,49 @@ class BaseTest < ActionCable::TestCase
   test "server configuration is available from ActionCable" do
     assert_same ActionCable::Configuration, ActionCable::Server::Configuration
     assert_instance_of ActionCable::Configuration, ActionCable::Server::Base.config
+  end
+
+  test "#perform_work dispatches work through the server" do
+    receiver = Class.new do
+      attr_reader :called_with
+
+      def call(value)
+        @called_with = value
+      end
+    end.new
+
+    @server.perform_work(Object.new, receiver, :call, "hello")
+
+    wait_for { receiver.called_with == "hello" }
+    assert_equal "hello", receiver.called_with
+  end
+
+  test "#post dispatches asynchronous work" do
+    called = false
+
+    @server.post { called = true }
+
+    wait_for { called }
+    assert called
+  end
+
+  test "#timer schedules recurring work" do
+    called = false
+    timer = @server.timer(0.01) { called = true }
+
+    wait_for { called }
+    assert called
+  ensure
+    timer&.shutdown
+  end
+
+  test "#schedule runs blocking work independently" do
+    called = false
+
+    @server.schedule { called = true }
+
+    wait_for { called }
+    assert called
   end
 
   test "ActionCable.server uses configured server class" do

--- a/actioncable/test/server/health_check_test.rb
+++ b/actioncable/test/server/health_check_test.rb
@@ -7,7 +7,7 @@ class HealthCheckTest < ActionCable::TestCase
   def setup
     @config = ActionCable::Server::Configuration.new
     @config.logger = Logger.new(nil)
-    @server = ActionCable::Server::Base.new config: @config
+    @server = ActionCable::Server::Base.new(config: @config)
     @server.config.cable = { adapter: "async" }.with_indifferent_access
 
     @app = Rack::Lint.new(@server)

--- a/actioncable/test/stubs/test_socket.rb
+++ b/actioncable/test/stubs/test_socket.rb
@@ -5,7 +5,7 @@ require "stubs/user"
 class TestSocket
   attr_reader :identifiers, :logger, :current_user, :server, :subscriptions, :transmissions
 
-  delegate :pubsub, :config, :executor, to: :server
+  delegate :pubsub, :config, :post, :timer, :schedule, to: :server
 
   def initialize(user = User.new("lifo"), coder: ActiveSupport::JSON, subscription_adapter: SuccessAdapter)
     @coder = coder

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -133,7 +133,8 @@ module CommonSubscriptionAdapterTest
 
   def wait_for_pubsub_executor(adapter)
     # We use a wrapper over ConcurrentRuby::ThreadPoolExecutor, so we need to dig deeper
-    executor = adapter.instance_variable_get(:@executor).instance_variable_get(:@executor)
-    wait_for_executor(executor)
+    server = adapter.instance_variable_get(:@server)
+    executor = server.instance_variable_get(:@executor)
+    wait_for_executor(executor.instance_variable_get(:@executor)) if executor
   end
 end

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -270,6 +270,10 @@ class RedisAdapterTest::ListenerReconnection < ActionCable::TestCase
     def post(task = nil, &block)
       (task || block).call
     end
+
+    def schedule(&block)
+      Thread.new(&block)
+    end
   end
 
   test "an in-flight subscription confirmation is delivered after a reconnect" do


### PR DESCRIPTION
### Motivation / Background

This builds on #57803 and includes that change squashed as the first commit so the PR can be reviewed directly against `main`.

If Action Cable can be backed by a custom server implementation, the server itself should be the public runtime boundary. Routing scheduling through `ActionCable.server` keeps `executor` and `worker_pool` as implementation details of the default server rather than configuration targets that external integrations need to depend on.

### Detail

* Add server-level scheduling APIs to `ActionCable::Server::Base`:
  * `perform_work(connection, receiver, method, *args, &block)`
  * `post(task = nil, &block)`
  * `timer(interval, &block)`
  * `schedule(&block)`
* Route connection, channel timer, socket, and subscription adapter work scheduling through the server.
* Keep `executor` and `worker_pool` private to `ActionCable::Server::Base`.
* Avoid forcing executor initialization from `pubsub`.

### Notes

The first commit contains the #57803 changes squashed into one commit. The second commit contains the scheduling changes.

### Verification

Passed locally:

```
ruby -Iactioncable/test actioncable/test/server/base_test.rb
ruby -Iactioncable/test actioncable/test/server/health_check_test.rb
ruby -Iactioncable/test actioncable/test/server/socket_test.rb
ruby -Iactioncable/test actioncable/test/channel/periodic_timers_test.rb
ruby -Iactioncable/test actioncable/test/subscription_adapter/async_test.rb
ruby -Iactioncable/test actioncable/test/subscription_adapter/inline_test.rb
ruby -Iactioncable/test actioncable/test/subscription_adapter/test_adapter_test.rb
ruby -Iactioncable/test actioncable/test/connection/test_case_test.rb
ruby -Iactioncable/test actioncable/test/channel/stream_test.rb
bundle exec rubocop actioncable/lib/action_cable.rb actioncable/lib/action_cable/configuration.rb actioncable/lib/action_cable/engine.rb actioncable/lib/action_cable/server/base.rb actioncable/lib/action_cable/server/socket.rb actioncable/lib/action_cable/connection/base.rb actioncable/lib/action_cable/channel/periodic_timers.rb actioncable/lib/action_cable/subscription_adapter/base.rb actioncable/lib/action_cable/subscription_adapter/async.rb actioncable/lib/action_cable/subscription_adapter/postgresql.rb actioncable/lib/action_cable/subscription_adapter/redis.rb actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb actioncable/test/server/base_test.rb actioncable/test/server/health_check_test.rb actioncable/test/channel/periodic_timers_test.rb actioncable/test/stubs/test_socket.rb actioncable/test/subscription_adapter/common.rb actioncable/test/subscription_adapter/redis_test.rb actioncable/test/subscription_adapter/channel_prefix.rb
```

Redis adapter tests timed out locally waiting for subscription confirmation, which appears environment related. PostgreSQL adapter tests were not run locally due missing local database setup.
