### PR TITLE
Separate `<h2>` through `<h6>` from neighbors in plain text conversion

### DIFF
--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -41,7 +41,7 @@ module ActionText
         "#{remove_trailing_newlines(plain_text_for_child_values(child_values))}\n\n"
       end
 
-      %i[ h1 p ].each do |element|
+      %i[ h1 h2 h3 h4 h5 h6 p ].each do |element|
         alias_method :"plain_text_for_#{element}_node", :plain_text_for_block
       end
 

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -52,6 +52,15 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "<h2> through <h6> tags are separated by two new lines" do
+    (2..6).each do |level|
+      assert_converted_to(
+        "Hello world!\n\nHow are you?",
+        "<h#{level}>Hello world!</h#{level}><div>How are you?</div>"
+      )
+    end
+  end
+
   test "<li> tags are separated by one new line" do
     assert_converted_to(
       "• one\n• two\n• three",


### PR DESCRIPTION
When converting rich text to plain text, only `<h1>` headings were surrounded by blank lines; `<h2>` through `<h6>` ran together with adjacent content:

```ruby
ActionText::Content.new("<h2>Title</h2><div>body</div>").to_plain_text
# Before: "Titlebody"
# After:  "Title\n\nbody"
```

All heading levels are now treated as blocks, consistent with how `<h1>` is already handled and with the markdown conversion, which supports `<h1>` through `<h6>`.