### PR TITLE
Only reset predicate builder on table_name exists

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -274,12 +274,12 @@ module ActiveRecord
         if defined?(@table_name)
           return if value == @table_name
           reset_column_information if connected?
+          @predicate_builder = nil
         end
 
         @table_name        = value
         @arel_table        = Arel::Table.new(klass: self)
         @sequence_name     = nil unless @explicit_sequence_name
-        @predicate_builder = nil
       end
 
       # Returns a quoted version of the table name.


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/57824

Table name computation was made lazy in rails/rails#57642, which incorrectly resets Active Record's predicate_builder. We need to only reset that when the table name changes, and not during the first computation.

### Detail

This Pull Request changes the predicate builder reset in table_name to only happen when an existing one is set. This way, we don't assume the table_name is set at query time using a custom type handler (Regexp, in tests).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
