### PR TITLE
Set browser binary when preloading system test driver

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -65,7 +65,9 @@ module ActionDispatch
         def resolve_driver_path(namespace)
           # The path method has been deprecated in 4.20.0
           if Gem::Version.new(::Selenium::WebDriver::VERSION) >= Gem::Version.new("4.20.0")
-            namespace::Service.driver_path = ::Selenium::WebDriver::DriverFinder.new(options, namespace::Service.new).driver_path
+            driver_finder = ::Selenium::WebDriver::DriverFinder.new(options, namespace::Service.new)
+            namespace::Service.driver_path = driver_finder.driver_path
+            options.binary = driver_finder.browser_path if driver_finder.browser_path?
           else
             namespace::Service.driver_path = ::Selenium::WebDriver::DriverFinder.path(options, namespace::Service)
           end

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -168,29 +168,33 @@ class DriverTest < ActiveSupport::TestCase
     end
   end
 
-  test "preloads browser's driver_path with DriverFinder if a path isn't already specified" do
+  test "preloads browser's driver_path and binary with DriverFinder if a path isn't already specified" do
     original_driver_path = ::Selenium::WebDriver::Chrome::Service.driver_path
     ::Selenium::WebDriver::Chrome::Service.driver_path = nil
 
-    # Our stub must return paths to a real executables, otherwise an internal Selenium assertion will fail.
-    # Note: SeleniumManager is private api
-    found_executable = RbConfig.ruby
-    ::Selenium::WebDriver::SeleniumManager.stub(:binary_paths, { "driver_path" => found_executable, "browser_path" => found_executable }) do
-      ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome)
+    # Note: SeleniumManager and Platform are private api
+    driver = ::Selenium::WebDriver::Platform.stub(:assert_executable, nil) do
+      ::Selenium::WebDriver::SeleniumManager.stub(:binary_paths, { "driver_path" => "chromedriver", "browser_path" => "chrome" }) do
+        ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome)
+      end
     end
 
-    assert_equal found_executable, ::Selenium::WebDriver::Chrome::Service.driver_path
+    assert_equal "chromedriver", ::Selenium::WebDriver::Chrome::Service.driver_path
+    assert_equal "chrome", driver.instance_variable_get(:@browser).options.binary
   ensure
     ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path
   end
 
   test "does not overwrite existing driver_path during preload" do
     original_driver_path = ::Selenium::WebDriver::Chrome::Service.driver_path
-    # The driver_path must point to a real executable, otherwise an internal Selenium assertion will fail.
-    ::Selenium::WebDriver::Chrome::Service.driver_path = RbConfig.ruby
 
-    assert_no_changes -> { ::Selenium::WebDriver::Chrome::Service.driver_path } do
-      ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome)
+    # Note: Platform is private api
+    ::Selenium::WebDriver::Platform.stub(:assert_executable, nil) do
+      ::Selenium::WebDriver::Chrome::Service.driver_path = "/path/to/chromedriver"
+
+      assert_no_changes -> { ::Selenium::WebDriver::Chrome::Service.driver_path } do
+        ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome)
+      end
     end
   ensure
     ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path


### PR DESCRIPTION
### Motivation / Background

When system tests preload the Selenium driver, `Browser#preload` sets the global `Chrome/Firefox::Service.driver_path` and relied on `DriverFinder` also setting `options.binary`. That assignment was an unintended side effect of `DriverFinder` mutating the options object, and Selenium 4.45 removed it. Now that `Service.driver_path` is set, Selenium skips Selenium Manager when each worker builds its driver, so it resolves only the driver path and never the browser path — leaving `options.binary` unset and failing with "cannot find Chrome binary."

See the upstream report: https://github.com/SeleniumHQ/selenium/issues/17698

### Detail

This Pull Request resolves the driver and browser paths from the same `DriverFinder` and assigns `options.binary` explicitly, rather than depending on the removed side effect. This works across the selenium-webdriver versions covered by the existing `>= 4.20.0` branch.

### Additional information

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
