### PR TITLE
Apply DISTINCT to a grouped `sum`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -549,6 +549,7 @@ module ActiveRecord
           column = relation.aggregate_column(column_name)
           column_alias = column_alias_tracker.alias_for("#{operation} #{column_name.to_s.downcase}")
           select_value = operation_over_aggregate_column(column, operation, distinct)
+          select_value.distinct = true if operation == "sum" && distinct
           select_value = select_value.as(model.adapter_class.quote_column_name(column_alias))
 
           select_values = [select_value]

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -199,6 +199,16 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal expected, Account.group(:firm_id).sum(:credit_limit)
   end
 
+  def test_should_group_by_distinct_summed_field
+    Account.delete_all
+    Account.create!(firm_id: 1, credit_limit: 50)
+    Account.create!(firm_id: 1, credit_limit: 50)
+    Account.create!(firm_id: 1, credit_limit: 60)
+
+    assert_equal 110, Account.where(firm_id: 1).distinct.sum(:credit_limit)
+    assert_equal({ 1 => 110 }, Account.where(firm_id: 1).group(:firm_id).distinct.sum(:credit_limit))
+  end
+
   def test_group_by_multiple_same_field
     accounts = Account.group(:firm_id)
 


### PR DESCRIPTION
`relation.distinct.sum(:column)` emits `SUM(DISTINCT column)` and de-duplicates values, but once a `group` is added the DISTINCT is dropped, so the grouped sum counts duplicate values and returns a numerically wrong total:

```ruby
Account.where(firm_id: 1).distinct.sum(:credit_limit)
# => 110          (SUM(DISTINCT credit_limit))

Account.where(firm_id: 1).group(:firm_id).distinct.sum(:credit_limit)
# before: {1 => 160}   (plain SUM, duplicates counted)
# after:  {1 => 110}
```

The ungrouped path sets `select_value.distinct = true if operation == "sum" && distinct`; the grouped path omitted that line. (DISTINCT already works for `count` in both paths, since count routes through `column.count(distinct)`.) The fix applies the same flag in the grouped path.