### PR TITLE
Return no rows without a query for `none.ids`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -373,6 +373,14 @@ module ActiveRecord
     #   Person.ids # SELECT people.id FROM people
     #   Person.joins(:company).ids # SELECT people.id FROM people INNER JOIN companies ON companies.id = people.company_id
     def ids
+      if @none
+        if @async
+          return Promise::Complete.new([])
+        else
+          return []
+        end
+      end
+
       primary_key_array = Array(primary_key)
 
       if loaded?

--- a/activerecord/test/cases/null_relation_test.rb
+++ b/activerecord/test/cases/null_relation_test.rb
@@ -40,6 +40,8 @@ class NullRelationTest < ActiveRecord::TestCase
   def test_none_chained_to_methods_firing_queries_straight_to_db
     assert_no_queries do
       assert_equal [],    Developer.none.pluck(:id, :name)
+      assert_equal [],    Developer.none.ids
+      assert_equal [],    Developer.none.async_ids.value
       assert_equal 0,     Developer.none.delete_all
       assert_equal 0,     Developer.none.update_all(name: "David")
       assert_equal 0,     Developer.none.delete(1)


### PR DESCRIPTION
### Summary

`Relation#none` marks a relation as a null object that should never touch the database. `pluck` already honors this — it short-circuits and returns `[]` without running a query — but `ids` did not: it fell through to a real `SELECT ... WHERE (1=0)`.

The only short-circuit `ids` had was for an empty-tuple `where` contradiction (e.g. `where(id: [])`). `none` builds its predicate from a raw `"1=0"` string, which is not detected as a contradiction, so `ids` executed the query.

### Behavior

Before:

```ruby
Post.none.ids        # SELECT "posts"."id" FROM "posts" WHERE (1=0)
Post.none.pluck(:id) # []  (no query)
```

After, both return `[]` without querying:

```ruby
Post.none.ids        # []  (no query)
Post.none.pluck(:id) # []  (no query)
```

`async_ids` is fixed by the same guard and returns a completed promise resolving to `[]` without a query.

### Why this is correct

A null relation is defined to yield nothing without hitting the database; the existing coverage in `null_relation_test.rb` asserts exactly this for `pluck`, `delete_all`, `update_all`, `exists?`, `count`, and friends. `ids` was the outlier. The fix adds to `ids` the same `@none` guard that `pluck` already uses, restoring parity between the two.
