### PR TITLE
Make LogSubscriber.log_levels ractor safe

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -64,7 +64,7 @@ module ActiveSupport
   class LogSubscriber < Subscriber
     include ColorizeLogging
 
-    class_attribute :log_levels, instance_accessor: false, default: {} # :nodoc:
+    class_attribute :log_levels, instance_accessor: false, default: {}.freeze # :nodoc:
 
     LEVEL_CHECKS = {
       debug: ActiveSupport::Ractors.shareable_lambda { |logger| !logger.debug? },
@@ -112,7 +112,7 @@ module ActiveSupport
         end
 
         def subscribe_log_level(method, level)
-          self.log_levels = log_levels.merge(method => LEVEL_CHECKS.fetch(level))
+          self.log_levels = log_levels.merge(method => LEVEL_CHECKS.fetch(level)).freeze
           set_event_levels
         end
     end

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -2,9 +2,11 @@
 
 require_relative "abstract_unit"
 require "active_support/log_subscriber/test_helper"
+require "active_support/testing/ractors_assertions"
 
 class SyncLogSubscriberTest < ActiveSupport::TestCase
   include ActiveSupport::LogSubscriber::TestHelper
+  include ActiveSupport::Testing::RactorsAssertions
 
   class MyLogSubscriber < ActiveSupport::LogSubscriber
     attr_reader :event
@@ -198,6 +200,10 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     instrument "debug_only.my_log_subscriber"
     wait
     assert_not_empty @logger.logged(:debug)
+  end
+
+  def test_log_levels_are_ractor_safe
+    assert_ractor_shareable MyLogSubscriber.log_levels
   end
 
   private


### PR DESCRIPTION

### Motivation / Background

Make `LogSubscriber.subscribe_log_level` ractor safe.

### Detail

The `LEVEL_CHECKS` are already frozen, but we need to freeze the subscriber's `log_levels` hash as we merge to it.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
