### PR TITLE
Deprecate Mime::SET, Mime::LOOKUP and Mime::EXTENSION_LOOKUP

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -105,7 +105,7 @@ end
 autoload :Mime, "action_dispatch/http/mime_type"
 
 ActiveSupport.on_load(:action_view) do
-  ActionView::Base.default_formats ||= Mime::SET.symbols
+  ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
   ActionView::LookupContext::DetailsKey.clear
 end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate `Mime::SET`, `Mime::LOOKUP`, `Mime::EXTENSION_LOOKUP`.
+
+    Use `Mime.symbols`, `Mime::Type.lookup` and `Mime::Type.lookup_by_extension` respectively instead.
+
+    `Mime.extensions` is also added to enumerate every registered extension
+    (including synonyms), replacing `Mime::EXTENSION_LOOKUP.map(&:first)`.
+
+    *Étienne Barrié*
+
 *   Add `config.action_dispatch.strict_accept_header` to stop forcing an
     HTML response when the `Accept` header contains the `*/*` wildcard.
 

--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -7,7 +7,7 @@ require "action_dispatch/http/mime_type"
 module AbstractController
   module Collector
     def self.generate_method_for_mime(mime)
-      sym = mime.is_a?(Symbol) ? mime : mime.to_sym
+      sym = mime.to_sym
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{sym}(...)
           custom(Mime[:#{sym}], ...)
@@ -15,7 +15,7 @@ module AbstractController
       RUBY
     end
 
-    Mime::SET.each do |mime|
+    Mime.symbols.each do |mime|
       generate_method_for_mime(mime)
     end
 
@@ -33,7 +33,7 @@ module AbstractController
           "format.html { |html| html.tablet { ... } }"
       end
 
-      if Mime::SET.include?(mime_constant)
+      if Mime.symbols.include?(mime_constant.to_sym)
         AbstractController::Collector.generate_method_for_mime(mime_constant)
         public_send(symbol, ...)
       else

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -161,7 +161,7 @@ end
 autoload :Mime, "action_dispatch/http/mime_type"
 
 ActiveSupport.on_load(:action_view) do
-  ActionView::Base.default_formats ||= Mime::SET.symbols
+  ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
   ActionView::LookupContext::DetailsKey.clear
 end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -3,6 +3,8 @@
 # :markup: markdown
 
 require "singleton"
+require "active_support/deprecation"
+require "action_dispatch/deprecator"
 
 module Mime
   class Mimes
@@ -43,27 +45,49 @@ module Mime
     end
   end
 
-  SET              = Mimes.new
-  EXTENSION_LOOKUP = {} # rubocop:disable Style/MutableConstant
-  LOOKUP           = {} # rubocop:disable Style/MutableConstant
+  @registry            = Mimes.new
+  @lookup_by_string    = {}
+  @lookup_by_extension = {}
+
+  SET = ActiveSupport::Deprecation::DeprecatedObjectProxy.new( # :nodoc:
+    @registry,
+    "Mime::SET is deprecated. Use Mime.symbols to enumerate registered types, or Mime[...] / Mime::Type.lookup to look one up.",
+    ActionDispatch.deprecator,
+  )
+  LOOKUP = ActiveSupport::Deprecation::DeprecatedObjectProxy.new( # :nodoc:
+    @lookup_by_string,
+    "Mime::LOOKUP is deprecated. Use Mime::Type.lookup instead.",
+    ActionDispatch.deprecator,
+  )
+  EXTENSION_LOOKUP = ActiveSupport::Deprecation::DeprecatedObjectProxy.new( # :nodoc:
+    @lookup_by_extension,
+    "Mime::EXTENSION_LOOKUP is deprecated. Use Mime.extensions to enumerate registered extensions, or Mime::Type.lookup_by_extension / Mime[...] to look one up.",
+    ActionDispatch.deprecator,
+  )
 
   class << self
+    attr_reader :registry, :lookup_by_string, :lookup_by_extension # :nodoc:
+
     def [](type)
       return type if type.is_a?(Type)
       Type.lookup_by_extension(type)
     end
 
     def symbols
-      SET.symbols
+      @registry.symbols
+    end
+
+    def extensions
+      @lookup_by_extension.keys
     end
 
     def valid_symbols?(symbols) # :nodoc:
-      SET.valid_symbols?(symbols)
+      @registry.valid_symbols?(symbols)
     end
 
     def fetch(type, &block)
       return type if type.is_a?(Type)
-      EXTENSION_LOOKUP.fetch(type.to_s, &block)
+      @lookup_by_extension.fetch(type.to_s, &block)
     end
   end
 
@@ -165,15 +189,16 @@ module Mime
       end
 
       def lookup(string)
-        return LOOKUP[string] if LOOKUP.key?(string)
+        lookup = Mime.lookup_by_string
+        return lookup[string] if lookup.key?(string)
 
         # fallback to the media-type without parameters if it was not found
         string = string.split(";", 2)[0]&.rstrip
-        LOOKUP[string] || Type.new(string)
+        lookup[string] || Type.new(string)
       end
 
       def lookup_by_extension(extension)
-        EXTENSION_LOOKUP[extension.to_s]
+        Mime.lookup_by_extension[extension.to_s]
       end
 
       # Registers an alias that's not used on MIME type lookup, but can be referenced
@@ -186,10 +211,9 @@ module Mime
       def register(string, symbol, mime_type_synonyms = [], extension_synonyms = [], skip_lookup = false)
         new_mime = Type.new(string, symbol, mime_type_synonyms)
 
-        SET << new_mime
-
-        ([string] + mime_type_synonyms).each { |str| LOOKUP[str] = new_mime } unless skip_lookup
-        ([symbol] + extension_synonyms).each { |ext| EXTENSION_LOOKUP[ext.to_s] = new_mime }
+        Mime.registry << new_mime
+        ([string] + mime_type_synonyms).each { |str| Mime.lookup_by_string[str] = new_mime } unless skip_lookup
+        ([symbol] + extension_synonyms).each { |ext| Mime.lookup_by_extension[ext.to_s] = new_mime }
 
         @register_callbacks.each do |callback|
           callback.call(new_mime)
@@ -234,7 +258,7 @@ module Mime
       # For an input of `'application'`, returns `[Mime[:html], Mime[:js], Mime[:xml],
       # Mime[:yaml], Mime[:atom], Mime[:json], Mime[:rss], Mime[:url_encoded_form]]`.
       def parse_data_with_trailing_star(type)
-        Mime::SET.select { |m| m.match?(type) }
+        Mime.registry.select { |m| m.match?(type) }
       end
 
       # This method is opposite of register method.
@@ -245,9 +269,9 @@ module Mime
       def unregister(symbol)
         symbol = symbol.downcase
         if mime = Mime[symbol]
-          SET.delete_if { |v| v.eql?(mime) }
-          LOOKUP.delete_if { |_, v| v.eql?(mime) }
-          EXTENSION_LOOKUP.delete_if { |_, v| v.eql?(mime) }
+          Mime.registry.delete_if { |v| v.eql?(mime) }
+          Mime.lookup_by_string.delete_if { |_, v| v.eql?(mime) }
+          Mime.lookup_by_extension.delete_if { |_, v| v.eql?(mime) }
         end
       end
     end

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -4,7 +4,7 @@ require "abstract_unit"
 
 class MimeTypeTest < ActiveSupport::TestCase
   test "parse single" do
-    Mime::LOOKUP.each_key do |mime_type|
+    Mime.lookup_by_string.each_key do |mime_type|
       unless mime_type == "image/*"
         assert_equal [Mime::Type.lookup(mime_type)], Mime::Type.parse(mime_type)
       end
@@ -26,6 +26,12 @@ class MimeTypeTest < ActiveSupport::TestCase
     ensure
       Mime::Type.unregister :mobile
     end
+  end
+
+  test "Mime::SET, Mime::LOOKUP and Mime::EXTENSION_LOOKUP are deprecated" do
+    assert_deprecated("Mime::SET", ActionDispatch.deprecator) { Mime::SET.symbols }
+    assert_deprecated("Mime::LOOKUP", ActionDispatch.deprecator) { Mime::LOOKUP.key?("text/html") }
+    assert_deprecated("Mime::EXTENSION_LOOKUP", ActionDispatch.deprecator) { Mime::EXTENSION_LOOKUP["html"] }
   end
 
   test "parse text with trailing star at the beginning" do
@@ -126,6 +132,21 @@ class MimeTypeTest < ActiveSupport::TestCase
     Mime::Type.unregister(:foo)
   end
 
+  test "extensions enumerates every registered extension, including synonyms" do
+    assert_includes Mime.extensions, "html"
+    assert_includes Mime.extensions, "jpg"
+    assert_includes Mime.extensions, "jpeg"
+  end
+
+  test "extensions includes custom extension aliases" do
+    Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]
+    assert_includes Mime.extensions, "foobar"
+    assert_includes Mime.extensions, "foo"
+    assert_includes Mime.extensions, "bar"
+  ensure
+    Mime::Type.unregister(:foobar)
+  end
+
   test "custom type with type aliases" do
     Mime::Type.register "text/foobar", :foobar, ["text/foo", "text/bar"]
     %w[text/foobar text/foo text/bar].each do |type|
@@ -159,7 +180,7 @@ class MimeTypeTest < ActiveSupport::TestCase
   test "custom type with extension aliases" do
     Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]
     %w[foobar foo bar].each do |extension|
-      assert_equal Mime[:foobar], Mime::EXTENSION_LOOKUP[extension]
+      assert_equal Mime[:foobar], Mime[extension]
     end
   ensure
     Mime::Type.unregister(:foobar)
@@ -167,7 +188,7 @@ class MimeTypeTest < ActiveSupport::TestCase
 
   test "register alias" do
     Mime::Type.register_alias "application/xhtml+xml", :foobar
-    assert_equal Mime[:html], Mime::EXTENSION_LOOKUP["foobar"]
+    assert_equal Mime[:html], Mime["foobar"]
   ensure
     Mime::Type.unregister(:foobar)
   end
@@ -178,7 +199,7 @@ class MimeTypeTest < ActiveSupport::TestCase
   end
 
   test "type convenience methods" do
-    types = Mime::SET.symbols.uniq - [:iphone]
+    types = Mime.symbols.uniq - [:iphone]
 
     types.each do |type|
       mime = Mime[type]
@@ -290,9 +311,9 @@ class MimeTypeTest < ActiveSupport::TestCase
   end
 
   test "holds a reference to mime symbols" do
-    old_symbols = Mime::SET.symbols
+    old_symbols = Mime.symbols
     Mime::Type.register_alias "application/xhtml+xml", :foobar
-    new_symbols = Mime::SET.symbols
+    new_symbols = Mime.symbols
 
     assert_same(old_symbols, new_symbols)
   ensure

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -31,7 +31,7 @@ class LookupContextTest < ActiveSupport::TestCase
   end
 
   test "normalizes details on initialization" do
-    assert_equal Mime::SET.to_a, @lookup_context.formats
+    assert_equal Mime.symbols, @lookup_context.formats
     assert_equal :en, @lookup_context.locale
   end
 
@@ -52,12 +52,12 @@ class LookupContextTest < ActiveSupport::TestCase
 
   test "handles */* formats" do
     @lookup_context.formats = ["*/*"]
-    assert_equal Mime::SET.to_a, @lookup_context.formats
+    assert_equal Mime.symbols, @lookup_context.formats
   end
 
   test "handles explicitly defined */* formats fallback to :js" do
     @lookup_context.formats = [:js, Mime::ALL]
-    assert_equal [:js, *Mime::SET.symbols].uniq, @lookup_context.formats
+    assert_equal [:js, *Mime.symbols].uniq, @lookup_context.formats
   end
 
   test "adds :html fallback to :js formats" do


### PR DESCRIPTION
These constants expose the MIME type registries directly, leaking mutable internal state. Everything they're used for is already covered by the public API, so deprecate direct access in favor of:

    Mime::SET              -> Mime.symbols / Mime[...] / Mime::Type.lookup
    Mime::LOOKUP           -> Mime::Type.lookup
    Mime::EXTENSION_LOOKUP -> Mime.extensions / Mime::Type.lookup_by_extension / Mime[...]

Enumerating every registered extension (including synonyms) was previously only possible through Mime::EXTENSION_LOOKUP, so Mime.extensions is added as the public counterpart to Mime.symbols to cover that case.

The constants become ActiveSupport::Deprecation::DeprecatedObjectProxy instances that still delegate to the registries but warn on use.
