### PR TITLE
Load ActionDispatch::Request::Session and Utils at boot time

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -170,7 +170,7 @@ module ActionController
     attr_internal_reader :response
 
     ##
-    # The ActionDispatch::Request::Session instance for the current request.
+    # The session instance for the current request.
     # See further details in the
     # [Active Controller Session guide](https://guides.rubyonrails.org/action_controller_overview.html#session).
     delegate :session, to: "@_request"

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -101,6 +101,11 @@ module ActionDispatch
     autoload :Parameters
     autoload :UploadedFile, "action_dispatch/http/upload"
     autoload :URL
+
+    eager_autoload do
+      autoload :Session
+      autoload :Utils
+    end
   end
 
   module Session
@@ -146,9 +151,10 @@ module ActionDispatch
   singleton_class.attr_accessor :verbose_redirect_logs
   self.verbose_redirect_logs = false
 
-  def eager_load!
+  def self.eager_load!
     super
     Routing.eager_load!
+    Http.eager_load!
   end
 end
 

--- a/actionpack/lib/action_dispatch/http/param_builder.rb
+++ b/actionpack/lib/action_dispatch/http/param_builder.rb
@@ -61,14 +61,14 @@ module ActionDispatch
 
     def from_hash(hash, encoding_template: nil)
       # Force encodings from encoding template
-      hash = Request::Utils::CustomParamEncoder.encode_for_template(hash, encoding_template)
+      hash = Http::Utils::CustomParamEncoder.encode_for_template(hash, encoding_template)
 
       # Assert valid encoding
-      Request::Utils.check_param_encoding(hash)
+      Http::Utils.check_param_encoding(hash)
 
       # Convert hashes to HWIA (or UploadedFile), and deep-munge nils
       # out of arrays
-      hash = Request::Utils.normalize_encode_params(hash)
+      hash = Http::Utils.normalize_encode_params(hash)
 
       hash
     end
@@ -128,7 +128,7 @@ module ActionDispatch
 
         if after == ""
           if k == "[]" && depth != 0
-            return (v || !ActionDispatch::Request::Utils.perform_deep_munge) ? [v] : []
+            return (v || !Http::Utils.perform_deep_munge) ? [v] : []
           else
             params[k] = v
           end
@@ -137,7 +137,7 @@ module ActionDispatch
         elsif after == "[]"
           params[k] ||= []
           raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
-          params[k] << v if v || !ActionDispatch::Request::Utils.perform_deep_munge
+          params[k] << v if v || !Http::Utils.perform_deep_munge
         elsif after.start_with?("[]")
           # Recognize x[][y] (hash inside array) parameters
           unless after[2] == "[" && after.end_with?("]") && (child_key = after[3, after.length - 4]) && !child_key.empty? && !child_key.index("[") && !child_key.index("]")

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -67,10 +67,10 @@ module ActionDispatch
       def path_parameters=(parameters) # :nodoc:
         @env.delete("action_dispatch.request.parameters")
 
-        parameters = Request::Utils.set_binary_encoding(self, parameters, parameters[:controller], parameters[:action])
+        parameters = Utils.set_binary_encoding(self, parameters, parameters[:controller], parameters[:action])
         # If any of the path parameters has an invalid encoding then raise since it's
         # likely to trigger errors further on.
-        Request::Utils.check_param_encoding(parameters)
+        Utils.check_param_encoding(parameters)
 
         @env[PARAMETERS_KEY] = parameters
       rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -28,9 +28,6 @@ module ActionDispatch
     include ActionDispatch::ContentSecurityPolicy::Request
     include Rack::Request::Env
 
-    autoload :Session, "action_dispatch/request/session"
-    autoload :Utils,   "action_dispatch/request/utils"
-
     LOCALHOST   = Regexp.union [/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
 
     ENV_METHODS = %w[ AUTH_TYPE GATEWAY_INTERFACE
@@ -388,17 +385,17 @@ module ActionDispatch
     end
 
     def session=(session) # :nodoc:
-      Session.set self, session
+      Http::Session.set self, session
     end
 
     def session_options=(options)
-      Session::Options.set self, options
+      Http::Session::Options.set self, options
     end
 
     # Override Rack's GET method to support indifferent access.
     def GET
       fetch_header("action_dispatch.request.query_parameters") do |k|
-        encoding_template = Request::Utils::CustomParamEncoder.action_encoding_template(self, path_parameters[:controller], path_parameters[:action])
+        encoding_template = Http::Utils::CustomParamEncoder.action_encoding_template(self, path_parameters[:controller], path_parameters[:action])
         rack_query_params = ActionDispatch::ParamBuilder.from_query_string(rack_request.query_string, encoding_template: encoding_template)
 
         set_header k, rack_query_params
@@ -411,7 +408,7 @@ module ActionDispatch
     # Override Rack's POST method to support indifferent access.
     def POST
       fetch_header("action_dispatch.request.request_parameters") do
-        encoding_template = Request::Utils::CustomParamEncoder.action_encoding_template(self, path_parameters[:controller], path_parameters[:action])
+        encoding_template = Http::Utils::CustomParamEncoder.action_encoding_template(self, path_parameters[:controller], path_parameters[:action])
 
         param_list = nil
         pr = parse_formatted_parameters(params_parsers) do
@@ -523,7 +520,7 @@ module ActionDispatch
       end
 
       def default_session
-        Session.disabled(self)
+        Http::Session.disabled(self)
       end
 
       def read_body_stream

--- a/actionpack/lib/action_dispatch/http/session.rb
+++ b/actionpack/lib/action_dispatch/http/session.rb
@@ -2,10 +2,11 @@
 
 # :markup: markdown
 
+require "active_support/core_ext/hash/keys"
 require "rack/session/abstract/id"
 
 module ActionDispatch
-  class Request
+  module Http
     # Session is responsible for lazily loading the session from store.
     class Session # :nodoc:
       DisabledSessionError    = Class.new(StandardError)
@@ -18,17 +19,17 @@ module ActionDispatch
       # Creates a session hash, merging the properties of the previous session if any.
       def self.create(store, req, default_options)
         session_was = find req
-        session     = Request::Session.new(store, req)
+        session     = new(store, req)
         session.merge! session_was if session_was
 
         set(req, session)
-        Options.set(req, Request::Session::Options.new(store, default_options))
+        Options.set(req, Options.new(store, default_options))
         session
       end
 
       def self.disabled(req)
         new(nil, req, enabled: false).tap do
-          Session::Options.set(req, Session::Options.new(nil, { id: nil }))
+          Options.set(req, Options.new(nil, { id: nil }))
         end
       end
 

--- a/actionpack/lib/action_dispatch/http/utils.rb
+++ b/actionpack/lib/action_dispatch/http/utils.rb
@@ -3,9 +3,12 @@
 # :markup: markdown
 
 require "active_support/core_ext/hash/indifferent_access"
+require "active_support/core_ext/module/attribute_accessors"
+require "action_dispatch/http/upload"
+require "rack/utils"
 
 module ActionDispatch
-  class Request
+  module Http
     class Utils # :nodoc:
       mattr_accessor :perform_deep_munge, default: true
 
@@ -86,7 +89,7 @@ module ActionDispatch
         def self.encode_for_template(params, encoding_template)
           return params unless encoding_template
           params.except(:controller, :action).each do |key, value|
-            ActionDispatch::Request::Utils.each_param_value(value) do |param|
+            Utils.each_param_value(value) do |param|
               # If `param` is frozen, it comes from the router defaults
               next if param.frozen?
 

--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -74,11 +74,11 @@ module ActionDispatch
       end
 
       def prepare_session(req)
-        Request::Session.create(self, req, @default_options)
+        Http::Session.create(self, req, @default_options)
       end
 
       def loaded_session?(session)
-        !session.is_a?(Request::Session) || session.loaded?
+        !session.is_a?(Http::Session) || session.loaded?
       end
     end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -82,7 +82,7 @@ module ActionDispatch
       ActiveSupport.on_load(:action_dispatch_request) do
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
         self.strict_accept_header = app.config.action_dispatch.strict_accept_header
-        ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
+        Http::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       end
 
       ActiveSupport.on_load(:action_dispatch_response) do

--- a/actionpack/test/dispatch/http/session_test.rb
+++ b/actionpack/test/dispatch/http/session_test.rb
@@ -4,7 +4,7 @@ require "abstract_unit"
 require "action_dispatch/middleware/session/abstract_store"
 
 module ActionDispatch
-  class Request
+  module Http
     class SessionTest < ActiveSupport::TestCase
       attr_reader :req
 

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -111,8 +111,8 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
   end
 
   test "perform_deep_munge" do
-    old_perform_deep_munge = ActionDispatch::Request::Utils.perform_deep_munge
-    ActionDispatch::Request::Utils.perform_deep_munge = false
+    old_perform_deep_munge = ActionDispatch::Http::Utils.perform_deep_munge
+    ActionDispatch::Http::Utils.perform_deep_munge = false
     begin
       assert_parses({ "action" => nil }, "action")
       assert_parses({ "action" => { "foo" => nil } }, "action[foo]")
@@ -122,7 +122,7 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
       assert_parses({ "action" => { "foo" => [{ "bar" => nil }] } }, "action[foo][][bar]")
       assert_parses({ "action" => ["1", nil] }, "action[]=1&action[]")
     ensure
-      ActionDispatch::Request::Utils.perform_deep_munge = old_perform_deep_munge
+      ActionDispatch::Http::Utils.perform_deep_munge = old_perform_deep_munge
     end
   end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1188,7 +1188,7 @@ class RequestParameters < BaseRequestTest
   test "path parameters don't re-encode frozen strings" do
     request = stub_request
 
-    ActionDispatch::Request::Utils::CustomParamEncoder.stub(:action_encoding_template, Hash.new { Encoding::BINARY }) do
+    ActionDispatch::Http::Utils::CustomParamEncoder.stub(:action_encoding_template, Hash.new { Encoding::BINARY }) do
       request.path_parameters = { foo: "frozen", bar: +"mutable", controller: "test_controller" }
       assert_equal Encoding::BINARY, request.params[:bar].encoding
       assert_equal Encoding::UTF_8, request.params[:foo].encoding
@@ -1228,7 +1228,7 @@ class RequestParameters < BaseRequestTest
   test "query parameters specified as ASCII_8BIT encoded do not raise InvalidParameterError" do
     request = stub_request("QUERY_STRING" => "foo=%81E")
 
-    ActionDispatch::Request::Utils::CustomParamEncoder.stub(:action_encoding_template, { "foo" => Encoding::ASCII_8BIT }) do
+    ActionDispatch::Http::Utils::CustomParamEncoder.stub(:action_encoding_template, { "foo" => Encoding::ASCII_8BIT }) do
       assert_nothing_raised do
         request.parameters
       end
@@ -1244,7 +1244,7 @@ class RequestParameters < BaseRequestTest
       :input => data
     )
 
-    ActionDispatch::Request::Utils::CustomParamEncoder.stub(:action_encoding_template, { "foo" => Encoding::ASCII_8BIT }) do
+    ActionDispatch::Http::Utils::CustomParamEncoder.stub(:action_encoding_template, { "foo" => Encoding::ASCII_8BIT }) do
       assert_nothing_raised do
         request.parameters
       end
@@ -1526,8 +1526,8 @@ class RequestSession < BaseRequestTest
   test "#session" do
     @request.session
 
-    assert_not_predicate(ActionDispatch::Request::Session.find(@request), :enabled?)
-    assert_instance_of(ActionDispatch::Request::Session::Options, ActionDispatch::Request::Session::Options.find(@request))
+    assert_not_predicate(ActionDispatch::Http::Session.find(@request), :enabled?)
+    assert_instance_of(ActionDispatch::Http::Session::Options, ActionDispatch::Http::Session::Options.find(@request))
   end
 end
 

--- a/actionpack/test/dispatch/session/abstract_secure_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_secure_store_test.rb
@@ -42,7 +42,7 @@ module ActionDispatch
         as.call(env)
 
         assert @env
-        assert Request::Session.find ActionDispatch::Request.new @env
+        assert ActionDispatch::Http::Session.find ActionDispatch::Request.new @env
       end
 
       def test_new_session_object_is_merged_with_old
@@ -51,11 +51,11 @@ module ActionDispatch
         as.call(env)
 
         assert @env
-        session = Request::Session.find ActionDispatch::Request.new @env
+        session = ActionDispatch::Http::Session.find ActionDispatch::Request.new @env
         session["foo"] = "bar"
 
         as.call(@env)
-        session1 = Request::Session.find ActionDispatch::Request.new @env
+        session1 = ActionDispatch::Http::Session.find ActionDispatch::Request.new @env
 
         assert_not_equal session, session1
         assert_equal session.to_hash, session1.to_hash

--- a/actionpack/test/dispatch/session/abstract_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_store_test.rb
@@ -33,7 +33,7 @@ module ActionDispatch
         as.call(env)
 
         assert @env
-        assert Request::Session.find ActionDispatch::Request.new @env
+        assert ActionDispatch::Http::Session.find ActionDispatch::Request.new @env
       end
 
       def test_new_session_object_is_merged_with_old
@@ -42,11 +42,11 @@ module ActionDispatch
         as.call(env)
 
         assert @env
-        session = Request::Session.find ActionDispatch::Request.new @env
+        session = ActionDispatch::Http::Session.find ActionDispatch::Request.new @env
         session["foo"] = "bar"
 
         as.call(@env)
-        session1 = Request::Session.find ActionDispatch::Request.new @env
+        session1 = ActionDispatch::Http::Session.find ActionDispatch::Request.new @env
 
         assert_not_equal session, session1
         assert_equal session.to_hash, session1.to_hash
@@ -56,7 +56,7 @@ module ActionDispatch
         env = {}
         as = MemoryStore.new app
         as.call(env)
-        session = Request::Session.find ActionDispatch::Request.new env
+        session = ActionDispatch::Http::Session.find ActionDispatch::Request.new env
 
         assert_raise TypeError do
           session.update("Not hashable")

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -254,7 +254,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       get "/get_class_after_reset_session"
       assert_response :success
       assert_not_equal [], headers["Set-Cookie"]
-      assert_equal "class: ActionDispatch::Request::Session", response.body
+      assert_equal "class: ActionDispatch::Http::Session", response.body
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

While working on ractor stuff I noticed `ActionDispatch::Request::Session` is not loaded until the first request. It is autoloaded since rails/rails@8ce6b0c to avoid circularly requiring `ActionDispatch::Request`.

### Detail

This class (and `Utils`) are no doced, so I don't think we need to keep it at `Request::Session`. We can move it to `Http::Session` like the other things `ActionDispatch::Request` relies on and require it when we load that file. That way it will be loaded at boot time with everything else.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
