### PR TITLE
Stop HTML-escaping JSON written by Coders::JSON

### DIFF
--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def initialize(options = nil)
         @options = options ? DEFAULT_OPTIONS.merge(options) : DEFAULT_OPTIONS
-        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(options)
+        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(@options)
       end
 
       def dump(obj)

--- a/activerecord/test/cases/coders/json_test.rb
+++ b/activerecord/test/cases/coders/json_test.rb
@@ -19,6 +19,11 @@ module ActiveRecord
         coder = JSON.new(symbolize_names: true)
         assert_equal({ foo: "bar" }, coder.load('{"foo":"bar"}'))
       end
+
+      def test_dump_does_not_html_escape
+        coder = JSON.new
+        assert_equal '{"k":"<>&"}', coder.dump({ "k" => "<>&" })
+      end
     end
   end
 end


### PR DESCRIPTION
`ActiveRecord::Coders::JSON` merges `escape: false` into its default options so that HTML escaping is skipped when writing into a database column. However, the encoder was constructed with the raw `options` argument instead of the merged `@options`, so the default was never applied.

`Coders::JSON.new.dump({ "k" => "<>&" })` returned `{"k":"\u003c\u003e\u0026"}` instead of `{"k":"<>&"}`, diverging from native JSON columns and `Type::Json`. The encoder now receives the merged options, and the output matches native JSON column serialization.