### PR TITLE
Make the Action View dependency tracker registry Ractor-shareable

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Deprecate registering dependency trackers after application initialization.
+
+    Calling `ActionView::DependencyTracker.register_tracker` after application initialization will
+    raise a FrozenError in the next version of Rails.
+
+    Instead, register trackers during application initialization, wrapped in a call to
+    `ActiveSupport.on_load(:action_view)` to wait until Action View is available.
+
+    *Étienne Barrié*
+
 *   Extract `current_page?`, `button_to`, and `link_to` methods to
     `ActionView::Helpers::NavigationHelper`
 

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -111,6 +111,7 @@ module ActionView
     super
     ActionView::Helpers.eager_load!
     ActionView::Template.eager_load!
+    ActionView::DependencyTracker.eager_load!
   end
 end
 

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "concurrent/map"
 require "action_view/path_set"
 require "action_view/render_parser"
 
@@ -31,7 +30,7 @@ module ActionView
     autoload :RubyTracker
     autoload :WildcardResolver
 
-    @trackers = Concurrent::Map.new
+    @trackers = {}
 
     def self.find_dependencies(name, template, view_paths = nil) # :nodoc:
       tracker = @trackers[template.handler]
@@ -49,17 +48,40 @@ module ActionView
     # +call(name, template)+ is also accepted for backwards compatibility.
     def self.register_tracker(extension, tracker)
       handler = Template.handler_for_extension(extension)
-      if tracker.respond_to?(:supports_view_paths?)
-        @trackers[handler] = tracker
+      callable = if tracker.respond_to?(:supports_view_paths?)
+        tracker
       else
-        @trackers[handler] = lambda { |name, template, _|
+        ActiveSupport::Ractors.try_shareable_proc { |name, template, _|
           tracker.call(name, template)
         }
+      end
+
+      if @trackers.frozen?
+        ActionView.deprecator.warn(<<~MSG)
+          Registering a dependency tracker after application initialization is deprecated.
+          Register trackers from a Railtie or an initializer instead.
+          This will raise a FrozenError in Rails 9.0.
+        MSG
+        @trackers = @trackers.merge(handler => callable).freeze
+      else
+        @trackers[handler] = callable
       end
     end
 
     def self.remove_tracker(handler) # :nodoc:
-      @trackers.delete(handler)
+      if @trackers.frozen?
+        @trackers = @trackers.except(handler).freeze
+      else
+        @trackers.delete(handler)
+      end
+    end
+
+    def self.eager_load! # :nodoc:
+      @trackers.freeze
+    end
+
+    def self.share_registry # :nodoc:
+      ActiveSupport::Ractors.make_shareable(@trackers)
     end
 
     case ActionView.render_tracker

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -2,9 +2,20 @@
 
 require "abstract_unit"
 require "action_view/dependency_tracker"
+require "active_support/testing/ractors_assertions"
 
 class NeckbeardTracker
   def self.call(name, template)
+    ["foo/#{name}"]
+  end
+end
+
+class BowtieTracker
+  def supports_view_paths?
+    true
+  end
+
+  def call(name, template, view_paths = nil)
     ["foo/#{name}"]
   end
 end
@@ -43,7 +54,7 @@ class DependencyTrackerTest < ActionView::TestCase
 
   def teardown
     ActionView::Template.unregister_template_handler :neckbeard
-    tracker.remove_tracker(:neckbeard)
+    tracker.remove_tracker(Neckbeard)
   end
 
   def test_finds_tracker_by_template_handler
@@ -364,5 +375,110 @@ class RubyTrackerTest < Minitest::Test
     tracker = make_tracker("posts/show", template)
 
     assert_equal ["posts/child"], tracker.dependencies
+  end
+end
+
+class DependencyTrackerRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  include ActiveSupport::Testing::RactorsAssertions
+
+  def trackers
+    ActionView::DependencyTracker.instance_variable_get(:@trackers)
+  end
+
+  def test_default_registry_is_shareable_after_share_registry
+    ActionView::DependencyTracker.share_registry
+    assert_ractor_shareable trackers
+  end
+
+  def test_class_handlers_stay_unfrozen_and_registry_is_shareable
+    # Mirrors how coffee-rails registers: a class handler keyed to a tracker.
+    handler = Class.new do
+      def self.call(template, source = nil)
+        source
+      end
+    end
+    ActionView::Template.register_template_handler(:fake_lang, handler)
+    ActionView::DependencyTracker.register_tracker(:fake_lang, ActionView::DependencyTracker::ERBTracker)
+
+    ActionView::DependencyTracker.share_registry
+
+    assert_not handler.frozen?, "class handlers must stay unfrozen so they keep their class-level state"
+    assert_ractor_shareable trackers
+  ensure
+    ActionView::Template.unregister_template_handler(:fake_lang)
+  end
+
+  def test_instance_level_tracker_stays_mutable_until_share_registry
+    handler = Class.new do
+      def self.call(template, source = nil)
+        source
+      end
+    end
+    ActionView::Template.register_template_handler(:bowtie, handler)
+    tracker = BowtieTracker.new
+    ActionView::DependencyTracker.register_tracker(:bowtie, tracker)
+
+    ActionView::DependencyTracker.eager_load!
+    assert_predicate trackers, :frozen?
+    assert_not tracker.frozen?, "eager_load! must not freeze the trackers themselves"
+
+    ActionView::DependencyTracker.share_registry
+    assert_ractor_shareable trackers
+  ensure
+    ActionView::Template.unregister_template_handler(:bowtie)
+  end
+
+  def test_registering_a_tracker_after_freeze_registry_is_deprecated
+    ActionView::DependencyTracker.eager_load!
+
+    handler = Class.new do
+      def self.call(template, source = nil)
+        source
+      end
+    end
+    ActionView::Template.register_template_handler(:bowtie, handler)
+
+    assert_deprecated(ActionView.deprecator) do
+      ActionView::DependencyTracker.register_tracker(:bowtie, BowtieTracker.new)
+    end
+
+    assert_instance_of BowtieTracker, trackers[ActionView::Template.handler_for_extension(:bowtie)]
+  ensure
+    ActionView::Template.unregister_template_handler(:bowtie)
+  end
+
+  def test_freeze_registry_tolerates_unshareable_trackers_and_handler_keys
+    mutable_handler = Object.new
+    def mutable_handler.call(template, source = nil)
+      source
+    end
+    ActionView::Template.register_template_handler(:bowtie, mutable_handler)
+
+    tracker = BowtieTracker.new
+    tracker.instance_variable_set(:@mutex, Mutex.new)
+
+    assert_not_deprecated(ActionView.deprecator) do
+      ActionView::DependencyTracker.register_tracker(:bowtie, tracker)
+    end
+
+    ActionView::DependencyTracker.eager_load!
+
+    assert_predicate trackers, :frozen?
+    assert_not mutable_handler.frozen?, "eager_load! must not freeze handler keys"
+    assert_not tracker.frozen?, "eager_load! must tolerate unshareable trackers"
+  ensure
+    ActionView::Template.unregister_template_handler(:bowtie)
+  end
+
+  if RUBY_VERSION >= "4.0"
+    def test_find_dependencies_is_callable_from_a_non_main_ractor
+      ActionView::DependencyTracker.share_registry
+      unregistered_handler = Object.new.freeze
+      template = Struct.new(:source, :handler).new("nope", unregistered_handler).freeze
+
+      result = Ractor.new(template) { |t| ActionView::DependencyTracker.find_dependencies("x", t) }.value
+      assert_equal [], result
+    end
   end
 end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -677,6 +677,7 @@ module Rails
       Ractor.make_shareable(Rails.event)
       Ractor.make_shareable(Rails.error)
       Ractor.make_shareable(Rails.backtrace_cleaner)
+      ActionView::DependencyTracker.share_registry if defined?(ActionView)
     end
 
   protected


### PR DESCRIPTION
This makes ActionView::DependencyTracker able to be ractor-shareable. It needs to receive ~`freeze_registry`~ `share_registry` before being shareable, but I didn't add that to an initializer to preserve compatibility, since a registered tracker might not be shareable.
We'll call that from `Rails.application.ractorize!` (https://github.com/rails/rails/pull/57825).

~I haven't done it but I think we should deprecate mutating the dependency tracker after application initialization. Not sure if it's best in this PR or in a follow-up.~

I also deprecated mutating the dependency tracker after configuration. However it's still possible to add an unshareable tracker for an unshareable handler, for compatibility reasons. Making the registry shareable is only for application opting into it via `ractorize!`.