### PR TITLE
Add `this_quarter?` to Date/Time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `#this_quarter?` to Date/Time.
+
+    It returns true if the date/time falls within the current quarter.
+
+    ```ruby
+    Date.current #=> Tue, 15 Feb 2000
+    Date.new(2000, 3, 31).this_quarter?  # => true
+    Date.new(2000, 4, 1).this_quarter?   # => false
+    ```
+
+    *Kenta Ishizaki*
+
 *   Added `ActiveSupport::ProxyLogger`.
 
     The proxy logger, is a logger that forwards all received logs to another

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -75,6 +75,11 @@ module DateAndTime
       ::Date.current.all_month.include?(to_date)
     end
 
+    # Returns true if the date/time falls within the current quarter.
+    def this_quarter?
+      ::Date.current.all_quarter.cover?(to_date)
+    end
+
     # Returns true if the date/time falls within the current year.
     def this_year?
       ::Date.current.all_year.include?(to_date)

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -400,6 +400,15 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_this_quarter
+    Date.stub(:current, Date.new(2000, 2, 15)) do
+      assert_equal false, Time.utc(1999, 12, 31, 23, 59, 59).this_quarter?
+      assert_equal true,  Time.utc(2000, 1, 1, 0, 0, 0).this_quarter?
+      assert_equal true,  Time.utc(2000, 3, 31, 23, 59, 59).this_quarter?
+      assert_equal false, Time.utc(2000, 4, 1, 0, 0, 0).this_quarter?
+    end
+  end
+
   def test_this_year
     Date.stub(:current, Date.new(2000, 6, 30)) do
       assert_equal false, Time.utc(1999, 12, 31, 23, 59, 59).this_year?


### PR DESCRIPTION
### Summary

Adds a `this_quarter?` predicate to Date, Time, DateTime, and `ActiveSupport::TimeWithZone`, returning true if the receiver falls within the current quarter.

This completes the `this_*?` predicate family. Quarter is currently the only period that has full calculation support but no membership predicate:

```
               week  month  quarter  year
beginning_of_*  ✓     ✓      ✓       ✓
end_of_*        ✓     ✓      ✓       ✓
all_*           ✓     ✓      ✓       ✓
next_*          ✓     ✓      ✓       ✓
prev_*          ✓     ✓      ✓       ✓
this_*?         ✓     ✓      —       ✓
```

This PR fills in the remaining `—`.

### Example

```ruby
# Assuming Date.current is Tue, 15 Feb 2000 (Q1)
Date.new(2000, 3, 31).this_quarter?  # => true
Date.new(2000, 4, 1).this_quarter?   # => false

Time.utc(2000, 1, 1).this_quarter?      # => true
DateTime.civil(2000, 4, 1).this_quarter? # => false
```

Behavior is consistent with `this_month?` / `this_year?`: membership is evaluated against `Date.current`, so it respects `Time.zone` the same way the existing predicates do.

### Motivation

Quarterly reporting is a common need (billing periods, OKR cycles, financial summaries), and today it requires spelling out `Date.current.all_quarter.include?(record.created_at.to_date)` by hand while the weekly/monthly/yearly equivalents each have a one-word predicate.

Discussed beforehand on the Rails forum with positive feedback and no objections:
https://discuss.rubyonrails.org/t/adding-this-quarter-to-complete-the-predicate-family/91262

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests added (`test_this_quarter` in `date_time_ext_test.rb`, covering both quarter boundaries in the same style as `test_this_month` / `test_this_year`).
- [x] CHANGELOG updated (activesupport).
