### PR TITLE
Make Arel BIND_BLOCK constants ractor safe

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -140,7 +140,7 @@ module Arel # :nodoc: all
           visit o.right, collector
         end
 
-        BIND_BLOCK = proc { |i| "$#{i}" }
+        BIND_BLOCK = ActiveSupport::Ractors.shareable_proc { |i| "$#{i}" }
         private_constant :BIND_BLOCK
 
         def bind_block; BIND_BLOCK; end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -765,7 +765,7 @@ module Arel # :nodoc: all
           collector << quote_table_name(join_name) << "." << quote_column_name(o.name)
         end
 
-        BIND_BLOCK = proc { "?" }
+        BIND_BLOCK = ActiveSupport::Ractors.shareable_proc { "?" }
         private_constant :BIND_BLOCK
 
         def bind_block; BIND_BLOCK; end


### PR DESCRIPTION
Wrap the bind-substitution procs in `Arel::Visitors::ToSql` and `Arel::Visitors::PostgreSQL` with `ActiveSupport::Ractors.shareable_proc` so the `BIND_BLOCK` constants are Ractor-shareable.

Neither proc captures any external state.