### PR TITLE
Comment ellipsis in guides examples

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1211,7 +1211,7 @@ limits, and upload options - that can be included:
 
 ```yaml
 amazon:
-  ...
+  # ...
   http_open_timeout: 0
   http_read_timeout: 0
   retry_limit: 0
@@ -1315,7 +1315,7 @@ for more information.
 ```yaml
 google:
   service: GCS
-  ...
+  # ...
   iam: true
 ```
 
@@ -1328,7 +1328,7 @@ present (e.g. local tests) and you may wish to use a non-default GSA.
 ```yaml
 google:
   service: GCS
-  ...
+  # ...
   iam: true
   gsa_email: "foobar@baz.iam.gserviceaccount.com"
 ```

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -422,12 +422,12 @@ If the resulting lines are too wide, say 200 columns or more, put the comment ab
 ```ruby
 # def self.find_by_login_and_activated(*args)
 #   options = args.extract_options!
-#   ...
+#   # ...
 # end
 self.class_eval %{
   def self.#{method_id}(*args)
     options = args.extract_options!
-    ...
+    # ...
   end
 }, __FILE__, __LINE__
 ```

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -723,12 +723,12 @@ Next, create a form so that comments can be added to an article. Render the
 underneath the `render @article.comments` line.
 
 ```erb
-...
+  <%# ... %>
   <%= render @article.comments %>
 
   <!-- Render the comments form -->
   <%= render "blorgh/comments/form" %>
-...
+  <%# ... %>
 ```
 
 Next, create the `blorgh/comments/form` partial that we just referenced. To do

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -631,9 +631,9 @@ Will output select boxes like:
 </select>
 <select name="person[birth_date(3i)]" id="person_birth_date_3i">
   <option value="1">1</option>
-  ...
+  <!-- ... -->
   <option value="21" selected="selected">21</option>
-  ...
+  <!-- ... -->
   <option value="31">31</option>
 </select>
 ```
@@ -689,7 +689,7 @@ Output:
   <option value="Midway Island">(GMT-11:00) Midway Island</option>
   <option value="Hawaii">(GMT-10:00) Hawaii</option>
   <option value="Alaska">(GMT-09:00) Alaska</option>
-  ...
+  <!-- ... -->
   <option value="Samoa">(GMT+13:00) Samoa</option>
   <option value="Tokelau Is.">(GMT+13:00) Tokelau Is.</option>
 </select>
@@ -1128,7 +1128,7 @@ The following form allows a user to create a `Person` and its associated address
 
         <%= addresses_form.label :street %>
         <%= addresses_form.text_field :street %>
-        ...
+        <!-- ... -->
       </li>
     <% end %>
   </ul>
@@ -1160,7 +1160,7 @@ Will output the following HTML:
 
         <label for="person_addresses_attributes_0_street">Street</label>
         <input type="text" name="person[addresses_attributes][0][street]" id="person_addresses_attributes_0_street">
-        ...
+        <!-- ... -->
       </li>
 
       <li>
@@ -1169,7 +1169,7 @@ Will output the following HTML:
 
         <label for="person_addresses_attributes_1_street">Street</label>
         <input type="text" name="person[addresses_attributes][1][street]" id="person_addresses_attributes_1_street">
-        ...
+        <!-- ... -->
       </li>
   </ul>
 </form>
@@ -1263,7 +1263,7 @@ destroyed. This form allows users to remove addresses:
         <%= addresses_form.checkbox :_destroy %>
         <%= addresses_form.label :kind %>
         <%= addresses_form.text_field :kind %>
-        ...
+        <!-- ... -->
       </li>
     <% end %>
   </ul>

--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -185,7 +185,7 @@ spec.homepage    = "http://example.com"
 spec.summary     = "Enhance your API endpoints"
 spec.description = "Adds common API functionality like request throttling, response caching, and automatic API documentation."
 
-...
+# ...
 
 spec.metadata["source_code_uri"] = "http://example.com"
 spec.metadata["changelog_uri"] = "http://example.com"

--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -119,6 +119,21 @@ store(dev)> Product.first
 ```
 ````
 
+### Shortening Examples
+
+If an example has a lot of lines that are irrelevant in the context, use an
+ellipsis. Comment out the ellipsis if the example is executable code:
+
+````markdown
+```ruby
+class User < ApplicationRecord
+  validates :name, presence: true
+  # ...
+end
+```
+````
+
+
 ### Code Highlighting
 
 For large examples small changes can be difficult to notice.


### PR DESCRIPTION
Copying an example should not output the plain ellipsis. This is problematic in Ruby where `...` is valid Ruby, while in other languages it will generate syntax errors.
Most ellipses are already commented out.

For output of Rails commands we can still use regular ellipsis as copying that output won't work anyway.

This also updates the guides guidelines with an example.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
