### PR TITLE
Fix color_field emitting invalid color values for strings containing a hex substring

### DIFF
--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -13,7 +13,7 @@ module ActionView
 
         private
           def validate_color_string(string)
-            regex = /#[0-9a-fA-F]{6}/
+            regex = /\A#[0-9a-fA-F]{6}\z/
             if regex.match?(string)
               string.downcase
             else

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1147,6 +1147,12 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
+  def test_color_field_with_string_containing_hex_color_substring
+    expected = %{<input id="car_color" name="car[color]" type="color" value="#000000" />}
+    @car.color = "Not a color #123456 at all"
+    assert_dom_equal(expected, color_field("car", "color"))
+  end
+
   def test_color_field_with_value_attr
     expected = %{<input id="car_color" name="car[color]" type="color" value="#00FF00" />}
     assert_dom_equal(expected, color_field("car", "color", value: "#00FF00"))


### PR DESCRIPTION
`color_field`'s `validate_color_string` matched a 6-digit hex run anywhere within the value. Strings like `"Not a color #123456 at all"` or 8-digit `"#rrggbbaa"` values passed validation and were rendered verbatim into `<input type="color">`, producing markup the browser cannot interpret as a valid color.

The regex is now anchored with `\A...\z` so only an exact `"#rrggbb"` string is accepted. Everything else falls back to `"#000000"`, matching the fallback already applied to other malformed input like `"#1234TR"`.