### PR TITLE
Fix incorrect RDoc examples in ActionView form helpers

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1528,7 +1528,7 @@ module ActionView
       #
       #   @user.born_on = Date.new(1984, 1, 27)
       #   month_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-01" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="month" value="1984-01" />
       #
       def month_field(object_name, method, options = {})
         Tags::MonthField.new(object_name, method, self, options).render
@@ -1545,7 +1545,7 @@ module ActionView
       #
       #   @user.born_on = Date.new(1984, 5, 12)
       #   week_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-W19" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="week" value="1984-W19" />
       #
       def week_field(object_name, method, options = {})
         Tags::WeekField.new(object_name, method, self, options).render

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -140,12 +140,12 @@ module ActionView
       # are deselected, web browsers do not send any value to the server. Unfortunately, this introduces a gotcha.
       # For example, given a multiple select in a form that edits people associated with a post:
       #
-      #   select :post, :person_ids, Person.all.collect { |p| [ p.name, p.id ] }, { multiple: true })
+      #   select :post, :person_ids, Person.all.collect { |p| [ p.name, p.id ] }, { multiple: true }
       #
       # would become:
       #
       #   <input name="post[person_ids][]" type="hidden" value="" autocomplete="off" />
-      #   <select name="post[person_ids][]" id="post_person_ids" multiple="true">
+      #   <select name="post[person_ids][]" id="post_person_ids" multiple="multiple">
       #     <option value="1">David</option>
       #     <option value="2">Eileen</option>
       #     <option value="3">Rafael</option>


### PR DESCRIPTION
### Summary

Three RDoc examples in ActionView form helpers documented output that the code cannot produce. Each is contradicted by a neighboring example in the same method/section, so the correct value is self-evident.

### Details

**`form_helper.rb` — `month_field` / `week_field`**

The "default value" examples showed `type="date"`, copied from `date_field`. `month_field` renders a `Tags::MonthField` (`type="month"`) and `week_field` renders a `Tags::WeekField` (`type="week"`) — exactly what the first example in each method already shows.

```diff
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-01" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="month" value="1984-01" />
```
```diff
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-W19" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="week" value="1984-W19" />
```

**`form_options_helper.rb` — `select` multiple-select gotcha**

The example showed `multiple="true"`, which the tag builder never emits — boolean attributes render as `multiple="multiple"`. Also removed a stray closing paren in the accompanying call example.

```diff
-      #   select :post, :person_ids, Person.all.collect { |p| [ p.name, p.id ] }, { multiple: true })
+      #   select :post, :person_ids, Person.all.collect { |p| [ p.name, p.id ] }, { multiple: true }
...
-      #   <select name="post[person_ids][]" id="post_person_ids" multiple="true">
+      #   <select name="post[person_ids][]" id="post_person_ids" multiple="multiple">
```