### PR TITLE
Update PostgreSQL database.yml sample in Command Line guide [ci skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -186,7 +186,7 @@ PostgreSQL option, it looks like this:
 # Install the pg driver:
 #   gem install pg
 # On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+#   gem install pg -- --with-pg-config=/opt/homebrew/bin/pg_config
 # On Windows:
 #   gem install pg
 #       Choose the win32 build.
@@ -200,7 +200,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 3 } %>
+  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 
 development:


### PR DESCRIPTION
### Motivation / Background

The Command Line guide's [Configure a Different Database](https://edgeguides.rubyonrails.org/command_line.html#configure-a-different-database) section presents the `config/database.yml` that `rails new booknotes --database=postgresql` generates, but the sample has drifted from what the generator actually produces on main. Rendered change in the guide's yaml block:

```diff
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+#   gem install pg -- --with-pg-config=/opt/homebrew/bin/pg_config
```

```diff
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 3 } %>
+  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
```

Besides being out of date, the old sample teaches the `pool:` key, which is deprecated in favor of `max_connections`.

### Detail

Updates the two drifted lines in `guides/source/command_line.md` to match the generator template ([`railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt`](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt#L6)), verified against a freshly generated app from this checkout. The pg_config path in the template moved to the Apple Silicon Homebrew prefix in 91a933a312.

### Additional information

Related: #57736 documents `max_connections` / `min_connections` in the configuring guide.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (Documentation-only change.)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. (Not needed for documentation changes.)
