### PR TITLE
Load database config when a connection is absent from the shared section

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -493,7 +493,7 @@ module Rails
               if config.is_a?(Hash) && config.values.all?(Hash)
                 if shared.is_a?(Hash) && shared.values.all?(Hash)
                   config.map do |name, sub_config|
-                    sub_config.reverse_merge!(shared[name])
+                    sub_config.reverse_merge!(shared[name]) if shared[name]
                   end
                 else
                   config.map do |name, sub_config|

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2528,6 +2528,26 @@ module ApplicationTests
       assert_equal "db/two", ar_config["development"]["two"]["migrations_path"]
     end
 
+    test "loads 3-tier database.yml when a connection is absent from the shared subsections" do
+      app_file "config/database.yml", <<-YAML
+        shared:
+          one:
+            migrations_path: "db/one"
+
+        development:
+          one:
+            adapter: sqlite3
+          two:
+            adapter: sqlite3
+      YAML
+
+      app "development"
+
+      ar_config = Rails.configuration.database_configuration
+      assert_equal "db/one",  ar_config["development"]["one"]["migrations_path"]
+      assert_equal "sqlite3", ar_config["development"]["two"]["adapter"]
+    end
+
     test "config.action_mailer.show_previews defaults to true in development" do
       app "development"
 


### PR DESCRIPTION
A 3-tier `database.yml` whose `shared` section defined only some of the named connections raised a `NoMethodError` while building the database configuration:

```yaml
shared:
  one:
    migrations_path: "db/one"

development:
  one:
    adapter: sqlite3
  two:            # no matching subsection under `shared`
    adapter: sqlite3
```

```ruby
Rails.application.config.database_configuration
# Before: NoMethodError: undefined method 'merge' for nil
# After:  loads, with "two" left as-is
```

Connections without a matching `shared` subsection are now left unchanged instead of crashing.