### PR TITLE
Fix incorrect RDoc output examples in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -128,7 +128,7 @@ module ActiveRecord
       #   person.pets.find(4) # => ActiveRecord::RecordNotFound: Couldn't find Pet with 'id'=4
       #
       #   person.pets.find(2) { |pet| pet.name.downcase! }
-      #   # => #<Pet id: 2, name: "fancy-fancy", person_id: 1>
+      #   # => #<Pet id: 2, name: "spook", person_id: 1>
       #
       #   person.pets.find(2, 3)
       #   # => [

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       #   # => "name='foo''bar' and group_id=4"
       #
       #   sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
-      #   # => "name='foo''bar' and group_id='4'"
+      #   # => "name='foo''bar' and group_id=4"
       #
       #   sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id='4'"


### PR DESCRIPTION
### Summary

Two RDoc output examples documented results the code cannot produce. Each is contradicted by sibling examples in the same file.

### Details

**`associations/collection_proxy.rb` — `find` with a block**

```diff
 #   person.pets.find(2) { |pet| pet.name.downcase! }
-#   # => #<Pet id: 2, name: "fancy-fancy", person_id: 1>
+#   # => #<Pet id: 2, name: "spook", person_id: 1>
```

The fixture in the same doc block defines pet `id: 2` as `name: "Spook"`, so downcasing it yields `"spook"`. `"fancy-fancy"` is the downcased form of pet `id: 1`'s `"Fancy-Fancy"`, which cannot coexist with `id: 2`.

**`sanitization.rb` — `sanitize_sql_for_conditions` named binds**

```diff
 #   sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
-#   # => "name='foo''bar' and group_id='4'"
+#   # => "name='foo''bar' and group_id=4"
```

Integer binds are not quoted. The positional-bind example just above shows `group_id=4`, as does the identical named-bind example for `sanitize_sql_array`. (The `'%s'` template examples correctly show `'4'` because those quotes are literal in the format string — left untouched.)