### PR TITLE
Deduplicate columns in `regroup`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -597,6 +597,7 @@ module ActiveRecord
 
     # Same as #regroup but operates on relation in-place instead of copying.
     def regroup!(*args) # :nodoc:
+      args.uniq!
       self.group_values = args
       self
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -466,6 +466,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal ["id desc"], topics.order_values
   end
 
+  def test_regroup_deduplication
+    topics = Topic.regroup(:author_id, :author_id)
+    assert_equal [:author_id], topics.group_values
+  end
+
   def test_finding_with_reorder_by_aliased_attributes
     topics = Topic.order("author_name").reorder(:heading)
     assert_equal 5, topics.to_a.size


### PR DESCRIPTION
`regroup` is documented as short-hand for `unscope(:group).group(fields)`. `group` deduplicates its columns (`group_values |= args`), but `regroup!` assigned the arguments verbatim, so the documented equivalence broke for duplicate columns:

```ruby
Post.regroup(:author_id, :author_id).group_values
# before: [:author_id, :author_id]
# after:  [:author_id]

Post.all.unscope(:group).group(:author_id, :author_id).group_values
# => [:author_id]
```

The fix deduplicates the arguments in `regroup!`, matching `reorder!`.
