### PR TITLE
Fix incorrect RDoc examples in Active Support

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -63,13 +63,13 @@ module ActiveSupport
       #     include ActiveSupport::Configurable
       #   end
       #
-      #   User.allowed_access # => nil
+      #   User.config.allowed_access # => nil
       #
       #   User.configure do |config|
       #     config.allowed_access = true
       #   end
       #
-      #   User.allowed_access # => true
+      #   User.config.allowed_access # => true
       def configure
         yield config
       end

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -185,8 +185,8 @@ module ActiveSupport
   #
   #   subscriber = ActiveSupport::Notifications.subscribe(/render/) { }
   #   ActiveSupport::Notifications.unsubscribe('render_template.action_view')
-  #   subscriber.matches?('render_template.action_view') # => false
-  #   subscriber.matches?('render_partial.action_view') # => true
+  #   subscriber.subscribed_to?('render_template.action_view') # => false
+  #   subscriber.subscribed_to?('render_partial.action_view') # => true
   #
   # == Default Queue
   #


### PR DESCRIPTION
- **`configurable.rb`** — the `#configure` example's class only does `include ActiveSupport::Configurable` without declaring a `config_accessor`, so the bare `User.allowed_access` reader is never defined and would raise `NoMethodError`. Read the value through `config`, matching the adjacent `#config` example. (The `#config_accessor` example below, which *does* declare the accessor, is left untouched.)
- **`notifications.rb`** — the object returned by `.subscribe` responds to `subscribed_to?`, not `matches?`; the example now calls `subscribed_to?`.

All changes are comment-only.