### PR TITLE
Validate offset value at call time like limit

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1294,6 +1294,7 @@ module ActiveRecord
     end
 
     def offset!(value) # :nodoc:
+      value = Integer(value) unless value.nil?
       self.offset_value = value
       self
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -200,6 +200,12 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_invalid_offset
+    assert_raises(ArgumentError) do
+      Topic.offset("asdfadf")
+    end
+  end
+
   def test_limit_should_sanitize_sql_injection_for_limit_without_commas
     assert_raises(ArgumentError) do
       Topic.limit("1 select * from schema")

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -62,7 +62,12 @@ module ActiveRecord
       assert_equal 5, relation.limit_value
     end
 
-    (Relation::SINGLE_VALUE_METHODS - [:limit, :lock, :reordering, :reverse_order, :create_with, :skip_query_cache, :strict_loading]).each do |method|
+    test "#offset!" do
+      assert relation.offset!(5).equal?(relation)
+      assert_equal 5, relation.offset_value
+    end
+
+    (Relation::SINGLE_VALUE_METHODS - [:limit, :offset, :lock, :reordering, :reverse_order, :create_with, :skip_query_cache, :strict_loading]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal :foo, relation.public_send("#{method}_value")


### PR DESCRIPTION
### Summary

`limit` rejects a non-integer argument at call time, but `offset` silently coerces one. This PR makes `offset` validate its argument the same way `limit` already does.

`limit!` runs the value through `Integer(value)` (since f46b838b3f), so an invalid limit raises `ArgumentError` immediately:

```ruby
Post.limit("abc")   # => ArgumentError: invalid value for Integer(): "abc"
```

`offset!` stored the value as-is and only coerced it with `offset_value.to_i` when building the SQL, so garbage was silently swallowed:

```ruby
Post.offset("abc").to_sql   # => "SELECT ... OFFSET 0"   (silently 0)
Post.offset("5x").to_sql    # => "SELECT ... OFFSET 5"   (silently truncated)
```

The stored offset is also used directly in arithmetic on the in-memory finder path (`offset_value + index`, `ids.size - offset_value`), which already assumes an integer. So a non-integer offset happens to work for a pure-SQL query but breaks the moment a finder path touches it — an inconsistency that's better surfaced at the source.

### Fix

Coerce the argument with `Integer(value)` in `offset!`, mirroring `limit!`:

```ruby
def offset!(value) # :nodoc:
  value = Integer(value) unless value.nil?
  self.offset_value = value
  self
end
```

Clean numeric strings such as `offset("3")` are unaffected (`Integer("3") == 3`), so the existing `test_finder_with_offset_string` keeps passing. Only genuinely invalid input changes behavior — from a silent `OFFSET 0` to a clear `ArgumentError`, matching `limit`.

Note this is a consistency/clear-error change, not a security fix: the existing `offset_value.to_i` already neutralized any injection attempt.
