### PR TITLE
Freeze config.action_dispatch.default_headers

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -382,7 +382,7 @@ module Rails
               "X-Content-Type-Options" => "nosniff",
               "X-Permitted-Cross-Domain-Policies" => "none",
               "Referrer-Policy" => "strict-origin-when-cross-origin"
-            }
+            }.freeze
           end
 
           if respond_to?(:active_record)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -58,7 +58,7 @@
 #   "X-Content-Type-Options" => "nosniff",
 #   "X-Permitted-Cross-Domain-Policies" => "none",
 #   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+# }.freeze
 
 ###
 # Controls whether the PostgresqlAdapter should decode bytea and money columns automatically with manual queries.


### PR DESCRIPTION
### Motivation / Background

Make `ActionDispatch::Request.default_headers` frozen by default

### Detail

I freeze the value on `config.action_dispatch.default_headers` that we assign to `ActionDispatch::Request.default_headers`. I decided not to `Ractor.make_shareable` the value when we assign in case there are unexpected values from the developer in there.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
