### PR TITLE
Extend expiration of active storage blobs

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix `Cache-Control` header of files served by `DiskController`
+
+    Matches `Cache-Control` lifetime of files served by the `DiskController`
+    with the lifetime of the redirect response by
+    `ActiveStorage::Blobs::RedirectController`. This fixes an issue with
+    Safari-based browsers purging the blob from its cache before the
+
+    Fixes #57950.
+
+    *Matthias Link*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/app/controllers/concerns/active_storage/file_server.rb
+++ b/activestorage/app/controllers/concerns/active_storage/file_server.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/hash/except"
 module ActiveStorage::FileServer # :nodoc:
   private
     def serve_file(path, content_type:, disposition:)
+      expires_in ActiveStorage.service_urls_expire_in, must_revalidate: true
+
       ::Rack::Files.new(nil).serving(request, path).tap do |(status, headers, body)|
         self.status = status
         self.response_body = body

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -11,6 +11,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_equal "inline; filename=\"hello.jpg\"; filename*=UTF-8''hello.jpg", response.headers["Content-Disposition"]
     assert_equal "image/jpeg", response.headers["Content-Type"]
+    assert_equal "max-age=300, private, must-revalidate", response.headers["Cache-Control"]
     assert_equal "Hello world!", response.body
   end
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Fixes #57950.

This Pull Request has been created because images served by Active Storage break after several redisplays in Safari. This is related to the  `Cache-control` headers, as outlined by issue #57950.

### Detail

This Pull Request changes the default expiration of files served by the `ActiveStorage::DiskContoller` to match `ActiveStorage.service_urls_expire_in` as used by `ActiveStorage::Blobs::RedirectController`. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.