### PR TITLE
Resolve dynamic permissions policy sources without a controller

### DIFF
--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -42,7 +42,7 @@ module ActionDispatch # :nodoc:
         request = ActionDispatch::Request.new(env)
 
         if policy = request.permissions_policy
-          headers[ActionDispatch::Constants::FEATURE_POLICY] = policy.build(request.controller_instance)
+          headers[ActionDispatch::Constants::FEATURE_POLICY] = policy.build(request.controller_instance || request)
         end
 
         if policy_empty?(policy)

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -99,6 +99,33 @@ class PermissionsPolicyMiddlewareTest < ActionDispatch::IntegrationTest
     assert_equal "gyroscope 'none'", response.headers[ActionDispatch::Constants::FEATURE_POLICY]
   end
 
+  test "dynamic sources resolve when no controller is present" do
+    dynamic_policy = ActionDispatch::PermissionsPolicy.new do |p|
+      p.gyroscope -> { "'self'" }
+    end
+
+    config_middleware = Class.new do
+      define_method(:initialize) { |app| @app = app }
+      define_method(:call) do |env|
+        env["action_dispatch.permissions_policy"] = dynamic_policy
+        env["action_dispatch.show_exceptions"] = :none
+        @app.call(env)
+      end
+    end
+
+    @app = config_middleware.new(
+      Rack::Lint.new(
+        ActionDispatch::PermissionsPolicy::Middleware.new(
+          Rack::Lint.new(->(env) { [200, { Rack::CONTENT_TYPE => "text/html" }, []] }),
+        ),
+      ),
+    )
+
+    get "/index"
+
+    assert_equal "gyroscope 'self'", response.headers[ActionDispatch::Constants::FEATURE_POLICY]
+  end
+
   private
     def build_app(app)
       PolicyConfigMiddleware.new(


### PR DESCRIPTION
A dynamic (callable) permissions policy source raised a `RuntimeError` whenever the response was built without a controller — for example a request served by a mounted Rack application or handled in middleware — because no context was available to evaluate the source:

```ruby
Rails.application.config.permissions_policy do |policy|
  policy.gyroscope -> { "'self'" }
end

# Before: RuntimeError: Missing context for the dynamic permissions policy source
# After:  gyroscope 'self'
```

The request is now used as the evaluation context when no controller is present, consistent with content security policies.