### PR TITLE
Make Active Record scope methods Ractor-shareable

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -168,21 +168,26 @@ module ActiveRecord
               "an instance method with the same name."
           end
 
-          extension = Module.new(&block) if block
+          extension = Module.new(&block).freeze if block
+          scope_method =
+            if body.respond_to?(:to_proc)
+              scope_body = ActiveSupport::Ractors.try_shareable_proc(&body)
+              proc do |*args|
+                scope = all._exec_scope(*args, &scope_body)
+                scope = scope.extending(extension) if extension
+                scope
+              end
+            else
+              callable = body
+              proc do |*args|
+                scope = callable.call(*args) || all
+                scope = scope.extending(extension) if extension
+                scope
+              end
+            end
+          scope_method = ActiveSupport::Ractors.try_shareable_proc(&scope_method)
 
-          if body.respond_to?(:to_proc)
-            singleton_class.define_method(name) do |*args|
-              scope = all._exec_scope(*args, &body)
-              scope = scope.extending(extension) if extension
-              scope
-            end
-          else
-            singleton_class.define_method(name) do |*args|
-              scope = body.call(*args) || all
-              scope = scope.extending(extension) if extension
-              scope
-            end
-          end
+          singleton_class.define_method(name, &scope_method)
           singleton_class.send(:ruby2_keywords, name)
 
           generate_relation_method(name)

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/core_ext/object/with"
 require "models/post"
 require "models/topic"
 require "models/comment"
@@ -46,6 +47,30 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal Topic.first,                   Topic.base.first
     assert_equal Topic.count,                   Topic.base.count
     assert_equal Topic.average(:replies_count), Topic.base.average(:replies_count)
+  end
+
+  def test_scope_defined_with_shareable_proc_is_ractor_safe
+    scope_class = Class.new(Topic)
+    ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+      assert_nothing_raised do
+        scope_class.scope :ractor_approved, -> { where(approved: true) }
+      end
+    end
+    assert scope_class.respond_to?(:ractor_approved)
+    assert_kind_of ActiveRecord::Relation, scope_class.ractor_approved
+    assert_match(/approved/, scope_class.ractor_approved.to_sql)
+  end
+
+  if RUBY_VERSION >= "4"
+    def test_scope_with_unshareable_proc_is_rejected_when_ractor_safe
+      scope_class = Class.new(Topic)
+      unshareable = +"approved"
+      ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+        assert_raises(Ractor::IsolationError) do
+          scope_class.scope :ractor_unsafe, -> { where(unshareable => true) }
+        end
+      end
+    end
   end
 
   def test_calling_merge_at_first_in_scope


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because scopes cannot be used on Ractors right now.

### Detail

This Pull Request changes the scope method to use Ractor-shareable procs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
