### PR TITLE
Raise when a block is passed to `with_recursive`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -515,7 +515,8 @@ module ActiveRecord
     #   # SELECT * FROM posts
     #
     # See `#with` for more information.
-    def with_recursive(*args)
+    def with_recursive(*args, &block)
+      raise ArgumentError, "ActiveRecord::Relation#with_recursive does not accept a block" if block
       check_if_method_has_arguments!(__callee__, args)
       spawn.with_recursive!(*args)
     end

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -143,6 +143,12 @@ module ActiveRecord
         end
       end
 
+      def test_relation_with_recursive_raises_when_using_block
+        assert_raises(ArgumentError, match: "does not accept a block") do
+          Post.all.with_recursive(attributes_for_inspect: :id) { }
+        end
+      end
+
       def test_class_with_calls_object_with_when_given_a_block
         original = Post.attributes_for_inspect
 


### PR DESCRIPTION
`ActiveRecord::Relation#with` raises `ArgumentError` when a block is passed, because the block would be silently ignored:

```ruby
Post.all.with(foo: Post.where(id: 1)) { }
# => ArgumentError: ActiveRecord::Relation#with does not accept a block
```

Its sibling `#with_recursive` was missing the same guard, so a mistakenly-passed block was dropped — with only Ruby's non-fatal `the block passed to 'with_recursive' ... may be ignored` warning:

```ruby
Post.all.with_recursive(foo: Post.where(id: 1)) { ... }   # block silently ignored
```

This raises the same `ArgumentError` from `#with_recursive`, matching `#with`.
