### PR TITLE
Remove the use of `$,` as a default value for `safe_join`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Calling `safe_join` in a view no longer fallbacks to the `$,` global variable.
+
+    Previously, calling `safe_join` would use `$,` by default to separate elements.
+    Ruby has deprecated the usage of setting `$,` for more than 10 years and its usage
+    in `safe_join` was never documented.
+
+    If your application relied on this behaviour, make sure to explictly pass the separator
+    to `safe_join` as the default is now `nil` (no separation).
+
+    *Edouard Chin*
+
 *   Fix `ActionView::TestCase#render` to reset `rendered`.
     The behavior was changed when memoization was added in #51093. Now it once again conforms to the documentation.
 

--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -30,7 +30,7 @@ module ActionView # :nodoc:
       #   safe_join([tag.p("foo"), tag.p("bar")], tag.br)
       #   # => "<p>foo</p><br><p>bar</p>"
       #
-      def safe_join(array, sep = $,)
+      def safe_join(array, sep = nil)
         sep = ERB::Util.unwrapped_html_escape(sep)
 
         array.flatten.map! { |i| ERB::Util.unwrapped_html_escape(i) }.join(sep).html_safe

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -35,24 +35,6 @@ class OutputSafetyHelperTest < ActionView::TestCase
     assert_equal "&quot;a&quot; &lt;br/&gt; &lt;b&gt; &lt;br/&gt; &lt;c&gt;", joined
   end
 
-  test "safe_join should return the safe string separated by $, when second argument is not passed" do
-    default_delimiter = $,
-
-    begin
-      $, = nil
-      joined = safe_join(["a", "b"])
-      assert_equal "ab", joined
-
-      silence_warnings do
-        $, = "|"
-      end
-      joined = safe_join(["a", "b"])
-      assert_equal "a|b", joined
-    ensure
-      $, = default_delimiter
-    end
-  end
-
   test "to_sentence should escape non-html_safe values" do
     actual = to_sentence(%w(< > & ' "))
     assert_predicate actual, :html_safe?


### PR DESCRIPTION
### Motivation / Background

`$,` isn't ractor safe. It's used by `safe_join` and I'd like to remove it without going through a deprecation cycle first.

### Detail

My rationale for not going with a deprecation cycle first is:

1. This behaviour was never documented in Rails. It only mention that you can give a separator, not that we'd use `$,` as a fallback.
2. Ruby has deprecated setting `$,` for almost 10 years. I'm thinking that users had plenty of time to resolve this warning.
3. [GitHub code search](https://github.com/search?q=%22%24%2C+%3D%22+language%3Aruby&type=code&p=4) returns only 275 results for `$, =`. Many of them are from forks of Ruby itself.

### Additional information

Set the default value of the `sep` argument as nil for the solution. That's the value returned by `$,` by default.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
