### PR TITLE
Make CookieStore::DEFAULT_SAME_SITE ractor safe

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -59,7 +59,7 @@ module ActionDispatch
         end
       end
 
-      DEFAULT_SAME_SITE = proc { |request| request.cookies_same_site_protection } # :nodoc:
+      DEFAULT_SAME_SITE = ActiveSupport::Ractors.shareable_proc { |request| request.cookies_same_site_protection } # :nodoc:
 
       def initialize(app, options = {})
         options[:cookie_only] = true


### PR DESCRIPTION
Wrap the default `:same_site` proc with `ActiveSupport::Ractors.shareable_proc` so `CookieStore::DEFAULT_SAME_SITE` is Ractor-shareable.

The proc receives the request as an argument and captures no external state.