### PR TITLE
Allow Arel to be required on its own

### DIFF
--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/ractors"
+
 require "arel/errors"
 
 require "arel/crud"

--- a/activerecord/test/cases/arel/require_test.rb
+++ b/activerecord/test/cases/arel/require_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+
+module Arel
+  class RequireTest < Arel::Test
+    # Arel references ActiveSupport::Ractors at load time, so requiring it on its
+    # own (as some libraries do for SQL inspection) must pull in that dependency.
+    def test_arel_can_be_required_on_its_own
+      arel_load_path = $LOAD_PATH.find { |path| File.exist?(File.join(path, "arel.rb")) }
+      active_support_load_path = $LOAD_PATH.find { |path| File.exist?(File.join(path, "active_support/ractors.rb")) }
+
+      output = IO.popen(
+        [Gem.ruby, "-I", arel_load_path, "-I", active_support_load_path, "-e", 'require "arel"'],
+        err: [:child, :out],
+        &:read
+      )
+
+      assert_predicate $?, :success?, "Expected `require \"arel\"` to succeed on its own, but got:\n#{output}"
+    end
+  end
+end


### PR DESCRIPTION
Requiring `arel` without Active Support already loaded raises a `NameError`:

```
$ ruby -I activerecord/lib -e 'require "arel"'
.../arel/visitors/to_sql.rb:768:in '<class:ToSql>': uninitialized constant Arel::Visitors::ToSql::ActiveSupport (NameError)

        BIND_BLOCK = ActiveSupport::Ractors.shareable_proc { "?" }
                     ^^^^^^^^^^^^^
```

`Arel::Visitors::ToSql` and `Arel::Visitors::PostgreSQL` reference `ActiveSupport::Ractors` while their classes are being defined. That constant is autoloaded by Active Support, so it resolves fine when Arel is loaded as part of Active Record, but not when `arel` is required on its own.

This pulls in `active_support/ractors` from `arel.rb` so `require "arel"` works standalone again, as libraries that inspect SQL through Arel directly rely on.

### Test

Added a regression test that requires `arel` in a fresh process with only the gem load paths available (no Active Support preloaded). It fails before this change and passes after.

>[!NOTE]
>Reported by @bquorning (rails#57840) — the [arsi](https://github.com/zendesk/arsi) test suite against Rails edge started failing.