### PR TITLE
Deduplicate columns in `default_order`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -806,6 +806,7 @@ module ActiveRecord
     # Same as #default_order but operates on relation in-place instead of copying.
     def default_order!(*args) # :nodoc:
       preprocess_order_args(args)
+      args.uniq!
       self.default_order_values = args
       self
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -485,6 +485,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [:author_id], topics.group_values
   end
 
+  def test_default_order_deduplication
+    topics = Topic.default_order("id desc", "id desc")
+    assert_equal ["id desc"], topics.default_order_values
+  end
+
   def test_finding_with_reorder_by_aliased_attributes
     topics = Topic.order("author_name").reorder(:heading)
     assert_equal 5, topics.to_a.size


### PR DESCRIPTION
`default_order` could emit the same column more than once in the generated `ORDER BY` clause when a column was passed repeatedly:

```ruby
User.default_order(:name, :name)
# Before: ORDER BY "users"."name" ASC, "users"."name" ASC
# After:  ORDER BY "users"."name" ASC
```

This is now consistent with `order` and `regroup`, which already collapse duplicate columns.