### PR TITLE
Change the order of Views and Controllers in the guides

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -66,6 +66,32 @@
         the Rails framework. This guide provides you with all you need to get
         started using Active Model classes.
 -
+  name: Routing and Controllers
+  documents:
+    -
+      name: Rails Routing from the Outside In
+      url: routing.html
+      description: >
+        The Rails router recognizes URLs and dispatches them to a controller's
+        action. This guide covers the user-facing features of Rails routing.
+        If you want to understand how to use routing in your own Rails
+        applications, start here.
+    -
+      name: Action Controller Overview
+      url: action_controller_overview.html
+      description: >
+        Action Controllers are the core of a web request in Rails.
+        This guide covers how controllers work and how they fit into the
+        request cycle of your application. Topics include accessing parameters in controller actions, using sessions and cookies, controller callbacks.
+    -
+      name: Action Controller Advanced Topics
+      url: action_controller_advanced_topics.html
+      description: >
+        This guide covers a number of advanced topics related to controllers in
+        a Rails application such as protecting against cross-site request
+        forgery, HTTP authentication, data streaming, and dealing with
+        exceptions, log filtering, and more.
+-
   name: Views
   documents:
     -
@@ -93,29 +119,6 @@
         the need to handle form control naming and its numerous attributes.
         Rails does away with this complexity by providing view helpers for
         generating form markup.
--
-  name: Controllers
-  documents:
-    -
-      name: Action Controller Overview
-      url: action_controller_overview.html
-      description: >
-        Action Controllers are the core of a web request in Rails.
-        This guide covers how controllers work and how they fit into the
-        request cycle of your application. Topics include accessing parameters in controller actions, using sessions and cookies, controller callbacks.
-    -
-      name: Action Controller Advanced Topics
-      url: action_controller_advanced_topics.html
-      description: >
-        This guide covers a number of advanced topics related to controllers in a Rails application such as protecting against cross-site request forgery, HTTP authentication, data streaming, and dealing with exceptions, log filtering, and more.
-    -
-      name: Rails Routing from the Outside In
-      url: routing.html
-      description: >
-        The Rails router recognizes URLs and dispatches them to a controller's
-        action. This guide covers the user-facing features of Rails routing.
-        If you want to understand how to use routing in your own Rails
-        applications, start here.
 -
   name: Other Components
   documents:


### PR DESCRIPTION
The guides currently mention the ActionView guides before the ActionController guides. This makes sense if the order is MVC.

However, some of the ActionView guides require knowledge of controllers and routes, whereas most of the ActionController guides can be read without knowledge of ActionView. Should we change the order and mention controllers and routing first?

Xavier proposed using the request lifecycle order: route -> controller -> view -> response.

This moves "Controllers" before "Views", renames "Controllers" to "Routing and Controllers", and moves the routing guide above the controllers guides.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
