### PR TITLE
Anchor `options` routes and add a format segment like other verbs

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -855,7 +855,7 @@ module ActionDispatch
         # [match](rdoc-ref:Base#match)
         #
         #     options 'carrots', to: 'food#carrots'
-        def options(*path_or_actions, as: DEFAULT, to: nil, controller: nil, action: nil, on: nil, defaults: nil, constraints: nil, anchor: false, format: false, path: nil, internal: nil, **mapping, &block)
+        def options(*path_or_actions, as: DEFAULT, to: nil, controller: nil, action: nil, on: nil, defaults: nil, constraints: nil, anchor: nil, format: nil, path: nil, internal: nil, **mapping, &block)
           if path_or_actions.grep(Hash).any? && (deprecated_options = path_or_actions.extract_options!)
             as = assign_deprecated_option(deprecated_options, :as, :options) if deprecated_options.key?(:as)
             to ||= assign_deprecated_option(deprecated_options, :to, :options)

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -74,6 +74,17 @@ module ActionDispatch
         assert_equal "/foo.:format", fakeset.asts.first.to_s
       end
 
+      def test_options_defaults_to_a_format_segment_like_other_verbs
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.get     "/foo", to: "posts#index", as: :foo
+        mapper.options "/bar", to: "posts#index", as: :bar
+
+        assert_equal "/foo(.:format)", fakeset.asts[0].to_s
+        assert_equal "/bar(.:format)", fakeset.asts[1].to_s
+        assert_equal "OPTIONS", fakeset.routes.to_a[1].verb
+      end
+
       def test_random_keys
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset


### PR DESCRIPTION
A route drawn with the `options` verb helper was matched as a prefix and carried no optional format segment, while `get`, `post`, `patch`, `put`, and `delete` anchor the path and accept a format:

```ruby
options "carrots", to: "food#carrots"
# Before: also matches OPTIONS /carrots/anything (unanchored), no (.:format)
# After:  matches OPTIONS /carrots and OPTIONS /carrots.json (anchored, formatted)
```

`options` is a standard HTTP verb helper in the same family as `get`/`post`/`patch`/`put`/`delete`: an app that draws `options "carrots"` expects the same anchored, format-aware route those five produce. It now behaves consistently with them.

This intentionally leaves `connect` unchanged. `connect` remains unanchored and format-less because CONNECT — and its WebSocket / HTTP2 upgrade usage — tunnels to arbitrary paths, where prefix matching and a trailing format segment don't apply. That divergence is deliberate; `options` shares no such semantics, so it belongs with the ordinary verb helpers.