### PR TITLE
Make `ActiveSupport::EventReport::LogSubscriber` ractor safe

### DIFF
--- a/activesupport/lib/active_support/event_reporter/log_subscriber.rb
+++ b/activesupport/lib/active_support/event_reporter/log_subscriber.rb
@@ -9,7 +9,7 @@ module ActiveSupport
 
       class << self
         def event_log_level(method_name, level)
-          log_levels[method_name.to_s] = level
+          self.log_levels = log_levels.merge(method_name.to_s => level).freeze
         end
 
         def logger
@@ -35,7 +35,7 @@ module ActiveSupport
         end
       end
 
-      class_attribute :log_levels, default: {} # :nodoc:
+      class_attribute :log_levels, default: {}.freeze # :nodoc:
 
       def emit(event)
         return unless logger

--- a/activesupport/test/event_reporter/log_subscriber_test.rb
+++ b/activesupport/test/event_reporter/log_subscriber_test.rb
@@ -2,8 +2,10 @@
 
 require_relative "../abstract_unit"
 require "active_support/log_subscriber/test_helper"
+require "active_support/testing/ractors_assertions"
 
 class ActiveSupport::EventReporter::LogSubscriberTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
   class MyLogSubscriber < ActiveSupport::EventReporter::LogSubscriber
     self.namespace = "test"
 
@@ -93,6 +95,10 @@ class ActiveSupport::EventReporter::LogSubscriberTest < ActiveSupport::TestCase
       ActiveSupport.event_reporter.notify("no_namespace_info_only")
       assert_equal [], @logger.logged(:info)
     end
+  end
+
+  test "MyLogSubscriber.event_log_level is ractor safe" do
+    assert_ractor_shareable MyLogSubscriber.log_levels
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

Make the `ActiveSupport::EventReport::LogSubscrib.event_log_level` api ractor safe.

### Detail

Dup, append and freeze the `log_levels` hash as we add new ones.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
