### PR TITLE
Make StructuredEventSubscriber::DEBUG_CHECK ractor safe

### DIFF
--- a/activesupport/lib/active_support/structured_event_subscriber.rb
+++ b/activesupport/lib/active_support/structured_event_subscriber.rb
@@ -31,7 +31,7 @@ module ActiveSupport
   class StructuredEventSubscriber < Subscriber
     class_attribute :debug_methods, instance_accessor: false, default: [] # :nodoc:
 
-    DEBUG_CHECK = proc { !ActiveSupport.event_reporter.debug_mode? }
+    DEBUG_CHECK = ActiveSupport::Ractors.shareable_proc { !ActiveSupport.event_reporter.debug_mode? }
 
     class << self
       def attach_to(...) # :nodoc:


### PR DESCRIPTION
Wrap the debug-mode check proc with `ActiveSupport::Ractors.shareable_proc` so `StructuredEventSubscriber::DEBUG_CHECK` is Ractor-shareable.

The proc only calls `ActiveSupport.event_reporter.debug_mode?` at the module level and captures no instance state.