### PR TITLE
Bump cgi to 0.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.5.0)
+    cgi (0.5.2)
     chef-utils (18.8.11)
       concurrent-ruby
     childprocess (5.1.0)


### PR DESCRIPTION
### Motivation / Background

The `guides` CI job started failing after `cgi` 0.5.2 was released to
rubygems.org on June 23, 2026:

https://buildkite.com/rails/rails/builds/130132#019ef792-5616-4168-a846-7c29f8203167

The `guides/bug_report_templates/*.rb` files each run via
`Bundler.unbundled_system` with `bundler/inline` `gemfile(true)`, which
resolves against rubygems.org independently of this `Gemfile.lock` and picks
up the latest `cgi` (0.5.2). The first template to run,
`action_controller.rb`, installs cgi 0.5.2 while the CI image's already
bundled cgi is activated, so it fails:

```
--- Running bug_report_templates/action_controller.rb
... snip ...
Installing rails 7.2.3.1
/usr/local/lib/ruby/3.1.0/bundler/runtime.rb:308:in `check_for_activated_spec!': You have already activated cgi 0.5.1, but your Gemfile requires cgi 0.5.2. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
	from bug_report_templates/action_controller.rb:5:in `<main>'
+++ 💥 FAILED (exit 1)
```

The remaining templates then reuse the now-installed cgi 0.5.2 and pass, so
only `action_controller.rb` (the first one) fails, which turns the job red.

### Detail

This Pull Request bumps `cgi` from 0.5.0 to 0.5.2 in `Gemfile.lock` so the CI
base image is rebuilt with cgi 0.5.2 already present in `GEM_HOME`. The first
bug report template then finds cgi 0.5.2 already installed and no longer
installs it mid-process, so the activation conflict no longer occurs.

### Additional information

This is the same recurring failure that happens whenever a default gem
publishes a new release, and the fix follows the established precedent of a
one-line `Gemfile.lock` bump:

* `e3a28aa3dc` Bump stringio to 3.1.1
* `2e8381c8b2` Bump strscan to 3.0.4
* `adf10e9406` Bump psych gem to 5.1.2
* `e9106d0b20` Bump psych to 5.1.1.1
* `36c49b3cf5` Bump timeout to 0.4.1

Eventually this class of issue should be fixed permanently in rubygems
(rubygems/rubygems#5529, rubygems/rubygems#5535).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
