### PR TITLE
Require `useragent` when loading `ActionController::AllowBrowser`

### DIFF
--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -55,14 +55,14 @@ module ActionController # :nodoc:
       #       allow_browser versions: { opera: 104, chrome: 119 }, only: :show
       #     end
       def allow_browser(versions:, block: -> { render file: Rails.root.join("public/406-unsupported-browser.html"), layout: false, status: :not_acceptable }, **options)
+        require "useragent"
+
         before_action -> { allow_browser(versions: versions, block: block) }, **options
       end
     end
 
     private
       def allow_browser(versions:, block:)
-        require "useragent"
-
         if BrowserBlocker.new(request, versions: versions).blocked?
           ActiveSupport::Notifications.instrument("browser_block.action_controller", request: request, versions: versions) do
             block.is_a?(Symbol) ? send(block) : instance_exec(&block)


### PR DESCRIPTION


### Motivation / Background

While working on Ractors I noticed we require `useragent` during the first request, even in eager loaded envrionments.

### Detail

Lets require it when we load `ActionController::AllowBrowser` instead.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
