### PR TITLE
Make Controller middlewares ractor safe

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -2,6 +2,8 @@
 
 # :markup: markdown
 
+require "active_support/ractors"
+require "active_support/core_ext/module/delegation"
 require "action_dispatch/middleware/stack"
 
 module ActionController
@@ -15,6 +17,25 @@ module ActionController
   #     end
   #
   class MiddlewareStack < ActionDispatch::MiddlewareStack # :nodoc:
+    class Proxy # :nodoc:
+      delegate_missing_to :@stack
+
+      def initialize(controller)
+        @controller = controller
+        @stack = @controller.middleware_stack
+      end
+
+      %w(unshift insert swap delete move move_after use).each do |method|
+        class_eval(<<~CODE, __FILE__, __LINE__ + 1)
+          def #{method}(...)
+            @controller.middleware_stack = @controller.middleware_stack.dup
+            @controller.middleware_stack.public_send(__method__, ...)
+            ActiveSupport::Ractors.try_make_shareable(@controller.middleware_stack)
+          end
+        CODE
+      end
+    end
+
     class Middleware < ActionDispatch::MiddlewareStack::Middleware # :nodoc:
       def initialize(klass, args, actions, strategy, block)
         @actions = actions
@@ -143,7 +164,7 @@ module ActionController
       private
         def inherited(subclass)
           super
-          subclass.middleware_stack = middleware_stack.dup
+          subclass.middleware_stack = ActiveSupport::Ractors.try_make_shareable(middleware_stack.dup)
           subclass.class_eval do
             @controller_name = nil
           end
@@ -289,7 +310,7 @@ module ActionController
       # Pushes the given Rack middleware and its arguments to the bottom of the
       # middleware stack.
       def use(...)
-        middleware_stack.use(...)
+        middleware.use(...)
       end
     end
 
@@ -306,7 +327,7 @@ module ActionController
     # (https://guides.rubyonrails.org/rails_on_rack.html#action-dispatcher-middleware-stack)
     # in the guides.
     def self.middleware
-      middleware_stack
+      ActionController::MiddlewareStack::Proxy.new(self)
     end
 
     # Returns a Rack endpoint for the given action name.

--- a/actionpack/test/controller/new_base/middleware_test.rb
+++ b/actionpack/test/controller/new_base/middleware_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 module MiddlewareTest
   class MyMiddleware
@@ -70,7 +71,12 @@ module MiddlewareTest
     end
   end
 
+  class RactorController < ActionController::Metal
+  end
+
   class TestMiddleware < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
     def setup
       @app = MyController.action(:index)
     end
@@ -97,6 +103,22 @@ module MiddlewareTest
 
       result = ActionsController.action(:index).call(env_for("/"))
       assert_nil result[1]["Middleware-Order"]
+    end
+
+    test "middleware stack is frozen" do
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+
+      RactorController.use(ExclaimerMiddleware)
+      RactorController.middleware.unshift(BlockMiddleware)
+      RactorController.middleware.insert(0, ExclaimerMiddleware)
+      RactorController.middleware.swap(ExclaimerMiddleware, MyMiddleware)
+      RactorController.middleware.move(0, MyMiddleware)
+      RactorController.middleware.move_after(ExclaimerMiddleware, MyMiddleware)
+
+      assert_ractor_shareable(RactorController.middleware_stack)
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
     end
 
     def env_for(url)


### PR DESCRIPTION
### Motivation / Background

The middleware for a controller (not to be confused with the rack middleware stack) isn't Ractor safe. It has to be made shareable (and all objects accessible from it).

### Detail

This commit implements a copy on write approach. One of the complication is that a controller can currently either call `use` (which is a wrapper around the MiddlewareStack object), or directly access the Middleware Stack. In the latter case, we need to create a proxy so that anytime a method on the stack is called, we can refreeze the stack.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
