### PR TITLE
Honor `distinct` in `pluck` on a loaded relation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -301,7 +301,7 @@ module ActiveRecord
         end
       end
 
-      if loaded? && all_attributes?(column_names)
+      if loaded? && all_attributes?(column_names) && !distinct_value
         result = records.pluck(*column_names)
         if @async
           return Promise::Complete.new(result)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1021,6 +1021,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [50, 53, 55, 60], Account.order(:credit_limit).distinct.pluck(:credit_limit)
   end
 
+  def test_pluck_and_distinct_when_loaded
+    relation = Account.order(:credit_limit).distinct
+    relation.load
+    assert_equal [50, 53, 55, 60], relation.pluck(:credit_limit)
+  end
+
   def test_pluck_in_relation
     company = Company.first
     contract = company.contracts.create!


### PR DESCRIPTION
Calling `pluck` on a loaded relation that was marked `distinct` returned duplicate values, while the same call on an unloaded relation returned distinct values:

```ruby
relation = Account.order(:credit_limit).distinct
relation.pluck(:credit_limit)   # [50, 53, 55, 60]

relation.load
relation.pluck(:credit_limit)
# Before: [50, 50, 50, 53, 55, 60]
# After:  [50, 53, 55, 60]
```

A loaded `distinct` relation now also returns distinct values.