### PR TITLE
Make EventReporter::LogSubscriber::LEVEL_CHECKS ractor safe

### DIFF
--- a/activesupport/lib/active_support/event_reporter/log_subscriber.rb
+++ b/activesupport/lib/active_support/event_reporter/log_subscriber.rb
@@ -6,9 +6,9 @@ module ActiveSupport
       include ColorizeLogging
 
       LEVEL_CHECKS = {
-        debug: -> (logger) { logger.debug? },
-        info: -> (logger) { logger.info? },
-        error: -> (logger) { logger.error? },
+        debug: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.debug? }),
+        info: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.info? }),
+        error: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.error? }),
       }.freeze
 
       class << self


### PR DESCRIPTION
Apply the same Ractor-safety treatment used in `ActiveSupport::LogSubscriber::LEVEL_CHECKS` to its `EventReporter` counterpart: wrap the level-check lambdas with `ActiveSupport::Ractors.shareable_lambda` so the constant is Ractor-shareable.