### PR TITLE
Honor `options[:drop]` in CacheStore session deletion

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
@@ -54,7 +54,7 @@ module ActionDispatch
       def delete_session(env, sid, options)
         @cache.delete(cache_key(sid.private_id))
         @cache.delete(cache_key(sid.public_id))
-        generate_sid
+        generate_sid unless options[:drop]
       end
 
       private

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -238,6 +238,19 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_delete_session_returns_nil_when_dropped
+    cache = ActiveSupport::Cache::MemoryStore.new
+    store = ActionDispatch::Session::CacheStore.new(->(env) { [200, {}, []] }, cache: cache)
+    sid = Rack::Session::SessionId.new("0" * 32)
+
+    # With options[:drop], delete_session must return nil so the session is
+    # dropped rather than reassigned a fresh id (Rack's delete_session contract).
+    assert_nil store.delete_session({}, sid, drop: true)
+
+    # Without :drop, a fresh session id is returned.
+    assert_not_nil store.delete_session({}, sid, {})
+  end
+
   private
     def cache_store_options(options = {})
       @cache_store_options ||= options


### PR DESCRIPTION
### Summary

`ActionDispatch::Session::CacheStore#delete_session` ignored `options[:drop]` and always returned a freshly generated session id, so a dropped session was reassigned a new id and cookie instead of being dropped.

### Details

Rack's `delete_session` contract is to return a new session id, or `nil` when `options[:drop]` is set, so that `commit_session` returns early and does not write a fresh session cookie. `CookieStore#delete_session` honors this:

```ruby
new_sid = generate_sid unless options[:drop]
```

But `CacheStore#delete_session` always generated a new id:

```ruby
def delete_session(env, sid, options)
  @cache.delete(cache_key(sid.private_id))
  @cache.delete(cache_key(sid.public_id))
  generate_sid
end
```

Now it returns `nil` when `options[:drop]` is set, matching CookieStore.
