### PR TITLE
Include call options in `Cache#exist?` instrumentation payload

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Include call options in `Cache#exist?` instrumentation payload,
+    consistent with `read`, `write`, and `delete`.
+
+    *Kenta Ishizaki*
+
 *   Declare `assert_not_pattern` as an alias for `refute_pattern`
 
     *Sean Doyle*

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -716,7 +716,7 @@ module ActiveSupport
         options = merged_options(options)
         key = normalize_key(name, options)
 
-        instrument(:exist?, key) do |payload|
+        instrument(:exist?, key, options) do |payload|
           entry = read_entry(key, **options, event: payload)
           (entry && !entry.expired? && !entry.mismatched?(normalize_version(name, options))) || false
         end

--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -105,6 +105,19 @@ module CacheInstrumentationBehavior
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 
+  def test_exist_instrumentation
+    key = SecureRandom.uuid
+
+    options = { namespace: "foo" }
+
+    events = capture_notifications("cache_exist?.active_support") { @cache.exist?(key, options) }
+
+    assert_equal %w[ cache_exist?.active_support ], events.map(&:name)
+    assert_equal normalized_key(key, options), events[0].payload[:key]
+    assert_equal @cache.class.name, events[0].payload[:store]
+    assert_equal "foo", events[0].payload[:namespace]
+  end
+
   def test_increment_instrumentation
     key_1 = SecureRandom.uuid
     @cache.write(key_1, 0, raw: true)


### PR DESCRIPTION
The `cache_exist?.active_support` notification payload omits the options passed to the call, so keys such as `:namespace`, `:version`, and `:expires_in` are missing from it.

```ruby
ActiveSupport::Notifications.subscribe("cache_exist?.active_support") do |event|
  event.payload[:namespace]
  # Before: nil   — options not passed through
  # After:  "foo" — consistent with read, write, and delete
end

Rails.cache.exist?("key", namespace: "foo")
```

The `read`, `write`, `delete`, and `fetch_hit` cache operations all include options in their instrumentation payloads. `exist?` now does too.