### PR TITLE
Fix normalizes on an enum attribute raises ArgumentError instead of normalizing before enum casting

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix `normalizes` to run before the underlying type validates an assigned
+    value.
+
+    When `normalizes` was combined with another type that rejects invalid
+    input (such as an Active Record `enum`), the underlying type's
+    `assert_valid_value` ran against the raw, un-normalized value and raised
+    before normalization had a chance to run. The normalization is now applied
+    first, so a value like `"  Pending  "` is normalized to `"pending"` and
+    accepted by the enum.
+
+    *Gabriel Quaresma*
+
 *   Fix `normalizes` re-applying normalizations on every validation of an
     unpersisted record, and speed up validation of normalized attributes.
 

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix `normalizes` to run before the underlying type validates an assigned
+    value.
+
+    When `normalizes` was combined with another type that rejects invalid
+    input (such as an Active Record `enum`), the underlying type's
+    `assert_valid_value` ran against the raw, un-normalized value and raised
+    before normalization had a chance to run. The normalization is now applied
+    first, so a value like `"  Pending  "` is normalized to `"pending"` and
+    accepted by the enum.
+
+    *Gabriel Quaresma*
+
 *   Fix `LengthValidator` raising `NoMethodError` when a `:minimum` (or `:is`)
     constraint is given as a proc and the validated value is `nil`.
 

--- a/activemodel/lib/active_model/attributes/normalization.rb
+++ b/activemodel/lib/active_model/attributes/normalization.rb
@@ -165,6 +165,10 @@ module ActiveModel
             normalize(super(value))
           end
 
+          def assert_valid_value(value)
+            cast_type.assert_valid_value(cast(value))
+          end
+
           def serialize(value)
             serialize_cast_value(cast(value))
           end

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -23,6 +23,11 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
     validate { self.validated_name = name.dup }
   end
 
+  class NormalizedEnumAircraft < Aircraft
+    enum :name, { pending: "pending", confirmed: "confirmed" }
+    normalizes :name, with: -> value { value.strip.downcase }
+  end
+
   setup do
     @time = Time.utc(1999, 12, 31, 12, 34, 56)
     @aircraft = NormalizedAircraft.create!(name: "fly HIGH", manufactured_at: @time)
@@ -58,6 +63,19 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
     admin_user.validate
 
     assert_equal({ "foo" => "bar", "baz" => "qux" }, admin_user.json_options)
+  end
+
+  test "normalizes value before enum casting" do
+    aircraft = NormalizedEnumAircraft.new(name: "  Pending  ")
+    assert_equal "pending", aircraft.name
+    assert_predicate aircraft, :pending?
+    assert aircraft.valid?
+  end
+
+  test "still raises for an invalid enum value after normalization" do
+    assert_raises(ArgumentError) do
+      NormalizedEnumAircraft.new(name: "  bogus  ")
+    end
   end
 
   test "minimizes number of times normalization is applied" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes #57828

This Pull Request has been created because combining `normalizes` with an attribute type that rejects invalid input — most notably an Active Record `enum` — raised an `ArgumentError` on assignment, before normalization had a chance to run:

```ruby
class Order < ApplicationRecord
  enum :status, { pending: "pending", confirmed: "confirmed" }
  normalizes :status, with: ->(v) { v.strip.downcase }
end

Order.new(status: "  Pending  ")
# => ArgumentError: '  Pending  ' is not a valid status
```

Because the raw, un-normalized value was validated first, it was impossible to use `normalizes` to sanitize user input destined for an enum — the two features conflicted.

### Detail

This Pull Request changes `ActiveModel::Attributes::Normalization::NormalizedValueType` to apply normalization **before** the underlying type validates the value.

Both `enum` and `normalizes` decorate an attribute's type, producing a stack of `NormalizedValueType → EnumType`. On assignment, `ActiveModel::Attribute#with_value_from_user` calls `type.assert_valid_value(value)` on the **raw** value before casting. `NormalizedValueType` overrode `cast` (which normalizes) but not `assert_valid_value`, so the check was delegated straight to `EnumType` with the un-normalized value and raised.

`NormalizedValueType` now overrides `assert_valid_value` to validate the normalized/cast value, mirroring exactly what `cast` stores:

```ruby
def assert_valid_value(value)
  cast_type.assert_valid_value(cast(value))
end
```

As a result, `"  Pending  "` is normalized to `"pending"` and accepted by the enum, while a genuinely invalid value (e.g. `"  bogus  "`) still raises `ArgumentError` after normalization. The change is scoped only to normalized attributes, so other attribute types are unaffected.

### Additional information

Regression tests were added in `activerecord/test/cases/normalized_attribute_test.rb` covering both the normalized-then-valid case and the still-invalid-after-normalization case. Verified the Active Model normalization suite, the Active Record enum suite, and the Active Record normalized-attribute suite all pass.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
