### PR TITLE
Allow the Evented LogSubscriber to be shareable

### DIFF
--- a/activesupport/lib/active_support/event_reporter/log_subscriber.rb
+++ b/activesupport/lib/active_support/event_reporter/log_subscriber.rb
@@ -5,11 +5,7 @@ module ActiveSupport
     class LogSubscriber
       include ColorizeLogging
 
-      LEVEL_CHECKS = {
-        debug: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.debug? }),
-        info: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.info? }),
-        error: ActiveSupport::Ractors.shareable_lambda(&-> (logger) { logger.error? }),
-      }.freeze
+      LOG_LEVELS = [:debug, :info, :error].freeze
 
       class << self
         def event_log_level(method_name, level)
@@ -45,7 +41,8 @@ module ActiveSupport
         return unless logger
         name = event[:name]
         event_method = name[name.index(".") + 1, name.length]
-        public_send(event_method, event) if LEVEL_CHECKS[log_levels[event_method]]&.call(logger)
+
+        public_send(event_method, event) if log_level_satisfied?(event_method)
       end
 
       def logger
@@ -55,6 +52,13 @@ module ActiveSupport
       private
         def namespace
           self.class.namespace
+        end
+
+        def log_level_satisfied?(event_method)
+          event_log_level = log_levels[event_method]
+          return false unless LOG_LEVELS.include?(event_log_level)
+
+          logger.public_send("#{event_log_level}?")
         end
     end
   end

--- a/activesupport/lib/active_support/structured_event_subscriber.rb
+++ b/activesupport/lib/active_support/structured_event_subscriber.rb
@@ -31,8 +31,6 @@ module ActiveSupport
   class StructuredEventSubscriber < Subscriber
     class_attribute :debug_methods, instance_accessor: false, default: [] # :nodoc:
 
-    DEBUG_CHECK = ActiveSupport::Ractors.shareable_proc { !ActiveSupport.event_reporter.debug_mode? }
-
     class << self
       def attach_to(...) # :nodoc:
         result = super
@@ -43,7 +41,7 @@ module ActiveSupport
       private
         def set_silenced_events
           if subscriber
-            subscriber.silenced_events = debug_methods.to_h { |method| ["#{method}.#{namespace}", DEBUG_CHECK] }
+            subscriber.silenced_events = debug_methods.to_h { |method| ["#{method}.#{namespace}", true] }
           end
         end
 
@@ -59,7 +57,7 @@ module ActiveSupport
     end
 
     def silenced?(event)
-      ActiveSupport.event_reporter.subscribers.none? || @silenced_events[event]&.call
+      ActiveSupport.event_reporter.subscribers.none? || (@silenced_events.key?(event) && !ActiveSupport.event_reporter.debug_mode?)
     end
 
     attr_writer :silenced_events # :nodoc:


### PR DESCRIPTION
### Motivation / Background

I'd like to make this codepath ractor safe. It currently is not because the constant holds procs which aren't ractor safe. The constant itself is frozen but that's not sufficient.

### Detail

Wrote a small refactor to prevent having procs inside this hash. We could wrap each proc inside a `Ractor.shareable_proc` but it's quite heavy and hard to read.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
