### PR TITLE
Reset lock_version to the savepoint value after a nested savepoint rollback

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -7,6 +7,21 @@
 
     *Ryosuke Okazuka*
 
+*   Restore `lock_version` to the savepoint value after a nested savepoint rollback.
+
+    When a record with optimistic locking was saved in a transaction and then saved
+    again inside a `transaction(requires_new: true)` block that rolled back, the
+    in-memory `lock_version` was reset all the way to its pristine transaction-start
+    value instead of the value the savepoint reverted to. Saving the record again then
+    raised `ActiveRecord::StaleObjectError` because the `WHERE` clause used a
+    `lock_version` lower than the one still persisted in the database.
+
+    The locking column is now restored to the value it held when the savepoint was
+    created, which also fixes rollbacks of deeply nested and sibling savepoints. This
+    completes the fix started in #57363 and #57400.
+
+    *Anas Khan*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -139,6 +139,8 @@ module ActiveRecord
               MSG
             end
 
+            remember_locking_column_before_savepoint(lock_attribute_was)
+
             self[locking_column] += 1
 
             affected_rows = self.class._update_record(
@@ -156,6 +158,33 @@ module ActiveRecord
           rescue Exception
             @attributes[locking_column] = lock_attribute_was
             raise
+          end
+        end
+
+        # Records the locking column value as it stands just before a save that
+        # happens inside a savepoint (a +requires_new: true+ block). A savepoint
+        # rollback only reverts the row to the point where the savepoint was
+        # created, so this pre-save value, rather than the snapshot's pristine
+        # transaction-start value, is what the in-memory record must be reset to.
+        # See +restore_transaction_record_state+.
+        def remember_locking_column_before_savepoint(lock_attribute)
+          self.class.with_connection do |connection|
+            # The outermost transaction lives at depth 1 and is restored in full
+            # from the snapshot; only deeper savepoints (which roll back partially)
+            # need the intermediate value captured here.
+            depth = connection.open_transactions
+            return unless depth > 1
+
+            states = (@_optimistic_locking_savepoint_states ||= {})
+            uuid = connection.current_transaction.user_transaction.uuid
+            # Only the first bump inside a given savepoint matters. Key by depth so
+            # the rollback can find it, but track the savepoint's identity too so a
+            # fresh sibling savepoint (which reuses the depth) replaces a stale entry
+            # left behind by a committed sibling.
+            existing = states[depth]
+            if existing.nil? || existing.first != uuid
+              states[depth] = [uuid, lock_attribute.value]
+            end
           end
         end
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -401,6 +401,7 @@ module ActiveRecord
     # but call it after the commit of a destroyed object.
     def committed!(should_run_callbacks: true) # :nodoc:
       @_start_transaction_state = nil
+      @_optimistic_locking_savepoint_states = nil
       if should_run_callbacks
         @_committed_already_called = true
         _run_commit_callbacks
@@ -457,6 +458,7 @@ module ActiveRecord
       def init_internals
         super
         @_start_transaction_state = nil
+        @_optimistic_locking_savepoint_states = nil
         @_last_transaction_return_status = nil
         @_committed_already_called = nil
         @_new_record_before_last_commit = nil
@@ -486,7 +488,10 @@ module ActiveRecord
       def clear_transaction_record_state
         return unless @_start_transaction_state
         @_start_transaction_state[:level] -= 1
-        @_start_transaction_state = nil if @_start_transaction_state[:level] < 1
+        if @_start_transaction_state[:level] < 1
+          @_start_transaction_state = nil
+          @_optimistic_locking_savepoint_states = nil
+        end
       end
 
       # Restore the new record state and id of a record that was previously saved by a call to save_record_state.
@@ -531,14 +536,28 @@ module ActiveRecord
             # savepoint too. Leaving the bumped value in memory after the
             # savepoint reverts those rows raises `StaleObjectError` on the next
             # save in the surrounding transaction. Reset just the locking column
-            # so subsequent saves can match the row that the savepoint restored.
-            locking_column = self.class.locking_column
-            attr = restore_state[:attributes][locking_column]
-            if attr
-              @attributes.write_from_database(locking_column, attr.original_value)
-            end
+            # to the value the savepoint actually reverted to, which `_update_row`
+            # captured before its first bump inside this savepoint. The snapshot's
+            # `original_value` can't be used here: it holds the pristine
+            # transaction-start value, which is too low when the record was already
+            # saved in the enclosing transaction before the savepoint opened.
+            restore_locking_column_after_savepoint
           end
         end
+      end
+
+      def restore_locking_column_after_savepoint
+        states = @_optimistic_locking_savepoint_states
+        return if states.nil? || states.empty?
+
+        # `rollback_transaction` pops the savepoint off the stack before rolling
+        # its records back, so the savepoint being unwound sat one level deeper
+        # than the transaction that is now current.
+        depth = self.class.with_connection { |connection| connection.open_transactions } + 1
+        recorded = states.delete(depth)
+        return unless recorded
+
+        @attributes.write_from_database(self.class.locking_column, recorded.last)
       end
 
       # Determine if a transaction included an action for :create, :update, or :destroy. Used in filtering callbacks.

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1121,4 +1121,100 @@ class OptimisticLockingRollbackTest < ActiveRecord::TestCase
     assert_equal 1, p.lock_version
     assert_equal "after-tx", Person.find(@person.id).first_name
   end
+
+  def test_lock_version_restored_to_savepoint_value_after_nested_savepoint_rollback
+    p = Person.find(@person.id)
+    assert_equal 0, p.lock_version
+
+    Person.transaction do
+      p.update!(first_name: "outer-save")
+      assert_equal 1, p.lock_version
+
+      Person.transaction(requires_new: true) do
+        p.update!(first_name: "savepoint-save")
+        assert_equal 2, p.lock_version
+        raise ActiveRecord::Rollback
+      end
+
+      # The savepoint only reverts the row to the value it had when the savepoint
+      # was created (1, from the earlier save in this transaction), not all the way
+      # back to the pristine transaction-start value (0). The in-memory record must
+      # match that intermediate value so the next save doesn't raise
+      # `StaleObjectError` against the row the savepoint restored.
+      assert_equal 1, Person.find(@person.id).lock_version
+      assert_equal 1, p.lock_version
+      assert_not p.will_save_change_to_attribute?(:lock_version)
+      assert_nothing_raised do
+        p.update!(first_name: "after-savepoint-rollback")
+      end
+      assert_equal 2, p.lock_version
+    end
+
+    assert_equal 2, Person.find(@person.id).lock_version
+    assert_equal "after-savepoint-rollback", Person.find(@person.id).first_name
+  end
+
+  def test_lock_version_restored_after_rollback_of_multiple_nested_savepoints
+    p = Person.find(@person.id)
+    assert_equal 0, p.lock_version
+
+    Person.transaction do
+      p.update!(first_name: "outer-save")
+
+      Person.transaction(requires_new: true) do
+        p.update!(first_name: "inner-save")
+        assert_equal 2, p.lock_version
+
+        Person.transaction(requires_new: true) do
+          p.update!(first_name: "innermost-save")
+          assert_equal 3, p.lock_version
+          raise ActiveRecord::Rollback
+        end
+
+        # The innermost savepoint reverts the row to 2.
+        assert_equal 2, Person.find(@person.id).lock_version
+        assert_equal 2, p.lock_version
+        assert_nothing_raised { p.update!(first_name: "after-innermost") }
+        assert_equal 3, p.lock_version
+        raise ActiveRecord::Rollback
+      end
+
+      # The outer savepoint reverts the row to 1.
+      assert_equal 1, Person.find(@person.id).lock_version
+      assert_equal 1, p.lock_version
+      assert_nothing_raised { p.update!(first_name: "after-outer-savepoint") }
+      assert_equal 2, p.lock_version
+    end
+
+    assert_equal 2, Person.find(@person.id).lock_version
+  end
+
+  def test_lock_version_restored_after_rollback_of_sibling_savepoint
+    p = Person.find(@person.id)
+    assert_equal 0, p.lock_version
+
+    Person.transaction do
+      p.update!(first_name: "outer-save")
+
+      Person.transaction(requires_new: true) do
+        p.update!(first_name: "first-savepoint")
+        raise ActiveRecord::Rollback
+      end
+
+      assert_equal 1, p.lock_version
+
+      # A sibling savepoint that reuses the same nesting depth must still see the
+      # value the previous savepoint restored, and must not raise `StaleObjectError`.
+      Person.transaction(requires_new: true) do
+        assert_nothing_raised { p.update!(first_name: "second-savepoint") }
+        assert_equal 2, p.lock_version
+      end
+
+      assert_equal 2, p.lock_version
+      assert_nothing_raised { p.update!(first_name: "after-siblings") }
+    end
+
+    assert_equal 3, Person.find(@person.id).lock_version
+    assert_equal "after-siblings", Person.find(@person.id).first_name
+  end
 end


### PR DESCRIPTION

### Motivation / Background

Optimistic locking still raises `ActiveRecord::StaleObjectError` after a nested
savepoint rollback in a scenario the fix in #57400 (and #57363) did not cover.

When a record with a `lock_version` column is saved inside a transaction and then
saved again inside a `transaction(requires_new: true)` block that rolls back, the
in-memory `lock_version` is currently reset all the way back to its pristine
transaction-start value instead of the value the savepoint actually reverted to.

A `SAVEPOINT` only reverts the row to the state it had when the savepoint was
created. When the record was already saved once in the enclosing transaction
before the savepoint opened, the row in the database is left at that intermediate
value (for example `1`), while `restore_transaction_record_state` resets the
in-memory locking column to the snapshot's `original_value`, which is the pristine
value (`0`). The next save then builds a `WHERE ... AND lock_version = 0` clause
that matches zero rows and raises `StaleObjectError`. This is the same failure
#57400 set out to prevent, recreated in the opposite direction (the value is now
too low rather than too high).

The two regression tests added in #57400
(`test_lock_version_restored_after_savepoint_rollback` and
`..._when_outer_commits`) save the record only once, inside the savepoint, so they
exercise the full-restore `if` branch, not the nested `elsif` this bug lives in.
The multi-level path was previously untested.

Reproduction (fails on `main`):

```ruby
# lock_version starts at 0
Person.transaction do
  person.update!(first_name: "outer")          # lock_version: 0 -> 1

  Person.transaction(requires_new: true) do
    person.update!(first_name: "savepoint")    # lock_version: 1 -> 2
    raise ActiveRecord::Rollback               # row reverts to lock_version 1
  end

  # main: in-memory lock_version is reset to 0 (pristine), DB row is 1
  person.update!(first_name: "after")          # raises ActiveRecord::StaleObjectError
end
```

### Detail

This Pull Request records the locking column value as it stands just before its
first bump inside a savepoint, and restores that value (rather than the pristine
`original_value`) when the savepoint rolls back.

- `ActiveRecord::Locking::Optimistic#_update_row` now calls a new private
  `remember_locking_column_before_savepoint`. It runs only when a savepoint is
  open (`open_transactions > 1`) and stores the pre-bump locking value keyed by
  the savepoint's nesting depth. It also records the savepoint's identity
  (`current_transaction.user_transaction.uuid`) so that a fresh sibling savepoint,
  which reuses the same depth, replaces a stale entry left by a committed sibling.
  Only the first bump inside a given savepoint is captured (first-write-wins),
  because that is the value the savepoint will revert to.

- `ActiveRecord::Transactions#restore_transaction_record_state` (the savepoint
  `elsif` branch) now calls a new private `restore_locking_column_after_savepoint`,
  which writes the recorded value back to the locking column. Because
  `rollback_transaction` pops the savepoint off the stack before running
  `rollback_records`, the savepoint being unwound sat one level deeper than the
  now-current transaction, so the value is looked up at `open_transactions + 1`.

- The per-record state map is cleared alongside the existing
  `@_start_transaction_state` in `committed!`, in `clear_transaction_record_state`
  (only when the outermost transaction unwinds), and in `init_internals`, mirroring
  the lifecycle of the existing start-transaction snapshot.

This also fixes rollbacks of deeply nested savepoints and sibling savepoints.

### Additional information

- Builds on and completes the fixes in #57363 and #57400 (both merged); those
  commits are ancestors of this branch.
- Adds three regression tests to
  `activerecord/test/cases/locking_test.rb` in the existing
  `OptimisticLockingRollbackTest` class: the reported single-level case, a
  three-level deeply nested case, and a sibling-savepoint case. Each fails on
  `main` (the in-memory `lock_version` comes back too low) and passes with this
  change.
- Adds an `activerecord/CHANGELOG.md` entry.
- Verified locally against sqlite3 (Ruby 4.0.x): `locking_test.rb` 79 runs / 0
  failures, plus `transactions_test.rb`, `dirty_test.rb`, `persistence_test.rb`
  and `nested_attributes_test.rb` all green. The mysql2 / postgresql / trilogy
  adapters and RuboCop were not run locally; CI covers them.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated (three regression tests, red on `main`, green here).
- [x] CHANGELOG files are updated for the changed library (`activerecord`).
