### PR TITLE
Quote the index name in MySQL enable_index/disable_index

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -537,7 +537,7 @@ module ActiveRecord
         raise NotImplementedError unless supports_disabling_indexes?
 
         query = <<~SQL
-          ALTER TABLE #{quote_table_name(table_name)} ALTER INDEX #{index_name} #{mariadb? ? "NOT IGNORED" : "VISIBLE"}
+          ALTER TABLE #{quote_table_name(table_name)} ALTER INDEX #{quote_column_name(index_name)} #{mariadb? ? "NOT IGNORED" : "VISIBLE"}
         SQL
         execute(query)
       end
@@ -546,7 +546,7 @@ module ActiveRecord
         raise NotImplementedError unless supports_disabling_indexes?
 
         query = <<~SQL
-          ALTER TABLE #{quote_table_name(table_name)} ALTER INDEX #{index_name} #{mariadb? ? "IGNORED" : "INVISIBLE"}
+          ALTER TABLE #{quote_table_name(table_name)} ALTER INDEX #{quote_column_name(index_name)} #{mariadb? ? "IGNORED" : "INVISIBLE"}
         SQL
         execute(query)
       end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -383,6 +383,16 @@ module ActiveRecord
 
           assert connection.index_exists?(:testings, :foo, enabled: false)
         end
+
+        def test_disable_and_enable_index_with_reserved_word_name
+          connection.add_index(:testings, :foo, name: "order")
+
+          connection.disable_index(:testings, "order")
+          assert connection.index_exists?(:testings, :foo, name: "order", enabled: false)
+
+          connection.enable_index(:testings, "order")
+          assert_not connection.index_exists?(:testings, :foo, name: "order", enabled: false)
+        end
       end
 
       private


### PR DESCRIPTION
`enable_index` and `disable_index` interpolated the index name into the `ALTER TABLE` statement without quoting. If the index name was a reserved word (e.g. `order`) or contained special characters, MySQL/MariaDB raised a syntax error:

```sql
-- Before
ALTER TABLE `testings` ALTER INDEX order VISIBLE

-- After
ALTER TABLE `testings` ALTER INDEX `order` VISIBLE
```

The name is now wrapped with `quote_column_name`, matching `rename_index` and other index operations in the adapter.