### PR TITLE
Match collection input `id` to label `for` when value sanitizes to empty

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -88,7 +88,8 @@ module ActionView
               add_default_name_and_field(options, field)
 
               if specified_field.blank? && options[field].present?
-                options[field] += "_#{sanitized_value(tag_value)}"
+                sanitized = sanitized_value(tag_value)
+                options[field] += "_#{sanitized}" unless sanitized.empty?
               end
             end
           end

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -259,6 +259,16 @@ class FormCollectionsHelperTest < ActionView::TestCase
     assert_no_select "label[for=user_active_]"
   end
 
+  test "collection radio input id matches label for when value sanitizes to empty" do
+    with_collection_radio_buttons :user, :active, [["Yes", "y"], ["Bang", "!"]], :last, :first
+
+    assert_select "input[type=radio]#user_active_y"
+    assert_select "label[for=user_active_y]", "Yes"
+    assert_select "input[type=radio]#user_active"
+    assert_select "label[for=user_active]", "Bang"
+    assert_no_select "input#user_active_"
+  end
+
   # COLLECTION CHECK BOXES
   test "collection check boxes accepts a collection and generate a series of checkboxes for value method" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]


### PR DESCRIPTION
A collection radio button or check box whose value is non-nil but sanitizes to an empty string got a trailing underscore in its input `id`, while the matching label's `for` attribute did not — breaking the association between them:

```ruby
collection_radio_buttons :user, :active, [["Bang", "!"]], :last, :first
# Before: <input id="user_active_" ...>  <label for="user_active">Bang</label>
# After:  <input id="user_active" ...>   <label for="user_active">Bang</label>
```

The input `id` now omits the underscore in that case, consistent with the label.