### PR TITLE
Don't run system tests in the generated CI workflow by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Don't run system tests in the generated GitHub Actions CI workflow by default.
+
+    A newly generated app has no system tests, so the `system-test` job in
+    `.github/workflows/ci.yml` failed on the very first push. `config/ci.rb`
+    already commented these out; the GitHub Actions workflow now matches it. In
+    place of the job, the workflow includes a comment explaining how to enable
+    system tests. Both CI templates now treat system tests the same way across
+    the default, `--skip-system-test`, and `--api` cases.
+
+    *Dominic Baratta*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Don't run system tests in the generated GitHub Actions CI workflow by default.
+
+    A newly generated app has no system tests, so the `system-test` job in
+    `.github/workflows/ci.yml` failed on the very first push. `config/ci.rb`
+    already commented these out; the GitHub Actions workflow now matches it. In
+    place of the job, the workflow includes a comment explaining how to enable
+    system tests. Both CI templates now treat system tests the same way across
+    the default, `--skip-system-test`, and `--api` cases.
+
+    *Dominic Baratta*
+
 *   Show a Rails-flavored startup banner (a small logo, Rails/Ruby
     version, a rotating tip about console helpers like `app`/`reload!`, and
     `Rails.root`) when starting `bin/rails console`.

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -27,8 +27,10 @@ CI.run do
 <% unless options.skip_active_record? -%>
       step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 <% end -%>
+<% unless options[:api] || options[:skip_system_test] -%>
       # Optional: Run system tests
       # step "Tests: System", "bin/rails test:system"
+<% end -%>
     end
 <% end -%>
   end

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -26,8 +26,10 @@ CI.run do
 <% unless options.skip_active_record? -%>
       step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 <% end -%>
+<% unless options[:api] || options[:skip_system_test] -%>
       # Optional: Run system tests
       # step "Tests: System", "bin/rails test:system"
+<% end -%>
     end
 <% end -%>
   end

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -152,84 +152,10 @@ jobs:
         run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test
   <%- unless options[:api] || options[:skip_system_test] -%>
 
-  system-test:
-    runs-on: ubuntu-latest
-
-    <%- if options[:database] == "sqlite3" -%>
-    # services:
-    #  redis:
-    #    image: valkey/valkey:9
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-    <%- else -%>
-    services:
-      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
-      mysql:
-        image: mysql
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- elsif options[:database] == "postgresql" -%>
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- end -%>
-
-      # redis:
-      #   image: valkey/valkey:9
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
-    <%- end -%>
-    steps:
-      <%- unless ci_packages.empty? -%>
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
-
-      <%- end -%>
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      <%- if using_bun? -%>
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: <%= dockerfile_bun_version %>
-      <%- end -%>
-
-      - name: Run System Tests
-        env:
-          RAILS_ENV: test
-          <%- if options[:database] == "mysql" -%>
-          DATABASE_URL: mysql2://127.0.0.1:3306
-          <%- elsif options[:database] == "trilogy" -%>
-          DATABASE_URL: trilogy://127.0.0.1:3306
-          <%- elsif options[:database] == "postgresql" -%>
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          <%- end -%>
-          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails <%= "db:test:prepare " unless skip_active_record? %>test:system
-
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore
+  # System tests don't run in CI by default: a newly generated app has none, so
+  # the job would fail until you add some. To run them, copy the "test" job above
+  # into a "system-test" job, change "test" to "test:system" in its run step, and
+  # add an actions/upload-artifact step to save tmp/screenshots on failure.
+  # See https://guides.rubyonrails.org/testing.html#system-testing
   <%- end -%>
 <%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -744,7 +744,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file ".github/workflows/ci.yml" do |content|
       assert_match(/db:test:prepare test/, content)
-      assert_match(/db:test:prepare test:system/, content)
+      # System tests are not run in CI by default, so there is no active
+      # system-test job.
+      assert_no_match(/^\s+system-test:/, content)
+      assert_no_match(/^\s+run: bin\/rails db:test:prepare test:system/, content)
     end
   end
 
@@ -755,7 +758,63 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file ".github/workflows/ci.yml" do |content|
       assert_no_match(/db:test:prepare/, content)
       assert_match(/bin\/rails test/, content)
-      assert_match(/bin\/rails test:system/, content)
+      assert_no_match(/^\s+run: bin\/rails test:system/, content)
+    end
+  end
+
+  def test_ci_does_not_run_system_tests_by_default
+    run_generator
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/^\s+step "Tests: System"/, content)
+      assert_match(/#\s+step "Tests: System", "bin\/rails test:system"/, content)
+    end
+
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/^\s+system-test:/, content)
+      assert_no_match(/^\s+run: bin\/rails .*test:system/, content)
+    end
+  end
+
+  def test_ci_does_not_run_system_tests_when_no_skip_system_test_is_given
+    # A freshly generated app has no system test files, so an active CI job
+    # would fail. --no-skip-system-test should behave like the default here.
+    run_generator [destination_root, "--no-skip-system-test"]
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/^\s+step "Tests: System"/, content)
+      assert_match(/#\s+step "Tests: System", "bin\/rails test:system"/, content)
+    end
+
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/^\s+system-test:/, content)
+      assert_no_match(/^\s+run: bin\/rails .*test:system/, content)
+    end
+  end
+
+  def test_ci_omits_system_tests_when_skip_system_test_is_given
+    run_generator [destination_root, "--skip-system-test"]
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/Tests: System/, content)
+      assert_no_match(/test:system/, content)
+    end
+
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/test:system/, content)
+    end
+  end
+
+  def test_ci_omits_system_tests_for_api_app
+    run_generator [destination_root, "--api"]
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/Tests: System/, content)
+      assert_no_match(/test:system/, content)
+    end
+
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/test:system/, content)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

A freshly generated app's `.github/workflows/ci.yml` runs a `system-test` job by
default, but a new app has no system tests. `bin/rails test:system` then fails:

```
cannot load such file -- <app>/test/system (LoadError)
  railties/lib/rails/test_unit/runner.rb:71:in 'load_tests'
```

So the very first push of a brand-new `rails new` app gets a red CI run.

Closes #57893 (see also the earlier #56853 and #56539).

`config/ci.rb` (used by `bin/ci`) already comments system tests out, from #56541
("Remove system tests from default CI template"). That change only touched
`config/ci.rb.tt`; `github/ci.yml.tt` was missed, so the two CI templates
disagree: `bin/ci` skips system tests while GitHub Actions runs them.

### Detail

This makes both CI templates handle system tests the same way:

| Scenario | `config/ci.rb` | `.github/workflows/ci.yml` |
| --- | --- | --- |
| default | commented out | comment explaining how to enable |
| `--skip-system-test` | omitted | omitted |
| `--api` | omitted | omitted |

Both templates now gate the system-test section on
`unless options[:api] || options[:skip_system_test]`. In `ci.yml.tt` the active
`system-test` job is replaced with a short comment, mirroring the commented step
`config/ci.rb` already had. The comment explains how to bring the job back (copy
the `test` job, swap `test` for `test:system`, add the `upload-artifact` step for
`tmp/screenshots`) and links the testing guide.

A note on two roads not taken:

- I did not keep the full `system-test` job commented out (as a previous attempt,
  #56856, did). No generator template ships a fully commented-out multi-line job;
  the largest commented block in the app templates is ~8 lines (the SMTP example
  in `production.rb`), and `config/ci.rb` disables system tests with a one-line
  commented step. A ~80-line `#`-prefixed job would be well outside that
  convention. The trade-off is that the `upload-artifact` screenshots step is the
  one non-obvious thing not preserved verbatim, so the comment calls it out.
  Happy to switch to a commented-out job if you'd rather keep it copy-paste-able.
- I did not wire `--no-skip-system-test` to an *active* job (#56856 did, via
  `options[:skip_system_test] == false`). No `rails new` variant generates system
  test files, so an active job would hit the same `LoadError` on a fresh app —
  it just moves the failure behind a flag. `--no-skip-system-test` therefore
  behaves like the default here.

### Additional information

Verified by generating apps for the default, `--skip-system-test`, and `--api`
cases and confirming the two templates agree and the generated `ci.yml` stays
valid YAML. Tests in `railties/test/generators/app_generator_test.rb` are updated
and extended to cover all three scenarios for both files, using anchored matchers
so an active job is distinguished from a commented hint.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
