### PR TITLE
Make Normalization.normalizes ractor safe

### DIFF
--- a/activemodel/lib/active_model/attributes/normalization.rb
+++ b/activemodel/lib/active_model/attributes/normalization.rb
@@ -9,7 +9,7 @@ module ActiveModel
         include ActiveModel::Dirty
         include ActiveModel::Validations::Callbacks
 
-        class_attribute :normalized_attributes, default: Set.new
+        class_attribute :normalized_attributes, default: Set.new.freeze
 
         before_validation :normalize_changed_in_place_attributes
       end
@@ -113,7 +113,7 @@ module ActiveModel
             NormalizedValueType.new(cast_type: cast_type, normalizer: with, normalize_nil: apply_to_nil)
           end
 
-          self.normalized_attributes += names.map(&:to_sym)
+          self.normalized_attributes = (normalized_attributes + names.map(&:to_sym)).freeze
         end
 
         # Normalizes a given +value+ using normalizations declared for +name+.

--- a/activemodel/test/cases/attributes/normalization_test.rb
+++ b/activemodel/test/cases/attributes/normalization_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/testing/ractors_assertions"
 
 class NormalizedAttributeTest < ActiveModel::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   class Aircraft
     include ActiveModel::API
     include ActiveModel::Attributes
@@ -114,5 +117,9 @@ class NormalizedAttributeTest < ActiveModel::TestCase
 
     aircraft.name.replace("0")
     assert_equal "0", aircraft.name
+  end
+
+  test ".normalized_attributes is ractor safe" do
+    assert_ractor_shareable NormalizedAircraft.normalized_attributes
   end
 end


### PR DESCRIPTION
### Motivation / Background

Make adding normalized attributes ractor safe.

### Detail

Dup, append and freeze.

Note, attribute registration that this relies on is still not ractor safe, its slightly more involved. Someone will do it next week probably.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
