### PR TITLE
Ractor safe counter cache configuration

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -38,8 +38,8 @@ module ActiveRecord::Associations::Builder # :nodoc:
       }
 
       klass = reflection.class_name.safe_constantize
-      klass._counter_cache_columns |= [cache_column] if klass && klass.respond_to?(:_counter_cache_columns)
-      model.counter_cached_association_names |= [reflection.name]
+      klass._counter_cache_columns = (klass._counter_cache_columns | [cache_column]).freeze if klass && klass.respond_to?(:_counter_cache_columns)
+      model.counter_cached_association_names = (model.counter_cached_association_names | [reflection.name]).freeze
     end
 
     def self.touch_record(o, changes, foreign_key, name, touch) # :nodoc:

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -6,8 +6,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_counter_cache_columns, instance_accessor: false, default: []
-      class_attribute :counter_cached_association_names, instance_writer: false, default: []
+      class_attribute :_counter_cache_columns, instance_accessor: false, default: [].freeze
+      class_attribute :counter_cached_association_names, instance_writer: false, default: [].freeze
     end
 
     module ClassMethods
@@ -212,7 +212,7 @@ module ActiveRecord
           name.to_sym
         end
 
-        self.counter_cached_association_names |= association_names
+        self.counter_cached_association_names = (counter_cached_association_names | association_names).freeze
       end
     end
 

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -20,8 +20,11 @@ require "models/subscription"
 require "models/book"
 require "models/cpk"
 require "active_support/core_ext/enumerable"
+require "active_support/testing/ractors_assertions"
 
 class CounterCacheTest < ActiveRecord::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   fixtures :topics, :categories, :categorizations, :cars, :dogs, :dog_lovers, :people, :friendships, :subscribers, :subscriptions, :books,
     :cpk_orders, :cpk_books
 
@@ -509,6 +512,11 @@ class CounterCacheTest < ActiveRecord::TestCase
     assert_queries_count(1) do
       assert_equal 2, car.tires.count
     end
+  end
+
+  test "counter cache configuration is ractor shareable" do
+    assert_ractor_shareable SpecialReply.counter_cached_association_names
+    assert_ractor_shareable SpecialReply._counter_cache_columns
   end
 
   private


### PR DESCRIPTION

### Motivation / Background

Make `ActiveRecord::CounterCaches._counter_cache_columns` and `.counter_cached_association_names` frozen by default so they are ractor safe.


### Detail


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
