### PR TITLE
Fix broken anchor links in guides [8-1-stable]

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -748,7 +748,7 @@ If the name is blank (`nil` or empty string), it returns the email address.
 
 If you don't pass a subject to the mail method, Action Mailer will try to find
 it in your translations. See the [Internationalization
-Guide](i18n.html#translations-for-action-mailer-e-mail-subjects) for more.
+Guide](i18n.html#action-mailer-e-mail-subjects) for more.
 
 ### Sending Emails without Template Rendering
 

--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -339,7 +339,7 @@ end
 ```
 
 If you do so, you will have to manually define the class name that is hosting
-[the fixtures](testing.html#the-low-down-on-fixtures) (`my_books.yml`) using the
+[the fixtures](testing.html#fixtures) (`my_books.yml`) using the
 `set_fixture_class` method in your test definition:
 
 ```ruby

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -650,7 +650,7 @@ class is initialized.
 
 NOTE: The `find_by_*` and `find_by_*!` methods are dynamic finders generated
 automatically for every attribute. Learn more about them in the [Dynamic finders
-section](active_record_querying.html#dynamic-finders).
+section](active_record_querying.html#dynamic-finder-methods).
 
 Conditional Callbacks
 ---------------------

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -451,8 +451,8 @@ also need to use `validates_associated`. More on that in the
 [validates_associated section](#validates-associated).
 
 If you validate the absence of an object associated via a
-[`has_one`](association_basics.html#the-has-one-association) or
-[`has_many`](association_basics.html#the-has-many-association) relationship, it
+[`has_one`](association_basics.html#has-one) or
+[`has_many`](association_basics.html#has-many) relationship, it
 will check that the object is neither `present?` nor `marked_for_destruction?`.
 
 Since `false.present?` is false, if you want to validate the absence of a
@@ -837,8 +837,8 @@ also need to use `validates_associated`. More on that
 [below](#validates-associated).
 
 If you validate the presence of an object associated via a
-[`has_one`](association_basics.html#the-has-one-association) or
-[`has_many`](association_basics.html#the-has-many-association) relationship, it
+[`has_one`](association_basics.html#has-one) or
+[`has_many`](association_basics.html#has-many) relationship, it
 will check that the object is neither `blank?` nor `marked_for_destruction?`.
 
 Since `false.blank?` is true, if you want to validate the presence of a boolean

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -361,7 +361,7 @@ In that case, declare the dependency explicitly with a special comment:
 ```
 
 In some cases, such as a [single table
-inheritance](association_basics.html#single-table-inheritance) setup, a helper
+inheritance](association_basics.html#single-table-inheritance-sti) setup, a helper
 may render different partials from the same directory. Instead of listing each
 template individually, you can use a wildcard to match the whole directory:
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -252,7 +252,7 @@ Accepts an array of paths from which Rails will autoload constants that won't be
 
 #### `config.autoload_paths`
 
-Accepts an array of paths from which Rails will autoload constants. Default is an empty array. Since [Rails 6](upgrading_ruby_on_rails.html#autoloading), it is not recommended to adjust this. See [Autoloading and Reloading Constants](autoloading_and_reloading_constants.html#autoload-paths).
+Accepts an array of paths from which Rails will autoload constants. Default is an empty array. Since [Rails 6](upgrading_ruby_on_rails.html#autoloading), it is not recommended to adjust this. See [Autoloading and Reloading Constants](autoloading_and_reloading_constants.html#config-autoload-paths).
 
 #### `config.beginning_of_week`
 

--- a/guides/source/getting_started_with_devcontainer.md
+++ b/guides/source/getting_started_with_devcontainer.md
@@ -20,7 +20,7 @@ Rails application in a container, without needing to install Ruby or Rails or it
 directly on your machine. This is the fastest way to get your Rails application up and running.
 
 This is an alternative to installing Ruby and Rails directly on your machine, which is
-covered in the [Getting Started guides](getting_started.html#creating-a-new-rails-project).
+covered in the [Getting Started guides](getting_started.html#creating-a-new-rails-app).
 Once you have completed this guide, you can continue building your application by following
 the Getting Started guide.
 

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -390,7 +390,7 @@ The unique request id can be used to trace a request end-to-end and would typica
 
 [`ActiveRecord::Migration::CheckPending`][] checks pending migrations and raises `ActiveRecord::PendingMigrationError` if any migrations are pending if [`config.action_dispatch.x_sendfile_header`][] is set to `:page_load`.
 
-[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-record-migration-error
+[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-dispatch-x-sendfile-header
 
 [`ActiveRecord::Migration::CheckPending`]: https://api.rubyonrails.org/classes/ActiveRecord/Migration/CheckPending.html
 
@@ -414,7 +414,7 @@ The unique request id can be used to trace a request end-to-end and would typica
 
 #### `Rack::ETag`
 
-[`Rack::ETag`][] adds an `ETag` header on all String bodies. ETags are used to validate the cache to facilitate "Conditional `GET`" requests as described above. See the [Caching with Rails](caching_with_rails.html#conditional-get-support) for further information.
+[`Rack::ETag`][] adds an `ETag` header on all String bodies. ETags are used to validate the cache to facilitate "Conditional `GET`" requests as described above. See the [Caching with Rails](caching_with_rails.html#conditional-gets) for further information.
 
 [`Rack::ETag`]: https://rack.github.io/rack/3.2/Rack/ETag.html
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1464,7 +1464,7 @@ edit_person GET    /people/:id/edit(.:format) people#edit
 
 ### Routes in Rails Console
 
-You can access route helpers using `Rails.application.routes.url_helpers` within the [Rails Console](command_line.html#bin-rails-console). They are also available via the [app](command_line.html#the-app-and-helper-objects) object. For example:
+You can access route helpers using `Rails.application.routes.url_helpers` within the [Rails Console](command_line.html#bin-rails-console). They are also available via the [app](command_line.html#the-app-object) object. For example:
 
 ```irb
 irb> Rails.application.routes.url_helpers.users_path

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1476,7 +1476,7 @@ Rails.application.config.content_security_policy_nonce_generator = -> request { 
 There are a few tradeoffs to consider when configuring the nonce generator.
 Using `SecureRandom.base64(16)` is a good default value, because it will
 generate a new random nonce for each request. However, this method is
-incompatible with [conditional GET caching](caching_with_rails.html#conditional-get-support)
+incompatible with [conditional GET caching](caching_with_rails.html#conditional-gets)
 because new nonces will result in new ETag values for every request. An
 alternative to per-request random nonces would be to use the session id:
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -78,7 +78,7 @@ The `application_system_test_case.rb` file holds the default configuration for y
 system tests.
 
 A `jobs` directory will also be created for your job tests when you first
-[generate a job](active_job_basics.html#create-the-job).
+[generate a job](active_job_basics.html#defining-a-job).
 
 ### The Test Environment
 


### PR DESCRIPTION
>[!NOTE]
>
> ### Backport of #57806 for 8-1-stable as requested by @skipkayhil.
> 
> 13 of the 16 anchor fixes apply to this branch. The remaining 3 target `active_storage_overview.html` sections that were renamed only on main, and 1 link in `engines.md` that doesn't exist on this branch.

## Fixes applied (old anchor → new anchor)

| File | old → new |
| --- | --- |
| action_mailer_basics.md | `i18n.html#translations-for-action-mailer-e-mail-subjects` → `#action-mailer-e-mail-subjects` |
| active_record_basics.md | `testing.html#the-low-down-on-fixtures` → `#fixtures` |
| active_record_callbacks.md | `active_record_querying.html#dynamic-finders` → `#dynamic-finder-methods` |
| active_record_validations.md | `association_basics.html#the-has-one-association` → `#has-one` (×2) |
| active_record_validations.md | `association_basics.html#the-has-many-association` → `#has-many` (×2) |
| caching_with_rails.md | `association_basics.html#single-table-inheritance` → `#single-table-inheritance-sti` |
| configuring.md | `autoloading_and_reloading_constants.html#autoload-paths` → `#config-autoload-paths` |
| getting_started_with_devcontainer.md | `getting_started.html#creating-a-new-rails-project` → `#creating-a-new-rails-app` |
| rails_on_rack.md | `configuring.html#config-action-record-migration-error` → `#config-action-dispatch-x-sendfile-header` (copy-paste fix) |
| rails_on_rack.md | `caching_with_rails.html#conditional-get-support` → `#conditional-gets` |
| security.md | `caching_with_rails.html#conditional-get-support` → `#conditional-gets` |
| routing.md | `command_line.html#the-app-and-helper-objects` → `#the-app-object` |
| testing.md | `active_job_basics.html#create-the-job` → `#defining-a-job` |

**Total:** 15 link locations across 11 files (15 insertions / 15 deletions).

## Skipped (not applicable to 8-1-stable — renamed only on main)

- contributing_to_ruby_on_rails.md → `active_storage_overview.html#analyzing-files`
- action_text_overview.md → `active_storage_overview.html#requirements` (×2)
- action_text_overview.md → `active_storage_overview.html#purging-unattached-uploads`
- engines.md → `engines.html#the-inheritance-hierarchy`

## Verification

Every new anchor was confirmed to exist in 8-1-stable's generated HTML structure by running the real `RailsGuides::Markdown` rendering pipeline over each target guide and collecting the `id=` attributes of `h2`–`h5` headings (the same id generation used by `rake guides:generate:html`). All 13 target anchors resolved. ✅
