### PR TITLE
Make rescue handlers ractor safe by default

### DIFF
--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -12,7 +12,7 @@ module ActiveSupport
     extend Concern
 
     included do
-      class_attribute :rescue_handlers, default: []
+      class_attribute :rescue_handlers, default: [].freeze
     end
 
     module ClassMethods
@@ -69,7 +69,7 @@ module ActiveSupport
           end
 
           # Put the new handler at the end because the list is read in reverse.
-          self.rescue_handlers += [[key, with]]
+          self.rescue_handlers = [*rescue_handlers, [key, with].freeze].freeze
         end
       end
 

--- a/activesupport/test/rescuable_test.rb
+++ b/activesupport/test/rescuable_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class WraithAttack < StandardError
 end
@@ -122,6 +123,8 @@ class CoolStargate < Stargate
 end
 
 class RescuableTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def setup
     @stargate = Stargate.new
     @cool_stargate = CoolStargate.new
@@ -172,5 +175,16 @@ class RescuableTest < ActiveSupport::TestCase
   def test_rescue_handles_loops_in_exception_cause_chain
     @stargate.dispatch :looped_crash
     assert_equal "unhandled", @stargate.result
+  end
+
+  def test_rescue_handlers_are_ractor_safe
+    klass = Class.new do
+      include ActiveSupport::Rescuable
+
+      rescue_from NoMethodError, with: :foo
+      rescue_from ArgumentError, &ActiveSupport::Ractors.shareable_proc { }
+    end
+
+    assert_ractor_shareable klass.rescue_handlers
   end
 end


### PR DESCRIPTION
### Motivation / Background

Make rescue handlers Ractor safe.

### Detail

This is an array contain arrays of key and handler pairs. We freeze the default array and then dup, append and freeze when adding more. The handler is proc we `call` so we cannot make it ractor shareable since it may rely on calling methods on `self`. So the user will need to do that.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
