### PR TITLE
Fix incorrect RDoc output examples in ActiveSupport

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -42,8 +42,8 @@ class Hash
   # Note that keys are treated differently than HashWithIndifferentAccess,
   # meaning that string and symbol keys will not match.
   #
-  #   { name: 'Rob', years: '28' }.assert_valid_keys(:name, :age) # => raises "ArgumentError: Unknown key: :years. Valid keys are: :name, :age"
-  #   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises "ArgumentError: Unknown key: :name. Valid keys are: 'name', 'age'"
+  #   { name: 'Rob', years: '28' }.assert_valid_keys(:name, :age) # => raises 'ArgumentError: Unknown key: :years. Valid keys are: :name, :age'
+  #   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises 'ArgumentError: Unknown key: :name. Valid keys are: "name", "age"'
   #   { name: 'Rob', age: '28' }.assert_valid_keys(:name, :age)   # => passes, raises nothing
   def assert_valid_keys(*valid_keys)
     valid_keys.flatten!

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -134,7 +134,7 @@ module ActiveSupport
     #   my_config.read # => "some_secret: 123\nsome_namespace:\n  another_secret: 456"
     #
     #   my_config.config
-    #   # => { some_secret: 123, some_namespace: { another_secret: 789 } }
+    #   # => { some_secret: 123, some_namespace: { another_secret: 456 } }
     #
     def config
       @config ||= deep_symbolize_keys(deserialize(read))


### PR DESCRIPTION
### Summary

Two RDoc output examples documented results the code cannot produce. Each is contradicted by sibling examples in the same file.

### Details

**`core_ext/hash/keys.rb` — `assert_valid_keys`**

```diff
-#   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises "ArgumentError: Unknown key: :name. Valid keys are: 'name', 'age'"
+#   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises "ArgumentError: Unknown key: :name. Valid keys are: \"name\", \"age\""
```

The error message is built with `valid_keys.map(&:inspect)`, and `String#inspect` always double-quotes, so the message contains `"name", "age"`, not single quotes. The sibling symbol-key example above is already correct.

**`encrypted_configuration.rb` — `config`**

```diff
 #   my_config.config
-#   # => { some_secret: 123, some_namespace: { another_secret: 789 } }
+#   # => { some_secret: 123, some_namespace: { another_secret: 456 } }
```

`config` just deserializes `read`, whose example value is `456`. The surrounding examples (the class header, `read`, and `keys`) all use `456`; only this one read `789`.