### PR TITLE
Declare `assert_not_pattern` alias for `refute_pattern`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Declare `assert_not_pattern` as an alias for `refute_pattern`
+
+    *Sean Doyle*
+
 *   `assert_difference`, `assert_no_difference`, `assert_changes`, and
     `assert_no_changes` now raise `ArgumentError` when given an expression that
     is not a callable (like a Proc), String, or Symbol.

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -339,6 +339,17 @@ module ActiveSupport
     alias :assert_not_operator :refute_operator
 
     ##
+    # :method: assert_not_pattern
+    #
+    # :call-seq:
+    #   assert_not_pattern() { || ... }
+    #
+    # Alias for: refute_pattern[https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-refute_pattern]
+
+    #
+    alias :assert_not_pattern :refute_pattern
+
+    ##
     # :method: assert_not_predicate
     #
     # :call-seq:

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -28,6 +28,11 @@ class AssertionsTest < ActiveSupport::TestCase
     assert_equal "custom", e.message
   end
 
+  def test_assert_not_pattern
+    assert_pattern { { a: true } => { a: true } }
+    assert_not_pattern { { a: true } => { a: false } }
+  end
+
   def test_assert_raises_with_match_pass
     assert_raises(ArgumentError, match: /incorrect/i) do
       raise ArgumentError, "Incorrect argument"


### PR DESCRIPTION
### Motivation / Background

Active Support provides `assert_not`-prefixed aliases for `refute`-prefixed Minitest methods (like [assert_not_equal][] as an alias for `refute_equal`).

However, there are no pattern matching aliases, which forces callers to use the Minitest built-in `refute_pattern` variation.

### Detail

Minitest introduced the [assert_pattern][] and [refute_pattern][] assertions in [v5.18.0][] ([minitest/minitest@0c44f4e][] released 2023-03-04).

This commit declares an `assert_not_pattern` alias for `refute_pattern` in `ActiveSupport::TestCase` to match the existing convention.

[assert_pattern]: https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert_pattern
[refute_pattern]: https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-refute_pattern
[v5.18.0]: https://github.com/minitest/minitest/blob/master/History.rdoc#5180--2023-03-04
[minitest/minitest@0c44f4e]: https://github.com/minitest/minitest/commit/0c44f4ea32b656bc5fabf49d9d312d9ef3b02843
[assert_not_equal]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/TestCase.html#method-i-assert_not_equal

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
