### PR TITLE
Fix `week_field` emitting invalid week strings at ISO year boundaries

### DIFF
--- a/actionview/lib/action_view/helpers/tags/week_field.rb
+++ b/actionview/lib/action_view/helpers/tags/week_field.rb
@@ -6,7 +6,7 @@ module ActionView
       class WeekField < DatetimeField # :nodoc:
         private
           def format_datetime(value)
-            value&.strftime("%Y-W%V")
+            value&.strftime("%G-W%V")
           end
       end
     end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1465,6 +1465,12 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, week_field("post", "written_on"))
   end
 
+  def test_week_field_with_iso_week_year_boundary
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2015-W53" />}
+    @post.written_on = DateTime.new(2016, 1, 1, 1, 2, 3)
+    assert_dom_equal(expected, week_field("post", "written_on"))
+  end
+
   def test_url_field
     expected = %{<input id="user_homepage" name="user[homepage]" type="url" />}
     assert_dom_equal(expected, url_field("user", "homepage"))


### PR DESCRIPTION
An `<input type="week">` value must be `yyyy-Www`, where `yyyy` is the ISO 8601 **week-numbering year** (the year that owns the week), not the Gregorian calendar year.

`WeekField#format_datetime` formatted the value with `strftime("%Y-W%V")`, pairing the calendar year (`%Y`) with the ISO week number (`%V`). For the boundary days of late December / early January — whose ISO week belongs to the adjacent year — this produces non-existent week strings that browsers reject:

```ruby
Date.new(2016, 1, 1).strftime("%Y-W%V")  # => "2016-W53"  (ISO year 2016 has no week 53)
Date.new(2016, 1, 1).strftime("%G-W%V")  # => "2015-W53"  (correct)
```

The fix pairs the ISO week number with its matching ISO week-numbering year (`%G`), the invariant the format is meant to express. The sibling `DatetimeField` subclasses (`DateField`, `MonthField`, `DatetimeLocalField`) already pair every directive with a consistent counterpart.

A boundary test (`DateTime.new(2016, 1, 1)` → `2015-W53`) is added; the existing `week_field` tests all used mid-year/`%Y == %G` dates, which is why this went unnoticed.