### PR TITLE
Fix incorrect RDoc example in Action Mailer mail helper

### DIFF
--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -61,7 +61,7 @@ module ActionMailer
     #   my_text = 'Here is a sample text with more than 40 characters'
     #
     #   format_paragraph(my_text, 25, 4)
-    #   # => "    Here is a sample text with\n    more than 40 characters"
+    #   # => "    Here is a sample text\n    with more than 40\n    characters"
     def format_paragraph(text, len = 72, indent = 2)
       sentences = [[]]
 


### PR DESCRIPTION
In `action_mailer/mail_helper.rb`, `format_paragraph`'s wrap check (`(sentences.last + [word]).join(" ").length > len`) ignores the indentation, so `format_paragraph(my_text, 25, 4)` wraps the sample text into **three** lines, not two. Updated the example output to match the actual result.

Comment-only change.