### PR TITLE
Make parameter parsers assignment ractor safe

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -30,7 +30,7 @@ module ActionDispatch
           attr_reader :parameter_parsers
         end
 
-        self.parameter_parsers = DEFAULT_PARSERS
+        @parameter_parsers = DEFAULT_PARSERS
       end
 
       module ClassMethods
@@ -44,7 +44,7 @@ module ActionDispatch
         #     new_parsers = original_parsers.merge(xml: xml_parser)
         #     ActionDispatch::Request.parameter_parsers = new_parsers
         def parameter_parsers=(parsers)
-          @parameter_parsers = parsers.transform_keys { |key| key.respond_to?(:symbol) ? key.symbol : key }
+          @parameter_parsers = parsers.transform_keys { |key| key.respond_to?(:symbol) ? key.symbol : key }.freeze
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

I already made the default param parsers ractor safe in https://github.com/rails/rails/commit/f2be45aaa8447b0d6efbcb7b42e5c6dbeb6b30b6. But I overlooked the fact that assigning them transforms the supplied hash so we need to freeze that.

### Detail

Freeze the parameters_parsers hash before assigning it. The procs in this are `called` so we can't safely make them shareable for the user. The user will have to do it.

Also I don't think it makes sense to go through the public api to assign the defualt parsers, which causes us to duplicate that hash. We can just put it directly on the ivar since we know it is in the right shapre.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
