### PR TITLE
Reverse a relation by its `query_constraints` when no order is given

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2087,8 +2087,8 @@ module ActiveRecord
 
       def reverse_sql_order(order_query)
         if order_query.empty?
-          if !_reverse_order_columns.empty?
-            return _reverse_order_columns.map { |column| table[column].desc }
+          if !_order_columns.empty?
+            return _order_columns.map { |column| table[column].desc }
           end
 
           raise IrreversibleOrderError, <<~MSG.squish
@@ -2118,13 +2118,6 @@ module ActiveRecord
             o
           end
         end
-      end
-
-      def _reverse_order_columns
-        roc = []
-        roc << model.implicit_order_column if model.implicit_order_column
-        roc << model.primary_key if model.primary_key
-        roc.flatten.uniq.compact
       end
 
       def does_not_support_reverse?(order)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -27,6 +27,7 @@ require "models/reader"
 require "models/category"
 require "models/categorization"
 require "models/edge"
+require "models/clothing_item"
 require "models/wheel"
 require "models/subscriber"
 require "models/cpk"
@@ -397,6 +398,19 @@ class RelationTest < ActiveRecord::TestCase
     edge_2 = ordered_edge.create!(source_id: 2, sink_id: 3)
     assert_equal edge_1.source_id, ordered_edge.all.first.source_id
     assert_equal edge_2.source_id, ordered_edge.all.reverse_order.first.source_id
+  end
+
+  def test_reverse_order_uses_query_constraints
+    ClothingItem.delete_all
+    # Insert so that the id order is the reverse of the query_constraints order,
+    # to catch a reverse_order that falls back to ordering by the primary key.
+    zzz = ClothingItem.create!(clothing_type: "zzz", color: "red")
+    aaa = ClothingItem.create!(clothing_type: "aaa", color: "blue")
+
+    assert_equal aaa.id, ClothingItem.all.first.id
+    assert_equal zzz.id, ClothingItem.all.last.id
+    assert_equal zzz.id, ClothingItem.all.reverse_order.first.id
+    assert_equal aaa.id, ClothingItem.all.reverse_order.last.id
   end
 
   def test_order_with_hash_and_symbol_generates_the_same_sql


### PR DESCRIPTION
`reverse_order` on an unordered relation reverses the relation's implicit order. For a model that declares `query_constraints`, `first`/`last` order by those columns, but `reverse_order` only reversed the primary key — so `reverse_order.first` did not equal `last`:

```ruby
class ClothingItem < ActiveRecord::Base
  query_constraints :clothing_type, :color
end

ClothingItem.all.reverse_order.to_sql
# before: ... ORDER BY "clothing_items"."id" DESC
# after:  ... ORDER BY "clothing_items"."clothing_type" DESC, "clothing_items"."color" DESC

ClothingItem.all.reverse_order.first == ClothingItem.last   # before: false, after: true
```

The fallback reverse order is now built from `query_constraints_list` (falling back to the primary key), mirroring the columns `first`/`last` use. Models without query constraints are unaffected — `query_constraints_list` is `nil` there, so the primary key is still used.