### PR TITLE
Make default scopes ractor safe

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -6,8 +6,9 @@ module ActiveRecord
       attr_reader :scope, :all_queries
 
       def initialize(scope, all_queries = nil)
-        @scope = scope
+        @scope = ActiveSupport::Ractors.try_shareable_proc(scope)
         @all_queries = all_queries
+        freeze
       end
     end
 
@@ -16,7 +17,7 @@ module ActiveRecord
 
       included do
         # Stores the default scope for the class.
-        class_attribute :default_scopes, instance_writer: false, instance_predicate: false, default: []
+        class_attribute :default_scopes, instance_writer: false, instance_predicate: false, default: [].freeze
       end
 
       module ClassMethods
@@ -138,7 +139,7 @@ module ActiveRecord
 
             default_scope = DefaultScope.new(scope, all_queries)
 
-            self.default_scopes += [default_scope]
+            self.default_scopes = [*default_scopes, default_scope].freeze
           end
 
           def build_default_scope(relation = relation(), all_queries: nil)

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -9,8 +9,12 @@ require "models/computer"
 require "models/cat"
 require "models/mentor"
 require "concurrent/atomic/cyclic_barrier"
+require "active_support/testing/ractors_assertions"
+require "active_support/core_ext/object/with"
 
 class DefaultScopingTest < ActiveRecord::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   fixtures :developers, :posts, :comments
 
   def test_default_scope
@@ -729,6 +733,26 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_with_abstract_class_scope_should_be_executed_in_correct_context
     assert_match %r/#{Regexp.escape(quote_table_name("lions.is_vegetarian"))}/i, Lion.all.to_sql
     assert_match %r/#{Regexp.escape(quote_table_name("lions.gender"))}/i, Lion.female.to_sql
+  end
+
+  def test_default_scopes_are_ractor_shareable
+    ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+      model = Class.new(ActiveRecord::Base) do
+        def self.name = "ractor_safe_posts"
+        self.table_name = "posts"
+
+        default_scope -> { ractor_safe }
+
+        def self.ractor_safe
+          where(type: "ractor_safe")
+        end
+      end
+
+      select_sql = capture_sql { model.all.to_a }.first
+
+      assert_match(/type/, select_sql)
+      assert_ractor_shareable model.default_scopes
+    end
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Make `ActiveRecord::Base.default_scope` ractor safe.

### Detail

Make the default scope value object frozen by default. The scope proc is instance_execed so we can safely try to make it shareable for the user. And then we dup, append, freeze the `default_scopes` array as new elements are added.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
