### PR TITLE
Attribute methods ractor safe

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -66,14 +66,18 @@ module ActiveModel
 
     NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
     CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
+    EMPTY_HASH = ActiveSupport::Ractors.make_shareable(Hash.new([])) # :nodoc:
 
     included do
       @attribute_method_patterns_cache = Concurrent::Map.new(initial_capacity: 4)
-      class_attribute :attribute_aliases, instance_writer: false, default: {}
+      class_attribute :attribute_aliases, instance_writer: false, default: {}.freeze
+      @aliases_by_attribute_name = EMPTY_HASH
       class_attribute :attribute_method_patterns, instance_writer: false, default: [ ClassMethods::AttributeMethodPattern.new ]
     end
 
     module ClassMethods
+      attr_reader :aliases_by_attribute_name # :nodoc:
+
       # Declares a method available for all attributes with the given prefix.
       # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method.
       #
@@ -202,10 +206,10 @@ module ActiveModel
       #   person.name_short?     # => true
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
-        old_name = old_name.to_s
-        new_name = new_name.to_s
-        self.attribute_aliases = attribute_aliases.merge(new_name => old_name)
-        aliases_by_attribute_name[old_name] |= [new_name]
+        old_name = -old_name.to_s
+        new_name = -new_name.to_s
+        self.attribute_aliases = attribute_aliases.merge(new_name => old_name).freeze
+        record_alias_by_attribute_name(old_name, new_name)
         eagerly_generate_alias_attribute_methods(new_name, old_name)
       end
 
@@ -380,16 +384,12 @@ module ActiveModel
         @attribute_method_patterns_cache.clear
       end
 
-      def aliases_by_attribute_name # :nodoc:
-        @aliases_by_attribute_name ||= Hash.new { |h, k| h[k] = [] }
-      end
-
       private
         def inherited(base) # :nodoc:
           super
           base.class_eval do
             @attribute_method_patterns_cache = Concurrent::Map.new(initial_capacity: 4)
-            @aliases_by_attribute_name = nil
+            @aliases_by_attribute_name = EMPTY_HASH
             @generated_attribute_methods = nil
           end
         end
@@ -454,6 +454,12 @@ module ActiveModel
               body <<
               "end"
           end
+        end
+
+        def record_alias_by_attribute_name(old_name, new_name)
+          @aliases_by_attribute_name = ActiveSupport::Ractors.make_shareable(aliases_by_attribute_name.merge(
+            old_name => (aliases_by_attribute_name[old_name] | [new_name])
+          ))
         end
 
         class AttributeMethodPattern # :nodoc:

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -66,13 +66,13 @@ module ActiveModel
 
     NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
     CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
-    EMPTY_HASH = ActiveSupport::Ractors.make_shareable(Hash.new([])) # :nodoc:
+    EMPTY_HASH = Hash.new([].freeze).freeze # :nodoc:
 
     included do
       @attribute_method_patterns_cache = Concurrent::Map.new(initial_capacity: 4)
       class_attribute :attribute_aliases, instance_writer: false, default: {}.freeze
       @aliases_by_attribute_name = EMPTY_HASH
-      class_attribute :attribute_method_patterns, instance_writer: false, default: [ ClassMethods::AttributeMethodPattern.new ]
+      class_attribute :attribute_method_patterns, instance_writer: false, default: [ ClassMethods::AttributeMethodPattern.new ].freeze
     end
 
     module ClassMethods
@@ -109,7 +109,8 @@ module ActiveModel
       #   person.clear_name
       #   person.name          # => nil
       def attribute_method_prefix(*prefixes, parameters: nil)
-        self.attribute_method_patterns += prefixes.map! { |prefix| AttributeMethodPattern.new(prefix: prefix, parameters: parameters) }
+        prefixes.map! { |prefix| AttributeMethodPattern.new(prefix: prefix, parameters: parameters) }
+        self.attribute_method_patterns = (attribute_method_patterns + prefixes).freeze
         undefine_attribute_methods
       end
 
@@ -143,7 +144,8 @@ module ActiveModel
       #   person.name          # => "Bob"
       #   person.name_short?   # => true
       def attribute_method_suffix(*suffixes, parameters: nil)
-        self.attribute_method_patterns += suffixes.map! { |suffix| AttributeMethodPattern.new(suffix: suffix, parameters: parameters) }
+        suffixes.map! { |suffix| AttributeMethodPattern.new(suffix: suffix, parameters: parameters) }
+        self.attribute_method_patterns = (attribute_method_patterns + suffixes).freeze
         undefine_attribute_methods
       end
 
@@ -178,7 +180,8 @@ module ActiveModel
       #   person.reset_name_to_default!
       #   person.name                         # => 'Default Name'
       def attribute_method_affix(*affixes)
-        self.attribute_method_patterns += affixes.map! { |affix| AttributeMethodPattern.new(**affix) }
+        affixes.map! { |affix| AttributeMethodPattern.new(**affix) }
+        self.attribute_method_patterns = (attribute_method_patterns + affixes).freeze
         undefine_attribute_methods
       end
 
@@ -468,12 +471,13 @@ module ActiveModel
           AttributeMethod = Struct.new(:proxy_target, :attr_name)
 
           def initialize(prefix: "", suffix: "", parameters: nil)
-            @prefix = prefix
-            @suffix = suffix
-            @parameters = parameters.nil? ? "..." : parameters
+            @prefix = -prefix
+            @suffix = -suffix
+            @parameters = parameters.nil? ? "..." : (parameters.is_a?(String) ? -parameters : parameters)
             @regex = /\A(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})\z/
-            @proxy_target = "#{@prefix}attribute#{@suffix}"
-            @method_name = "#{prefix}%s#{suffix}"
+            @proxy_target = "#{@prefix}attribute#{@suffix}".freeze
+            @method_name = "#{prefix}%s#{suffix}".freeze
+            freeze
           end
 
           def match(method_name)

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -440,4 +440,16 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_ractor_shareable model.aliases_by_attribute_name
     assert_ractor_shareable model.attribute_aliases
   end
+
+  test "attribute method affixes are ractor safe" do
+    model = Class.new do
+      include ActiveModel::AttributeMethods
+
+      attribute_method_affix prefix: "before_", suffix: "after_"
+      attribute_method_prefix "before_", parameters: "foo"
+      attribute_method_suffix(+"after_", parameters: +"bar")
+    end
+
+    assert_ractor_shareable model.attribute_method_patterns
+  end
 end

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/testing/ractors_assertions"
 
 class ModelWithAttributes
   include ActiveModel::AttributeMethods
@@ -101,6 +102,8 @@ class ModelWithoutAttributesMethod
 end
 
 class AttributeMethodsTest < ActiveModel::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   test "method missing works correctly even if attributes method is not defined" do
     assert_raises(NoMethodError) { ModelWithoutAttributesMethod.new.foo }
   end
@@ -422,5 +425,19 @@ class AttributeMethodsTest < ActiveModel::TestCase
     instance = subclass.new("George")
     assert_equal "George", instance.name
     assert_equal "George", instance.nickname
+  end
+
+  test "alias attributes are ractor safe" do
+    model = Class.new do
+      include ActiveModel::AttributeMethods
+
+      attr_accessor :name
+      define_attribute_methods :name
+
+      alias_attribute :fullname, :name
+    end
+
+    assert_ractor_shareable model.aliases_by_attribute_name
+    assert_ractor_shareable model.attribute_aliases
   end
 end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -41,8 +41,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   teardown do
-    ActiveRecord::Base.send(:attribute_method_patterns).clear
-    ActiveRecord::Base.send(:attribute_method_patterns).concat(@old_matchers)
+    ActiveRecord::Base.attribute_method_patterns = @old_matchers
   end
 
   test "#id_value alias is defined if id column exist" do


### PR DESCRIPTION
### Motivation / Background

Making `AttributeMethods.aliases_by_attribute_name`, `.attribute_aliases` and `.attribute_method_patterns` Ractor safe.

### Detail

Make these frozen by default so they can be accessed across Ractors.
- Make the `AttributeMethodPattern` value object frozen by default
- Assign `aliases_by_attribute_name` at inheritance time instead of lazily
- Instead mutating `aliases_by_attribute_name` in the default proc, just return a frozen array missing keys.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
