### PR TITLE
Fix distinct count with composite primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `distinct.count` for models with composite primary keys.
+
+    *Gaston Ramos*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -673,7 +673,8 @@ module ActiveRecord
         # SQLite and older MySQL does not support `COUNT DISTINCT` with `*` or
         # multiple columns, so we need to use subquery for this.
         operation == "count" &&
-          (((column_name == :all || select_values.many?) && distinct) || has_limit_or_offset?)
+          (((column_name == :all || select_values.many? || column_name.is_a?(Array)) &&
+            distinct) || has_limit_or_offset?)
       end
 
       def build_count_subquery(relation, column_name, distinct)
@@ -681,6 +682,9 @@ module ActiveRecord
           column_alias = Arel.star
           relation.select_values = [ Arel.sql(FinderMethods::ONE_AS_ONE) ] unless distinct
           relation.unscope!(:order)
+        elsif column_name.is_a?(Array)
+          column_alias = Arel.star
+          relation.select_values = relation.arel_columns(column_name)
         else
           column_alias = Arel.sql("count_column")
           relation.select_values = [ relation.aggregate_column(column_name).as(column_alias) ]

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -433,6 +433,10 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal(1, Cpk::Book.where(author_id: book.author_id, id: book.id).count)
   end
 
+  def test_distinct_count_for_a_composite_primary_key_model
+    assert_equal Cpk::Book.count, Cpk::Book.distinct.count
+  end
+
   def test_group_by_count_for_a_composite_primary_key_model
     book = cpk_books(:cpk_great_author_first_book)
     expected = { book.author_id => Cpk::Book.where(author_id: book.author_id).count }


### PR DESCRIPTION
### Motivation / Background

Fixes #55401.

`distinct.count` currently generates invalid SQL for models with composite
primary keys on SQLite.

For a model whose primary key is `["author_id", "id"]`,
`Cpk::Book.distinct.count` tries to count the primary key array as a single
aggregate column:

```sql
SELECT COUNT(DISTINCT ["author_id", "id"]) FROM "cpk_books"
```

SQLite rejects that query with:

```text
SQLite3::SQLException: no such column: "author_id", "id"
```

### Detail

This Pull Request updates Active Record's count subquery handling to treat an
array `column_name` as a multiple-column count target when `distinct` is used.

When the count target is an array, Active Record now builds a subquery that
selects the individual columns and counts the subquery rows, instead of passing
the array into `COUNT(DISTINCT ...)` as one aggregate expression.

The generated query becomes:

```sql
SELECT COUNT(*) FROM (
  SELECT DISTINCT "cpk_books"."author_id", "cpk_books"."id" FROM "cpk_books"
) AS subquery_for_count
```

This matches the existing subquery strategy used for `COUNT DISTINCT` shapes
that are not supported consistently across adapters.

The PR also adds a regression test covering `Cpk::Book.distinct.count`.

### Additional information

Tests run:

```bash
ARCONN=sqlite3 bin/test test/cases/calculations_test.rb -i test_distinct_count_for_a_composite_primary_key_model
```

```text
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

```bash
ARCONN=sqlite3 bin/test test/cases/calculations_test.rb
```

```text
234 runs, 626 assertions, 0 failures, 0 errors, 1 skips
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.