### PR TITLE
Fix stale instance variable in `stale?` RDoc example

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -217,7 +217,7 @@ module ActionController
     #       @article = Article.find(params[:id])
     #
     #       if stale?(@article, public: true, cache_control: { no_cache: true })
-    #         @statistics = @articles.really_expensive_call
+    #         @statistics = @article.really_expensive_call
     #         respond_to do |format|
     #           # all the supported formats
     #         end


### PR DESCRIPTION
### Summary

The single-record `stale?` example in `ActionController::ConditionalGet` defines `@article` and passes it to `stale?`, but then referenced an undefined `@articles`.

### Details

`conditional_get.rb`:

```diff
 #       if stale?(@article, public: true, cache_control: { no_cache: true })
-#         @statistics = @articles.really_expensive_call
+#         @statistics = @article.really_expensive_call
```

The snippet defines `@article = Article.find(params[:id])` and passes `@article` to `stale?`; `@articles` is never defined in this example. The sibling single-record `stale?` examples above already use `@article`.

(The collection example elsewhere in the file that uses `@articles = Article.all` is correct and left untouched.)