### PR TITLE
Make `ActiveSupport::ProxyLogger#silence` suppress logs

### DIFF
--- a/activesupport/lib/active_support/proxy_logger.rb
+++ b/activesupport/lib/active_support/proxy_logger.rb
@@ -24,12 +24,15 @@ module ActiveSupport
     include ::Logger::Severity
 
     def initialize(logger, level = ::Logger::DEBUG)
+      super()
       @logger = logger
       @level = ::Logger::Severity.coerce(level)
     end
 
     # Logging severity threshold (e.g. <tt>Logger::INFO</tt>).
-    attr_reader :level
+    def level
+      local_level || @level
+    end
 
     # Sets the log level; returns +severity+.
     #

--- a/activesupport/test/proxy_logger_test.rb
+++ b/activesupport/test/proxy_logger_test.rb
@@ -34,6 +34,25 @@ module ActiveSupport
       assert_equal %w(REAL-1 PROXY-1), @io.string.split("\n")
     end
 
+    def test_silence
+      @logger.silence do
+        @logger.info("SILENCED")
+        @logger.error("PASSES")
+      end
+      @logger.info("AFTER")
+
+      assert_equal %w(PASSES AFTER), @io.string.split("\n")
+    end
+
+    def test_silence_only_affects_the_receiver
+      other = ProxyLogger.new(@real_logger)
+      @logger.silence do
+        other.info("OTHER")
+      end
+
+      assert_equal %w(OTHER), @io.string.split("\n")
+    end
+
     def test_close_and_reopen
       @logger.debug("BEFORE")
       @logger.close


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::ProxyLogger` (not yet included in any release) includes `LoggerSilence`, but calling `silence` had no effect — entries below the temporary severity were still forwarded to the underlying logger:

```ruby
proxy = ActiveSupport::ProxyLogger.new(ActiveSupport::Logger.new($stdout))
proxy.silence { proxy.info("noise") }
# Expected: nothing logged (this is what ActiveSupport::Logger does)
# Actual:   "noise" is logged
```

Rails itself calls `logger.silence` internally (for example around migrations), and the class is documented as supporting almost all of the standard Logger interface, so a proxy that ignores `silence` breaks that contract before the class ships in a release.

### Detail

`silence` on a `ProxyLogger` now suppresses entries below the temporary severity for the duration of the block, and only for the receiver — silencing one proxy does not affect other proxies sharing the same underlying logger. This matches the behavior of `ActiveSupport::Logger#silence`.

### Additional information

No CHANGELOG entry since `ProxyLogger` has not been released yet.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
