### PR TITLE
Return all parameters from `deconstruct_keys` when no keys are requested

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -318,7 +318,8 @@ module ActionController
     end
 
     def deconstruct_keys(keys)
-      slice(*keys).each.with_object({}) { |(key, value), hash| hash.merge!(key.to_sym => value) }
+      params = keys ? slice(*keys) : self
+      params.each.with_object({}) { |(key, value), hash| hash.merge!(key.to_sym => value) }
     end
 
     # Returns a safe ActiveSupport::HashWithIndifferentAccess representation of the

--- a/actionpack/test/controller/parameters/equality_test.rb
+++ b/actionpack/test/controller/parameters/equality_test.rb
@@ -70,4 +70,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_kind_of ActionController::Parameters, person
     assert_kind_of ActionController::Parameters, addresses.first
   end
+
+  test "deconstruct_keys matches a pattern with a rest binding" do
+    @params => { person: { age:, **rest } }
+
+    assert_equal "32", age
+    assert_equal %i[name addresses].sort, rest.keys.map(&:to_sym).sort
+  end
 end


### PR DESCRIPTION
Pattern matching against `ActionController::Parameters` with a rest binding (such as `{ key:, **rest }`) or a find pattern failed to match, because the deconstruction returned an empty hash when the pattern requested no specific keys:

```ruby
params = ActionController::Parameters.new(name: "Bob", age: 22).permit!

case params
in { name:, **rest }
  # Before: never reached (no match)
  # After:  name => "Bob", rest => { age: 22 }
end
```

All parameters are now returned in that case, matching `Hash#deconstruct_keys`.