### PR TITLE
Raise on ignored `if_exists` option in `change_table`'s `remove_timestamps`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -849,6 +849,7 @@ module ActiveRecord
       #
       # See {connection.remove_timestamps}[rdoc-ref:SchemaStatements#remove_timestamps]
       def remove_timestamps(**options)
+        raise_on_if_exist_options(options)
         @base.remove_timestamps(name, **options)
       end
 

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -419,6 +419,14 @@ module ActiveRecord
           end
         end
       end
+
+      def test_remove_timestamps_with_if_exists_raises_error
+        assert_raises(ArgumentError) do
+          with_change_table do |t|
+            t.remove_timestamps if_exists: true
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Inside a `change_table` block, helpers like `t.timestamps`, `t.remove`, and `t.remove_index` raise an `ArgumentError` when given `if_exists:` or `if_not_exists:` options they cannot honor. `t.remove_timestamps` was the only sibling that silently accepted and discarded the option, misleading callers into thinking it applied.

`t.remove_timestamps` now calls `raise_on_if_exist_options` like its siblings, so the unsupported option is surfaced immediately instead of being quietly ignored.