### PR TITLE
Fix incorrect RDoc example in Action Mailbox

### DIFF
--- a/actionmailbox/lib/action_mailbox/base.rb
+++ b/actionmailbox/lib/action_mailbox/base.rb
@@ -45,7 +45,7 @@ module ActionMailbox
   #
   #     private
   #       def ensure_sender_is_a_user
-  #         unless User.exist?(email_address: mail.from)
+  #         unless User.exists?(email_address: mail.from)
   #           bounce_with UserRequiredMailer.missing(inbound_email)
   #         end
   #       end


### PR DESCRIPTION
In `action_mailbox/base.rb`, the `ForwardsMailbox` example called `User.exist?(...)`, but the Active Record existence predicate is `exists?`. `User.exist?` would raise `NoMethodError`. Updated the example accordingly.

Comment-only change.