### PR TITLE
Fix alias_attribute precedence over included modules

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `alias_attribute` overriding methods defined in included modules.
+
+    *Gaston Ramos*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `alias_attribute` overriding methods defined in included modules.
+
+    *Gaston Ramos*
+
 *   Avoid unnecessary association preloader queries for nil foreign keys when
     the foreign key and association primary key have different types.
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -44,6 +44,7 @@ module ActiveRecord
         private_constant :GeneratedAttributeMethods
         @attribute_methods_generated = false
         @alias_attributes_mass_generated = false
+        @alias_attribute_method_definition_owners = {}
         include @generated_attribute_methods
 
         super
@@ -65,9 +66,13 @@ module ActiveRecord
       #   # SELECT "people".* FROM "people" WHERE "people"."name" = "Bob"
       def alias_attribute(new_name, old_name)
         super
+        if alias_attribute_method_needs_own_definition_owner?(new_name)
+          @alias_attribute_method_definition_owners[new_name.to_s] = generated_alias_attribute_methods
+        end
 
         if @alias_attributes_mass_generated
-          ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
+          owner = alias_attribute_method_definition_owner(new_name)
+          ActiveSupport::CodeGenerator.batch(owner, __FILE__, __LINE__) do |code_generator|
             generate_alias_attribute_methods(code_generator, new_name, old_name)
           end
         end
@@ -129,9 +134,10 @@ module ActiveRecord
 
         return if @alias_attributes_mass_generated
 
-        ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
-          aliases_by_attribute_name.each do |old_name, new_names|
-            new_names.each do |new_name|
+        aliases_by_attribute_name.each do |old_name, new_names|
+          new_names.each do |new_name|
+            owner = alias_attribute_method_definition_owner(new_name)
+            ActiveSupport::CodeGenerator.batch(owner, __FILE__, __LINE__) do |code_generator|
               generate_alias_attribute_methods(code_generator, new_name, old_name)
             end
           end
@@ -143,6 +149,7 @@ module ActiveRecord
       def undefine_attribute_methods # :nodoc:
         GeneratedAttributeMethods::LOCK.synchronize do
           super if @attribute_methods_generated
+          undefine_generated_alias_attribute_methods if @attribute_methods_generated
           @attribute_methods_generated = false
           @alias_attributes_mass_generated = false
         end
@@ -262,6 +269,45 @@ module ActiveRecord
       end
 
       private
+        def generated_alias_attribute_methods
+          @generated_alias_attribute_methods ||= begin
+            mod = const_set(:GeneratedAliasAttributeMethods, GeneratedAttributeMethods.new)
+            private_constant :GeneratedAliasAttributeMethods
+            include mod
+
+            mod
+          end
+        end
+
+        def alias_attribute_method_definition_owner(new_name)
+          @alias_attribute_method_definition_owners.fetch(new_name.to_s) do
+            if alias_attribute_method_needs_own_definition_owner?(new_name)
+              @alias_attribute_method_definition_owners[new_name.to_s] = generated_alias_attribute_methods
+            else
+              generated_attribute_methods
+            end
+          end
+        end
+
+        def alias_attribute_method_needs_own_definition_owner?(new_name)
+          method_name = new_name.to_s
+          method_defined = method_defined?(method_name) || private_method_defined?(method_name)
+
+          return false unless method_defined
+
+          method_owner = instance_method(method_name).owner
+
+          return false if method_owner == self || method_owner.is_a?(GeneratedAttributeMethods)
+
+          ancestors.index(method_owner) < ancestors.index(generated_attribute_methods)
+        end
+
+        def undefine_generated_alias_attribute_methods
+          @generated_alias_attribute_methods&.module_eval do
+            undef_method(*instance_methods)
+          end
+        end
+
         def inherited(child_class)
           super
           child_class.initialize_generated_modules

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -44,6 +44,7 @@ module ActiveRecord
         private_constant :GeneratedAttributeMethods
         @attribute_methods_generated = false
         @alias_attributes_mass_generated = false
+        @alias_attribute_method_definition_owners = {}
         include @generated_attribute_methods
 
         super
@@ -65,9 +66,13 @@ module ActiveRecord
       #   # SELECT "people".* FROM "people" WHERE "people"."name" = "Bob"
       def alias_attribute(new_name, old_name)
         super
+        if alias_attribute_method_needs_own_definition_owner?(new_name)
+          @alias_attribute_method_definition_owners[new_name.to_s] = generated_alias_attribute_methods
+        end
 
         if @alias_attributes_mass_generated
-          ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
+          owner = alias_attribute_method_definition_owner(new_name)
+          ActiveSupport::CodeGenerator.batch(owner, __FILE__, __LINE__) do |code_generator|
             generate_alias_attribute_methods(code_generator, new_name, old_name)
           end
         end
@@ -128,9 +133,10 @@ module ActiveRecord
 
         return if @alias_attributes_mass_generated
 
-        ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
-          aliases_by_attribute_name.each do |old_name, new_names|
-            new_names.each do |new_name|
+        aliases_by_attribute_name.each do |old_name, new_names|
+          new_names.each do |new_name|
+            owner = alias_attribute_method_definition_owner(new_name)
+            ActiveSupport::CodeGenerator.batch(owner, __FILE__, __LINE__) do |code_generator|
               generate_alias_attribute_methods(code_generator, new_name, old_name)
             end
           end
@@ -142,6 +148,7 @@ module ActiveRecord
       def undefine_attribute_methods # :nodoc:
         GeneratedAttributeMethods::LOCK.synchronize do
           super if @attribute_methods_generated
+          undefine_generated_alias_attribute_methods if @attribute_methods_generated
           @attribute_methods_generated = false
           @alias_attributes_mass_generated = false
         end
@@ -261,6 +268,45 @@ module ActiveRecord
       end
 
       private
+        def generated_alias_attribute_methods
+          @generated_alias_attribute_methods ||= begin
+            mod = const_set(:GeneratedAliasAttributeMethods, GeneratedAttributeMethods.new)
+            private_constant :GeneratedAliasAttributeMethods
+            include mod
+
+            mod
+          end
+        end
+
+        def alias_attribute_method_definition_owner(new_name)
+          @alias_attribute_method_definition_owners.fetch(new_name.to_s) do
+            if alias_attribute_method_needs_own_definition_owner?(new_name)
+              @alias_attribute_method_definition_owners[new_name.to_s] = generated_alias_attribute_methods
+            else
+              generated_attribute_methods
+            end
+          end
+        end
+
+        def alias_attribute_method_needs_own_definition_owner?(new_name)
+          method_name = new_name.to_s
+          method_defined = method_defined?(method_name) || private_method_defined?(method_name)
+
+          return false unless method_defined
+
+          method_owner = instance_method(method_name).owner
+
+          return false if method_owner == self || method_owner.is_a?(GeneratedAttributeMethods)
+
+          ancestors.index(method_owner) < ancestors.index(generated_attribute_methods)
+        end
+
+        def undefine_generated_alias_attribute_methods
+          @generated_alias_attribute_methods&.module_eval do
+            undef_method(*instance_methods)
+          end
+        end
+
         def inherited(child_class)
           super
           child_class.initialize_generated_modules

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1414,6 +1414,42 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal("hey", obj.subject)
   end
 
+  test "#alias_attribute override methods defined in included modules" do
+    subject_override = Module.new do
+      def subject
+        "Abstract Subject"
+      end
+    end
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      include subject_override
+      alias_attribute :subject, :title
+    end
+
+    obj = klass.new
+    obj.title = "hey"
+    assert_equal("hey", obj.subject)
+  end
+
+  test "#alias_attribute override methods from modules included after the alias declaration" do
+    subject_override = Module.new do
+      def subject
+        "Abstract Subject"
+      end
+    end
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      alias_attribute :subject, :title
+      include subject_override
+    end
+
+    obj = klass.new
+    obj.title = "hey"
+    assert_equal("hey", obj.subject)
+  end
+
   test "aliases to the same attribute name do not conflict with each other" do
     first_model_object = ToBeLoadedFirst.new(author_name: "author 1")
     assert_equal("author 1", first_model_object.subject)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1360,6 +1360,42 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal("hey", obj.subject)
   end
 
+  test "#alias_attribute override methods defined in included modules" do
+    subject_override = Module.new do
+      def subject
+        "Abstract Subject"
+      end
+    end
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      include subject_override
+      alias_attribute :subject, :title
+    end
+
+    obj = klass.new
+    obj.title = "hey"
+    assert_equal("hey", obj.subject)
+  end
+
+  test "#alias_attribute override methods from modules included after the alias declaration" do
+    subject_override = Module.new do
+      def subject
+        "Abstract Subject"
+      end
+    end
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      alias_attribute :subject, :title
+      include subject_override
+    end
+
+    obj = klass.new
+    obj.title = "hey"
+    assert_equal("hey", obj.subject)
+  end
+
   test "aliases to the same attribute name do not conflict with each other" do
     first_model_object = ToBeLoadedFirst.new(author_name: "author 1")
     assert_equal("author 1", first_model_object.subject)


### PR DESCRIPTION
### Motivation / Background

Fixes #50048.

`alias_attribute` should allow an attribute alias to override a method with the same name that comes from an included module. For example, if a model includes a module that defines `display_name`, and the model then declares `alias_attribute :display_name, :title`, calling `display_name` should read the `title` attribute.

Before this change, the method generated for the alias was defined in `GeneratedAttributeMethods`. Included modules can appear before `GeneratedAttributeMethods` in the ancestor chain, so Ruby resolved the method from the included module first and never reached the generated alias method.

### Detail

This Pull Request detects when an alias attribute method would be generated below an existing method with higher precedence in the ancestor chain. In that case, it generates the alias methods in a separate `GeneratedAliasAttributeMethods` module that is included with higher precedence.

Aliases without that conflict continue to use `GeneratedAttributeMethods`, so the normal alias generation path remains unchanged.

The change also clears generated alias methods when attribute methods are undefined, matching the existing regeneration lifecycle for generated attribute methods.

### Additional information

A regression test covers an included module defining the alias reader before `alias_attribute` is declared.

Validation run locally with Ruby 3.4.9:

```bash
cd activerecord
bin/test test/cases/attribute_methods_test.rb -i "/alias_attribute override methods defined in included modules/"
bin/test test/cases/attribute_methods_test.rb -i "/alias_attribute/"
bin/test test/cases/attribute_methods_test.rb
```

RuboCop:

```bash
bundle exec rubocop activerecord/lib/active_record/attribute_methods.rb activerecord/test/cases/attribute_methods_test.rb
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.

