### PR TITLE
Make Mime types ractor-shareable

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -105,7 +105,16 @@ end
 autoload :Mime, "action_dispatch/http/mime_type"
 
 ActiveSupport.on_load(:action_view) do
-  ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
   ActionView::LookupContext::DetailsKey.clear
+
+  unless ActionView::Base.default_formats
+    ActionView::Base.default_formats = previous_symbols = Mime.symbols
+    # TODO: remove in Rails 9, when late Mime::Type registration raises
+    Mime::Type.on_change do
+      if !previous_symbols.equal?(Mime.symbols) && ActionView::Base.default_formats.equal?(previous_symbols)
+        ActionView::Base.default_formats = previous_symbols = Mime.symbols
+      end
+    end
+  end
 end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `Mime::Type.register_callback`.
+
+    It was never intended as a public API and has no replacement.
+
+    *Étienne Barrié*
+
 *   Allow HTTP token authentication to require specific authentication schemes.
 
     Pass `scheme:` to `authenticate_or_request_with_http_token` (and the other

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate registering and unregistering MIME types after application initialization.
+
+    `Mime::Type.register`, `Mime::Type.register_alias`, and `Mime::Type.unregister` will raise
+    a `FrozenError` when called after application initialization in the next version of Rails.
+    Instead, register or unregister MIME types during initialization (e.g. in
+    `config/initializers/mime_types.rb` or a Railtie `initializer` block).
+
+    *Étienne Barrié*
+
 *   Deprecate `Mime::Type.register_callback`.
 
     It was never intended as a public API and has no replacement.

--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -19,7 +19,8 @@ module AbstractController
       generate_method_for_mime(mime)
     end
 
-    Mime::Type.register_callback do |mime|
+    Mime::Type.on_change do |mime, registered|
+      next unless registered
       generate_method_for_mime(mime) unless instance_methods.include?(mime.to_sym)
     end
 

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -161,7 +161,16 @@ end
 autoload :Mime, "action_dispatch/http/mime_type"
 
 ActiveSupport.on_load(:action_view) do
-  ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
   ActionView::LookupContext::DetailsKey.clear
+
+  unless ActionView::Base.default_formats
+    ActionView::Base.default_formats = previous_symbols = Mime.symbols
+    # TODO: remove in Rails 9, when late Mime::Type registration raises
+    Mime::Type.on_change do
+      if !previous_symbols.equal?(Mime.symbols) && ActionView::Base.default_formats.equal?(previous_symbols)
+        ActionView::Base.default_formats = previous_symbols = Mime.symbols
+      end
+    end
+  end
 end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -188,6 +188,11 @@ module Mime
         @on_change_callbacks << block
       end
 
+      def register_callback(&block)
+        on_change { |mime, registered| block.call(mime) if registered }
+      end
+      ActionDispatch.deprecator.deprecate_methods(self, :register_callback)
+
       def lookup(string)
         lookup = Mime.lookup_by_string
         return lookup[string] if lookup.key?(string)

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -108,7 +108,7 @@ module Mime
   class Type
     attr_reader :symbol
 
-    @register_callbacks = []
+    @on_change_callbacks = []
 
     # A simple helper class used in parsing the accept header.
     class AcceptItem # :nodoc:
@@ -184,8 +184,8 @@ module Mime
       PARAMETER_SEPARATOR_REGEXP = /;\s*q="?/
       ACCEPT_HEADER_REGEXP = /[^,\s"](?:[^,"]|"[^"]*")*/
 
-      def register_callback(&block)
-        @register_callbacks << block
+      def on_change(&block) # :nodoc:
+        @on_change_callbacks << block
       end
 
       def lookup(string)
@@ -215,8 +215,8 @@ module Mime
         ([string] + mime_type_synonyms).each { |str| Mime.lookup_by_string[str] = new_mime } unless skip_lookup
         ([symbol] + extension_synonyms).each { |ext| Mime.lookup_by_extension[ext.to_s] = new_mime }
 
-        @register_callbacks.each do |callback|
-          callback.call(new_mime)
+        @on_change_callbacks.each do |callback|
+          callback.call(new_mime, true)
         end
         new_mime
       end
@@ -272,6 +272,10 @@ module Mime
           Mime.registry.delete_if { |v| v.eql?(mime) }
           Mime.lookup_by_string.delete_if { |_, v| v.eql?(mime) }
           Mime.lookup_by_extension.delete_if { |_, v| v.eql?(mime) }
+
+          @on_change_callbacks.each do |callback|
+            callback.call(mime, false)
+          end
         end
       end
     end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -5,6 +5,7 @@
 require "singleton"
 require "active_support/deprecation"
 require "action_dispatch/deprecator"
+require "active_support/core_ext/string/filters"
 
 module Mime
   class Mimes
@@ -16,6 +17,19 @@ module Mime
       @mimes = []
       @symbols = []
       @symbols_set = Set.new
+    end
+
+    def initialize_copy(_other)
+      @mimes = @mimes.dup
+      @symbols = @symbols.dup
+      @symbols_set = @symbols_set.dup
+    end
+
+    def freeze
+      @mimes.freeze
+      @symbols.freeze
+      @symbols_set.freeze
+      super
     end
 
     def each(&block)
@@ -88,6 +102,34 @@ module Mime
     def fetch(type, &block)
       return type if type.is_a?(Type)
       @lookup_by_extension.fetch(type.to_s, &block)
+    end
+
+    def eager_load! # :nodoc:
+      @registry.freeze
+      @lookup_by_string.freeze
+      @lookup_by_extension.freeze
+      nil
+    end
+
+    def update # :nodoc:
+      if @registry.frozen?
+        ActionDispatch.deprecator.warn(<<~DEPRECATION.squish)
+          Registering or unregistering a MIME type after the application has been initialized is deprecated.
+          Register custom MIME types from an initializer instead (e.g. config/initializers/mime_types.rb).
+          This will raise a FrozenError in Rails 9.0.
+        DEPRECATION
+        registry, string_lookup, extension_lookup = @registry.dup, @lookup_by_string.dup, @lookup_by_extension.dup
+        yield registry, string_lookup, extension_lookup
+        @registry = registry.freeze
+        @lookup_by_string = string_lookup.freeze
+        @lookup_by_extension = extension_lookup.freeze
+
+        SET.target = @registry
+        LOOKUP.target = @lookup_by_string
+        EXTENSION_LOOKUP.target = @lookup_by_extension
+      else
+        yield @registry, @lookup_by_string, @lookup_by_extension
+      end
     end
   end
 
@@ -216,9 +258,11 @@ module Mime
       def register(string, symbol, mime_type_synonyms = [], extension_synonyms = [], skip_lookup = false)
         new_mime = Type.new(string, symbol, mime_type_synonyms)
 
-        Mime.registry << new_mime
-        ([string] + mime_type_synonyms).each { |str| Mime.lookup_by_string[str] = new_mime } unless skip_lookup
-        ([symbol] + extension_synonyms).each { |ext| Mime.lookup_by_extension[ext.to_s] = new_mime }
+        Mime.update do |registry, string_lookup, extension_lookup|
+          registry << new_mime
+          ([string] + mime_type_synonyms).each { |str| string_lookup[-str] = new_mime } unless skip_lookup
+          ([symbol] + extension_synonyms).each { |ext| extension_lookup[-ext.to_s] = new_mime }
+        end
 
         @on_change_callbacks.each do |callback|
           callback.call(new_mime, true)
@@ -274,9 +318,11 @@ module Mime
       def unregister(symbol)
         symbol = symbol.downcase
         if mime = Mime[symbol]
-          Mime.registry.delete_if { |v| v.eql?(mime) }
-          Mime.lookup_by_string.delete_if { |_, v| v.eql?(mime) }
-          Mime.lookup_by_extension.delete_if { |_, v| v.eql?(mime) }
+          Mime.update do |registry, string_lookup, extension_lookup|
+            registry.delete_if { |v| v.eql?(mime) }
+            string_lookup.delete_if { |_, v| v.eql?(mime) }
+            extension_lookup.delete_if { |_, v| v.eql?(mime) }
+          end
 
           @on_change_callbacks.each do |callback|
             callback.call(mime, false)
@@ -294,13 +340,19 @@ module Mime
 
     class InvalidMimeType < StandardError; end
 
-    def initialize(string, symbol = nil, synonyms = [])
+    def initialize(string, symbol = nil, synonyms = nil)
       unless MIME_REGEXP.match?(string)
         raise InvalidMimeType, "#{string.inspect} is not a valid MIME type"
       end
-      @symbol, @synonyms = symbol, synonyms
-      @string = string
+      @symbol = symbol
+      @synonyms = if synonyms&.any?
+        synonyms.map { |synonym| synonym.dup.freeze }.freeze
+      else
+        [].freeze
+      end
+      @string = string.dup.freeze
       @hash = [@string, @synonyms, @symbol].hash
+      freeze
     end
 
     def to_s

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -52,6 +52,7 @@ module ActionDispatch
     config.action_dispatch.cookies_rotations = ActiveSupport::Messages::RotationConfiguration.new
 
     config.eager_load_namespaces << ActionDispatch
+    config.eager_load_namespaces << Mime
 
     guard_load_hooks(
       :action_dispatch_response, :action_dispatch_system_test_case,

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -165,14 +165,17 @@ class MimeTypeTest < ActiveSupport::TestCase
     Mime::Type.unregister(:example_api)
   end
 
-  test "register callbacks" do
-    registered_mimes = []
-    Mime::Type.register_callback do |mime|
-      registered_mimes << mime
+  test "on_change callbacks fire on register and unregister" do
+    changes = []
+    Mime::Type.on_change do |mime, registered|
+      changes << [mime, registered]
     end
 
     mime = Mime::Type.register("text/foo", :foo)
-    assert_equal [mime], registered_mimes
+    assert_equal [[mime, true]], changes
+
+    Mime::Type.unregister(:foo)
+    assert_equal [[mime, true], [mime, false]], changes
   ensure
     Mime::Type.unregister(:foo)
   end

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class MimeTypeTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
+  test "Mime::Type instances are shareable" do
+    assert_ractor_shareable Mime[:html]
+    assert_ractor_shareable Mime::ALL
+    assert_ractor_shareable Mime::Type.new("application/x-custom")
+  end
+
   test "parse single" do
     Mime.lookup_by_string.each_key do |mime_type|
       unless mime_type == "image/*"
@@ -328,13 +337,76 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   end
 
-  test "holds a reference to mime symbols" do
-    old_symbols = Mime.symbols
-    Mime::Type.register_alias "application/xhtml+xml", :foobar
-    new_symbols = Mime.symbols
+  test "Mime.symbols returns a live reference that tracks register and unregister" do
+    symbols = Mime.symbols
 
-    assert_same(old_symbols, new_symbols)
+    Mime::Type.register_alias "application/xhtml+xml", :foobar
+    assert_includes symbols, :foobar
+
+    Mime::Type.unregister(:foobar)
+    assert_not_includes symbols, :foobar
   ensure
     Mime::Type.unregister(:foobar)
+  end
+end
+
+class MimeTypeRegistryFreezeTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  include ActiveSupport::Testing::RactorsAssertions
+
+  test "after eager_load! the registries are shareable" do
+    Mime.eager_load!
+
+    assert_ractor_shareable Mime.registry
+    assert_ractor_shareable Mime.lookup_by_string
+    assert_ractor_shareable Mime.lookup_by_extension
+  end
+
+  test "registering after eager_load! is deprecated, falls back to copy-on-write, and stays shareable" do
+    Mime.eager_load!
+
+    assert_deprecated("after the application has been initialized", ActionDispatch.deprecator) do
+      Mime::Type.register("text/x-ractor", :ractor)
+    end
+
+    assert_equal Mime[:ractor], Mime::Type.lookup("text/x-ractor")
+    assert_includes Mime.symbols, :ractor
+
+    assert_ractor_shareable Mime.registry
+    assert_ractor_shareable Mime.lookup_by_string
+    assert_ractor_shareable Mime.lookup_by_extension
+  end
+
+  test "after eager_load! a reference captured before the freeze no longer tracks unregister" do
+    Mime::Type.register_alias "application/xhtml+xml", :foobar
+    captured = Mime.symbols
+    Mime.eager_load!
+
+    assert_includes captured, :foobar
+
+    assert_deprecated("after the application has been initialized", ActionDispatch.deprecator) do
+      Mime::Type.unregister(:foobar)
+    end
+
+    assert_not_includes Mime.symbols, :foobar
+    assert_includes captured, :foobar
+  end
+
+  test "deprecated Mime::SET, Mime::LOOKUP and Mime::EXTENSION_LOOKUP proxies reflect registration after eager_load!" do
+    Mime.eager_load!
+
+    assert_deprecated("after the application has been initialized", ActionDispatch.deprecator) do
+      Mime::Type.register("text/x-ractor", :ractor)
+    end
+
+    assert_deprecated("Mime::SET is deprecated", ActionDispatch.deprecator) do
+      assert_includes Mime::SET.symbols, :ractor
+    end
+    assert_deprecated("Mime::LOOKUP is deprecated", ActionDispatch.deprecator) do
+      assert_equal Mime[:ractor], Mime::LOOKUP["text/x-ractor"]
+    end
+    assert_deprecated("Mime::EXTENSION_LOOKUP is deprecated", ActionDispatch.deprecator) do
+      assert_equal Mime[:ractor], Mime::EXTENSION_LOOKUP["ractor"]
+    end
   end
 end

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -180,6 +180,21 @@ class MimeTypeTest < ActiveSupport::TestCase
     Mime::Type.unregister(:foo)
   end
 
+  test "register_callback is deprecated and only fires on register" do
+    registered_mimes = []
+    assert_deprecated("register_callback is deprecated", ActionDispatch.deprecator) do
+      Mime::Type.register_callback { |mime| registered_mimes << mime }
+    end
+
+    mime = Mime::Type.register("text/foo", :foo)
+    assert_equal [mime], registered_mimes
+
+    Mime::Type.unregister(:foo)
+    assert_equal [mime], registered_mimes
+  ensure
+    Mime::Type.unregister(:foo)
+  end
+
   test "custom type with extension aliases" do
     Mime::Type.register "text/foobar", :foobar, [], [:foo, "bar"]
     %w[foobar foo bar].each do |extension|

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -7,7 +7,7 @@ module ActionView
     # SimpleType is mostly just a stub implementation for when Action View
     # is used without Action Dispatch.
     class SimpleType # :nodoc:
-      @symbols = [ :html, :text, :js, :css, :xml, :json ]
+      @symbols = [ :html, :text, :js, :css, :xml, :json ].freeze
       class << self
         attr_reader :symbols
 
@@ -28,6 +28,7 @@ module ActionView
 
       def initialize(symbol)
         @symbol = symbol.to_sym
+        freeze
       end
 
       def to_s

--- a/actionview/test/template/types_test.rb
+++ b/actionview/test/template/types_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/testing/ractors_assertions"
+require "action_view/template/types"
+
+class ActionView::Template::SimpleTypeTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
+  test "the symbols list is shareable" do
+    assert_ractor_shareable ActionView::Template::SimpleType.symbols
+  end
+
+  test "instances are shareable" do
+    assert_ractor_shareable ActionView::Template::SimpleType[:html]
+  end
+end


### PR DESCRIPTION
When eager loading an application, freeze the Mime::Type registry (and associated indexes). Types are initialized frozen with frozen instance variables.

Registering or unregistering a MIME type after that point is now deprecated. After deprecation, `update_registries` can be removed.

Because `update_registries` replaces the registry objects when they're frozen, the deprecated Mime constant proxies are re-pointed at the new registries so they don't return stale data. This relies on a `target=` setter on DeprecatedObjectProxy.

`ActionView::Base.default_formats` shares the `Mime.symbols` array (https://github.com/rails/rails/pull/38141), so it's re-pointed the same way through `Mime::Type.on_change`
(unless it has since been replaced).