### PR TITLE
Make ActionMailbox::Callbacks::TERMINATOR ractor safe

### DIFF
--- a/actionmailbox/lib/action_mailbox/callbacks.rb
+++ b/actionmailbox/lib/action_mailbox/callbacks.rb
@@ -10,10 +10,10 @@ module ActionMailbox
     extend  ActiveSupport::Concern
     include ActiveSupport::Callbacks
 
-    TERMINATOR = ->(mailbox, chain) do
+    TERMINATOR = ActiveSupport::Ractors.shareable_lambda(&->(mailbox, chain) do
       chain.call
       mailbox.finished_processing?
-    end
+    end)
 
     included do
       define_callbacks :process, terminator: TERMINATOR, skip_after_callbacks_if_terminated: true


### PR DESCRIPTION
Wrap the callback terminator lambda with `ActiveSupport::Ractors.shareable_lambda` so `ActionMailbox::Callbacks::TERMINATOR` is Ractor-shareable.

The lambda receives `mailbox` and `chain` as arguments and captures no external state.

Complements #57629 (which makes the callbacks machinery itself ractor-safe); this covers the terminator: lambda passed by Action Mailbox.