### PR TITLE
Fix incorrect RDoc in Railties

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -307,7 +307,7 @@ module Rails
   #     helper MyEngine::SharedEngineHelper
   #   end
   #
-  # If you want to include all of the engine's helpers, you can use the #helper method on an engine's
+  # If you want to include all of the engine's helpers, you can use the #helpers method on an engine's
   # instance:
   #
   #   class ApplicationController < ActionController::Base

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -33,7 +33,7 @@ module Rails
     # want this behavior, so you can give <tt>:with</tt> as option.
     #
     #   root.add "config/routes", with: "config/routes.rb"
-    #   root["config/routes"].inspect # => ["config/routes.rb"]
+    #   root["config/routes"].to_ary.inspect # => ["config/routes.rb"]
     #
     # The #add method accepts the following options as arguments:
     # +eager_load+, +autoload+, +autoload_once+, and +glob+.


### PR DESCRIPTION
- **`rails/engine.rb`** — the prose referenced "the `#helper` method on an engine's instance", but the instance method is `helpers` (the example right below already calls `MyEngine::Engine.helpers`). The singular `#helper` also renders a broken RDoc cross-reference.
- **`rails/paths.rb`** — `Rails::Paths::Path` doesn't define `#inspect`, so `root["config/routes"].inspect` returns the default object representation, not the array. The sibling examples use `.to_ary.inspect`; added the missing `.to_ary`.

All changes are comment-only.