### PR TITLE
Minor Active Support Cache refactorings

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -1066,28 +1066,37 @@ module ActiveSupport
         end
 
         def instrument(operation, key, options = nil, &block)
-          _instrument(operation, key: key, options: options, &block)
+          unless silence?
+            logger&.debug do
+              debug_key = ": #{key}" if key
+              debug_options = " (#{options.inspect})" unless options.blank?
+              "Cache #{operation}#{debug_key}#{debug_options}"
+            end
+          end
+
+          payload = {
+            store: self.class.name,
+            key: key
+          }
+          payload.merge!(options) if options.is_a?(Hash)
+          ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload) do
+            block&.call(payload)
+          end
         end
 
         def instrument_multi(operation, keys, options = nil, &block)
-          _instrument(operation, multi: true, key: keys, options: options, &block)
-        end
-
-        def _instrument(operation, multi: false, options: nil, **payload, &block)
-          if logger && logger.debug? && !silence?
-            debug_key =
-              if multi
-                ": #{payload[:key].size} key(s) specified"
-              elsif payload[:key]
-                ": #{payload[:key]}"
-              end
-
-            debug_options = " (#{options.inspect})" unless options.blank?
-
-            logger.debug "Cache #{operation}#{debug_key}#{debug_options}"
+          unless silence?
+            logger&.debug do
+              debug_key = ": #{keys.size} key(s) specified"
+              debug_options = " (#{options.inspect})" unless options.blank?
+              "Cache #{operation}#{debug_key}#{debug_options}"
+            end
           end
 
-          payload[:store] = self.class.name
+          payload = {
+            store: self.class.name,
+            key: keys
+          }
           payload.merge!(options) if options.is_a?(Hash)
           ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload) do
             block&.call(payload)

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -102,7 +102,7 @@ module ActiveSupport
       # Preemptively iterates through all stored keys and removes the ones which have expired.
       def cleanup(options = nil)
         options = merged_options(options)
-        _instrument(:cleanup, size: @data.size) do
+        instrument(:cleanup, nil, size: @data.size) do
           keys = synchronize { @data.keys }
           keys.each do |key|
             entry = deserialize_entry(@data[key])

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -109,14 +109,14 @@ module ActiveSupport
 
         def increment(name, amount = 1, **options) # :nodoc:
           return super unless local_cache
-          value = bypass_local_cache { super }
+          value = super
           write_cache_value(name, value, raw: true, **options)
           value
         end
 
         def decrement(name, amount = 1, **options) # :nodoc:
           return super unless local_cache
-          value = bypass_local_cache { super }
+          value = super
           write_cache_value(name, value, raw: true, **options)
           value
         end
@@ -231,10 +231,6 @@ module ActiveSupport
 
           def local_cache_key
             @local_cache_key ||= "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
-          end
-
-          def bypass_local_cache(&block)
-            use_temporary_local_cache(nil, &block)
           end
 
           def use_temporary_local_cache(temporary_cache)

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -67,7 +67,7 @@ module LocalCacheBehavior
       @cache.write(key, value)
       assert_equal value, @cache.read(key)
 
-      @cache.send(:bypass_local_cache) { @cache.write(key, other_value) }
+      @cache.send(:use_temporary_local_cache, nil) { @cache.write(key, other_value) }
       assert_equal value, @cache.read(key)
 
       @cache.cleanup
@@ -110,7 +110,7 @@ module LocalCacheBehavior
     value = SecureRandom.alphanumeric
     @cache.with_local_cache do
       assert_nil @cache.read(key)
-      @cache.send(:bypass_local_cache) { @cache.write(key, value) }
+      @cache.send(:use_temporary_local_cache, nil) { @cache.write(key, value) }
       assert_nil @cache.read(key)
     end
   end
@@ -211,6 +211,20 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_increment_miss
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, 5, raw: true)
+      @peek.delete(key)
+
+      @cache.increment(key)
+
+      expected = @peek.read(key, raw: true)
+      assert_equal 1, Integer(expected)
+      assert_equal expected, @cache.read(key, raw: true)
+    end
+  end
+
   def test_local_cache_of_decrement
     key = SecureRandom.uuid
     @cache.with_local_cache do
@@ -221,6 +235,22 @@ module LocalCacheBehavior
 
       expected = @peek.read(key, raw: true)
       assert_equal 2, Integer(expected)
+      assert_equal expected, @cache.read(key, raw: true)
+    end
+  end
+
+  def test_local_cache_of_decrement_miss
+    key = SecureRandom.uuid
+    @cache.with_local_cache do
+      @cache.write(key, 5, raw: true)
+      @peek.delete(key)
+
+      @cache.decrement(key)
+
+      expected = @peek.read(key, raw: true)
+      unless expected == "0" # Memcached doesn't go negative
+        assert_equal(-1, Integer(expected))
+      end
       assert_equal expected, @cache.read(key, raw: true)
     end
   end
@@ -298,7 +328,7 @@ module LocalCacheBehavior
     key = "key#{rand}"
     @cache.with_local_cache do
       @cache.write(key, "foo")
-      @cache.send(:bypass_local_cache) { @cache.write(key, "bar") }
+      @cache.send(:use_temporary_local_cache, nil) { @cache.write(key, "bar") }
 
       assert_equal({ key => "foo" }, @cache.read_multi(key))
     end

--- a/activesupport/test/cache/stores/deprecated_redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/deprecated_redis_cache_store_test.rb
@@ -618,7 +618,7 @@ module ActiveSupport::Cache::DeprecatedRedisCacheStoreTests
       @cache.with_local_cache do
         @cache.write("foo", "bar")
         # Overwrite in remote behind local cache's back
-        @cache.send(:bypass_local_cache) { @cache.write("foo", "baz") }
+        @cache.send(:use_temporary_local_cache, nil) { @cache.write("foo", "baz") }
         # Without delete, local cache returns stale value
         assert_equal "bar", @cache.read("foo")
         # With delete, it should bypass local cache and hit remote

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -578,7 +578,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       @cache.with_local_cache do
         @cache.write("foo", "bar")
         # Overwrite in remote behind local cache's back
-        @cache.send(:bypass_local_cache) { @cache.write("foo", "baz") }
+        @cache.send(:use_temporary_local_cache, nil) { @cache.write("foo", "baz") }
         # Without delete, local cache returns stale value
         assert_equal "bar", @cache.read("foo")
         # With delete, it should bypass local cache and hit remote


### PR DESCRIPTION
### Cleanup ActiveSupport::Cache#instrument

Eliminate the `_instrument` helper, that cause some minor duplication,
but makes the code easier to read.

Also use the `Logger#debug` block form instead of checking levels.

### Active Support Local Cache: simplify increment method

I see no reason to change swap the local cache to forward
the increment call to the real implementation.

Get rid of `bypass_local_cache` method, as it's no longer useful.