### PR TITLE
Make `add_index(if_not_exists: true)` reversible

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -275,7 +275,7 @@ module ActiveRecord
             raise ActiveRecord::IrreversibleMigration, "remove_index is only reversible if given a :column option."
           end
 
-          options.delete(:if_exists)
+          options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
 
           args = [table, columns]
           args << options unless options.empty?
@@ -299,6 +299,13 @@ module ActiveRecord
         def invert_change_column_null(args)
           args[2] = !args[2]
           [:change_column_null, args]
+        end
+
+        def invert_add_index(args)
+          if (options = args.last).is_a?(Hash)
+            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
+          end
+          super
         end
 
         def invert_add_foreign_key(args)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -326,6 +326,11 @@ module ActiveRecord
         assert_equal [:remove_index, [:table, :one, algorithm: :concurrently], nil], remove
       end
 
+      def test_invert_add_index_if_not_exists
+        remove = @recorder.inverse_of :add_index, [:table, :one, if_not_exists: true]
+        assert_equal [:remove_index, [:table, :one, if_exists: true], nil], remove
+      end
+
       if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
         def test_invert_add_index_with_disabled_option
           remove = @recorder.inverse_of :add_index, [:table, :one, enabled: false]
@@ -371,6 +376,11 @@ module ActiveRecord
       def test_invert_remove_index_with_no_special_options
         add = @recorder.inverse_of :remove_index, [:table, { column: [:one, :two] }]
         assert_equal [:add_index, [:table, [:one, :two]]], add
+      end
+
+      def test_invert_remove_index_if_exists
+        add = @recorder.inverse_of :remove_index, [:table, { column: [:one, :two], if_exists: true }]
+        assert_equal [:add_index, [:table, [:one, :two], if_not_exists: true]], add
       end
 
       def test_invert_remove_index_with_no_column


### PR DESCRIPTION
The migration inverters for `add_index` and `remove_index` did not translate `:if_not_exists` / `:if_exists` between each other.

Inverting `remove_index ..., if_exists: true` produced an `add_index` with `:if_exists` silently dropped. Rolling back such a migration raised when the index already existed. Inverting `add_index ..., if_not_exists: true` carried the option through to `remove_index`, which only honors `:if_exists`, so it was silently dropped and the rollback raised when the index was already absent.

`:if_exists` and `:if_not_exists` are now translated to each other when inverting, matching `invert_add_foreign_key` / `invert_remove_foreign_key` (#57972) and the corresponding `check_constraint` inverters.