### PR TITLE
Fix the has_and_belongs_to_many join model's owner (left_side) association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix the `has_and_belongs_to_many` join model's owner association.
+
+    The auto-generated join model's `belongs_to` back to the owner (`left_side`) was keyed to
+    a non-existent `left_side_id` column, so reading it always returned `nil`. It now uses the
+    owner's foreign key (including the composite key when `foreign_key:` is an array), and is
+    set as the inverse of the join's `has_many`, so the owner is populated in memory when a join
+    record is built through the owner instead of triggering a reload.
+
+    *Oliver Morgan*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 
@@ -24,7 +34,6 @@
     other spatial types (`GEOMETRY`, `POLYGON`, `LINESTRING`, ...).
 
     *Ryosuke Okazuka*
-
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -51,26 +51,32 @@ module ActiveRecord::Associations::Builder # :nodoc:
       join_model.table_name_resolver = -> { table_name }
       join_model.left_model          = lhs_model
 
-      join_model.add_left_association :left_side, anonymous_class: lhs_model
+      join_model.add_left_association :left_side, anonymous_class: lhs_model, foreign_key: left_foreign_key, inverse_of: middle_name
       join_model.add_right_association association_name, belongs_to_options(options)
       join_model
     end
 
     def middle_reflection(join_model)
-      middle_name = [lhs_model.name.downcase.pluralize,
-                     association_name.to_s].sort.join("_").gsub("::", "_").to_sym
-      middle_options = middle_options join_model
-
       HasMany.create_reflection(lhs_model,
                                 middle_name,
                                 nil,
-                                middle_options)
+                                middle_options(join_model))
     end
 
     private
+      def middle_name
+        [lhs_model.name.downcase.pluralize,
+         association_name.to_s].sort.join("_").gsub("::", "_").to_sym
+      end
+
+      def left_foreign_key
+        options[:foreign_key] || options[:query_constraints] || lhs_model.model_name.to_s.foreign_key
+      end
+
       def middle_options(join_model)
         middle_options = {}
         middle_options[:class_name] = "#{lhs_model.name}::#{join_model.name}"
+        middle_options[:inverse_of] = :left_side
         if options.key? :foreign_key
           middle_options[:foreign_key] = options[:foreign_key]
         end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -130,6 +130,22 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :categories, :posts, :categories_posts, :developers, :projects, :developers_projects,
            :parrots, :pirates, :parrots_pirates, :treasures, :price_estimates, :tags, :taggings, :computers
 
+  def test_habtm_join_model_left_side_is_keyed_to_the_owner
+    join_model = Developer.const_get(:HABTM_Projects)
+
+    assert_equal "developer_id", join_model.left_reflection.foreign_key
+
+    join_record = join_model.find_by(developer_id: developers(:david).id)
+    assert_equal developers(:david), join_record.left_side
+  end
+
+  def test_habtm_join_model_left_side_is_set_in_memory_when_built_through_the_owner
+    developer = Developer.new
+    join_record = developer.association(:projects).send(:build_through_record, Project.new)
+
+    assert_same developer, join_record.left_side
+  end
+
   def setup_data_for_habtm_case
     ActiveRecord::Base.lease_connection.execute("delete from countries_treaties")
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -717,6 +717,12 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal ["blog_id", "tag_id"], reflection.association_foreign_key
   end
 
+  def test_habtm_join_model_left_side_uses_composite_owner_foreign_key
+    join_model = Sharded::BlogPost.const_get(:HABTM_TagsWithCompositeFk)
+
+    assert_equal ["blog_id", "blog_post_id"], join_model.left_reflection.foreign_key
+  end
+
   def test_using_query_constraints_warns_about_changing_behavior
     has_many_expected_message = <<~MSG.squish
       Setting `query_constraints:` option on `Firm.has_many :clients` is not allowed.


### PR DESCRIPTION
### Motivation / Background

Fixes #57909.

The join model that `has_and_belongs_to_many` generates defines a `belongs_to` back to the owner named `left_side`. It is built without a `:foreign_key`, so it defaults to a `left_side_id` column that does not exist on the join table, and reading the association always returns `nil`. (The right-hand `belongs_to` is unaffected because it is named after the association and its default foreign key happens to match the column.)

It also has no `inverse_of`, so even once the key is correct, the owner is reloaded from the database when a join record is built through the owner rather than reused from memory.

### Detail

- Key `left_side` to the owner's foreign key, mirroring the column the middle reflection already uses. When the owner's foreign key is composite — passed as an array `foreign_key:`, which the reflection relocates to `query_constraints` before the builder runs — the composite key is used as well.
- Declare `left_side` and the join's `has_many` as inverses of each other. The names (`:left_side` / the sorted middle name) don't match the conventions `automatic_inverse_of` infers from, and the explicit `:foreign_key` disables automatic inverse detection, so the inverse is set explicitly. With it, building a join record through the owner populates `left_side` in memory instead of issuing a reload.

### Additional information

Before:

```ruby
Developer.const_get(:HABTM_Projects).left_reflection.foreign_key # => "left_side_id"
developer.association(:projects).send(:build_through_record, project).left_side # => reload
```

After:

```ruby
Developer.const_get(:HABTM_Projects).left_reflection.foreign_key # => "developer_id"
developer.association(:projects).send(:build_through_record, project).left_side.equal?(developer) # => true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
