### PR TITLE
Make `remove_foreign_key(if_exists: true)` reversible

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -314,6 +314,7 @@ module ActiveRecord
           from_table, to_table = args
 
           to_table ||= options.delete(:to_table)
+          options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
 
           raise ActiveRecord::IrreversibleMigration, "remove_foreign_key is only reversible if given a second table" if to_table.nil?
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -464,6 +464,11 @@ module ActiveRecord
         assert_equal [:add_foreign_key, [:dogs, :people, column: "owner_id"]], enable
       end
 
+      def test_invert_remove_foreign_key_if_exists
+        enable = @recorder.inverse_of :remove_foreign_key, [:dogs, :people, if_exists: true]
+        assert_equal [:add_foreign_key, [:dogs, :people, if_not_exists: true]], enable
+      end
+
       def test_invert_add_foreign_key_with_column_and_name
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]
         assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"], nil], enable


### PR DESCRIPTION
Inverting `remove_foreign_key ..., if_exists: true` produced `add_foreign_key ..., if_exists: true`. `add_foreign_key` does not understand `:if_exists`, so the rollback was not idempotent.

`:if_exists` is now translated to `:if_not_exists` when inverting, matching `invert_add_foreign_key` (8d5c5bd2f5) and `invert_remove_check_constraint`.