### PR TITLE
Use the float value for `:wait` if passed to `ActiveJob.retry_on`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow `retry_on` to accept a Float for `:wait`.
+
+    Similar to `ActiveJob.set(wait: 1.5)`, allow a Float to be passed.
+    Also, passing an unsupported `:wait` type will now raise when loading the
+    job class.
+
+    *Kenta Ishizaki, Petrik de Heus*
+
 *   Allow queue adapters to inspect a job when deciding whether to interrupt at
     a checkpoint, and to optionally return a specific interruption reason.
 

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -188,7 +188,7 @@ module ActiveJob
           delay_jitter = determine_jitter_for_delay(delay, jitter)
           delay + delay_jitter + 2
         when ActiveSupport::Duration, Integer, Float
-          delay = seconds_or_duration_or_algorithm.to_i
+          delay = seconds_or_duration_or_algorithm.to_f
           delay_jitter = determine_jitter_for_delay(delay, jitter)
           delay + delay_jitter
         when Proc

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -122,13 +122,13 @@ class ExceptionsTest < ActiveSupport::TestCase
     test "float wait job" do
       travel_to Time.now
       random_amount = 1
-      delay_for_jitter = random_amount * 2 * ActiveJob::Base.retry_jitter
+      delay_for_jitter = random_amount * 4.5 * ActiveJob::Base.retry_jitter
 
       Kernel.stub(:rand, random_amount) do
         RetryJob.perform_later "FloatWaitError", 2, :log_scheduled_at
         assert_equal [
           "Raised FloatWaitError for the 1st time",
-          "Next execution scheduled at #{(Time.now + 2.seconds + delay_for_jitter).to_f}",
+          "Next execution scheduled at #{(Time.now + 4.5.seconds + delay_for_jitter).to_f}",
           "Successfully completed job"
         ], JobBuffer.values
       end

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -34,7 +34,7 @@ class RetryJob < ActiveJob::Base
   retry_on ZeroJitterError, jitter: 0.0
   retry_on FirstRetryableErrorOfTwo, SecondRetryableErrorOfTwo, attempts: 4
   retry_on LongWaitError, wait: 1.hour, attempts: 10
-  retry_on FloatWaitError, wait: 2.5, attempts: 10
+  retry_on FloatWaitError, wait: 4.5, attempts: 10
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10
   retry_on PolynomialWaitTenAttemptsError, wait: :polynomially_longer, attempts: 10
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10


### PR DESCRIPTION
If we are going to allow passing a Float, we should use the float value instead of converting it to an Integer.
This is similar to `ActiveJob.set(wait: 4.5)` where we [use the float value](https://github.com/rails/rails/blob/b8990a6e917570d9c4e3f6a694fcc5cfa755ae53/activejob/lib/active_job/core.rb#L176-L177) as well.

By calling `to_f` instead of `to_i` durations with floats, lile `1.5.seconds`, work as well.

This also changes the test to use a float of `4.5` to distinguish it from the 2 for the amount of retries.

https://github.com/rails/rails/pull/57727 was also missing a Changelog entry.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
