### PR TITLE
Fix incorrect RDoc examples in Active Model

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -71,7 +71,7 @@ module ActiveModel
     #   person.errors.add(:name, :too_short, count: 2)
     #   person.errors.each do |error|
     #     # Will yield <#ActiveModel::Error attribute=name, type=too_short,
-    #                                       options={:count=>3}>
+    #                                       options={:count=>2}>
     #   end
 
     ##

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -293,8 +293,8 @@ module ActiveModel
       #    attr_accessor :name
       #  end
       #
-      #  User.attribute_method?(:name) # => true
-      #  User.attribute_method?(:age)  # => false
+      #  Person.attribute_method?(:name) # => true
+      #  Person.attribute_method?(:age)  # => false
       def attribute_method?(attribute)
         method_defined?(attribute)
       end


### PR DESCRIPTION
### Summary

Two RDoc code examples in Active Model show output that doesn't match the example code right above it. Both are documentation-only fixes (`[ci skip]`).

#### 1. `ActiveModel::Validations::ClassMethods#attribute_method?`

`activemodel/lib/active_model/validations.rb`

The example defines a class named `Person` but then calls `User.attribute_method?` — a leftover from copy-pasting. The calls should be on the class that the example actually defines.

```ruby
class Person
  include ActiveModel::Validations

  attr_accessor :name
end

User.attribute_method?(:name) # => true   # <- should be Person
User.attribute_method?(:age)  # => false  # <- should be Person
```

#### 2. `ActiveModel::Errors#each`

`activemodel/lib/active_model/errors.rb`

The example adds an error with `count: 2`, but the yielded error in the comment is shown with `options={:count=>3}`. The two should match.

```ruby
person.errors.add(:name, :too_short, count: 2)
person.errors.each do |error|
  # Will yield <#ActiveModel::Error attribute=name, type=too_short,
  #                                 options={:count=>3}>   # <- should be 2
end
```
