### PR TITLE
Treat a Symbol stream name as a literal stream in channel test assertions

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -286,6 +286,7 @@ module ActionCable
         #
         def assert_has_stream(stream)
           check_subscribed!
+          stream = String(stream)
           assert subscription.stream_names.include?(stream), "Stream #{stream} has not been started"
         end
 
@@ -309,6 +310,7 @@ module ActionCable
         #
         def assert_has_no_stream(stream)
           check_subscribed!
+          stream = String(stream)
           assert subscription.stream_names.exclude?(stream), "Stream #{stream} has been started"
         end
 
@@ -329,7 +331,7 @@ module ActionCable
           end
 
           def broadcasting_for(stream_or_object)
-            return stream_or_object if stream_or_object.is_a?(String)
+            return stream_or_object if stream_or_object.is_a?(String) || stream_or_object.is_a?(Symbol)
 
             self.class.channel_class.broadcasting_for(stream_or_object)
           end

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -140,6 +140,31 @@ class StreamsTestChannelTest < ActionCable::Channel::TestCase
   end
 end
 
+class SymbolStreamsTestChannel < ActionCable::Channel::Base
+  def subscribed
+    stream_from :my_room
+  end
+end
+
+class SymbolStreamsTestChannelTest < ActionCable::Channel::TestCase
+  def test_assert_has_stream_with_symbol_broadcasting
+    subscribe
+
+    # stream_from coerces the broadcasting with String(), so it is stored as a
+    # String; the assertion must coerce its argument the same way to match.
+    assert_equal ["my_room"], subscription.stream_names
+    assert_has_stream :my_room
+  end
+
+  def test_assert_has_no_stream_with_symbol_broadcasting
+    subscribe
+
+    # The stream is active, so asserting its absence must fail loudly rather
+    # than silently passing because the raw Symbol never matched the String key.
+    assert_raises(Minitest::Assertion) { assert_has_no_stream :my_room }
+  end
+end
+
 class StreamsForTestChannel < ActionCable::Channel::Base
   def subscribed
     stream_for User.new(params[:id])
@@ -219,6 +244,26 @@ class PerformUnsubscribedTestChannelTest < ActionCable::Channel::TestCase
   def test_perform_when_unsubscribed
     assert_raises do
       perform :echo
+    end
+  end
+end
+
+class SymbolBroadcastTestChannel < ActionCable::Channel::Base
+end
+
+class SymbolBroadcastTestChannelTest < ActionCable::Channel::TestCase
+  def test_assert_broadcasts_with_string_stream_name
+    # Control: a String stream name already works.
+    assert_broadcasts("my_room", 1) do
+      ActionCable.server.broadcast("my_room", { text: "hi" })
+    end
+  end
+
+  def test_assert_broadcasts_with_symbol_stream_name
+    # A Symbol naming a literal stream must be treated as that stream, like
+    # stream_from(:my_room) does, not scoped to the channel as a broadcastable.
+    assert_broadcasts(:my_room, 1) do
+      ActionCable.server.broadcast("my_room", { text: "hi" })
     end
   end
 end


### PR DESCRIPTION
### Summary

In production, `stream_from(:my_room)` names the literal stream `"my_room"`, so a Symbol and the equivalent String refer to the same stream. The `ActionCable::Channel::TestCase` assertions did not agree, and a Symbol stream name was handled inconsistently across them:

- `assert_broadcasts(:my_room)` / `assert_broadcast_on(:my_room)` scoped the Symbol to the channel instead of treating it as a literal stream, so they counted a different stream and reported zero broadcasts:

  ```ruby
  assert_broadcasts(:my_room, 1) { ActionCable.server.broadcast("my_room", { text: "hi" }) }
  # => 1 broadcasts to my_channel:my_room expected, but 0 were sent.
  ```

- `assert_has_stream(:my_room)` failed even while that stream was active (`Stream my_room has not been started`).

- `assert_has_no_stream(:my_room)` passed silently even while that stream *was* active — a false-green where the assertion verifies nothing and can mask a real regression. This is the same dangerous failure mode #57698 flagged for `assert_no_broadcasts`.

The String form of each assertion already works, and non-String broadcastings are an explicitly supported part of the streaming API (`stream_test.rb` covers "stream from non-string channel"). So this is a divergence between the assertions and the API, not the spec.

### Fix

Treat a Symbol the same as the equivalent String in all four assertions, so a Symbol stream name refers to the same literal stream the streaming API does. The String case is unchanged.

### Notes

This consolidates #57703 and #57704, which fixed the same Symbol-vs-String asymmetry in two adjacent layers of the same file. They are merged here as a single change because they touch the same file and the same test file and tell one story: aligning the channel test assertions with the streaming API's treatment of a Symbol stream name. Follow-up to #57698, which addressed the same asymmetry in the test adapter accessors.