### PR TITLE
Refactor Arel::Table to use keyword name: argument

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -721,7 +721,7 @@ module ActiveRecord
             end
           end
 
-          table = Arel::Table.new(table_name)
+          table = Arel::Table.new(name: table_name)
           manager = Arel::InsertManager.new(table)
 
           if values_list.size == 1

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
     def initialize(pool)
       @pool = pool
-      @arel_table = Arel::Table.new(table_name)
+      @arel_table = Arel::Table.new(name: table_name)
     end
 
     def primary_key

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2023,7 +2023,7 @@ module ActiveRecord
       end
 
       def build_with_join_node(name, kind = Arel::Nodes::InnerJoin)
-        with_table = Arel::Table.new(name)
+        with_table = Arel::Table.new(name: name)
 
         table.join(with_table, kind).on(
           with_table[model.model_name.to_s.foreign_key].eq(table[model.primary_key])

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
     def initialize(pool)
       @pool = pool
-      @arel_table = Arel::Table.new(table_name)
+      @arel_table = Arel::Table.new(name: table_name)
     end
 
     def create_version(version)

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -42,7 +42,7 @@ module ActiveRecord
         TableMetadata.new(association_klass, arel_table)
       else
         type_caster = TypeCaster::Connection.new(klass, table_name)
-        arel_table = Arel::Table.new(table_name, type_caster: type_caster)
+        arel_table = Arel::Table.new(name: table_name, type_caster: type_caster)
         TableMetadata.new(nil, arel_table)
       end
     end

--- a/activerecord/lib/arel/nodes/cte.rb
+++ b/activerecord/lib/arel/nodes/cte.rb
@@ -29,7 +29,7 @@ module Arel # :nodoc: all
       end
 
       def to_table
-        Arel::Table.new(name)
+        Arel::Table.new(name: name)
       end
     end
   end

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -21,7 +21,7 @@ module Arel # :nodoc: all
     # The following example creates an equality constraint where the value of the name column on the users table
     # matches the value DHH.
     #
-    #   users = Arel::Table.new(:users)
+    #   users = Arel::Table.new(name: :users)
     #   constraint = users[:name].eq("DHH")
     #
     #   # => Arel::Nodes::Equality.new(

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -11,7 +11,7 @@ module Arel # :nodoc: all
     attr_writer :name
     attr_reader :table_alias, :klass
 
-    def initialize(name = nil, as: nil, klass: nil, type_caster: klass&.type_caster)
+    def initialize(name: nil, as: nil, klass: nil, type_caster: klass&.type_caster)
       raise ArgumentError, "A name or klass is required." unless klass || name
       name = name.name if name.is_a?(Symbol)
 

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -6,12 +6,12 @@ module Arel
   module Attributes
     class AttributeTest < Arel::Test
       test "#not_eq should create a NotEqual node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::NotEqual, relation[:id].not_eq(10)
       end
 
       test "#not_eq should generate != in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].not_eq(10)
         assert_like %{
@@ -20,7 +20,7 @@ module Arel
       end
 
       test "#not_eq should handle nil" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].not_eq(nil)
         assert_like %{
@@ -29,12 +29,12 @@ module Arel
       end
 
       test "#not_eq_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].not_eq_any([1, 2])
       end
 
       test "#not_eq_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].not_eq_any([1, 2])
         assert_like %{
@@ -43,12 +43,12 @@ module Arel
       end
 
       test "#not_eq_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].not_eq_all([1, 2])
       end
 
       test "#not_eq_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].not_eq_all([1, 2])
         assert_like %{
@@ -57,12 +57,12 @@ module Arel
       end
 
       test "#gt should create a GreaterThan node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::GreaterThan, relation[:id].gt(10)
       end
 
       test "#gt should generate > in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].gt(10)
         assert_like %{
@@ -71,7 +71,7 @@ module Arel
       end
 
       test "#gt should handle comparing with a subquery" do
-        users = Table.new(:users)
+        users = Table.new(name: :users)
 
         avg = users.project(users[:karma].average)
         mgr = users.project(Arel.star).where(users[:karma].gt(avg))
@@ -82,7 +82,7 @@ module Arel
       end
 
       test "#gt should accept various data types." do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].gt("fake_name")
         assert_match %{"users"."name" > 'fake_name'}, mgr.to_sql
@@ -93,12 +93,12 @@ module Arel
       end
 
       test "#gt_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].gt_any([1, 2])
       end
 
       test "#gt_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].gt_any([1, 2])
         assert_like %{
@@ -107,12 +107,12 @@ module Arel
       end
 
       test "#gt_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].gt_all([1, 2])
       end
 
       test "#gt_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].gt_all([1, 2])
         assert_like %{
@@ -121,12 +121,12 @@ module Arel
       end
 
       test "#gteq should create a GreaterThanOrEqual node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::GreaterThanOrEqual, relation[:id].gteq(10)
       end
 
       test "#gteq should generate >= in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].gteq(10)
         assert_like %{
@@ -135,7 +135,7 @@ module Arel
       end
 
       test "#gteq should accept various data types." do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].gteq("fake_name")
         assert_match %{"users"."name" >= 'fake_name'}, mgr.to_sql
@@ -146,12 +146,12 @@ module Arel
       end
 
       test "#gteq_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].gteq_any([1, 2])
       end
 
       test "#gteq_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].gteq_any([1, 2])
         assert_like %{
@@ -160,12 +160,12 @@ module Arel
       end
 
       test "#gteq_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].gteq_all([1, 2])
       end
 
       test "#gteq_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].gteq_all([1, 2])
         assert_like %{
@@ -174,12 +174,12 @@ module Arel
       end
 
       test "#lt should create a LessThan node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::LessThan, relation[:id].lt(10)
       end
 
       test "#lt should generate < in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].lt(10)
         assert_like %{
@@ -188,7 +188,7 @@ module Arel
       end
 
       test "#lt should accept various data types." do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].lt("fake_name")
         assert_match %{"users"."name" < 'fake_name'}, mgr.to_sql
@@ -199,12 +199,12 @@ module Arel
       end
 
       test "#lt_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].lt_any([1, 2])
       end
 
       test "#lt_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].lt_any([1, 2])
         assert_like %{
@@ -213,12 +213,12 @@ module Arel
       end
 
       test "#lt_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].lt_all([1, 2])
       end
 
       test "#lt_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].lt_all([1, 2])
         assert_like %{
@@ -227,12 +227,12 @@ module Arel
       end
 
       test "#lteq should create a LessThanOrEqual node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::LessThanOrEqual, relation[:id].lteq(10)
       end
 
       test "#lteq should generate <= in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].lteq(10)
         assert_like %{
@@ -241,7 +241,7 @@ module Arel
       end
 
       test "#lteq should accept various data types." do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].lteq("fake_name")
         assert_match %{"users"."name" <= 'fake_name'}, mgr.to_sql
@@ -252,12 +252,12 @@ module Arel
       end
 
       test "#lteq_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].lteq_any([1, 2])
       end
 
       test "#lteq_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].lteq_any([1, 2])
         assert_like %{
@@ -266,12 +266,12 @@ module Arel
       end
 
       test "#lteq_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].lteq_all([1, 2])
       end
 
       test "#lteq_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].lteq_all([1, 2])
         assert_like %{
@@ -280,12 +280,12 @@ module Arel
       end
 
       test "#average should create an AVG node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Avg, relation[:id].average
       end
 
       test "#average should generate the proper SQL" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id].average
         assert_like %{
           SELECT AVG("users"."id")
@@ -294,12 +294,12 @@ module Arel
       end
 
       test "#maximum should create a MAX node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Max, relation[:id].maximum
       end
 
       test "#maximum should generate proper SQL" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id].maximum
         assert_like %{
           SELECT MAX("users"."id")
@@ -308,12 +308,12 @@ module Arel
       end
 
       test "#minimum should create a Min node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Min, relation[:id].minimum
       end
 
       test "#minimum should generate proper SQL" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id].minimum
         assert_like %{
           SELECT MIN("users"."id")
@@ -322,12 +322,12 @@ module Arel
       end
 
       test "#sum should create a SUM node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Sum, relation[:id].sum
       end
 
       test "#sum should generate the proper SQL" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id].sum
         assert_like %{
           SELECT SUM("users"."id")
@@ -336,12 +336,12 @@ module Arel
       end
 
       test "#count should return a count node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Count, relation[:id].count
       end
 
       test "#count should take a distinct param" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         count = relation[:id].count(nil)
         assert_kind_of Nodes::Count, count
         assert_nil count.distinct
@@ -356,7 +356,7 @@ module Arel
       end
 
       test "#eq should generate = in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].eq(10)
         assert_like %{
@@ -365,7 +365,7 @@ module Arel
       end
 
       test "#eq should handle nil" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].eq(nil)
         assert_like %{
@@ -374,12 +374,12 @@ module Arel
       end
 
       test "#eq_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].eq_any([1, 2])
       end
 
       test "#eq_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].eq_any([1, 2])
         assert_like %{
@@ -388,7 +388,7 @@ module Arel
       end
 
       test "#eq_any should not eat input" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         values = [1, 2]
         mgr.where relation[:id].eq_any(values)
@@ -396,12 +396,12 @@ module Arel
       end
 
       test "#eq_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].eq_all([1, 2])
       end
 
       test "#eq_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].eq_all([1, 2])
         assert_like %{
@@ -410,7 +410,7 @@ module Arel
       end
 
       test "#eq_all should not eat input" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         values = [1, 2]
         mgr.where relation[:id].eq_all(values)
@@ -418,12 +418,12 @@ module Arel
       end
 
       test "#matches should create a Matches node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Matches, relation[:name].matches("%bacon%")
       end
 
       test "#matches should generate LIKE in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].matches("%bacon%")
         assert_like %{
@@ -432,12 +432,12 @@ module Arel
       end
 
       test "#matches_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:name].matches_any(["%chunky%", "%bacon%"])
       end
 
       test "#matches_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].matches_any(["%chunky%", "%bacon%"])
         assert_like %{
@@ -446,12 +446,12 @@ module Arel
       end
 
       test "#matches_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:name].matches_all(["%chunky%", "%bacon%"])
       end
 
       test "#matches_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].matches_all(["%chunky%", "%bacon%"])
         assert_like %{
@@ -460,12 +460,12 @@ module Arel
       end
 
       test "#does_not_match should create a DoesNotMatch node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::DoesNotMatch, relation[:name].does_not_match("%bacon%")
       end
 
       test "#does_not_match should generate NOT LIKE in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].does_not_match("%bacon%")
         assert_like %{
@@ -474,12 +474,12 @@ module Arel
       end
 
       test "#does_not_match_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:name].does_not_match_any(["%chunky%", "%bacon%"])
       end
 
       test "#does_not_match_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].does_not_match_any(["%chunky%", "%bacon%"])
         assert_like %{
@@ -488,12 +488,12 @@ module Arel
       end
 
       test "#does_not_match_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:name].does_not_match_all(["%chunky%", "%bacon%"])
       end
 
       test "#does_not_match_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].does_not_match_all(["%chunky%", "%bacon%"])
         assert_like %{
@@ -659,7 +659,7 @@ module Arel
       end
 
       test "#in can be constructed with a subquery" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].does_not_match_all(["%chunky%", "%bacon%"])
         attribute = Attribute.new nil, nil
@@ -695,7 +695,7 @@ module Arel
       end
 
       test "#in should generate IN in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].in([1, 2, 3])
         assert_like %{
@@ -704,12 +704,12 @@ module Arel
       end
 
       test "#in_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].in_any([1, 2])
       end
 
       test "#in_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].in_any([[1, 2], [3, 4]])
         assert_like %{
@@ -718,12 +718,12 @@ module Arel
       end
 
       test "#in_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].in_all([1, 2])
       end
 
       test "#in_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].in_all([[1, 2], [3, 4]])
         assert_like %{
@@ -876,7 +876,7 @@ module Arel
       end
 
       test "#not_in can be constructed with a subquery" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:name].does_not_match_all(["%chunky%", "%bacon%"])
         attribute = Attribute.new nil, nil
@@ -887,7 +887,7 @@ module Arel
       end
 
       test "#not_in can be constructed with a Union" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr1 = relation.project(relation[:id])
         mgr2 = relation.project(relation[:id])
 
@@ -924,7 +924,7 @@ module Arel
       end
 
       test "#not_in should generate NOT IN in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].not_in([1, 2, 3])
         assert_like %{
@@ -933,12 +933,12 @@ module Arel
       end
 
       test "#not_in_any should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].not_in_any([1, 2])
       end
 
       test "#not_in_any should generate ORs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].not_in_any([[1, 2], [3, 4]])
         assert_like %{
@@ -947,12 +947,12 @@ module Arel
       end
 
       test "#not_in_all should create a Grouping node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].not_in_all([1, 2])
       end
 
       test "#not_in_all should generate ANDs in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].not_in_all([[1, 2], [3, 4]])
         assert_like %{
@@ -961,12 +961,12 @@ module Arel
       end
 
       test "#eq_all should create a Grouping node (2)" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Grouping, relation[:id].eq_all([1, 2])
       end
 
       test "#eq_all should generate ANDs in sql (2)" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.where relation[:id].eq_all([1, 2])
         assert_like %{
@@ -975,12 +975,12 @@ module Arel
       end
 
       test "#asc should create an Ascending node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Ascending, relation[:id].asc
       end
 
       test "#asc should generate ASC in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.order relation[:id].asc
         assert_like %{
@@ -989,12 +989,12 @@ module Arel
       end
 
       test "#desc should create a Descending node" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         assert_kind_of Nodes::Descending, relation[:id].desc
       end
 
       test "#desc should generate DESC in sql" do
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         mgr = relation.project relation[:id]
         mgr.order relation[:id].desc
         assert_like %{
@@ -1003,37 +1003,37 @@ module Arel
       end
 
       test "#contains should create a Contains node" do
-        relation = Table.new(:products)
+        relation = Table.new(name: :products)
         assert_kind_of Nodes::Contains, relation[:tags].contains(["foo", "bar"])
       end
 
       test "#contains should generate @> in sql" do
-        relation = Table.new(:products, type_caster: fake_pg_caster)
+        relation = Table.new(name: :products, type_caster: fake_pg_caster)
         mgr = relation.project relation[:id]
         mgr.where relation[:tags].contains(["foo", "bar"])
         assert_like %{ SELECT "products"."id" FROM "products" WHERE "products"."tags" @> '{foo,bar}' }, mgr.to_sql
       end
 
       test "#overlaps should create an Overlaps node" do
-        relation = Table.new(:products)
+        relation = Table.new(name: :products)
         assert_kind_of Nodes::Overlaps, relation[:tags].overlaps(["foo", "bar"])
       end
 
       test "#overlaps should generate && in sql" do
-        relation = Table.new(:products, type_caster: fake_pg_caster)
+        relation = Table.new(name: :products, type_caster: fake_pg_caster)
         mgr = relation.project relation[:id]
         mgr.where relation[:tags].overlaps(["foo", "bar"])
         assert_like %{ SELECT "products"."id" FROM "products" WHERE "products"."tags" && '{foo,bar}' }, mgr.to_sql
       end
 
       test "equality #to_sql should produce sql" do
-        table = Table.new :users
+        table = Table.new name: :users
         condition = table["id"].eq 1
         assert_equal '"users"."id" = 1', condition.to_sql
       end
 
       test "type casting does not type cast by default" do
-        table = Table.new(:foo)
+        table = Table.new(name: :foo)
         condition = table["id"].eq("1")
 
         assert_not table.able_to_type_cast?
@@ -1049,7 +1049,7 @@ module Arel
             value
           end
         end
-        table = Table.new(:foo, type_caster: fake_caster)
+        table = Table.new(name: :foo, type_caster: fake_caster)
         condition = table["id"].eq("1").and(table["other_id"].eq("2"))
 
         assert_predicate table, :able_to_type_cast?
@@ -1061,7 +1061,7 @@ module Arel
         def fake_caster.type_cast_for_database(attr_name, value)
           value.to_i
         end
-        table = Table.new(:foo, type_caster: fake_caster)
+        table = Table.new(name: :foo, type_caster: fake_caster)
         condition = table["id"].eq(Arel.sql("(select 1)"))
 
         assert_predicate table, :able_to_type_cast?

--- a/activerecord/test/cases/arel/attributes/math_test.rb
+++ b/activerecord/test/cases/arel/attributes/math_test.rb
@@ -7,35 +7,35 @@ module Arel
     class MathTest < Arel::Test
       %i[* /].each do |math_operator|
         test "average should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             AVG("users"."id") #{math_operator} 2
           }, table[:id].average.public_send(math_operator, 2).to_sql
         end
 
         test "count should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             COUNT("users"."id") #{math_operator} 2
           }, table[:id].count.public_send(math_operator, 2).to_sql
         end
 
         test "maximum should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             MAX("users"."id") #{math_operator} 2
           }, table[:id].maximum.public_send(math_operator, 2).to_sql
         end
 
         test "minimum should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             MIN("users"."id") #{math_operator} 2
           }, table[:id].minimum.public_send(math_operator, 2).to_sql
         end
 
         test "attribute node should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             "users"."id" #{math_operator} 2
           }, table[:id].public_send(math_operator, 2).to_sql
@@ -44,35 +44,35 @@ module Arel
 
       %i[+ - & | ^ << >>].each do |math_operator|
         test "average should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             (AVG("users"."id") #{math_operator} 2)
           }, table[:id].average.public_send(math_operator, 2).to_sql
         end
 
         test "count should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             (COUNT("users"."id") #{math_operator} 2)
           }, table[:id].count.public_send(math_operator, 2).to_sql
         end
 
         test "maximum should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             (MAX("users"."id") #{math_operator} 2)
           }, table[:id].maximum.public_send(math_operator, 2).to_sql
         end
 
         test "minimum should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             (MIN("users"."id") #{math_operator} 2)
           }, table[:id].minimum.public_send(math_operator, 2).to_sql
         end
 
         test "attribute node should be compatible with #{math_operator}" do
-          table = Arel::Table.new :users
+          table = Arel::Table.new name: :users
           assert_like %{
             ("users"."id" #{math_operator} 2)
           }, table[:id].public_send(math_operator, 2).to_sql

--- a/activerecord/test/cases/arel/attributes_test.rb
+++ b/activerecord/test/cases/arel/attributes_test.rb
@@ -5,7 +5,7 @@ require_relative "helper"
 module Arel
   class AttributesTest < Arel::Test
     test "responds to lower" do
-      relation  = Table.new(:users)
+      relation  = Table.new(name: :users)
       attribute = relation[:foo]
       node      = attribute.lower
       assert_equal "LOWER", node.name

--- a/activerecord/test/cases/arel/collectors/bind_test.rb
+++ b/activerecord/test/cases/arel/collectors/bind_test.rb
@@ -29,7 +29,7 @@ module Arel
         end
 
         def ast_with_binds(bvs)
-          table = Table.new(:users)
+          table = Table.new(name: :users)
           manager = Arel::SelectManager.new table
           manager.where(table[:age].eq(Nodes::BindParam.new(bvs.shift)))
           manager.where(table[:name].eq(Nodes::BindParam.new(bvs.shift)))

--- a/activerecord/test/cases/arel/collectors/composite_test.rb
+++ b/activerecord/test/cases/arel/collectors/composite_test.rb
@@ -46,7 +46,7 @@ module Arel
         end
 
         def ast_with_binds(bvs)
-          table = Table.new(:users)
+          table = Table.new(name: :users)
           manager = Arel::SelectManager.new table
           manager.where(table[:age].eq(Nodes::BindParam.new(bvs.shift)))
           manager.where(table[:name].eq(Nodes::BindParam.new(bvs.shift)))

--- a/activerecord/test/cases/arel/collectors/sql_string_test.rb
+++ b/activerecord/test/cases/arel/collectors/sql_string_test.rb
@@ -30,7 +30,7 @@ module Arel
         end
 
         def ast_with_binds
-          table = Table.new(:users)
+          table = Table.new(name: :users)
           manager = Arel::SelectManager.new table
           manager.where(table[:age].eq(Nodes::BindParam.new("hello")))
           manager.where(table[:name].eq(Nodes::BindParam.new("world")))

--- a/activerecord/test/cases/arel/collectors/substitute_bind_collector_test.rb
+++ b/activerecord/test/cases/arel/collectors/substitute_bind_collector_test.rb
@@ -13,7 +13,7 @@ module Arel
       end
 
       def ast_with_binds
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         manager = Arel::SelectManager.new table
         manager.where(table[:age].eq(Nodes::BindParam.new("hello")))
         manager.where(table[:name].eq(Nodes::BindParam.new("world")))

--- a/activerecord/test/cases/arel/crud_test.rb
+++ b/activerecord/test/cases/arel/crud_test.rb
@@ -33,7 +33,7 @@ module Arel
 
   class CrudTest < Arel::Test
     test "insert should call insert on the connection" do
-      table = Table.new :users
+      table = Table.new name: :users
       fc = FakeCrudder.new
       fc.from table
       im = fc.compile_insert [[table[:id], "foo"]]
@@ -41,7 +41,7 @@ module Arel
     end
 
     test "update should call update on the connection" do
-      table = Table.new :users
+      table = Table.new name: :users
       fc = FakeCrudder.new
       fc.from table
       stmt = fc.compile_update [[table[:id], "foo"]], Arel::Attributes::Attribute.new(table, "id")
@@ -49,7 +49,7 @@ module Arel
     end
 
     test "delete should call delete on the connection" do
-      table = Table.new :users
+      table = Table.new name: :users
       fc = FakeCrudder.new
       fc.from table
       stmt = fc.compile_delete

--- a/activerecord/test/cases/arel/delete_manager_test.rb
+++ b/activerecord/test/cases/arel/delete_manager_test.rb
@@ -9,7 +9,7 @@ module Arel
     include TreeManagerBehavior
 
     test "handles limit properly" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       dm = Arel::DeleteManager.new
       dm.take 10
       dm.from table
@@ -18,20 +18,20 @@ module Arel
     end
 
     test "from uses from" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       dm = Arel::DeleteManager.new
       dm.from table
       assert_like %{ DELETE FROM "users" }, dm.to_sql
     end
 
     test "from chains" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       dm = Arel::DeleteManager.new
       assert_equal dm, dm.from(table)
     end
 
     test "where uses where values" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       dm = Arel::DeleteManager.new
       dm.from table
       dm.where table[:id].eq(10)
@@ -39,13 +39,13 @@ module Arel
     end
 
     test "where chains" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       dm = Arel::DeleteManager.new
       assert_equal dm, dm.where(table[:id].eq(10))
     end
 
     test "#returning accepts a returning clause" do
-      users   = Table.new :users
+      users   = Table.new name: :users
       manager = Arel::DeleteManager.new
       manager.from users
       manager.returning Arel.star
@@ -56,7 +56,7 @@ module Arel
     end
 
     test "#returning accepts multiple values as returning clause" do
-      users   = Table.new :users
+      users   = Table.new name: :users
       manager = Arel::DeleteManager.new
       manager.from users
       manager.returning Arel.star

--- a/activerecord/test/cases/arel/factory_methods_test.rb
+++ b/activerecord/test/cases/arel/factory_methods_test.rb
@@ -67,7 +67,7 @@ module Arel
       end
 
       def test_coalesce
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         field_node = relation[:active]
         coalesce = @factory.coalesce field_node, 0
         assert_instance_of Nodes::NamedFunction, coalesce
@@ -76,7 +76,7 @@ module Arel
       end
 
       def test_cast
-        relation = Table.new(:users)
+        relation = Table.new(name: :users)
         field_node = relation[:active]
         cast = @factory.cast field_node, "boolean"
         assert_instance_of Nodes::NamedFunction, cast

--- a/activerecord/test/cases/arel/insert_manager_test.rb
+++ b/activerecord/test/cases/arel/insert_manager_test.rb
@@ -17,7 +17,7 @@ module Arel
 
     test "insert allows sql literals" do
       manager = Arel::InsertManager.new
-      manager.into Table.new(:users)
+      manager.into Table.new(name: :users)
       manager.values = manager.create_values([Arel.sql("*")])
 
       assert_like %{
@@ -26,7 +26,7 @@ module Arel
     end
 
     test "insert works with multiple values" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       manager.into table
 
@@ -45,7 +45,7 @@ module Arel
     end
 
     test "insert literals in multiple values are not escaped" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       manager.into table
 
@@ -62,7 +62,7 @@ module Arel
     end
 
     test "insert works with multiple single values" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       manager.into table
 
@@ -80,7 +80,7 @@ module Arel
     end
 
     test "insert inserts false" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
 
       manager.insert [[table[:bool], false]]
@@ -90,7 +90,7 @@ module Arel
     end
 
     test "insert inserts null" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       manager.insert [[table[:id], nil]]
 
@@ -100,7 +100,7 @@ module Arel
     end
 
     test "insert inserts time" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
 
       time = Time.now
@@ -113,7 +113,7 @@ module Arel
     end
 
     test "insert takes a list of lists" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       manager.into table
       manager.insert [[table[:id], 1], [table[:name], "aaron"]]
@@ -124,7 +124,7 @@ module Arel
     end
 
     test "insert defaults the table" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       manager.insert [[table[:id], 1], [table[:name], "aaron"]]
 
@@ -134,7 +134,7 @@ module Arel
     end
 
     test "insert noop for empty list" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       manager.insert [[table[:id], 1]]
       manager.insert []
@@ -145,7 +145,7 @@ module Arel
     end
 
     test "insert is chainable" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::InsertManager.new
       insert_result = manager.insert [[table[:id], 1]]
 
@@ -155,11 +155,11 @@ module Arel
     test "into takes a Table and chains" do
       manager = Arel::InsertManager.new
 
-      assert_equal manager, manager.into(Table.new(:users))
+      assert_equal manager, manager.into(Table.new(name: :users))
     end
 
     test "into converts to sql" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into table
 
@@ -169,7 +169,7 @@ module Arel
     end
 
     test "columns converts to sql" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into table
       manager.columns << table[:id]
@@ -180,7 +180,7 @@ module Arel
     end
 
     test "values converts to sql" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into table
       manager.values = Nodes::ValuesList.new([[1], [2]])
@@ -191,7 +191,7 @@ module Arel
     end
 
     test "values accepts sql literals" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into table
       manager.values = Arel.sql("DEFAULT VALUES")
@@ -202,7 +202,7 @@ module Arel
     end
 
     test "combo combines columns and values list in order" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into table
 
@@ -216,7 +216,7 @@ module Arel
     end
 
     test "select accepts a select query in place of a VALUES clause" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into table
 
@@ -234,7 +234,7 @@ module Arel
     end
 
     test "#returning accepts a returning clause" do
-      users   = Table.new :users
+      users   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into users
       manager.returning Arel.star
@@ -245,7 +245,7 @@ module Arel
     end
 
     test "#returning accepts multiple values as returning clause" do
-      users   = Table.new :users
+      users   = Table.new name: :users
       manager = Arel::InsertManager.new
       manager.into users
       manager.returning Arel.star

--- a/activerecord/test/cases/arel/nodes/as_test.rb
+++ b/activerecord/test/cases/arel/nodes/as_test.rb
@@ -6,20 +6,20 @@ module Arel
   module Nodes
     class AsTest < Arel::Test
       test "#as makes an AS node" do
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         as = attr.as(Arel.sql("foo"))
         assert_equal attr, as.left
         assert_equal "foo", as.right
       end
 
       test "#as converts right to SqlLiteral if a string" do
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         as = attr.as("foo")
         assert_kind_of Arel::Nodes::SqlLiteral, as.right
       end
 
       test "#as converts right to SqlLiteral if a symbol" do
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         as = attr.as(:foo)
         assert_kind_of Arel::Nodes::SqlLiteral, as.right
       end
@@ -35,7 +35,7 @@ module Arel
       end
 
       test "#to_cte returns a Cte node using the LHS's name and the RHS as the relation" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         as_node = As.new(table, "foo")
         cte_node = as_node.to_cte
 

--- a/activerecord/test/cases/arel/nodes/count_test.rb
+++ b/activerecord/test/cases/arel/nodes/count_test.rb
@@ -4,14 +4,14 @@ require_relative "../helper"
 
 class Arel::Nodes::CountTest < Arel::Test
   test "as should alias the count" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       COUNT("users"."id") AS foo
     }, table[:id].count.as("foo").to_sql
   end
 
   test "eq should compare the count" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       COUNT("users"."id") = 2
     }, table[:id].count.eq(2).to_sql

--- a/activerecord/test/cases/arel/nodes/equality_test.rb
+++ b/activerecord/test/cases/arel/nodes/equality_test.rb
@@ -16,14 +16,14 @@ module Arel
         }
         engine.lease_connection.quote_count = 0
 
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         test = attr.eq(10)
         test.to_sql engine
         assert_equal 3, engine.lease_connection.quote_count
       end
 
       test "or makes an OR node" do
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         left  = attr.eq(10)
         right = attr.eq(11)
         node  = left.or right
@@ -32,7 +32,7 @@ module Arel
       end
 
       test "and makes and AND node" do
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         left  = attr.eq(10)
         right = attr.eq(11)
         node  = left.and right

--- a/activerecord/test/cases/arel/nodes/extract_test.rb
+++ b/activerecord/test/cases/arel/nodes/extract_test.rb
@@ -4,21 +4,21 @@ require_relative "../helper"
 
 class Arel::Nodes::ExtractTest < Arel::Test
   test "should extract field" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       EXTRACT(DATE FROM "users"."timestamp")
     }, table[:timestamp].extract("date").to_sql
   end
 
   test "as should alias the extract" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       EXTRACT(DATE FROM "users"."timestamp") AS foo
     }, table[:timestamp].extract("date").as("foo").to_sql
   end
 
   test "as should not mutate the extract" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     extract = table[:timestamp].extract("date")
     before = extract.dup
     extract.as("foo")
@@ -26,13 +26,13 @@ class Arel::Nodes::ExtractTest < Arel::Test
   end
 
   test "equality is equal with equal ivars" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     array = [table[:attr].extract("foo"), table[:attr].extract("foo")]
     assert_equal 1, array.uniq.size
   end
 
   test "equality is not equal with different ivars" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     array = [table[:attr].extract("foo"), table[:attr].extract("bar")]
     assert_equal 2, array.uniq.size
   end

--- a/activerecord/test/cases/arel/nodes/filter_test.rb
+++ b/activerecord/test/cases/arel/nodes/filter_test.rb
@@ -6,7 +6,7 @@ module Arel
   module Nodes
     class ::FilterTest < Arel::Test
       test "Filter should add filter to expression" do
-        table = Arel::Table.new :users
+        table = Arel::Table.new name: :users
 
         assert_like %{
           COUNT("users"."id") FILTER (WHERE "users"."income" >= 40000)
@@ -14,7 +14,7 @@ module Arel
       end
 
       test "Filter as should alias the expression" do
-        table = Arel::Table.new :users
+        table = Arel::Table.new name: :users
 
         assert_like %{
           COUNT("users"."id") FILTER (WHERE "users"."income" >= 40000) AS rich_users_count
@@ -22,7 +22,7 @@ module Arel
       end
 
       test "Filter over should reference the window definition by name" do
-        table = Arel::Table.new :users
+        table = Arel::Table.new name: :users
         window = Arel::Nodes::Window.new.partition(table[:year])
 
         assert_like %{

--- a/activerecord/test/cases/arel/nodes/homogeneous_in_test.rb
+++ b/activerecord/test/cases/arel/nodes/homogeneous_in_test.rb
@@ -6,7 +6,7 @@ require "active_model"
 
 class Arel::Nodes::HomogeneousInTest < Arel::Test
   test "in" do
-    table = Arel::Table.new :users, type_caster: fake_pg_caster
+    table = Arel::Table.new name: :users, type_caster: fake_pg_caster
 
     expr = Arel::Nodes::HomogeneousIn.new(["Bobby", "Robert"], table[:name], :in)
 
@@ -16,7 +16,7 @@ class Arel::Nodes::HomogeneousInTest < Arel::Test
   end
 
   test "custom attribute node" do
-    table = Arel::Table.new :users, type_caster: fake_pg_caster
+    table = Arel::Table.new name: :users, type_caster: fake_pg_caster
 
     node = TypedNode.new("COALESCE",
                          [table[:nickname], table[:name]],

--- a/activerecord/test/cases/arel/nodes/not_test.rb
+++ b/activerecord/test/cases/arel/nodes/not_test.rb
@@ -6,7 +6,7 @@ module Arel
   module Nodes
     class NotTest < Arel::Test
       test "#not makes a NOT node" do
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         expr  = attr.eq(10)
         node  = expr.not
 

--- a/activerecord/test/cases/arel/nodes/or_test.rb
+++ b/activerecord/test/cases/arel/nodes/or_test.rb
@@ -6,7 +6,7 @@ module Arel
   module Nodes
     class OrTest < Arel::Test
       test "#or makes an OR node" do
-        attr = Table.new(:users)[:id]
+        attr = Table.new(name: :users)[:id]
         left  = attr.eq(10)
         right = attr.eq(11)
         node  = left.or right

--- a/activerecord/test/cases/arel/nodes/over_test.rb
+++ b/activerecord/test/cases/arel/nodes/over_test.rb
@@ -4,35 +4,35 @@ require_relative "../helper"
 
 class Arel::Nodes::OverTest < Arel::Test
   test "as should alias the expression" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       COUNT("users"."id") OVER () AS foo
     }, table[:id].count.over.as("foo").to_sql
   end
 
   test "with literal should reference the window definition by name" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       COUNT("users"."id") OVER "foo"
     }, table[:id].count.over("foo").to_sql
   end
 
   test "with SQL literal should reference the window definition by name" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       COUNT("users"."id") OVER foo
     }, table[:id].count.over(Arel.sql("foo")).to_sql
   end
 
   test "with no expression should use empty definition" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       COUNT("users"."id") OVER ()
     }, table[:id].count.over.to_sql
   end
 
   test "with expression should use definition in sub-expression" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     window = Arel::Nodes::Window.new.order(table["foo"])
     assert_like %{
       COUNT("users"."id") OVER (ORDER BY \"users\".\"foo\")

--- a/activerecord/test/cases/arel/nodes/sum_test.rb
+++ b/activerecord/test/cases/arel/nodes/sum_test.rb
@@ -4,7 +4,7 @@ require_relative "../helper"
 
 class Arel::Nodes::SumTest < Arel::Test
   test "as should alias the sum" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       SUM("users"."id") AS foo
     }, table[:id].sum.as("foo").to_sql
@@ -21,7 +21,7 @@ class Arel::Nodes::SumTest < Arel::Test
   end
 
   test "order should order the sum" do
-    table = Arel::Table.new :users
+    table = Arel::Table.new name: :users
     assert_like %{
       SUM("users"."id") DESC
     }, table[:id].sum.desc.to_sql

--- a/activerecord/test/cases/arel/nodes/table_alias_test.rb
+++ b/activerecord/test/cases/arel/nodes/table_alias_test.rb
@@ -6,25 +6,25 @@ module Arel
   module Nodes
     class TableAliasTest < Arel::Test
       test "equality is equal with equal ivars" do
-        relation1 = Table.new(:users)
+        relation1 = Table.new(name: :users)
         node1     = TableAlias.new relation1, :foo
-        relation2 = Table.new(:users)
+        relation2 = Table.new(name: :users)
         node2     = TableAlias.new relation2, :foo
         array = [node1, node2]
         assert_equal 1, array.uniq.size
       end
 
       test "equality is not equal with different ivars" do
-        relation1 = Table.new(:users)
+        relation1 = Table.new(name: :users)
         node1     = TableAlias.new relation1, :foo
-        relation2 = Table.new(:users)
+        relation2 = Table.new(name: :users)
         node2     = TableAlias.new relation2, :bar
         array = [node1, node2]
         assert_equal 2, array.uniq.size
       end
 
       test "#to_cte returns a Cte node using the TableAlias's name and relation" do
-        relation = Table.new(:users).project(Arel.star)
+        relation = Table.new(name: :users).project(Arel.star)
         table_alias = TableAlias.new(relation, :foo)
         cte = table_alias.to_cte
 

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -11,7 +11,7 @@ module Arel
     end
 
     test "backwards compatibility project accepts symbols as sql literals" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.project :id
       manager.from table
@@ -20,7 +20,7 @@ module Arel
     end
 
     test "backwards compatibility order accepts symbols" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.project Nodes::SqlLiteral.new "*"
       manager.from table
@@ -29,7 +29,7 @@ module Arel
     end
 
     test "backwards compatibility group takes a symbol" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.group :foo
@@ -63,7 +63,7 @@ module Arel
     end
 
     test "backwards compatibility from ignores strings when table of same name exists" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
 
       manager.from table
@@ -73,7 +73,7 @@ module Arel
     end
 
     test "backwards compatibility from should support any ast" do
-      table = Table.new :users
+      table = Table.new name: :users
       manager1 = Arel::SelectManager.new
 
       manager2 = Arel::SelectManager.new
@@ -89,14 +89,14 @@ module Arel
     end
 
     test "backwards compatibility having converts strings to SQLLiterals" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       mgr.having Arel.sql("foo")
       assert_like %{ SELECT FROM "users" HAVING foo }, mgr.to_sql
     end
 
     test "backwards compatibility having can have multiple items specified separately" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       mgr.having Arel.sql("foo")
       mgr.having Arel.sql("bar")
@@ -104,14 +104,14 @@ module Arel
     end
 
     test "backwards compatibility having can receive any node" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       mgr.having Arel::Nodes::And.new([Arel.sql("foo"), Arel.sql("bar")])
       assert_like %{ SELECT FROM "users" HAVING foo AND bar }, mgr.to_sql
     end
 
     test "backwards compatibility on converts to sqlliterals" do
-      table = Table.new :users
+      table = Table.new name: :users
       right = table.alias
       mgr   = table.from
       mgr.join(right).on("omg")
@@ -119,7 +119,7 @@ module Arel
     end
 
     test "backwards compatibility on converts to sqlliterals with multiple items" do
-      table = Table.new :users
+      table = Table.new name: :users
       right = table.alias
       mgr   = table.from
       mgr.join(right).on("omg", "123")
@@ -127,7 +127,7 @@ module Arel
     end
 
     test "clone creates new cores" do
-      table = Table.new :users, as: "foo"
+      table = Table.new name: :users, as: "foo"
       mgr = table.from
       m2 = mgr.clone
       m2.project "foo"
@@ -135,7 +135,7 @@ module Arel
     end
 
     test "clone makes updates to the correct copy" do
-      table = Table.new :users, as: "foo"
+      table = Table.new name: :users, as: "foo"
       mgr = table.from
       m2 = mgr.clone
       m3 = m2.clone
@@ -145,34 +145,34 @@ module Arel
     end
 
     test "initialize uses alias in sql" do
-      table = Table.new :users, as: "foo"
+      table = Table.new name: :users, as: "foo"
       mgr = table.from
       mgr.skip 10
       assert_like %{ SELECT FROM "users" "foo" OFFSET 10 }, mgr.to_sql
     end
 
     test "skip should add an offset" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       mgr.skip 10
       assert_like %{ SELECT FROM "users" OFFSET 10 }, mgr.to_sql
     end
 
     test "skip should chain" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       assert_like %{ SELECT FROM "users" OFFSET 10 }, mgr.skip(10).to_sql
     end
 
     test "offset should add an offset" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       mgr.offset = 10
       assert_like %{ SELECT FROM "users" OFFSET 10 }, mgr.to_sql
     end
 
     test "offset should remove an offset" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       mgr.offset = 10
       assert_like %{ SELECT FROM "users" OFFSET 10 }, mgr.to_sql
@@ -182,14 +182,14 @@ module Arel
     end
 
     test "offset should return the offset" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       mgr.offset = 10
       assert_equal 10, mgr.offset
     end
 
     test "exists should create an exists clause" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::SelectManager.new table
       manager.project Nodes::SqlLiteral.new "*"
       m2 = Arel::SelectManager.new
@@ -198,7 +198,7 @@ module Arel
     end
 
     test "exists can be aliased" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       manager = Arel::SelectManager.new table
       manager.project Nodes::SqlLiteral.new "*"
       m2 = Arel::SelectManager.new
@@ -208,7 +208,7 @@ module Arel
 
 
     test "union should union two managers" do
-      table = Table.new :users
+      table = Table.new name: :users
       @m1 = Arel::SelectManager.new table
       @m1.project Arel.star
       @m1.where(table[:age].lt(18))
@@ -226,7 +226,7 @@ module Arel
     end
 
     test "union should union all" do
-      table = Table.new :users
+      table = Table.new name: :users
       @m1 = Arel::SelectManager.new table
       @m1.project Arel.star
       @m1.where(table[:age].lt(18))
@@ -242,7 +242,7 @@ module Arel
 
 
     test "intersect should intersect two managers" do
-      table = Table.new :users
+      table = Table.new name: :users
       @m1 = Arel::SelectManager.new table
       @m1.project Arel.star
       @m1.where(table[:age].gt(18))
@@ -261,7 +261,7 @@ module Arel
 
 
     test "except should except two managers" do
-      table = Table.new :users
+      table = Table.new name: :users
       @m1 = Arel::SelectManager.new table
       @m1.project Arel.star
       @m1.where(table[:age].between(18..60))
@@ -279,9 +279,9 @@ module Arel
     end
 
     test "with should support basic WITH" do
-      users          = Table.new(:users)
-      users_top      = Table.new(:users_top)
-      comments       = Table.new(:comments)
+      users          = Table.new(name: :users)
+      users_top      = Table.new(name: :users_top)
+      comments       = Table.new(name: :comments)
 
       top            = users.project(users[:id]).where(users[:karma].gt(100))
       users_as       = Arel::Nodes::As.new(users_top, top)
@@ -293,11 +293,11 @@ module Arel
     end
 
     test "with should support WITH RECURSIVE" do
-      comments           = Table.new(:comments)
+      comments           = Table.new(name: :comments)
       comments_id        = comments[:id]
       comments_parent_id = comments[:parent_id]
 
-      replies            = Table.new(:replies)
+      replies            = Table.new(name: :replies)
       replies_id         = replies[:id]
 
       non_recursive_term = Arel::SelectManager.new
@@ -324,7 +324,7 @@ module Arel
     end
 
     test "ast should return the ast" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       assert mgr.ast
     end
@@ -337,13 +337,13 @@ module Arel
 
     # This should fail on other databases
     test "lock adds a lock node" do
-      table = Table.new :users
+      table = Table.new name: :users
       mgr = table.from
       assert_like %{ SELECT FROM "users" FOR UPDATE }, mgr.lock.to_sql
     end
 
     test "orders returns order clauses" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       order = table[:id]
       manager.order table[:id]
@@ -351,7 +351,7 @@ module Arel
     end
 
     test "order generates order clauses" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.project Nodes::SqlLiteral.new "*"
       manager.from table
@@ -362,7 +362,7 @@ module Arel
 
     # FIXME: I would like to deprecate this
     test "order takes *args" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.project Nodes::SqlLiteral.new "*"
       manager.from table
@@ -372,13 +372,13 @@ module Arel
     end
 
     test "order chains" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       assert_equal manager, manager.order(table[:id])
     end
 
     test "order has order attributes" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.project Nodes::SqlLiteral.new "*"
       manager.from table
@@ -388,7 +388,7 @@ module Arel
     end
 
     test "on takes two params" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
       manager   = Arel::SelectManager.new
@@ -403,7 +403,7 @@ module Arel
     end
 
     test "on takes three params" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
       manager   = Arel::SelectManager.new
@@ -474,7 +474,7 @@ module Arel
     end
 
     test "join responds to join" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
       manager   = Arel::SelectManager.new
@@ -488,7 +488,7 @@ module Arel
     end
 
     test "join takes a class" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
       manager   = Arel::SelectManager.new
@@ -502,7 +502,7 @@ module Arel
     end
 
     test "join takes the full outer join class" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
       manager   = Arel::SelectManager.new
@@ -516,7 +516,7 @@ module Arel
     end
 
     test "join takes the right outer join class" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
       manager   = Arel::SelectManager.new
@@ -535,7 +535,7 @@ module Arel
     end
 
     test "join raises EmptyJoinError on empty" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       manager   = Arel::SelectManager.new
 
       manager.from left
@@ -545,7 +545,7 @@ module Arel
     end
 
     test "outer join responds to join" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
       manager   = Arel::SelectManager.new
@@ -564,7 +564,7 @@ module Arel
     end
 
     test "joins returns inner join sql" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       aliaz   = table.alias
       manager = Arel::SelectManager.new
       manager.from Nodes::InnerJoin.new(aliaz, table[:id].eq(aliaz[:id]))
@@ -573,7 +573,7 @@ module Arel
     end
 
     test "joins returns outer join sql" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       aliaz   = table.alias
       manager = Arel::SelectManager.new
       manager.from Nodes::OuterJoin.new(aliaz, table[:id].eq(aliaz[:id]))
@@ -582,8 +582,8 @@ module Arel
     end
 
     test "joins can have a non-table alias as relation name" do
-      users    = Table.new :users
-      comments = Table.new :comments
+      users    = Table.new name: :users
+      comments = Table.new name: :comments
 
       counts = comments.from.
         group(comments[:user_id]).
@@ -598,7 +598,7 @@ module Arel
     end
 
     test "joins joins itself" do
-      left      = Table.new :users
+      left      = Table.new name: :users
       right     = left.alias
       predicate = left[:id].eq(right[:id])
 
@@ -619,7 +619,7 @@ module Arel
     end
 
     test "group takes an attribute" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.group table[:id]
@@ -628,13 +628,13 @@ module Arel
     end
 
     test "group chains" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       assert_equal manager, manager.group(table[:id])
     end
 
     test "group takes multiple args" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.group table[:id], table[:name]
@@ -644,7 +644,7 @@ module Arel
 
     # FIXME: backwards compat
     test "group makes strings literals" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.group "foo"
@@ -652,7 +652,7 @@ module Arel
     end
 
     test "window definition can be empty" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window")
@@ -661,7 +661,7 @@ module Arel
     end
 
     test "window definition takes an order" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").order(table["foo"].asc)
@@ -670,7 +670,7 @@ module Arel
     end
 
     test "window definition takes an order with multiple columns" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").order(table["foo"].asc, table["bar"].desc)
@@ -679,7 +679,7 @@ module Arel
     end
 
     test "window definition takes a partition" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").partition(table["bar"])
@@ -688,7 +688,7 @@ module Arel
     end
 
     test "window definition takes a partition and an order" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").partition(table["foo"]).order(table["foo"].asc)
@@ -698,7 +698,7 @@ module Arel
     end
 
     test "window definition takes a partition with multiple columns" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").partition(table["bar"], table["baz"])
@@ -707,7 +707,7 @@ module Arel
     end
 
     test "window definition takes a rows frame, unbounded preceding" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").rows(Arel::Nodes::Preceding.new)
@@ -716,7 +716,7 @@ module Arel
     end
 
     test "window definition takes a rows frame, bounded preceding" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").rows(Arel::Nodes::Preceding.new(5))
@@ -725,7 +725,7 @@ module Arel
     end
 
     test "window definition takes a rows frame, unbounded following" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").rows(Arel::Nodes::Following.new)
@@ -734,7 +734,7 @@ module Arel
     end
 
     test "window definition takes a rows frame, bounded following" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").rows(Arel::Nodes::Following.new(5))
@@ -743,7 +743,7 @@ module Arel
     end
 
     test "window definition takes a rows frame, current row" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").rows(Arel::Nodes::CurrentRow.new)
@@ -752,7 +752,7 @@ module Arel
     end
 
     test "window definition takes a rows frame, between two delimiters" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       window = manager.window("a_window")
@@ -768,7 +768,7 @@ module Arel
     end
 
     test "window definition takes a range frame, unbounded preceding" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").range(Arel::Nodes::Preceding.new)
@@ -777,7 +777,7 @@ module Arel
     end
 
     test "window definition takes a range frame, bounded preceding" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").range(Arel::Nodes::Preceding.new(5))
@@ -786,7 +786,7 @@ module Arel
     end
 
     test "window definition takes a range frame, unbounded following" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").range(Arel::Nodes::Following.new)
@@ -795,7 +795,7 @@ module Arel
     end
 
     test "window definition takes a range frame, bounded following" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").range(Arel::Nodes::Following.new(5))
@@ -804,7 +804,7 @@ module Arel
     end
 
     test "window definition takes a range frame, current row" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.window("a_window").range(Arel::Nodes::CurrentRow.new)
@@ -813,7 +813,7 @@ module Arel
     end
 
     test "window definition takes a range frame, between two delimiters" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       window = manager.window("a_window")
@@ -829,7 +829,7 @@ module Arel
     end
 
     test "delete copies from" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       stmt = manager.compile_delete
@@ -838,7 +838,7 @@ module Arel
     end
 
     test "delete copies where" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.where table[:id].eq 10
@@ -849,7 +849,7 @@ module Arel
     end
 
     test "where_sql gives me back the where sql" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.where table[:id].eq 10
@@ -857,7 +857,7 @@ module Arel
     end
 
     test "where_sql joins wheres with AND" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.where table[:id].eq 10
@@ -868,7 +868,7 @@ module Arel
     test "where_sql handles database-specific statements" do
       old_visitor = Table.engine.lease_connection.visitor
       Table.engine.lease_connection.visitor = Visitors::PostgreSQL.new Table.engine.lease_connection
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.where table[:id].eq 10
@@ -878,14 +878,14 @@ module Arel
     end
 
     test "where_sql returns nil when there are no wheres" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       assert_nil manager.where_sql
     end
 
     test "update creates an update statement" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       stmt = manager.compile_update({ table[:id] => 1 }, Arel::Attributes::Attribute.new(table, "id"))
@@ -895,7 +895,7 @@ module Arel
     end
 
     test "update takes a string" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       stmt = manager.compile_update(Nodes::SqlLiteral.new("foo = bar"), Arel::Attributes::Attribute.new(table, "id"))
@@ -904,7 +904,7 @@ module Arel
     end
 
     test "update copies limits" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.take 1
@@ -917,7 +917,7 @@ module Arel
     end
 
     test "update copies order" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from table
       manager.order :foo
@@ -930,7 +930,7 @@ module Arel
     end
 
     test "update copies where clauses" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.where table[:id].eq 10
       manager.from table
@@ -941,7 +941,7 @@ module Arel
     end
 
     test "update copies where clauses when nesting is triggered" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.where table[:foo].eq 10
       manager.take 42
@@ -985,7 +985,7 @@ module Arel
     end
 
     test "take knows take" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from(table).project(table["id"])
       manager.where(table["id"].eq(1))
@@ -1013,7 +1013,7 @@ module Arel
     end
 
     test "where knows where" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from(table).project(table["id"])
       manager.where(table["id"].eq(1))
@@ -1024,14 +1024,14 @@ module Arel
     end
 
     test "where chains" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       manager.from(table)
       assert_equal manager, manager.project(table["id"]).where(table["id"].eq 1)
     end
 
     test "from makes sql" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
 
       manager.from table
@@ -1040,7 +1040,7 @@ module Arel
     end
 
     test "from chains" do
-      table   = Table.new :users
+      table   = Table.new name: :users
       manager = Arel::SelectManager.new
       assert_equal manager, manager.from(table).project(table["id"])
       assert_like 'SELECT "users"."id" FROM "users"', manager.to_sql
@@ -1069,7 +1069,7 @@ module Arel
 
     test "distinct_on sets the quantifier" do
       manager = Arel::SelectManager.new
-      table = Table.new :users
+      table = Table.new name: :users
 
       manager.distinct_on(table["id"])
       assert_equal Arel::Nodes::DistinctOn.new(table["id"]), manager.ast.cores.last.set_quantifier
@@ -1080,7 +1080,7 @@ module Arel
 
     test "distinct_on chains" do
       manager = Arel::SelectManager.new
-      table = Table.new :users
+      table = Table.new name: :users
 
       assert_equal manager, manager.distinct_on(table["id"])
       assert_equal manager, manager.distinct_on(false)
@@ -1093,7 +1093,7 @@ module Arel
 
     test "comment appends a comment to the generated query" do
       manager = Arel::SelectManager.new
-      table = Table.new :users
+      table = Table.new name: :users
       manager.from(table).project(table["id"])
 
       manager.comment("selecting")

--- a/activerecord/test/cases/arel/support/tree_manager_behavior.rb
+++ b/activerecord/test/cases/arel/support/tree_manager_behavior.rb
@@ -26,7 +26,7 @@ module Arel
 
     included do
       test "to_sql uses given table's engine if available" do
-        table = Table.new(:users, klass: MyEngine)
+        table = Table.new(name: :users, klass: MyEngine)
         manager = build_manager(table)
 
         assert_includes manager.to_sql, "@users@"

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -9,7 +9,7 @@ module Arel
     end
 
     setup do
-      @relation = Table.new(:users)
+      @relation = Table.new(name: :users)
     end
 
     test "should create join nodes" do
@@ -102,23 +102,23 @@ module Arel
     end
 
     test "new should accept a hash" do
-      rel = Table.new :users, as: "foo"
+      rel = Table.new name: :users, as: "foo"
       assert_equal "foo", rel.table_alias
     end
 
     test "new ignores as if it equals name" do
-      rel = Table.new :users, as: "users"
+      rel = Table.new name: :users, as: "users"
       assert_nil rel.table_alias
     end
 
     test "new should accept literal SQL" do
-      rel = Table.new Arel.sql("generate_series(4, 2)")
+      rel = Table.new name: Arel.sql("generate_series(4, 2)")
       assert_equal Arel.sql("generate_series(4, 2)"), rel.name
     end
 
     test "new should accept Arel nodes" do
       node = Arel::Nodes::NamedFunction.new("generate_series", [4, 2])
-      rel = Table.new node
+      rel = Table.new name: node
       assert_equal node, rel.name
     end
 
@@ -164,15 +164,15 @@ module Arel
     end
 
     test "equality is equal with equal ivars" do
-      relation1 = Table.new(:users, as: "zomg")
-      relation2 = Table.new(:users, as: "zomg")
+      relation1 = Table.new(name: :users, as: "zomg")
+      relation2 = Table.new(name: :users, as: "zomg")
       array = [relation1, relation2]
       assert_equal 1, array.uniq.size
     end
 
     test "equality is not equal with different ivars" do
-      relation1 = Table.new(:users, as: "zomg")
-      relation2 = Table.new(:users, as: "zomg2")
+      relation1 = Table.new(name: :users, as: "zomg")
+      relation2 = Table.new(name: :users, as: "zomg2")
       array = [relation1, relation2]
       assert_equal 2, array.uniq.size
     end

--- a/activerecord/test/cases/arel/update_manager_test.rb
+++ b/activerecord/test/cases/arel/update_manager_test.rb
@@ -8,7 +8,7 @@ module Arel
     include TreeManagerBehavior
 
     test "should not quote sql literals" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       um = Arel::UpdateManager.new
       um.table table
       um.set [[table[:name], Arel::Nodes::BindParam.new(1)]]
@@ -16,7 +16,7 @@ module Arel
     end
 
     test "handles limit properly" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       um = Arel::UpdateManager.new
       um.key = "id"
       um.take 10
@@ -26,8 +26,8 @@ module Arel
     end
 
     test "having sets having" do
-      users_table = Table.new(:users)
-      posts_table = Table.new(:posts)
+      users_table = Table.new(name: :users)
+      posts_table = Table.new(name: :posts)
       join_source = Arel::Nodes::InnerJoin.new(users_table, posts_table)
 
       update_manager = Arel::UpdateManager.new
@@ -39,8 +39,8 @@ module Arel
     end
 
     test "group adds columns to the AST when group value is a String" do
-      users_table = Table.new(:users)
-      posts_table = Table.new(:posts)
+      users_table = Table.new(name: :users)
+      posts_table = Table.new(name: :posts)
       join_source = Arel::Nodes::InnerJoin.new(users_table, posts_table)
 
       update_manager = Arel::UpdateManager.new
@@ -56,8 +56,8 @@ module Arel
     end
 
     test "group adds columns to the AST when group value is a Symbol" do
-      users_table = Table.new(:users)
-      posts_table = Table.new(:posts)
+      users_table = Table.new(name: :users)
+      posts_table = Table.new(name: :posts)
       join_source = Arel::Nodes::InnerJoin.new(users_table, posts_table)
 
       update_manager = Arel::UpdateManager.new
@@ -73,7 +73,7 @@ module Arel
     end
 
     test "set updates with null" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       um = Arel::UpdateManager.new
       um.table table
       um.set [[table[:name], nil]]
@@ -81,7 +81,7 @@ module Arel
     end
 
     test "set takes a string" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       um = Arel::UpdateManager.new
       um.table table
       um.set Nodes::SqlLiteral.new "foo = bar"
@@ -89,7 +89,7 @@ module Arel
     end
 
     test "set takes a list of lists" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       um = Arel::UpdateManager.new
       um.table table
       um.set [[table[:id], 1], [table[:name], "hello"]]
@@ -99,29 +99,29 @@ module Arel
     end
 
     test "set chains" do
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       um = Arel::UpdateManager.new
       assert_equal um, um.set([[table[:id], 1], [table[:name], "hello"]])
     end
 
     test "table generates an update statement" do
       um = Arel::UpdateManager.new
-      um.table Table.new(:users)
+      um.table Table.new(name: :users)
       assert_like %{ UPDATE "users" }, um.to_sql
     end
 
     test "table chains" do
       um = Arel::UpdateManager.new
-      assert_equal um, um.table(Table.new(:users))
+      assert_equal um, um.table(Table.new(name: :users))
     end
 
     test "table generates an update statement with joins" do
       um = Arel::UpdateManager.new
 
-      table = Table.new(:users)
+      table = Table.new(name: :users)
       join_source = Arel::Nodes::JoinSource.new(
         table,
-        [table.create_join(Table.new(:posts))]
+        [table.create_join(Table.new(name: :posts))]
       )
 
       um.table join_source
@@ -129,7 +129,7 @@ module Arel
     end
 
     test "where generates a where clause" do
-      table = Table.new :users
+      table = Table.new name: :users
       um = Arel::UpdateManager.new
       um.table table
       um.where table[:id].eq(1)
@@ -139,28 +139,28 @@ module Arel
     end
 
     test "where chains" do
-      table = Table.new :users
+      table = Table.new name: :users
       um = Arel::UpdateManager.new
       um.table table
       assert_equal um, um.where(table[:id].eq(1))
     end
 
     test "key can be set" do
-      table = Table.new :users
+      table = Table.new name: :users
       um = Arel::UpdateManager.new
       um.key = table[:foo]
       assert_equal table[:foo], um.ast.key
     end
 
     test "key can be accessed" do
-      table = Table.new :users
+      table = Table.new name: :users
       um = Arel::UpdateManager.new
       um.key = table[:foo]
       assert_equal table[:foo], um.key
     end
 
     test "#returning accepts a returning clause" do
-      users   = Table.new :users
+      users   = Table.new name: :users
       manager = Arel::UpdateManager.new
       manager.table users
       manager.returning Arel.star
@@ -171,7 +171,7 @@ module Arel
     end
 
     test "#returning accepts multiple values as returning clause" do
-      users   = Table.new :users
+      users   = Table.new name: :users
       manager = Arel::UpdateManager.new
       manager.table users
       manager.returning Arel.star

--- a/activerecord/test/cases/arel/visitors/dispatch_contamination_test.rb
+++ b/activerecord/test/cases/arel/visitors/dispatch_contamination_test.rb
@@ -41,7 +41,7 @@ module Arel
     class DispatchContaminationTest < Arel::Test
       setup do
         @connection = Table.engine.lease_connection
-        @table = Table.new(:users)
+        @table = Table.new(name: :users)
       end
 
       test "dispatches properly after failing upwards" do

--- a/activerecord/test/cases/arel/visitors/dot_test.rb
+++ b/activerecord/test/cases/arel/visitors/dot_test.rb
@@ -144,7 +144,7 @@ module Arel
       end
 
       def test_Arel_Nodes_RegExp
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         node = Arel::Nodes::Regexp.new(table[:name], Nodes.build_quoted("foo%"))
 
         dot = @visitor.accept(node, Arel::Collectors::PlainString.new).value
@@ -156,7 +156,7 @@ module Arel
       end
 
       def test_Arel_Nodes_NotRegExp
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         node = Arel::Nodes::NotRegexp.new(table[:name], Nodes.build_quoted("foo%"))
 
         dot = @visitor.accept(node, Arel::Collectors::PlainString.new).value

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -23,7 +23,7 @@ module Arel
 
       test "should escape LIMIT" do
         sc = Arel::Nodes::UpdateStatement.new
-        sc.relation = Table.new(:users)
+        sc.relation = Table.new(name: :users)
         sc.limit = Nodes::Limit.new(Nodes.build_quoted("omg"))
         assert_equal "UPDATE \"users\" LIMIT 'omg'", compile(sc)
       end
@@ -45,7 +45,7 @@ module Arel
       end
 
       test "concat concats columns" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         query = table[:name].concat(table[:name])
         assert_like %{
           CONCAT("users"."name", "users"."name")
@@ -53,7 +53,7 @@ module Arel
       end
 
       test "concat concats a string" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         query = table[:name].concat(Nodes.build_quoted("abc"))
         assert_like %{
           CONCAT("users"."name", 'abc')
@@ -61,42 +61,42 @@ module Arel
       end
 
       test "Nodes::IsNotDistinctFrom should construct a valid generic SQL statement" do
-        node = Table.new(:users)[:name].is_not_distinct_from "Aaron Patterson"
+        node = Table.new(name: :users)[:name].is_not_distinct_from "Aaron Patterson"
         assert_like %{
           "users"."name" <=> 'Aaron Patterson'
         }, compile(node)
       end
 
       test "Nodes::IsNotDistinctFrom should handle column names on both sides" do
-        node = Table.new(:users)[:first_name].is_not_distinct_from Table.new(:users)[:last_name]
+        node = Table.new(name: :users)[:first_name].is_not_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           "users"."first_name" <=> "users"."last_name"
         }, compile(node)
       end
 
       test "Nodes::IsNotDistinctFrom should handle nil" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         value = Nodes.build_quoted(nil, table[:active])
         sql = compile Nodes::IsNotDistinctFrom.new(table[:name], value)
         assert_like %{ "users"."name" <=> NULL }, sql
       end
 
       test "Nodes::IsDistinctFrom should handle column names on both sides" do
-        node = Table.new(:users)[:first_name].is_distinct_from Table.new(:users)[:last_name]
+        node = Table.new(name: :users)[:first_name].is_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           NOT "users"."first_name" <=> "users"."last_name"
         }, compile(node)
       end
 
       test "Nodes::IsDistinctFrom should handle nil" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         value = Nodes.build_quoted(nil, table[:active])
         sql = compile Nodes::IsDistinctFrom.new(table[:name], value)
         assert_like %{ NOT "users"."name" <=> NULL }, sql
       end
 
       test "Nodes::Regexp should know how to visit" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         node = table[:name].matches_regexp("foo.*")
         assert_kind_of Nodes::Regexp, node
         assert_like %{
@@ -105,7 +105,7 @@ module Arel
       end
 
       test "Nodes::Regexp can handle subqueries" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         attr = table[:id]
         subquery = table.project(:id).where(table[:name].matches_regexp("foo.*"))
         node = attr.in subquery
@@ -115,7 +115,7 @@ module Arel
       end
 
       test "Nodes::NotRegexp should know how to visit" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         node = table[:name].does_not_match_regexp("foo.*")
         assert_kind_of Nodes::NotRegexp, node
         assert_like %{
@@ -124,7 +124,7 @@ module Arel
       end
 
       test "Nodes::NotRegexp can handle subqueries" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         attr = table[:id]
         subquery = table.project(:id).where(table[:name].does_not_match_regexp("foo.*"))
         node = attr.in subquery
@@ -134,35 +134,35 @@ module Arel
       end
 
       test "Nodes::Ordering should handle nulls first" do
-        node = Table.new(:users)[:first_name].asc.nulls_first
+        node = Table.new(name: :users)[:first_name].asc.nulls_first
         assert_like %{
           "users"."first_name" IS NOT NULL, "users"."first_name" ASC
         }, compile(node)
       end
 
       test "Nodes::Ordering should handle nulls last" do
-        node = Table.new(:users)[:first_name].asc.nulls_last
+        node = Table.new(name: :users)[:first_name].asc.nulls_last
         assert_like %{
           "users"."first_name" IS NULL, "users"."first_name" ASC
         }, compile(node)
       end
 
       test "Nodes::Ordering should handle nulls first reversed" do
-        node = Table.new(:users)[:first_name].asc.nulls_first.reverse
+        node = Table.new(name: :users)[:first_name].asc.nulls_first.reverse
         assert_like %{
           "users"."first_name" IS NULL, "users"."first_name" DESC
         }, compile(node)
       end
 
       test "Nodes::Ordering should handle nulls last reversed" do
-        node = Table.new(:users)[:first_name].asc.nulls_last.reverse
+        node = Table.new(name: :users)[:first_name].asc.nulls_last.reverse
         assert_like %{
           "users"."first_name" IS NOT NULL, "users"."first_name" DESC
         }, compile(node)
       end
 
       test "Nodes::Cte ignores MATERIALIZED modifiers" do
-        cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), materialized: true)
+        cte = Nodes::Cte.new("foo", Table.new(name: :bar).project(Arel.star), materialized: true)
 
         assert_like %{
           "foo" AS (SELECT * FROM "bar")
@@ -170,7 +170,7 @@ module Arel
       end
 
       test "Nodes::Cte ignores NOT MATERIALIZED modifiers" do
-        cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), materialized: false)
+        cte = Nodes::Cte.new("foo", Table.new(name: :bar).project(Arel.star), materialized: false)
 
         assert_like %{
           "foo" AS (SELECT * FROM "bar")

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -7,7 +7,7 @@ module Arel
     class PostgresTest < Arel::Test
       setup do
         @visitor = PostgreSQL.new Table.engine.lease_connection
-        @table = Table.new(:users)
+        @table = Table.new(name: :users)
         @attr = @table[:id]
       end
 
@@ -217,7 +217,7 @@ module Arel
       end
 
       test "update statements with joins render RETURNING" do
-        posts = Table.new(:posts)
+        posts = Table.new(name: :posts)
         join_source = Arel::Nodes::JoinSource.new(
           @table,
           [@table.create_join(posts)]
@@ -306,35 +306,35 @@ module Arel
       end
 
       test "Nodes::IsNotDistinctFrom should construct a valid generic SQL statement" do
-        node = Table.new(:users)[:name].is_not_distinct_from "Aaron Patterson"
+        node = Table.new(name: :users)[:name].is_not_distinct_from "Aaron Patterson"
         assert_like %{
           "users"."name" IS NOT DISTINCT FROM 'Aaron Patterson'
         }, compile(node)
       end
 
       test "Nodes::IsNotDistinctFrom should handle column names on both sides" do
-        node = Table.new(:users)[:first_name].is_not_distinct_from Table.new(:users)[:last_name]
+        node = Table.new(name: :users)[:first_name].is_not_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           "users"."first_name" IS NOT DISTINCT FROM "users"."last_name"
         }, compile(node)
       end
 
       test "Nodes::IsNotDistinctFrom should handle nil" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         value = Nodes.build_quoted(nil, table[:active])
         sql = compile Nodes::IsNotDistinctFrom.new(table[:name], value)
         assert_like %{ "users"."name" IS NOT DISTINCT FROM NULL }, sql
       end
 
       test "Nodes::IsDistinctFrom should handle column names on both sides" do
-        node = Table.new(:users)[:first_name].is_distinct_from Table.new(:users)[:last_name]
+        node = Table.new(name: :users)[:first_name].is_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           "users"."first_name" IS DISTINCT FROM "users"."last_name"
         }, compile(node)
       end
 
       test "Nodes::IsDistinctFrom should handle nil" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         value = Nodes.build_quoted(nil, table[:active])
         sql = compile Nodes::IsDistinctFrom.new(table[:name], value)
         assert_like %{ "users"."name" IS DISTINCT FROM NULL }, sql
@@ -342,13 +342,13 @@ module Arel
 
       test "Nodes::InfixOperation should handle Contains" do
         inner = Nodes.build_quoted('{"foo":"bar"}')
-        outer = Table.new(:products)[:metadata]
+        outer = Table.new(name: :products)[:metadata]
         sql = compile Nodes::Contains.new(outer, inner)
         assert_like %{ "products"."metadata" @> '{"foo":"bar"}' }, sql
       end
 
       test "Nodes::InfixOperation should handle Overlaps" do
-        column = Table.new(:products)[:tags]
+        column = Table.new(name: :products)[:tags]
         search = Nodes.build_quoted("{foo,bar,baz}")
         sql = compile Nodes::Overlaps.new(column, search)
         assert_like %{ "products"."tags" && '{foo,bar,baz}' }, sql

--- a/activerecord/test/cases/arel/visitors/sqlite_test.rb
+++ b/activerecord/test/cases/arel/visitors/sqlite_test.rb
@@ -22,35 +22,35 @@ module Arel
       end
 
       test "Nodes::IsNotDistinctFrom should construct a valid generic SQL statement" do
-        test = Table.new(:users)[:name].is_not_distinct_from "Aaron Patterson"
+        test = Table.new(name: :users)[:name].is_not_distinct_from "Aaron Patterson"
         assert_like %{
           "users"."name" IS 'Aaron Patterson'
         }, compile(test)
       end
 
       test "Nodes::IsNotDistinctFrom should handle column names on both sides" do
-        test = Table.new(:users)[:first_name].is_not_distinct_from Table.new(:users)[:last_name]
+        test = Table.new(name: :users)[:first_name].is_not_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           "users"."first_name" IS "users"."last_name"
         }, compile(test)
       end
 
       test "Nodes::IsNotDistinctFrom should handle nil" do
-        @table = Table.new(:users)
+        @table = Table.new(name: :users)
         val = Nodes.build_quoted(nil, @table[:active])
         sql = compile Nodes::IsNotDistinctFrom.new(@table[:name], val)
         assert_like %{ "users"."name" IS NULL }, sql
       end
 
       test "Nodes::IsDistinctFrom should handle column names on both sides" do
-        test = Table.new(:users)[:first_name].is_distinct_from Table.new(:users)[:last_name]
+        test = Table.new(name: :users)[:first_name].is_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           "users"."first_name" IS NOT "users"."last_name"
         }, compile(test)
       end
 
       test "Nodes::IsDistinctFrom should handle nil" do
-        @table = Table.new(:users)
+        @table = Table.new(name: :users)
         val = Nodes.build_quoted(nil, @table[:active])
         sql = compile Nodes::IsDistinctFrom.new(@table[:name], val)
         assert_like %{ "users"."name" IS NOT NULL }, sql

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -9,7 +9,7 @@ module Arel
       setup do
         @conn = Table.engine
         @visitor = ToSql.new @conn.lease_connection
-        @table = Table.new(:users)
+        @table = Table.new(name: :users)
         @attr = @table[:id]
       end
 
@@ -185,14 +185,14 @@ module Arel
       end
 
       test "Nodes::Equality should escape strings" do
-        test = Table.new(:users)[:name].eq "Aaron Patterson"
+        test = Table.new(name: :users)[:name].eq "Aaron Patterson"
         assert_like %{
           "users"."name" = 'Aaron Patterson'
         }, compile(test)
       end
 
       test "Nodes::Equality should handle false" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         val = Nodes.build_quoted(false, table[:active])
         sql = compile Nodes::Equality.new(val, val)
         assert_like %{ 'f' = 'f' }, sql
@@ -221,14 +221,14 @@ module Arel
       end
 
       test "Nodes::IsNotDistinctFrom should construct a valid generic SQL statement" do
-        test = Table.new(:users)[:name].is_not_distinct_from "Aaron Patterson"
+        test = Table.new(name: :users)[:name].is_not_distinct_from "Aaron Patterson"
         assert_like %{
           CASE WHEN "users"."name" = 'Aaron Patterson' OR ("users"."name" IS NULL AND 'Aaron Patterson' IS NULL) THEN 0 ELSE 1 END = 0
         }, compile(test)
       end
 
       test "Nodes::IsNotDistinctFrom should handle column names on both sides" do
-        test = Table.new(:users)[:first_name].is_not_distinct_from Table.new(:users)[:last_name]
+        test = Table.new(name: :users)[:first_name].is_not_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           CASE WHEN "users"."first_name" = "users"."last_name" OR ("users"."first_name" IS NULL AND "users"."last_name" IS NULL) THEN 0 ELSE 1 END = 0
         }, compile(test)
@@ -241,7 +241,7 @@ module Arel
       end
 
       test "Nodes::IsDistinctFrom should handle column names on both sides" do
-        test = Table.new(:users)[:first_name].is_distinct_from Table.new(:users)[:last_name]
+        test = Table.new(name: :users)[:first_name].is_distinct_from Table.new(name: :users)[:last_name]
         assert_like %{
           CASE WHEN "users"."first_name" = "users"."last_name" OR ("users"."first_name" IS NULL AND "users"."last_name" IS NULL) THEN 0 ELSE 1 END = 1
         }, compile(test)
@@ -275,21 +275,21 @@ module Arel
       end
 
       test "should contain a single space before ORDER BY" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         test = table.order(table[:name])
         sql = compile test
         assert_match(/"users" ORDER BY/, sql)
       end
 
       test "should quote LIMIT without column type coercion" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         sc = table.where(table[:name].eq(0)).take(1).ast
         assert_match(/WHERE "users"."name" = 0 LIMIT 1/, compile(sc))
       end
 
       test "should visit_DateTime" do
         dt = DateTime.now
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         test = table[:created_at].eq dt
         sql = compile test
 
@@ -297,7 +297,7 @@ module Arel
       end
 
       test "should visit_Float" do
-        test = Table.new(:products)[:price].eq 2.14
+        test = Table.new(name: :products)[:price].eq 2.14
         sql = compile test
         assert_like %{"products"."price" = 2.14}, sql
       end
@@ -337,7 +337,7 @@ module Arel
 
       test "should visit_Date" do
         dt = Date.today
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         test = table[:created_at].eq dt
         sql = compile test
 
@@ -354,7 +354,7 @@ module Arel
       end
 
       test "should visit_Arel_SelectManager, which is a subquery" do
-        mgr = Table.new(:foo).project(:bar)
+        mgr = Table.new(name: :foo).project(:bar)
         assert_like '(SELECT bar FROM "foo")', compile(mgr)
       end
 
@@ -384,7 +384,7 @@ module Arel
       end
 
       test "should visit_TrueClass" do
-        test = Table.new(:users)[:bool].eq(true)
+        test = Table.new(name: :users)[:bool].eq(true)
         assert_like %{ "users"."bool" = 't' }, compile(test)
       end
 
@@ -514,7 +514,7 @@ module Arel
       end
 
       test "Nodes::In can handle subqueries" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         subquery = table.project(:id).where(table[:name].eq("Aaron"))
         node = @attr.in subquery
         assert_like %{
@@ -531,7 +531,7 @@ module Arel
       end
 
       test "Nodes::In is preparable when a subselect" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         subquery = table.project(table[:id]).where(table[:name].eq("Aaron"))
         node = @attr.in subquery
 
@@ -541,84 +541,84 @@ module Arel
       end
 
       test "Nodes::InfixOperation should handle Multiplication" do
-        node = Arel::Attribute.new(Table.new(:products), :price) * Arel::Attribute.new(Table.new(:currency_rates), :rate)
+        node = Arel::Attribute.new(Table.new(name: :products), :price) * Arel::Attribute.new(Table.new(name: :currency_rates), :rate)
         assert_equal %("products"."price" * "currency_rates"."rate"), compile(node)
       end
 
       test "Nodes::InfixOperation should handle Division" do
-        node = Arel::Attribute.new(Table.new(:products), :price) / 5
+        node = Arel::Attribute.new(Table.new(name: :products), :price) / 5
         assert_equal %("products"."price" / 5), compile(node)
       end
 
       test "Nodes::InfixOperation should handle Addition" do
-        node = Arel::Attribute.new(Table.new(:products), :price) + 6
+        node = Arel::Attribute.new(Table.new(name: :products), :price) + 6
         assert_equal %(("products"."price" + 6)), compile(node)
       end
 
       test "Nodes::InfixOperation should handle Subtraction" do
-        node = Arel::Attribute.new(Table.new(:products), :price) - 7
+        node = Arel::Attribute.new(Table.new(name: :products), :price) - 7
         assert_equal %(("products"."price" - 7)), compile(node)
       end
 
       test "Nodes::InfixOperation should handle Concatenation" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         node = table[:name].concat(table[:name])
         assert_equal %("users"."name" || "users"."name"), compile(node)
       end
 
       test "Nodes::InfixOperation should handle Contains" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         node = table[:name].contains(table[:name])
         assert_equal %("users"."name" @> "users"."name"), compile(node)
       end
 
       test "Nodes::InfixOperation should handle Overlaps" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         node = table[:name].overlaps(table[:name])
         assert_equal %("users"."name" && "users"."name"), compile(node)
       end
 
       test "Nodes::InfixOperation should handle BitwiseAnd" do
-        node = Arel::Attribute.new(Table.new(:products), :bitmap) & 16
+        node = Arel::Attribute.new(Table.new(name: :products), :bitmap) & 16
         assert_equal %(("products"."bitmap" & 16)), compile(node)
       end
 
       test "Nodes::InfixOperation should handle BitwiseOr" do
-        node = Arel::Attribute.new(Table.new(:products), :bitmap) | 16
+        node = Arel::Attribute.new(Table.new(name: :products), :bitmap) | 16
         assert_equal %(("products"."bitmap" | 16)), compile(node)
       end
 
       test "Nodes::InfixOperation should handle BitwiseXor" do
-        node = Arel::Attribute.new(Table.new(:products), :bitmap) ^ 16
+        node = Arel::Attribute.new(Table.new(name: :products), :bitmap) ^ 16
         assert_equal %(("products"."bitmap" ^ 16)), compile(node)
       end
 
       test "Nodes::InfixOperation should handle BitwiseShiftLeft" do
-        node = Arel::Attribute.new(Table.new(:products), :bitmap) << 4
+        node = Arel::Attribute.new(Table.new(name: :products), :bitmap) << 4
         assert_equal %(("products"."bitmap" << 4)), compile(node)
       end
 
       test "Nodes::InfixOperation should handle BitwiseShiftRight" do
-        node = Arel::Attribute.new(Table.new(:products), :bitmap) >> 4
+        node = Arel::Attribute.new(Table.new(name: :products), :bitmap) >> 4
         assert_equal %(("products"."bitmap" >> 4)), compile(node)
       end
 
       test "Nodes::InfixOperation should handle arbitrary operators" do
         node = Arel::Nodes::InfixOperation.new(
           "&&",
-          Arel::Attribute.new(Table.new(:products), :name),
-          Arel::Attribute.new(Table.new(:products), :name)
+          Arel::Attribute.new(Table.new(name: :products), :name),
+          Arel::Attribute.new(Table.new(name: :products), :name)
         )
         assert_equal %("products"."name" && "products"."name"), compile(node)
       end
 
       test "Nodes::UnaryOperation should handle BitwiseNot" do
-        node = ~ Arel::Attribute.new(Table.new(:products), :bitmap)
+        node = ~ Arel::Attribute.new(Table.new(name: :products), :bitmap)
         assert_equal %( ~ "products"."bitmap"), compile(node)
       end
 
       test "Nodes::UnaryOperation should handle arbitrary operators" do
-        node = Arel::Nodes::UnaryOperation.new("!", Arel::Attribute.new(Table.new(:products), :active))
+        node = Arel::Nodes::UnaryOperation.new("!", Arel::Attribute.new(Table.new(name: :products), :active))
         assert_equal %( ! "products"."active"), compile(node)
       end
 
@@ -633,7 +633,7 @@ module Arel
       end
 
       test "Nodes::Union encloses SELECT statements with parentheses" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         left = table.where(table[:name].eq(0)).take(1).ast
         right = table.where(table[:name].eq(1)).take(1).ast
         node = Nodes::Union.new left, right
@@ -651,7 +651,7 @@ module Arel
       end
 
       test "Nodes::UnionAll encloses SELECT statements with parentheses" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         left = table.where(table[:name].eq(0)).take(1).ast
         right = table.where(table[:name].eq(1)).take(1).ast
         node = Nodes::UnionAll.new left, right
@@ -701,7 +701,7 @@ module Arel
       end
 
       test "Nodes::NotIn can handle subqueries" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         subquery = table.project(:id).where(table[:name].eq("Aaron"))
         node = @attr.not_in subquery
         assert_like %{
@@ -718,7 +718,7 @@ module Arel
       end
 
       test "Nodes::NotIn is preparable when a subselect" do
-        table = Table.new(:users)
+        table = Table.new(name: :users)
         subquery = table.project(table[:id]).where(table[:name].eq("Aaron"))
         node = @attr.not_in subquery
 
@@ -728,14 +728,14 @@ module Arel
       end
 
       test "Constants should handle true" do
-        test = Table.new(:users).create_true
+        test = Table.new(name: :users).create_true
         assert_like %{
           TRUE
         }, compile(test)
       end
 
       test "Constants should handle false" do
-        test = Table.new(:users).create_false
+        test = Table.new(name: :users).create_false
         assert_like %{
           FALSE
         }, compile(test)
@@ -822,14 +822,14 @@ module Arel
       end
 
       test "Table should compile node names" do
-        test = Table.new(:users).alias("zomgusers")[:id].eq "3"
+        test = Table.new(name: :users).alias("zomgusers")[:id].eq "3"
         assert_like %{
           "zomgusers"."id" = '3'
         }, compile(test)
       end
 
       test "Table should compile literal SQL" do
-        test = Table.new Arel.sql("generate_series(4, 2)")
+        test = Table.new name: Arel.sql("generate_series(4, 2)")
         assert_like %{ generate_series(4, 2) }, compile(test)
       end
 
@@ -845,7 +845,7 @@ module Arel
       end
 
       test "TableAlias should use the underlying table for checking columns" do
-        test = Table.new(:users).alias("zomgusers")[:id].eq "3"
+        test = Table.new(name: :users).alias("zomgusers")[:id].eq "3"
         assert_like %{
           "zomgusers"."id" = '3'
         }, compile(test)
@@ -935,9 +935,9 @@ module Arel
       end
 
       test "Nodes::With handles table aliases" do
-        manager = Table.new(:foo).project(Arel.star).from(Arel.sql("expr2"))
-        expr1 = Table.new(:bar).project(Arel.star).as("expr1")
-        expr2 = Table.new(:baz).project(Arel.star).as("expr2")
+        manager = Table.new(name: :foo).project(Arel.star).from(Arel.sql("expr2"))
+        expr1 = Table.new(name: :bar).project(Arel.star).as("expr1")
+        expr2 = Table.new(name: :baz).project(Arel.star).as("expr2")
         manager.with(expr1, expr2)
 
         assert_like %{
@@ -946,8 +946,8 @@ module Arel
       end
 
       test "Nodes::With handles Cte nodes" do
-        cte = Arel::Nodes::Cte.new("expr1", Table.new(:bar).project(Arel.star))
-        manager = Table.new(:foo).
+        cte = Arel::Nodes::Cte.new("expr1", Table.new(name: :bar).project(Arel.star))
+        manager = Table.new(name: :foo).
           project(Arel.star).
           with(cte).
           from(cte.to_table).
@@ -959,8 +959,8 @@ module Arel
       end
 
       test "Nodes::WithRecursive handles table aliases" do
-        manager = Table.new(:foo).project(Arel.star).from(Arel.sql("expr1"))
-        expr1 = Table.new(:bar).project(Arel.star).as("expr1")
+        manager = Table.new(name: :foo).project(Arel.star).from(Arel.sql("expr1"))
+        expr1 = Table.new(name: :bar).project(Arel.star).as("expr1")
         manager.with(:recursive, expr1)
 
         assert_like %{
@@ -969,7 +969,7 @@ module Arel
       end
 
       test "Nodes::Cte handles CTEs with no MATERIALIZED modifier" do
-        cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star))
+        cte = Nodes::Cte.new("foo", Table.new(name: :bar).project(Arel.star))
 
         assert_like %{
           "foo" AS (SELECT * FROM "bar")
@@ -977,7 +977,7 @@ module Arel
       end
 
       test "Nodes::Cte handles CTEs with a MATERIALIZED modifier" do
-        cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), materialized: true)
+        cte = Nodes::Cte.new("foo", Table.new(name: :bar).project(Arel.star), materialized: true)
 
         assert_like %{
           "foo" AS MATERIALIZED (SELECT * FROM "bar")
@@ -985,7 +985,7 @@ module Arel
       end
 
       test "Nodes::Cte handles CTEs with a NOT MATERIALIZED modifier" do
-        cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), materialized: false)
+        cte = Nodes::Cte.new("foo", Table.new(name: :bar).project(Arel.star), materialized: false)
 
         assert_like %{
           "foo" AS NOT MATERIALIZED (SELECT * FROM "bar")

--- a/activerecord/test/cases/relation/where_clause_test.rb
+++ b/activerecord/test/cases/relation/where_clause_test.rb
@@ -60,7 +60,7 @@ class ActiveRecord::Relation
     end
 
     test "merge allows for columns with the same name from different tables" do
-      table2 = Arel::Table.new("table2")
+      table2 = Arel::Table.new(name: "table2")
       a = WhereClause.new(
         [table["id"].eq(bind_param(1)), table2["id"].eq(bind_param(2))],
       )
@@ -287,7 +287,7 @@ class ActiveRecord::Relation
 
     private
       def table
-        Arel::Table.new("table")
+        Arel::Table.new(name: "table")
       end
 
       def bind_param(value)

--- a/activerecord/test/cases/table_metadata_test.rb
+++ b/activerecord/test/cases/table_metadata_test.rb
@@ -6,7 +6,7 @@ require "models/developer"
 module ActiveRecord
   class TableMetadataTest < ActiveSupport::TestCase
     test "#associated_table creates the right type caster for joined table with different association name" do
-      base_table_metadata = TableMetadata.new(AuditRequiredDeveloper, Arel::Table.new("developers"))
+      base_table_metadata = TableMetadata.new(AuditRequiredDeveloper, Arel::Table.new(name: "developers"))
 
       associated_table_metadata = base_table_metadata.associated_table("audit_logs")
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because as of https://github.com/rails/rails/pull/57642, `Arel::Table` now takes an optional optional argument. We can make this a keyword instead. The class is nodoc so it is private API.

### Detail

This Pull Request changes `Arel::Table` names to be keywords instead of needing to pass nil for the klass use-case.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
