### PR TITLE
Keep `HashWithIndifferentAccess#filter` returning indifferent access

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -338,6 +338,7 @@ module ActiveSupport
       return to_enum(:select) unless block_given?
       dup.tap { |hash| hash.select!(*args, &block) }
     end
+    alias_method :filter, :select
 
     def reject(*args, &block)
       return to_enum(:reject) unless block_given?

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -456,6 +456,13 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 
+  def test_indifferent_filter
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).filter { |k, v| v == 1 }
+
+    assert_equal({ "a" => 1 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
   def test_indifferent_select_bang
     indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
     indifferent_strings.select! { |k, v| v == 1 }


### PR DESCRIPTION
### Summary

`Hash#filter` is an alias of `Hash#select`, so calling either on a `HashWithIndifferentAccess` should return the same thing. `HashWithIndifferentAccess` overrides `#select` to return a `HashWithIndifferentAccess`, but `#filter` was never aliased to it, so it fell through to the inherited `Hash#select` and returned a plain `Hash` — silently dropping indifferent access.

```ruby
h = ActiveSupport::HashWithIndifferentAccess.new(a: 1, b: 2)

h.select { |k, v| v > 1 }.class # => ActiveSupport::HashWithIndifferentAccess
h.filter { |k, v| v > 1 }.class # => Hash   (before this change)

h.select { |k, v| v > 1 }[:b]   # => 2
h.filter { |k, v| v > 1 }[:b]   # => nil    (before this change)
```

### Fix

Alias `#filter` to the overridden `#select`, mirroring how Ruby aliases `Hash#filter` to `Hash#select`.

The in-place `#filter!` / `#select!` were already correct: they are inherited from `Hash`, mutate the receiver in place, and therefore preserve the `HashWithIndifferentAccess` class. Only the non-mutating `#filter` (which builds a new hash) was affected.