### PR TITLE
Freeze the inflection rules after the app boots

### DIFF
--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -42,6 +42,15 @@ module ActiveSupport
           @pattern = nil
         end
 
+        def freeze
+          build_pattern
+          @members.each(&:freeze)
+          @members.freeze
+          @pattern.freeze
+
+          super
+        end
+
         def delete(entry)
           @members.delete(entry)
           @pattern = nil
@@ -67,17 +76,26 @@ module ActiveSupport
 
         def uncountable?(str)
           if @pattern.nil?
-            members_pattern = Regexp.union(@members.map { |w| /#{Regexp.escape(w)}/i })
-            @pattern = /\b#{members_pattern}\Z/i
+            build_pattern
           end
           @pattern.match?(str)
         end
+
+        private
+          def build_pattern
+            members_pattern = Regexp.union(@members.map { |w| /#{Regexp.escape(w)}/i })
+            @pattern = /\b#{members_pattern}\Z/i
+          end
       end
 
       def self.instance(locale = :en)
         return @__en_instance__ ||= new if locale == :en
 
         @__instance__[locale] ||= new
+      end
+
+      def self.all_instances # :nodoc:
+        [@__en_instance__] + @__instance__.values
       end
 
       def self.instance_or_fallback(locale)
@@ -97,6 +115,17 @@ module ActiveSupport
       def initialize
         @plurals, @singulars, @uncountables, @humans, @acronyms = [], [], Uncountables.new, [], {}
         define_acronym_regex_patterns
+      end
+
+      def freeze
+        freeze_rules(@plurals)
+        freeze_rules(@singulars)
+        freeze_rules(@humans)
+
+        @uncountables.freeze
+        @acronyms.freeze
+
+        super
       end
 
       # Private, for the test suite.
@@ -269,6 +298,14 @@ module ActiveSupport
           @acronym_regex             = sorted_acronyms.empty? ? /(?=a)b/ : /#{sorted_acronyms.join("|")}/
           @acronyms_camelize_regex   = /^(?:#{@acronym_regex}(?=\b|[A-Z_])|\w)/
           @acronyms_underscore_regex = /(?:(?<=([A-Za-z\d]))|\b)(#{@acronym_regex})(?=\b|[^a-z])/
+        end
+
+        def freeze_rules(rules)
+          rules.each do |pair|
+            pair.each(&:freeze)
+            pair.freeze
+          end
+          rules.freeze
         end
     end
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -178,5 +178,11 @@ module ActiveSupport
           app.config.active_support.use_message_serializer_for_metadata
       end
     end
+
+    initializer "active_support.freeze_inflections" do
+      config.after_initialize do
+        ActiveSupport::Inflector::Inflections.all_instances.each(&:freeze)
+      end
+    end
   end
 end

--- a/railties/test/application/active_support_railtie_test.rb
+++ b/railties/test/application/active_support_railtie_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "active_support/testing/ractors_assertions.rb"
+
+module ApplicationTests
+  class ActiveSupportRailtieTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
+
+    setup :build_app
+    teardown :teardown_app
+
+    test "inflections instances are frozen after the app boots" do
+      app "development"
+
+      ActiveSupport::Inflector::Inflections.all_instances.each do |instance|
+        assert_ractor_shareable(instance)
+      end
+
+      assert_ractor_shareable(ActiveSupport::Inflector.inflections)
+    end
+
+    test "mutating inflections after the app boots is deprecated" do
+      app "development"
+
+      ActiveSupport::Inflector.inflections do |inflect|
+        assert_raises(FrozenError) do
+          inflect.plural("animal", "animaux")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

It's currently possible to mutate the inflection rules after the application boots. This behaviour is strange and may introduce bugs that could be hard to track down as it introduceds a non deterministic codepath that suddenly change how Rails inflects bunch of information such as table name.

I also want to introduce this change so that this codepath is Ractor safe.

### Detail

In this patch we now freeze all inflection instance (one per lang) after the app boots.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
