### PR TITLE
Fix `unique_constraint_exists?` to accept `:column` instead of `:expression`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1034,8 +1034,8 @@ module ActiveRecord
         #   unique_constraint_exists?(:sections, name: "unique_position")
         #
         def unique_constraint_exists?(table_name, **options)
-          if !options.key?(:name) && !options.key?(:expression)
-            raise ArgumentError, "At least one of :name or :expression must be supplied"
+          if !options.key?(:name) && !options.key?(:column)
+            raise ArgumentError, "At least one of :name or :column must be supplied"
           end
           unique_constraint_for(table_name, **options).present?
         end

--- a/activerecord/test/cases/migration/unique_constraint_test.rb
+++ b/activerecord/test/cases/migration/unique_constraint_test.rb
@@ -204,6 +204,9 @@ if ActiveRecord::Base.lease_connection.supports_unique_constraints?
           assert_not @connection.unique_constraint_exists?(:non_sections, name: "unique_constraint")
           assert_not @connection.unique_constraint_exists?(:sections, column: :non_position, name: "unique_constraint")
           assert_not @connection.unique_constraint_exists?(:sections, name: "other_check")
+
+          assert @connection.unique_constraint_exists?(:sections, column: :position)
+          assert_not @connection.unique_constraint_exists?(:sections, column: :non_position)
         end
 
         def test_remove_unique_constraint


### PR DESCRIPTION
### Summary

On PostgreSQL, `unique_constraint_exists?(:table, column: ...)` raised `ArgumentError` instead of returning a boolean.

### Details

PostgreSQL unique constraints are identified by column (or name), not by expression — `unique_constraint_for` branches on `options.key?(:column)` and `remove_unique_constraint` works off `column:`. But `unique_constraint_exists?` guarded on `:name`/`:expression`:

```ruby
def unique_constraint_exists?(table_name, **options)
  if !options.key?(:name) && !options.key?(:expression)
    raise ArgumentError, "At least one of :name or :expression must be supplied"
  end
  unique_constraint_for(table_name, **options).present?
end
```

So a column-based lookup raised, and the error message named an option (`:expression`) that unique constraints never accept. The guard was copied from `exclusion_constraint_exists?`, where `:expression` is legitimate (exclusion constraints are expression-based).

The guard (and its message) now check `:column`, matching the rest of the unique-constraint API.