### PR TITLE
Add missing `&block` to `merge!` `:call-seq:` in `ActionController::Parameters`

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -1072,7 +1072,7 @@ module ActionController
     end
 
     ##
-    # :call-seq: merge!(*other_hashes)
+    # :call-seq: merge!(*other_hashes, &block)
     #
     # Returns the current `ActionController::Parameters` instance with `other_hashes`
     # merged into current hash.


### PR DESCRIPTION
### Summary

The `:call-seq:` for `ActionController::Parameters#merge!` omits the block argument that the method accepts:

`actionpack/lib/action_controller/metal/strong_parameters.rb`

```ruby
# :call-seq: merge!(*other_hashes)
#
# Returns the current `ActionController::Parameters` instance with `other_hashes`
# merged into current hash.
def merge!(*other_hashes, &block)
  @parameters.merge!(*other_hashes.map!(&:to_h), &block)
  self
end
```

The method forwards `&block` to `Hash#merge!`, so a block can be passed to resolve conflicting keys. The sibling `deep_merge!` already documents its block argument in its `:call-seq`, so this conforms the documentation to the existing convention in the same class:

```ruby
# :call-seq:
#     deep_merge!(other_hash, &block)
```
