### PR TITLE
Require fileutils in Cache::FileStore

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "active_support/core_ext/file/atomic"
 require "active_support/inspect_backport"
 require "active_support/core_ext/string/conversions"


### PR DESCRIPTION
`ActiveSupport::Cache::FileStore` calls `FileUtils.makedirs` and `FileUtils.rm_r` but never required `"fileutils"` itself. Under the full Rails stack this went unnoticed because another file transitively loaded the constant, but using `FileStore` in a standalone ActiveSupport process raised `NameError` on the first write or clear.

The file now requires the library it depends on.