### PR TITLE
Fix incorrect RDoc examples in Active Model

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -313,7 +313,7 @@ module ActiveModel
     #
     #   person.errors.add(:name, :too_long, count: 25)
     #   person.errors.messages
-    #   # => ["is too long (maximum is 25 characters)"]
+    #   # => {:name=>["is too long (maximum is 25 characters)"]}
     #
     # If +type+ is a proc, it will be called, allowing for things like
     # <tt>Time.now</tt> to be used within an error.

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -26,7 +26,7 @@ module ActiveModel
       #   user = User.find(1)
       #   user.as_json
       #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #     "created_at" => "2006-08-01T17:27:133.000Z", "awesome" => true}
+      #   #     "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true}
       #
       #   ActiveRecord::Base.include_root_in_json = true
       #

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -72,7 +72,7 @@ module ActiveModel
       #   <tt>on: [:create, :custom_validation_context]</tt>)
       # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
       #   Runs in all validation contexts by default +nil+. You can pass a symbol
-      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   or an array of symbols. (e.g. <tt>except_on: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:allow_nil</tt> - Specify a method, proc, or boolean, to skip
@@ -153,7 +153,7 @@ module ActiveModel
       #   <tt>on: [:create, :custom_validation_context]</tt>)
       # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
       #   Runs in all validation contexts by default +nil+. You can pass a symbol
-      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   or an array of symbols. (e.g. <tt>except_on: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:if</tt> - Specifies a method or proc to call to determine

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -80,7 +80,7 @@ module ActiveModel
       #   <tt>on: [:create, :custom_validation_context]</tt>)
       # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
       #   Runs in all validation contexts by default +nil+. You can pass a symbol
-      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   or an array of symbols. (e.g. <tt>except_on: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine


### PR DESCRIPTION
While reading the Active Model docs I noticed a few RDoc examples that disagree with the code right next to them:

- **`serializers/json.rb`** — the `as_json` example printed `"created_at" => "2006-08-01T17:27:133.000Z"`, which has an impossible `133`-second component. The same example record appears seven other times in the file, all as `"2006-08-01T17:27:13.000Z"`.
- **`validations.rb`** (two bullets) and **`validations/validates.rb`** — the `:except_on` option is illustrated with `except: :create`. There is no `:except` option (`VALID_OPTIONS_FOR_VALIDATE` lists `:except_on`), and the sibling examples on the following lines already use `except_on:`.
- **`errors.rb`** — `Errors#messages` returns a Hash keyed by attribute, but the `#add` example showed a bare Array. Every other example in the same RDoc block shows the Hash form; this one now matches.

All changes are comment-only.