### PR TITLE
Combine `:except_on` across shared and validator-level options

### DIFF
--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -114,10 +114,11 @@ module ActiveModel
       #
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
       #
-      # When +:if+, +:unless+, or +:on+ appear at both the +validates+ level and
-      # inside a specific validator's options, they are combined rather than the
-      # inner option replacing the outer one. All +:if+ conditions must pass,
-      # any +:unless+ condition will skip validation, and +:on+ contexts are merged:
+      # When +:if+, +:unless+, +:on+, or +:except_on+ appear at both the +validates+
+      # level and inside a specific validator's options, they are combined rather than
+      # the inner option replacing the outer one. All +:if+ conditions must pass, any
+      # +:unless+ condition will skip validation, and +:on+ and +:except_on+ contexts
+      # are merged:
       #
       #   validates :password, presence: { if: :local_check? }, if: :global_check?
       #   # Equivalent to: validates_presence_of :password, if: [:global_check?, :local_check?]
@@ -181,7 +182,7 @@ module ActiveModel
 
       def _merge_validates_options(defaults, validator_options)
         defaults.merge(validator_options) do |key, default_val, validator_val|
-          if key == :if || key == :unless || key == :on
+          if key == :if || key == :unless || key == :on || key == :except_on
             Array(default_val) + Array(validator_val)
           else
             validator_val

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -502,6 +502,19 @@ class ValidationsTest < ActiveModel::TestCase
     assert topic.validate(:custom_context)
   end
 
+  def test_validate_with_except_on_combined_across_levels
+    Topic.validates :title, presence: { except_on: :one }, except_on: :two
+
+    # Excluded in both the shared and the validator-level context
+    assert Topic.new.validate(:one)
+    assert Topic.new.validate(:two)
+
+    # Still runs in any other context
+    topic = Topic.new
+    topic.validate(:three)
+    assert_equal ["can't be blank"], topic.errors[:title]
+  end
+
   def test_validations_some_with_except
     Topic.validates :title, presence: { except_on: :custom_context }, length: { maximum: 10 }
 


### PR DESCRIPTION
When `validates` was given an `:except_on` context both as a shared option and inside an individual validator, only the validator-level context was kept and the shared one was dropped, so validations ran in a context that should have been excluded:

```ruby
validates :title, presence: { except_on: :one }, except_on: :two
# Before: still validated in context :two
# After:  excluded in both :one and :two
```

Both contexts are now honored, consistent with how `:on` is combined.