### PR TITLE
Make ActiveSupport::JSON encoders Ractor-shareable

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -61,22 +61,22 @@ module ActiveSupport
       U2029 = -"\u2029".b
 
       ESCAPED_CHARS = {
-        U2028 => '\u2028'.b,
-        U2029 => '\u2029'.b,
-        ">".b => '\u003e'.b,
-        "<".b => '\u003c'.b,
-        "&".b => '\u0026'.b,
+        U2028 => -'\u2028'.b,
+        U2029 => -'\u2029'.b,
+        ">".b => -'\u003e'.b,
+        "<".b => -'\u003c'.b,
+        "&".b => -'\u0026'.b,
       }.freeze
 
-      HTML_ENTITIES_REGEX = Regexp.union(*(ESCAPED_CHARS.keys - [U2028, U2029]))
-      FULL_ESCAPE_REGEX = Regexp.union(*ESCAPED_CHARS.keys)
-      JS_SEPARATORS_REGEX = Regexp.union(U2028, U2029)
+      HTML_ENTITIES_REGEX = Regexp.union(*(ESCAPED_CHARS.keys - [U2028, U2029])).freeze
+      FULL_ESCAPE_REGEX = Regexp.union(*ESCAPED_CHARS.keys).freeze
+      JS_SEPARATORS_REGEX = Regexp.union(U2028, U2029).freeze
 
       class JSONGemEncoder # :nodoc:
         attr_reader :options
 
         def initialize(options = nil)
-          @options = options || {}
+          @options = options.dup.freeze || {}.freeze
         end
 
         # Encode the given object into a JSON string
@@ -149,7 +149,7 @@ module ActiveSupport
       if defined?(::JSON::Coder) && Gem::Version.new(::JSON::VERSION) >= Gem::Version.new("2.15.2")
         class JSONGemCoderEncoder # :nodoc:
           JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
-          CODER = ::JSON::Coder.new do |value, is_key|
+          CODER = ::JSON::Coder.new(&ActiveSupport::Ractors.shareable_proc { |value, is_key|
             # Serialize non-String/Symbol keys via #to_s based on the key's own type,
             # mirroring the legacy `jsonify` encoder. (#as_json is intentionally not
             # consulted here: Time#as_json returns an ISO8601 String, yet the key must
@@ -177,8 +177,7 @@ module ActiveSupport
               count -= 1
             end
             json_value
-          end
-
+          }).freeze
 
           def initialize(options = nil)
             if options
@@ -240,8 +239,8 @@ module ActiveSupport
 
         def json_encoder=(encoder)
           @json_encoder = encoder
-          @encoder_without_options = encoder.new
-          @encoder_without_escape = encoder.new(escape: false)
+          @encoder_without_options = encoder.new.freeze
+          @encoder_without_escape = encoder.new(escape: false).freeze
         end
 
         def encode_without_options(value) # :nodoc:

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -603,6 +603,21 @@ EXPECTED
     end
 end
 
+if RUBY_VERSION >= "4.0"
+  class JSONRactorShareabilityTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def test_encoders_are_ractor_shareable
+      assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }, escape: false) }.value
+      assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }) }.value
+      ActiveSupport::JSON::Encoding.with(escape_js_separators_in_json: false) do
+        assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }) }.value
+      end
+      assert_equal '{"a":1}', Ractor.new { ActiveSupport::JSON.encode({ a: 1 }, escape_html_entities: false) }.value
+    end
+  end
+end
+
 if defined?(::JSON::Coder)
   class OldJSONEncodingTest < TestJSONEncoding
     setup do

--- a/tools/strict_warnings.rb
+++ b/tools/strict_warnings.rb
@@ -24,6 +24,9 @@ module RailsStrictWarnings # :nodoc:
 
     # Emitted by zlib
     /attempt to close unfinished zstream/,
+
+    # Ractors are experimental
+    /Ractor( API) is experimental/,
   )
 
   def warn(message, ...)


### PR DESCRIPTION
Take 2 on #57814 

Using `ActiveSupport::Testing::Isolation`, we can get around the Ruby crashes.