### PR TITLE
Fix copy-paste RDoc in Action Cable connection test case

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -230,7 +230,7 @@ module ActionCable
     # ## Connection is automatically inferred
     #
     # ActionCable::Connection::TestCase will automatically infer the connection
-    # under test from the test class name. If the channel cannot be inferred from
+    # under test from the test class name. If the connection cannot be inferred from
     # the test class name, you can explicitly set it with `tests`.
     #
     #     class ConnectionTest < ActionCable::Connection::TestCase


### PR DESCRIPTION
In `action_cable/connection/test_case.rb`, the "Connection is automatically inferred" paragraph is about the connection under test, but one sentence read "If the **channel** cannot be inferred" — a copy-paste leftover from the channel test case. Changed it to "connection".

Comment-only change.