### PR TITLE
Report PostgreSQL default timestamp/time precision as 6

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Report PostgreSQL default timestamp and time precision as 6.
+
+    Bare PostgreSQL `timestamp` and `time` columns now use their effective
+    microsecond precision in Active Record type metadata, matching the
+    database's persisted precision.
+
+    *Adrianna Chang*
+
 *   Fix inverse association matching for `has_many` and `has_one` associations
     with association-specific composite primary keys.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -810,6 +810,14 @@ module ActiveRecord
           end
         end
 
+        def register_class_with_precision(mapping, key, klass, **kwargs) # :nodoc:
+          mapping.register_type(key) do |_, fmod, _sql_type|
+            precision = fmod == -1 ? 6 : fmod
+
+            klass.new(precision: precision, **kwargs).freeze
+          end
+        end
+
         # Registers a callback to extend the type map during initialization.
         # Useful for third-party gems that need to register custom SQL types.
         #
@@ -868,6 +876,7 @@ module ActiveRecord
           self.class.initialize_type_map(m)
 
           self.class.register_class_with_precision m, "time", Type::Time, timezone: @default_timezone
+          self.class.register_class_with_precision m, "timetz", Type::Time, timezone: @default_timezone
           self.class.register_class_with_precision m, "timestamp", OID::Timestamp, timezone: @default_timezone
           self.class.register_class_with_precision m, "timestamptz", OID::TimestampWithTimeZone
 

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -165,6 +165,7 @@ end
 
 class PostgresqlTimestampMigrationTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlTimestampWithZone < ActiveRecord::Base; end
+  class PostgresqlTimestampPrecision < ActiveRecord::Base; end
 
   def test_adds_column_as_timestamp
     original, $stdout = $stdout, StringIO.new
@@ -206,4 +207,65 @@ class PostgresqlTimestampMigrationTest < ActiveRecord::PostgreSQLTestCase
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES.delete(:datetimes_as_enum)
     $stdout = original
   end
+
+  def test_timestamp_precision_metadata_uses_postgresql_default_for_bare_timestamp_types
+    with_timestamp_precision_table do
+      columns = columns_hash(PostgresqlTimestampPrecision)
+
+      assert_equal 6, columns["bare_timestamp"].precision
+      assert_equal 6, columns["bare_timestamptz"].precision
+      assert_equal 6, columns["explicit_timestamp_6"].precision
+      assert_equal 0, columns["explicit_timestamp_0"].precision
+      assert_equal 3, columns["explicit_timestamp_3"].precision
+    end
+  end
+
+  def test_time_precision_metadata_uses_postgresql_default_for_bare_time_types
+    with_timestamp_precision_table do
+      columns = columns_hash(PostgresqlTimestampPrecision)
+
+      assert_equal 6, columns["bare_time"].precision
+      assert_equal 6, columns["bare_timetz"].precision
+      assert_equal 0, columns["explicit_time_0"].precision
+      assert_equal 3, columns["explicit_timetz_3"].precision
+    end
+  end
+
+  def test_bare_timestamp_type_casting_uses_postgresql_default_precision
+    with_timestamp_precision_table do
+      time = ::Time.now.change(nsec: 123456789)
+      record = PostgresqlTimestampPrecision.new(bare_timestamp: time, bare_timestamptz: time)
+
+      assert_equal 123456000, record.bare_timestamp.nsec
+      assert_equal 123456000, record.bare_timestamptz.nsec
+    end
+  end
+
+  private
+    def with_timestamp_precision_table
+      connection = PostgresqlTimestampPrecision.lease_connection
+      connection.drop_table :postgresql_timestamp_precisions, if_exists: true
+      connection.execute(<<~SQL)
+        CREATE TABLE postgresql_timestamp_precisions (
+          bare_timestamp timestamp without time zone,
+          bare_timestamptz timestamp with time zone,
+          explicit_timestamp_6 timestamp(6) without time zone,
+          explicit_timestamp_0 timestamp(0) without time zone,
+          explicit_timestamp_3 timestamp(3) without time zone,
+          bare_time time without time zone,
+          bare_timetz time with time zone,
+          explicit_time_0 time(0) without time zone,
+          explicit_timetz_3 time(3) with time zone
+        )
+      SQL
+      PostgresqlTimestampPrecision.reset_column_information
+      yield
+    ensure
+      PostgresqlTimestampPrecision.reset_column_information
+      connection&.drop_table :postgresql_timestamp_precisions, if_exists: true
+    end
+
+    def columns_hash(model)
+      model.columns.index_by(&:name)
+    end
 end

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -46,7 +46,7 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
       assert_equal 123456000, foo.updated_at.nsec
     end
 
-    unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+    unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
       def test_no_datetime_precision_isnt_truncated_on_assignment
         @connection.create_table(:foos, force: true)
         @connection.add_column :foos, :created_at, :datetime, precision: nil
@@ -236,13 +236,24 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
       assert_match %r{t\.datetime\s+"updated_at",\s+null: false$}, output
     end
 
-    def test_schema_dump_with_without_precision_has_precision_as_nil
-      @connection.create_table(:foos, force: true) do |t|
-        t.timestamps precision: nil
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_schema_dump_with_postgresql_default_precision_is_not_dumped
+        @connection.create_table(:foos, force: true) do |t|
+          t.timestamps precision: nil
+        end
+        output = dump_table_schema("foos")
+        assert_match %r{t\.datetime\s+"created_at",\s+null: false$}, output
+        assert_match %r{t\.datetime\s+"updated_at",\s+null: false$}, output
       end
-      output = dump_table_schema("foos")
-      assert_match %r{t\.datetime\s+"created_at",\s+precision: nil,\s+null: false$}, output
-      assert_match %r{t\.datetime\s+"updated_at",\s+precision: nil,\s+null: false$}, output
+    else
+      def test_schema_dump_with_without_precision_has_precision_as_nil
+        @connection.create_table(:foos, force: true) do |t|
+          t.timestamps precision: nil
+        end
+        output = dump_table_schema("foos")
+        assert_match %r{t\.datetime\s+"created_at",\s+precision: nil,\s+null: false$}, output
+        assert_match %r{t\.datetime\s+"updated_at",\s+precision: nil,\s+null: false$}, output
+      end
     end
 
     if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -152,12 +152,12 @@ class PostgresqlDefaultExpressionTest < ActiveRecord::TestCase
       if ActiveRecord::Base.lease_connection.database_version >= 100000
         assert_match %r/t\.date\s+"modified_date",\s+default: -> { "CURRENT_DATE" }/, output
         assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
-        assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+        assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
         assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
       else
         assert_match %r/t\.date\s+"modified_date",\s+default: -> { "\('now'::text\)::date" }/, output
         assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "now\(\)" }/, output
-        assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { "now\(\)" }/, output
+        assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+default: -> { "now\(\)" }/, output
         assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { "now\(\)" }/, output
       end
       assert_match %r/t\.date\s+"modified_date_function",\s+default: -> { "now\(\)" }/, output

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -742,6 +742,8 @@ module ActiveRecord
         def precision_implicit_default
           if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
             { precision: 0 }
+          elsif current_adapter?(:PostgreSQLAdapter)
+            { precision: 6 }
           else
             { precision: nil }
           end
@@ -849,6 +851,8 @@ module DefaultPrecisionImplicitTestCases
     def precision_implicit_default
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
         { precision: 0 }
+      elsif current_adapter?(:PostgreSQLAdapter)
+        { precision: 6 }
       else
         { precision: nil }
       end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -970,7 +970,11 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
     assert_match %r{t\.string\s+"string_with_default",.*?default: "Hello!"}, output
     assert_match %r{t\.date\s+"date_with_default",\s+default: "2014-06-05"}, output
     assert_match %r{t\.datetime\s+"datetime_with_default",\s+default: "2014-06-05 07:17:04"}, output
-    assert_match %r{t\.time\s+"time_with_default",\s+default: "2000-01-01 07:17:04"}, output
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_match %r{t\.time\s+"time_with_default",\s+precision: 6,\s+default: "2000-01-01 07:17:04"}, output
+    else
+      assert_match %r{t\.time\s+"time_with_default",\s+default: "2000-01-01 07:17:04"}, output
+    end
     assert_match %r{t\.decimal\s+"decimal_with_default",\s+precision: 20,\s+scale: 10,\s+default: "1234567890.0123456789"}, output
   end
 

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -45,7 +45,7 @@ class TimePrecisionTest < ActiveRecord::TestCase
       assert_equal 123456000, foo.finish.nsec
     end
 
-    unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+    unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
       def test_no_time_precision_isnt_truncated_on_assignment
         @connection.create_table(:foos, force: true)
         @connection.add_column :foos, :start,  :time


### PR DESCRIPTION
### Motivation / Background

PostgreSQL omits the typmod for bare timestamp/time columns, but those types still behave with microsecond precision by default. Reflect that effective precision in Active Record metadata so type casting normalizes timestamps consistently with persisted database values.

### Detail

  This change now uses the PostgreSQL typmod value passed through the type map
  instead of parsing the formatted SQL type string. When `fmod == -1`, Active
  Record reports precision `6`; otherwise it uses the explicit typmod precision.
  That keeps column metadata and type casting aligned with PostgreSQL's effective
  behavior for bare and explicit `timestamp`, `timestamptz`, `time`, and `timetz`
  columns.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
