### PR TITLE
Fix incorrect RDoc method names in Active Storage

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -78,7 +78,7 @@ class ActiveStorage::Variant
   #
   # Use <tt>url_for(variant)</tt> (or the implied form, like <tt>link_to variant</tt> or <tt>redirect_to variant</tt>) to get the stable URL
   # for a variant that points to the ActiveStorage::Representations::ProxyController or ActiveStorage::Representations::RedirectController,
-  # which in turn will use this +service_call+ method for its redirection.
+  # which in turn will use this +url+ method for its redirection.
   def url(expires_in: ActiveStorage.service_urls_expire_in, disposition: :inline)
     service.url key, expires_in: expires_in, disposition: disposition, filename: filename, content_type: content_type
   end

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -7,7 +7,7 @@ module ActiveStorage
   # Wraps a set of mirror services and provides a single ActiveStorage::Service object that will all
   # have the files uploaded to them. A +primary+ service is designated to answer calls to:
   # * +download+
-  # * +exists?+
+  # * +exist?+
   # * +url+
   # * +url_for_direct_upload+
   # * +headers_for_direct_upload+


### PR DESCRIPTION
- **`service/mirror_service.rb`** — the list of methods the primary service answers names `+exists?+`, but the method is `exist?` (the class delegates `:exist?`, and every service defines `def exist?`).
- **`app/models/active_storage/variant.rb`** — the `#url` docs say the controllers "will use this `+service_call+` method", but there is no `service_call` method anywhere in Active Storage; the redirection goes through the documented `#url`. Reference `+url+` instead.

All changes are comment-only.