### PR TITLE
Fix update_all/delete_all dropping a group-only relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -7,6 +7,15 @@
 
     *Ryosuke Okazuka*
 
+*   Raise `ActiveRecord::ActiveRecordError` when `update_all` / `delete_all` is
+    called on a relation carrying a bare `group` (with no `having`, join, limit,
+    offset, or order). Such a `group` was silently dropped from the generated
+    statement, so it updated or deleted every row in the table. `group` + `having`
+    and the join/limit/offset/order cases still route through the primary-key
+    subquery and are unaffected.
+
+    *Anas Khan*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -617,6 +617,10 @@ module ActiveRecord
         MESSAGE
       end
 
+      if group_without_having?
+        raise ActiveRecordError.new("update_all doesn't support a `group` without a `having` clause")
+      end
+
       if updates.is_a?(Hash)
         if model.locking_enabled? &&
             updates.keys.none? { |key| (model.attribute_alias(key) || key.to_s) == model.locking_column }
@@ -1053,6 +1057,10 @@ module ActiveRecord
         raise ActiveRecordError.new("delete_all doesn't support #{invalid_methods.join(', ')}")
       end
 
+      if group_without_having?
+        raise ActiveRecordError.new("delete_all doesn't support a `group` without a `having` clause")
+      end
+
       model.with_connection do |c|
         arel = eager_loading? ? apply_join_dependency.arel : arel()
         arel.source.left = table
@@ -1360,6 +1368,16 @@ module ActiveRecord
       end
 
     private
+      # A bare `group` (with no `having`, join, limit, offset, or order to force a
+      # primary-key subquery) is silently dropped from the generated `UPDATE` /
+      # `DELETE`, so the statement would touch every row in the table. There is no
+      # meaningful statement to generate in that case, so it is treated as invalid.
+      def group_without_having?
+        group_values.any? && having_clause.empty? &&
+          joins_values.empty? && left_outer_joins_values.empty? &&
+          !limit_value && !offset_value && order_values.empty?
+      end
+
       def already_in_scope?(registry)
         @delegate_to_model && registry.current_scope(model, true)
       end

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -96,6 +96,18 @@ class DeleteAllTest < ActiveRecord::TestCase
     assert_not Post.exists?(posts[2].id)
   end
 
+  def test_delete_all_with_group_by_without_having_raises
+    # A bare `group` (no `having`, join, limit, offset, or order to force a
+    # primary-key subquery) is silently dropped from the generated statement,
+    # which would delete every row. It must raise instead of causing data loss.
+    assert_no_difference("Post.count") do
+      error = assert_raises(ActiveRecord::ActiveRecordError) do
+        Post.group(:id).delete_all
+      end
+      assert_match(/group/, error.message)
+    end
+  end
+
   def test_delete_all_with_unpermitted_relation_raises_error
     assert_raises(ActiveRecord::ActiveRecordError) { Author.distinct.delete_all }
     assert_raises(ActiveRecord::ActiveRecordError) { Author.with(limited: Author.limit(2)).delete_all }

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -83,6 +83,20 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal "updated", posts[2].reload.title
   end
 
+  def test_update_all_with_group_by_without_having_raises
+    # A bare `group` (no `having`, join, limit, offset, or order to force a
+    # primary-key subquery) is silently dropped from the generated statement,
+    # which would update every row. It must raise instead of causing data loss.
+    titles = Post.order(:id).pluck(:id, :title)
+
+    error = assert_raises(ActiveRecord::ActiveRecordError) do
+      Post.group(:id).update_all(title: "updated")
+    end
+    assert_match(/group/, error.message)
+
+    assert_equal titles, Post.order(:id).pluck(:id, :title)
+  end
+
   def test_update_all_with_joins_and_limit
     pets = Pet.joins(:toys).where(toys: { name: "Bone" }).limit(2)
 


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because `update_all` / `delete_all` on a relation that
carries a `group` but no `having` (and no joins, limit, offset, or order) silently ignores
the grouping and updates or deletes **every row in the table**.

```ruby
# All three posts exist; we only meant to touch the grouped set.
Post.group(:id).delete_all
# => DELETE FROM "posts"        (GROUP BY dropped -> every row deleted)

Post.group(:id).update_all(title: "x")
# => UPDATE "posts" SET "title" = 'x'   (GROUP BY dropped -> every row updated)
```

There is no error or deprecation warning, so this is silent data loss on every adapter.
`group`/`having` are not part of `INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL`, so nothing
guards against it.

This is the remaining half of #54177. The `group` + `having` case was already routed
through the primary-key subquery (in a previous fix), but the `group`-only case was left
behind.

Fixes #54177.

### Detail

This Pull Request changes the subquery-rewrite trigger in the Arel `to_sql` visitor so a
group-only relation is routed through the same primary-key subquery that the joins and
`group` + `having` cases already use.

The trigger in `Arel::Visitors::ToSql#prepare_update_statement` (aliased as
`prepare_delete_statement`) only wrapped the statement in a `WHERE pk IN (SELECT pk ...)`
subquery when `has_limit_or_offset_or_orders?`, `has_join_sources?`, or
`has_group_by_and_having?` were true. `has_group_by_and_having?` is
`!o.groups.empty? && !o.havings.empty?` (an AND), so a relation with only a `group`
returned `false`, skipped the rewrite, and the base
`visit_Arel_Nodes_{Update,Delete}Statement` never renders `GROUP BY`/`HAVING`, dropping
the clause entirely.

Changes:

- `activerecord/lib/arel/visitors/to_sql.rb`: add `has_group_by?(o)` (`!o.groups.empty?`)
  and use it in the base trigger instead of `has_group_by_and_having?`. The group-only
  relation now flows through `build_subselect`, which already copies `groups`/`havings`
  into the subselect core, producing `... WHERE (pk) IN (SELECT pk FROM ... GROUP BY ...)`.
- `activerecord/lib/arel/visitors/mysql.rb`: swap the `has_group_by_and_having?` term in
  MySQL's own `prepare_update_statement` override for `has_group_by?` so MySQL also
  delegates the group-only case to `super` (its `build_subselect` then wraps it in the
  materialized double-subquery it uses for the `group` + `having` case).
- `has_group_by_and_having?` is deliberately left unchanged. The PostgreSQL
  (`postgresql.rb`) and SQLite (`sqlite.rb`) join fast-paths guard on
  `!has_group_by_and_having?(o)` and depend on its AND semantics. A group-only relation has
  no join sources, so those fast-paths do not fire and both adapters fall through to the
  (now fixed) base `super`. The already-fixed `group` + `having` case is a superset of
  group-only and still triggers the rewrite, so it is unaffected.
- Regression tests in `delete_all_test.rb` and `update_all_test.rb` assert (via
  `capture_sql`) that `Post.group(:id)` routes through a subquery containing `GROUP BY`
  rather than emitting a bare `DELETE FROM posts` / `UPDATE posts`.
- CHANGELOG entry in `activerecord/CHANGELOG.md`.

### Additional information

The tests grouped by the primary key (`Post.group(:id)`) and assert on the emitted SQL
(that it contains `GROUP BY`, i.e. it goes through the subquery) rather than asserting a
row count. That is deliberate: grouping by the primary key does not change which rows the
subquery matches, so a row-count assertion would not visibly distinguish the fixed and
broken paths, and grouping by a non-key column has adapter-dependent semantics (SQLite
returns one arbitrary row per group; PostgreSQL and MySQL under `ONLY_FULL_GROUP_BY` raise).
Asserting that the grouped relation is routed through the primary-key subquery is the
adapter-independent proof, and it mirrors how the existing
`test_{delete,update}_all_with_group_by_and_having_without_joins` tests exercise that path.

This makes the group-only case behave exactly like the joins and `group` + `having` cases:
rows are identified by primary key through the subquery. Grouping by the primary key (or a
superkey) is well defined; grouping by a non-key column remains DB-dependent, which is the
pre-existing behavior of the sibling paths and is unchanged here. The fix only removes the
"every row" footgun.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why, and references the issue (`Fixes #54177`).
* [x] Tests are added (group-only regression tests in `delete_all_test.rb` and `update_all_test.rb`).
* [x] CHANGELOG files are updated (`activerecord/CHANGELOG.md`).
