### PR TITLE
Fix belongs_to change tracking for composite foreign keys

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -80,11 +80,11 @@ module ActiveRecord
       end
 
       def target_changed?
-        owner.attribute_changed?(reflection.foreign_key) || (!foreign_key_present? && target&.new_record?)
+        Array(reflection.foreign_key).any? { |fk| owner.attribute_changed?(fk) } || (!foreign_key_present? && target&.new_record?)
       end
 
       def target_previously_changed?
-        owner.attribute_previously_changed?(reflection.foreign_key)
+        Array(reflection.foreign_key).any? { |fk| owner.attribute_previously_changed?(fk) }
       end
 
       def saved_change_to_target?

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1789,6 +1789,24 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_predicate comment, :author_previously_changed?
   end
 
+  test "tracking change for composite foreign key from one persisted record to another" do
+    old_order = Cpk::Order.create!(id: [1, 2])
+    new_order = Cpk::Order.create!(id: [1, 3])
+    book = Cpk::Book.create!(id: [3, 4], order: old_order)
+    book.reload
+
+    assert_not book.order_changed?
+    assert_not book.order_previously_changed?
+
+    book.order = new_order
+    assert book.order_changed?
+    assert_not book.order_previously_changed?
+
+    book.save!
+    assert_not book.order_changed?
+    assert book.order_previously_changed?
+  end
+
   class ShipRequired < ActiveRecord::Base
     self.table_name = "ships"
     belongs_to :developer, required: true


### PR DESCRIPTION

### Motivation / Background

`association_changed?` and `association_previously_changed?` always return `false`
for a `belongs_to` with a composite foreign key, even when the foreign key has
actually changed.

`BelongsToAssociation#target_changed?` and `#target_previously_changed?` read
`reflection.foreign_key`, which for a composite key is an array such as
`["shop_id", "order_id"]`, and pass that whole array to the scalar dirty helpers
(`attribute_changed?` / `attribute_previously_changed?`). Those call `to_s` on the
name, so the array stringifies to `'["shop_id", "order_id"]'` and never matches a
real attribute. The public change-tracking methods generated in
`Associations::Builder::BelongsTo` therefore always report no change for a
composite-key association.

Single-column foreign keys are unaffected, which is why this has gone unnoticed.

### Detail

This Pull Request changes `BelongsToAssociation#target_changed?` and
`#target_previously_changed?` to check each foreign key column individually with
`Array(reflection.foreign_key).any? { |fk| ... }`, mirroring the handling already
used elsewhere in the same file for composite keys (`replace_keys`,
`foreign_key_present?`) and the presence check in `Builder::BelongsTo`. Wrapping in
`Array(...)` leaves the scalar path unchanged, since `Array("shop_id") == ["shop_id"]`.

The polymorphic subclass (`BelongsToPolymorphicAssociation`) calls `super` and then
ORs the `foreign_type` check, so it inherits the fix; polymorphic foreign keys are
scalar, so their behavior is unchanged.

A regression test in `belongs_to_associations_test.rb` reassigns a persisted
`Cpk::Book`'s composite-key `belongs_to :order` to another persisted order (keeping
`shop_id`, changing `order_id`) and asserts `order_changed?` before save and
`order_previously_changed?` after save. It fails on `main` (both were always false)
and passes with this change.

### Additional information

This is the same class of "a composite foreign key array gets stringified by a
scalar helper" bug that has been fixed in nearby code paths; the two dirty-tracking
methods were missed.

Scope note: I deliberately left `saved_change_to_target?` (used only by the
counter-cache and touch callbacks, not by the public change-tracking API) untouched.
Fixing it in isolation would make the `after_update` callback increment the new
parent's counter while `decrement_counters_before_last_save` still no-ops on the old
parent, inflating the counter cache. The counter-cache path for composite keys is a
separate concern already being addressed in #57608, so this PR stays focused on the
public `association_changed?` / `association_previously_changed?` API.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
