### PR TITLE
Fix incorrect number_to_percentage default precision in docs [ci skip]

### DIFF
--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -181,7 +181,7 @@ module ActiveSupport
     #
     # [+:precision+]
     #   The level of precision, or +nil+ to preserve +number+'s precision.
-    #   Defaults to 2.
+    #   Defaults to 3.
     #
     #     number_to_percentage(12.3456789, precision: 4) # => "12.3457%"
     #     number_to_percentage(99.999, precision: 0)     # => "100%"


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because the RDoc for `number_to_percentage`
documents the wrong default for the `:precision` option. It states the option
"Defaults to 2", but percentage formatting actually defaults to a precision of 3.

The base number format default precision is 3
(`ActiveSupport::NumberHelper::NumberConverter::DEFAULTS[:format][:precision]`).
Only `:currency` overrides that to 2; the `:percentage` namespace overrides only
`:delimiter` and `:format`, so it inherits the base precision of 3. The method's
own doc examples already show three decimals
(`number_to_percentage(100) # => "100.000%"`), and the test suite asserts the same
(`number_to_percentage(100) == "100.000%"`), so the option description contradicted
both the examples directly above it and the actual behavior.

### Detail

This Pull Request changes a single line in the `number_to_percentage` documentation
in `activesupport/lib/active_support/number_helper.rb`: the `:precision` option
description now reads "Defaults to 3." instead of "Defaults to 2." The correct
"Defaults to 2." in the separate `number_to_currency` documentation is left
untouched.

```diff
     # [+:precision+]
     #   The level of precision, or +nil+ to preserve +number+'s precision.
-    #   Defaults to 2.
+    #   Defaults to 3.
     #
     #     number_to_percentage(12.3456789, precision: 4) # => "12.3457%"
```

### Additional information

Sources of truth confirming the default is 3 for percentage:

- `activesupport/lib/active_support/number_helper/number_converter.rb`:
  base `DEFAULTS[:format][:precision]` is 3; `currency` overrides it to 2; the
  `percentage` entry overrides only `:delimiter` and `:format` and therefore
  inherits 3.
- `activesupport/lib/active_support/locale/en.yml`: `number.format.precision` is 3;
  `number.currency.format.precision` is 2; `number.percentage.format` does not set
  `precision`, so it inherits 3.
- Existing tests corroborate the corrected default:
  `activesupport/test/number_helper_test.rb` and
  `activesupport/test/core_ext/numeric_ext_test.rb` both assert
  `number_to_percentage(100) == "100.000%"`.

The sibling helpers that also inherit the base default already document
"Defaults to 3." (`number_to_rounded`, `number_to_human_size`,
`number_to_human`); `number_to_percentage` was the only inconsistent one.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature. (N/A: documentation-only change; existing tests already assert the corrected default.)
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. (N/A: the template explicitly says documentation changes should not be included in the CHANGELOG.)

---

