### PR TITLE
Introduce a system testing server without a Capybara dependency

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -7,6 +7,20 @@
 
     *Étienne Barrié*
 
+*   Introduce `ActionDispatch::ServerSystemTestCase`, a base class for system
+    tests that boots the Rails application as a real server without depending on
+    Capybara.
+
+    It exposes the running application's base URL through `app_host` and
+    generates URL helpers (`root_url`, `users_path`, ...) against it, so browser
+    automation tools other than Capybara (Playwright, Ferrum, plain `Net::HTTP`,
+    ...) can drive a real Rails server. It also supports a separate bind host
+    and browser-facing app host, and reraises server-side application errors
+    during teardown. `ActionDispatch::SystemTestCase` remains the
+    Capybara-based default.
+
+    *YusukeIwaki*
+
 *   Add `config.action_dispatch.strict_accept_header` to stop forcing an
     HTML response when the `Accept` header contains the `*/*` wildcard.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -8,16 +8,13 @@
     *Étienne Barrié*
 
 *   Introduce `ActionDispatch::ServerSystemTestCase`, a base class for system
-    tests that boots the Rails application as a real server without depending on
+    tests that boots the application as a real server without depending on
     Capybara.
 
-    It exposes the running application's base URL through `app_host` and
-    generates URL helpers (`root_url`, `users_path`, ...) against it, so browser
-    automation tools other than Capybara (Playwright, Ferrum, plain `Net::HTTP`,
-    ...) can drive a real Rails server. It also supports a separate bind host
-    and browser-facing app host, and reraises server-side application errors
-    during teardown. `ActionDispatch::SystemTestCase` remains the
-    Capybara-based default.
+    It only boots the server and exposes its `base_url`, generating URL helpers
+    against it. You are then free to interact with the application using any
+    browser automation tool, such as Playwright or Ferrum.
+    `ActionDispatch::SystemTestCase` remains the Capybara-based default.
 
     *YusukeIwaki*
 

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -141,6 +141,7 @@ module ActionDispatch
     autoload :AssertionResponse
   end
 
+  autoload :ServerSystemTestCase, "action_dispatch/server_system_test_case"
   autoload :SystemTestCase, "action_dispatch/system_test_case"
 
   ##

--- a/actionpack/lib/action_dispatch/server_system_test_case.rb
+++ b/actionpack/lib/action_dispatch/server_system_test_case.rb
@@ -2,93 +2,113 @@
 
 # :markup: markdown
 
+require "monitor"
 require "action_controller"
+require "action_dispatch/system_testing/test_adapter"
+require "action_dispatch/system_testing/test_adapters"
 require "action_dispatch/system_testing/test_session"
 require "action_dispatch/system_testing/url_helpers_proxy"
 
 module ActionDispatch
   # # Server System Testing
   #
-  # `ActionDispatch::ServerSystemTestCase` boots your Rails application as a
-  # real server for system testing. It does not depend on Capybara.
+  # System tests run your application as a real server so you can interact with
+  # it in the browser. `ActionDispatch::ServerSystemTestCase` lets you do that
+  # with any browser automation tool -- Playwright, Ferrum, or your own --
+  # instead of Capybara.
   #
-  # It is responsible only for the part of system testing that genuinely belongs
-  # to Rails: booting the application as a real Rack server, binding it to a
-  # host/port, waiting until it is actually serving requests, exposing the base
-  # URL it is reachable on, and tearing it down at the end of the run. URL
-  # helpers (`root_url`, `users_path`, ...) are generated against that running
-  # server, so the host they produce points at the live application.
+  # It boots your application on a real port, waits until it is serving
+  # requests, and gives you the URL it is running on through `base_url`. URL
+  # helpers (`root_url`, `users_path`, ...) point at that running server.
+  # Interacting with the page is up to the adapter you select.
   #
-  # Everything above that -- driving a browser, filling in forms, asserting on
-  # the page, taking screenshots -- is left to the test author or to a browser
-  # automation tool of their choice (Capybara, Playwright, Ferrum, ...).
-  # `ActionDispatch::SystemTestCase` provides the familiar Capybara-based
-  # experience separately, while sharing the same URL helper behavior.
-  #
-  # Configure how the application is served, and wire up the browser automation
-  # tool of your choice, in your `ApplicationSystemTestCase`, so that individual
-  # tests stay focused on the interaction being tested. `served_by` is optional --
-  # by default the server binds to an available port on `0.0.0.0`. For example,
-  # with Playwright:
+  # Extend your `ApplicationSystemTestCase` from it and pick an adapter with
+  # `testing_with`. `served_by` is optional -- by default the server binds to an
+  # available port on `0.0.0.0`:
   #
   #     require "test_helper"
-  #     require "playwright"
   #
   #     class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  #       # Launch Playwright and the browser once for the whole run; a fresh
-  #       # browser context per test is enough to isolate one test from the next.
-  #       def self.browser
-  #         @browser ||= begin
-  #           execution = Playwright.create(playwright_cli_executable_path: "./node_modules/.bin/playwright")
-  #           at_exit { execution.stop }
-  #           execution.playwright.chromium.launch(headless: true)
-  #         end
-  #       end
-  #
-  #       setup do
-  #         @context = ApplicationSystemTestCase.browser.new_context(baseURL: base_url)
-  #         @page = @context.new_page
-  #       end
-  #
-  #       teardown { @context&.close }
+  #       testing_with :playwright
   #     end
   #
-  # Individual tests then only drive the page. URL helpers (`root_url`,
-  # `new_user_url`, ...) are generated against the running server, so they point
-  # at the live application:
+  # Your tests then interact with the page. URL helpers point at the running
+  # server, so they reach the live application:
   #
   #     require "application_system_test_case"
   #
   #     class UsersTest < ApplicationSystemTestCase
   #       test "creating a user" do
-  #         @page.goto new_user_url # => http://127.0.0.1:<port>/users/new
+  #         page.goto new_user_url # => http://127.0.0.1:<port>/users/new
   #
-  #         @page.fill "input[name='user[name]']", "Arya"
-  #         @page.click "text=Create User"
+  #         page.get_by_label("Name").fill("Arya")
+  #         page.get_by_role("button", name: "Create User").click
   #
-  #         assert_includes @page.content, "Arya"
+  #         assert page.get_by_text("Arya").visible?
   #       end
   #     end
   #
-  # Any browser automation tool works the same way; only the
-  # `ApplicationSystemTestCase` wiring changes.
+  # A browser library can ship its own adapter, so you interact with the page
+  # through its native API instead of a shared driver API.
   #
-  # Because the running server is reachable over plain HTTP, a test does not even
-  # need a browser. `base_url` (aliased as `app_host`) points at the live
-  # application, so an HTTP client such as Faraday can drive it directly:
+  # You don't even need a browser. `base_url` (aliased as `app_host`) points at
+  # the running application, so an HTTP client such as Faraday can interact with
+  # it directly:
   #
   #     class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
   #       setup { @client = Faraday.new(url: base_url) }
   #     end
   #
-  # and using `@client` in tests (`@client.get("/up")`, ...).
+  # You then use `@client` in your tests (`@client.get("/up")`, ...).
   #
-  # The application server is booted before each system test starts. The first
-  # test in the process starts the shared test session; later tests reuse it.
+  # The server boots before each system test. The first test in the process
+  # starts the shared session; later tests reuse it.
   class ServerSystemTestCase < ActiveSupport::TestCase
     include SystemTesting::UrlHelpersProxy
 
+    # Keep adapter selection isolated between system test base classes, so a
+    # test suite can define multiple subclasses that use different adapters.
+    class_attribute :test_adapter, instance_accessor: false
+
+    class TestAdapterInstances # :nodoc:
+      def initialize
+        @adapters = []
+        @monitor = Monitor.new
+      end
+
+      def <<(adapter)
+        @monitor.synchronize { @adapters << adapter }
+        adapter
+      end
+
+      def shutdown_all
+        adapters = @monitor.synchronize do
+          pending = @adapters.reverse
+          @adapters.clear
+          pending
+        end
+        first_error = nil
+
+        adapters.each do |adapter|
+          adapter.shutdown
+        rescue => error
+          first_error ||= error
+        end
+
+        raise first_error if first_error
+      end
+    end
+
+    TEST_ADAPTER_INSTANCES = TestAdapterInstances.new
+
     class << self
+      # Shuts down every adapter installed by testing_with, running the teardown
+      # callbacks registered by their global helpers. Runs at the end of the
+      # test run.
+      def shutdown_all_test_adapters # :nodoc:
+        TEST_ADAPTER_INSTANCES.shutdown_all
+      end
+
       # Configures how the Rails application is served. By default it binds to
       # an available port on `0.0.0.0`, so most suites never need to call this.
       #
@@ -99,6 +119,21 @@ module ActionDispatch
       #     served_by app_host: "http://rails-app:4000", port: 4000
       def served_by(host: "0.0.0.0", port: 0, app_host: nil)
         SystemTesting.test_session.configure(host: host, port: port, app_host: app_host)
+      end
+
+      # Selects the adapter that provides browser objects to system tests.
+      #
+      #     testing_with :playwright
+      #
+      # Adapter options are forwarded to the adapter:
+      #
+      #     testing_with :playwright, browser_type: :firefox, headless: false
+      def testing_with(adapter_name, **options)
+        adapter_class = SystemTesting::TestAdapters.lookup(adapter_name)
+        adapter = adapter_class.new(**options)
+        TEST_ADAPTER_INSTANCES << adapter
+        adapter.install(self)
+        self.test_adapter = adapter
       end
     end
 
@@ -111,11 +146,16 @@ module ActionDispatch
     def before_setup
       test_session.start
       test_session.clear_server_errors
+      self.class.test_adapter&.before_setup
       super
     end
 
     def after_teardown
-      test_session.raise_server_errors
+      begin
+        self.class.test_adapter&.after_teardown
+      ensure
+        test_session.raise_server_errors
+      end
     ensure
       super
     end
@@ -141,7 +181,15 @@ module ActionDispatch
   end
 end
 
-# Stop every server booted during the run once the suite is finished.
 Minitest.after_run do
+  ActionDispatch::ServerSystemTestCase.shutdown_all_test_adapters
+ensure
+  ActionDispatch::SystemTesting.test_session.shutdown
+end
+
+# Parallel test workers do not run Minitest's after_run hooks.
+ActiveSupport::Testing::Parallelization.run_cleanup_hook do
+  ActionDispatch::ServerSystemTestCase.shutdown_all_test_adapters
+ensure
   ActionDispatch::SystemTesting.test_session.shutdown
 end

--- a/actionpack/lib/action_dispatch/server_system_test_case.rb
+++ b/actionpack/lib/action_dispatch/server_system_test_case.rb
@@ -36,18 +36,17 @@ module ActionDispatch
   #
   #     class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
   #       # Launch Playwright and the browser once for the whole run; a fresh
-  #       # browser context per test is enough to isolate one test from the next,
-  #       # and is far cheaper than relaunching the browser each time.
+  #       # browser context per test is enough to isolate one test from the next.
   #       def self.browser
   #         @browser ||= begin
-  #           execution = Playwright.create(playwright_cli_executable_path: "npx playwright")
+  #           execution = Playwright.create(playwright_cli_executable_path: "./node_modules/.bin/playwright")
   #           at_exit { execution.stop }
-  #           execution.playwright.chromium.launch
+  #           execution.playwright.chromium.launch(headless: true)
   #         end
   #       end
   #
   #       setup do
-  #         @context = ApplicationSystemTestCase.browser.new_context
+  #         @context = ApplicationSystemTestCase.browser.new_context(baseURL: base_url)
   #         @page = @context.new_page
   #       end
   #

--- a/actionpack/lib/action_dispatch/server_system_test_case.rb
+++ b/actionpack/lib/action_dispatch/server_system_test_case.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+require "action_controller"
+require "action_dispatch/system_testing/test_session"
+require "action_dispatch/system_testing/url_helpers_proxy"
+
+module ActionDispatch
+  # # Server System Testing
+  #
+  # `ActionDispatch::ServerSystemTestCase` boots your Rails application as a
+  # real server for system testing. It does not depend on Capybara.
+  #
+  # It is responsible only for the part of system testing that genuinely belongs
+  # to Rails: booting the application as a real Rack server, binding it to a
+  # host/port, waiting until it is actually serving requests, exposing the base
+  # URL it is reachable on, and tearing it down at the end of the run. URL
+  # helpers (`root_url`, `users_path`, ...) are generated against that running
+  # server, so the host they produce points at the live application.
+  #
+  # Everything above that -- driving a browser, filling in forms, asserting on
+  # the page, taking screenshots -- is left to the test author or to a browser
+  # automation tool of their choice (Capybara, Playwright, Ferrum, ...).
+  # `ActionDispatch::SystemTestCase` provides the familiar Capybara-based
+  # experience separately, while sharing the same URL helper behavior.
+  #
+  # Configure how the application is served, and wire up the browser automation
+  # tool of your choice, in your `ApplicationSystemTestCase`, so that individual
+  # tests stay focused on the interaction being tested. `served_by` is optional --
+  # by default the server binds to an available port on `0.0.0.0`. For example,
+  # with Playwright:
+  #
+  #     require "test_helper"
+  #     require "playwright"
+  #
+  #     class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  #       # Launch Playwright and the browser once for the whole run; a fresh
+  #       # browser context per test is enough to isolate one test from the next,
+  #       # and is far cheaper than relaunching the browser each time.
+  #       def self.browser
+  #         @browser ||= begin
+  #           execution = Playwright.create(playwright_cli_executable_path: "npx playwright")
+  #           at_exit { execution.stop }
+  #           execution.playwright.chromium.launch
+  #         end
+  #       end
+  #
+  #       setup do
+  #         @context = ApplicationSystemTestCase.browser.new_context
+  #         @page = @context.new_page
+  #       end
+  #
+  #       teardown { @context&.close }
+  #     end
+  #
+  # Individual tests then only drive the page. URL helpers (`root_url`,
+  # `new_user_url`, ...) are generated against the running server, so they point
+  # at the live application:
+  #
+  #     require "application_system_test_case"
+  #
+  #     class UsersTest < ApplicationSystemTestCase
+  #       test "creating a user" do
+  #         @page.goto new_user_url # => http://127.0.0.1:<port>/users/new
+  #
+  #         @page.fill "input[name='user[name]']", "Arya"
+  #         @page.click "text=Create User"
+  #
+  #         assert_includes @page.content, "Arya"
+  #       end
+  #     end
+  #
+  # Any browser automation tool works the same way; only the
+  # `ApplicationSystemTestCase` wiring changes.
+  #
+  # Because the running server is reachable over plain HTTP, a test does not even
+  # need a browser. `base_url` (aliased as `app_host`) points at the live
+  # application, so an HTTP client such as Faraday can drive it directly:
+  #
+  #     class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  #       setup { @client = Faraday.new(url: base_url) }
+  #     end
+  #
+  # and using `@client` in tests (`@client.get("/up")`, ...).
+  #
+  # The application server is booted before each system test starts. The first
+  # test in the process starts the shared test session; later tests reuse it.
+  class ServerSystemTestCase < ActiveSupport::TestCase
+    include SystemTesting::UrlHelpersProxy
+
+    class << self
+      # Configures how the Rails application is served. By default it binds to
+      # an available port on `0.0.0.0`, so most suites never need to call this.
+      #
+      # When the browser must reach the application at a different URL than the
+      # bind address -- for example from another Docker container -- set
+      # `app_host`:
+      #
+      #     served_by app_host: "http://rails-app:4000", port: 4000
+      def served_by(host: "0.0.0.0", port: 0, app_host: nil)
+        SystemTesting.test_session.configure(host: host, port: port, app_host: app_host)
+      end
+    end
+
+    # Returns the base URL used as the host for URL helpers.
+    def base_url
+      test_session.app_host
+    end
+    alias_method :app_host, :base_url
+
+    def before_setup
+      test_session.start
+      test_session.clear_server_errors
+      super
+    end
+
+    def after_teardown
+      test_session.raise_server_errors
+    ensure
+      super
+    end
+
+    private
+      def test_session
+        SystemTesting.test_session
+      end
+
+      def url_helpers
+        @url_helpers ||=
+          if ActionDispatch.test_app
+            Class.new do
+              include ActionDispatch.test_app.routes.url_helpers
+              include ActionDispatch.test_app.routes.mounted_helpers
+
+              def url_options
+                default_url_options.reverse_merge(host: ActionDispatch::SystemTesting.test_session.app_host)
+              end
+            end.new
+          end
+      end
+  end
+end
+
+# Stop every server booted during the run once the suite is finished.
+Minitest.after_run do
+  ActionDispatch::SystemTesting.test_session.shutdown
+end

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -7,9 +7,11 @@ gem "capybara", ">= 3.26"
 require "capybara/dsl"
 require "capybara/minitest"
 require "action_controller"
+require "rack/builder"
 require "action_dispatch/system_testing/driver"
 require "action_dispatch/system_testing/browser"
 require "action_dispatch/system_testing/server"
+require "action_dispatch/system_testing/url_helpers_proxy"
 require "action_dispatch/system_testing/test_helpers/screenshot_helper"
 require "action_dispatch/system_testing/test_helpers/setup_and_teardown"
 
@@ -111,9 +113,15 @@ module ActionDispatch
   # Because `ActionDispatch::SystemTestCase` is a shim between Capybara and Rails,
   # any driver that is supported by Capybara is supported by system tests as long
   # as you include the required gems and files.
+  #
+  # `ActionDispatch::SystemTestCase` is the Capybara-based system testing class.
+  # `ActionDispatch::ServerSystemTestCase` provides a Capybara-agnostic
+  # alternative for browser automation tools that want Rails to boot a test
+  # server directly.
   class SystemTestCase < ActiveSupport::TestCase
     include Capybara::DSL
     include Capybara::Minitest::Assertions
+    include SystemTesting::UrlHelpersProxy
     include SystemTesting::TestHelpers::SetupAndTeardown
     include SystemTesting::TestHelpers::ScreenshotHelper
 
@@ -186,18 +194,6 @@ module ActionDispatch
               end
             end.new
           end
-      end
-
-      def method_missing(name, ...)
-        if url_helpers.respond_to?(name)
-          url_helpers.public_send(name, ...)
-        else
-          super
-        end
-      end
-
-      def respond_to_missing?(name, include_private = false)
-        url_helpers.respond_to?(name)
       end
   end
 end

--- a/actionpack/lib/action_dispatch/system_testing/available_port_finder.rb
+++ b/actionpack/lib/action_dispatch/system_testing/available_port_finder.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "socket"
+
+module ActionDispatch
+  module SystemTesting
+    class AvailablePortFinder # :nodoc:
+      def initialize(host)
+        @host = host
+      end
+
+      def find
+        server = TCPServer.new(@host, 0)
+        port = server.addr[1]
+        server.close
+
+        # Binding the selected port again verifies it is available for the
+        # requested host, including hosts that resolve to multiple interfaces.
+        server = TCPServer.new(@host, port)
+        port
+      rescue Errno::EADDRINUSE
+        retry
+      ensure
+        server&.close
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/system_testing/readiness_checker.rb
+++ b/actionpack/lib/action_dispatch/system_testing/readiness_checker.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+module ActionDispatch
+  module SystemTesting
+    class ReadinessChecker # :nodoc:
+      class Middleware # :nodoc:
+        PATH = "/__object_id__"
+
+        def initialize(app)
+          @app = app
+          @object_id = app.object_id.to_s
+        end
+
+        def call(env)
+          if env["REQUEST_METHOD"] == "GET" && env["PATH_INFO"] == PATH
+            [200, { "Content-Type" => "text/plain" }, [@object_id]]
+          else
+            @app.call(env)
+          end
+        end
+      end
+
+      class TimeoutError < StandardError # :nodoc:
+      end
+
+      def initialize(app, host, port)
+        @object_id = app.object_id.to_s
+        @host = host
+        @port = port
+      end
+
+      def responsive?
+        response = Net::HTTP.start(@host, @port, read_timeout: 2, max_retries: 0) do |http|
+          http.get(Middleware::PATH)
+        end
+
+        response.is_a?(Net::HTTPSuccess) && response.body == @object_id
+      rescue EOFError, SystemCallError, Net::ReadTimeout
+        false
+      end
+
+      def wait_for_responsive(timeout:)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        until responsive?
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= start_time + timeout
+            raise TimeoutError.new("Rack application timed out during boot")
+          end
+
+          sleep 0.01
+        end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/system_testing/test_adapter.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_adapter.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  module SystemTesting
+    # = System Testing \Test Adapter
+    #
+    # Subclass +TestAdapter+ to let a browser tool work with
+    # ActionDispatch::ServerSystemTestCase. An adapter hands each test the
+    # objects it interacts with the page through -- typically a browser and a
+    # page, but it can provide any per-test or per-run resource.
+    #
+    # Declare each resource as a _helper_. A helper is defined with a block that
+    # builds the resource and returns it; a test reads it by calling a method of
+    # the same name. Helpers come in two kinds:
+    #
+    # * A global helper is built at most once per run.
+    # * A regular helper is built at most once per test.
+    #
+    # A helper block declares its dependencies as required keyword arguments.
+    # Each dependency resolves to another helper of the same name, or to the
+    # running server's +base_url+:
+    #
+    #     class MyBrowserAdapter < ActionDispatch::SystemTesting::TestAdapter
+    #       global_helper :browser do
+    #         browser = Browser.launch
+    #         on_teardown { browser.close }
+    #         browser
+    #       end
+    #
+    #       helper :page do |browser:, base_url:|
+    #         page = browser.new_page(base_url: base_url)
+    #         on_teardown { page.close }
+    #         page
+    #       end
+    #     end
+    #
+    # Register the adapter under a name so applications can select it with
+    # +testing_with+:
+    #
+    #     ActionDispatch::SystemTesting::TestAdapters.register(:my_browser, MyBrowserAdapter)
+    #
+    # Helpers are built lazily the first time a test reads them. Use
+    # +on_teardown+ to clean the resource up: the callback runs after the test
+    # for a regular helper, or after the run for a global helper.
+    class TestAdapter
+      # A single helper definition: its name, whether it is global (built once
+      # per run) or not (built once per test), and the block that builds its
+      # value.
+      class Helper < Struct.new(:name, :global, :block, keyword_init: true)
+        def global?
+          global
+        end
+      end
+      private_constant :Helper
+
+      # Holds the values already resolved for one lifecycle scope -- the whole
+      # run for global helpers, a single test for regular helpers -- along with
+      # the teardown callbacks those helpers registered.
+      class HelperScope # :nodoc:
+        attr_reader :teardowns
+
+        def initialize
+          @values = {}
+          @resolving = []
+          @teardowns = []
+        end
+
+        def resolved?(name)
+          @values.key?(name)
+        end
+
+        def value(name)
+          @values[name]
+        end
+
+        def store(name, value, teardowns)
+          @teardowns.concat(teardowns)
+          @values[name] = value
+        end
+
+        # Marks +name+ as being resolved for the duration of the block, so a
+        # helper that depends on itself -- directly or through another helper --
+        # raises instead of looping forever.
+        def resolving(name)
+          if @resolving.include?(name)
+            path = (@resolving + [name]).join(" -> ")
+            raise ArgumentError, "circular system test helper dependency: #{path}"
+          end
+
+          @resolving << name
+          begin
+            yield
+          ensure
+            @resolving.pop
+          end
+        end
+      end
+      private_constant :HelperScope
+
+      class << self
+        # Defines a helper built at most once per test run.
+        def global_helper(name, &block)
+          register_helper(name, global: true, block: block)
+        end
+
+        # Defines a helper built at most once per test.
+        def helper(name, &block)
+          register_helper(name, global: false, block: block)
+        end
+
+        # The helpers this adapter declares, keyed by name.
+        def helpers # :nodoc:
+          @helpers ||= {}
+        end
+
+        # Adapters are leaf classes: they inherit directly from TestAdapter and
+        # are not themselves subclassed, so an adapter's helpers are exactly the
+        # ones it declares -- there is no definition chain to merge.
+        def inherited(subclass)
+          super
+
+          unless equal?(TestAdapter)
+            raise TypeError, "system test adapters cannot be subclassed; inherit directly from ActionDispatch::SystemTesting::TestAdapter"
+          end
+        end
+
+        private
+          def register_helper(name, global:, block:)
+            raise ArgumentError, "a block is required" unless block
+
+            name = name.to_sym
+
+            if block.parameters.any? { |kind, _| kind != :keyreq }
+              raise ArgumentError, "system test helper #{name.inspect} must declare its dependencies as required keyword arguments"
+            end
+
+            helpers[name] = Helper.new(name: name, global: global, block: block)
+          end
+      end
+
+      attr_reader :options
+
+      def initialize(**options)
+        @options = options.freeze
+        @global_scope = HelperScope.new
+        @test_scope = HelperScope.new
+      end
+
+      # Installs an accessor for every helper on the test case class, so a test
+      # can read a helper's value by calling a method of the same name.
+      def install(test_case_class)
+        test_case_class.include(helper_module_for_install)
+      end
+
+      # Discards the previous test's helpers and starts a fresh scope, so each
+      # test gets its own set of regular helpers.
+      def before_setup
+        @test_scope = HelperScope.new
+      end
+
+      # Runs the teardown callbacks registered by the current test's helpers.
+      def after_teardown
+        run_teardowns(@test_scope.teardowns)
+      end
+
+      # Runs the teardown callbacks registered by global helpers, at the end of
+      # the run.
+      def shutdown
+        scope = @global_scope
+        @global_scope = HelperScope.new
+        run_teardowns(scope.teardowns)
+      end
+
+      # Returns the value of the helper named +name+, resolving it (and its
+      # dependencies) the first time it is read. Called by the accessors that
+      # #install adds to the test case, so +name+ is always a declared helper.
+      def resolve(name, test_case) # :nodoc:
+        resolve_helper(self.class.helpers[name], test_case)
+      end
+
+      private
+        def helper_module_for_install
+          adapter = self
+
+          Module.new do
+            adapter.class.helpers.each_key do |name|
+              define_method(name) { adapter.resolve(name, self) }
+            end
+          end
+        end
+
+        # Resolves +helper+ in the scope it belongs to: global helpers live for
+        # the whole run, regular helpers only for the current test.
+        def resolve_helper(helper, test_case)
+          scope = helper.global? ? @global_scope : @test_scope
+          resolve_in_scope(scope, helper, test_case)
+        end
+
+        # Resolves +helper+ within +scope+: returns the value if it was already
+        # resolved there, otherwise resolves each dependency, runs the block
+        # against the adapter -- so it can call the adapter's support methods and
+        # +on_teardown+ directly -- and memoizes the value with its teardowns.
+        def resolve_in_scope(scope, helper, test_case)
+          return scope.value(helper.name) if scope.resolved?(helper.name)
+
+          scope.resolving(helper.name) do
+            dependencies = {}
+            helper.block.parameters.each do |_kind, name|
+              dependencies[name] = resolve_dependency(helper, name, test_case)
+            end
+
+            outer_teardowns = @current_teardowns
+            @current_teardowns = []
+            begin
+              value = instance_exec(**dependencies, &helper.block)
+              scope.store(helper.name, value, @current_teardowns)
+              value
+            rescue
+              run_teardowns(@current_teardowns)
+              raise
+            ensure
+              @current_teardowns = outer_teardowns
+            end
+          end
+        end
+
+        # Resolves a single dependency +name+ of +helper+ to another helper, or
+        # to the running server's +base_url+.
+        def resolve_dependency(helper, name, test_case)
+          if (dependency = self.class.helpers[name])
+            if helper.global? && !dependency.global?
+              raise ArgumentError, "global system test helper cannot depend on test helper #{name.inspect}"
+            end
+
+            resolve_helper(dependency, test_case)
+          elsif name == :base_url
+            test_case.base_url
+          else
+            raise ArgumentError, "system test helper #{helper.name.inspect} has an unknown dependency #{name.inspect}"
+          end
+        end
+
+        # Registers a cleanup callback for the helper currently being built.
+        # Only meaningful while a helper block runs, so it stays private and is
+        # not part of the adapter's public API.
+        def on_teardown(&block)
+          raise ArgumentError, "a block is required" unless block
+
+          @current_teardowns << block
+        end
+
+        def run_teardowns(teardowns)
+          first_error = nil
+
+          teardowns.reverse_each do |teardown|
+            teardown.call
+          rescue => error
+            first_error ||= error
+          end
+
+          teardowns.clear
+          raise first_error if first_error
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/system_testing/test_adapters.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_adapters.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "action_dispatch/system_testing/test_adapter"
+
+module ActionDispatch
+  module SystemTesting
+    # Resolves symbolic names used by `ServerSystemTestCase.testing_with`.
+    module TestAdapters
+      class AdapterNotFoundError < StandardError
+      end
+
+      class << self
+        # Registers an adapter class under a symbolic name.
+        #
+        #     TestAdapters.register(:my_browser, MyBrowserAdapter)
+        def register(name, adapter)
+          if !name.is_a?(String) && !name.is_a?(Symbol)
+            raise ArgumentError, "system test adapter name must be a String or Symbol"
+          end
+
+          if adapter.is_a?(Class) && adapter < TestAdapter
+            adapters[name.to_sym] = adapter
+          else
+            raise ArgumentError, "system test adapter must inherit from ActionDispatch::SystemTesting::TestAdapter"
+          end
+        end
+
+        # Returns the adapter class registered for +name+.
+        def lookup(name)
+          if !name.is_a?(String) && !name.is_a?(Symbol)
+            raise ArgumentError, "system test adapter name must be a String or Symbol"
+          end
+
+          adapters[name.to_sym] or raise AdapterNotFoundError, "system test adapter not found: #{name.inspect}"
+        end
+
+        private
+          def adapters
+            @adapters ||= {}
+          end
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/system_testing/test_server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_server.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "uri"
+require "action_dispatch/system_testing/available_port_finder"
+require "action_dispatch/system_testing/readiness_checker"
+
+module ActionDispatch
+  module SystemTesting
+    class TestServer # :nodoc:
+      BOOT_TIMEOUT = 60
+      DEFAULT_OPTIONS = { Threads: "0:4", workers: 0, daemon: false, Silent: true }.freeze
+      REQUIRED_PUMA_VERSION = Gem::Requirement.new(">= 5.6.3")
+
+      class ErrorCollecting # :nodoc:
+        def initialize(app, reportable_errors: [Exception])
+          @app = app
+          @reportable_errors = reportable_errors
+          @mutex = Mutex.new
+          @errors = []
+        end
+
+        def call(env)
+          @app.call(env)
+        rescue *@reportable_errors => error
+          @mutex.synchronize { @errors << error }
+          raise
+        end
+
+        def collect_errors
+          @mutex.synchronize do
+            return @errors.dup
+          end
+        end
+
+        def clear_errors
+          @mutex.synchronize { @errors.clear }
+        end
+      end
+
+      def initialize(app:, host: nil, port: nil)
+        @host = host || "0.0.0.0"
+        @connect_host = @host == "0.0.0.0" ? "127.0.0.1" : @host # `0.0.0.0` is a bind address, not an address clients can connect to.
+        @port = detect_or_use(port)
+
+        @checker = ReadinessChecker.new(app, @connect_host, @port)
+        @app_with_error_collecting_and_readiness_check = ErrorCollecting.new(ReadinessChecker::Middleware.new(app))
+      end
+
+      def boot
+        if server_thread_alive? && @checker.responsive?
+          return self
+        end
+
+        @server = build_server
+        @server_thread = @server.run
+        begin
+          @checker.wait_for_responsive(timeout: BOOT_TIMEOUT)
+        rescue ReadinessChecker::TimeoutError
+          stop
+          raise
+        end
+
+        self
+      end
+
+      def stop
+        @server&.stop(true)
+      end
+
+      def base_url
+        URI::HTTP.build(host: @connect_host, port: @port).to_s
+      end
+
+      def collect_server_errors
+        @app_with_error_collecting_and_readiness_check.collect_errors
+      end
+
+      def clear_server_errors
+        @app_with_error_collecting_and_readiness_check.clear_errors
+      end
+
+      private
+        def detect_or_use(port)
+          port = Integer(port || 0)
+
+          unless port.between?(0, 65_535)
+            raise ArgumentError, "port must be in the range 0..65535"
+          end
+
+          port.zero? ? AvailablePortFinder.new(@host).find : port
+        rescue ArgumentError, TypeError
+          raise ArgumentError, "port must be in the range 0..65535"
+        end
+
+        def ensure_server_dependencies
+          begin
+            require "puma"
+          rescue LoadError
+            raise LoadError, "Unable to load `puma` for Action Dispatch system testing server. Please add `puma` to your project."
+          end
+
+          unless REQUIRED_PUMA_VERSION.satisfied_by?(Gem::Version.new(Puma::Const::PUMA_VERSION))
+            raise LoadError, "Action Dispatch system testing server requires `puma` version 5.6.3 or newer."
+          end
+
+          rack_handler_puma
+        end
+
+        def rack_handler_puma
+          require "rack/handler/puma"
+
+          # Puma >= 6.1 defines Rackup::Handler::Puma
+          # https://github.com/puma/puma/commit/8092bf80852f8881b37003e019e8f64ab9d430b9
+          if defined?(Rackup::Handler::Puma)
+            Rackup::Handler::Puma
+          elsif defined?(Rack::Handler::Puma)
+            Rack::Handler::Puma
+          else
+            raise LoadError, "Unable to load `puma` rack handler for Action Dispatch system testing server."
+          end
+        end
+
+        def server_thread_alive?
+          @server_thread && @server_thread.join(0).nil?
+        end
+
+        def with_rack_env_test
+          rack_env_defined = ENV.key?("RACK_ENV")
+          rack_env = ENV["RACK_ENV"]
+
+          ENV["RACK_ENV"] = "test"
+          yield
+        ensure
+          if rack_env_defined
+            ENV["RACK_ENV"] = rack_env
+          else
+            ENV.delete("RACK_ENV")
+          end
+        end
+
+        def build_server
+          ensure_server_dependencies
+
+          with_rack_env_test do
+            config = rack_handler_puma.config(
+              @app_with_error_collecting_and_readiness_check,
+              DEFAULT_OPTIONS.merge(Host: @host, Port: @port),
+            )
+            config.clamp
+            config.options[:log_writer] = puma_logger(config)
+
+            server = Puma::Server.new(
+              config.app,
+              nil,
+              config.options
+            )
+            server.binder.parse(config.options[:binds], server.log_writer)
+
+            server
+          end
+        end
+
+        def puma_logger(config)
+          if config.options[:Silent]
+            Puma::LogWriter.strings
+          else
+            Puma::LogWriter.stdio
+          end
+        end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/system_testing/test_session.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_session.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "action_dispatch/system_testing/test_server"
+
+module ActionDispatch
+  module SystemTesting
+    class TestSession # :nodoc:
+      class ServerNotStartedError < StandardError # :nodoc:
+      end
+
+      def initialize(app: nil)
+        @app = app
+        @server = nil
+        @host = nil
+        @port = nil
+        @app_host = nil
+      end
+
+      def configure(host:, port:, app_host: nil)
+        if started? && server_configuration_changed?(host, port)
+          raise ArgumentError, "system test session has already started; configure server host and port before the first test runs"
+        end
+
+        @host = host
+        @port = port
+        @app_host = app_host
+
+        self
+      end
+
+      def start
+        return self if started?
+
+        server = TestServer.new(
+          app: @app || Rails.application,
+          host: @host,
+          port: @port,
+        )
+        server.boot
+
+        @server = server
+        self
+      end
+
+      def started?
+        !!@server
+      end
+
+      def app_host
+        raise ServerNotStartedError, "system test session has not started" unless started?
+
+        @app_host || @server.base_url
+      end
+
+      def clear_server_errors
+        @server&.clear_server_errors
+      end
+
+      def raise_server_errors
+        return unless @server
+
+        errors = @server.collect_server_errors
+        raise errors.first if errors.any?
+      end
+
+      def shutdown
+        server = @server
+        @server = nil
+        server&.stop
+
+        self
+      end
+
+      private
+        def server_configuration_changed?(host, port)
+          @host != host || @port != port
+        end
+    end
+
+    TEST_SESSION = TestSession.new
+
+    def self.test_session
+      TEST_SESSION
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/system_testing/url_helpers_proxy.rb
+++ b/actionpack/lib/action_dispatch/system_testing/url_helpers_proxy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  module SystemTesting
+    module UrlHelpersProxy # :nodoc:
+      private
+        def method_missing(name, ...)
+          if url_helpers.respond_to?(name)
+            url_helpers.public_send(name, ...)
+          else
+            super
+          end
+        end
+
+        def respond_to_missing?(name, include_private = false)
+          url_helpers.respond_to?(name) || super
+        end
+    end
+  end
+end

--- a/actionpack/test/dispatch/system_testing/available_port_finder_test.rb
+++ b/actionpack/test/dispatch/system_testing/available_port_finder_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_dispatch/system_testing/available_port_finder"
+
+class AvailablePortFinderTest < ActiveSupport::TestCase
+  test "find returns a port available on the given host" do
+    host = "127.0.0.1"
+    port = ActionDispatch::SystemTesting::AvailablePortFinder.new(host).find
+    assert_kind_of Integer, port
+
+    # Ensure TCP connection is really available.
+    server = TCPServer.new(host, port)
+    assert_equal port, server.addr[1]
+  ensure
+    server&.close
+  end
+end

--- a/actionpack/test/dispatch/system_testing/readiness_checker_middleware_test.rb
+++ b/actionpack/test/dispatch/system_testing/readiness_checker_middleware_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_dispatch/system_testing/readiness_checker"
+
+class ReadinessCheckerMiddlewareTest < ActiveSupport::TestCase
+  test "GET to object id endpoint returns the app object id" do
+    downstream_called = false
+    app = lambda do |_env|
+      downstream_called = true
+      [404, {}, ["downstream"]]
+    end
+    middleware = ActionDispatch::SystemTesting::ReadinessChecker::Middleware.new(app)
+
+    status, headers, body = middleware.call(Rack::MockRequest.env_for("/__object_id__", method: "GET"))
+
+    assert_equal 200, status
+    assert_equal "text/plain", headers["Content-Type"]
+    assert_equal app.object_id.to_s, body.join
+    assert_not downstream_called
+  end
+
+  test "non endpoint requests are delegated to the app" do
+    app = lambda do |env|
+      [200, {}, [env["PATH_INFO"]]]
+    end
+    middleware = ActionDispatch::SystemTesting::ReadinessChecker::Middleware.new(app)
+
+    status, _headers, body = middleware.call(Rack::MockRequest.env_for("/posts", method: "GET"))
+
+    assert_equal 200, status
+    assert_equal "/posts", body.join
+  end
+
+  test "non-GET requests to object id endpoint are delegated to the app" do
+    app = lambda do |env|
+      [200, {}, [env["REQUEST_METHOD"]]]
+    end
+    middleware = ActionDispatch::SystemTesting::ReadinessChecker::Middleware.new(app)
+
+    status, _headers, body = middleware.call(Rack::MockRequest.env_for("/__object_id__", method: "OPTIONS"))
+    assert_equal 200, status
+    assert_equal "OPTIONS", body.join
+
+    status, _headers, body = middleware.call(Rack::MockRequest.env_for("/__object_id__", method: "POST"))
+    assert_equal 200, status
+    assert_equal "POST", body.join
+  end
+end

--- a/actionpack/test/dispatch/system_testing/readiness_checker_test.rb
+++ b/actionpack/test/dispatch/system_testing/readiness_checker_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "socket"
+require "timeout"
+require "action_dispatch/system_testing/available_port_finder"
+require "action_dispatch/system_testing/readiness_checker"
+
+class ReadinessCheckerTest < ActiveSupport::TestCase
+  class BaseHttpServer
+    attr_reader :port
+
+    def initialize(port: 0)
+      @mutex = Mutex.new
+      @connection_count = 0
+      @server = TCPServer.new("127.0.0.1", port)
+      @port = @server.addr[1]
+      @thread = Thread.new do
+        Thread.current.report_on_exception = false
+        handle_requests
+      end
+    end
+
+    def self.start(**options)
+      server = new(**options)
+      begin
+        yield server
+      ensure
+        server.stop
+      end
+    end
+
+    def connection_count
+      @mutex.synchronize { @connection_count }
+    end
+
+    def request_method
+      @mutex.synchronize { @request_method }
+    end
+
+    def request_path
+      @mutex.synchronize { @request_path }
+    end
+
+    def stop
+      close_server
+    ensure
+      @thread.kill
+      begin
+        @thread.join
+      rescue StandardError
+      end
+    end
+
+    def wait
+      @thread.join
+    end
+
+    private
+      def handle_requests
+        socket = nil
+
+        loop do
+          socket = @server.accept
+          record_connection
+          handle_socket(socket)
+          socket.close
+          socket = nil
+        end
+      rescue IOError, Errno::EBADF
+      ensure
+        socket&.close
+        close_server
+      end
+
+      def handle_socket(socket)
+        raise NotImplementedError
+      end
+
+      def close_server
+        @server.close unless @server.closed?
+      rescue IOError, Errno::EBADF
+      end
+
+      def record_connection
+        @mutex.synchronize { @connection_count += 1 }
+      end
+
+      def read_request_line(socket)
+        request_line = socket.gets
+        return unless request_line
+
+        request_method, request_path, = request_line.split
+        @mutex.synchronize do
+          @request_method = request_method
+          @request_path = request_path
+        end
+
+        request_line
+      end
+  end
+
+  class SingleRequestServer < BaseHttpServer
+    def initialize(port: 0, body:)
+      @body = body
+      super(port: port)
+    end
+
+    private
+      def handle_socket(socket)
+        return unless read_request_line(socket)
+
+        socket.write(<<~HTTP)
+          HTTP/1.1 200 OK\r
+          Content-Type: text/plain\r
+          Content-Length: #{@body.bytesize}\r
+          Connection: close\r
+          \r
+        HTTP
+
+        socket.write(@body)
+
+        close_server
+      end
+  end
+
+  class ClosingServer < BaseHttpServer
+    private
+      def handle_socket(_socket)
+        close_server
+      end
+  end
+
+  class HangingServer < BaseHttpServer
+    private
+      def handle_socket(socket)
+        read_request_line(socket)
+        sleep
+      end
+  end
+
+  test "responsive when object id endpoint responds with app object id" do
+    app = ->(_env) { [200, {}, []] }
+    SingleRequestServer.start(body: app.object_id.to_s) do |server|
+      checker = ActionDispatch::SystemTesting::ReadinessChecker.new(app, "127.0.0.1", server.port)
+
+      assert checker.responsive?
+      assert_equal "GET", server.request_method
+      assert_equal "/__object_id__", server.request_path
+    end
+  end
+
+  test "not responsive when object id endpoint responds with a different object id" do
+    app = ->(_env) { [200, {}, []] }
+    SingleRequestServer.start(body: "another-app") do |server|
+      checker = ActionDispatch::SystemTesting::ReadinessChecker.new(app, "127.0.0.1", server.port)
+
+      assert_not checker.responsive?
+    end
+  end
+
+  test "not responsive when the endpoint cannot be reached" do
+    app = ->(_env) { [200, {}, []] }
+    port = ActionDispatch::SystemTesting::AvailablePortFinder.new("127.0.0.1").find
+    checker = ActionDispatch::SystemTesting::ReadinessChecker.new(app, "127.0.0.1", port)
+
+    assert_not checker.responsive?
+  end
+
+  test "responsive does not retry dropped HTTP connections" do
+    app = ->(_env) { [200, {}, []] }
+    ClosingServer.start do |server|
+      checker = ActionDispatch::SystemTesting::ReadinessChecker.new(app, "127.0.0.1", server.port)
+
+      assert_not checker.responsive?
+      assert_equal 1, server.connection_count
+    end
+  end
+
+  test "responsive times out when HTTP server accepts but does not respond" do
+    app = ->(_env) { [200, {}, []] }
+    HangingServer.start do |server|
+      checker = ActionDispatch::SystemTesting::ReadinessChecker.new(app, "127.0.0.1", server.port)
+
+      Timeout.timeout(5) do
+        assert_not checker.responsive?
+      end
+    end
+  end
+
+  test "wait for responsive returns when endpoint becomes responsive" do
+    app = ->(_env) { [200, {}, []] }
+    port = ActionDispatch::SystemTesting::AvailablePortFinder.new("127.0.0.1").find
+    checker = ActionDispatch::SystemTesting::ReadinessChecker.new(app, "127.0.0.1", port)
+    server = nil
+    server_thread = Thread.new do
+      Thread.current.report_on_exception = false
+      sleep 0.01
+      server = SingleRequestServer.new(port: port, body: app.object_id.to_s)
+    end
+
+    assert_nil checker.wait_for_responsive(timeout: 5)
+  ensure
+    server&.stop
+    server_thread&.kill
+    server_thread&.join
+  end
+
+  test "wait for responsive raises when timeout expires" do
+    app = ->(_env) { [200, {}, []] }
+    port = ActionDispatch::SystemTesting::AvailablePortFinder.new("127.0.0.1").find
+    checker = ActionDispatch::SystemTesting::ReadinessChecker.new(app, "127.0.0.1", port)
+
+    error = assert_raises(ActionDispatch::SystemTesting::ReadinessChecker::TimeoutError) do
+      checker.wait_for_responsive(timeout: 0)
+    end
+
+    assert_equal "Rack application timed out during boot", error.message
+  end
+end

--- a/actionpack/test/dispatch/system_testing/server_system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/server_system_test_case_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "net/http"
+require "action_dispatch/server_system_test_case"
+
+class ServerSystemTestCaseTest < ActiveSupport::TestCase
+  FakeApp = lambda do |env|
+    if env["PATH_INFO"] == "/boom"
+      raise "boom"
+    else
+      [200, { "content-type" => "text/plain" }, ["ok"]]
+    end
+  end
+
+  class MyApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  end
+
+  def new_test_case
+    Class.new(MyApplicationSystemTestCase) do
+      def test_something
+      end
+    end
+  end
+
+  test "served_by configures the test session" do
+    with_test_session do |session|
+      klass = new_test_case
+      klass.served_by host: "127.0.0.1", port: 0, app_host: "http://rails-app:4000"
+
+      error = assert_raises(ActionDispatch::SystemTesting::TestSession::ServerNotStartedError) do
+        klass.new("test_something").base_url
+      end
+      assert_equal "system test session has not started", error.message
+
+      session.start
+
+      instance = klass.new("test_something")
+      assert_equal "http://rails-app:4000", instance.base_url
+      assert_equal "http://rails-app:4000", instance.app_host
+    end
+  end
+
+  test "before_setup starts the test session" do
+    with_test_session do |session|
+      klass = new_test_case
+      klass.served_by host: "127.0.0.1", port: 0
+      instance = klass.new("test_something")
+
+      instance.send(:before_setup)
+
+      assert_match %r{\Ahttp://127\.0\.0\.1:\d+\z}, session.app_host
+      assert_equal session.app_host, instance.base_url
+      assert_equal session.app_host, instance.app_host
+    end
+  end
+
+  test "before_setup clears previous server errors" do
+    with_test_session do |session|
+      klass = new_test_case
+      klass.served_by host: "127.0.0.1", port: 0
+      session.start
+      request_error(session)
+      assert_raises(RuntimeError) do
+        session.raise_server_errors
+      end
+      instance = klass.new("test_something")
+
+      instance.send(:before_setup)
+
+      assert_nothing_raised do
+        session.raise_server_errors
+      end
+    end
+  end
+
+  test "test session is shared by all test case classes" do
+    with_test_session do |session|
+      a = new_test_case
+      b = new_test_case
+      a.served_by host: "127.0.0.1", port: 0
+      session.start
+
+      assert_equal session.app_host, b.new("test_something").base_url
+    end
+  end
+
+  test "served_by raises when changing settings after the test session starts" do
+    with_test_session do |session|
+      klass = new_test_case
+      klass.served_by host: "127.0.0.1", port: 0
+      session.start
+      app_host = session.app_host
+
+      error = assert_raises(ArgumentError) do
+        klass.served_by host: "127.0.0.1", port: 1
+      end
+
+      assert_equal "system test session has already started; configure server host and port before the first test runs", error.message
+      assert_equal app_host, klass.new("test_something").base_url
+    end
+  end
+
+  test "url helpers are generated against base_url" do
+    routes = ActionDispatch::Routing::RouteSet.new
+    routes.draw do
+      get "/users/new", to: "users#new", as: :new_user
+    end
+
+    with_test_session do |session|
+      session.configure(host: "127.0.0.1", port: 0, app_host: "http://127.0.0.1:9999")
+      session.start
+
+      with_test_app(Struct.new(:routes).new(routes)) do
+        instance = new_test_case.new("test_something")
+
+        assert_equal "http://127.0.0.1:9999/users/new", instance.new_user_url
+        assert_equal "/users/new", instance.new_user_path
+        assert_respond_to instance, :new_user_url
+      end
+    end
+  end
+
+  test "server errors are raised during teardown" do
+    with_test_session do |session|
+      klass = new_test_case
+      klass.served_by host: "127.0.0.1", port: 0
+      session.start
+      request_error(session)
+      instance = klass.new("test_something")
+      instance.assert true
+
+      error = assert_raises(RuntimeError) do
+        instance.send(:after_teardown)
+      end
+
+      assert_equal "boom", error.message
+    end
+  end
+
+  private
+    def with_test_session
+      session = ActionDispatch::SystemTesting::TestSession.new(app: FakeApp)
+      ActionDispatch::SystemTesting.stub(:test_session, session) do
+        yield session
+      end
+    ensure
+      session.shutdown
+    end
+
+    def with_test_app(app)
+      old = ActionDispatch.test_app
+      ActionDispatch.test_app = app
+      yield
+    ensure
+      ActionDispatch.test_app = old
+    end
+
+    def request_error(session)
+      Net::HTTP.get_response(URI("#{session.app_host}/boom"))
+    rescue EOFError, Errno::ECONNRESET
+      # Puma may close the connection after the application raises.
+    end
+end

--- a/actionpack/test/dispatch/system_testing/server_system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/server_system_test_case_test.rb
@@ -16,6 +16,13 @@ class ServerSystemTestCaseTest < ActiveSupport::TestCase
   class MyApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
   end
 
+  class ExampleAdapter < ActionDispatch::SystemTesting::TestAdapter
+    global_helper(:adapter_name) { options.fetch(:name) }
+    helper(:adapter_page) { |adapter_name:| "#{adapter_name} page" }
+  end
+
+  ActionDispatch::SystemTesting::TestAdapters.register(:example, ExampleAdapter)
+
   def new_test_case
     Class.new(MyApplicationSystemTestCase) do
       def test_something
@@ -41,6 +48,58 @@ class ServerSystemTestCaseTest < ActiveSupport::TestCase
     end
   end
 
+  test "testing_with installs an adapter and forwards its options" do
+    adapter = nil
+
+    with_test_session do
+      klass = new_test_case
+      klass.testing_with :example, name: "example"
+      adapter = klass.test_adapter
+      instance = klass.new("test_something")
+
+      instance.send(:before_setup)
+
+      assert_instance_of ExampleAdapter, adapter
+      assert_equal "example page", instance.adapter_page
+      instance.assert true
+
+      instance.send(:after_teardown)
+    end
+  ensure
+    adapter&.shutdown
+  end
+
+  test "shuts down adapters created by testing_with" do
+    events = []
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      global_helper :resource do
+        on_teardown { events << :closed }
+        :resource
+      end
+    end
+    ActionDispatch::SystemTesting::TestAdapters.register(:shutdown_example, adapter_class)
+    klass = new_test_case
+    klass.testing_with :shutdown_example
+    instance = klass.new("test_something")
+    instance.resource
+
+    ActionDispatch::ServerSystemTestCase.shutdown_all_test_adapters
+
+    assert_equal [:closed], events
+  ensure
+    klass&.test_adapter&.shutdown
+  end
+
+  test "testing_with leaves invalid adapter name errors to lookup" do
+    klass = new_test_case
+
+    error = assert_raises(ArgumentError) do
+      klass.testing_with ExampleAdapter
+    end
+
+    assert_equal "system test adapter name must be a String or Symbol", error.message
+  end
+
   test "before_setup starts the test session" do
     with_test_session do |session|
       klass = new_test_case
@@ -52,6 +111,22 @@ class ServerSystemTestCaseTest < ActiveSupport::TestCase
       assert_match %r{\Ahttp://127\.0\.0\.1:\d+\z}, session.app_host
       assert_equal session.app_host, instance.base_url
       assert_equal session.app_host, instance.app_host
+    end
+  end
+
+  test "works without an adapter by interacting with the server through base_url" do
+    with_test_session do
+      klass = new_test_case
+      klass.served_by host: "127.0.0.1", port: 0
+      instance = klass.new("test_something")
+
+      instance.send(:before_setup)
+      response = Net::HTTP.get_response(URI("#{instance.base_url}/"))
+      instance.assert true
+      instance.send(:after_teardown)
+
+      assert_equal "200", response.code
+      assert_equal "ok", response.body
     end
   end
 

--- a/actionpack/test/dispatch/system_testing/test_adapter_test.rb
+++ b/actionpack/test/dispatch/system_testing/test_adapter_test.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_dispatch/system_testing/test_adapter"
+
+class TestAdapterTest < ActiveSupport::TestCase
+  class TestCase
+    def base_url
+      "http://example.test"
+    end
+  end
+
+  test "global and test helpers resolve keyword dependencies" do
+    events = []
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      global_helper :browser do
+        events << :open_browser
+        on_teardown { events << :close_browser }
+        :browser
+      end
+
+      global_helper :browser_context do |base_url:, browser:|
+        events << [:open_context, base_url, browser]
+        on_teardown { events << :close_context }
+        :browser_context
+      end
+
+      helper :page do |browser_context:|
+        events << [:open_page, browser_context]
+        on_teardown { events << :close_page }
+        Object.new
+      end
+    end
+
+    adapter = adapter_class.new
+    adapter.install(TestCase)
+
+    first_test = TestCase.new
+    adapter.before_setup
+    first_page = first_test.page
+
+    assert_same first_page, first_test.page
+    assert_equal [
+      :open_browser,
+      [:open_context, "http://example.test", :browser],
+      [:open_page, :browser_context],
+    ], events
+
+    adapter.after_teardown
+
+    second_test = TestCase.new
+    adapter.before_setup
+    second_page = second_test.page
+    adapter.after_teardown
+
+    assert_not_same first_page, second_page
+    assert_equal 1, events.count(:open_browser)
+    assert_equal 0, events.count(:close_context)
+    assert_equal 2, events.count(:close_page)
+
+    adapter.shutdown
+
+    assert_equal [:close_context, :close_browser], events.last(2)
+  end
+
+  test "test helpers can depend on other test helpers" do
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      helper(:one) { 1 }
+      helper(:two) { |one:| one + 1 }
+    end
+    adapter = adapter_class.new
+    adapter.install(TestCase)
+    test_case = TestCase.new
+    adapter.before_setup
+
+    assert_equal 2, test_case.two
+  ensure
+    adapter&.after_teardown if test_case
+    adapter&.shutdown
+  end
+
+  test "adapters cannot be subclassed" do
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter)
+
+    error = assert_raises(TypeError) { Class.new(adapter_class) }
+    assert_equal "system test adapters cannot be subclassed; inherit directly from ActionDispatch::SystemTesting::TestAdapter", error.message
+  end
+
+  test "helpers must declare dependencies as required keyword arguments" do
+    error = assert_raises(ArgumentError) do
+      Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+        helper(:value) { |missing: :default| missing }
+      end
+    end
+
+    assert_equal "system test helper :value must declare its dependencies as required keyword arguments", error.message
+  end
+
+  test "global helpers cannot depend on test helpers" do
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      helper(:page) { :page }
+      global_helper(:browser) { |page:| page }
+    end
+    adapter = adapter_class.new
+    adapter.install(TestCase)
+    test_case = TestCase.new
+    adapter.before_setup
+
+    error = assert_raises(ArgumentError) { test_case.browser }
+    assert_equal "global system test helper cannot depend on test helper :page", error.message
+  ensure
+    adapter&.after_teardown if test_case
+    adapter&.shutdown
+  end
+
+  test "circular helper dependencies raise a descriptive error" do
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      helper(:a) { |b:| b }
+      helper(:b) { |c:| c }
+      helper(:c) { |d:| d }
+      helper(:d) { |a:| a }
+    end
+    adapter = adapter_class.new
+    adapter.install(TestCase)
+    test_case = TestCase.new
+    adapter.before_setup
+
+    error = assert_raises(ArgumentError) { test_case.a }
+    assert_equal "circular system test helper dependency: a -> b -> c -> d -> a", error.message
+  ensure
+    adapter&.after_teardown if test_case
+    adapter&.shutdown
+  end
+
+  test "unknown required dependencies raise a descriptive error" do
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      helper(:page) { |missing:| missing }
+    end
+    adapter = adapter_class.new
+    adapter.install(TestCase)
+    test_case = TestCase.new
+    adapter.before_setup
+
+    error = assert_raises(ArgumentError) { test_case.page }
+    assert_equal "system test helper :page has an unknown dependency :missing", error.message
+  ensure
+    adapter&.after_teardown if test_case
+    adapter&.shutdown
+  end
+
+  test "registered teardown callbacks run when helper initialization fails" do
+    events = []
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      helper :page do
+        on_teardown { events << :closed }
+        raise "failed to open page"
+      end
+    end
+    adapter = adapter_class.new
+    adapter.install(TestCase)
+    test_case = TestCase.new
+    adapter.before_setup
+
+    error = assert_raises(RuntimeError) { test_case.page }
+    assert_equal "failed to open page", error.message
+    assert_equal [:closed], events
+  ensure
+    adapter&.after_teardown if test_case
+    adapter&.shutdown
+  end
+
+  test "all teardown callbacks run when one raises" do
+    events = []
+    adapter_class = Class.new(ActionDispatch::SystemTesting::TestAdapter) do
+      helper :page do
+        on_teardown { events << :last }
+        on_teardown do
+          events << :first
+          raise "failed to close"
+        end
+        :page
+      end
+    end
+    adapter = adapter_class.new
+    adapter.install(TestCase)
+    test_case = TestCase.new
+    adapter.before_setup
+    test_case.page
+
+    error = assert_raises(RuntimeError) { adapter.after_teardown }
+
+    assert_equal "failed to close", error.message
+    assert_equal [:first, :last], events
+  ensure
+    adapter&.shutdown
+  end
+
+  test "on_teardown is only exposed while initializing a helper" do
+    adapter = ActionDispatch::SystemTesting::TestAdapter.new
+
+    assert_not_respond_to adapter, :on_teardown
+  ensure
+    adapter&.shutdown
+  end
+end

--- a/actionpack/test/dispatch/system_testing/test_adapters_test.rb
+++ b/actionpack/test/dispatch/system_testing/test_adapters_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_dispatch/system_testing/test_adapters"
+
+class TestAdaptersTest < ActiveSupport::TestCase
+  class ExampleAdapter < ActionDispatch::SystemTesting::TestAdapter
+  end
+
+  test "lookup accepts registered adapter names as symbols and strings" do
+    ActionDispatch::SystemTesting::TestAdapters.register(:lookup_example, ExampleAdapter)
+
+    assert_same ExampleAdapter, ActionDispatch::SystemTesting::TestAdapters.lookup(:lookup_example)
+    assert_same ExampleAdapter, ActionDispatch::SystemTesting::TestAdapters.lookup("lookup_example")
+  end
+
+  test "lookup rejects names that are not strings or symbols" do
+    error = assert_raises(ArgumentError) do
+      ActionDispatch::SystemTesting::TestAdapters.lookup(ExampleAdapter)
+    end
+
+    assert_equal "system test adapter name must be a String or Symbol", error.message
+  end
+
+  test "lookup raises AdapterNotFoundError for an unknown adapter" do
+    error = assert_raises(ActionDispatch::SystemTesting::TestAdapters::AdapterNotFoundError) do
+      ActionDispatch::SystemTesting::TestAdapters.lookup(:missing_test_adapter)
+    end
+
+    assert_equal "system test adapter not found: :missing_test_adapter", error.message
+  end
+end

--- a/actionpack/test/dispatch/system_testing/test_server_test.rb
+++ b/actionpack/test/dispatch/system_testing/test_server_test.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "net/http"
+require "puma"
+require "timeout"
+require "action_dispatch/system_testing/test_server"
+
+class TestServerTest < ActiveSupport::TestCase
+  def app
+    @app ||= lambda do |env|
+      case env["PATH_INFO"]
+      when "/"
+        [200, { "content-type" => "text/plain" }, ["Hello from TestServer"]]
+      else
+        [404, { "content-type" => "text/plain" }, ["Not Found"]]
+      end
+    end
+  end
+
+  def get(server, path)
+    Net::HTTP.get(URI("#{server.base_url}#{path}"))
+  end
+
+  test "requires a rack app" do
+    assert_raises(ArgumentError) do
+      ActionDispatch::SystemTesting::TestServer.new
+    end
+  end
+
+  test "defaults host and finds an available port" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app)
+    uri = URI(server.base_url)
+
+    assert_equal "127.0.0.1", uri.host
+    assert_kind_of Integer, uri.port
+  end
+
+  test "normalizes the 0.0.0.0 bind host to 127.0.0.1 in base_url" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "0.0.0.0", port: 4567)
+
+    assert_equal "http://127.0.0.1:4567", server.base_url
+  end
+
+  test "treats port 0 as a request for an available port" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1", port: 0)
+    uri = URI(server.base_url)
+
+    assert_kind_of Integer, uri.port
+    assert_not_equal 0, uri.port
+  end
+
+  test "uses numeric string ports" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1", port: "4567")
+
+    assert_equal "http://127.0.0.1:4567", server.base_url
+  end
+
+  test "builds base_url for IPv6 hosts" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "::1", port: 4567)
+
+    assert_equal "http://[::1]:4567", server.base_url
+  end
+
+  test "raises ArgumentError for invalid ports" do
+    error1 = assert_raises(ArgumentError) do
+      ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1", port: -1)
+    end
+    error2 = assert_raises(ArgumentError) do
+      ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1", port: 65536)
+    end
+    error3 = assert_raises(ArgumentError) do
+      ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1", port: "not-a-port")
+    end
+
+    assert_equal "port must be in the range 0..65535", error1.message
+    assert_equal "port must be in the range 0..65535", error2.message
+    assert_equal "port must be in the range 0..65535", error3.message
+  end
+
+  test "boot starts a puma server that serves the rack app and object id endpoint" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1")
+    server.boot
+
+    assert_match %r{\Ahttp://127\.0\.0\.1:\d+\z}, server.base_url
+    assert_equal "Hello from TestServer", get(server, "/")
+    assert_equal app.object_id.to_s, get(server, "/__object_id__")
+  ensure
+    server&.stop
+  end
+
+  test "loads the puma rack handler" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1")
+
+    assert_respond_to server.send(:rack_handler_puma), :config
+  end
+
+  test "server errors are collected and cleared in the test process" do
+    app = lambda do |env|
+      if env["PATH_INFO"] == "/boom"
+        raise "boom"
+      else
+        [200, { "content-type" => "text/plain" }, ["ok"]]
+      end
+    end
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1")
+    server.boot
+
+    begin
+      get(server, "/boom")
+    rescue EOFError, Errno::ECONNRESET
+      # Puma may close the connection after the application raises.
+    end
+
+    errors = server.collect_server_errors
+    assert_equal 1, errors.size
+    error = errors.first
+    assert_equal "boom", error.message
+
+    server.clear_server_errors
+    assert_empty server.collect_server_errors
+  ensure
+    server&.stop
+  end
+
+  test "boot raises when the configured port is already in use" do
+    host = "127.0.0.1"
+    blocker = TCPServer.new(host, 0)
+    port = blocker.addr[1]
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: host, port: port)
+
+    assert_raises(Errno::EADDRINUSE) do
+      server.boot
+    end
+  ensure
+    server&.stop
+    blocker&.close
+  end
+
+  test "stop shuts down the puma server" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1")
+    server.boot
+
+    server.stop
+
+    assert_raises(Errno::ECONNREFUSED) do
+      get(server, "/")
+    end
+  ensure
+    server&.stop
+  end
+
+  test "stop shuts down gracefully" do
+    request_started = Queue.new
+    finish_request = Queue.new
+    app = lambda do |env|
+      if env["PATH_INFO"] == "/slow"
+        request_started << true
+        finish_request.pop
+        [200, { "content-type" => "text/plain" }, ["finished"]]
+      else
+        [200, { "content-type" => "text/plain" }, ["ok"]]
+      end
+    end
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1")
+    server.boot
+
+    request_thread = Thread.new { get(server, "/slow") }
+    Timeout.timeout(5) { request_started.pop }
+
+    stop_thread = Thread.new { server.stop }
+    assert_nil stop_thread.join(0.1), "expected server.stop to wait for in-flight requests"
+
+    finish_request << true
+
+    assert_equal "finished", Timeout.timeout(5) { request_thread.value }
+    Timeout.timeout(5) { stop_thread.value }
+  ensure
+    finish_request << true if finish_request
+    server&.stop
+    request_thread&.join(1)
+    stop_thread&.join(1)
+  end
+
+  test "boot requires puma 5.6.3 or newer" do
+    server = ActionDispatch::SystemTesting::TestServer.new(app: app, host: "127.0.0.1")
+
+    old_version = Puma::Const::PUMA_VERSION
+    silence_warnings do
+      Puma::Const.const_set(:PUMA_VERSION, "5.6.2")
+    end
+
+    error = assert_raises(LoadError) do
+      server.boot
+    end
+
+    assert_equal "Action Dispatch system testing server requires `puma` version 5.6.3 or newer.", error.message
+  ensure
+    silence_warnings do
+      Puma::Const.const_set(:PUMA_VERSION, old_version)
+    end
+  end
+end

--- a/actionpack/test/dispatch/system_testing/test_session_test.rb
+++ b/actionpack/test/dispatch/system_testing/test_session_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "net/http"
+require "action_dispatch/system_testing/test_session"
+
+class TestSessionTest < ActiveSupport::TestCase
+  FakeApp = lambda do |env|
+    if env["PATH_INFO"] == "/boom"
+      raise "boom"
+    else
+      [200, { "content-type" => "text/plain" }, ["ok"]]
+    end
+  end
+
+  setup do
+    @sessions = []
+  end
+
+  teardown do
+    @sessions.each(&:shutdown)
+  end
+
+  test "app_host raises before the session starts" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 4000, app_host: "http://rails-app:4000")
+
+    error = assert_raises(ActionDispatch::SystemTesting::TestSession::ServerNotStartedError) do
+      session.app_host
+    end
+
+    assert_equal "system test session has not started", error.message
+  end
+
+  test "start boots a server with configured settings" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0)
+
+    session.start
+
+    assert_match %r{\Ahttp://127\.0\.0\.1:\d+\z}, session.app_host
+    assert_equal "ok", get(session.app_host, "/").body
+  end
+
+  test "start is idempotent" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0)
+
+    session.start
+    app_host = session.app_host
+    session.start
+
+    assert_equal app_host, session.app_host
+  end
+
+  test "configure can change settings before the session starts" do
+    session = new_session
+    port = ActionDispatch::SystemTesting::AvailablePortFinder.new("127.0.0.1").find
+
+    session.configure(host: "127.0.0.1", port: 4000)
+    session.configure(host: "127.0.0.1", port: port)
+    session.start
+
+    assert_equal "http://127.0.0.1:#{port}", session.app_host
+  end
+
+  test "configure accepts the same settings after the session starts" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0, app_host: "http://rails-app:4000")
+    session.start
+
+    assert_nothing_raised do
+      session.configure(host: "127.0.0.1", port: 0, app_host: "http://rails-app:4000")
+    end
+  end
+
+  test "configure updates app_host after the session starts" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0, app_host: "http://rails-app:4000")
+    session.start
+
+    session.configure(host: "127.0.0.1", port: 0, app_host: "http://remote-browser:4000")
+
+    assert_equal "http://remote-browser:4000", session.app_host
+  end
+
+  test "configure rejects different server settings after the session starts" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0)
+    session.start
+    app_host = session.app_host
+    port = URI(app_host).port
+
+    error = assert_raises(ArgumentError) do
+      session.configure(host: "127.0.0.1", port: port + 1)
+    end
+
+    assert_equal "system test session has already started; configure server host and port before the first test runs", error.message
+    assert_equal app_host, session.app_host
+  end
+
+  test "shutdown stops the server and allows reconfiguration" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0)
+    session.start
+
+    session.shutdown
+
+    assert_not session.started?
+
+    session.configure(host: "127.0.0.1", port: 0)
+    session.start
+
+    assert_match %r{\Ahttp://127\.0\.0\.1:\d+\z}, session.app_host
+  end
+
+  test "clear_server_errors delegates to the server" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0)
+    session.start
+    request_error(session)
+
+    error = assert_raises(RuntimeError) do
+      session.raise_server_errors
+    end
+    assert_equal "boom", error.message
+
+    session.clear_server_errors
+
+    assert_nothing_raised do
+      session.raise_server_errors
+    end
+  end
+
+  test "raise_server_errors does nothing before the session starts" do
+    session = new_session
+
+    assert_nothing_raised do
+      session.raise_server_errors
+    end
+  end
+
+  test "raise_server_errors raises the first collected error" do
+    session = new_session
+    session.configure(host: "127.0.0.1", port: 0)
+    session.start
+    request_error(session)
+
+    error = assert_raises(RuntimeError) do
+      session.raise_server_errors
+    end
+
+    assert_equal "boom", error.message
+  end
+
+  private
+    def new_session
+      ActionDispatch::SystemTesting::TestSession.new(app: FakeApp).tap do |session|
+        @sessions << session
+      end
+    end
+
+    def get(base_url, path)
+      Net::HTTP.get_response(URI("#{base_url}#{path}"))
+    end
+
+    def request_error(session)
+      get(session.app_host, "/boom")
+    rescue EOFError, Errno::ECONNRESET
+      # Puma may close the connection after the application raises.
+    end
+end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1806,19 +1806,18 @@ require "test_helper"
 require "playwright"
 
 class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  # Launch Playwright and the browser once for the whole run; a fresh browser
-  # context per test is enough to isolate one test from the next, and is far
-  # cheaper than relaunching the browser each time.
+  # Launch Playwright and the browser once for the whole run; a fresh
+  # browser context per test is enough to isolate one test from the next.
   def self.browser
     @browser ||= begin
-      execution = Playwright.create(playwright_cli_executable_path: "npx playwright")
+      execution = Playwright.create(playwright_cli_executable_path: "./node_modules/.bin/playwright")
       at_exit { execution.stop }
-      execution.playwright.chromium.launch
+      execution.playwright.chromium.launch(headless: true)
     end
   end
 
   setup do
-    @context = ApplicationSystemTestCase.browser.new_context
+    @context = ApplicationSystemTestCase.browser.new_context(baseURL: base_url)
     @page = @context.new_page
   end
 
@@ -1826,7 +1825,10 @@ class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
 end
 ```
 
-with tests driving `@page` (`@page.goto new_article_url`, ...).
+with tests driving `@page`. Because the context is created with
+`baseURL: base_url`, relative paths resolve against the running server
+(`@page.goto new_article_path`, ...), and absolute URL helpers point at it too
+(`@page.goto new_article_url`, ...).
 
 When the browser needs to reach the application at a different URL than the bind
 address (for example when the test runs in a separate Docker container), set

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -68,11 +68,9 @@ When you first [generate system tests](#generating-system-tests), a `system`
 directory and an `application_system_test_case.rb` file will be created.
 
 The `system` directory holds [system tests](#system-testing), which are
-used for full browser testing of your application. System tests allow you to
-test your application the way your users experience it and help you test your
-JavaScript as well. System tests inherit from
-[Capybara](https://github.com/teamcapybara/capybara) and perform in-browser
-tests for your application.
+used for full browser testing of your application. System tests let you
+test your application the way your users experience it, including its
+JavaScript, by interacting with it in a real browser.
 
 The `application_system_test_case.rb` file holds the default configuration for your
 system tests.
@@ -1785,11 +1783,7 @@ default, so you usually don't need to configure it.
 Adapters for browser tools such as Playwright and Ferrum are provided as
 separate libraries, each registered under a name you pass to `testing_with`.
 
-#### Playwright
-
-The Playwright adapter is distributed as a separate library and requires the
-`playwright-ruby-client` gem and the Playwright npm package. Once it is loaded,
-select it with `testing_with`:
+For example, with a Playwright adapter:
 
 ```ruby
 require "test_helper"
@@ -1800,7 +1794,7 @@ end
 ```
 
 The adapter starts one browser for the test run and provides a new
-`browser_context` and `page` for each test. Tests use Playwright's native API:
+`browser_context` and `page` for each test. Tests use the tool's native API:
 
 ```ruby
 require "application_system_test_case"
@@ -1818,90 +1812,32 @@ class ArticlesTest < ApplicationSystemTestCase
 end
 ```
 
-The context uses the running server's `base_url`, so relative paths resolve
-against the Rails application. URL helpers (`articles_url`, `new_article_path`,
-...) also point at the running server.
-
-The adapter uses Chromium in headless mode and
-`./node_modules/.bin/playwright` by default. Options can select another browser
-or configure browser launch and context creation:
-
-```ruby
-class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  testing_with :playwright,
-    browser_type: :firefox,
-    headless: false,
-    browser_context_options: { locale: "ja-JP" }
-end
-```
-
-Set `PLAYWRIGHT_CLI_EXECUTABLE_PATH` to use another Playwright executable. To
-connect to a Playwright browser server, set `PLAYWRIGHT_WS_ENDPOINT` or pass
-`browser_server_endpoint_url` to `testing_with`.
-
-#### Ferrum
-
-The Ferrum adapter is distributed as a separate library and requires the
-`ferrum` gem and Chrome or Chromium. Once it is loaded, select it with
-`testing_with`:
-
-```ruby
-require "test_helper"
-
-class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  testing_with :ferrum
-end
-```
-
-The adapter starts one browser for the test run and provides a new isolated
-`browser_context` and `page` for each test. It sets Ferrum's `base_url` to the
-running Rails server, so both relative paths and URL helpers can be used:
-
-```ruby
-class ArticlesTest < ApplicationSystemTestCase
-  test "viewing an article" do
-    page.go_to article_path(articles(:welcome))
-
-    assert_equal "Welcome", page.at_css("h1").text
-  end
-end
-```
-
-Options in `browser_options` are passed to `Ferrum::Browser.new`, while
-`browser_context_options` are passed when creating each browser context:
-
-```ruby
-class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  testing_with :ferrum,
-    browser_options: {
-      headless: false,
-      browser_path: "/path/to/chrome",
-      timeout: 10
-    }
-end
-```
-
-Ferrum also reads `BROWSER_PATH`. To connect to a running Chrome instance,
-pass its remote debugging URL with `browser_options: { url: "http://chrome:9222" }`.
+For the options each adapter accepts and its setup, see the adapter library's
+own documentation.
 
 When the browser needs to reach the application at a different URL than the bind
 address (for example when the test runs in a separate Docker container), set
 `app_host` with `served_by`:
 
 ```ruby
-class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  served_by app_host: "http://rails-app:4000", port: 4000
-  testing_with :playwright
+class DockerizedApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  served_by port: 3000, app_host: "http://rails:3000"
+  testing_with :playwright,
+    browser_type: :chromium,
+    browser_server_endpoint_url: "ws://playwright:8080/ws"
 end
 ```
 
-#### System Test Adapters
+#### Using Other Browser Tools with a Custom Adapter
 
-A browser library can provide an adapter without implementing a Capybara driver
-or translating its browser API. Adapters inherit from
-`ActionDispatch::SystemTesting::TestAdapter`. A `global_helper` lives for the
-test run, while a `helper` lives for one test. Required keyword parameters make
-dependencies explicit:
+Any browser automation tool can be used by writing an adapter: subclass
+`ActionDispatch::SystemTesting::TestAdapter`, register it under a name, and select
+it with `testing_with`.
+
+Inside an adapter, declare resources as helpers. `global_helper` builds a resource
+once and shares it across the whole run, while `helper` builds one fresh for each
+test. Dependencies are declared as keyword arguments, and `on_teardown` registers
+cleanup:
 
 ```ruby
 class MyBrowserAdapter < ActionDispatch::SystemTesting::TestAdapter
@@ -1927,11 +1863,8 @@ end
 ActionDispatch::SystemTesting::TestAdapters.register(:my_browser, MyBrowserAdapter)
 ```
 
-Applications can then select it with `testing_with :my_browser`. Helpers are
-initialized when first used. Use `on_teardown` to clean each resource up; the
-callback runs after each test for a `helper` and after the test run for a
-`global_helper`. A test helper can depend on a global helper, but a global
-helper cannot depend on a test helper.
+Registered this way, `testing_with :my_browser` makes the adapter's helpers
+(`page`, and so on) available in every test.
 
 Test Helpers
 ------------

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1744,6 +1744,100 @@ system testing tests your application as if a real user were using it. With
 system tests, you can test anything that a user would do in your application
 such as commenting, deleting articles, publishing draft articles, etc.
 
+### System Tests with a Capybara-independent Server
+
+System tests are driven by Capybara by default.
+[`ActionDispatch::ServerSystemTestCase`](https://api.rubyonrails.org/classes/ActionDispatch/ServerSystemTestCase.html)
+boots your Rails application as a real server for system testing without
+depending on Capybara. It takes care of only the part that belongs to Rails:
+booting your application as a real server, waiting until it is actually serving
+requests, exposing the URL it is reachable on, and shutting it down at the end
+of the run. Everything above that -- driving a browser, filling in forms, making
+assertions -- is left to a tool of your choice.
+
+This is useful when you drive the browser with a tool that does not go through
+Capybara, such as [Ferrum](https://github.com/rubycdp/ferrum) or
+[Playwright](https://github.com/YusukeIwaki/playwright-ruby-client).
+
+To use it, inherit from `ActionDispatch::ServerSystemTestCase` in your
+`application_system_test_case.rb` and wire up your browser automation tool there,
+so that individual tests stay focused on the interaction being tested. The server
+binds to an available port on `0.0.0.0` by default, so you usually don't need to
+configure it. For example, with [Ferrum](https://github.com/rubycdp/ferrum),
+which speaks the Chrome DevTools Protocol directly:
+
+```ruby
+require "test_helper"
+require "ferrum"
+
+class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  setup    { @browser = Ferrum::Browser.new }
+  teardown { @browser&.quit }
+end
+```
+
+Individual tests then only drive the page. URL helpers (`articles_url`,
+`new_article_url`, ...) are generated against the running server, so the host
+they produce points at the live application:
+
+```ruby
+require "application_system_test_case"
+
+class ArticlesTest < ApplicationSystemTestCase
+  test "creating an article" do
+    @browser.goto new_article_url # => http://127.0.0.1:<port>/articles/new
+
+    @browser.at_css("input[name='article[title]']").focus.type("Hello Rails")
+    @browser.at_css("textarea[name='article[body]']").focus.type("Body")
+    @browser.at_css("input[type=submit]").click
+
+    assert_includes @browser.body, "Hello Rails"
+  end
+end
+```
+
+Any tool works the same way; only the `ApplicationSystemTestCase` wiring changes.
+With [Playwright](https://github.com/YusukeIwaki/playwright-ruby-client), for
+example, launch the browser once for the whole run and create a fresh context
+per test:
+
+```ruby
+require "test_helper"
+require "playwright"
+
+class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  # Launch Playwright and the browser once for the whole run; a fresh browser
+  # context per test is enough to isolate one test from the next, and is far
+  # cheaper than relaunching the browser each time.
+  def self.browser
+    @browser ||= begin
+      execution = Playwright.create(playwright_cli_executable_path: "npx playwright")
+      at_exit { execution.stop }
+      execution.playwright.chromium.launch
+    end
+  end
+
+  setup do
+    @context = ApplicationSystemTestCase.browser.new_context
+    @page = @context.new_page
+  end
+
+  teardown { @context&.close }
+end
+```
+
+with tests driving `@page` (`@page.goto new_article_url`, ...).
+
+When the browser needs to reach the application at a different URL than the bind
+address (for example when the test runs in a separate Docker container), set
+`app_host` with `served_by`:
+
+```ruby
+class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  served_by app_host: "http://rails-app:4000", port: 4000
+end
+```
+
 Test Helpers
 ------------
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1420,8 +1420,13 @@ System Testing
 Similarly to integration testing, system testing allows you to test how the
 components of your app work together, but from the point of view of a user. It
 does this by running tests in either a real or a headless browser (a browser
-which runs in the background without opening a visible window). System tests use
-[Capybara](https://www.rubydoc.info/github/jnicklas/capybara) under the hood.
+which runs in the background without opening a visible window).
+
+Rails supports two ways of writing system tests: the long-standing default built
+on [Capybara](https://www.rubydoc.info/github/jnicklas/capybara), and a lighter
+option that boots your app as a real server so you can interact with it using a
+modern browser automation tool. [Two Ways to Run System
+Tests](#two-ways-to-run-system-tests) explains when to use each.
 
 ### When to Use System Tests
 
@@ -1445,6 +1450,36 @@ tests for:
 For most features, integration tests provide a better balance of coverage and
 maintainability. Save system tests for scenarios where you need to verify the
 complete user experience.
+
+### Two Ways to Run System Tests
+
+Rails provides two base classes for system tests, and they differ in what
+controls the browser:
+
+* [`ActionDispatch::SystemTestCase`](https://api.rubyonrails.org/classes/ActionDispatch/SystemTestCase.html)
+  is the default and is built on Capybara. Capybara boots your application,
+  controls the browser, and gives you a DSL of assertions and screenshot helpers
+  out of the box. It needs the least setup and has been the standard Rails
+  approach for years.
+
+* [`ActionDispatch::ServerSystemTestCase`](https://api.rubyonrails.org/classes/ActionDispatch/ServerSystemTestCase.html)
+  is a thin wrapper that only boots your application as a real server and exposes
+  its URL. It does not touch the browser itself; instead you pair it with a
+  modern browser automation tool such as
+  [Playwright](https://github.com/YusukeIwaki/playwright-ruby-client) or
+  [Ferrum](https://github.com/rubycdp/ferrum) and interact with the page through
+  that tool's native API.
+
+Start with Capybara: it needs the least setup and is enough for most suites.
+Reach for `ActionDispatch::ServerSystemTestCase` when you want to use a modern
+automation tool directly. Those tools have advanced quickly and provide features
+such as auto-waiting for elements, which makes tests far less flaky, and the
+Capybara DSL cannot expose all of them. Because
+`ActionDispatch::ServerSystemTestCase` is only a thin server wrapper, the tool's
+API and behavior reach your tests unchanged.
+
+The rest of this section covers generating a system test, then each approach in
+turn.
 
 ### Generating System Tests
 
@@ -1736,99 +1771,118 @@ Rails.
 The `take_screenshot` helper method can be included anywhere in your tests to
 take a screenshot of the browser.
 
-#### Taking It Further
+### System Tests Without Capybara
 
-System testing is similar to [integration testing](#integration-testing) in that
-it tests the user's interaction with your controller, model, and view, but
-system testing tests your application as if a real user were using it. With
-system tests, you can test anything that a user would do in your application
-such as commenting, deleting articles, publishing draft articles, etc.
-
-### System Tests with a Capybara-independent Server
-
-System tests are driven by Capybara by default.
+When you want to use a modern browser automation tool instead of Capybara,
+inherit from
 [`ActionDispatch::ServerSystemTestCase`](https://api.rubyonrails.org/classes/ActionDispatch/ServerSystemTestCase.html)
-boots your Rails application as a real server for system testing without
-depending on Capybara. It takes care of only the part that belongs to Rails:
-booting your application as a real server, waiting until it is actually serving
-requests, exposing the URL it is reachable on, and shutting it down at the end
-of the run. Everything above that -- driving a browser, filling in forms, making
-assertions -- is left to a tool of your choice.
+in `application_system_test_case.rb`. It boots your application as a real server,
+waits until it is serving requests, and exposes its URL through `base_url`. You
+select a browser adapter with `testing_with` and interact with the page through
+that tool's native API. The server binds to an available port on `0.0.0.0` by
+default, so you usually don't need to configure it.
 
-This is useful when you drive the browser with a tool that does not go through
-Capybara, such as [Ferrum](https://github.com/rubycdp/ferrum) or
-[Playwright](https://github.com/YusukeIwaki/playwright-ruby-client).
+Adapters for browser tools such as Playwright and Ferrum are provided as
+separate libraries, each registered under a name you pass to `testing_with`.
 
-To use it, inherit from `ActionDispatch::ServerSystemTestCase` in your
-`application_system_test_case.rb` and wire up your browser automation tool there,
-so that individual tests stay focused on the interaction being tested. The server
-binds to an available port on `0.0.0.0` by default, so you usually don't need to
-configure it. For example, with [Ferrum](https://github.com/rubycdp/ferrum),
-which speaks the Chrome DevTools Protocol directly:
+#### Playwright
+
+The Playwright adapter is distributed as a separate library and requires the
+`playwright-ruby-client` gem and the Playwright npm package. Once it is loaded,
+select it with `testing_with`:
 
 ```ruby
 require "test_helper"
-require "ferrum"
 
 class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  setup    { @browser = Ferrum::Browser.new }
-  teardown { @browser&.quit }
+  testing_with :playwright
 end
 ```
 
-Individual tests then only drive the page. URL helpers (`articles_url`,
-`new_article_url`, ...) are generated against the running server, so the host
-they produce points at the live application:
+The adapter starts one browser for the test run and provides a new
+`browser_context` and `page` for each test. Tests use Playwright's native API:
 
 ```ruby
 require "application_system_test_case"
 
 class ArticlesTest < ApplicationSystemTestCase
   test "creating an article" do
-    @browser.goto new_article_url # => http://127.0.0.1:<port>/articles/new
+    page.goto new_article_path
 
-    @browser.at_css("input[name='article[title]']").focus.type("Hello Rails")
-    @browser.at_css("textarea[name='article[body]']").focus.type("Body")
-    @browser.at_css("input[type=submit]").click
+    page.get_by_label("Title").fill("Hello Rails")
+    page.get_by_label("Body").fill("Body")
+    page.get_by_role("button", name: "Create Article").click
 
-    assert_includes @browser.body, "Hello Rails"
+    assert page.get_by_text("Hello Rails").visible?
   end
 end
 ```
 
-Any tool works the same way; only the `ApplicationSystemTestCase` wiring changes.
-With [Playwright](https://github.com/YusukeIwaki/playwright-ruby-client), for
-example, launch the browser once for the whole run and create a fresh context
-per test:
+The context uses the running server's `base_url`, so relative paths resolve
+against the Rails application. URL helpers (`articles_url`, `new_article_path`,
+...) also point at the running server.
+
+The adapter uses Chromium in headless mode and
+`./node_modules/.bin/playwright` by default. Options can select another browser
+or configure browser launch and context creation:
+
+```ruby
+class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  testing_with :playwright,
+    browser_type: :firefox,
+    headless: false,
+    browser_context_options: { locale: "ja-JP" }
+end
+```
+
+Set `PLAYWRIGHT_CLI_EXECUTABLE_PATH` to use another Playwright executable. To
+connect to a Playwright browser server, set `PLAYWRIGHT_WS_ENDPOINT` or pass
+`browser_server_endpoint_url` to `testing_with`.
+
+#### Ferrum
+
+The Ferrum adapter is distributed as a separate library and requires the
+`ferrum` gem and Chrome or Chromium. Once it is loaded, select it with
+`testing_with`:
 
 ```ruby
 require "test_helper"
-require "playwright"
 
 class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
-  # Launch Playwright and the browser once for the whole run; a fresh
-  # browser context per test is enough to isolate one test from the next.
-  def self.browser
-    @browser ||= begin
-      execution = Playwright.create(playwright_cli_executable_path: "./node_modules/.bin/playwright")
-      at_exit { execution.stop }
-      execution.playwright.chromium.launch(headless: true)
-    end
-  end
-
-  setup do
-    @context = ApplicationSystemTestCase.browser.new_context(baseURL: base_url)
-    @page = @context.new_page
-  end
-
-  teardown { @context&.close }
+  testing_with :ferrum
 end
 ```
 
-with tests driving `@page`. Because the context is created with
-`baseURL: base_url`, relative paths resolve against the running server
-(`@page.goto new_article_path`, ...), and absolute URL helpers point at it too
-(`@page.goto new_article_url`, ...).
+The adapter starts one browser for the test run and provides a new isolated
+`browser_context` and `page` for each test. It sets Ferrum's `base_url` to the
+running Rails server, so both relative paths and URL helpers can be used:
+
+```ruby
+class ArticlesTest < ApplicationSystemTestCase
+  test "viewing an article" do
+    page.go_to article_path(articles(:welcome))
+
+    assert_equal "Welcome", page.at_css("h1").text
+  end
+end
+```
+
+Options in `browser_options` are passed to `Ferrum::Browser.new`, while
+`browser_context_options` are passed when creating each browser context:
+
+```ruby
+class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
+  testing_with :ferrum,
+    browser_options: {
+      headless: false,
+      browser_path: "/path/to/chrome",
+      timeout: 10
+    }
+end
+```
+
+Ferrum also reads `BROWSER_PATH`. To connect to a running Chrome instance,
+pass its remote debugging URL with `browser_options: { url: "http://chrome:9222" }`.
 
 When the browser needs to reach the application at a different URL than the bind
 address (for example when the test runs in a separate Docker container), set
@@ -1837,8 +1891,47 @@ address (for example when the test runs in a separate Docker container), set
 ```ruby
 class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
   served_by app_host: "http://rails-app:4000", port: 4000
+  testing_with :playwright
 end
 ```
+
+#### System Test Adapters
+
+A browser library can provide an adapter without implementing a Capybara driver
+or translating its browser API. Adapters inherit from
+`ActionDispatch::SystemTesting::TestAdapter`. A `global_helper` lives for the
+test run, while a `helper` lives for one test. Required keyword parameters make
+dependencies explicit:
+
+```ruby
+class MyBrowserAdapter < ActionDispatch::SystemTesting::TestAdapter
+  global_helper :browser do
+    browser = MyBrowser.launch
+    on_teardown { browser.close }
+    browser
+  end
+
+  helper :browser_context do |base_url:, browser:|
+    context = browser.new_context(base_url: base_url)
+    on_teardown { context.close }
+    context
+  end
+
+  helper :page do |browser_context:|
+    page = browser_context.new_page
+    on_teardown { page.close }
+    page
+  end
+end
+
+ActionDispatch::SystemTesting::TestAdapters.register(:my_browser, MyBrowserAdapter)
+```
+
+Applications can then select it with `testing_with :my_browser`. Helpers are
+initialized when first used. Use `on_teardown` to clean each resource up; the
+callback runs after each test for a `helper` and after the test run for a
+`global_helper`. A test helper can depend on a global helper, but a global
+helper cannot depend on a test helper.
 
 Test Helpers
 ------------


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Rails system tests currently boot and manage the application server through Capybara (Capybara::Server). This works well for the traditional Capybara-based workflow, where the Rails server and browser-testing DSL methods such as fill_in, click_on, and assertions are provided together.

However, Rails does not currently provide a Rails-owned primitive for the narrower task of simply booting the application under test and exposing its base URL. As a result, tools that do not use Capybara's DSL — such as Playwright, Ferrum, Puppeteer, or other browser automation libraries — still need to depend on Capybara indirectly or implement their own server lifecycle.

Capybara should remain the default system testing experience in Rails, and this change does not aim to replace it. The motivation is smaller: extract the server lifecycle that belongs to Rails, so that browser automation can remain pluggable.

This follows the direction discussed in https://github.com/rails/rails/discussions/56698: provide a Capybara-independent test server setup that other tools can build on, while keeping ActionDispatch::SystemTestCase unchanged as the Capybara-based default.

### Detail

This Pull Request introduces `ActionDispatch::ServerSystemTestCase`, a base class that boots the Rails application with Puma as a real server for system tests and does not depend on Capybara.
It owns only the part that belongs to Rails: booting the app, exposing the URL it is reachable on (`base_url` / `app_host`), generating URL helpers against it, and tearing it down.
Driving a browser, filling in forms, and assertions are left to the tool of the author's choice.

`ActionDispatch::SystemTestCase` (Capybara) remains the default and is unchanged. Both share URL-helper behavior through `SystemTesting::UrlHelpersProxy` rather than one inheriting from the other, so existing system tests are unaffected.

#### Usage

The server and the browser are configured once in `ApplicationSystemTestCase`, so individual tests stay focused on the interaction:

```ruby
# The simplest usage with typical Playwright configuration connecting to localhost:<available port>.
class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
  testing_with: :playwright
end
```

```ruby
require "application_system_test_case"

class UsersTest < ApplicationSystemTestCase
  test "creating a user" do
    # `page` is an instance of Playwright::Page
    page.goto new_user_url # URL helper points at the booted server

    # Playwright-native Locators are available, with auto-waiting feature.
    page.get_by_label("Name").fill("Arya")
    page.get_by_role("button", name: "Create User").click
    assert page.get_by_text("Arya").visible?
  end
end
```

Also, detailed options can be passed like this:

```ruby
class DockerizedApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
  served_by port: 3000, app_host: "http://rails:3000"
  testing_with :playwright,
    browser_type: :chromium,
    browser_server_endpoint_url: "ws://playwright:8080/ws"
end
```

or we can also bring a custom adapter for any other tools:

```ruby
class MyBrowserAdapter < ActionDispatch::SystemTesting::TestAdapter
  global_helper :browser do
    browser = Browser.launch(**options)
    on_teardown { browser.close }
    browser
  end

  helper :page do |browser:, base_url:|
    page = browser.new_page(base_url: base_url)
    on_teardown { page.close }
    page
  end
end

ActionDispatch::SystemTesting::TestAdapters.register(:my_browser, MyBrowserAdapter)
```

```ruby
class ApplicationSystemTestCase < ActionDispatch::ServerSystemTestCase
  testing_with :my_browser
end
```

#### Lifecycle

```mermaid
%%{init: {'sequence': {'boxMargin': 24, 'mirrorActors':false}}}%%
sequenceDiagram
    actor R as Test runner (Minitest)
    participant TC as ServerSystemTestCase
    participant S as TestSession (process-wide)
    participant Sv as TestServer
    participant App as Rails app (Puma)

    R->>TC: served_by(host:, port:)
    TC->>S: configure(host, port, app_host)

    loop every test
        R->>TC: before_setup
        TC->>S: start
        opt first test only
            S->>Sv: new(app, host, port) + boot
            Sv->>App: start Puma serving Rails.application
            Sv->>App: wait until `GET /__object_id__` returns 200 OK
            App-->>Sv: responsive
        end

        Note over TC,App: Test Body

        R->>TC: after_teardown
        TC->>S: raise_server_errors
    end

    R->>TC: after_run (whole suite finished)
    TC->>S: shutdown
    S->>Sv: stop
```

- **`ServerSystemTestCase`** — the base class; `served_by` configures
  the session and the class hooks `before_setup`/`after_teardown`.
- **`TestSession`** — a process-wide session that owns a single server
  for the whole run (boot once, reuse across tests, shut down after the
  suite) and surfaces server-side errors.
- **`TestServer`** — boots the Rails app in a background Puma server and
  blocks until it is actually serving requests.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

- ServerSystemTestCase requires Puma >= 5.6.3 for depending on `Puma::LogWriter`
- No breaking change to existing behavior of `ActionDispatch::SystemTestCase`; the new class is just opt-in.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
