### PR TITLE
Fix incorrect RDoc examples across frameworks

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -230,7 +230,7 @@ module ActionCable
     # ## Connection is automatically inferred
     #
     # ActionCable::Connection::TestCase will automatically infer the connection
-    # under test from the test class name. If the channel cannot be inferred from
+    # under test from the test class name. If the connection cannot be inferred from
     # the test class name, you can explicitly set it with `tests`.
     #
     #     class ConnectionTest < ActionCable::Connection::TestCase

--- a/actionmailbox/lib/action_mailbox/base.rb
+++ b/actionmailbox/lib/action_mailbox/base.rb
@@ -45,7 +45,7 @@ module ActionMailbox
   #
   #     private
   #       def ensure_sender_is_a_user
-  #         unless User.exist?(email_address: mail.from)
+  #         unless User.exists?(email_address: mail.from)
   #           bounce_with UserRequiredMailer.missing(inbound_email)
   #         end
   #       end

--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -61,7 +61,7 @@ module ActionMailer
     #   my_text = 'Here is a sample text with more than 40 characters'
     #
     #   format_paragraph(my_text, 25, 4)
-    #   # => "    Here is a sample text with\n    more than 40 characters"
+    #   # => "    Here is a sample text\n    with more than 40\n    characters"
     def format_paragraph(text, len = 72, indent = 2)
       sentences = [[]]
 

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -516,7 +516,7 @@ module ActionController
       end
 
       # This method takes an authorization body and splits up the key-value pairs by
-      # the standardized `:`, `;`, or `\t` delimiters defined in
+      # the standardized `,`, `;`, or `\t` delimiters defined in
       # `AUTHN_PAIR_DELIMITERS`.
       def raw_params(auth)
         _raw_params = auth.sub(TOKEN_REGEX, "").split(AUTHN_PAIR_DELIMITERS).map(&:strip)

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -146,7 +146,7 @@ module ActionController
   #
   #     params = ActionController::Parameters.new(a: "123", b: "456")
   #     params.permit(:c)
-  #     # => ActionController::UnpermittedParameters: found unpermitted keys: a, b
+  #     # => ActionController::UnpermittedParameters: found unpermitted parameters: :a, :b
   #
   # Please note that these options *are not thread-safe*. In a multi-threaded
   # environment they should only be set once at boot-time and never mutated at

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -120,7 +120,7 @@ module ActionText
     #     content.to_plain_text # => "Funny times!"
     #
     #     content = ActionText::Content.new("<div onclick='action()'>safe<script>unsafe</script></div>")
-    #     content.to_plain_text # => "safeunsafe"
+    #     content.to_plain_text # => "safe"
     #
     # NOTE: that the returned string is not HTML safe and should not be rendered in
     # browsers without additional sanitization.
@@ -180,7 +180,7 @@ module ActionText
 
     # Safely transforms Content into an HTML String.
     #
-    #     content = ActionText::Content.new(content: "<h1>Funny times!</h1>")
+    #     content = ActionText::Content.new("<h1>Funny times!</h1>")
     #     content.to_s # => "<h1>Funny times!</h1>"
     #
     #     content = ActionText::Content.new("<div onclick='action()'>safe<script>unsafe</script></div>")

--- a/activejob/lib/active_job/continuation/test_helper.rb
+++ b/activejob/lib/active_job/continuation/test_helper.rb
@@ -51,10 +51,10 @@ module ActiveJob
       #    cattr_accessor :items, default: []
       #
       #    def perform
-      #      step :step_one { items << 1 }
-      #      step :step_two { items << 2 }
-      #      step :step_three { items << 3 }
-      #      step :step_four { items << 4 }
+      #      step(:step_one) { items << 1 }
+      #      step(:step_two) { items << 2 }
+      #      step(:step_three) { items << 3 }
+      #      step(:step_four) { items << 4 }
       #    end
       #  end
       #

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -313,7 +313,7 @@ module ActiveModel
     #
     #   person.errors.add(:name, :too_long, count: 25)
     #   person.errors.messages
-    #   # => ["is too long (maximum is 25 characters)"]
+    #   # => {:name=>["is too long (maximum is 25 characters)"]}
     #
     # If +type+ is a proc, it will be called, allowing for things like
     # <tt>Time.now</tt> to be used within an error.

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -26,7 +26,7 @@ module ActiveModel
       #   user = User.find(1)
       #   user.as_json
       #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
-      #   #     "created_at" => "2006-08-01T17:27:133.000Z", "awesome" => true}
+      #   #     "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true}
       #
       #   ActiveRecord::Base.include_root_in_json = true
       #

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -72,7 +72,7 @@ module ActiveModel
       #   <tt>on: [:create, :custom_validation_context]</tt>)
       # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
       #   Runs in all validation contexts by default +nil+. You can pass a symbol
-      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   or an array of symbols. (e.g. <tt>except_on: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:allow_nil</tt> - Specify a method, proc, or boolean, to skip
@@ -153,7 +153,7 @@ module ActiveModel
       #   <tt>on: [:create, :custom_validation_context]</tt>)
       # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
       #   Runs in all validation contexts by default +nil+. You can pass a symbol
-      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   or an array of symbols. (e.g. <tt>except_on: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:if</tt> - Specifies a method or proc to call to determine

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -80,7 +80,7 @@ module ActiveModel
       #   <tt>on: [:create, :custom_validation_context]</tt>)
       # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
       #   Runs in all validation contexts by default +nil+. You can pass a symbol
-      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   or an array of symbols. (e.g. <tt>except_on: :create</tt> or
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:if</tt> - Specifies a method, proc or string to call to determine

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -78,7 +78,7 @@ class ActiveStorage::Variant
   #
   # Use <tt>url_for(variant)</tt> (or the implied form, like <tt>link_to variant</tt> or <tt>redirect_to variant</tt>) to get the stable URL
   # for a variant that points to the ActiveStorage::Representations::ProxyController or ActiveStorage::Representations::RedirectController,
-  # which in turn will use this +service_call+ method for its redirection.
+  # which in turn will use this +url+ method for its redirection.
   def url(expires_in: ActiveStorage.service_urls_expire_in, disposition: :inline)
     service.url key, expires_in: expires_in, disposition: disposition, filename: filename, content_type: content_type
   end

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -7,7 +7,7 @@ module ActiveStorage
   # Wraps a set of mirror services and provides a single ActiveStorage::Service object that will all
   # have the files uploaded to them. A +primary+ service is designated to answer calls to:
   # * +download+
-  # * +exists?+
+  # * +exist?+
   # * +url+
   # * +url_for_direct_upload+
   # * +headers_for_direct_upload+

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -63,13 +63,13 @@ module ActiveSupport
       #     include ActiveSupport::Configurable
       #   end
       #
-      #   User.allowed_access # => nil
+      #   User.config.allowed_access # => nil
       #
       #   User.configure do |config|
       #     config.allowed_access = true
       #   end
       #
-      #   User.allowed_access # => true
+      #   User.config.allowed_access # => true
       def configure
         yield config
       end

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -185,8 +185,8 @@ module ActiveSupport
   #
   #   subscriber = ActiveSupport::Notifications.subscribe(/render/) { }
   #   ActiveSupport::Notifications.unsubscribe('render_template.action_view')
-  #   subscriber.matches?('render_template.action_view') # => false
-  #   subscriber.matches?('render_partial.action_view') # => true
+  #   subscriber.subscribed_to?('render_template.action_view') # => false
+  #   subscriber.subscribed_to?('render_partial.action_view') # => true
   #
   # == Default Queue
   #

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -307,7 +307,7 @@ module Rails
   #     helper MyEngine::SharedEngineHelper
   #   end
   #
-  # If you want to include all of the engine's helpers, you can use the #helper method on an engine's
+  # If you want to include all of the engine's helpers, you can use the #helpers method on an engine's
   # instance:
   #
   #   class ApplicationController < ActionController::Base

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -22,10 +22,10 @@ module Rails
     # allows you to easily add extra paths:
     #
     #   path.is_a?(Enumerable) # => true
-    #   path.to_ary.inspect    # => ["app/controllers"]
+    #   path.to_ary    # => ["app/controllers"]
     #
     #   path << "lib/controllers"
-    #   path.to_ary.inspect    # => ["app/controllers", "lib/controllers"]
+    #   path.to_ary    # => ["app/controllers", "lib/controllers"]
     #
     # Notice that when you add a path using #add, the
     # Path[rdoc-ref:Rails::Paths::Path] object created already contains the path
@@ -33,7 +33,7 @@ module Rails
     # want this behavior, so you can give <tt>:with</tt> as option.
     #
     #   root.add "config/routes", with: "config/routes.rb"
-    #   root["config/routes"].inspect # => ["config/routes.rb"]
+    #   root["config/routes"].to_ary # => ["config/routes.rb"]
     #
     # The #add method accepts the following options as arguments:
     # +eager_load+, +autoload+, +autoload_once+, and +glob+.


### PR DESCRIPTION
A number of RDoc examples document behavior that the code does not actually produce — wrong method names, malformed output, or examples that would raise. This corrects them. All changes are comment-only ([ci skip]).

(Consolidated per reviewer request from the per-framework PRs #57878–#57887 into a single PR.)

### Active Model
- **`errors.rb`** — `messages` returns a `Hash` keyed by attribute, not an `Array`.
- **`serializers/json.rb`** — fix a malformed timestamp in the `as_json` output (`17:27:133.000Z` → `17:27:13.000Z`).
- **`validations.rb`, `validations/validates.rb`** — the `:except_on` example used `except:`; corrected to `except_on:`.

### Action Pack
- **`http_authentication.rb`** — `AUTHN_PAIR_DELIMITERS` splits on `,`, not `:`.
- **`strong_parameters.rb`** — match the actual `UnpermittedParameters` message (`found unpermitted parameters: :a, :b`).

### Action Text
- **`content.rb`** — `to_plain_text` drops `<script>` contents (`"safe"`, not `"safeunsafe"`); also fix the `Content.new` example to pass a positional argument.

### Active Job
- **`continuation/test_helper.rb`** — `step :x { }` is a syntax error; the block requires parentheses: `step(:x) { }`.

### Active Storage
- **`variant.rb`** — the redirection uses this `url` method, not `service_call`.
- **`mirror_service.rb`** — the primary service answers `exist?`, not `exists?`.

### Active Support
- **`configurable.rb`** — the `#configure` example's class declares no `config_accessor`, so the bare `User.allowed_access` reader is undefined; read through `config`, matching the adjacent `#config` example.
- **`notifications.rb`** — the subscriber responds to `subscribed_to?`, not `matches?`.

### Action Mailbox
- **`base.rb`** — the example called `User.exist?`; the method is `exists?`.

### Action Mailer
- **`mail_helper.rb`** — correct the wrapped output of `format_paragraph`.

### Action Cable
- **`connection/test_case.rb`** — fix copy-paste referring to "channel" where the **connection** is inferred from the test class name.

### Railties
- **`engine.rb`** — the method to include all helpers is `#helpers`, not `#helper`.
- **`paths.rb`** — `root[...]` returns a `Rails::Paths::Path`; call `to_ary` to get the `Array` shown in the example.