### PR TITLE
Add missing enumerator note to each_value doc [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -415,7 +415,8 @@ module ActionController
     alias_method :each, :each_pair
 
     # Convert all hashes in values into parameters, then yield each value in the
-    # same way as `Hash#each_value`.
+    # same way as `Hash#each_value`. If no block is given, an enumerator is
+    # returned instead.
     def each_value(&block)
       return to_enum(:each_value) unless block_given?
       @parameters.each_pair do |key, value|


### PR DESCRIPTION
## Problem

`ActionController::Parameters#each_value` returns an enumerator when called without a block:

```ruby
return to_enum(:each_value) unless block_given?
```

However, its RDoc comment did not mention this behavior. The sibling method `each_key` (whose implementation is delegated to `Hash#each_key`) already carries the sentence in its doc:

> If no block is given, an enumerator is returned instead.

`each_value`'s comment was missing that sentence, leaving a documentation inconsistency.

## Fix

Append the same enumerator sentence to `each_value`'s doc comment, matching `each_key`'s wording exactly.

## Notes

- Documentation-only change; no tests needed.
- `[ci skip]` added per Rails convention for doc-only commits.