### PR TITLE
Make `add_foreign_key(if_not_exists: true)` reversible

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -302,7 +302,10 @@ module ActiveRecord
         end
 
         def invert_add_foreign_key(args)
-          args.last.delete(:validate) if args.last.is_a?(Hash)
+          if (options = args.last).is_a?(Hash)
+            options.delete(:validate)
+            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
+          end
           super
         end
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -454,6 +454,11 @@ module ActiveRecord
         assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], enable
       end
 
+      def test_invert_add_foreign_key_if_not_exists
+        enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, if_not_exists: true]
+        assert_equal [:remove_foreign_key, [:dogs, :people, if_exists: true], nil], enable
+      end
+
       def test_invert_remove_foreign_key_with_column
         enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people, column: "owner_id"]
         assert_equal [:add_foreign_key, [:dogs, :people, column: "owner_id"]], enable


### PR DESCRIPTION
Inverting `add_foreign_key ..., if_not_exists: true` produced `remove_foreign_key ..., if_not_exists: true`:

```ruby
recorder.inverse_of(:add_foreign_key, [:articles, :authors, if_not_exists: true])
# => [:remove_foreign_key, [:articles, :authors, {if_not_exists: true}], nil]
```

`remove_foreign_key` does not understand `:if_not_exists`, so rolling back such a migration was not the idempotent inverse of the addition. The fix translates `:if_not_exists` into `:if_exists` when inverting, exactly as `invert_add_check_constraint` already does:

```ruby
# => [:remove_foreign_key, [:articles, :authors, {if_exists: true}], nil]
```
