### PR TITLE
Introduce ractorize

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -22,6 +22,18 @@ module ActionDispatch
           @memos           = Hash.new { |h, k| h[k] = [] }
         end
 
+        def freeze
+          return self if frozen?
+
+          @memos.default_proc = nil
+          @stdparam_states.freeze
+          @regexp_states.freeze
+          @string_states.freeze
+          @accepting.freeze
+          @memos.freeze
+          super
+        end
+
         def add_accepting(state)
           @accepting[state] = true
         end

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -60,11 +60,24 @@ module ActiveSupport
     def initialize(key_generator)
       @key_generator = key_generator
       @cache_keys = Concurrent::Map.new
+      @ractor_key = nil
+    end
+
+    def freeze
+      @ractor_key = "_caching_key_generator_#{object_id}".to_sym
+      Ractor[@ractor_key] = @cache_keys
+      @cache_keys = nil
+      super
     end
 
     # Returns a derived key suitable for use.
     def generate_key(*args)
-      @cache_keys[args.join("|")] ||= @key_generator.generate_key(*args)
+      cache_keys[args.join("|")] ||= @key_generator.generate_key(*args)
     end
+
+    private
+      def cache_keys
+        @cache_keys || (Ractor[@ractor_key] ||= Concurrent::Map.new)
+      end
   end
 end

--- a/activesupport/lib/active_support/messages/rotation_coordinator.rb
+++ b/activesupport/lib/active_support/messages/rotation_coordinator.rb
@@ -9,7 +9,7 @@ module ActiveSupport
 
       def initialize(&secret_generator)
         raise ArgumentError, "A secret generator block is required" unless secret_generator
-        @secret_generator = secret_generator
+        @secret_generator = ActiveSupport::Ractors.try_shareable_proc(secret_generator)
         @rotate_options = []
         @on_rotation = nil
         @codecs = {}

--- a/activesupport/lib/active_support/testing/ractors_assertions.rb
+++ b/activesupport/lib/active_support/testing/ractors_assertions.rb
@@ -5,6 +5,18 @@ module ActiveSupport
     module RactorsAssertions # :nodoc: all
       private
         if RUBY_VERSION >= "4.0"
+          def on_ractor(*args, &block)
+            block = Ractor.shareable_proc(&block)
+
+            port = Ractor::Port.new
+
+            Ractor.new(port, block, args) do |port, block, args|
+              port.send block.call(*args)
+            end.join
+
+            port.receive
+          end
+
           def assert_ractor_make_shareable(obj)
             assert_nothing_raised { Ractor.make_shareable(obj) }
           end
@@ -13,6 +25,10 @@ module ActiveSupport
             assert Ractor.shareable?(obj), "Expected #{obj.inspect} to be shareable, but it is not."
           end
         else
+          def on_ractor(*args)
+            yield(*args)
+          end
+
           def assert_ractor_make_shareable(obj)
             assert true
           end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -121,11 +121,9 @@ else
       caching_generator = ActiveSupport::CachingKeyGenerator.new(key_generator)
       ActiveSupport::Ractors.make_shareable(caching_generator)
 
-      port = Ractor::Port.new
-      Ractor.new(port, caching_generator) do |port, caching_generator|
-        port.send caching_generator.generate_key("some_salt", 32)
-      end.join
-      key = port.receive
+      key = on_ractor(caching_generator) do |caching_generator|
+        caching_generator.generate_key("some_salt", 32)
+      end
 
       assert_equal key, caching_generator.generate_key("some_salt", 32)
     end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require "active_support/testing/ractors_assertions"
+require "active_support/testing/isolation"
 
 begin
   require "openssl"
@@ -99,6 +101,33 @@ else
       different_length_key = @caching_generator.generate_key("1", 337)
 
       assert_not_equal derived_key, different_length_key
+    end
+  end
+
+  class RactorKeyGeneratorTest < ActiveSupport::TestCase
+    # This test has to be isolated due to a bug with Ractors on 4.0.5. We can move it back with the other
+    # tests once 4.0.6 is released.
+    include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
+
+    test "CachingKeyGenerator can work across ractors" do
+      # OpenSSL::Digest are not Ractor-safe, but the fix is already merged upstream. This test can be updated
+      # to use our implementation once a version of Ruby ships with ruby/openssl@502bc6c
+      key_generator = Class.new(ActiveSupport::KeyGenerator) do
+        def generate_key(salt, key_size)
+          OpenSSL::PKCS5.pbkdf2_hmac(@secret, salt, @iterations, key_size, "SHA1")
+        end
+      end.new("foo", iterations: 2)
+      caching_generator = ActiveSupport::CachingKeyGenerator.new(key_generator)
+      ActiveSupport::Ractors.make_shareable(caching_generator)
+
+      port = Ractor::Port.new
+      Ractor.new(port, caching_generator) do |port, caching_generator|
+        port.send caching_generator.generate_key("some_salt", 32)
+      end.join
+      key = port.receive
+
+      assert_equal key, caching_generator.generate_key("some_salt", 32)
     end
   end
 end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -772,7 +772,7 @@ module Rails
       end
 
       def coerce_same_site_protection(protection)
-        protection.respond_to?(:call) ? protection : proc { protection }
+        protection.respond_to?(:call) ? protection : ActiveSupport::Ractors.shareable_proc { protection }
       end
 
       def filter_parameters

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -668,6 +668,17 @@ module Rails
       Rails.autoloaders.each(&:eager_load)
     end
 
+    def ractorize! # :nodoc:
+      warn "Ractor support in Rails is experimental and subject to change.", category: :experimental, uplevel: 1
+
+      env_config
+      routes
+
+      @autoloaders, @reloaders, @routes_reloader = nil, nil, nil
+
+      Ractor.make_shareable(self)
+    end
+
   protected
     alias :build_middleware_stack :app
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -215,8 +215,8 @@ module Rails
     #
     def message_verifiers
       @message_verifiers ||=
-        ActiveSupport::MessageVerifiers.new do |salt, secret_key_base: self.secret_key_base|
-          key_generator(secret_key_base).generate_key(salt)
+        ActiveSupport::MessageVerifiers.new do |salt, secret_key_base: Rails.application.secret_key_base|
+          Rails.application.key_generator(secret_key_base).generate_key(salt)
         end.rotate_defaults
     end
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -677,6 +677,9 @@ module Rails
       @autoloaders, @reloaders, @routes_reloader = nil, nil, nil
 
       Ractor.make_shareable(self)
+      Ractor.make_shareable(Rails.event)
+      Ractor.make_shareable(Rails.error)
+      Ractor.make_shareable(Rails.backtrace_cleaner)
     end
 
   protected

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -116,9 +116,25 @@ module Rails
         @after_generate_callbacks = []
       end
 
+      def freeze
+        return self if frozen?
+
+        @aliases.default_proc = nil
+        @options.default_proc = nil
+        @aliases.freeze
+        @options.freeze
+        @fallbacks.freeze
+        @templates.freeze
+        @hidden_namespaces.freeze
+        @after_generate_callbacks.freeze
+        super
+      end
+
       def initialize_copy(source)
         @aliases = @aliases.deep_dup
+        @aliases.default_proc = proc { |h, k| h[k] = {} }
         @options = @options.deep_dup
+        @options.default_proc = proc { |h, k| h[k] = {} }
         @fallbacks = @fallbacks.deep_dup
         @templates = @templates.dup
       end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -448,6 +448,14 @@ module Rails
       super
     end
 
+    def freeze
+      return self if frozen?
+
+      app
+      @app_build_lock = nil
+      super
+    end
+
     # Load console and invoke the registered hooks.
     # Check Rails::Railtie.console for more info.
     def load_console(app = self)

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -47,6 +47,17 @@ module Rails
         concat(initializers) if initializers
       end
 
+      def freeze
+        return self if frozen?
+
+        @order.default_proc = nil
+        @resolve.default_proc = nil
+        @order.freeze
+        @resolve.freeze
+        @collection.freeze
+        super
+      end
+
       def to_a
         @collection
       end

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "active_support/testing/ractors_assertions"
+
+if RUBY_VERSION >= "4.0"
+  module ApplicationTests
+    class RactorsTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::Isolation
+      include ActiveSupport::Testing::RactorsAssertions
+
+      def setup
+        build_app
+
+        add_to_env_config "production", "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+
+        # Remove defaults that are not compatible
+        add_to_env_config "production", "config.logger = ActiveSupport::Ractors::Logger.new"
+        add_to_env_config "production", "config.public_file_server.enabled = false" # Requires release of https://github.com/rack/rack/pull/2469
+        add_to_env_config "production", "config.cache_store = :null_store"
+        add_to_env_config "production", "config.action_cable.mount_path = nil"
+      end
+
+      def teardown
+        teardown_app
+      end
+
+      test "ractorize! makes the app shareable in production mode" do
+        app "production"
+
+        begin
+          @original_experimental_warning = Warning[:experimental]
+          Warning[:experimental] = false
+          Rails.application.ractorize!
+        ensure
+          Warning[:experimental] = @original_experimental_warning
+        end
+
+        assert_ractor_shareable Rails.application
+      end
+    end
+  end
+end

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -37,6 +37,9 @@ if RUBY_VERSION >= "4.0"
         end
 
         assert_ractor_shareable Rails.application
+        assert_ractor_shareable Rails.event
+        assert_ractor_shareable Rails.error
+        assert_ractor_shareable Rails.backtrace_cleaner
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

We are working on making the framework Ractor safe. This PR enables a basic Rails application to be made ractor shareable.

### Detail

We introduce the `Rails::Application#ractorize!` method which prepares the application to be shared and then calls `Ractor.make_shareable` on it. For now, there are some restrictions on the setup of the application:

- Application code and routes must be eager loaded
- Action cable is not supported
- App must use a null cache store

We hope to remove these restrictions as the feature becomes more mature, this is simply a starting point.

For the last few weeks we have been setting the groundwork, but this PR includes a few final pieces to get this working:

- Making inheritable options ractor safe (there is a separate PR for this with some debate around approach https://github.com/rails/rails/pull/57757, I thought it'd be helpful to open this PR to continue that discussion)
- Removing default procs that mutate the hash when freezing some hashes
- We make the application's key generators store Ractor local, since concurrent map is not Ractor-shareable. If we have a production ready ractor-safe map in the future we can use that, but this is a pragmatic compromise for now.
- Eagerly building each engine's app and throwing away the mutex, which is not ractor shareable
- Making a few procs ractor shareable

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
