### PR TITLE
Skip HTML escaping in ActiveRecord::Coders::JSON#dump by default

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix `ActiveRecord::Coders::JSON#dump` to skip HTML escaping by default.
+
+    `Coders::JSON` builds its effective options from `DEFAULT_OPTIONS`
+    (`{ escape: false }`), but the JSON encoder was constructed from the raw
+    `options` argument, so a coder created without explicit options (the common
+    case for `serialize coder: JSON` and `store coder: JSON` on a text column)
+    still HTML-escaped the serialized JSON. The encoder now honors the merged
+    options, matching native `json`/`jsonb` column encoding.
+
+    *Anas Khan*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def initialize(options = nil)
         @options = options ? DEFAULT_OPTIONS.merge(options) : DEFAULT_OPTIONS
-        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(options)
+        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(@options)
       end
 
       def dump(obj)

--- a/activerecord/test/cases/coders/json_test.rb
+++ b/activerecord/test/cases/coders/json_test.rb
@@ -19,6 +19,17 @@ module ActiveRecord
         coder = JSON.new(symbolize_names: true)
         assert_equal({ foo: "bar" }, coder.load('{"foo":"bar"}'))
       end
+
+      def test_dump_does_not_html_escape_by_default
+        coder = JSON.new
+        assert_equal({ "html" => "<b>a & b</b>" }, coder.load(coder.dump("html" => "<b>a & b</b>")))
+        assert_equal '{"html":"<b>a & b</b>"}', coder.dump("html" => "<b>a & b</b>")
+      end
+
+      def test_dump_escapes_when_escape_option_is_true
+        coder = JSON.new(escape: true)
+        assert_equal '{"html":"\u003cb\u003ea \u0026 b\u003c/b\u003e"}', coder.dump("html" => "<b>a & b</b>")
+      end
     end
   end
 end


### PR DESCRIPTION

### Motivation / Background

`ActiveRecord::Coders::JSON` (used by `serialize coder: JSON` and
`store coder: JSON` on a plain text column) is meant to write JSON without HTML
escaping: it defines `DEFAULT_OPTIONS = { escape: false }` and merges it into the
effective options in `#initialize`. That intent came from 90616277e3 ("Skip JSON
escaping when writing into JSON columns"), which fixed the native `Type::Json`
path but slipped on the coder.

The encoder, however, is constructed from the raw `options` argument rather than
the merged `@options`. For a coder created without explicit options (the common
case) `options` is `nil`, so the encoder falls back to `escape: true` and `#dump`
still HTML-escapes the serialized JSON:

```ruby
ActiveRecord::Coders::JSON.new.dump("html" => "<b>a & b</b>")
# => "{\"html\":\"\\u003cb\\u003ea \\u0026 b\\u003c/b\\u003e\"}"   # escaped (bug)
# expected:
# => "{\"html\":\"<b>a & b</b>\"}"                                # unescaped
```

The value still round-trips (`JSON.decode` reverses the `\uXXXX` escapes, so
there is no data corruption), but it defeats the referenced optimization, bloats
the stored JSON, and makes `coder: JSON` diverge from how native `json`/`jsonb`
columns are encoded (`Type::Json#serialize` emits unescaped JSON).

### Detail

This Pull Request changes `ActiveRecord::Coders::JSON#initialize` to build the
encoder from the merged `@options` instead of the raw `options` argument:

```ruby
-        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(options)
+        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(@options)
```

`@options` already includes `DEFAULT_OPTIONS` (`{ escape: false }`) merged with
any caller-supplied options, and `#load` on the line below already uses
`@options`, so this makes `#dump` consistent with `#load` and with the coder's
declared defaults. A caller can still opt back into escaping with
`JSON.new(escape: true)`.

Two regression tests are added to
`activerecord/test/cases/coders/json_test.rb`:

- `test_dump_does_not_html_escape_by_default` - a default coder does not escape
  `<`, `>`, `&` and still round-trips through `#load`.
- `test_dump_escapes_when_escape_option_is_true` - an explicit `escape: true`
  coder still escapes, so the option is honored end to end.

A CHANGELOG entry is added to `activerecord/CHANGELOG.md` (behavior change).

### Additional information

- Root cause traced to 90616277e3, which introduced the `@options` merge on the
  line above but left the encoder reading the raw `options` argument.
- Verified locally against Ruby 4.0.5 with `json` 2.20.0 (encoder
  `ActiveSupport::JSON::Encoding::JSONGemCoderEncoder`); the fix is also correct
  for the pre-2.15.2 `JSONGemEncoder`, whose escape guard is
  `@options.fetch(:escape, true)`.
- `RED -> GREEN` confirmed: reverting only the one-line source change makes
  `test_dump_does_not_html_escape_by_default` fail (actual
  `{"html":"\u003cb\u003ea \u0026 b\u003c/b\u003e"}`); restoring it passes.
- Ran on sqlite3 with no regressions:
  `coders/json_test.rb` (5 runs), `serialized_attribute_test.rb` (105 runs,
  1 pre-existing skip), `store_test.rb` (53 runs),
  `adapters/sqlite3/json_test.rb` (29 runs), and Active Support
  `json/encoding_test.rb` (159 runs).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
