### PR TITLE
Fix `Http::Headers#merge` mutating the original request

### DIFF
--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -102,7 +102,7 @@ module ActionDispatch
       # Returns a new Http::Headers instance containing the contents of
       # `headers_or_env` and the original instance.
       def merge(headers_or_env)
-        headers = @req.dup.headers
+        headers = Headers.new(@req.dup)
         headers.merge!(headers_or_env)
         headers
       end

--- a/actionpack/test/dispatch/header_test.rb
+++ b/actionpack/test/dispatch/header_test.rb
@@ -131,6 +131,20 @@ class HeaderTest < ActiveSupport::TestCase
                   "HTTP_REFERER" => "/some/page" }, @headers.env)
   end
 
+  test "merge does not mutate the original request when headers are memoized" do
+    request = ActionDispatch::Request.new(
+      "CONTENT_TYPE" => "text/plain",
+      "HTTP_REFERER" => "/some/page"
+    )
+    request.headers # memoize the Http::Headers instance on the request
+
+    combined = request.headers.merge("HTTP_HOST" => "http://example.com")
+
+    assert_equal "http://example.com", combined["HTTP_HOST"]
+    assert_not request.headers.key?("HTTP_HOST")
+    assert_nil request.get_header("HTTP_HOST")
+  end
+
   test "env variables with . are not modified" do
     headers = make_headers({})
     headers.merge! "rack.input" => "",


### PR DESCRIPTION
## Summary

`ActionDispatch::Http::Headers#merge` is documented to return a **new** `Http::Headers` instance, leaving the receiver (and its request) untouched:

```ruby
# Returns a new Http::Headers instance containing the contents of
# `headers_or_env` and the original instance.
def merge(headers_or_env)
  headers = @req.dup.headers
  headers.merge!(headers_or_env)
  headers
end
```

In practice it mutates the original request's env.

## Root cause (a Ruby `dup` shallow-copy footgun)

`Request#headers` memoizes its `Http::Headers` instance, and that instance holds a reference back to the request:

```ruby
def headers
  @headers ||= Http::Headers.new(self)
end
```

`merge` builds its copy via `@req.dup.headers`. `Object#dup` copies instance variables **by reference**, and `Rack::Request::Env#initialize_copy` only re-dups `@env` — it does not reset `@headers`. So once `@headers` has been memoized on the request, the duplicated request shares the *same* memoized `Http::Headers` object, which still points back at the **original** request.

`merge` then calls `merge!` on that shared headers object, and `merge!` writes through `@req.set_header` to the **original** request's env.

Reading `request.headers` at least once is the normal lifecycle of any request (middleware and controllers routinely read it), so `merge` ends up mutating the caller's request whenever it is used on a live request.
