### PR TITLE
Simplify `config.action_view.render_tracker`

### DIFF
--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -92,21 +92,6 @@ module ActionView
   autoload :CacheExpiry
   autoload :TestCase
 
-  singleton_class.attr_reader :render_tracker
-
-  def self.render_tracker=(value)
-    @render_tracker = value
-    case value
-    when :ruby
-      DependencyTracker.register_tracker :erb, DependencyTracker::RubyTracker
-    else
-      DependencyTracker.register_tracker :erb, DependencyTracker::ERBTracker
-    end
-    value
-  end
-
-  self.render_tracker = :regex
-
   def self.eager_load!
     super
     ActionView::Helpers.eager_load!

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -186,6 +186,21 @@ module ActionView # :nodoc:
     # Configured via `config.action_view.remove_hidden_field_autocomplete`
     cattr_accessor :remove_hidden_field_autocomplete, default: false
 
+    singleton_class.attr_reader :render_tracker # :nodoc:
+
+    def self.render_tracker=(value) # :nodoc:
+      @render_tracker = value
+      case value
+      when :ruby
+        DependencyTracker.register_tracker :erb, DependencyTracker::RubyTracker
+      else
+        DependencyTracker.register_tracker :erb, DependencyTracker::ERBTracker
+      end
+      value
+    end
+
+    self.render_tracker = :regex
+
     class << self
       delegate :erb_trim_mode=, to: "ActionView::Template::Handlers::ERB"
 

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -61,12 +61,5 @@ module ActionView
     def self.remove_tracker(handler) # :nodoc:
       @trackers.delete(handler)
     end
-
-    case ActionView.render_tracker
-    when :ruby
-      register_tracker :erb, RubyTracker
-    else
-      register_tracker :erb, ERBTracker
-    end
   end
 end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -82,7 +82,6 @@ module ActionView
     config.after_initialize do |app|
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
-          next if k == :render_tracker
           send "#{k}=", v
         end
       end
@@ -102,10 +101,6 @@ module ActionView
           ActionView::Resolver.caching = !app.config.reloading_enabled?
         end
       end
-    end
-
-    initializer "action_view.set_render_tracker" do |app|
-      ActionView.render_tracker = app.config.action_view.render_tracker
     end
 
     initializer "action_view.setup_action_pack" do |app|

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -51,17 +51,17 @@ class DependencyTrackerTest < ActionView::TestCase
   def test_changing_render_tracker_re_registers_erb_tracker
     erb_handler = ActionView::Template.handler_for_extension("erb")
     trackers = ActionView::DependencyTracker.instance_variable_get(:@trackers)
-    original = ActionView.render_tracker
+    original = ActionView::Base.render_tracker
 
-    ActionView.render_tracker = :ruby
+    ActionView::Base.render_tracker = :ruby
     assert_equal ActionView::DependencyTracker::RubyTracker, trackers[erb_handler],
       "Expected RubyTracker after setting render_tracker to :ruby"
 
-    ActionView.render_tracker = :regex
+    ActionView::Base.render_tracker = :regex
     assert_equal ActionView::DependencyTracker::ERBTracker, trackers[erb_handler],
       "Expected ERBTracker after setting render_tracker to :regex"
   ensure
-    ActionView.render_tracker = original
+    ActionView::Base.render_tracker = original
   end
 
   def test_returns_empty_array_if_no_tracker_is_found


### PR DESCRIPTION
render_tracker was the only config.action_view option that needed custom setup. Its accessor lived on ActionView, so it could not be applied by the after_initialize hook that sends all the config.action_view options to ActionView::Base.