### PR TITLE
Use `Range#cover?` for `this_week?`/`this_month?`/`this_year?`

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -67,12 +67,12 @@ module DateAndTime
     # Week is assumed to start on +start_day+, default is
     # +Date.beginning_of_week+ or +config.beginning_of_week+ when set.
     def this_week?(start_day = Date.beginning_of_week)
-      ::Date.current.all_week(start_day).include?(to_date)
+      ::Date.current.all_week(start_day).cover?(to_date)
     end
 
     # Returns true if the date/time falls within the current month.
     def this_month?
-      ::Date.current.all_month.include?(to_date)
+      ::Date.current.all_month.cover?(to_date)
     end
 
     # Returns true if the date/time falls within the current quarter.
@@ -82,7 +82,7 @@ module DateAndTime
 
     # Returns true if the date/time falls within the current year.
     def this_year?
-      ::Date.current.all_year.include?(to_date)
+      ::Date.current.all_year.cover?(to_date)
     end
 
     # Returns true if the date/time falls before <tt>date_or_time</tt>.


### PR DESCRIPTION
### Summary

Follow-up to #57963, as suggested by @fatkodima.

The existing `this_week?`, `this_month?`, and `this_year?` predicates use `Range#include?`, which iterates through the range via `#succ`. Since `all_week`/`all_month`/`all_year` return Date ranges, this means `this_year?` walks ~365 dates on every call.

`Range#cover?` compares endpoints only, returning the same result 10–100x faster depending on the period. `this_quarter?` already uses `cover?` after #57963 — this brings the siblings in line.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] No test changes needed (existing boundary tests pass as-is).