### PR TITLE
Fix reversibility check for `drop_virtual_table`

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -404,7 +404,7 @@ module ActiveRecord
         end
 
         def invert_drop_virtual_table(args)
-          _enum, values = args.dup.tap(&:extract_options!)
+          _table_name, _module_name, values = args.dup.tap(&:extract_options!)
           raise ActiveRecord::IrreversibleMigration, "drop_virtual_table is only reversible if given options." unless values
           super
         end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -632,6 +632,12 @@ module ActiveRecord
           @recorder.inverse_of :drop_virtual_table, [:searchables]
         end
       end
+
+      def test_invert_drop_virtual_table_without_values
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :drop_virtual_table, [:searchables, :fts5]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

`invert_drop_virtual_table` checked the wrong positional argument for reversibility, so a recorded `drop_virtual_table` missing its column values passed the reversibility guard and produced a `create_virtual_table` inverse that cannot be replayed.

### Details

`drop_virtual_table(table_name, module_name, values, **options)` carries the column `values` in its **third** positional argument. But the inverter destructured only two positionals — copied from `invert_drop_enum`, whose `values` is the **second** argument:

```ruby
def invert_drop_virtual_table(args)
  _enum, values = args.dup.tap(&:extract_options!)
  raise ActiveRecord::IrreversibleMigration, "..." unless values
  super
end
```

So `values` was bound to `module_name` and the guard checked the wrong slot: since `module_name` is always present, the `IrreversibleMigration` guard never fired even when the real `values` were missing.

Fixed by destructuring the third positional so the guard checks the actual `values`.
