### PR TITLE
Make some ActiveSupport constants ractor safe

### DIFF
--- a/activesupport/lib/active_support/event_reporter/log_subscriber.rb
+++ b/activesupport/lib/active_support/event_reporter/log_subscriber.rb
@@ -6,9 +6,9 @@ module ActiveSupport
       include ColorizeLogging
 
       LEVEL_CHECKS = {
-        debug: -> (logger) { logger.debug? },
-        info: -> (logger) { logger.info? },
-        error: -> (logger) { logger.error? },
+        debug: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.debug? }),
+        info: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.info? }),
+        error: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.error? }),
       }.freeze
 
       class << self

--- a/activesupport/lib/active_support/structured_event_subscriber.rb
+++ b/activesupport/lib/active_support/structured_event_subscriber.rb
@@ -31,7 +31,7 @@ module ActiveSupport
   class StructuredEventSubscriber < Subscriber
     class_attribute :debug_methods, instance_accessor: false, default: [] # :nodoc:
 
-    DEBUG_CHECK = proc { !ActiveSupport.event_reporter.debug_mode? }
+    DEBUG_CHECK = ActiveSupport::Ractors.shareable_proc { !ActiveSupport.event_reporter.debug_mode? }
 
     class << self
       def attach_to(...) # :nodoc:


### PR DESCRIPTION
Wrap the level-check lambdas in `EventReporter::LogSubscriber::LEVEL_CHECKS` and the debug-mode check proc in `StructuredEventSubscriber::DEBUG_CHECK` with `ActiveSupport::Ractors.shareable_lambda` / `.shareable_proc` so both constants are Ractor-shareable.

Neither captures any instance state — the lambdas receive the logger as an argument, and the proc only makes a module-level call to `ActiveSupport.event_reporter.debug_mode?`.