### PR TITLE
Fix Guides Index flyout menu overflowing its panel

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -758,14 +758,15 @@ body.guide {
       display: flex;
       flex-direction: column;
       flex-wrap: wrap;
+      column-gap: 2em;
       max-height: 60em;
       width: 100%;
 
       .guides-section {
         flex: auto;
-        margin: 0 2em 0.5em 0;
+        margin: 0 0 0.5em 0;
         text-align: left;
-        width: 33%;
+        width: calc((100% - 4em) / 3);
 
         dt,
         dd {


### PR DESCRIPTION
### Summary

The desktop **Guides Index** flyout menu overflows its panel. The three columns are laid out with `width: 33%` plus a `2em` right margin on each `.guides-section`, which sums to more than 100% of the container. The rightmost column (Contributing / Policies / Release Notes) is pushed past the panel's right edge, so long links like "Installing Rails Core Development Dependencies" spill outside the box.

### Fix

Move the inter-column spacing to `column-gap` and size each section with `calc((100% - 4em) / 3)`, so the three columns plus their two gaps fill exactly 100%.

```diff
 .guides-section-container {
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
+  column-gap: 2em;
   max-height: 60em;
   width: 100%;

   .guides-section {
     flex: auto;
-    margin: 0 2em 0.5em 0;
+    margin: 0 0 0.5em 0;
     text-align: left;
-    width: 33%;
+    width: calc((100% - 4em) / 3);
```

## Before

<img width="2894" height="1646" alt="CleanShot 2026-07-04 at 12 44 26@2x" src="https://github.com/user-attachments/assets/8637ed38-d74e-4ef9-8eaa-245ad0dd4126" />

## After

<img width="2784" height="1666" alt="CleanShot 2026-07-04 at 12 44 38@2x" src="https://github.com/user-attachments/assets/38c928bf-5328-4c09-ace2-7065511b1c62" />

