### PR TITLE
Initialize ActionView::LookupContext.view_context_class early

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -58,7 +58,6 @@ module ActionView
 
       @details_keys = Concurrent::Map.new
       @digest_cache = Concurrent::Map.new
-      @view_context_mutex = Mutex.new
 
       def self.digest_cache(details)
         @digest_cache[details_cache_key(details)] ||= Concurrent::Map.new
@@ -80,7 +79,7 @@ module ActionView
         ActionView::PathRegistry.all_resolvers.each do |resolver|
           resolver.clear_cache
         end
-        @view_context_class = nil
+        ActionView::LookupContext.reset_view_context_class
         @details_keys.clear
         @digest_cache.clear
       end
@@ -88,13 +87,21 @@ module ActionView
       def self.digest_caches
         @digest_cache.values
       end
+    end
 
-      def self.view_context_class
-        @view_context_mutex.synchronize do
-          @view_context_class ||= ActionView::Base.with_empty_template_cache
-        end
+    def self.reset_view_context_class
+      @view_context_mutex.synchronize { @view_context_class = nil }
+    end
+
+    def self.view_context_class
+      return @view_context_class if @view_context_class
+      base = ActionView::Base # prevent recursive locking
+      @view_context_mutex.synchronize do
+        @view_context_class = base.with_empty_template_cache
       end
     end
+    @view_context_mutex = Mutex.new
+    ActiveSupport.on_load(:action_view) { ActionView::LookupContext.view_context_class }
 
     # Add caching behavior on top of Details.
     module DetailsCache

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -80,7 +80,7 @@ module ActionView
       end
 
       def view_context_class
-        klass = ActionView::LookupContext::DetailsKey.view_context_class
+        klass = ActionView::LookupContext.view_context_class
 
         @view_context_class ||= build_view_context_class(klass, supports_path?, _routes, _helpers)
 

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -199,6 +199,22 @@ class LookupContextTest < ActiveSupport::TestCase
   end
 end
 
+if RUBY_VERSION >= "4.0"
+  class LookupContextRactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    test "view_context_class is Ractor-shareable" do
+      @original_experimental_warning = Warning[:experimental]
+      Warning[:experimental] = false
+      ActionView::LookupContext.view_context_class # needs to be eager-loaded to be ractor-shareable
+      assert_same ActionView::LookupContext.view_context_class,
+        Ractor.new { ActionView::LookupContext.view_context_class }.value
+    ensure
+      Warning[:experimental] = @original_experimental_warning
+    end
+  end
+end
+
 class TestMissingTemplate < ActiveSupport::TestCase
   def setup
     @lookup_context = ActionView::LookupContext.new("/Path/to/views", {})


### PR DESCRIPTION
This avoids interacting with the mutex when possible, i.e. when enable_reloading is false.

This lets us use the view context class from Ractors without any additional setup.
