### PR TITLE
Fix unparseable RDoc example in Active Job continuation test helper

### DIFF
--- a/activejob/lib/active_job/continuation/test_helper.rb
+++ b/activejob/lib/active_job/continuation/test_helper.rb
@@ -51,10 +51,10 @@ module ActiveJob
       #    cattr_accessor :items, default: []
       #
       #    def perform
-      #      step :step_one { items << 1 }
-      #      step :step_two { items << 2 }
-      #      step :step_three { items << 3 }
-      #      step :step_four { items << 4 }
+      #      step(:step_one) { items << 1 }
+      #      step(:step_two) { items << 2 }
+      #      step(:step_three) { items << 3 }
+      #      step(:step_four) { items << 4 }
       #    end
       #  end
       #


### PR DESCRIPTION
In `active_job/continuation/test_helper.rb`, the example wrote `step :step_one { items << 1 }`. A brace block cannot follow a method call with an unparenthesized symbol argument, so this raises `SyntaxError: unexpected '{' after a method call without parenthesis` (verified with `ruby -c`). Parenthesized the argument — `step(:step_one) { items << 1 }` — so the block binds correctly and the example parses. The sibling `interrupt_job_during_step` example just above uses the valid `do |step| ... end` form.

Comment-only change.