### PR TITLE
Make ActiveSupport::JSON encoders Ractor-shareable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.15.2)
+    json (2.19.9)
     jwt (2.10.1)
       base64
     kamal (2.4.0)
@@ -853,7 +853,7 @@ CHECKSUMS
   jbuilder (2.13.0) sha256=7200a38a1c0081aa81b7a9757e7a299db75bc58cf1fd45ca7919a91627d227d6
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
-  json (2.15.2) sha256=1068e1d966d2d0dcaf953eaed09c2d30e4104c64c1e3140c435d17be08d1fa27
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
   kamal (2.4.0) sha256=5f62f1858cc15c1506e55b60b075c89a1e7ef9c6bb0a7e3c01b54af190f85181
   kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -61,22 +61,22 @@ module ActiveSupport
       U2029 = -"\u2029".b
 
       ESCAPED_CHARS = {
-        U2028 => '\u2028'.b,
-        U2029 => '\u2029'.b,
-        ">".b => '\u003e'.b,
-        "<".b => '\u003c'.b,
-        "&".b => '\u0026'.b,
+        U2028 => -'\u2028'.b,
+        U2029 => -'\u2029'.b,
+        ">".b => -'\u003e'.b,
+        "<".b => -'\u003c'.b,
+        "&".b => -'\u0026'.b,
       }.freeze
 
-      HTML_ENTITIES_REGEX = Regexp.union(*(ESCAPED_CHARS.keys - [U2028, U2029]))
-      FULL_ESCAPE_REGEX = Regexp.union(*ESCAPED_CHARS.keys)
-      JS_SEPARATORS_REGEX = Regexp.union(U2028, U2029)
+      HTML_ENTITIES_REGEX = Regexp.union(*(ESCAPED_CHARS.keys - [U2028, U2029])).freeze
+      FULL_ESCAPE_REGEX = Regexp.union(*ESCAPED_CHARS.keys).freeze
+      JS_SEPARATORS_REGEX = Regexp.union(U2028, U2029).freeze
 
       class JSONGemEncoder # :nodoc:
         attr_reader :options
 
         def initialize(options = nil)
-          @options = options || {}
+          @options = options.dup.freeze || {}.freeze
         end
 
         # Encode the given object into a JSON string
@@ -149,7 +149,7 @@ module ActiveSupport
       if defined?(::JSON::Coder) && Gem::Version.new(::JSON::VERSION) >= Gem::Version.new("2.15.2")
         class JSONGemCoderEncoder # :nodoc:
           JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
-          CODER = ::JSON::Coder.new do |value, is_key|
+          CODER = ::JSON::Coder.new(&ActiveSupport::Ractors.shareable_proc { |value, is_key|
             # Serialize non-String/Symbol keys via #to_s based on the key's own type,
             # mirroring the legacy `jsonify` encoder. (#as_json is intentionally not
             # consulted here: Time#as_json returns an ISO8601 String, yet the key must
@@ -177,8 +177,7 @@ module ActiveSupport
               count -= 1
             end
             json_value
-          end
-
+          }).freeze
 
           def initialize(options = nil)
             if options
@@ -240,8 +239,8 @@ module ActiveSupport
 
         def json_encoder=(encoder)
           @json_encoder = encoder
-          @encoder_without_options = encoder.new
-          @encoder_without_escape = encoder.new(escape: false)
+          @encoder_without_options = encoder.new.freeze
+          @encoder_without_escape = encoder.new(escape: false).freeze
         end
 
         def encode_without_options(value) # :nodoc:

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -582,6 +582,23 @@ EXPECTED
     assert_equal '{"a":1}', ActiveSupport::JSON.encode(hash)
   end
 
+  if RUBY_VERSION >= "4.0"
+    def test_encoders_are_ractor_shareable
+      skip "Missing Ractor-shareable JSON::Coder" unless Gem::Version.new(::JSON::VERSION) >= Gem::Version.new("2.17.0")
+      begin
+        original_experimental, Warning[:experimental] = Warning[:experimental], false
+        assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }, escape: false) }.value
+        assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }) }.value
+        ActiveSupport::JSON::Encoding.with(escape_js_separators_in_json: false) do
+          assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }) }.value
+        end
+        assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }, escape_html_entities: false) }.value
+      ensure
+        Warning[:experimental] = original_experimental
+      end
+    end
+  end
+
   private
     def object_keys(json_object)
       json_object[1..-2].scan(/([^{}:,\s]+):/).flatten.sort


### PR DESCRIPTION
If we freeze early, we can avoid having to call `Ractor.make_shareable` and just use the ractor-shareable JSON encoders from Ractors.

On 3.4 and below the test is not defined at all to avoid failing skips. Updating JSON was also necessary for the skips not to fail in Ruby 4.0.