### PR TITLE
Make ActiveSupport::DateFormats @list ractor shareable

### DIFF
--- a/activesupport/lib/active_support/date_formats.rb
+++ b/activesupport/lib/active_support/date_formats.rb
@@ -8,13 +8,13 @@ module ActiveSupport
       db: "%Y-%m-%d",
       inspect: "%Y-%m-%d",
       number: "%Y%m%d",
-      long_ordinal: lambda { |date|
+      long_ordinal: ActiveSupport::Ractors.shareable_lambda { |date|
         day_format = ActiveSupport::Inflector.ordinalize(date.day)
         date.strftime("%B #{day_format}, %Y") # => "April 25th, 2007"
       },
       rfc822: "%d %b %Y",
       rfc2822: "%d %b %Y",
-      iso8601: lambda { |date| date.iso8601 }
+      iso8601: ActiveSupport::Ractors.shareable_lambda { |date| date.iso8601 }
     }.freeze
 
     singleton_class.attr_reader :list # :nodoc:


### PR DESCRIPTION
### Motivation / Background

32d830b318 made `ActiveSupport::TimeFormats` `@list` Ractor-shareable by wrapping its lambda formats with `ActiveSupport::Ractors.shareable_lambda`. `ActiveSupport::DateFormats` holds the same shape of frozen format list with two plain lambdas (`:long_ordinal` and `:iso8601`), so its list is still not shareable:

```ruby
Ractor.shareable?(ActiveSupport::TimeFormats.list) # => true
Ractor.shareable?(ActiveSupport::DateFormats.list) # => false
```

### Detail

The two lambda formats are wrapped with `ActiveSupport::Ractors.shareable_lambda`, making the whole list shareable. Format output is unchanged (`Date.new(2007, 4, 25).to_fs(:long_ordinal)` still returns `"April 25th, 2007"`).

### Additional information

Same treatment as 32d830b318 applied to the sibling module.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
