### PR TITLE
Render nothing for an empty cached collection without a partial

### DIFF
--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -134,7 +134,7 @@ module ActionView
         # Homogeneous
         render_collection_with_partial(collection, paths.first, context, block)
       else
-        if @options[:cached]
+        if @options[:cached] && paths.any?
           raise NotImplementedError, "render caching requires a template. Please specify a partial when rendering"
         end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -1087,6 +1087,10 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
     assert_nil @view.render(partial: "test/cached_customer", collection: [], cached: true)
   end
 
+  test "collection caching with empty collection and a derived partial" do
+    assert_nil @view.render(partial: [], cached: true)
+  end
+
   test "collection caching with repeated collection" do
     sets = [
         [1, 2, 3, 4, 5],


### PR DESCRIPTION
Rendering an empty collection with `cached: true` and no explicit partial raised a `NotImplementedError`, even though the same collection rendered with an explicit partial, or without caching, simply rendered nothing:

```ruby
render partial: [], cached: true
# Before: NotImplementedError: render caching requires a template. Please specify a partial when rendering
# After:  nil (renders nothing)
```

An empty cached collection now renders nothing, consistent with an empty collection rendered with an explicit partial.