### PR TITLE
Fix use of `class_attribute` for `primary_key_definition`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -6,6 +6,10 @@ module ActiveRecord
     module PrimaryKey
       extend ActiveSupport::Concern
 
+      included do
+        class_attribute :_primary_key_definition, instance_accessor: false
+      end
+
       # Returns this record's primary key value wrapped in an array if one is
       # available.
       def to_key
@@ -131,7 +135,6 @@ module ActiveRecord
             def inherited(base)
               super
               base.class_eval do
-                class_attribute :_primary_key_definition, instance_accessor: false
                 @attributes_builder = nil
               end
             end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -228,10 +228,11 @@ class PrimaryKeysTest < ActiveRecord::TestCase
 
   def test_primary_key_inherited
     k = Class.new(ActiveRecord::Base)
-    subclass = Class.new(k)
     k.primary_key = "foo"
-    assert_equal "foo", k.primary_key
-    assert_equal "foo", subclass.primary_key
+    subclass = Class.new(k)
+
+    assert_equal "foo", k._primary_key_definition&.name
+    assert_equal "foo", subclass._primary_key_definition&.name
   end
 
   def test_auto_detect_primary_key_from_schema


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/57775

Defining it in `inherited` is incorrect, as we'll keep redefining the same accessor in all children and grand-children.

The proper hook is when the concern is included.
