### PR TITLE
Fix preloader reusing loaded associations across scoped has_many :through preloads

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -96,19 +96,21 @@ module ActiveRecord
       # associations before querying the database. This can save database
       # queries by reusing in-memory objects. The optimization is only applied
       # to single associations (i.e. :belongs_to, :has_one) with no scopes.
-      def initialize(records:, associations:, scope: nil, available_records: [], associate_by_default: true)
+      def initialize(records:, associations:, scope: nil, available_records: [], associate_by_default: true, reuse_loaded_association: true)
         @records = records
         @associations = associations
         @scope = scope
         @available_records = available_records || []
         @associate_by_default = associate_by_default
+        @reuse_loaded_association = reuse_loaded_association
 
         @tree = Branch.new(
           parent: nil,
           association: nil,
           children: @associations,
           associate_by_default: @associate_by_default,
-          scope: @scope
+          scope: @scope,
+          reuse_loaded_association: @reuse_loaded_association
         )
         @tree.preloaded_records = @records
       end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -248,7 +248,7 @@ module ActiveRecord
           end
 
           def associate_records_to_owner(owner, records)
-            return if loaded?(owner)
+            return if loadable?(owner)
 
             association = owner.association(reflection.name)
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -77,7 +77,7 @@ module ActiveRecord
             def populate_keys_to_load_and_already_loaded_records
               loaders.each do |loader|
                 loader.owners_by_key.each do |key, owners|
-                  if loaded_owner = owners.find { |owner| loader.loaded?(owner) }
+                  if loaded_owner = owners.find { |owner| loader.loadable?(owner) }
                     already_loaded_records_by_key[key] = loader.target_for(loaded_owner)
                   else
                     keys_to_load << key
@@ -101,14 +101,15 @@ module ActiveRecord
 
         attr_reader :klass
 
-        def initialize(klass, owners, reflection, preload_scope, reflection_scope, associate_by_default)
+        def initialize(klass, owners, reflection, preload_scope, reflection_scope, associate_by_default, reuse_loaded_association = true)
           @klass         = klass
           @owners        = owners.uniq(&:__id__)
           @reflection    = reflection
           @preload_scope = preload_scope
           @reflection_scope = reflection_scope
-          @associate     = associate_by_default || !preload_scope || preload_scope.empty_scope?
-          @model         = owners.first && owners.first.class
+          @associate = associate_by_default || !preload_scope || preload_scope.empty_scope?
+          @reuse_loaded_association = reuse_loaded_association
+          @model = owners.first && owners.first.class
           @run = false
         end
 
@@ -171,6 +172,10 @@ module ActiveRecord
             key = derive_key(owner, owner_key_name)
             (result[key] ||= []) << owner if key.is_a?(Array) ? key.all? : key
           end
+        end
+
+        def loadable?(owner)
+          @reuse_loaded_association && loaded?(owner)
         end
 
         def loaded?(owner)

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -5,10 +5,10 @@ module ActiveRecord
     class Preloader
       class Branch # :nodoc:
         attr_reader :association, :children, :parent
-        attr_reader :scope, :associate_by_default
+        attr_reader :scope, :associate_by_default, :reuse_loaded_association
         attr_writer :preloaded_records
 
-        def initialize(association:, children:, parent:, associate_by_default:, scope:)
+        def initialize(association:, children:, parent:, associate_by_default:, scope:, reuse_loaded_association: true)
           @association = if association
             begin
               @association = association.to_sym
@@ -19,6 +19,7 @@ module ActiveRecord
           @parent = parent
           @scope = scope
           @associate_by_default = associate_by_default
+          @reuse_loaded_association = reuse_loaded_association
 
           @children = build_children(children)
           @loaders = nil
@@ -101,7 +102,7 @@ module ActiveRecord
 
             [klass, reflection_scope]
           end.map do |(rhs_klass, reflection_scope), rs|
-            preloader_for(reflection).new(rhs_klass, rs, reflection, scope, reflection_scope, associate_by_default)
+            preloader_for(reflection).new(rhs_klass, rs, reflection, scope, reflection_scope, associate_by_default, reuse_loaded_association)
           end
         end
 
@@ -132,7 +133,8 @@ module ActiveRecord
                   association: parent,
                   children: child,
                   associate_by_default: associate_by_default,
-                  scope: scope
+                  scope: scope,
+                  reuse_loaded_association: reuse_loaded_association
                 )
               }
             }

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -68,7 +68,13 @@ module ActiveRecord
           end
 
           def source_preloaders
-            @source_preloaders ||= ActiveRecord::Associations::Preloader.new(records: middle_records, associations: source_reflection.name, scope: scope, associate_by_default: false).loaders
+            @source_preloaders ||= ActiveRecord::Associations::Preloader.new(
+              records: middle_records,
+              associations: source_reflection.name,
+              scope: scope,
+              associate_by_default: false,
+              reuse_loaded_association: scope.empty_scope? || through_scope.eager_loading?
+            ).loaders
           end
 
           def middle_records
@@ -76,7 +82,13 @@ module ActiveRecord
           end
 
           def through_preloaders
-            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(records: owners, associations: through_reflection.name, scope: through_scope, associate_by_default: false).loaders
+            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(
+              records: owners,
+              associations: through_reflection.name,
+              scope: through_scope,
+              associate_by_default: false,
+              reuse_loaded_association: through_scope.empty_scope?
+            ).loaders
           end
 
           def through_reflection

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1218,6 +1218,18 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 2, post_with_readers.lazy_readers_skimmers_or_not.to_a.size
   end
 
+  def test_preload_multiple_scoped_has_many_through_associations_on_same_join_table
+    author = Author.create!(name: "Preload Test")
+    Categorization.create!(author: author, post: posts(:thinking), category: categories(:general))
+    Categorization.create!(author: author, post: posts(:welcome), category: categories(:technology))
+    Categorization.create!(author: author, post: posts(:welcome), category: categories(:cooking))
+
+    author_with_preloads = Author.preload(:categories, :categories_like_general).find(author.id)
+
+    assert_equal 3, author_with_preloads.categories.size
+    assert_equal [categories(:general)], author_with_preloads.categories_like_general
+  end
+
   def test_eager_loading_with_conditions_on_string_joined_table_preloads
     posts = assert_queries_count(2) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: "INNER JOIN comments on comments.post_id = posts.id", where: "comments.body like 'Thank you%'", order: "posts.id").to_a


### PR DESCRIPTION
### Motivation / Background

When preloading both an unscoped and a scoped `has_many :through` association through the same join table, the scoped association incorrectly reuses the unscoped association's loaded records.

```ruby
Post.preload(:tags, :inactive_tags).find(post.id)
```

The unscoped `:tags` preload loads taggings and tags. The scoped `:inactive_tags` preload sees `loaded? == true` and reuses them, ignoring `where(active: false)`.

This PR Fixes #57861 (that bug)

### Detail

Introduce `reuse_loaded_association` to control whether a preloader may reuse an already-loaded association. Use `loadable?` (`@reuse_loaded_association && loaded?`) consistently for both query skipping and association assignment.

A `has_many :through` preload runs in two stages. For `Post.preload(:tags, :inactive_tags)`:

1. **through preloader** — middle association (`:taggings`)
2. **source preloader** — final association (`:tag`)

The reuse rules differ between the two stages.

#### through preloader

```ruby
reuse_loaded_association: through_scope.empty_scope?
```

The through preloader can skip querying when the post's `:taggings` are already loaded. `reuse_loaded_association` controls whether that is allowed.

- `:tags` (unscoped) → `through_scope.empty_scope?` is true → reuse
- `:inactive_tags` (scoped) → false → do not reuse

`:inactive_tags` should load only the taggings linked to tags with `active: false`. `:tags` loads all taggings for the post.

When `:tags` is preloaded first, the post's taggings become `loaded? == true`. If reuse is allowed here, the through preloader for `:inactive_tags` keeps those taggings and skips the scoped query.

So for scoped through associations, reuse is disabled when `through_scope.empty_scope?` is false. `:inactive_tags` reloads taggings on its own.

This is the main cause of the reported bug.

#### source preloader

```ruby
reuse_loaded_association: scope.empty_scope? || through_scope.eager_loading?
```

- unscoped source (`:tags`) → OK
- through already eager loaded (`:inactive_tags` with `where` + `includes` JOIN) → OK
- other scoped sources (e.g. `limit` only) → not OK

For a scoped through association where through_scope.eager_loading? is true, the through preloader has already loaded the source records under the scoped through query.
In that case, the source preloader does not need to query again. Reuse is safe.

For scoped sources where the through association is not eager loaded (e.g. `limit` only), the `tag` set by `:tags` cannot be trusted, so reuse is disabled.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
