### PR TITLE
Fix `remove_check_constraint` with `if_exists` for the expression form

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1445,7 +1445,7 @@ module ActiveRecord
       def remove_check_constraint(table_name, expression = nil, if_exists: false, **options)
         return unless supports_check_constraints?
 
-        return if if_exists && !check_constraint_exists?(table_name, **options)
+        return if if_exists && !check_constraint_exists?(table_name, expression: expression, **options)
 
         chk_name_to_delete = check_constraint_for!(table_name, expression: expression, **options).name
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -101,7 +101,7 @@ module ActiveRecord
         end
 
         def remove_check_constraint(table_name, expression = nil, if_exists: false, **options)
-          return if if_exists && !check_constraint_exists?(table_name, **options)
+          return if if_exists && !check_constraint_exists?(table_name, expression: expression, **options)
 
           check_constraints = check_constraints(table_name)
           chk_name_to_delete = check_constraint_for!(table_name, expression: expression, **options).name

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -274,6 +274,10 @@ if ActiveRecord::Base.lease_connection.supports_check_constraints?
             @connection.remove_check_constraint :trades, name: "quantity_check", if_exists: true
           end
 
+          assert_nothing_raised do
+            @connection.remove_check_constraint :trades, "quantity > 0", if_exists: true
+          end
+
           error = assert_raises ArgumentError do
             @connection.remove_check_constraint :trades, name: "quantity_check"
           end


### PR DESCRIPTION
### Summary

`remove_check_constraint :products, "price > 0", if_exists: true` raised `ArgumentError` instead of becoming a no-op when the constraint did not exist (and failed to find it by expression when it did).

### Details

`remove_check_constraint` resolves the constraint via:

```ruby
check_constraint_for!(table_name, expression: expression, **options)
```

but the `if_exists` existence check omitted the expression:

```ruby
return if if_exists && !check_constraint_exists?(table_name, **options)
```

Since `expression` is a positional argument it is not part of `**options`, so the existence check reached `check_constraint_exists?` with neither `:name` nor `:expression` and raised:

```
ArgumentError: At least one of :name or :expression must be supplied
```

This is the opposite of what `if_exists: true` is supposed to do. The expression form is explicitly endorsed by the method's own documentation for reversible migrations.

The same bug existed in both the abstract adapter and the SQLite3 adapter (which overrides `remove_check_constraint`); both now forward `expression: expression` to the existence check so it identifies the same constraint as the removal.
