### PR TITLE
Make `remove_index(if_exists: true)` reversible

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -275,7 +275,7 @@ module ActiveRecord
             raise ActiveRecord::IrreversibleMigration, "remove_index is only reversible if given a :column option."
           end
 
-          options.delete(:if_exists)
+          options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
 
           args = [table, columns]
           args << options unless options.empty?

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -373,6 +373,11 @@ module ActiveRecord
         assert_equal [:add_index, [:table, [:one, :two]]], add
       end
 
+      def test_invert_remove_index_if_exists
+        add = @recorder.inverse_of :remove_index, [:table, { column: [:one, :two], if_exists: true }]
+        assert_equal [:add_index, [:table, [:one, :two], if_not_exists: true]], add
+      end
+
       def test_invert_remove_index_with_no_column
         assert_raises(ActiveRecord::IrreversibleMigration) do
           @recorder.inverse_of :remove_index, [:table, name: "new_index"]


### PR DESCRIPTION
Reverting `remove_index ..., if_exists: true` produced an `add_index` with `:if_exists` silently dropped. Rolling back such a migration raised when the index already existed.

`:if_exists` is now translated to `:if_not_exists` when inverting, matching `invert_remove_foreign_key` (#57972) and `invert_remove_check_constraint`.