### PR TITLE
Only document the public ActionView::DependencyTracker API [ci skip]

### DIFF
--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -5,7 +5,26 @@ require "action_view/path_set"
 require "action_view/render_parser"
 
 module ActionView
-  class DependencyTracker # :nodoc:
+  # = Action View Dependency Tracker
+  #
+  # When the digestor builds a template's dependency tree (to compute the cache
+  # keys used by +cache+ blocks and +stale?+ checks), it asks the dependency
+  # tracker which other templates a given template renders.
+  #
+  # Dependencies are tracked per template handler, because every template
+  # language spells +render+ differently. Action View ships ERBTracker for ERB;
+  # handlers for other template languages register their own with
+  # ::register_tracker, typically from an +ActiveSupport.on_load(:action_view)+
+  # block so it runs once Action View is available:
+  #
+  #   ActiveSupport.on_load(:action_view) do
+  #     ActionView::Template.register_template_handler :mtl, MyTemplateLanguage::Handler
+  #     ActionView::DependencyTracker.register_tracker :mtl, MyTemplateLanguage::DependencyTracker
+  #   end
+  #
+  # Languages whose +render+ calls look like Ruby's can register ERBTracker
+  # instead of writing their own tracker.
+  class DependencyTracker
     extend ActiveSupport::Autoload
 
     autoload :ERBTracker
@@ -14,13 +33,20 @@ module ActionView
 
     @trackers = Concurrent::Map.new
 
-    def self.find_dependencies(name, template, view_paths = nil)
+    def self.find_dependencies(name, template, view_paths = nil) # :nodoc:
       tracker = @trackers[template.handler]
       return [] unless tracker
 
       tracker.call(name, template, view_paths)
     end
 
+    # Registers the +tracker+ used to find the dependencies of templates
+    # rendered by the handler registered for +extension+.
+    #
+    # +tracker+ is any object that responds to
+    # +call(name, template, view_paths)+ and returns the array of template
+    # names +template+ depends on. An object responding only to
+    # +call(name, template)+ is also accepted for backwards compatibility.
     def self.register_tracker(extension, tracker)
       handler = Template.handler_for_extension(extension)
       if tracker.respond_to?(:supports_view_paths?)
@@ -32,7 +58,7 @@ module ActionView
       end
     end
 
-    def self.remove_tracker(handler)
+    def self.remove_tracker(handler) # :nodoc:
       @trackers.delete(handler)
     end
 

--- a/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
@@ -2,7 +2,16 @@
 
 module ActionView
   class DependencyTracker # :nodoc:
-    class ERBTracker # :nodoc:
+    # = Action View ERB Dependency Tracker
+    #
+    # Finds the dependencies of an ERB template by scanning its source with
+    # regular expressions for +render+ calls and <tt># Template Dependency:</tt>
+    # comments.
+    #
+    # Because it matches against the source, it also handles template languages
+    # whose +render+ calls look like Ruby.
+    class ERBTracker
+      # :stopdoc:
       EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
 
       # A valid ruby identifier - suitable for class, method and specially variable names


### PR DESCRIPTION
register_tracker is the supported way to teach Action View how to find the template dependencies of a new template language, and ERBTracker is the tracker gems reuse when their render calls look like Ruby's. Both are already used through the ActionView::DependencyTracker namespace:

  - coffee-rails: https://github.com/rails/coffee-rails/blob/v5.0.0/lib/coffee/rails/template_handler.rb#L25
  - haml-rails:   https://github.com/haml/haml-rails/blob/v3.0.0/lib/haml-rails.rb#L34

They were undocumented only because the whole DependencyTracker class was marked :nodoc:.

Document DependencyTracker, register_tracker, and ERBTracker, and keep the internals (find_dependencies, remove_tracker, the tracker regexes, and RubyTracker) :nodoc:, so the generated API only lists the supported entry points.
