### PR TITLE
Wrap a single attachable Hash instead of splitting it in has_many_attached

### DIFF
--- a/activestorage/lib/active_storage/attached/changes/create_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_many.rb
@@ -6,7 +6,7 @@ module ActiveStorage
     attr_accessor :record
 
     def initialize(name, record, attachables, pending_uploads: [])
-      @name, @record, @attachables = name, record, Array(attachables)
+      @name, @record, @attachables = name, record, Array.wrap(attachables)
       blobs.each(&:identify_without_saving)
       @pending_uploads = Array(pending_uploads) + subchanges_without_blobs
       attachments

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -241,7 +241,7 @@ module ActiveStorage
           end
 
           def #{name}=(attachables)
-            attachables = Array(attachables).compact_blank
+            attachables = Array.wrap(attachables).compact_blank
             pending_uploads = attachment_changes["#{name}"].try(:pending_uploads)
 
             attachment_changes["#{name}"] = if attachables.none?

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -244,6 +244,12 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert ActiveStorage::Blob.service.exist?(@user.highlights.second.key)
   end
 
+  test "updating an existing record to attach a single blob from a Hash" do
+    @user.highlights = { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg" }
+    assert_equal 1, @user.highlights.size
+    assert_equal "town.jpg", @user.highlights.first.filename.to_s
+  end
+
   test "unsuccessfully updating an existing record to attach new blobs from uploaded files" do
     assert_not @user.update(name: "", highlights: [ fixture_file_upload("racecar.jpg"), fixture_file_upload("video.mp4") ])
     assert_equal "racecar.jpg", @user.highlights.first.filename.to_s


### PR DESCRIPTION
### Summary

Assigning a Hash attachable to a `has_many_attached` association raises an `ArgumentError` instead of attaching the file:

```ruby
record.highlights = { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg" }
# => ArgumentError: Could not find or build blob: expected attachable, got [:io, #<StringIO:...>]
```

The collection setter normalizes its argument with `Kernel#Array`:

```ruby
attachables = Array(attachables).compact_blank
```

But `Kernel#Array` does **not** wrap a Hash — it splits it into its key/value pairs:

```ruby
Array({ io: "...", filename: "town.jpg", content_type: "image/jpeg" })
# => [[:io, "..."], [:filename, "town.jpg"], [:content_type, "image/jpeg"]]
```

Each pair is then rejected as an invalid attachable.

A Hash is a valid single attachable — `CreateOne#find_or_build_blob` has a `when Hash` branch that builds a blob from `{ io:, filename:, content_type: }`, and the `has_one_attached` setter accepts a bare Hash. So the collection setter is the odd one out.

### Fix

Use `Array.wrap`, which wraps a Hash in a one-element array rather than splitting it:

```ruby
attachables = Array.wrap(attachables).compact_blank
```

```ruby
Array.wrap({ io: "...", filename: "town.jpg", content_type: "image/jpeg" })
# => [{ io: "...", filename: "town.jpg", content_type: "image/jpeg" }]
```

The same `Array(...)` → `Array.wrap(...)` change is applied to `Attached::Changes::CreateMany`, which has the same normalization. Arrays, blobs, and uploaded files are unaffected (they all behave identically under `Array.wrap`).
