### PR TITLE
Mark a connection unverified when a non-StandardError interrupts a query

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1149,6 +1149,13 @@ module ActiveRecord
               downgrade_connection_after_error(translated_exception)
 
               raise translated_exception
+            rescue Exception
+              # A non-StandardError (a Timeout, or a fiber scheduler's cancel) abandoned
+              # the query partway through, so we mark the connection unverified, just as
+              # a failed query would, forcing a reconnect before it's used again.
+              @last_activity = nil
+              @verified = false
+              raise
             ensure
               dirty_current_transaction if materialize_transactions
             end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -735,6 +735,23 @@ module ActiveRecord
         assert_not_predicate @connection, :needs_reconnect?
       end
 
+      test "a non-StandardError interrupt marks the connection for re-verification" do
+        # A recently-used, verified connection is the state a mid-query interrupt poisons.
+        @connection.execute("SELECT 1")
+        error = Class.new(Exception)
+
+        assert_raises error do
+          @connection.send(:with_raw_connection) do
+            raise error
+          end
+        end
+
+        # It can't be reused on the "verified" flag or the recently-used shortcut, so both
+        # are cleared and the connection is re-verified before its next use.
+        assert_not_predicate @connection, :verified?
+        assert_nil @connection.instance_variable_get(:@last_activity)
+      end
+
       test "quoting a string on a 'clean' failed connection will not prevent reconnecting" do
         remote_disconnect @connection
 


### PR DESCRIPTION
### Motivation / Background

`ConnectionAdapters::AbstractAdapter#with_raw_connection` rescues only `StandardError`. When a query is interrupted by an exception outside that hierarchy, such as a `Timeout` or a fiber scheduler's cancel (`Async::Stop` and `Async::Cancel` both subclass `Exception`), the exception propagates past the rescue while the connection is still mid-protocol.

Active Record then returns that connection to the pool still marked verified and recently used. The next checkout reuses the desynced socket and fails with an `EOFError` or `ActiveRecord::ConnectionFailed` on a query that has nothing to do with the original interrupt. One interrupted request corrupts a later, unrelated one.

This is a pool-integrity fix. The interrupted query is left failed and its exception re-raised unchanged; the one thing that changes is that the connection it abandoned is no longer trusted on the next checkout. Fiber schedulers make the path routine: running Rails on Falcon, a cancel raises `Async::Stop` directly into the fiber mid-query, which is where we hit it.

### Detail

After a failed query, `with_raw_connection` already downgrades the connection: the `rescue => e` clause runs `downgrade_connection_after_error` and re-raises, so the next use re-verifies. The gap is the one exception class `rescue => e` cannot see.

This adds a `rescue Exception` clause that applies the same downgrade and re-raises:

```ruby
rescue Exception
  @last_activity = nil
  @verified = false
  raise
```

Those two writes are exactly what `downgrade_connection_after_error` does for a non-retryable error. That method also sets `@needs_reconnect = true`, but only for an error it can classify as a retryable connection error. An arbitrary interrupt gives no such signal, and clearing `@verified` with `@last_activity` already forces verification on the next use, so this path stops at the two writes.

Both writes are load-bearing. With `@verified = false` alone, the next checkout still takes the recently-used shortcut and [skips verification](https://github.com/rails/rails/blob/b4379f0180a0b7f3e8e5e390c97e9586d556d817/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1105-L1106):

```ruby
elsif !@needs_reconnect && (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
  # We haven't actually verified the connection since we acquired it, but it
  # has been used very recently. We're going to assume it's still okay.
```

Clearing `@last_activity` sends the next use down the verify path, which reconnects when the socket is dead.

The bare `rescue Exception` has precedent in this file: `attempt_configure_connection` uses `rescue Exception` to handle `Timeout::ExitException`. Nothing is disconnected eagerly on the interrupt path; the connection heals on next use. `StandardError` failures keep their existing behavior.

### Additional information

**Verification.** A new `adapter_test.rb` case warms the connection with a query, raises a non-`StandardError` through `with_raw_connection`, and asserts the connection is left unverified with `@last_activity` cleared. It fails without the change (the connection stays verified) and passes with it. Confirmed on sqlite3 and trilogy.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.