### PR TITLE
Return a composite has_and_belongs_to_many association_foreign_key as an array

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -576,7 +576,7 @@ module ActiveRecord
       end
 
       def association_foreign_key
-        @association_foreign_key ||= -(options[:association_foreign_key]&.to_s || class_name.foreign_key)
+        @association_foreign_key ||= ActiveRecord::Key.for(options[:association_foreign_key] || class_name.foreign_key).name
       end
 
       def association_primary_key(klass = nil)

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -710,6 +710,13 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal ["blog_id", "blog_post_id"], reflection.foreign_key
   end
 
+  def test_habtm_composite_keys_are_returned_as_arrays
+    reflection = Sharded::BlogPost.reflect_on_association(:tags_with_composite_fk)
+
+    assert_equal ["blog_id", "blog_post_id"], reflection.foreign_key
+    assert_equal ["blog_id", "tag_id"], reflection.association_foreign_key
+  end
+
   def test_using_query_constraints_warns_about_changing_behavior
     has_many_expected_message = <<~MSG.squish
       Setting `query_constraints:` option on `Firm.has_many :clients` is not allowed.

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -14,6 +14,12 @@ module Sharded
     has_many :blog_post_tags
     has_many :tags, through: :blog_post_tags
 
+    has_and_belongs_to_many :tags_with_composite_fk,
+      class_name: "Sharded::Tag",
+      join_table: "sharded_blog_posts_tags",
+      foreign_key: [:blog_id, :blog_post_id],
+      association_foreign_key: [:blog_id, :tag_id]
+
     has_many :comments_with_composite_pk,
       class_name: "Sharded::Comment",
       primary_key: [:blog_id, :id],


### PR DESCRIPTION
### Motivation / Background

Fixes #57908.

`has_and_belongs_to_many` already accepts composite `foreign_key:` / `association_foreign_key:` options (the generated join model's `belongs_to`s handle them), and `Reflection#foreign_key` returns a composite key as an array of column names. But `Reflection#association_foreign_key` calls `#to_s` on the option, so a composite `association_foreign_key: [:blog_id, :tag_id]` comes back as the string `"[:blog_id, :tag_id]"` instead of `["blog_id", "tag_id"]`.

The association itself works (writing/reading the join row is fine), but the public reflection method is inconsistent with `#foreign_key` and unusable for introspecting a composite HABTM.

### Detail

`association_foreign_key` now resolves through `ActiveRecord::Key.for(...).name`, exactly like `foreign_key`, so a composite key is returned as an array of column-name strings while a scalar key is unchanged.

Added a composite `has_and_belongs_to_many` to the `Sharded::BlogPost` test model and a reflection test asserting both `foreign_key` and `association_foreign_key` return arrays.

A small consistency follow-up in the composite-key area (related to the composite `belongs_to` fixes in #57904 / #57906). cc @nvasilevski.
