### PR TITLE
Make the Action View template handler registry Ractor-shareable

### DIFF
--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -9,54 +9,63 @@ module ActionView # :nodoc:
       autoload :Html, "action_view/template/handlers/html"
       autoload :Builder, "action_view/template/handlers/builder"
 
-      def self.extended(base)
-        base.register_default_template_handler :raw, Raw.new
-        base.register_template_handler :erb, ERB.new
-        base.register_template_handler :html, Html.new
-        base.register_template_handler :builder, Builder.new
-        base.register_template_handler :ruby, lambda { |_, source| source }
-      end
+      @template_handlers = {}.freeze
+      @template_extensions = [].freeze
+      @default_template_handler = nil
 
-      @@template_handlers = {}
-      @@default_template_handlers = nil
+      class << self
+        attr_reader :template_handlers, :default_template_handler
 
-      def self.extensions
-        @@template_extensions ||= @@template_handlers.keys
+        def extensions
+          @template_extensions
+        end
+
+        def register(*extensions, handler)
+          handler = ActiveSupport::Ractors.try_shareable_proc(handler) if handler.is_a?(Proc)
+          handlers = @template_handlers.dup
+          extensions.each do |extension|
+            handlers[extension.to_sym] = handler
+          end
+          @template_handlers = handlers.freeze
+          @template_extensions = @template_handlers.keys.freeze
+        end
+
+        def register_default(extension, handler)
+          register(extension, handler)
+          @default_template_handler = @template_handlers[extension.to_sym]
+        end
+
+        def unregister(*extensions)
+          handlers = @template_handlers.dup
+          extensions.each do |extension|
+            handler = handlers.delete extension.to_sym
+            @default_template_handler = nil if @default_template_handler == handler
+          end
+          @template_handlers = handlers.freeze
+          @template_extensions = @template_handlers.keys.freeze
+        end
       end
 
       def register_template_handler(*extensions, handler)
         raise(ArgumentError, "Extension is required") if extensions.empty?
-        extensions.each do |extension|
-          @@template_handlers[extension.to_sym] = handler
-        end
-        @@template_extensions = nil
+        Handlers.register(*extensions, handler)
       end
 
       # Opposite to register_template_handler.
       def unregister_template_handler(*extensions)
-        extensions.each do |extension|
-          handler = @@template_handlers.delete extension.to_sym
-          @@default_template_handlers = nil if @@default_template_handlers == handler
-        end
-        @@template_extensions = nil
-      end
-
-      def template_handler_extensions
-        @@template_handlers.keys.map(&:to_s).sort
-      end
-
-      def registered_template_handler(extension)
-        extension && @@template_handlers[extension.to_sym]
-      end
-
-      def register_default_template_handler(extension, klass)
-        register_template_handler(extension, klass)
-        @@default_template_handlers = klass
+        Handlers.unregister(*extensions)
       end
 
       def handler_for_extension(extension)
-        registered_template_handler(extension) || @@default_template_handlers
+        handler = Handlers.template_handlers[extension.to_sym] if extension
+        handler || Handlers.default_template_handler
       end
+
+      register_default :raw, Raw.new.freeze
+      register :erb, ERB.new.freeze
+      register :html, Html.new.freeze
+      register :builder, Builder.new.freeze
+      register :ruby, ActiveSupport::Ractors.shareable_lambda { |_, source| source }
     end
   end
 end

--- a/actionview/lib/action_view/template/handlers/builder.rb
+++ b/actionview/lib/action_view/template/handlers/builder.rb
@@ -6,20 +6,12 @@ module ActionView
       class_attribute :default_format, default: :xml
 
       def call(template, source)
-        require_engine
+        require "builder" unless defined?(::Builder)
         # the double assignment is to silence "assigned but unused variable" warnings
         "xml = xml = ::Builder::XmlMarkup.new(indent: 2, target: output_buffer.raw);" \
           "#{source};" \
           "output_buffer.to_s"
       end
-
-      private
-        def require_engine # :doc:
-          @required ||= begin
-            require "builder"
-            true
-          end
-        end
     end
   end
 end

--- a/actionview/test/template/handlers_test.rb
+++ b/actionview/test/template/handlers_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/testing/ractors_assertions"
+require "active_support/core_ext/object/with"
+
+class TemplateHandlersTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  include ActiveSupport::Testing::RactorsAssertions
+
+  def test_built_in_handler_registry_is_ractor_shareable
+    assert_ractor_shareable ActionView::Template::Handlers.template_handlers
+    assert_ractor_shareable ActionView::Template::Handlers.extensions
+  end
+
+  if defined?(Ractor) && RUBY_VERSION >= "4.0"
+    def test_handlers_can_be_looked_up_from_a_ractor
+      handler_name = Ractor.new do
+        ActionView::Template.handler_for_extension(:erb).class.name
+      end.value
+
+      assert_equal "ActionView::Template::Handlers::ERB", handler_name
+    end
+  end
+
+  def test_registering_a_proc_handler_keeps_the_registry_shareable
+    ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+      ActionView::Template.register_template_handler :custom, lambda { |_, source| source }
+
+      assert_ractor_shareable ActionView::Template::Handlers.template_handlers
+    end
+  ensure
+    ActionView::Template.unregister_template_handler :custom
+  end
+end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -691,7 +691,7 @@ module RenderTestCases
     assert_not ActionView::Template::Handlers.extensions.include?(:foo)
     assert_equal "Hello, World!", @view.render(inline: "Hello, World!", type: :foo)
   ensure
-    ActionView::Template::Handlers.class_variable_get(:@@template_handlers).delete(:foo)
+    ActionView::Template.unregister_template_handler :foo
   end
 
   def test_render_ignores_templates_with_malformed_template_handlers

--- a/tools/strict_warnings.rb
+++ b/tools/strict_warnings.rb
@@ -26,7 +26,7 @@ module RailsStrictWarnings # :nodoc:
     /attempt to close unfinished zstream/,
 
     # Ractors are experimental
-    /Ractor( API) is experimental/,
+    /Ractor( API)? is experimental/,
   )
 
   def warn(message, ...)


### PR DESCRIPTION
Template.handler_for_extension and Template::Handlers.extensions are read on the template lookup and render path. The registry was kept in class variables, but the module is only extended in Template, so it wasn't necessary.

Move the registry to module instance variables on Template::Handlers, which non-main Ractors can read once the value is shareable, and make the stored handlers shareable: the built-in handler instances are frozen, the :ruby handler is built with ActiveSupport::Ractors.shareable_lambda, and app-provided Proc handlers are routed through
ActiveSupport::Ractors.try_shareable_proc. Registration now rebuilds a frozen copy of the Hash (copy-on-write) and eagerly recomputes the frozen extensions list rather than memoizing it lazily, so a read never writes.

The state and the registration logic now live on the Handlers module itself, so the built-in handlers are registered directly when the module is loaded rather than from the self.extended hook. The instance methods kept for the public and private (for tests) ActionView::Template.* API simply delegate to the module. Template still extends Handlers to expose them.

ActionView::Template::Handlers::Builder memoized its `require "builder"` call in an instance variable, which a frozen handler cannot write. Using a `defined?` guard instead.
