### PR TITLE
Reduce allocations in Mime::Type#==

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -320,9 +320,10 @@ module Mime
 
     def ==(mime_type)
       return false unless mime_type
-      (@synonyms + [ self ]).any? do |synonym|
-        synonym.to_s == mime_type.to_s || synonym.to_sym == mime_type.to_sym
-      end
+      other_string = mime_type.to_s
+      other_symbol = mime_type.to_sym
+      @string == other_string || @symbol == other_symbol ||
+        @synonyms.any? { |synonym| synonym.to_s == other_string || synonym.to_sym == other_symbol }
     end
 
     def eql?(other)

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -198,6 +198,42 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_operator Mime[:html], :==, :html
   end
 
+  test "#== is true when compared to an equal type" do
+    assert_equal true, Mime[:json] == Mime[:json]
+  end
+
+  test "#== is true when compared to its registered string" do
+    assert_equal true, Mime[:json] == "application/json"
+  end
+
+  test "#== is true when compared to its registered symbol" do
+    assert_equal true, Mime[:json] == :json
+  end
+
+  test "#== is true when compared to a synonym string" do
+    assert_equal true, Mime[:html] == "application/xhtml+xml"
+  end
+
+  test "#== is true when compared to a synonym symbol" do
+    assert_equal true, Mime[:html] == :"application/xhtml+xml"
+  end
+
+  test "#== is false when compared to a different type" do
+    assert_equal false, Mime[:html] == Mime[:json]
+  end
+
+  test "#== is false when compared to a non-matching string" do
+    assert_equal false, Mime[:html] == "application/json"
+  end
+
+  test "#== is false when compared to a non-matching symbol" do
+    assert_equal false, Mime[:html] == :json
+  end
+
+  test "#== is false when compared to nil" do
+    assert_equal false, Mime[:html] == nil
+  end
+
   test "type convenience methods" do
     types = Mime.symbols.uniq - [:iphone]
 


### PR DESCRIPTION
### Motivation / Background

`Mime::Type#==` runs on every request during content negotiation (`respond_to`, format checks, `request.format == ...`). On each call it allocated a throwaway `@synonyms + [self]` array and recomputed the argument's `to_s`/`to_sym` once per synonym, even though those values are constant within the call.

### Detail

This Pull Request checks the type itself inline and computes the argument's string and symbol once, before iterating the synonyms.

The rewrite is behavior-preserving: _"some candidate matches A or B"_ is equivalent to _"some candidate matches A, or some candidate matches B"_, so the boolean result is identical for every input. The reproduction script below verifies this across every registered type compared against every type, its symbol, its string, and `nil` — with no divergences.

### Additional information

Microbenchmark comparing `Mime[:html]` against a mix of an equal type, its symbol, its string, and a non-matching type (released Rails, Ruby 4.0 — exact numbers vary by machine):

|        | throughput | allocations         |
| ------ | ---------- | ------------------- |
| before | 0.78M i/s  | 2.50 obj/comparison |
| after  | 2.10M i/s  | 0.25 obj/comparison |

Roughly **2.7x faster** with **~90% fewer allocations**.

Nine focused `#==` tests were added covering equality by type, string, symbol, synonym string, and synonym symbol, plus the non-matching and `nil` cases.

<details>
<summary><b>Reproduction</b> — <code>ruby bench_mime_equality.rb</code> (installs its own gems, no Gemfile needed)</summary>

```ruby
# frozen_string_literal: true
#
# Before/after benchmark for the Mime::Type#== optimization (actionpack).
# PR: https://github.com/ikraamg/rails/pull/1
#
#   $ ruby bench_mime_equality.rb        # installs its own gems, no Gemfile
#
# "before" is the Mime::Type#== that Rails ships today; "after" is the proposed
# implementation, added alongside as #eq_after. The script proves they agree on
# every input, then compares allocations and speed.

require "bundler/inline"
gemfile do
  source "https://rubygems.org"
  gem "actionpack"
  gem "benchmark-ips"
end
require "action_dispatch/http/mime_type"
require "benchmark/ips"

# Proposed implementation, added next to the shipped #== (left untouched):
# check the type itself inline and compute the argument's string/symbol once.
module Mime
  class Type
    def eq_after(other)
      return false unless other
      other_string = other.to_s
      other_symbol = other.to_sym
      @string == other_string || @symbol == other_symbol ||
        @synonyms.any? { |s| s.to_s == other_string || s.to_sym == other_symbol }
    end
  end
end

def objects_allocated
  GC.start
  GC.disable
  starting = GC.stat(:total_allocated_objects)
  yield
  GC.stat(:total_allocated_objects) - starting
ensure
  GC.enable
end

types = Mime.respond_to?(:lookup_by_string) ? Mime.lookup_by_string.values.uniq : Mime::SET.to_a

# CORRECTNESS: "after" must match the shipped #== on every input.
candidates  = types + types.map(&:to_s) + types.map(&:to_sym) + [nil]
comparisons = 0
mismatches  = []
types.each do |t|
  candidates.each do |o|
    comparisons += 1
    mismatches << [t, o] if (t == o) != t.eq_after(o)
  end
end

puts "CORRECTNESS  #{comparisons} comparisons (#{types.size} types x every type/string/symbol/nil)"
if mismatches.empty?
  puts "  ✓ 'after' matches the shipped #== on every input (0 mismatches)"
else
  puts "  ✗ #{mismatches.size} mismatches, e.g. " +
       mismatches.first(3).map { |t, o| "#{t.inspect} == #{o.inspect}" }.join(", ")
  exit 1
end

# Workload: an equal type, its symbol, its string, and a non-match -- the four
# shapes content negotiation actually compares against.
html = Mime[:html]
work = [html, :html, "text/html", Mime[:json]]
n    = 20_000
b    = objects_allocated { n.times { work.each { |o| html == o } } }.to_f / (n * work.size)
a    = objects_allocated { n.times { work.each { |o| html.eq_after(o) } } }.to_f / (n * work.size)

puts "\nALLOCATIONS (objects per comparison)"
puts "  before #{format('%.2f', b)}   after #{format('%.2f', a)}   (#{(100 * (1 - a / b)).round}% fewer)"

puts "\nSPEED"
Benchmark.ips do |x|
  x.report("before") { work.each { |o| html == o } }
  x.report("after")  { work.each { |o| html.eq_after(o) } }
  x.compare!
end
```

</details>

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG — N/A: internal optimization with no behavior or API change.
