### PR TITLE
Make ActionController Renderers ractor safe

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Deprecated the ActionController::Renderers::RENDERERS constant.
+
+    This constant was for internal usage but had a documentation and wasn't set
+    as private or :nodoc:.
+    Applications that needs to add or remove renderers should be using the public API instead:
+
+    ```ruby
+    ActionController.add_renderer(:rtf) do
+    end
+
+    ActionController.remove_renderer(:rtf)
+    ```
+
+    Gems or applications that used the constant to see the list of renderers, can now use a frozen
+    reader:
+
+    ```ruby
+    ActionController::Renderers.all.include?(:csv)
+    ```
+
+    *Edouard Chin*
+
 *   Deprecate `Mime::SET`, `Mime::LOOKUP`, `Mime::EXTENSION_LOOKUP`.
 
     Use `Mime.symbols`, `Mime::Type.lookup` and `Mime::Type.lookup_by_extension` respectively instead.

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -67,8 +67,8 @@ module ActionController
       extend ActiveSupport::Concern
       include Renderers
 
-      included do
-        self._renderers = RENDERERS
+      def _all_renderers # :nodoc:
+        _renderers + Renderers.all
       end
     end
 
@@ -102,7 +102,9 @@ module ActionController
     #     end
     def self.add(key, &block)
       define_method(_render_with_renderer_method_name(key), &block)
-      @all << key.to_sym
+      (@all += [key.to_sym]).freeze
+
+      RENDERERS.target = @all
     end
 
     # This method is the opposite of add method.
@@ -111,9 +113,11 @@ module ActionController
     #
     #     ActionController::Renderers.remove(:csv)
     def self.remove(key)
-      @all.delete(key.to_sym)
+      (@all -= [key.to_sym]).freeze
       method_name = _render_with_renderer_method_name(key)
       remove_possible_method(method_name)
+
+      RENDERERS.target = @all
     end
 
     def self._render_with_renderer_method_name(key) # :nodoc:
@@ -171,7 +175,7 @@ module ActionController
     end
 
     def _render_to_body_with_renderer(options) # :nodoc:
-      _renderers.each do |name|
+      _all_renderers.each do |name|
         if options.key?(name)
           _process_options(options)
           method_name = Renderers._render_with_renderer_method_name(name)
@@ -179,6 +183,10 @@ module ActionController
         end
       end
       nil
+    end
+
+    def _all_renderers # :nodoc:
+      _renderers
     end
 
     add :json do |json, options|

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -2,6 +2,8 @@
 
 # :markup: markdown
 
+require "active_support/deprecation"
+
 module ActionController
   # See Renderers.add
   def self.add_renderer(key, &block)
@@ -23,9 +25,22 @@ module ActionController
   module Renderers
     extend ActiveSupport::Concern
 
-    # A Set containing renderer names that correspond to available renderer procs.
-    # Default values are `:json`, `:js`, `:xml`.
-    RENDERERS = Set.new
+    class << self
+      # Returns a Set of renderers name. By default, Action Controller adds the
+      # `json`, `js`, `xml`, `markdown` and `svg` renderers.
+      #
+      # You can use `ActionController::Renderers.all` to see what renderers exists for an application.
+      attr_reader :all # :doc:
+    end
+
+    @all = Set.new.freeze
+    RENDERERS = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+      @all,
+      "ActionController::Renderers::RENDERERS is deprecated. Use ActionController.add_renderer, or ActionController.remove_renderer " \
+        "to add or remove renderers. If you need to check which renderers exists for an application, you can instead use " \
+        "ActionController::Renderers.all",
+      ActionController.deprecator,
+    )
 
     module DeprecatedEscapeJsonResponses # :nodoc:
       def escape_json_responses=(value)
@@ -87,7 +102,7 @@ module ActionController
     #     end
     def self.add(key, &block)
       define_method(_render_with_renderer_method_name(key), &block)
-      RENDERERS << key.to_sym
+      @all << key.to_sym
     end
 
     # This method is the opposite of add method.
@@ -96,7 +111,7 @@ module ActionController
     #
     #     ActionController::Renderers.remove(:csv)
     def self.remove(key)
-      RENDERERS.delete(key.to_sym)
+      @all.delete(key.to_sym)
       method_name = _render_with_renderer_method_name(key)
       remove_possible_method(method_name)
     end
@@ -114,7 +129,7 @@ module ActionController
       #
       # Both ActionController::Base and ActionController::API include
       # ActionController::Renderers::All, making all renderers available in the
-      # controller. See Renderers::RENDERERS and Renderers.add.
+      # controller. See Renderers.add.
       #
       # Since ActionController::Metal controllers cannot render, the controller must
       # include AbstractController::Rendering, ActionController::Rendering, and

--- a/actionpack/test/controller/renderers_test.rb
+++ b/actionpack/test/controller/renderers_test.rb
@@ -3,8 +3,11 @@
 require "abstract_unit"
 require "controller/fake_models"
 require "active_support/logger"
+require "active_support/testing/ractors_assertions"
 
 class RenderersTest < ActionController::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   class XmlRenderable
     def to_xml(options)
       options[:root] ||= "i-am-xml"
@@ -126,5 +129,15 @@ class RenderersTest < ActionController::TestCase
     end
   ensure
     ActionController::Renderers.remove(:foo)
+  end
+
+  test "set of renderers if frozen" do
+    assert_ractor_shareable(ActionController::Renderers.all)
+
+    ActionController.add_renderer(:rtf) { }
+    assert_ractor_shareable(ActionController::Renderers.all)
+
+    ActionController.remove_renderer(:rtf)
+    assert_ractor_shareable(ActionController::Renderers.all)
   end
 end

--- a/actionpack/test/controller/renderers_test.rb
+++ b/actionpack/test/controller/renderers_test.rb
@@ -117,4 +117,14 @@ class RenderersTest < ActionController::TestCase
     assert_equal Mime[:svg], @response.media_type
     assert_equal "<svg><circle cx=\"50\" cy=\"50\" r=\"40\"/></svg>", @response.body
   end
+
+  test "accessing the RENDERERS constant is deprecated" do
+    ActionController::Renderers.add(:foo) { }
+
+    assert_deprecated(/ActionController::Renderers::RENDERERS is deprecated/, ActionController.deprecator) do
+      assert_includes(ActionController::Renderers::RENDERERS, :foo)
+    end
+  ensure
+    ActionController::Renderers.remove(:foo)
+  end
 end

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -42,6 +42,10 @@ module ActiveSupport
         @deprecator = deprecator
       end
 
+      def target=(object)
+        @object = object
+      end
+
       private
         def target
           @object

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -120,6 +120,22 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_deprecated(/:bomb:/, @deprecator) { deprecated_object.to_s }
   end
 
+  test "DeprecatedObjectProxy can set the target afterwards" do
+    list = []
+    deprecated_object = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(list, ":bomb:", @deprecator)
+
+    list = [1]
+    assert_deprecated(/:bomb:/, @deprecator) do
+      assert_not_includes(deprecated_object, 1)
+    end
+
+    deprecated_object.target = list
+
+    assert_deprecated(/:bomb:/, @deprecator) do
+      assert_includes(deprecated_object, 1)
+    end
+  end
+
   test "DeprecatedObjectProxy requires a deprecator" do
     assert_raises(ArgumentError) do
       ActiveSupport::Deprecation::DeprecatedObjectProxy.new(Object.new, ":bomb:")


### PR DESCRIPTION
### Motivation / Background

I'd like to make Action Controller Renderers Ractor safe. It currently is not because an object that holds the name of the renderers (`js`, `xml`...) isn't frozen. I can't just freeze it because we mutate it at boot time.

### Detail

This PR includes 3 commits

1. Deprecate a constant (It was documented but I think this should be for internal usage only).
2. Add a way for deprecated constant to change their target after initialization.
3. Stop mutating a Set when adding or removing renderer and freeze the set.

I added more explanation in each commit.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
