### PR TITLE
Add ActiveSupport::Ractors.try_make_shareable

### DIFF
--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -40,6 +40,33 @@ module ActiveSupport
         end
       end
 
+      # Attempt to make an object shareable. If successful, a shareable object is returned.
+      # If a Ractor::IsolationError is raised, the outcome will depend on how
+      # the user's application configuration:
+      #
+      # :raise - The error is raised
+      # :warn  - A deprecation warning is triggered and the original unshareable object is returned.
+      def try_make_shareable(obj)
+        return obj unless unshareable_proc_action
+
+        make_shareable(obj)
+      rescue Ractor::IsolationError
+        case unshareable_proc_action
+        when :raise
+          raise
+        when :warn
+          ActiveSupport.deprecator.warn(<<~MSG)
+            Rails attempted to make an object from your application Ractor shareable but a Ractor
+            Isolation error was raised. The object being returned is not Ractor safe and a runtime
+            error may occur anytime during the request lifecycle.
+
+            #{obj.inspect}
+          MSG
+
+          obj
+        end
+      end
+
       if defined?(Ractor) && RUBY_VERSION >= "4.0"
         # Makes +obj+ Ractor-shareable by delegating to +Ractor.make_shareable+.
         #

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -98,5 +98,58 @@ class KernelRactorShareabilityTest < ActiveSupport::TestCase
     ensure
       ActiveSupport::Ractors.unshareable_proc_action = old
     end
+
+    def test_try_make_shareable_when_action_is_nil
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = nil
+
+      obj = +"hello"
+      attempted = ActiveSupport::Ractors.try_make_shareable(obj)
+
+      assert_same(obj, attempted)
+      assert_not ActiveSupport::Ractors.shareable?(obj)
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_try_make_shareable_makes_the_object_shareable
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+
+      obj = +"hello"
+      attempted = ActiveSupport::Ractors.try_make_shareable(obj)
+
+      assert_same(obj, attempted)
+      assert ActiveSupport::Ractors.shareable?(attempted)
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_try_make_shareable_raises
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+
+      obj = proc { }
+
+      assert_raises(Ractor::IsolationError) do
+        ActiveSupport::Ractors.try_make_shareable(obj)
+      end
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_try_make_shareable_warns
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :warn
+
+      obj = proc { }
+
+      assert_deprecated(/Rails attempted to make an object .* Ractor shareable/, ActiveSupport.deprecator) do
+        attempted = ActiveSupport::Ractors.try_make_shareable(obj)
+        assert_same(obj, attempted)
+      end
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we need a way to attempt to make objects other than procs Ractor shareable.

### Detail

This Pull Request adds `ActiveSupport::Ractors.try_make_shareable` which will work differently depending on `unshareable_proc_action`:

- `raise` will raise ractor isolation errors
- `warn` will emit a warning on ractor isolation errors
- `nil` will ignore the ractor isolation error entirely

Similar to existing `try_shareable_proc` (https://github.com/rails/rails/pull/57626), but for objects. I would like to use this in #57852.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
