### PR TITLE
Avoid intermediate strings for tag attributes

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -1519,7 +1519,7 @@ module ActionView
                 next if k.blank? || v.nil?
 
                 output << sep
-                output << prefix_tag_option(key, k, v, escape)
+                prefix_tag_option(output, key, k, v, escape)
               end
             elsif type == :aria && value.is_a?(Hash)
               value.each_pair do |k, v|
@@ -1536,16 +1536,16 @@ module ActionView
                 end
 
                 output << sep
-                output << prefix_tag_option(key, k, v, escape)
+                prefix_tag_option(output, key, k, v, escape)
               end
             elsif type == :boolean
               if value
                 output << sep
-                output << boolean_tag_option(key)
+                boolean_tag_option(output, key)
               end
             elsif !value.nil?
               output << sep
-              output << tag_option(key, value, escape)
+              tag_option(output, key, value, escape)
             end
           end
           output unless output.empty?
@@ -1566,11 +1566,12 @@ module ActionView
             "<#{name}#{tag_options(options, escape)}#{tag_suffix}".html_safe
           end
 
-          def boolean_tag_option(key)
-            %(#{key}="#{key}")
+          def boolean_tag_option(output, key)
+            key = key.to_s
+            output << key << '="' << key << '"'
           end
 
-          def tag_option(key, value, escape)
+          def tag_option(output, key, value, escape)
             key = ERB::Util.xml_name_escape(key) if escape
 
             case value
@@ -1584,15 +1585,15 @@ module ActionView
             end
             value = value.gsub('"', "&quot;") if value.include?('"')
 
-            %(#{key}="#{value}")
+            output << key.to_s << '="' << value << '"'
           end
 
-          def prefix_tag_option(prefix, key, value, escape)
+          def prefix_tag_option(output, prefix, key, value, escape)
             key = "#{prefix}-#{key.to_s.dasherize}"
             unless value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(BigDecimal)
               value = value.to_json
             end
-            tag_option(key, value, escape)
+            tag_option(output, key, value, escape)
           end
 
           def respond_to_missing?(*args)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -21,6 +21,37 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<span class=\"bookmark\"></span>", tag.span(class: "bookmark")
   end
 
+  def test_tag_builder_renders_multiple_attributes_in_order
+    assert_equal %(<input type="text" name="q" id="search">),
+      tag.input(type: "text", name: "q", id: "search")
+  end
+
+  def test_tag_builder_escapes_double_quotes_within_an_attribute_value
+    assert_equal %(<input value="say &quot;hi&quot;">), tag.input(value: 'say "hi"')
+  end
+
+  def test_tag_builder_renders_a_boolean_attribute_as_its_own_key
+    assert_equal %(<input required="required">), tag.input(required: true)
+  end
+
+  def test_tag_builder_renders_a_data_hash_as_dasherized_prefixed_attributes
+    assert_equal %(<div data-controller="modal" data-action="reveal"></div>),
+      tag.div(data: { controller: "modal", action: "reveal" })
+  end
+
+  def test_tag_builder_renders_an_aria_hash_as_prefixed_attributes
+    assert_equal %(<div aria-label="Close" aria-hidden="true"></div>),
+      tag.div(aria: { label: "Close", hidden: true })
+  end
+
+  def test_tag_builder_joins_an_array_class_with_spaces
+    assert_equal %(<div class="a b c"></div>), tag.div(class: ["a", "b", "c"])
+  end
+
+  def test_tag_builder_stringifies_a_symbol_attribute_value
+    assert_equal %(<input type="text">), tag.input(type: :text)
+  end
+
   def test_tag_builder_void_tag
     assert_equal "<br>", tag.br
     assert_equal "<br class=\"some_class\">", tag.br(class: "some_class")


### PR DESCRIPTION
### Motivation / Background

ActionView's tag builder renders attributes on every helper-generated tag (`tag.div`, `content_tag`, `link_to`, form fields, …). For each attribute it built a freshly interpolated `key="value"` string, appended it to the shared output buffer, and threw it away — one intermediate string allocation per attribute.

### Detail

This Pull Request appends the key and value pieces directly to the buffer in `tag_option`, `boolean_tag_option`, and `prefix_tag_option`, instead of returning a newly interpolated string. The `="` and `"` fragments are frozen string literals, so each attribute avoids one intermediate allocation. Output is byte-identical.

`boolean_tag_option` computes `key.to_s` **once** and reuses it: a boolean attribute key is usually a Symbol, and since Ruby 3.1 a Symbol in `#{...}` interpolation allocates no intermediate string (`objtostring` returns the symbol's cached frozen string), so converting it twice with `key.to_s` would *add* an allocation. Doing it once keeps that path neutral for Symbol keys and a win for String keys.

### Additional information

Allocations measured **per changed branch** (objects per attribute), `before` = the shipped original helper:

| branch | input | before | after |
| ------ | ----- | ------ | ----- |
| `boolean_tag_option` | Symbol key | 1 | 1 (neutral) |
| `boolean_tag_option` | String key | 1 | **0** |
| `tag_option` | String value | 1 | **0** |
| `tag_option` | Array `class` | 8 | **7** |
| `tag_option` | value with `"` | 2 | **1** |
| `prefix_tag_option` | `data` / `aria` | 3 | **2** |

Every changed path is neutral-or-better, and output is byte-identical (verified per branch and by the full `tag_helper_test`). The reproduction script below decomposes the measurement per branch and per input type (and shows both the naive rewrite, which regresses the Symbol-key boolean path, and the fix).

<details>
<summary><b>Reproduction (per-branch)</b> — <code>ruby bench_tag_perbranch.rb</code> (installs its own gems, no Gemfile needed)</summary>

```ruby
# frozen_string_literal: true
# Per-branch allocation benchmark for the tag-attribute PR (the decomposition we
# SHOULD have done). frozen_string_literal above is REQUIRED to match tag_helper.rb.
#   ruby bench_tag_perbranch.rb
require "bundler/inline"
gemfile { source "https://rubygems.org"; gem "actionview" }
require "action_view"
require "bigdecimal"

module ActionView
  module Helpers
    module TagHelper
      class TagBuilder
        # boolean: the PR as SHIPPED (key.to_s TWICE) vs the FIX (key.to_s once)
        def boolean_shipped(output, key)
          output << key.to_s << '="' << key.to_s << '"'
        end
        def boolean_fixed(output, key)
          key = key.to_s
          output << key << '="' << key << '"'
        end
        def tag_option_after(output, key, value, escape)
          key = ERB::Util.xml_name_escape(key) if escape
          case value
          when Array, Hash
            value = TagHelper.build_tag_values(value) if key.to_s == "class"
            value = escape ? @view_context.safe_join(value, " ") : value.join(" ")
          when Regexp
            value = escape ? ERB::Util.unwrapped_html_escape(value.source) : value.source
          else
            value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
          end
          value = value.gsub('"', "&quot;") if value.include?('"')
          output << key.to_s << '="' << value << '"'
        end
        def prefix_tag_option_after(output, prefix, key, value, escape)
          key = "#{prefix}-#{key.to_s.dasherize}"
          unless value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(BigDecimal)
            value = value.to_json
          end
          tag_option_after(output, key, value, escape)
        end
      end
    end
  end
end

def per_call(n)
  GC.start
  GC.disable
  s = GC.stat(:total_allocated_objects)
  n.times { yield }
  (GC.stat(:total_allocated_objects) - s).to_f / n
ensure
  GC.enable
end
def flag(before, after)
  after > before ? "REGRESSION +#{(after - before).round}" : (after < before ? "win -#{(before - after).round}" : "neutral")
end

view = Class.new { include ActionView::Helpers::TagHelper }.new
tb = view.tag
buf = +""
N = 100_000

puts "ruby #{RUBY_VERSION}  (frozen_string_literal: true, matching tag_helper.rb)"
puts "PER-BRANCH allocations (objects/attr). before = shipped Rails original.\n\n"

puts "boolean_tag_option:"
[[:disabled, "Symbol key"], ["disabled", "String key"]].each do |key, desc|
  orig    = per_call(N) { buf.clear; buf << tb.send(:boolean_tag_option, key) }
  shipped = per_call(N) { buf.clear; tb.boolean_shipped(buf, key) }
  fixed   = per_call(N) { buf.clear; tb.boolean_fixed(buf, key) }
  puts format("  %-11s  original %.2f   shipped-PR %.2f [%s]   FIXED %.2f [%s]",
              desc, orig, shipped, flag(orig, shipped), fixed, flag(orig, fixed))
end

puts "\ntag_option:"
[["type", "text", "String value"], ["class", %w[a b], "Array class"], ["title", 'say "hi"', "value w/ quote"]].each do |k, v, desc|
  b = per_call(N) { buf.clear; buf << tb.send(:tag_option, k, v, true) }
  a = per_call(N) { buf.clear; tb.tag_option_after(buf, k, v, true) }
  puts format("  %-16s original %.2f   after %.2f   [%s]", desc, b, a, flag(b, a))
end

puts "\nprefix_tag_option:"
[["data", "controller", "modal"], ["aria", "label", "Search"]].each do |pfx, k, v|
  b = per_call(N) { buf.clear; buf << tb.send(:prefix_tag_option, pfx, k, v, true) }
  a = per_call(N) { buf.clear; tb.prefix_tag_option_after(buf, pfx, k, v, true) }
  puts format("  %-16s original %.2f   after %.2f   [%s]", pfx, b, a, flag(b, a))
end

puts "\nCORRECTNESS (original == fixed/after output, per branch):"
cb = ->(m, *a) { (+"").tap { |s| s << tb.send(m, *a) } }
ca = ->(m, *a) { (+"").tap { |s| tb.public_send(m, s, *a) } }
{
  "boolean sym" => [cb.(:boolean_tag_option, :disabled),          ca.(:boolean_fixed, :disabled)],
  "boolean str" => [cb.(:boolean_tag_option, "disabled"),         ca.(:boolean_fixed, "disabled")],
  "tag_option"  => [cb.(:tag_option, "type", "text", true),       ca.(:tag_option_after, "type", "text", true)],
  "tag quote"   => [cb.(:tag_option, "title", 'say "hi"', true),  ca.(:tag_option_after, "title", 'say "hi"', true)],
  "prefix data" => [cb.(:prefix_tag_option, "data", "controller", "modal", true), ca.(:prefix_tag_option_after, "data", "controller", "modal", true)],
}.each { |label, (bef, aft)| puts "  #{label}: #{bef == aft ? "✓ #{aft.inspect}" : "✗ DIFF #{bef.inspect} vs #{aft.inspect}"}" }
```

</details>

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG — N/A: internal optimization with no behavior or API change.
