### PR TITLE
Reject an out-of-range time zone offset in `TimeZone#rfc3339`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `TimeZone#rfc3339` silently accepting an out-of-range time zone
+    offset such as `+99:99` instead of raising `ArgumentError`.
+
+    *Kenta Ishizaki*
+
 *   Add `#this_quarter?` to Date/Time.
 
     It returns true if the date/time falls within the current quarter.

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -476,7 +476,7 @@ module ActiveSupport
     def rfc3339(str)
       parts = Date._rfc3339(str)
 
-      raise ArgumentError, "invalid date" if parts.empty?
+      raise ArgumentError, "invalid date" if parts.empty? || parts[:offset].nil?
 
       time = Time.new(
         parts.fetch(:year),

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -554,6 +554,16 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "invalid date", exception.message
   end
 
+  def test_rfc3339_with_out_of_range_offset
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+    exception = assert_raises(ArgumentError) do
+      zone.rfc3339("1999-12-31T19:00:00+99:99")
+    end
+
+    assert_equal "invalid date", exception.message
+  end
+
   def test_rfc3339_with_old_date
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     twz = zone.rfc3339("1883-12-31T19:00:00-05:00")


### PR DESCRIPTION
`TimeZone#rfc3339` is documented to be much stricter than `parse`/`iso8601` and to raise `ArgumentError` on an invalid string, but an out-of-range offset like `+99:99` is silently accepted and produces a time in the local zone:

```ruby
zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]

zone.rfc3339("1999-12-31T19:00:00+99:99")
# Before: => Fri, 31 Dec 1999 19:00:00.000000000 EST -05:00  (silently accepted)
# After:  ArgumentError: invalid date
```

Such an offset is now rejected like any other invalid date, consistent with the documented contract.