### PR TITLE
Keep nil elements named in the series for `in_order_of`

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -196,7 +196,7 @@ module Enumerable
   # the +filter+ option is set to +false+.
   def in_order_of(key, series, filter: true)
     if filter
-      group_by(&key).values_at(*series).flatten(1).compact
+      group_by(&key).values_at(*series).compact.flatten(1)
     else
       sort_by { |v| series.index(v.public_send(key)) || series.size }
     end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -416,6 +416,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [ 1, 2, 3, nil ], values.in_order_of(:itself, [ 1, 2, 3 ], filter: false)
   end
 
+  def test_in_order_of_preserves_nil_elements_named_in_series
+    values = [ 3, nil, 1, 2 ]
+    assert_equal [ 1, nil, 2, 3 ], values.in_order_of(:itself, [ 1, nil, 2, 3 ])
+  end
+
   def test_sole
     expected_raise = Enumerable::SoleItemExpectedError
 


### PR DESCRIPTION
`Enumerable#in_order_of` with the default `filter: true` drops `nil` elements even when `nil` is explicitly named in the series:

```ruby
[3, nil, 1, 2].in_order_of(:itself, [1, nil, 2, 3])
# Before: [1, 2, 3]        — nil is lost
# After:  [1, nil, 2, 3]   — nil is preserved as requested
```

`filter: false` already preserves nil elements correctly, so the two modes are now consistent.