### PR TITLE
Fix incorrect RDoc examples in Action Text

### DIFF
--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -120,7 +120,7 @@ module ActionText
     #     content.to_plain_text # => "Funny times!"
     #
     #     content = ActionText::Content.new("<div onclick='action()'>safe<script>unsafe</script></div>")
-    #     content.to_plain_text # => "safeunsafe"
+    #     content.to_plain_text # => "safe"
     #
     # NOTE: that the returned string is not HTML safe and should not be rendered in
     # browsers without additional sanitization.
@@ -180,7 +180,7 @@ module ActionText
 
     # Safely transforms Content into an HTML String.
     #
-    #     content = ActionText::Content.new(content: "<h1>Funny times!</h1>")
+    #     content = ActionText::Content.new("<h1>Funny times!</h1>")
     #     content.to_s # => "<h1>Funny times!</h1>"
     #
     #     content = ActionText::Content.new("<div onclick='action()'>safe<script>unsafe</script></div>")


### PR DESCRIPTION
In `action_text/content.rb`:

- `to_plain_text` strips the content of `<script>` (and `<style>`) nodes — they are aliased to `plain_text_for_unsupported_node`, which returns `""`. So the example output is `"safe"`, not `"safeunsafe"`. (The separate `to_s` example below legitimately keeps `safeunsafe` and is unchanged.)
- `ActionText::Content.new` takes its HTML as a positional argument, not a `content:` keyword. Passing the keyword binds a Hash and the fragment is built from its `to_s`. Dropped the keyword so the `to_s` example matches the other examples in the file.

All changes are comment-only.