### PR TITLE
Apply source mappings to dynamic permissions policy sources

### DIFF
--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -206,7 +206,8 @@ module ActionDispatch # :nodoc:
           if context.nil?
             raise RuntimeError, "Missing context for the dynamic permissions policy source: #{source.inspect}"
           else
-            context.instance_exec(&source)
+            resolved = context.instance_exec(&source)
+            apply_mappings(Array.wrap(resolved))
           end
         else
           raise RuntimeError, "Unexpected permissions policy source: #{source.inspect}"

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -39,6 +39,20 @@ class PermissionsPolicyTest < ActiveSupport::TestCase
 
     assert_equal "Invalid HTTP permissions policy source: [:non_existent]", exception.message
   end
+
+  def test_dynamic_directive
+    context = Object.new
+
+    @policy.geolocation -> { :self }
+    assert_equal "geolocation 'self'", @policy.build(context)
+  end
+
+  def test_dynamic_directive_returning_multiple_sources
+    context = Object.new
+
+    @policy.geolocation -> { [:self, "https://example.com"] }
+    assert_equal "geolocation 'self' https://example.com", @policy.build(context)
+  end
 end
 
 class PermissionsPolicyMiddlewareTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
A dynamic (callable) permissions policy source that returned a mapped keyword such as `:self` emitted the bare word `self` instead of the mapped value `'self'`, producing an invalid policy:

```ruby
policy.geolocation -> { :self }
# Before: geolocation self
# After:  geolocation 'self'
```

Dynamic source results are now mapped the same way as static sources, consistent with content security policies.