### PR TITLE
Don't constrain shared columns in composite `where(association: nil)`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Don't constrain shared query-constraint columns when querying a composite `belongs_to` with `nil`.
+
+    When a composite foreign key shares a column with the owner's own query constraints (e.g. a
+    multi-tenant/shard key), `where(association: nil)` constrained every foreign-key column to
+    `NULL`, including the shared one. Combined with any existing scope on that column (such as the
+    tenant) this produced an impossible `shard_id = ? AND shard_id IS NULL` condition. It now only
+    constrains the columns that uniquely identify the target.
+
+    Fixes #57904.
+
+    *Oliver Morgan*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -13,11 +13,22 @@ module ActiveRecord
         id_list = ids
         id_list = id_list.pluck(primary_key) if key.composite? && id_list.is_a?(Relation)
 
-        key.where_clauses(id_list)
+        clauses = key.where_clauses(id_list)
+        return clauses unless key.composite?
+
+        clauses.map { |clause| prune_shared_null_columns(clause) }
       end
 
       private
         attr_reader :reflection, :value
+
+        def prune_shared_null_columns(clause)
+          return clause unless clause.values.all?(&:nil?)
+
+          owner_keys = Array(reflection.active_record.query_constraints_list).map(&:to_s)
+          pruned = clause.reject { |column, _| owner_keys.include?(column) }
+          pruned.empty? ? clause : pruned
+        end
 
         def ids
           case value

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -434,6 +434,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal blog_post, comment.blog_post
   end
 
+  def test_where_with_nil_composite_belongs_to_only_constrains_owned_columns
+    blog = Sharded::Blog.create!
+    blog_post = Sharded::BlogPost.create!(blog: blog)
+    with_post = Sharded::Comment.create!(blog: blog, blog_post: blog_post)
+    without_post = Sharded::Comment.create!(blog: blog)
+
+    relation = Sharded::Comment.where(blog_id: blog.id).where(blog_post: nil)
+
+    assert_includes relation, without_post
+    assert_not_includes relation, with_post
+  end
+
   def test_building_the_belonging_object_with_implicit_sti_base_class
     account = Account.new
     company = account.build_firm


### PR DESCRIPTION
**Motivation / Background**

Fixes #57904. When a composite foreign key shares a column with the owner's own query_constraints (e.g. a multi-tenant/shard key), where(association: nil) constrained every FK column to NULL including the shared one. Combined with any existing scope on that column (e.g. the tenant), this produced an impossible shard_id = ? AND shard_id IS NULL and silently returned nothing. The nil-handling that surfaced this was added in #53706.

**Detail**

AssociationQueryValue#queries now prunes, for a nil value, the FK columns that belong to the owner's query_constraints, keeping only the columns that uniquely identify the target. A pure composite FK that shares no column still nulls all of its columns (unchanged).

**Related**

There's a write-side twin: record.association = nil (BelongsToAssociation#replace_keys) still nulls the shared column for query_constraints-only owners - issue #49671. That behavior is currently asserted by test_nullify_composite_foreign_key_belongs_to_association (added in #47565), so aligning the write side is a deliberate behaviour change rather than a clean fix. Happy to follow up on that separately if you'd like the two sides made symmetric. CC @nvasilevski EDIT: Opened PR for the write-side here https://github.com/rails/rails/pull/57906