### PR TITLE
Return an `ActiveRecord::Promise` from `async_ids` on a contradictory relation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -396,7 +396,7 @@ module ActiveRecord
       relation.select_values = columns
 
       result = if relation.where_clause.contradiction?
-        ActiveRecord::Result.empty
+        ActiveRecord::Result.empty(async: @async)
       else
         skip_query_cache_if_necessary do
           model.with_connection do |c|

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1118,6 +1118,7 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_queries_count(0) do
       assert_equal company_ids, Company.where(id: empty_scope_ids).ids
     end
+    assert_async_equal company_ids, Company.where(id: empty_scope_ids).async_ids
   end
 
   def test_ids_with_join


### PR DESCRIPTION
`async_ids` is documented to always return an `ActiveRecord::Promise`. But when the relation has a contradictory where-clause (e.g. `where(id: [])`), `ids` short-circuits with `ActiveRecord::Result.empty` — omitting the `async:` argument:

```ruby
result = if relation.where_clause.contradiction?
  ActiveRecord::Result.empty            # no async:
else
  ...select_all(relation, ..., async: @async)
end
result.then { |result| type_cast_pluck_values(result, columns) }
```

With a non-async `Result`, the trailing `.then` runs synchronously via `Kernel#then` and returns a raw `Array`, breaking the Promise contract:

```ruby
Model.where(id: []).async_ids   # => []  (Array, not a Promise)
```

The fix builds the empty result with `async: @async`, matching the sibling `pluck`, which already uses `ActiveRecord::Result.empty(async: @async)` for the same contradiction short-circuit.