### PR TITLE
Fix incorrect human_size round_mode doc example

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -87,7 +87,7 @@ module ActiveSupport
     #  1234567890123456.to_fs(:human_size)                       # => "1.1 PB"
     #  1234567890123456789.to_fs(:human_size)                    # => "1.07 EB"
     #  1234567.to_fs(:human_size, precision: 2)                  # => "1.2 MB"
-    #  1234567.to_fs(:human_size, precision: 2, round_mode: :up) # => "1.3 MB"
+    #  1234567.to_fs(:human_size, precision: 2, round_mode: :down) # => "1.1 MB"
     #  483989.to_fs(:human_size, precision: 2)                   # => "470 KB"
     #  1234567.to_fs(:human_size, precision: 2, separator: ',')  # => "1,2 MB"
     #  1234567890123.to_fs(:human_size, precision: 5)            # => "1.1228 TB"


### PR DESCRIPTION
### Motivation / Background

The RDoc example for `Numeric#to_fs` (`activesupport/lib/active_support/core_ext/numeric/conversions.rb`) showed:

```
1234567.to_fs(:human_size, precision: 2)                  # => "1.2 MB"
1234567.to_fs(:human_size, precision: 2, round_mode: :up) # => "1.3 MB"
```

The second line is wrong on two counts. `1234567` bytes is ~1.1774 MB, so at two significant digits it rounds to `"1.2 MB"` with the default mode — and `round_mode: :up` also produces `"1.2 MB"`, identical to the line right above it. So the example neither returns the documented `"1.3 MB"` nor demonstrates that `round_mode` changes anything.

### Detail

Switch the example to `round_mode: :down`, which keeps the same input (consistent with the rest of the block, which all uses `1234567`) and actually changes the output:

```
1234567.to_fs(:human_size, precision: 2, round_mode: :down) # => "1.1 MB"
```

No code change — the implementation already rounds correctly. The sibling example for `number_to_human_size` (`number_helper.rb`) already demonstrates `round_mode: :up` correctly with a different input (`123456 … round_mode: :up # => "130 KB"` vs default `"120 KB"`); only this `to_fs` example had picked an input where `:up` makes no difference.

### Additional information

Verified against the current code:

```
1234567.to_fs(:human_size, precision: 2)                    # => "1.2 MB"
1234567.to_fs(:human_size, precision: 2, round_mode: :down) # => "1.1 MB"
1234567.to_fs(:human_size, precision: 2, round_mode: :up)   # => "1.2 MB"  # no change vs default
```

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature. — N/A, documentation-only change.
* [ ] CHANGELOG files are updated... — N/A, documentation change.
