### PR TITLE
Fix incorrect RDoc in Action Pack

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -516,7 +516,7 @@ module ActionController
       end
 
       # This method takes an authorization body and splits up the key-value pairs by
-      # the standardized `:`, `;`, or `\t` delimiters defined in
+      # the standardized `,`, `;`, or `\t` delimiters defined in
       # `AUTHN_PAIR_DELIMITERS`.
       def raw_params(auth)
         _raw_params = auth.sub(TOKEN_REGEX, "").split(AUTHN_PAIR_DELIMITERS).map(&:strip)

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -146,7 +146,7 @@ module ActionController
   #
   #     params = ActionController::Parameters.new(a: "123", b: "456")
   #     params.permit(:c)
-  #     # => ActionController::UnpermittedParameters: found unpermitted keys: a, b
+  #     # => ActionController::UnpermittedParameters: found unpermitted parameters: :a, :b
   #
   # Please note that these options *are not thread-safe*. In a multi-threaded
   # environment they should only be set once at boot-time and never mutated at


### PR DESCRIPTION
- **`action_controller/metal/strong_parameters.rb`** — the `action_on_unpermitted_parameters = :raise` example showed `found unpermitted keys: a, b`, but the real exception message (built in `UnpermittedParameters#initialize`, and shown correctly by the sibling example above) is `found unpermitted parameters: :a, :b`.
- **`action_controller/metal/http_authentication.rb`** — `AUTHN_PAIR_DELIMITERS` is `/(?:,|;|\t)/`, so the comment describing the delimiters should list `` `,` `` rather than `` `:` ``.

All changes are comment-only.