### PR TITLE
Fix `number_to_human`/`number_to_human_size` crashing on `precision: nil`

### DIFF
--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -36,7 +36,7 @@ module ActiveSupport
         end
 
         def absolute_precision(number)
-          if options[:significant] && options[:precision] > 0
+          if options[:significant] && options[:precision] && options[:precision] > 0
             options[:precision] - digit_count(convert_to_decimal(number))
           else
             options[:precision]

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -360,6 +360,7 @@ module ActiveSupport
           assert_equal "1.0 KB",   number_helper.number_to_human_size(kilobytes(1.0123), precision: 2, strip_insignificant_zeros: false)
           assert_equal "1.012 KB",   number_helper.number_to_human_size(kilobytes(1.0123), precision: 3, significant: false)
           assert_equal "1 KB",   number_helper.number_to_human_size(kilobytes(1.0123), precision: 0, significant: true) # ignores significant it precision is 0
+          assert_equal "120.5625 KB", number_helper.number_to_human_size(123456, precision: nil)
         end
       end
 
@@ -395,6 +396,7 @@ module ActiveSupport
           assert_equal "1 Million", number_helper.number_to_human(1234567, precision: 0, significant: true, separator: ",") # significant forced to false
           assert_equal "1 Million", number_helper.number_to_human(999999)
           assert_equal "1 Billion", number_helper.number_to_human(999999999)
+          assert_equal "123.456 Thousand", number_helper.number_to_human(123456, precision: nil)
         end
       end
 


### PR DESCRIPTION
`precision: nil` is a supported option across the number helpers — it is accepted and tested by `number_to_currency`, `number_to_percentage`, etc. But `number_to_human` and `number_to_human_size`, the only helpers that default to `significant: true`, route through `RoundingHelper#absolute_precision`:

```ruby
if options[:significant] && options[:precision] > 0   # nil > 0  => NoMethodError
```

So passing `precision: nil` raises `NoMethodError: undefined method '>' for nil`:

```ruby
number_to_human(123456, precision: nil)       # crash
number_to_human_size(123456, precision: nil)  # crash
```

The fix guards the comparison on a present precision, matching the sibling `NumberToRoundedConverter#convert`, which checks `if precision = options[:precision]` before testing `precision > 0`. `RoundingHelper` was extracted from that converter and dropped the guard.