### PR TITLE
Skip attribute materialization in LazyAttributeSet#keys

### DIFF
--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -34,8 +34,12 @@ module ActiveModel
     end
 
     def keys
-      keys = values.keys | types.keys | @attributes.keys
-      keys.keep_if { |name| self[name].initialized? }
+      names = values.keys
+      names.keep_if { |name| !@attributes.key?(name) || self[name].initialized? } unless @attributes.empty?
+      (types.keys | @attributes.keys).each do |name|
+        names << name if !values.key?(name) && self[name].initialized?
+      end
+      names
     end
 
     def fetch_value(name, &block)

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -120,6 +120,44 @@ module ActiveModel
       assert_equal [:foo], attributes.keys
     end
 
+    test "keys keeps value-present and defaulted attributes, drops uninitialized, in order" do
+      defaults = { qux: Attribute.from_user(:qux, 9, Type::Integer.new) }
+      builder = AttributeSet::Builder.new(
+        { foo: Type::Integer.new, bar: Type::Float.new, qux: Type::Integer.new }, defaults
+      )
+      attributes = builder.build_from_database(foo: "1")
+
+      assert_equal [:foo, :qux], attributes.keys
+    end
+
+    test "keys returns value-present names in values order, dropping interleaved uninitialized ones" do
+      builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Float.new, baz: Type::String.new)
+      attributes = builder.build_from_database(foo: "1", baz: "hi")
+
+      assert_equal [:foo, :baz], attributes.keys
+    end
+
+    test "keys does not materialize an attribute for value-present names" do
+      builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Integer.new)
+      attributes = builder.build_from_database(foo: "1", bar: "2")
+
+      attributes.keys
+
+      # NOTE: @attributes is the lazy materialization cache. Probing
+      # self[name].initialized? per column (the pre-optimization path) would
+      # populate it with a FromDatabase per column; staying empty proves keys
+      # allocated no Attribute for the value-present names.
+      assert_empty attributes.instance_variable_get(:@attributes)
+    end
+
+    test "keys agrees with key? when an uninitialized attribute overrides a value-present slot" do
+      builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Integer.new)
+      attributes = builder.build_from_database(foo: "1", bar: "2")
+      attributes[:foo] = Attribute.uninitialized(:foo, Type::Integer.new)
+
+      assert_equal attributes.key?(:foo), attributes.keys.include?(:foo)
+    end
+
     test "uninitialized attributes return false for key?" do
       attributes = attributes_with_uninitialized_key
       assert attributes.key?(:foo)
@@ -137,6 +175,15 @@ module ActiveModel
 
       assert_equal 1, attributes.fetch_value(:foo)
       assert_equal 2.2, attributes.fetch_value(:bar)
+    end
+
+    test "fetch_value serves a value-present name after keys has listed it" do
+      builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Float.new)
+      attributes = builder.build_from_database(foo: "1.1", bar: "2.2")
+
+      attributes.keys
+
+      assert_equal 1, attributes.fetch_value(:foo)
     end
 
     test "fetch_value returns nil for unknown attributes" do


### PR DESCRIPTION
While profiling `as_json`, I noticed `ActiveModel::LazyAttributeSet#keys` allocates an attribute object per column.

`#keys` backs `attribute_names`, and through it `as_json`, `#attributes`, and serialization. For each name it evaluates `self[name].initialized?`, and `self[name]` materializes an `Attribute::FromDatabase` for that column — so listing the keys of a freshly loaded record allocates one object per column just to check `initialized?`.

A name that has a database value is always initialized: `Attribute#initialized?` returns `true`, and only `Attribute::Uninitialized` returns `false`, which is never built for a value-present name. So those names can be kept with a `values.key?` lookup, leaving the `initialized?` probe only for the value-absent ones (defaults, virtual, uninitialized). Membership and order are unchanged, and `fetch_value` serves the kept names from its existing `@casted_values` path.

Allocations on a freshly loaded 9-column model, per record:

| | before | after |
| --- | --- | --- |
| `attribute_names` | 15 | 4 |
| `as_json` | 25 | 14 |

These are **total** allocated objects (`GC.stat(:total_allocated_objects)`), so the drop is a net saving, not a deferral. Reading the values afterwards doesn't rebuild the skipped attributes — `fetch_value` deserializes into `@casted_values` rather than materializing an `Attribute` — so the record's attribute cache stays empty after `as_json` and the avoided allocations never reappear.

The existing ActiveModel and ActiveRecord attribute/serialization/dirty suites pass unchanged.

<details>
<summary>Reproduction — <code>ruby bench.rb</code> (installs its own gems)</summary>

```ruby
# frozen_string_literal: true
RubyVM::YJIT.enable if defined?(RubyVM::YJIT)
require "bundler/inline"
gemfile do
  source "https://rubygems.org"
  gem "activerecord", "~> 8.0"
  gem "sqlite3"
end
require "active_record"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.verbose = false
ActiveRecord::Schema.define do
  create_table :posts do |t|
    t.string :title; t.text :body; t.integer :author_id; t.integer :views
    t.boolean :published; t.decimal :rating; t.timestamps
  end
end
class Post < ActiveRecord::Base; end
now = Time.now
Post.insert_all(Array.new(200) { |i|
  { title: "t#{i}", body: "b", author_id: i % 50, views: i, published: true,
    rating: 0.25, created_at: now, updated_at: now } })

module ActiveModel
  class LazyAttributeSet
    def keys_current
      keys = values.keys | types.keys | @attributes.keys
      keys.keep_if { |name| self[name].initialized? }
    end
    def keys_proposed
      names = values.keys
      (types.keys | @attributes.keys).each do |name|
        names << name if !values.key?(name) && self[name].initialized?
      end
      names
    end
  end
end
def use_keys(which) = ActiveModel::LazyAttributeSet.send(:alias_method, :keys, "keys_#{which}")

def allocs(n, op)
  recs = Post.limit(n).to_a
  GC.start; GC.disable
  s = GC.stat(:total_allocated_objects)
  recs.each(&op)
  d = GC.stat(:total_allocated_objects) - s
  GC.enable; d
end

n = 200
%i[current proposed].each do |which|
  use_keys(which)
  printf "%-9s attribute_names: %2d obj/rec   as_json: %2d obj/rec\n",
    which, allocs(n, :attribute_names) / n, allocs(n, :as_json) / n
end
```
</details>

