### PR TITLE
Allow a trailing slash URL with a blank path to take query params

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -170,7 +170,7 @@ module ActionDispatch
           path = options[:script_name].to_s.chomp("/")
           path << options[:path] if options.key?(:path)
 
-          path = "/" if options[:trailing_slash] && path.blank?
+          path = +"/" if options[:trailing_slash] && path.blank?
 
           add_params(path, options[:params]) if options.key?(:params)
           add_anchor(path, options[:anchor]) if options.key?(:anchor)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -72,6 +72,12 @@ class RequestUrlFor < BaseRequestTest
   test "url_for accepts a frozen params hash" do
     assert_equal "/x?a=1", url_for(only_path: true, path: "/x", params: { a: 1, b: nil }.freeze)
   end
+
+  test "url_for keeps query params and anchor with a trailing slash and a blank path" do
+    assert_equal "http://www.example.com/?search=books", url_for(trailing_slash: true, params: { search: "books" })
+    assert_equal "http://www.example.com/#signup", url_for(trailing_slash: true, anchor: "signup")
+    assert_equal "/?a=1", url_for(only_path: true, trailing_slash: true, path: "", params: { a: 1 })
+  end
 end
 
 class RequestIP < BaseRequestTest


### PR DESCRIPTION
Generating a URL with `trailing_slash: true` and a blank path raised a `FrozenError` as soon as query params or an anchor were appended:

```ruby
url_for(only_path: true, trailing_slash: true, path: "", params: { a: 1 })
# Before: FrozenError: can't modify frozen String: "/"
# After:  "/?a=1"
```

Params and anchors are now appended just as they are for a non-blank path.