### PR TITLE
Fix `in_order_of` raising on CTE & custom attributes

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -737,7 +737,9 @@ module ActiveRecord
       else
         arel_column = order_column(column.to_s)
 
-        unless arel_column.is_a?(Arel::Nodes::SqlLiteral)
+        if arel_column.is_a?(Arel::Nodes::SqlLiteral)
+          values = values.map { |value| model.type_caster.type_cast_for_database(column, value) }
+        else
           values = cast_values_for_in_order_of(values, arel_column.type_caster)
         end
         return spawn.none! if values.empty?

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -8,6 +8,24 @@ require "models/book"
 class FieldOrderedValuesTest < ActiveRecord::TestCase
   fixtures :posts
 
+  FormatValue = Struct.new(:value)
+
+  MyType = Class.new(ActiveModel::Type::Value) do
+    def cast(value)
+      FormatValue[value]
+    end
+
+    def serialize(value)
+      return nil if value.nil?
+
+      value.is_a?(FormatValue) ? value.value : value.to_s
+    end
+  end
+
+  ActiveModel::Type.register(MyType.name.to_sym, MyType)
+
+  TYPE = MyType.new
+
   def test_in_order_of
     order = [3, 4, 1]
     posts = Post.in_order_of(:id, order)
@@ -198,6 +216,35 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
         .in_order_of(:book_format, order)
 
       assert_equal(order, books.map(&:book_format))
+    end
+
+    def test_in_order_of_with_column_from_cte_serializes_custom_attribute_values
+      model = Class.new(Book) do
+        def self.name = "BookWithSerializedFormat"
+
+        attribute :format, TYPE
+      end
+
+      model.destroy_all
+      model.create!(format: "paperback")
+      model.create!(format: "ebook")
+      model.create!(format: "hardcover")
+
+      cte = model.select(:id, :format)
+
+      order = [
+        FormatValue["hardcover"],
+        FormatValue["paperback"],
+        FormatValue["ebook"]
+      ]
+
+      books = model
+        .with(cte_books: cte)
+        .from("cte_books")
+        .select(:id, :format)
+        .in_order_of(:format, order)
+
+      assert_equal(order, books.map(&:format))
     end
   end
 end

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -8,6 +8,18 @@ require "models/book"
 class FieldOrderedValuesTest < ActiveRecord::TestCase
   fixtures :posts
 
+  FormatValue = Struct.new(:value)
+
+  class FormatType < ActiveModel::Type::Value
+    def cast(value)
+      value.is_a?(FormatValue) ? value : FormatValue[value]
+    end
+
+    def serialize(value)
+      cast(value)&.value
+    end
+  end
+
   def test_in_order_of
     order = [3, 4, 1]
     posts = Post.in_order_of(:id, order)
@@ -198,6 +210,29 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
         .in_order_of(:book_format, order)
 
       assert_equal(order, books.map(&:book_format))
+    end
+
+    def test_in_order_of_with_column_from_cte_serializes_custom_attribute_values
+      model = Class.new(Book) do
+        def self.name = "BookWithSerializedFormat"
+
+        attribute :format, FormatType.new
+      end
+
+      model.destroy_all
+      model.create!(format: "paperback")
+      model.create!(format: "ebook")
+      model.create!(format: "hardcover")
+
+      order = [FormatValue["hardcover"], FormatValue["paperback"], FormatValue["ebook"]]
+
+      books = model
+        .with(cte_books: model.select(:id, :format))
+        .from("cte_books")
+        .select(:id, :format)
+        .in_order_of(:format, order)
+
+      assert_equal(order, books.map(&:format))
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

For custom attributes we still need to call the "default" type caster so that value objects are casted to expected values.

See the new test example for an MRE.

Follow-up to https://github.com/rails/rails/pull/44746

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

### Additional information

```
Error:
FieldOrderedValuesTest#test_in_order_of_with_column_from_cte_serializes_custom_attribute_values:
TypeError: can't quote FieldOrderedValuesTest::FormatValue
    lib/active_record/connection_adapters/abstract/quoting.rb:87:in 'ActiveRecord::ConnectionAdapters::Quoting#quote'
    lib/active_record/connection_adapters/sqlite3/quoting.rb:62:in 'ActiveRecord::ConnectionAdapters::SQLite3::Quoting#quote'
    lib/arel/visitors/to_sql.rb:886:in 'Arel::Visitors::ToSql#quote'
    lib/arel/visitors/to_sql.rb:103:in 'Arel::Visitors::ToSql#visit_Arel_Nodes_Casted'
    lib/arel/visitors/visitor.rb:30:in 'Arel::Visitors::Visitor#visit'
    lib/arel/visitors/to_sql.rb:917:in 'block in Arel::Visitors::ToSql#inject_join'
    lib/arel/visitors/to_sql.rb:915:in 'Array#each'
    lib/arel/visitors/to_sql.rb:915:in 'Enumerable#each_with_index'
    lib/arel/visitors/to_sql.rb:915:in 'Arel::Visitors::ToSql#inject_join'

```

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
