### PR TITLE
Warn when a database config provides both a `url` and conflicting keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Warn when a database configuration provides both a `url` and conflicting
+    keys such as `database:` or `host:` in the same entry (for example a
+    `database:` alongside a `url:` inherited via a YAML anchor). The value from
+    the URL still takes precedence; the warning just surfaces the otherwise
+    silent conflict. URLs provided through the `DATABASE_URL` environment
+    variable are unaffected.
+
+    *Chris Moore*
+
 *   Support polymorphic associations with custom primary keys through `:inverse_of`.
 
     When using polymorphic associations with `:inverse_of`, ActiveRecord now respects

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -277,12 +277,46 @@ module ActiveRecord
         config_without_url = config.dup
         config_without_url.delete :url
 
+        warn_about_keys_ignored_by_url(env_name, name, url, config_without_url) if url
+
         DatabaseConfigurations.db_config_handlers.reverse_each do |handler|
           config = handler.call(env_name, name, url, config_without_url)
           return config if config
         end
 
         nil
+      end
+
+      # When a configuration provides both a +url+ and keys that the URL also
+      # sets (for example a +database:+ alongside a +url:+ inherited via a YAML
+      # anchor), the value parsed from the URL takes precedence and the explicit
+      # key is silently discarded. Warn so the conflict is visible; the
+      # precedence itself is unchanged. URLs supplied through +DATABASE_URL+ and
+      # friends are merged separately and are unaffected.
+      def warn_about_keys_ignored_by_url(env_name, name, url, config)
+        return if config.empty? || url.start_with?("jdbc:", "http:", "https:")
+
+        url_hash =
+          begin
+            ConnectionUrlResolver.new(url).to_hash
+          rescue StandardError
+            return
+          end
+
+        ignored = url_hash.filter_map do |key, value|
+          next unless config.key?(key)
+          next if config[key].to_s == value.to_s
+          key
+        end
+
+        return if ignored.empty?
+
+        warn(
+          "Database configuration for #{name.inspect} (#{env_name}) provides both a " \
+          "`url` and the conflicting key(s): #{ignored.map(&:to_s).sort.join(", ")}. " \
+          "The value(s) from the URL take precedence, so the explicitly configured " \
+          "value(s) are ignored."
+        )
       end
 
       def merge_db_environment_variables(current_env, configs)

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -24,6 +24,53 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     assert_equal ["arunit"], configs.map(&:env_name)
   end
 
+  def test_warns_when_url_and_conflicting_key_are_given_in_the_same_config
+    warning = capture(:stderr) do
+      ActiveRecord::DatabaseConfigurations.new(
+        "default_env" => { "primary" => { "url" => "postgres://localhost/from_url", "database" => "from_yaml" } }
+      ).configs_for(env_name: "default_env")
+    end
+
+    assert_match(/\bdatabase\b/, warning)
+    assert_match(/url/, warning)
+  end
+
+  def test_does_not_warn_when_only_a_url_is_given
+    warning = capture(:stderr) do
+      ActiveRecord::DatabaseConfigurations.new(
+        "default_env" => { "primary" => { "url" => "postgres://localhost/from_url" } }
+      ).configs_for(env_name: "default_env")
+    end
+
+    assert_predicate warning, :blank?, "expected no warning, got:\n#{warning}"
+  end
+
+  def test_does_not_warn_when_the_explicit_key_matches_the_url
+    warning = capture(:stderr) do
+      ActiveRecord::DatabaseConfigurations.new(
+        "default_env" => { "primary" => { "url" => "postgres://localhost/same_db", "database" => "same_db" } }
+      ).configs_for(env_name: "default_env")
+    end
+
+    assert_predicate warning, :blank?, "expected no warning, got:\n#{warning}"
+  end
+
+  def test_does_not_warn_when_the_url_comes_from_the_environment
+    previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
+    previous_url, ENV["DATABASE_URL"] = ENV["DATABASE_URL"], "postgres://localhost/from_env"
+
+    warning = capture(:stderr) do
+      ActiveRecord::DatabaseConfigurations.new(
+        "default_env" => { "primary" => { "adapter" => "sqlite3", "database" => "from_yaml" } }
+      ).configs_for(env_name: "default_env")
+    end
+
+    assert_predicate warning, :blank?, "expected no warning for a DATABASE_URL override, got:\n#{warning}"
+  ensure
+    ENV["RAILS_ENV"] = previous_env
+    ENV["DATABASE_URL"] = previous_url
+  end
+
   def test_configs_for_getter_with_name
     previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit2"
 


### PR DESCRIPTION
### Summary

In a multi-database `config/database.yml`, a secondary database commonly inherits the primary's `url:` via a YAML anchor and then sets its own `database:`:

```yaml
production:
  primary: &primary
    url: <%= ENV["DATABASE_URL"] %>   # e.g. postgres://user:pass@host/myapp_production
  queue:
    <<: *primary
    database: myapp_production_queue   # silently ignored
```

Because the value parsed from the URL takes precedence over sibling keys, `queue` silently connects to `myapp_production`, not `myapp_production_queue`. A confusing downstream symptom: `db:prepare` then appears to "skip" the secondary — it resolves to the primary database, whose `schema_migrations` table already exists, so nothing is created.

### What this changes

This does **not** change precedence — the URL still wins, which is intentional. It only adds a warning when a single configuration entry provides both a `url` and a conflicting key (`database:`, `host:`, …), so the otherwise-silent conflict becomes visible:

```
Database configuration for "queue" (production) provides both a `url` and the
conflicting key(s): database. The value(s) from the URL take precedence, so the
explicitly configured value(s) are ignored.
```

The check lives in `build_db_config_from_hash`, so it applies only to a literal `url:` key written alongside other keys in the same entry. URLs supplied through the `DATABASE_URL` environment variable go through a separate path (`environment_url_config`) and are intentionally **not** warned about — overriding `database.yml` via `DATABASE_URL` is a supported, common pattern.

The warning uses `Kernel#warn` (writes to `$stderr`, silenceable), fires only on a genuine conflict (explicit value present and different), and never interferes with config loading (the URL parsing in the check is guarded).

### Notes

- A CHANGELOG entry and tests are included (conflict warns; url-only doesn't; matching value doesn't; `DATABASE_URL` override doesn't).
- If a warning in this code path is undesirable, I'm happy to convert this into a documentation clarification in the multiple-databases guide instead.
