### PR TITLE
Expand Action Mailer `delivery_method` configuration docs [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2834,6 +2834,38 @@ Sets the host for the assets. Useful when CDNs are used for hosting assets rathe
 
 Accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action Mailer. Set to `nil` to disable logging.
 
+#### `config.action_mailer.delivery_method`
+
+Defines the delivery method. The following options are available:
+
+* `:smtp` - Sends email using SMTP. Configure it with
+  [`config.action_mailer.smtp_settings`][]. This is the default.
+* `:sendmail` - Sends email using sendmail. Configure it with
+  [`config.action_mailer.sendmail_settings`][].
+* `:file` - Saves emails to files. Configure it with
+  [`config.action_mailer.file_settings`][].
+* `:test` - Saves emails to the `ActionMailer::Base.deliveries` array.
+
+You can also use a custom delivery method by either:
+
+* Setting `config.action_mailer.delivery_method` to a custom delivery method
+  object. The object must accept settings during initialization and respond to
+  `deliver!(mail)`. See the Mail gem's [`Mail::SMTP` delivery method][] for an
+  example implementation.
+* Registering a custom delivery method with
+  [`ActionMailer::Base.add_delivery_method`][] and setting
+  `config.action_mailer.delivery_method` to its registered name.
+
+See the [configuration section in the Action Mailer guide][] for configuration
+examples.
+
+[`config.action_mailer.smtp_settings`]: #config-action-mailer-smtp-settings
+[`config.action_mailer.sendmail_settings`]: #config-action-mailer-sendmail-settings
+[`config.action_mailer.file_settings`]: #config-action-mailer-file-settings
+[`ActionMailer::Base.add_delivery_method`]: https://api.rubyonrails.org/classes/ActionMailer/DeliveryMethods/ClassMethods.html#method-i-add_delivery_method
+[`Mail::SMTP` delivery method]: https://github.com/mikel/mail/blob/master/lib/mail/network/delivery_methods/smtp.rb
+[configuration section in the Action Mailer guide]: action_mailer_basics.html#action-mailer-configuration
+
 #### `config.action_mailer.smtp_settings`
 
 Allows detailed configuration for the `:smtp` delivery method. It accepts a hash of options, which can include any of these options:
@@ -2884,10 +2916,6 @@ Configures the `:file` delivery method. It accepts a hash of options, which can 
 #### `config.action_mailer.raise_delivery_errors`
 
 Specifies whether to raise an error if email delivery cannot be completed. It defaults to `true`.
-
-#### `config.action_mailer.delivery_method`
-
-Defines the delivery method and defaults to `:smtp`. See the [configuration section in the Action Mailer guide](action_mailer_basics.html#action-mailer-configuration) for more info.
 
 #### `config.action_mailer.perform_deliveries`
 


### PR DESCRIPTION
### Motivation / Background

Fixes #57876.

As you described in the issue linked above, the documentation for `delivery_method` is cyclical and doesn't provide the reader with a sufficient level of information to use the feature successfully. In this PR, I'm adding enough details to make the document more useful (and to lose the cyclical aspect).
Note that I moved `config.action_mailer.delivery_method` up above `config.action_mailer.*_settings` (`smtp`, `sendmail`, `file`), since those three settings are dependent on the used delivery method.

### Additional information

I generated the guides locally and reviewed the updated guide in the browser.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
