### PR TITLE
Construct And nodes as Nary instead of Binary

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -156,7 +156,7 @@ module ActiveRecord
         if queries.one?
           queries.first
         else
-          queries.map! { |query| query.reduce(&:and) }
+          queries.map! { |query| Arel::Nodes::And.new(query) }
           queries = Arel::Nodes::Or.new(queries)
           Arel::Nodes::Grouping.new(queries)
         end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -196,7 +196,13 @@ module ActiveRecord
         if queries.one?
           queries.first
         else
-          queries.map! { |query| query.reduce(&:and) }
+          queries.map! { |query|
+            if query.one?
+              query
+            else
+              Arel::Nodes::And.new(query)
+            end
+          }
           queries = Arel::Nodes::Or.new(queries)
           Arel::Nodes::Grouping.new(queries)
         end


### PR DESCRIPTION
Using reduce will create trees like:

```
And
  And
    And
      Query
    Query
  Query
```

Whereas this commit creates them like

```
And
  Query
  Query
  Query
```