### PR TITLE
Add support for the HTTP QUERY method

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add support for the HTTP QUERY method defined in RFC 10008.
+
+    QUERY is a safe and idempotent HTTP method that conveys the query in the
+    request content, making it suitable for queries too large or structured
+    for a URL query string:
+
+        # config/routes.rb
+        query "search", to: "search#index"
+        match "filter", to: "search#filter", via: :query
+
+        # request handling
+        request.query?                # => true
+        request.request_method_symbol # => :query
+
+        # integration tests
+        query "/search", params: { filters: { status: "active" } }, as: :json
+
+    Like GET and HEAD, QUERY requests are exempt from forgery protection:
+    HTML forms cannot emit QUERY requests, and cross-origin QUERY requests
+    always require a CORS preflight.
+
+    Note that the application server must also accept the method. For
+    example, Puma only accepts the eight standard HTTP methods by default;
+    QUERY can be enabled with its `supported_http_methods` option.
+
+    *Magno Gouveia*
+
 *   Deprecate registering and unregistering MIME types after application initialization.
 
     `Mime::Type.register`, `Mime::Type.register_alias`, and `Mime::Type.unregister` will raise

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add support for the HTTP QUERY method defined in RFC 10008.
+
+    QUERY is a safe and idempotent HTTP method that conveys the query in the
+    request content, making it suitable for queries too large or structured
+    for a URL query string:
+
+        # config/routes.rb
+        query "search", to: "search#index"
+        match "filter", to: "search#filter", via: :query
+
+        # request handling
+        request.query?                # => true
+        request.request_method_symbol # => :query
+
+        # integration tests
+        query "/search", params: { filters: { status: "active" } }, as: :json
+
+    Like GET and HEAD, QUERY requests are exempt from forgery protection:
+    HTML forms cannot emit QUERY requests, and cross-origin QUERY requests
+    always require a CORS preflight.
+
+    Note that the application server must also accept the method. For
+    example, Puma only accepts the eight standard HTTP methods by default;
+    QUERY can be enabled with its `supported_http_methods` option.
+
+    *Magno Gouveia*
+
 *   Split keyword arguments off `#args` on `Rails.application.middleware` entries.
 
     Middleware entries now expose keyword arguments through a new `#kwargs`

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -17,13 +17,15 @@
 
     Like GET and HEAD, QUERY requests are exempt from forgery protection:
     HTML forms cannot emit QUERY requests, and cross-origin QUERY requests
-    always require a CORS preflight.
+    always require a CORS preflight. The exemption applies only to requests
+    that actually arrive with the QUERY method: a `_method=query` override
+    tunneled through a form POST is verified like any other POST.
 
     Note that the application server must also accept the method. For
     example, Puma only accepts the eight standard HTTP methods by default;
     QUERY can be enabled with its `supported_http_methods` option.
 
-    *Magno Gouveia*
+    *Magno Gouveia*, *Jeremy Daer*
 
 *   Split keyword arguments off `#args` on `Rails.application.middleware` entries.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -21,6 +21,10 @@
     that actually arrive with the QUERY method: a `_method=query` override
     tunneled through a form POST is verified like any other POST.
 
+    Routes drawn with `via: :all` (and custom constraints that don't check
+    the request method) now receive QUERY requests, where previously such
+    requests were refused with a 405 before routing ran.
+
     Note that the application server must also accept the method. For
     example, Puma only accepts the eight standard HTTP methods by default;
     QUERY can be enabled with its `supported_http_methods` option.

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -140,8 +140,8 @@ module ActionController # :nodoc:
     end
 
     module ClassMethods
-      # Turn on request forgery protection. Bear in mind that GET and HEAD requests
-      # are not checked.
+      # Turn on request forgery protection. Bear in mind that GET, HEAD, and QUERY
+      # requests are not checked.
       #
       #     class ApplicationController < ActionController::Base
       #       protect_from_forgery
@@ -604,10 +604,13 @@ module ActionController # :nodoc:
       # *   `:header_only` - Uses Sec-Fetch-Site header only (default)
       # *   `:header_or_legacy_token` - Uses Sec-Fetch-Site header with fallback to token
       #
-      # For all strategies, GET and HEAD requests are allowed without verification.
+      # For all strategies, GET, HEAD, and QUERY requests are allowed without
+      # verification. HTML forms cannot issue QUERY requests, and cross-origin
+      # QUERY requests always require a CORS preflight, so they cannot be forged
+      # through a victim's browser.
       #
       def verified_request? # :doc:
-        request.get? || request.head? || !protect_against_forgery? ||
+        request.get? || request.head? || request.query? || !protect_against_forgery? ||
           (valid_request_origin? && verified_request_for_forgery_protection?)
       end
 

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -582,7 +582,7 @@ module ActionController # :nodoc:
       # GET and QUERY requests are checked for cross-origin JavaScript after
       # rendering.
       def mark_for_same_origin_verification! # :doc:
-        @_marked_for_same_origin_verification = request.get? || request.query?
+        @_marked_for_same_origin_verification = request.get? || verified_query_request?
       end
 
       # If the `verify_request_for_forgery_protection` before_action ran,
@@ -608,11 +608,23 @@ module ActionController # :nodoc:
       # For all strategies, GET, HEAD, and QUERY requests are allowed without
       # verification. HTML forms cannot issue QUERY requests, and cross-origin
       # QUERY requests always require a CORS preflight, so they cannot be forged
-      # through a victim's browser.
+      # through a victim's browser. A request tunneled through a form POST with
+      # `_method=query` does not share that protection, so it is verified like
+      # any other POST.
       #
       def verified_request? # :doc:
-        request.get? || request.head? || request.query? || !protect_against_forgery? ||
+        request.get? || request.head? || verified_query_request? || !protect_against_forgery? ||
           (valid_request_origin? && verified_request_for_forgery_protection?)
+      end
+
+      # QUERY requests are exempt from forgery protection like GET and HEAD,
+      # but only when the request actually arrived with the QUERY method. A
+      # request tunneled through POST with a `_method=query` override (as newer
+      # Rack::MethodOverride versions support) was submitted as an ordinary
+      # form POST, which the exemption's rationale — HTML forms cannot emit
+      # QUERY, and cross-origin QUERY is always preflighted — does not cover.
+      def verified_query_request? # :doc:
+        request.query? && request.method == "QUERY"
       end
 
       def verified_request_for_forgery_protection?

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -579,14 +579,15 @@ module ActionController # :nodoc:
         end
       end
 
-      # GET requests are checked for cross-origin JavaScript after rendering.
+      # GET and QUERY requests are checked for cross-origin JavaScript after
+      # rendering.
       def mark_for_same_origin_verification! # :doc:
-        @_marked_for_same_origin_verification = request.get?
+        @_marked_for_same_origin_verification = request.get? || request.query?
       end
 
       # If the `verify_request_for_forgery_protection` before_action ran,
       # verify that JavaScript responses are only served to same-origin
-      # GET requests.
+      # GET and QUERY requests.
       def marked_for_same_origin_verification? # :doc:
         @_marked_for_same_origin_verification ||= false
       end

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -470,13 +470,23 @@ module ActionController
         process(action, method: "HEAD", **args)
       end
 
+      # Simulate a QUERY request with the given parameters and set/volley the
+      # response. Params are sent as the request body, per
+      # [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008), with a default
+      # `Content-Type` of `application/x-www-form-urlencoded` (RFC 10008
+      # requires QUERY requests to declare one) — pass `as: :json` to send a
+      # JSON body instead. See `get` for more details.
+      def query(action, **args)
+        process(action, method: "QUERY", **args)
+      end
+
       # Simulate an HTTP request to `action` by specifying request method, parameters
       # and set/volley the response.
       #
       # *   `action`: The controller action to call.
       # *   `method`: Request method used to send the HTTP request. Possible values
-      #     are `GET`, `POST`, `PATCH`, `PUT`, `DELETE`, `HEAD`. Defaults to `GET`.
-      #     Can be a symbol.
+      #     are `GET`, `POST`, `PATCH`, `PUT`, `DELETE`, `HEAD`, `QUERY`. Defaults
+      #     to `GET`. Can be a symbol.
       # *   `params`: The hash with HTTP parameters that you want to pass. This may be
       #     `nil`.
       # *   `body`: The request body with a string that is appropriately encoded
@@ -499,9 +509,9 @@ module ActionController
       #       session: { user_id: 1 },
       #       flash: { notice: 'This is flash message' }
       #
-      # To simulate `GET`, `POST`, `PATCH`, `PUT`, `DELETE`, and `HEAD` requests
-      # prefer using #get, #post, #patch, #put, #delete and #head methods respectively
-      # which will make tests more expressive.
+      # To simulate `GET`, `POST`, `PATCH`, `PUT`, `DELETE`, `HEAD`, and `QUERY`
+      # requests prefer using #get, #post, #patch, #put, #delete, #head and #query
+      # methods respectively which will make tests more expressive.
       #
       # It's not recommended to make more than one request in the same test. Instance
       # variables that are set in one request will not persist to the next request,

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -129,8 +129,10 @@ module ActionDispatch
     RFC4791 = %w(MKCALENDAR).freeze
     # HTTP methods from [RFC 5789: PATCH Method for HTTP](https://www.ietf.org/rfc/rfc5789.txt)
     RFC5789 = %w(PATCH).freeze
+    # HTTP methods from [RFC 10008: The HTTP QUERY Method](https://www.ietf.org/rfc/rfc10008.txt)
+    RFC10008 = %w(QUERY).freeze
 
-    HTTP_METHODS = RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789
+    HTTP_METHODS = RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789 + RFC10008
 
     # Populate the HTTP method lookup cache.
     HTTP_METHOD_LOOKUP = HTTP_METHODS.each.with_object({}) { |method, hash|
@@ -203,6 +205,13 @@ module ActionDispatch
     # Returns a symbol form of the #request_method.
     def request_method_symbol
       HTTP_METHOD_LOOKUP[request_method]
+    end
+
+    # Checks the HTTP request method (or verb) to see if it was of type `QUERY`.
+    # QUERY is a safe and idempotent HTTP method for queries with a request body,
+    # defined in [RFC 10008: The HTTP QUERY Method](https://www.ietf.org/rfc/rfc10008.txt).
+    def query?
+      request_method == "QUERY"
     end
 
     # Returns the original value of the environment's REQUEST_METHOD, even if it was

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -478,10 +478,10 @@ module ActionDispatch
       authorization.to_s[/\ABearer (.+)\z/i, 1]
     end
 
-    # True if the request method is safe per RFC 9110 §9.2.1
-    # (GET, HEAD, OPTIONS, or TRACE).
+    # True if the request method is safe per RFC 9110 §9.2.1 (GET, HEAD,
+    # OPTIONS, or TRACE) or RFC 10008 (QUERY).
     def safe_method?
-      get? || head? || options? || trace?
+      get? || head? || query? || options? || trace?
     end
 
     # True if the request method may modify resources. Inverse of #safe_method?.

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -12,7 +12,7 @@ module ActionDispatch
       alias :conditions :constraints
 
       module VerbMatchers
-        VERBS = %w{ DELETE GET HEAD OPTIONS LINK PATCH POST PUT TRACE UNLINK }.freeze
+        VERBS = %w{ DELETE GET HEAD OPTIONS LINK PATCH POST PUT QUERY TRACE UNLINK }.freeze
         VERBS.each do |v|
           class_eval <<-eoc, __FILE__, __LINE__ + 1
             # frozen_string_literal: true

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -67,6 +67,10 @@ module ActionDispatch
     # :stopdoc: Default to 2 years as recommended on hstspreload.org.
     HSTS_EXPIRES_IN = 63072000
 
+    # QUERY is deliberately not included: 301 permits clients to rewrite the
+    # method to GET, which would drop the request body, so QUERY (like POST and
+    # other body-carrying methods) gets a 307 that preserves method and body
+    # per RFC 10008's redirect semantics.
     PERMANENT_REDIRECT_REQUEST_METHODS = %w[GET HEAD].freeze # :nodoc:
 
     def self.default_hsts_options

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -851,6 +851,17 @@ module ActionDispatch
           self
         end
 
+        # Define a route that only recognizes HTTP QUERY. QUERY is a safe and
+        # idempotent method for queries with a request body, defined in [RFC 10008:
+        # The HTTP QUERY Method](https://www.ietf.org/rfc/rfc10008.txt). For
+        # supported arguments, see [match](rdoc-ref:Base#match)
+        #
+        #     query 'bacon', to: 'food#bacon'
+        def query(*path_or_actions, as: DEFAULT, to: nil, controller: nil, action: nil, on: nil, defaults: nil, constraints: nil, anchor: nil, format: nil, path: nil, internal: nil, **mapping, &block)
+          match(*path_or_actions, as:, to:, controller:, action:, on:, defaults:, constraints:, anchor:, format:, path:, internal:, **mapping, via: :query, &block)
+          self
+        end
+
         # Define a route that only recognizes HTTP OPTIONS. For supported arguments, see
         # [match](rdoc-ref:Base#match)
         #

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -55,6 +55,12 @@ module ActionDispatch
         process(:options, path, **args)
       end
 
+      # Performs a QUERY request with the given parameters. See
+      # ActionDispatch::Integration::Session#process for more details.
+      def query(path, **args)
+        process(:query, path, **args)
+      end
+
       # Follow a single redirect response. If the last response was not a redirect, an
       # exception will be raised. Otherwise, the redirect is performed on the location
       # header. If the redirection is a 307 or 308 redirect, the same HTTP verb will

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -55,7 +55,11 @@ module ActionDispatch
         process(:options, path, **args)
       end
 
-      # Performs a QUERY request with the given parameters. See
+      # Performs a QUERY request with the given parameters. Params are sent as
+      # the request body, per [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008),
+      # with a default `Content-Type` of `application/x-www-form-urlencoded`
+      # (RFC 10008 requires QUERY requests to declare one) — pass `as: :json` or
+      # an explicit `CONTENT_TYPE` header to override. See
       # ActionDispatch::Integration::Session#process for more details.
       def query(path, **args)
         process(:query, path, **args)
@@ -394,7 +398,7 @@ module ActionDispatch
         @integration_session = nil
       end
 
-      %w(get post patch put head delete cookies assigns follow_redirect!).each do |method|
+      %w(get post patch put head delete query cookies assigns follow_redirect!).each do |method|
         # reset the html_document variable, except for cookies/assigns calls
         unless method == "cookies" || method == "assigns"
           reset_html_document = "@html_document = nil"

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -84,6 +84,13 @@ class SessionTest < ActiveSupport::TestCase
     end
   end
 
+  def test_query
+    path = "/index"; params = "blah"; headers = { location: "blah" }
+    assert_called_with @session, :process, [:query, path], params: params, headers: headers do
+      @session.query(path, params: params, headers: headers)
+    end
+  end
+
   def test_xml_http_request_get
     path = "/index"; params = "blah"; headers = { location: "blah" }
     assert_called_with @session, :process, [:get, path], params: params, headers: headers, xhr: true do
@@ -519,6 +526,14 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_query
+    with_test_route_set do
+      query "/method"
+      assert_equal 200, status
+      assert_equal "method: query", body
+    end
+  end
+
   def test_generate_url_with_controller
     assert_equal "http://www.example.com/foo", url_for(controller: "foo")
   end
@@ -652,7 +667,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
           get "moved" => redirect("/method")
 
           ActionDispatch.deprecator.silence do
-            match ":action", to: controller, via: [:get, :post], as: :action
+            match ":action", to: controller, via: [:get, :post, :query], as: :action
             get "get/:action", to: controller, as: :get_action
           end
         end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -126,6 +126,13 @@ class SessionTest < ActiveSupport::TestCase
     end
   end
 
+  def test_xml_http_request_query
+    path = "/index"; params = "blah"; headers = { location: "blah" }
+    assert_called_with @session, :process, [:query, path], params: params, headers: headers, xhr: true do
+      @session.query(path, params: params, headers: headers, xhr: true)
+    end
+  end
+
   def test_xml_http_request_head
     path = "/index"; params = "blah"; headers = { location: "blah" }
     assert_called_with @session, :process, [:head, path], params: params, headers: headers, xhr: true do
@@ -200,7 +207,7 @@ class IntegrationTestUsesCorrectClass < ActionDispatch::IntegrationTest
     reset!
     headers = { "Origin" => "*" }
 
-    %w( get post head patch put delete options ).each do |verb|
+    %w( get post head patch put delete options query ).each do |verb|
       assert_nothing_raised { __send__(verb, "/", headers: headers) }
     end
   end
@@ -265,6 +272,14 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
 
     def redirect_308
       redirect_to action_url("post"), status: 308
+    end
+
+    def redirect_303
+      redirect_to action_url("get"), status: 303
+    end
+
+    def query_params
+      render plain: "#{request.media_type}|#{request.request_parameters["foo"]}|#{request.query_parameters["foo"].inspect}"
     end
 
     def remove_header
@@ -531,6 +546,40 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       query "/method"
       assert_equal 200, status
       assert_equal "method: query", body
+    end
+  end
+
+  def test_query_sends_params_as_request_body
+    with_test_route_set do
+      query "/query_params", params: { foo: "bar" }
+      assert_response :success
+      assert_equal "application/x-www-form-urlencoded|bar|nil", response.body
+    end
+  end
+
+  def test_query_as_json
+    with_test_route_set do
+      query "/query_params", params: { foo: "bar" }, as: :json
+      assert_response :success
+      assert_equal "application/json|bar|nil", response.body
+    end
+  end
+
+  def test_307_redirect_preserves_query_verb
+    with_test_route_set do
+      query "/redirect_307"
+      assert_equal 307, status
+      follow_redirect!
+      assert_equal "QUERY", request.method
+    end
+  end
+
+  def test_303_redirect_switches_query_to_get
+    with_test_route_set do
+      query "/redirect_303"
+      assert_equal 303, status
+      follow_redirect!
+      assert_equal "GET", request.method
     end
   end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -702,6 +702,21 @@ class EtagRenderTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_query_conditional_request
+    query :fresh
+    assert_response :success
+    assert_not_nil etag = @response.etag
+
+    @request.if_none_match = etag
+    query :fresh
+    assert_response :not_modified
+    assert_predicate @response.body, :blank?
+
+    @request.if_none_match = %("nomatch")
+    query :fresh
+    assert_response :success
+  end
+
   def test_array
     @request.if_none_match = weak_etag([%w(1 2 3), "ab", :cde, [:f]])
     get :array

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -429,6 +429,10 @@ module RequestForgeryProtectionTests
     assert_not_blocked { head :index }
   end
 
+  def test_should_allow_query
+    assert_not_blocked { process :index, method: "QUERY" }
+  end
+
   def test_should_allow_post_without_token_on_unsafe_action
     assert_not_blocked { post :unsafe }
   end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -433,6 +433,11 @@ module RequestForgeryProtectionTests
     assert_not_blocked { process :index, method: "QUERY" }
   end
 
+  def test_should_allow_query_without_token_or_sec_fetch_site
+    session[:_csrf_token] = nil
+    assert_not_blocked { query :index }
+  end
+
   def test_should_allow_post_without_token_on_unsafe_action
     assert_not_blocked { post :unsafe }
   end
@@ -663,6 +668,22 @@ module RequestForgeryProtectionTests
     ensure
       ActionController::LogSubscriber.logger = old_logger
       ActionController::Base.log_warning_on_csrf_failure = true
+    end
+  end
+
+  def test_should_only_allow_same_origin_js_query_with_xhr_header
+    assert_cross_origin_blocked { query :same_origin_js }
+    assert_cross_origin_blocked { query :same_origin_js, format: "js" }
+    assert_cross_origin_blocked do
+      @request.accept = "text/javascript"
+      query :negotiate_same_origin
+    end
+
+    assert_cross_origin_not_blocked { query :same_origin_js, xhr: true }
+    assert_cross_origin_not_blocked { query :same_origin_js, xhr: true, format: "js" }
+    assert_cross_origin_not_blocked do
+      @request.accept = "text/javascript"
+      query :negotiate_same_origin, xhr: true
     end
   end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -438,6 +438,14 @@ module RequestForgeryProtectionTests
     assert_not_blocked { query :index }
   end
 
+  def test_should_not_exempt_query_tunneled_through_method_override
+    # A POST carrying _method=query (tunneled by newer Rack::MethodOverride
+    # versions) was submitted as an ordinary form POST and must be verified
+    # like one, not inherit QUERY's exemption.
+    @request.env["rack.methodoverride.original_method"] = "POST"
+    assert_blocked { query :index }
+  end
+
   def test_should_allow_post_without_token_on_unsafe_action
     assert_not_blocked { post :unsafe }
   end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -297,6 +297,25 @@ class TestCaseTest < ActionController::TestCase
     assert_equal 200, @response.status
   end
 
+  def test_query
+    query :test_params, params: { foo: "bar" }
+    assert_equal 200, @response.status
+    assert_equal "QUERY", @request.request_method
+    parsed_params = ::JSON.parse(@response.body)
+    assert_equal "bar", parsed_params["foo"]
+  end
+
+  def test_query_sends_params_as_request_body
+    query :test_request_parameters, params: { foo: "bar" }
+    assert_match "foo", @response.body
+    assert_match "bar", @response.body
+  end
+
+  def test_query_does_not_populate_query_string
+    query :test_query_parameters, params: { foo: "bar" }
+    assert_equal({}, ::JSON.parse(@response.body))
+  end
+
   def test_process_without_flash
     process :set_flash
     assert_equal "><", flash["test"]

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -102,6 +102,22 @@ module ActionDispatch
         assert_equal("PUT", fakeset.routes.first.verb)
       end
 
+      def test_query_helper
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.query "/search", to: "posts#search", as: :search
+        assert_equal("QUERY", fakeset.routes.first.verb)
+        assert_equal({ controller: "posts", action: "search" },
+                     fakeset.defaults.first)
+      end
+
+      def test_query_helper_formatted
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        mapper.query "/search", to: "posts#search", as: :search, format: true
+        assert_equal "/search.:format", fakeset.asts.first.to_s
+      end
+
       def test_to_scope
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -100,6 +100,20 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "parses JSON params for QUERY requests" do
+    with_routing do |set|
+      set.draw do
+        ActionDispatch.deprecator.silence do
+          query ":action", to: ::JsonParamsParsingTest::TestController
+        end
+      end
+
+      query "/parse", params: '{"person": {"name": "David"}}', headers: { "CONTENT_TYPE" => "application/json" }
+      assert_response :ok
+      assert_equal({ "person" => { "name" => "David" } }, TestController.last_request_parameters)
+    end
+  end
+
   private
     def assert_parses(expected, actual, headers = {})
       with_test_routing do

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -897,6 +897,22 @@ class RequestMethod < BaseRequestTest
       request.method(:POST)
     end
   end
+
+  test "QUERY method is recognized" do
+    request = stub_request("REQUEST_METHOD" => "QUERY")
+
+    assert_equal "QUERY", request.request_method
+    assert_equal :query, request.request_method_symbol
+    assert_predicate request, :query?
+    assert_not_predicate request, :get?
+    assert_not_predicate request, :post?
+  end
+
+  test "query? returns false when the request is not a QUERY" do
+    request = stub_request("REQUEST_METHOD" => "GET")
+
+    assert_not_predicate request, :query?
+  end
 end
 
 class RequestSafety < BaseRequestTest

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -913,6 +913,18 @@ class RequestMethod < BaseRequestTest
 
     assert_not_predicate request, :query?
   end
+
+  test "post masquerading as query" do
+    request = stub_request(
+      "REQUEST_METHOD" => "QUERY",
+      "rack.methodoverride.original_method" => "POST"
+    )
+
+    assert_equal "POST", request.method
+    assert_equal :post, request.method_symbol
+    assert_equal "QUERY", request.request_method
+    assert_predicate request, :query?
+  end
 end
 
 class RequestSafety < BaseRequestTest

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -916,7 +916,7 @@ class RequestMethod < BaseRequestTest
 end
 
 class RequestSafety < BaseRequestTest
-  %w[GET HEAD OPTIONS TRACE].each do |method|
+  %w[GET HEAD QUERY OPTIONS TRACE].each do |method|
     test "#{method} is a safe method" do
       request = stub_request("REQUEST_METHOD" => method)
       assert_predicate request, :safe_method?

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -354,6 +354,30 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "openid#login", @response.body
   end
 
+  def test_query
+    draw do
+      query "search", to: "search#index"
+    end
+
+    query "/search"
+    assert_equal "search#index", @response.body
+  end
+
+  def test_query_via_match
+    draw do
+      match "search", via: :query, to: "search#index"
+    end
+
+    query "/search"
+    assert_equal "search#index", @response.body
+
+    get "/search"
+    assert_equal 404, @response.status
+
+    post "/search"
+    assert_equal 404, @response.status
+  end
+
   def test_websocket
     draw do
       connect "chat/live", to: "chat#live"

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -361,6 +361,21 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
     query "/search"
     assert_equal "search#index", @response.body
+    assert_equal "/search", search_path
+  end
+
+  def test_query_route_on_collection
+    draw do
+      resources :products do
+        collection do
+          query :search
+        end
+      end
+    end
+
+    query "/products/search"
+    assert_equal "products#search", @response.body
+    assert_equal "/products/search", search_products_path
   end
 
   def test_query_via_match
@@ -4372,6 +4387,7 @@ class TestHttpMethods < ActionDispatch::IntegrationTest
   RFC5323 = %w(SEARCH).freeze
   RFC4791 = %w(MKCALENDAR).freeze
   RFC5789 = %w(PATCH).freeze
+  RFC10008 = %w(QUERY).freeze
 
   def simple_app(response)
     lambda { |env| [ 200, { "Content-Type" => "text/plain" }, [response] ] }
@@ -4385,13 +4401,13 @@ class TestHttpMethods < ActionDispatch::IntegrationTest
     @app = RoutedRackApp.new routes
 
     routes.draw do
-      (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789).each do |method|
+      (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789 + RFC10008).each do |method|
         match "/" => s.simple_app(method), :via => method.underscore.to_sym
       end
     end
   end
 
-  (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789).each do |method|
+  (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789 + RFC10008).each do |method|
     test "request method #{method.underscore} can be matched" do
       get "/", headers: { "REQUEST_METHOD" => method }
       assert_equal method, @response.body

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -378,6 +378,17 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/products/search", search_products_path
   end
 
+  def test_query_via_all
+    draw do
+      match "search", via: :all, to: "search#index"
+    end
+
+    # Previously a QUERY request was refused with a 405 before routing ran,
+    # so via: :all routes never received it.
+    query "/search"
+    assert_equal "search#index", @response.body
+  end
+
   def test_query_via_match
     draw do
       match "search", via: :query, to: "search#index"

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -65,6 +65,14 @@ class RedirectSSLTest < SSLTest
     assert_post_redirected
   end
 
+  test "http QUERY is redirected to https with status 307, preserving method and body" do
+    self.app = build_app
+
+    query "http://a/b?c=d"
+    assert_response 307
+    assert_redirected_to "https://a/b?c=d"
+  end
+
   test "redirect with custom status" do
     assert_redirected redirect: { status: 308 }
   end

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -458,6 +458,34 @@ module ActionDispatch
         assert called
       end
 
+      def test_recognize_cares_about_query_verbs
+        match "/books(/:action(.:format))", to: "foo#bar", via: :query
+
+        env = rails_env "PATH_INFO" => "/books/list.rss",
+                        "REQUEST_METHOD" => "QUERY"
+
+        called = false
+        router.recognize(env) do |r, params|
+          called = true
+        end
+
+        assert called
+      end
+
+      def test_query_verb_does_not_match_other_verbs
+        match "/books(/:action(.:format))", to: "foo#bar", via: :query
+
+        env = rails_env "PATH_INFO" => "/books/list.rss",
+                        "REQUEST_METHOD" => "GET"
+
+        called = false
+        router.recognize(env) do |r, params|
+          called = true
+        end
+
+        assert_not called
+      end
+
       def test_multi_verb_recognition
         match "/books(/:action(.:format))", to: "foo#bar", via: [:post, :get]
 

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -512,6 +512,22 @@ module ActionDispatch
         assert_not called
       end
 
+      def test_get_routes_do_not_match_query_requests
+        # The HEAD->GET fallback does not extend to QUERY: a GET route never
+        # serves a QUERY request.
+        match "/books(/:action(.:format))", to: "foo#bar", via: :get
+
+        env = rails_env "PATH_INFO" => "/books/list.rss",
+                        "REQUEST_METHOD" => "QUERY"
+
+        called = false
+        router.recognize(env) do |r, params|
+          called = true
+        end
+
+        assert_not called
+      end
+
       def test_eager_load_with_routes
         get "/foo-bar", to: "foo#bar"
         assert_nil router.eager_load!

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `current_page?` matches HTTP QUERY requests
+    ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) with
+    `method: :query`. The default `method: :get` deliberately does not match
+    QUERY.
+
+    *Jeremy Daer*
+
 *   Configuring ERB options is now to be made on the ActionView::Base class.
 
     The `ActionView::Template::Handlers::ERB` class is now private API. Applications

--- a/actionview/lib/action_view/helpers/navigation_helper.rb
+++ b/actionview/lib/action_view/helpers/navigation_helper.rb
@@ -79,6 +79,16 @@ module ActionView
       #   current_page?(controller: 'product', action: 'index', method: [:get, :post])
       #   # => true
       #
+      # The default <tt>method: :get</tt> matches GET and HEAD requests, but not
+      # other safe methods: after an HTTP QUERY request to
+      # <tt>http://www.example.com/search</tt>,
+      #
+      #   current_page?('/search')
+      #   # => false
+      #
+      #   current_page?('/search', method: :query)
+      #   # => true
+      #
       # We can also pass in the symbol arguments instead of strings.
       #
       def current_page?(options = nil, check_parameters: false, method: :get, **options_as_kwargs)

--- a/actionview/test/template/navigation_helper_test.rb
+++ b/actionview/test/template/navigation_helper_test.rb
@@ -729,6 +729,14 @@ class NavigationHelperTest < ActiveSupport::TestCase
     assert current_page?("/events", method: :post)
   end
 
+  def test_current_page_with_query_verb
+    @request = request_for_url("/search", method: :query)
+
+    assert_not current_page?("/search")
+    assert current_page?("/search", method: :query)
+    assert current_page?("/search", method: [:get, :query])
+  end
+
   def test_current_page_with_array_of_methods_including_request_method
     @request = request_for_url("/events", method: :post)
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   The database selector middleware treats HTTP QUERY requests
+    ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) as reads, routing
+    them to the replica like GET and HEAD, subject to the same
+    recent-write-window primary fallback.
+
+    *Jeremy Daer*
+
 *   Fix performance regression in `method_missing` for virtual SELECT alias
     attributes.
 

--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -49,7 +49,7 @@ module ActiveRecord
         end
 
         def reading_request?(request)
-          request.get? || request.head?
+          request.get? || request.head? || request.query?
         end
 
         private

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -298,6 +298,34 @@ module ActiveRecord
       assert_equal [200, {}, ["body"]], middleware.call("REQUEST_METHOD" => "GET")
     end
 
+    def test_the_middleware_chooses_reading_role_with_QUERY_request
+      middleware = ActiveRecord::Middleware::DatabaseSelector.new(lambda { |env|
+        assert ActiveRecord::Base.connected_to?(role: :reading)
+        [200, {}, ["body"]]
+      })
+      cache = ActiveSupport::Cache::MemoryStore.new
+      middleware = ActionDispatch::Session::CacheStore.new(middleware, cache: cache, key: "_session_id")
+
+      assert_equal [200, {}, ["body"]], middleware.call("REQUEST_METHOD" => "QUERY")
+    end
+
+    def test_the_middleware_chooses_primary_for_QUERY_request_within_the_write_window
+      roles = []
+      middleware = ActiveRecord::Middleware::DatabaseSelector.new(lambda { |env|
+        roles << (ActiveRecord::Base.connected_to?(role: :writing) ? :writing : :reading)
+        [200, {}, ["body"]]
+      })
+      cache = ActiveSupport::Cache::MemoryStore.new
+      middleware = ActionDispatch::Session::CacheStore.new(middleware, cache: cache, key: "_session_id")
+      middleware = ActionDispatch::Cookies.new(middleware)
+
+      _, headers, _ = middleware.call("REQUEST_METHOD" => "POST")
+      cookie = headers["set-cookie"]
+      middleware.call("REQUEST_METHOD" => "QUERY", "HTTP_COOKIE" => cookie)
+
+      assert_equal [:writing, :writing], roles
+    end
+
     class ReadonlyResolver < ActiveRecord::Middleware::DatabaseSelector::Resolver
       def reading_request?(request)
         true

--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -34,7 +34,10 @@ The first step to avoid this type of attack is to ensure that all "destructive"
 actions (create, update, and destroy) in your application use non-GET requests (like POST, PUT and DELETE).
 
 However, a malicious site can still send a non-GET request to your site, so
-Rails builds in request forgery protection into controllers by default.
+Rails builds in request forgery protection into controllers by default. Safe
+methods — GET, HEAD, and the HTTP QUERY method
+([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) — are exempt from this
+verification, since they must not change state.
 
 This is done by adding a token using the
 [protect_from_forgery](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery)

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -115,9 +115,12 @@ Data sent by the incoming request is available in your controller in the
 
 - Query string parameters which are sent as part of the URL (for example, after
   the `?` in `http://example.com/accounts?filter=free`).
-- POST parameters which are submitted from an HTML form.
+- Body parameters which are submitted in the request content — from an HTML
+  form POST, or from an HTTP QUERY request
+  ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)), which carries its
+  query in the request body rather than the URL.
 
-Rails does not make a distinction between query string parameters and POST
+Rails does not make a distinction between query string parameters and body
 parameters; both are available in the `params` hash in your controller. For
 example:
 
@@ -1209,7 +1212,8 @@ documentation.
 | `domain(n=2)`                             | The hostname's first `n` segments, starting from the right (the TLD).            |
 | `format`                                  | The content type requested by the client.                                        |
 | `method`                                  | The HTTP method used for the request.                                            |
-| `get?`, `post?`, `patch?`, `put?`, `delete?`, `head?` | Returns true if the HTTP method is GET/POST/PATCH/PUT/DELETE/HEAD.   |
+| `get?`, `post?`, `patch?`, `put?`, `delete?`, `head?`, `query?` | Returns true if the HTTP method is GET/POST/PATCH/PUT/DELETE/HEAD/QUERY. |
+| `safe_method?`, `unsafe_method?`          | Returns true if the HTTP method is safe (GET, HEAD, QUERY, OPTIONS, TRACE) / unsafe. |
 | `headers`                                 | Returns a hash containing the headers associated with the request.               |
 | `port`                                    | The port number (integer) used for the request.                                  |
 | `protocol`                                | Returns a string containing the protocol used plus "://", for example "http://". |
@@ -1320,3 +1324,19 @@ To get a full list of the available methods, refer to the [Rails API
 documentation](https://api.rubyonrails.org/classes/ActionDispatch/Response.html)
 and [Rack
 Documentation](https://rack.github.io/rack/main/Rack/Response.html).
+
+Handling HTTP QUERY Requests
+----------------------------
+
+The HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) is
+a safe, idempotent, cacheable method that carries its query in the request body
+instead of the URL — "GET with a body". It's useful when a query is too large,
+too structured, or too sensitive to encode in a URL's query string.
+
+Rails routes QUERY requests with the [`query`](routing.html#http-verb-constraints)
+routing helper, parses the request body into `params` based on its
+`Content-Type` (form-encoded and JSON bodies work out of the box), exempts
+QUERY from CSRF verification like GET and HEAD, and answers conditional
+requests (`fresh_when`/`stale?`) with `304 Not Modified` just as it does for
+GET. You can check for a QUERY request with `request.query?`.
+

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -557,6 +557,13 @@ When both `last_modified` and `etag` are set, the behavior depends on
 considered, as specified by RFC 7232 section 6. If it is `false`, both headers
 are checked and the response is considered fresh only if they both match.
 
+Conditional requests apply to the HTTP QUERY method
+([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) exactly as they do to
+GET: `fresh_when` and `stale?` in a QUERY action answer a matching
+`If-None-Match` with `304 Not Modified`. Note that the middleware-level
+`Rack::ConditionalGet` only handles GET and HEAD, so QUERY freshness is served
+at the controller level by these helpers.
+
 #### Strong vs. Weak ETags
 
 An ETag is a token (often a hash) that uniquely represents a particular version

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -750,13 +750,19 @@ This will define a `user_path` helper that will match `/:username` (e.g. `/jane`
 
 ### HTTP Verb Constraints
 
-In general, you should use the [`get`][], [`post`][], [`put`][], [`patch`][], and [`delete`][] methods to constrain a route to a particular verb. There is a [`match`][] method that you could use with the `:via` option to match multiple verbs at once:
+In general, you should use the [`get`][], [`post`][], [`put`][], [`patch`][], [`delete`][], and [`query`][] methods to constrain a route to a particular verb. There is a [`match`][] method that you could use with the `:via` option to match multiple verbs at once:
 
 ```ruby
 match "photos", to: "photos#show", via: [:get, :post]
 ```
 
 The above route matches GET and POST requests to the `show` action of the `PhotosController`.
+
+The [`query`][] method defines routes for the HTTP QUERY method defined in [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html), a safe and idempotent verb that conveys the query in the request body instead of the URL query string:
+
+```ruby
+query "search", to: "search#index"
+```
 
 You can match all verbs to a particular route using `via: :all`:
 
@@ -772,6 +778,7 @@ general, avoid routing all verbs to a single action unless you have a good
 reason.
 
 [`match`]: https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-match
+[`query`]: https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/HttpHelpers.html#method-i-query
 
 ### Segment Constraints
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -758,10 +758,14 @@ match "photos", to: "photos#show", via: [:get, :post]
 
 The above route matches GET and POST requests to the `show` action of the `PhotosController`.
 
-The [`query`][] method defines routes for the HTTP QUERY method defined in [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html), a safe and idempotent verb that conveys the query in the request body instead of the URL query string:
+The [`query`][] method defines routes for the HTTP QUERY method defined in [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html), a safe and idempotent verb that conveys the query in the request body instead of the URL query string. It works standalone and on resource collections and members:
 
 ```ruby
 query "search", to: "search#index"
+
+resources :products do
+  query :search, on: :collection
+end
 ```
 
 You can match all verbs to a particular route using `via: :all`:

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -592,7 +592,7 @@ An incoming GET request to `/photos/1/preview` will route to the `preview` actio
 
 Within the `member` block, each route definition specifies the HTTP verb (`get`
 in the above example with `get 'preview'`). In addition to [`get`][], you can
-use [`patch`][], [`put`][], [`post`][], or [`delete`][].
+use [`patch`][], [`put`][], [`post`][], [`delete`][], or [`query`][].
 
 If you don't have multiple `member` routes, you can also
 pass `:on` to a route, eliminating the block:

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -520,7 +520,7 @@ NOTE: _First, as is required by the W3C, use GET and POST appropriately. Secondl
 
 #### Use GET and POST Appropriately
 
-The HTTP protocol basically provides two main types of requests - GET and POST (DELETE, PUT, and PATCH should be used like POST). The World Wide Web Consortium (W3C) provides a checklist for choosing HTTP GET or POST:
+The HTTP protocol basically provides two main types of requests - GET and POST (DELETE, PUT, and PATCH should be used like POST, while QUERY — a safe, read-only method that carries its query in the request body — should be used like GET). The World Wide Web Consortium (W3C) provides a checklist for choosing HTTP GET or POST:
 
 **Use GET if:**
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -534,7 +534,7 @@ The HTTP protocol basically provides two main types of requests - GET and POST (
 
 If your web application is RESTful, you might be used to additional HTTP verbs, such as PATCH, PUT, or DELETE. Some legacy web browsers, however, do not support them - only GET and POST. Rails uses a hidden `_method` field to handle these cases.
 
-The HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)) is safe and idempotent like GET, but conveys the query in the request body. Like GET and HEAD, QUERY requests are not checked for the security token: HTML forms cannot issue QUERY requests, and cross-origin QUERY requests from scripts always require a CORS preflight. As with GET, never change state in response to a QUERY request.
+The HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)) is safe and idempotent like GET, but conveys the query in the request body. Like GET and HEAD, QUERY requests are not checked for the security token: HTML forms cannot issue QUERY requests, and cross-origin QUERY requests from scripts always require a CORS preflight. This exemption applies only to requests that actually arrive with the QUERY method: a request tunneled through a form POST with `_method=query` is verified like any other POST, since an ordinary form submission enjoys none of those structural protections. As with GET, never change state in response to a QUERY request.
 
 _POST requests can be sent automatically, too_. In this example, the link www.harmless.com is shown as the destination in the browser's status bar. But it has actually dynamically created a new form that sends a POST request.
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -534,6 +534,8 @@ The HTTP protocol basically provides two main types of requests - GET and POST (
 
 If your web application is RESTful, you might be used to additional HTTP verbs, such as PATCH, PUT, or DELETE. Some legacy web browsers, however, do not support them - only GET and POST. Rails uses a hidden `_method` field to handle these cases.
 
+The HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)) is safe and idempotent like GET, but conveys the query in the request body. Like GET and HEAD, QUERY requests are not checked for the security token: HTML forms cannot issue QUERY requests, and cross-origin QUERY requests from scripts always require a CORS preflight. As with GET, never change state in response to a QUERY request.
+
 _POST requests can be sent automatically, too_. In this example, the link www.harmless.com is shown as the destination in the browser's status bar. But it has actually dynamically created a new form that sends a POST request.
 
 ```html

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1008,7 +1008,7 @@ post articles_url, params: { article: { body: "Rails is awesome!", title: "Hello
 ### HTTP Request Types for Functional Tests
 
 If you're familiar with the HTTP protocol, you'll know that `get` is a type of
-request. There are 6 request types supported in Rails functional tests:
+request. There are 7 request types supported in Rails functional tests:
 
 * `get`
 * `post`
@@ -1016,6 +1016,19 @@ request. There are 6 request types supported in Rails functional tests:
 * `put`
 * `head`
 * `delete`
+* `query`
+
+The `query` helper issues an HTTP QUERY request
+([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) and sends `params` as
+the request body, matching how QUERY carries its query in the request content:
+
+```ruby
+test "can search articles" do
+  query articles_search_url, params: { q: "Rails" }
+
+  assert_response :success
+end
+```
 
 All of the request types have equivalent methods that you can use. In a typical
 CRUD application you'll be using `post`, `get`, `put`, and `delete` most
@@ -1032,7 +1045,7 @@ fetched from the server using asynchronous HTTP requests and the relevant parts
 of the page are updated without requiring a full page load.
 
 To test AJAX requests, you can specify the `xhr: true` option to `get`, `post`,
-`patch`, `put`, and `delete` methods. For example:
+`patch`, `put`, `delete`, and `query` methods. For example:
 
 ```ruby
 test "AJAX request" do


### PR DESCRIPTION
### Summary

Registers the HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html), June 2026, Proposed Standard) as a known HTTP method and wires it through Action Pack:

```ruby
# config/routes.rb
query "search", to: "search#index"
match "filter", to: "search#filter", via: :query

# app code
request.query?                # => true
request.request_method_symbol # => :query

# integration tests
query "/search", params: { filters: { status: "active" } }, as: :json
```

### Motivation

QUERY is registered in the [IANA HTTP Method Registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml) as safe and idempotent. It behaves like GET but carries the query in the request content, for queries too large or structured for a URL query string: complex filters, search endpoints, GraphQL, JSON-RPC.

Rails currently rejects the method before it reaches application code: `request_method` raises `ActionController::UnknownHttpMethod` (rendered as a 405), `request.get?` raises instead of returning false, and `match ..., via: :query` draws a route that can never match.

Proposed beforehand on the rails-core forum by Muhammet Dilmaç in [Proposal: Support for the HTTP QUERY method (RFC 10008)](https://discuss.rubyonrails.org/t/proposal-support-for-the-http-query-method-rfc-10008/91255); this implements that proposal. Node.js core parses QUERY since 21.7.2, nginx supports it in recent mainline, and Spring has an open PR (spring-projects/spring-framework#34993).

### Detail

* `ActionDispatch::Request`: `RFC10008` constant appended to `HTTP_METHODS`, plus a `query?` predicate (`Rack::Request::Helpers` does not define one).
* Journey: `QUERY` added to `VerbMatchers::VERBS`.
* Mapper: `query` verb helper alongside `get`/`post`/`patch`/`put`/`delete`.
* Integration tests: `query` request helper. No `ActionController::TestCase` wrapper, mirroring `options`; `process(:index, method: "QUERY")` works there.
* Forgery protection: QUERY requests are exempt, like GET and HEAD. HTML forms cannot issue QUERY requests, and cross-origin QUERY requests always require a CORS preflight (QUERY is not a CORS-safelisted method), so the forgery surface is smaller than GET's. The exemption is a self-contained hunk with its own tests and is easy to drop if a token-required default is preferred.

Body parameter parsing needs no changes: parsing is keyed on Content-Type rather than the request method, so JSON and form-encoded QUERY bodies already parse into `params`.

No behavior changes for existing applications: QUERY requests previously raised before reaching any application code, so no framework default is needed.

Out of scope here: the `Accept-Query` response header, content-based cache keys for QUERY responses (RFC 10008 §2.7), `resources` integration, method override, and a `Rack::Request#query?` upstream addition.

Note on servers: Puma only allows the eight standard methods by default and answers QUERY with a 501 unless its `supported_http_methods` option is extended. That is a deployment concern outside Rails; this change makes Rails ready for the method without changing any server behavior.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
