### PR TITLE
Eagerly assign ExecutionWrapper's active key

### DIFF
--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -14,6 +14,14 @@ module ActiveSupport
     define_callbacks :run
     define_callbacks :complete
 
+    class << self
+      attr_reader :active_key # :nodoc:
+    end
+
+    def self.inherited(subclass)
+      subclass.class_eval { @active_key = :"active_execution_wrapper_#{object_id}" }
+    end
+
     def self.to_run(*args, &block)
       set_callback(:run, *args, &block)
     end
@@ -109,10 +117,6 @@ module ActiveSupport
 
     def self.error_reporter # :nodoc:
       ActiveSupport.error_reporter
-    end
-
-    def self.active_key # :nodoc:
-      @active_key ||= :"active_execution_wrapper_#{object_id}"
     end
 
     def self.active? # :nodoc:


### PR DESCRIPTION

### Motivation / Background

We can't assign class instance variables on the non-main Ractor. So we should assign ExecutionWrapper subclasses `active_key` when they are loaded, otherwise we will get a ractor isolation error if the first request is served in a ractor.

### Detail

Assign it in an inherited hook.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
