### PR TITLE
Fix broken anchor links in guides

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -748,7 +748,7 @@ If the name is blank (`nil` or empty string), it returns the email address.
 
 If you don't pass a subject to the mail method, Action Mailer will try to find
 it in your translations. See the [Internationalization
-Guide](i18n.html#translations-for-action-mailer-e-mail-subjects) for more.
+Guide](i18n.html#action-mailer-e-mail-subjects) for more.
 
 ### Sending Emails without Template Rendering
 

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -187,7 +187,7 @@ documentation](https://api.rubyonrails.org/classes/ActionText/RichText.html).
 
 NOTE: If there's an attached resource within `content` field, it might not show
 properly unless you have the necessary [dependencies for Active
-Storage](active_storage_overview.html#requirements) installed.
+Storage](active_storage_overview.html#third-party-software) installed.
 
 ## Customizing the Rich Text Content Editor (Trix)
 
@@ -251,7 +251,7 @@ Storage as well as attachments that are linked to a Signed GlobalID.
 
 When uploading an image within your rich text editor, it uses Action Text which
 in turn uses Active Storage. However, [Active Storage has some
-dependencies](active_storage_overview.html#requirements) which are not provided
+dependencies](active_storage_overview.html#third-party-software) which are not provided
 by Rails. To use the built-in previewers, you must install these libraries.
 
 Some, but not all of these libraries are required and they are dependent on the
@@ -284,7 +284,7 @@ property.
 NOTE: It is possible for files uploaded by Action Text through [Active Storage
 Direct Uploads](active_storage_overview.html#direct-uploads) to never be
 embedded within rich text content. Consider [purging unattached
-uploads](active_storage_overview.html#purging-unattached-uploads) regularly.
+uploads](active_storage_overview.html#purging-unattached-uploads-and-detach) regularly.
 
 ### Signed GlobalID
 

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -339,7 +339,7 @@ end
 ```
 
 If you do so, you will have to manually define the class name that is hosting
-[the fixtures](testing.html#the-low-down-on-fixtures) (`my_books.yml`) using the
+[the fixtures](testing.html#fixtures) (`my_books.yml`) using the
 `set_fixture_class` method in your test definition:
 
 ```ruby

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -650,7 +650,7 @@ class is initialized.
 
 NOTE: The `find_by_*` and `find_by_*!` methods are dynamic finders generated
 automatically for every attribute. Learn more about them in the [Dynamic finders
-section](active_record_querying.html#dynamic-finders).
+section](active_record_querying.html#dynamic-finder-methods).
 
 Conditional Callbacks
 ---------------------

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -451,8 +451,8 @@ also need to use `validates_associated`. More on that in the
 [validates_associated section](#validates-associated).
 
 If you validate the absence of an object associated via a
-[`has_one`](association_basics.html#the-has-one-association) or
-[`has_many`](association_basics.html#the-has-many-association) relationship, it
+[`has_one`](association_basics.html#has-one) or
+[`has_many`](association_basics.html#has-many) relationship, it
 will check that the object is neither `present?` nor `marked_for_destruction?`.
 
 Since `false.present?` is false, if you want to validate the absence of a
@@ -837,8 +837,8 @@ also need to use `validates_associated`. More on that
 [below](#validates-associated).
 
 If you validate the presence of an object associated via a
-[`has_one`](association_basics.html#the-has-one-association) or
-[`has_many`](association_basics.html#the-has-many-association) relationship, it
+[`has_one`](association_basics.html#has-one) or
+[`has_many`](association_basics.html#has-many) relationship, it
 will check that the object is neither `blank?` nor `marked_for_destruction?`.
 
 Since `false.blank?` is true, if you want to validate the presence of a boolean

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -361,7 +361,7 @@ In that case, declare the dependency explicitly with a special comment:
 ```
 
 In some cases, such as a [single table
-inheritance](association_basics.html#single-table-inheritance) setup, a helper
+inheritance](association_basics.html#single-table-inheritance-sti) setup, a helper
 may render different partials from the same directory. Instead of listing each
 template individually, you can use a wildcard to match the whole directory:
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -268,7 +268,7 @@ Accepts an array of paths from which Rails will autoload constants that won't be
 
 #### `config.autoload_paths`
 
-Accepts an array of paths from which Rails will autoload constants. Default is an empty array. Since [Rails 6](upgrading_ruby_on_rails.html#autoloading), it is not recommended to adjust this. See [Autoloading and Reloading Constants](autoloading_and_reloading_constants.html#autoload-paths).
+Accepts an array of paths from which Rails will autoload constants. Default is an empty array. Since [Rails 6](upgrading_ruby_on_rails.html#autoloading), it is not recommended to adjust this. See [Autoloading and Reloading Constants](autoloading_and_reloading_constants.html#config-autoload-paths).
 
 #### `config.beginning_of_week`
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -609,7 +609,7 @@ The Ruby on Rails [guides](https://guides.rubyonrails.org/) provide a high-level
 
 If your PR adds a new feature or changes how an existing feature behaves, check the relevant documentation and update it or add to it as necessary.
 
-For example, if you modify Active Storage's image analyzer to add a new metadata field, you should update the [Analyzing Files](active_storage_overview.html#analyzing-files) section of the Active Storage guide to reflect that.
+For example, if you modify Active Storage's image analyzer to add a new metadata field, you should update the [Analyzing Files](active_storage_overview.html#analyzing-files-for-metadata) section of the Active Storage guide to reflect that.
 
 ### Updating the CHANGELOG
 

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -25,7 +25,7 @@ Engines can be thought of as miniature applications that encapsulate specific
 functionality and integrate with a larger Rails application. An engine extends a
 [plugin](plugins.html), with the
 [`Rails::Engine`](https://api.rubyonrails.org/classes/Rails/Engine.html) class
-[inheriting](engines.html#the-inheritance-hierarchy) behavior from
+[inheriting](engines.html#inheritance-hierarchy) behavior from
 [`Rails::Railtie`](https://api.rubyonrails.org/classes/Rails/Railtie.html).
 
 Some examples of engines in action:

--- a/guides/source/getting_started_with_devcontainer.md
+++ b/guides/source/getting_started_with_devcontainer.md
@@ -20,7 +20,7 @@ Rails application in a container, without needing to install Ruby or Rails or it
 directly on your machine. This is the fastest way to get your Rails application up and running.
 
 This is an alternative to installing Ruby and Rails directly on your machine, which is
-covered in the [Getting Started guides](getting_started.html#creating-a-new-rails-project).
+covered in the [Getting Started guides](getting_started.html#creating-a-new-rails-app).
 Once you have completed this guide, you can continue building your application by following
 the Getting Started guide.
 

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -390,7 +390,7 @@ The unique request id can be used to trace a request end-to-end and would typica
 
 [`ActiveRecord::Migration::CheckPending`][] checks pending migrations and raises `ActiveRecord::PendingMigrationError` if any migrations are pending if [`config.action_dispatch.x_sendfile_header`][] is set to `:page_load`.
 
-[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-record-migration-error
+[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-dispatch-x-sendfile-header
 
 [`ActiveRecord::Migration::CheckPending`]: https://api.rubyonrails.org/classes/ActiveRecord/Migration/CheckPending.html
 
@@ -414,7 +414,7 @@ The unique request id can be used to trace a request end-to-end and would typica
 
 #### `Rack::ETag`
 
-[`Rack::ETag`][] adds an `ETag` header on all String bodies. ETags are used to validate the cache to facilitate "Conditional `GET`" requests as described above. See the [Caching with Rails](caching_with_rails.html#conditional-get-support) for further information.
+[`Rack::ETag`][] adds an `ETag` header on all String bodies. ETags are used to validate the cache to facilitate "Conditional `GET`" requests as described above. See the [Caching with Rails](caching_with_rails.html#conditional-gets) for further information.
 
 [`Rack::ETag`]: https://rack.github.io/rack/3.2/Rack/ETag.html
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1464,7 +1464,7 @@ edit_person GET    /people/:id/edit(.:format) people#edit
 
 ### Routes in Rails Console
 
-You can access route helpers using `Rails.application.routes.url_helpers` within the [Rails Console](command_line.html#bin-rails-console). They are also available via the [app](command_line.html#the-app-and-helper-objects) object. For example:
+You can access route helpers using `Rails.application.routes.url_helpers` within the [Rails Console](command_line.html#bin-rails-console). They are also available via the [app](command_line.html#the-app-object) object. For example:
 
 ```irb
 irb> Rails.application.routes.url_helpers.users_path

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1469,7 +1469,7 @@ Rails.application.config.content_security_policy_nonce_generator = -> request { 
 There are a few tradeoffs to consider when configuring the nonce generator.
 Using `SecureRandom.base64(16)` is a good default value, because it will
 generate a new random nonce for each request. However, this method is
-incompatible with [conditional GET caching](caching_with_rails.html#conditional-get-support)
+incompatible with [conditional GET caching](caching_with_rails.html#conditional-gets)
 because new nonces will result in new ETag values for every request. An
 alternative to per-request random nonces would be to use the session id:
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -78,7 +78,7 @@ The `application_system_test_case.rb` file holds the default configuration for y
 system tests.
 
 A `jobs` directory will also be created for your job tests when you first
-[generate a job](active_job_basics.html#create-the-job).
+[generate a job](active_job_basics.html#defining-a-job).
 
 ### The Test Environment
 


### PR DESCRIPTION
Several internal guide links pointed to section anchors that have since been renamed (or, in one case, copy-pasted wrong), so clicking them no longer scrolled to the referenced section. Repoint to the current anchors. Every target was verified to exist in the generated HTML.

Method: generated all 76 guides to HTML, collected every `id=` as ground truth, then cross-checked author-written `](file.html#anchor)` links from the markdown source. 16 links across 14 files fixed; the remaining broken links are sections that were removed/moved (need author judgement) or live in historical release-notes/upgrading guides.

Renamed-section fixes:
- active_record_validations.md  association_basics#the-has-one-association ×2 → #has-one
- active_record_validations.md  association_basics#the-has-many-association ×2 → #has-many
- active_record_callbacks.md    active_record_querying#dynamic-finders → #dynamic-finder-methods
- active_record_basics.md       testing#the-low-down-on-fixtures → #fixtures
- caching_with_rails.md         association_basics#single-table-inheritance → #single-table-inheritance-sti (conform to form_helpers.md which already uses -sti)
- configuring.md                autoloading…#autoload-paths → #config-autoload-paths
- contributing…md               active_storage_overview#analyzing-files → #analyzing-files-for-metadata
- action_text_overview.md       active_storage_overview#requirements ×2 → #third-party-software
- action_text_overview.md       active_storage_overview#purging-unattached-uploads → #purging-unattached-uploads-and-detach
- action_mailer_basics.md       i18n#translations-for-action-mailer-e-mail-subjects → #action-mailer-e-mail-subjects
- engines.md                    engines#the-inheritance-hierarchy → #inheritance-hierarchy
- getting_started_with_devcontainer.md  getting_started#creating-a-new-rails-project → #creating-a-new-rails-app
- rails_on_rack.md / security.md  caching_with_rails#conditional-get-support → #conditional-gets
- routing.md                    command_line#the-app-and-helper-objects → #the-app-object (text says "via the app object")
- testing.md                    active_job_basics#create-the-job → #defining-a-job

Wrong-target (copy-paste) fix:
- rails_on_rack.md  the reference for `config.action_dispatch.x_sendfile_header` pointed at #config-action-record-migration-error; conform to the correct sibling reference (#config-action-dispatch-x-sendfile-header) on line 450.

Left for a follow-up (section removed/moved, needs author intent):
- action_mailer_basics → active_job_basics#action-mailer
- active_record_querying → active_record_basics#transactions
- configuring → caching_with_rails#cache-stores
- active_record_composite_primary_keys → active_record_querying#conditions-with-id
- engines → i18n#providing-translations-for-internationalized-strings