### PR TITLE
Only document the public ActionView::Template API [ci skip]

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -7,8 +7,6 @@ module ActionView
   class Template
     extend ActiveSupport::Autoload
 
-    STRICT_LOCALS_REGEX = /\#\s+locals:\s+\((.*?)\)(?=\s*-?%>|\s*$)/m
-
     # === Encodings in ActionView::Template
     #
     # ActionView::Template is one of a few sources of potential
@@ -174,12 +172,26 @@ module ActionView
       autoload :Types
     end
 
+    ##
+    # :singleton-method: register_template_handler
+    #
+    # Register an object that knows how to handle template files with the given
+    # extensions. This can be used to implement new template types. The handler
+    # must respond to +:call+, which will be passed the template and should
+    # return the rendered template as a String.
+    #
+    #   ActionView::Template.register_template_handler :foo, FooHandler
+
     extend Template::Handlers
 
-    singleton_class.attr_accessor :frozen_string_literal
+    singleton_class.attr_accessor :frozen_string_literal # :nodoc:
     @frozen_string_literal = false
 
-    class << self # :nodoc:
+    # :stopdoc:
+
+    STRICT_LOCALS_REGEX = /\#\s+locals:\s+\((.*?)\)(?=\s*-?%>|\s*$)/m
+
+    class << self
       def mime_types_implementation=(implementation)
         # This method isn't thread-safe, but it's not supposed
         # to be called after initialization

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -24,10 +24,6 @@ module ActionView # :nodoc:
         @@template_extensions ||= @@template_handlers.keys
       end
 
-      # Register an object that knows how to handle template files with the given
-      # extensions. This can be used to implement new template types.
-      # The handler must respond to +:call+, which will be passed the template
-      # and should return the rendered template as a String.
       def register_template_handler(*extensions, handler)
         raise(ArgumentError, "Extension is required") if extensions.empty?
         extensions.each do |extension|

--- a/actionview/lib/action_view/template/handlers/builder.rb
+++ b/actionview/lib/action_view/template/handlers/builder.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   module Template::Handlers
-    class Builder
+    class Builder # :nodoc:
       class_attribute :default_format, default: :xml
 
       def call(template, source)

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/erb/util"
 module ActionView
   class Template
     module Handlers
-      class ERB
+      class ERB # :nodoc:
         autoload :Erubi, "action_view/template/handlers/erb/erubi"
 
         # Specify trim mode for the ERB compiler. Defaults to '-'.

--- a/actionview/lib/action_view/template/handlers/html.rb
+++ b/actionview/lib/action_view/template/handlers/html.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   module Template::Handlers
-    class Html < Raw
+    class Html < Raw # :nodoc:
       def call(template, source)
         "ActionView::OutputBuffer.new #{super}"
       end

--- a/actionview/lib/action_view/template/handlers/raw.rb
+++ b/actionview/lib/action_view/template/handlers/raw.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   module Template::Handlers
-    class Raw
+    class Raw # :nodoc:
       def call(template, source)
         "#{source.inspect}.html_safe;"
       end

--- a/actionview/lib/action_view/template/sources.rb
+++ b/actionview/lib/action_view/template/sources.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   class Template
-    module Sources
+    module Sources # :nodoc:
       extend ActiveSupport::Autoload
 
       eager_autoload do

--- a/actionview/lib/action_view/template/sources/file.rb
+++ b/actionview/lib/action_view/template/sources/file.rb
@@ -3,7 +3,7 @@
 module ActionView
   class Template
     module Sources
-      class File
+      class File # :nodoc:
         def initialize(filename)
           @filename = filename
         end


### PR DESCRIPTION
register_template_handler is the supported way to teach Action View about a new template type, and gems such as [haml](https://github.com/haml/haml/blob/v7.2.0/lib/haml/rails_template.rb#L55) and [markaby](https://github.com/markaby/markaby/blob/v0.9.4/lib/markaby/rails.rb#L9) already call it as ActionView::Template.register_template_handler. It was undocumented because it is defined on the internal Template::Handlers module that Template extends, which is marked :nodoc:.

Document it as a singleton method on ActionView::Template, where it actually lives once the module is extended, mirroring how local_assigns is documented.

Everything else under ActionView::Template is internal: the registry helper methods, the built-in handler classes (ERB, Raw, Html, Builder), and Template's own class and instance methods are not meant to be called by applications. Mark the handler classes :nodoc: and use :stopdoc: to stop documenting Template past its public entry points, so the API page only lists register_template_handler and local_assigns.

This also drops the :nodoc: on Template's `class << self`, which never had any effect: RDoc does not honor :nodoc: on a singleton class, so mime_types_implementation=, validate_formats and normalized_formats had been showing up as public API.
