### PR TITLE
Make NestedAttributes::REJECT_ALL_BLANK_PROC ractor safe

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -300,7 +300,7 @@ module ActiveRecord
     #     }
     #   }
     module ClassMethods
-      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+      REJECT_ALL_BLANK_PROC = ActiveSupport::Ractors.shareable_proc { |attributes| attributes.all? { |key, value| key == "_destroy" || value.blank? } }
 
       # Defines an attributes writer for the specified association(s).
       #


### PR DESCRIPTION
Wrap the `:all_blank` reject proc with `ActiveSupport::Ractors.shareable_proc` so `ActiveRecord::NestedAttributes::ClassMethods::REJECT_ALL_BLANK_PROC` is Ractor-shareable.

The proc receives the attributes hash as an argument and captures no external state.