### PR TITLE
Fix incorrect number_to_rounded doc example [ci skip]

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -269,7 +269,7 @@ module ActiveSupport
     #
     #   number_to_rounded(12345.6789)                # => "12345.679"
     #   number_to_rounded(12345.6789, precision: 2)  # => "12345.68"
-    #   number_to_rounded(12345.6789, precision: 0)  # => "12345"
+    #   number_to_rounded(12345.6789, precision: 0)  # => "12346"
     #   number_to_rounded(12345, precision: 5)       # => "12345.00000"
     #
     # ==== Options


### PR DESCRIPTION
### Motivation / Background

The RDoc example for `ActiveSupport::NumberHelper#number_to_rounded` showed
`number_to_rounded(12345.6789, precision: 0) # => "12345"`, which is wrong:
the method rounds rather than truncates, so it returns `"12346"`. The
incorrect example implies truncation and can mislead anyone copying it. The
adjacent examples in the same block (`12345.679`, `12345.68`, `12345.00000`)
are all correct — only the `precision: 0` line was off.

### Detail

This Pull Request fixes the documented output of the `precision: 0` example
from `"12345"` to `"12346"` in `activesupport/lib/active_support/number_helper.rb`.
No code change — the implementation already rounds correctly.

### Additional information

Verified against the current code:

    ActiveSupport::NumberHelper.number_to_rounded(12345.6789, precision: 0) # => "12346"
    ActiveSupport::NumberHelper.number_to_rounded(12345.4,    precision: 0) # => "12345"  # rounds, not truncates
    ActiveSupport::NumberHelper.number_to_rounded(12345.6,    precision: 0) # => "12346"

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature. — N/A, documentation-only change; no behavior change to test.
* [ ] CHANGELOG files are updated... — N/A, per the guideline "documentation changes should not be included."
