### PR TITLE
Bump json to 2.20.0 and pass `allow_comments: true`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.15.2)
+    json (2.20.0)
     jwt (2.10.1)
       base64
     kamal (2.4.0)
@@ -853,7 +853,7 @@ CHECKSUMS
   jbuilder (2.13.0) sha256=7200a38a1c0081aa81b7a9757e7a299db75bc58cf1fd45ca7919a91627d227d6
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
-  json (2.15.2) sha256=1068e1d966d2d0dcaf953eaed09c2d30e4104c64c1e3140c435d17be08d1fa27
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
   kamal (2.4.0) sha256=5f62f1858cc15c1506e55b60b075c89a1e7ef9c6bb0a7e3c01b54af190f85181
   kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c

--- a/activesupport/lib/active_support/messages/serializer_with_fallback.rb
+++ b/activesupport/lib/active_support/messages/serializer_with_fallback.rb
@@ -88,7 +88,7 @@ module ActiveSupport
           end
 
           def _load(dumped)
-            ActiveSupport::JSON.decode(dumped)
+            ActiveSupport::JSON.decode(dumped, allow_comments: true)
           end
 
           JSON_START_WITH = /\A(?:[{\["]|-?\d|true|false|null)/

--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -183,7 +183,7 @@ module Rails
             def devcontainer_json
               return unless File.exist?(devcontainer_json_path)
 
-              @devcontainer_json ||= JSON.parse(File.read(devcontainer_json_path))
+              @devcontainer_json ||= JSON.parse(File.read(devcontainer_json_path), allow_comments: true)
             end
 
             def devcontainer_json_path

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -131,7 +131,7 @@ module GeneratorsTestHelper
 
   def assert_devcontainer_json_file
     assert_file ".devcontainer/devcontainer.json" do |content|
-      yield JSON.load(content)
+      yield JSON.load(content, allow_comments: true)
     rescue JSON::ParserError
       puts "Failed to parse JSON: #{content}"
       raise


### PR DESCRIPTION
### Motivation / Background

This Pull Request bumps the bundled json gem to 2.20.0.

json 2.20.0 (ruby/json#1001, commit 138b9a2c) deprecates the parser's default
support for JavaScript comments in favor of an `allow_comments: true` option.
Parsing JSON that contains `//` or `/* */` comments without that option now
emits a deprecation warning ("Encountered comment in JSON. This will raise an
error in json 3.0 unless enabled via `allow_comments: true`").

### Detail

This Pull Request bumps json `2.15.2` → `2.20.0` in `Gemfile.lock` and passes
`allow_comments: true` at the parse sites that intentionally read comment-bearing
JSON:

- Active Support's JSON message serializer fallback `_load`
  (`active_support/messages/serializer_with_fallback.rb`), which loads irregular
  JSON through `ActiveSupport::JSON.decode`.
- Railties' `devcontainer.json`, which is JSONC by spec: the `db:system:change`
  generator that re-reads it (`change_generator.rb`) and the generator test
  helper that asserts on the generated file (`generators_test_helper.rb`).

The comments are intentional in both subsystems — the Active Support test
exercises comment tolerance, and `devcontainer.json` is JSONC by spec — so the
change opts in to `allow_comments: true` rather than removing the comments.

This fixes the failures observed in the nightly build
([rails-nightly #4483](https://buildkite.com/rails/rails-nightly/builds/4483)):

- `MessagesSerializerWithFallbackTest#test_:json_serializer_can_load_irregular_JSON` ([log](https://buildkite.com/rails/rails-nightly/builds/4483#019ef648-9b6f-463e-9828-03260b201c87/L7951))
- `AppGeneratorTest#test_devcontainer_skip_kamal` ([log](https://buildkite.com/rails/rails-nightly/builds/4483#019ef648-9b73-49c0-8b0c-91f869c53beb/L1340))
- `Rails::Generators::Db::System::ChangeGeneratorTest#test_change_from_db_with_devcontainer_service_to_one_without` ([log](https://buildkite.com/rails/rails-nightly/builds/4483#019ef648-9b74-4ea5-a182-f3a5ed24f19f/L1490))

<details>
<summary>Failures fixed (nightly #4483)</summary>

```
MessagesSerializerWithFallbackTest#test_:json_serializer_can_load_irregular_JSON:
RailsStrictWarnings::WarningError: /rails/activesupport/lib/active_support/json/decoding.rb:23: warning: Encountered comment in JSON. This will raise an error in json 3.0 unless enabled via `allow_comments: true` at line 1 column 15
    lib/active_support/messages/serializer_with_fallback.rb:91:in '...JsonWithFallback#_load'
    test/messages/serializer_with_fallback_test.rb:60

AppGeneratorTest#test_devcontainer_skip_kamal:
RailsStrictWarnings::WarningError: /rails/railties/test/generators/generators_test_helper.rb:134: warning: Encountered comment in JSON. This will raise an error in json 3.0 unless enabled via `allow_comments: true` at line 2 column 1
    test/generators/app_generator_test.rb:1598

Rails::Generators::Db::System::ChangeGeneratorTest#test_change_from_db_with_devcontainer_service_to_one_without:
RailsStrictWarnings::WarningError: /rails/railties/lib/rails/generators/rails/db/system/change/change_generator.rb:186: warning: Encountered comment in JSON. This will raise an error in json 3.0 unless enabled via `allow_comments: true` at line 2 column 1
    test/generators/db_system_change_generator_test.rb:207
```
</details>

### Additional information

- Upstream change: ruby/json#1001 ([commit 138b9a2c](https://github.com/ruby/json/commit/138b9a2c4932ad2df1024ce3af18a5cc3ae9e901)).
- `allow_comments: true` is harmless on older json: it is accepted without error
  on json 2.7.1, the default gem in Ruby 3.3.1 (verified on Ruby 3.3.1).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
