### PR TITLE
Make autosave association callbacks Ractor-safe

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -156,23 +156,28 @@ module ActiveRecord
 
     module ClassMethods # :nodoc:
       private
-        def define_non_cyclic_method(name, &block)
+        def define_non_cyclic_method(name, reflection, method)
           return if method_defined?(name, false)
 
-          define_method(name) do |*args|
-            result = true; @_already_called ||= {}
-            # Loop prevention for validation of associations
-            unless @_already_called[name]
-              begin
-                @_already_called[name] = true
-                result = instance_eval(&block)
-              ensure
-                @_already_called[name] = false
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
+            def #{name}(*args)
+              result = true; @_already_called ||= {}
+              # Loop prevention for validation of associations
+              unless @_already_called[:#{name}]
+                reflection = self.class._reflect_on_association(:#{reflection.name})
+                if reflection
+                  begin
+                    @_already_called[:#{name}] = true
+                    result = #{method}(reflection)
+                  ensure
+                    @_already_called[:#{name}] = false
+                  end
+                end
               end
-            end
 
-            result
-          end
+              result
+            end
+          RUBY
         end
 
         # Adds validation and save callbacks for the association as specified by
@@ -192,12 +197,12 @@ module ActiveRecord
           if reflection.collection?
             around_save :around_save_collection_association
 
-            define_non_cyclic_method(save_method) { save_collection_association(reflection) }
+            define_non_cyclic_method(save_method, reflection, :save_collection_association)
             # Doesn't use after_save as that would save associations added in after_create/after_update twice
             after_create save_method
             after_update save_method
           elsif reflection.has_one?
-            define_non_cyclic_method(save_method) { save_has_one_association(reflection) }
+            define_non_cyclic_method(save_method, reflection, :save_has_one_association)
             # Configures two callbacks instead of a single after_save so that
             # the model may rely on their execution order relative to its
             # own callbacks.
@@ -209,7 +214,7 @@ module ActiveRecord
             after_create save_method
             after_update save_method
           else
-            define_non_cyclic_method(save_method) { throw(:abort) if save_belongs_to_association(reflection) == false }
+            define_non_cyclic_method(save_method, reflection, :autosave_belongs_to_association)
             before_save save_method
           end
 
@@ -227,7 +232,7 @@ module ActiveRecord
               method = :validate_belongs_to_association
             end
 
-            define_non_cyclic_method(validation_method) { send(method, reflection) }
+            define_non_cyclic_method(validation_method, reflection, method)
             validate validation_method
             after_validation :_ensure_no_duplicate_errors
           end
@@ -528,6 +533,10 @@ module ActiveRecord
 
         class_name = record._read_attribute(reflection.inverse_of.foreign_type)
         reflection.active_record.polymorphic_name != class_name
+      end
+
+      def autosave_belongs_to_association(reflection) # :nodoc:
+        throw(:abort) if save_belongs_to_association(reflection) == false
       end
 
       # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `define_non_cyclic_method` defined its callbacks with `define_method` and a block, which captures an un-shareable `Proc` and can't be called from a non-main Ractor. Define the methods with `class_eval` instead, dispatching to the association method by name.

### Detail

This Pull Request changes `define_non_cyclic_method` implementation to use class_eval and symbols instead of `define_method` and blocks.

<details>
  <summary>Benchmark Source</summary>

```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  # Load the Rails checkout in the current working directory so that switching
  # git branches switches the code under benchmark.
  root = ENV["RAILS_ROOT"] || Dir.pwd
  gem "activesupport", path: "#{root}/activesupport"
  gem "activemodel",   path: "#{root}/activemodel"
  gem "activerecord",  path: "#{root}/activerecord"

  gem "sqlite3"
  gem "benchmark-ips", require: "benchmark/ips"
end

require "active_record"
require "tmpdir"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.verbose = false
ActiveRecord::Schema.define do
  create_table :posts, force: true
  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments, autosave: true
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

post = Post.new

HOLD_FILE = File.join(Dir.tmpdir, "autosave_association_benchmark.json")

Benchmark.ips do |x|
  # Both reports call the same callback; "before" is recorded on the first run
  # (baseline branch) and "after" on the second run (branch under test).
  x.report("before") { post.send(:autosave_associated_records_for_comments) }
  x.report("after")  { post.send(:autosave_associated_records_for_comments) }

  x.hold! HOLD_FILE
  x.compare!
end

```

</details>

```
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after   455.826k i/100ms
Calculating -------------------------------------
               after      4.411M (± 2.7%) i/s  (226.70 ns/i) -     22.335M in   5.063481s

Comparison:
before:  4491233.7 i/s
 after:  4411090.7 i/s - same-ish: difference falls within error
```
Same-ish performance.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
