### PR TITLE
Match HTTP auth scheme case-insensitively for Token and Bearer

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -426,7 +426,7 @@ module ActionController
     #     RewriteRule ^(.*)$ dispatch.fcgi [E=X-HTTP_AUTHORIZATION:%{HTTP:Authorization},QSA,L]
     module Token
       TOKEN_KEY = "token="
-      TOKEN_REGEX = /^(Token|Bearer)\s+/
+      TOKEN_REGEX = /^(Token|Bearer)\s+/i
       AUTHN_PAIR_DELIMITERS = /(?:,|;|\t)/
       extend self
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -467,7 +467,7 @@ module ActionDispatch
 
     # Returns the bearer token embedded in the authorization header or nil if missing.
     def bearer_token
-      authorization.to_s[/\ABearer (.+)\z/, 1]
+      authorization.to_s[/\ABearer (.+)\z/i, 1]
     end
 
     # True if the request method is safe per RFC 9110 §9.2.1

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -105,6 +105,15 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "successful authentication request with case-insensitive scheme" do
+    ["bearer lifo", "BEARER lifo", "token lifo", "TOKEN lifo"].each do |header|
+      @request.env["HTTP_AUTHORIZATION"] = header
+      get :index
+
+      assert_response :success, "expected #{header.inspect} to authenticate"
+    end
+  end
+
   test "authentication request with tab in header" do
     @request.env["HTTP_AUTHORIZATION"] = "Token\ttoken=\"lifo\""
     get :index

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1567,6 +1567,11 @@ class RequestBearerToken < BaseRequestTest
     request = stub_request("X-HTTP_AUTHORIZATION" => "Bearer my-secret-token")
     assert_equal "my-secret-token", request.bearer_token
   end
+
+  test "bearer_token recognizes case-insensitive scheme" do
+    request = stub_request("HTTP_AUTHORIZATION" => "bearer my-secret-token")
+    assert_equal "my-secret-token", request.bearer_token
+  end
 end
 
 class RequestIfModifiedSince < BaseRequestTest


### PR DESCRIPTION
The `auth-scheme` token in an HTTP `Authorization` header is case-insensitive per RFC 9110 §11.1, and real-world clients and proxies do emit non-canonical casings such as `bearer` or `TOKEN`.

**Before:** `Token` and `Bearer` were matched case-sensitively, so `bearer abc123` parsed to no token and the request was rejected with `401`. `ActionDispatch::Request#bearer_token` likewise returned `nil` for any casing other than `Bearer`.

**After:** Both recognize the scheme regardless of case. This matches the sibling Basic scheme in the same file, which already compares case-insensitively.

The PR fixes both the controller-side `Token::TOKEN_REGEX` and `Request#bearer_token` together, so the two Bearer entry points stay consistent.