### PR TITLE
Preserve the owner's query constraint columns when clearing a composite belongs_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Preserve the owner's query-constraint columns when clearing a composite `belongs_to`.
+
+    Setting a composite `belongs_to` to `nil` nulled every foreign-key column, including any
+    column shared with the owner's own query constraints (e.g. a tenant/shard key that also
+    backs other associations and the record's own identity). Such columns are now left untouched
+    when clearing the association; only the columns that uniquely identify the target are nulled.
+
+    Fixes #49671.
+
+    *Oliver Morgan*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -135,9 +135,9 @@ module ActiveRecord
             target_key_values = record ? Array(primary_key(record.class)).map { |key| record._read_attribute(key) } : []
 
             if force || reflection_fk.map { |fk| owner._read_attribute(fk) } != target_key_values
-              owner_pk = Array(owner.class.primary_key)
+              owner_keys = Array(owner.class.query_constraints_list || owner.class.primary_key).map(&:to_s)
               reflection_fk.each_with_index do |key, index|
-                next if record.nil? && owner_pk.include?(key)
+                next if record.nil? && owner_keys.include?(key.to_s)
                 owner[key] = target_key_values[index]
               end
             end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -359,9 +359,10 @@ class AssociationsTest < ActiveRecord::TestCase
   def test_nullify_composite_foreign_key_belongs_to_association
     comment = sharded_comments(:great_comment_blog_post_one)
     assert_not_nil(comment.blog_post)
+    blog_id = comment.blog_id
 
     comment.blog_post = nil
-    assert_nil(comment.blog_id)
+    assert_equal(blog_id, comment.blog_id)
     assert_nil(comment.blog_post_id)
 
     comment.save


### PR DESCRIPTION
### Motivation / Background

Fixes #49671.

Setting a composite `belongs_to` to `nil` nulls *every* foreign-key column. When one of those columns is part of the owner's own query constraints — a shared tenant/shard key that also identifies the record and backs other associations — clearing the association wrongly nulls that shared column too.

`replace_keys` already exempts the owner's **primary-key** columns from being nulled, which covers the composite-primary-key case. But a shared column declared via `query_constraints` on a model with a scalar primary key (e.g. the `Sharded::Comment` test model — `query_constraints :blog_id, :id`) is not in `primary_key`, so it is still nulled. That is the case discussed in #49671 by @nvasilevski, @matthewd and @palkan.

This implements @matthewd's suggested first cut from that thread:

> a first cut (which I'm leaning toward calling a bug fix) would be to exempt columns derived from the parent model's query constraints from overwriting assignments in consumer associations: those are by definition expected to be shared with other associations and the model itself

### Detail

`BelongsToAssociation#replace_keys` now exempts the owner's full `query_constraints_list` (falling back to the primary key) — not just the primary key — when clearing the association. Only the foreign-key columns that uniquely identify the target are nulled.

`test_nullify_composite_foreign_key_belongs_to_association` is updated to assert the shared `blog_id` is preserved. Existing assignment behavior is unchanged (e.g. `test_assign_persisted_composite_foreign_key_belongs_to_association` still passes).

### Scope / open questions

I deliberately limited this to the **clearing** (`association = nil`) case, which is the unambiguous part of #49671. I left the assignment side untouched because it needs decisions that didn't converge in the thread:

- the `test_adding_association` case from the issue (assigning a record shouldn't populate the owner's own tenant column), and
- @matthewd's point that assigning a record with a *different* tenant key should probably raise rather than silently reparent.

Those feel better suited to the broader `foreign_key:` / `query_constraints:` decoupling @palkan and @nvasilevski discussed. Happy to extend this PR or follow up separately — guidance welcome, @nvasilevski.

This is the write-side twin of #57904 (the read side — `where(association: nil)` adding an impossible `shard_id IS NULL`), which I've filed separately.
