### PR TITLE
Make some Active Record constants ractor safe

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -300,7 +300,7 @@ module ActiveRecord
     #     }
     #   }
     module ClassMethods
-      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+      REJECT_ALL_BLANK_PROC = ActiveSupport::Ractors.shareable_proc { |attributes| attributes.all? { |key, value| key == "_destroy" || value.blank? } }
 
       # Defines an attributes writer for the specified association(s).
       #

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -140,7 +140,7 @@ module Arel # :nodoc: all
           visit o.right, collector
         end
 
-        BIND_BLOCK = proc { |i| "$#{i}" }
+        BIND_BLOCK = ActiveSupport::Ractors.shareable_proc { |i| "$#{i}" }
         private_constant :BIND_BLOCK
 
         def bind_block; BIND_BLOCK; end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -765,7 +765,7 @@ module Arel # :nodoc: all
           collector << quote_table_name(join_name) << "." << quote_column_name(o.name)
         end
 
-        BIND_BLOCK = proc { "?" }
+        BIND_BLOCK = ActiveSupport::Ractors.shareable_proc { "?" }
         private_constant :BIND_BLOCK
 
         def bind_block; BIND_BLOCK; end


### PR DESCRIPTION
Wrap the bind-substitution procs in `Arel::Visitors::ToSql` and `Arel::Visitors::PostgreSQL`, and the `:all_blank` reject proc in `ActiveRecord::NestedAttributes::ClassMethods`, with `ActiveSupport::Ractors.shareable_proc` so all three constants are Ractor-shareable.

None of the procs capture any external state — each receives its input as an argument.