### PR TITLE
Make parameter encodings ractor safe by default

### DIFF
--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -8,13 +8,15 @@ module ActionController
     extend ActiveSupport::Concern
 
     module ClassMethods
+      attr_reader :_parameter_encodings # :nodoc:
+
       def inherited(klass) # :nodoc:
         super
         klass.setup_param_encode
       end
 
       def setup_param_encode # :nodoc:
-        @_parameter_encodings = Hash.new { |h, k| h[k] = {} }
+        @_parameter_encodings = ActiveSupport::Ractors.make_shareable(Hash.new({}))
       end
 
       def action_encoding_template(action) # :nodoc:
@@ -48,7 +50,9 @@ module ActionController
       # encoded as ASCII-8BIT. This is useful in the case where an application must
       # handle data but encoding of the data is unknown, like file system data.
       def skip_parameter_encoding(action)
-        @_parameter_encodings[action.to_s] = Hash.new { Encoding::ASCII_8BIT }
+        @_parameter_encodings = ActiveSupport::Ractors.make_shareable(
+          @_parameter_encodings.merge(action.to_s => Hash.new(Encoding::ASCII_8BIT))
+        )
       end
 
       # Specify the encoding for a parameter on an action. If not specified the
@@ -77,7 +81,13 @@ module ActionController
       # where an application must handle data but encoding of the data is unknown,
       # like file system data.
       def param_encoding(action, param, encoding)
-        @_parameter_encodings[action.to_s][param.to_s] = encoding
+        action = action.to_s
+        param = param.to_s
+        action_encodings = @_parameter_encodings[action].merge(param => encoding)
+
+        @_parameter_encodings = ActiveSupport::Ractors.make_shareable(
+          @_parameter_encodings.merge(action => action_encodings)
+        )
       end
     end
   end

--- a/actionpack/test/controller/parameter_encoding_test.rb
+++ b/actionpack/test/controller/parameter_encoding_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class ParameterEncodingController < ActionController::Base
   def test_undeclared_parameter
@@ -25,6 +26,8 @@ end
 
 class ParameterEncodingTest < ActionController::TestCase
   tests ParameterEncodingController
+
+  include ActiveSupport::Testing::RactorsAssertions
 
   test "properly transcodes undeclared parameters into UTF-8 encodings" do
     post :test_undeclared_parameter, params: { "foo" => "foo" }
@@ -60,5 +63,9 @@ class ParameterEncodingTest < ActionController::TestCase
 
     assert_response :success
     assert_equal "ASCII-8BIT", @response.body
+  end
+
+  test "parameter encodings are ractor safe" do
+    assert_ractor_shareable ParameterEncodingController._parameter_encodings
   end
 end


### PR DESCRIPTION
### Motivation / Background

`ActionController::Base.parameter_encodings` ractor safe.

### Detail

This is a hash where the keys are actions and the values are a hash mapping params to encodings. We need to make the hash frozen at all times and dup, append, freeze to keep this Ractor safe.

The hash has a default proc that mutates that hash populate missing keys, but since the hash is now frozen that doesn't make sense. Instead we can just have a frozen empty hash as the default value.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
