### PR TITLE
Fix polymorphic belongs_to primary key for sharded targets

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -936,17 +936,23 @@ module ActiveRecord
       # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
         if options[:primary_key]
-          @association_primary_key ||= ActiveRecord::Key.for(options[:primary_key]).name
-        elsif polymorphic? && options[:inverse_of] && klass
-          inverse = klass.reflect_on_association(options[:inverse_of])
-          if inverse && inverse.options[:primary_key]
-            ActiveRecord::Key.for(inverse.options[:primary_key]).name
-          else
-            derive_primary_key(klass) { |model| model.composite_query_constraints_list }
-          end
-        else
-          derive_primary_key(klass || self.klass) { |model| model.composite_query_constraints_list }
+          return @association_primary_key ||= ActiveRecord::Key.for(options[:primary_key]).name
         end
+
+        if polymorphic? && options[:inverse_of] && klass
+          inverse = klass.reflect_on_association(options[:inverse_of])
+          if inverse && inverse.options[:primary_key] && !inverse.options[:query_constraints]
+            return ActiveRecord::Key.for(inverse.options[:primary_key]).name
+          end
+        end
+
+        klass ||= self.klass
+
+        if klass.has_query_constraints? && options[:foreign_key] && !options[:query_constraints]
+          return klass.primary_key_definition.inferred_id || primary_key(klass).freeze
+        end
+
+        derive_primary_key(klass) { |model| model.composite_query_constraints_list }
       end
 
       def join_primary_key(klass = nil)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -38,6 +38,9 @@ require "models/car"
 require "models/sharded/blog"
 require "models/sharded/blog_post"
 require "models/sharded/comment"
+require "models/image"
+require "models/shipment"
+require "models/adjustment"
 require "models/dats"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
@@ -2134,5 +2137,23 @@ class BelongsToPolymorphicInversePrimaryKeyTest < ActiveRecord::TestCase
 
     assert_equal author, author_comment.reload.person
     assert_equal person, person_comment.reload.person
+  end
+end
+
+class BelongsToPolymorphicShardedPrimaryKeyTest < ActiveRecord::TestCase
+  def test_explicit_foreign_key_to_sharded_target_resolves_single_primary_key
+    reflection = Image.reflect_on_association(:imageable)
+
+    assert_predicate Sharded::BlogPost, :has_query_constraints?
+    assert_equal "id", reflection.association_primary_key(Sharded::BlogPost)
+  end
+
+  def test_inverse_with_composite_query_constraints_resolves_single_primary_key
+    reflection = Adjustment.reflect_on_association(:adjustable)
+    inverse = Shipment.reflect_on_association(:adjustments)
+
+    assert_equal [:region_id, :adjustable_id], inverse.options[:query_constraints]
+    assert_equal [:region_id, :id], inverse.options[:primary_key]
+    assert_equal "id", reflection.association_primary_key(Shipment)
   end
 end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -44,6 +44,11 @@ require "models/drink_designer"
 require "models/cpk"
 require "models/human"
 require "models/face"
+require "models/image"
+require "models/sharded/blog"
+require "models/sharded/blog_post"
+require "models/shipment"
+require "models/adjustment"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_works_even_when_other_callbacks_update_the_parent_model
@@ -2522,5 +2527,33 @@ class AutosavePolymorphicInversePrimaryKeyTest < ActiveRecord::TestCase
 
     assert_equal author, author_comment.reload.person
     assert_equal person, person_comment.reload.person
+  end
+end
+
+class AutosavePolymorphicShardedPrimaryKeyTest < ActiveRecord::TestCase
+  def test_autosave_polymorphic_belongs_to_with_explicit_foreign_key_to_sharded_target
+    blog = Sharded::Blog.create!
+    post = Sharded::BlogPost.new(title: "Post", blog: blog)
+    image = Image.new(imageable: post)
+
+    image.save!
+
+    assert_predicate post, :persisted?
+    assert_equal post.id, image.imageable_identifier
+    assert_equal "Sharded::BlogPost", image.imageable_class
+    assert_equal post, image.reload.imageable
+  end
+
+  def test_autosave_polymorphic_belongs_to_with_composite_query_constraints_inverse
+    shipment = Shipment.new(region_id: 7)
+    adjustment = Adjustment.new(region_id: 7)
+    adjustment.adjustable = shipment
+
+    adjustment.save!
+
+    assert_predicate shipment, :persisted?
+    assert_equal shipment.id, adjustment.adjustable_id
+    assert_equal "Shipment", adjustment.adjustable_type
+    assert_equal shipment, adjustment.reload.adjustable
   end
 end

--- a/activerecord/test/models/adjustment.rb
+++ b/activerecord/test/models/adjustment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Adjustment < ActiveRecord::Base
+  belongs_to :adjustable, polymorphic: true, inverse_of: :adjustments, autosave: true
+end

--- a/activerecord/test/models/shipment.rb
+++ b/activerecord/test/models/shipment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Shipment < ActiveRecord::Base
+  has_many :adjustments,
+    as: :adjustable,
+    foreign_key: [:region_id, :adjustable_id],
+    primary_key: [:region_id, :id],
+    inverse_of: :adjustable
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -376,6 +376,15 @@ ActiveRecord::Schema.define do
     t.integer :tag_id
   end
 
+  create_table :shipments, force: true do |t|
+    t.integer :region_id
+  end
+
+  create_table :adjustments, force: true do |t|
+    t.integer :region_id
+    t.references :adjustable, polymorphic: true
+  end
+
   create_table :clubs, force: true do |t|
     t.string :name
     t.integer :category_id


### PR DESCRIPTION
`BelongsToReflection#association_primary_key` can resolve a composite
primary key (a sharded model's `query_constraints` list, e.g.
`[:shard_id, :id]`) while the `belongs_to` only holds a single foreign
key. `AutosaveAssociation` then zips the primary key against the foreign
key, so the trailing primary key column is paired with a `nil` foreign
key and raises `ActiveModel::MissingAttributeError`.

This regressed when `compute_primary_key` was [removed][1] from
`AutosaveAssociation` in favor of `association_primary_key`, which lost
two of its guards. The `:inverse_of` branch adopts
`inverse.options[:primary_key]` verbatim, which is correct for a genuine
custom single key (e.g. `:uuid`) but wrong for a sharded inverse
`has_many` that declares a composite `:primary_key`. The fallthrough
branch expands any `has_query_constraints?` target to its composite
list, even when the `belongs_to` pins an explicit single `:foreign_key`.

This commit fixes the issue by restoring both guards: a composite
`:foreign_key` on the inverse populates its `:query_constraints` option,
so the inverse key is only adopted when `:query_constraints` is absent,
and an explicit single `:foreign_key` always resolves the target's
single primary key.

[1]: https://github.com/rails/rails/commit/7b429b51183566dba3286645323eaf48a88220b0