### PR TITLE
Fix flaky test_parallel_group_stops_launching_new_steps_with_*_flag

### DIFF
--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -311,9 +311,9 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
             @CI.run("CI", nil) do
               group "Checks", parallel: 2 do
                 step "Fail", "false"
-                step "Should not run 1", "true"
-                step "Should not run 2", "true"
-                step "Should not run 3", "true"
+                step "Should not run 1", "sleep", "0.1"
+                step "Should not run 2", "sleep", "0.1"
+                step "Should not run 3", "sleep", "0.1"
               end
             end
           end


### PR DESCRIPTION
### Motivation / Background

This Pull Request addresses a flaky failure of
`ContinuousIntegrationTest#test_parallel_group_stops_launching_new_steps_with_*_flag`,
observed on two independent CI runs (each `*_flag` variant failed once):

- `--fail-fast` — https://buildkite.com/rails/rails/builds/130019#019ee5dc-f207-4b3a-9d10-f4c7961968ad/L8002
- `-f` — https://buildkite.com/rails/rails-nightly/builds/4492#019f05bb-ba27-427b-b7d9-e0e45b19274b/L7959

### Detail

This Pull Request replaces the three `true` steps with `sleep 0.1` so each
should-not-run step (~0.1s) outlasts "Fail" (~0.02s). The failure is then
observed before a worker can dequeue the third step, independent of spawn
jitter. There is no production code change — only the test.

The actual failure (nightly build 4492) — "Should not run 3" is launched
after "Fail" has already failed:

```
  4) Failure:
ContinuousIntegrationTest#test_parallel_group_stops_launching_new_steps_with_-f_flag [test/continuous_integration_test.rb:325]:
Expected /Should not run 3/ to not match "[\"\\e[1;32mCI\\e[0m\\n\\e[1;35m\\n\\nShould not run 1\\e[0m\\n\\e[1;90mtrue\\n\\e[0m\\n\\e[1;32m\\n✅ Should not run 1 passed in 0.01s\\e[0m\\n\\n\\n\\r\\e[K\\e[1;36mChecks (0s) - Fail...\\e[0m\\r\\e[2A\\e[J\\e[1;35m\\n\\nShould not run 2\\e[0m\\n\\e[1;90mtrue\\n\\e[0m\\n\\e[1;32m\\n✅ Should not run 2 passed in 0.01s\\e[0m\\n\\n\\n\\r\\e[K\\e[1;36mChecks (0s) - Fail...\\e[0m\\r\\e[2A\\e[J\\e[1;35m\\n\\nFail\\e[0m\\n\\e[1;90mfalse\\n\\e[0m\\n\\e[1;31m\\n❌ Fail failed in 0.02s\\e[0m\\n\\n\\n\\r\\e[K\\e[1;36mChecks (0s) - Should not run 3...\\e[0m\\r\\e[2A\\e[J\\e[1;35m\\n\\nShould not run 3\\e[0m\\n\\e[1;90mtrue\\n\\e[0m\\n\\e[1;32m\\n✅ Should not run 3 passed in 0.01s\\e[0m\\n\", \"\"]".
```

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
