### PR TITLE
Reference `ActionCable::Configuration` in the Action Cable guide

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -850,7 +850,7 @@ config.action_cable.log_tags = [
 ```
 
 For a full list of all configuration options, see the
-`ActionCable::Server::Configuration` class.
+`ActionCable::Configuration` class.
 
 ## Running Standalone Cable Servers
 


### PR DESCRIPTION
The Action Cable guide's "Configuration" section points readers at `ActionCable::Server::Configuration` for the full list of configuration options. That class now lives at the top level as `ActionCable::Configuration` (the old name is kept only as a backward-compatible alias), so the guide should name the canonical class.