### PR TITLE
Make `add_column(if_not_exists: true)` reversible

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -301,6 +301,13 @@ module ActiveRecord
           [:change_column_null, args]
         end
 
+        def invert_add_column(args)
+          if (options = args.last).is_a?(Hash)
+            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
+          end
+          super
+        end
+
         def invert_add_index(args)
           if (options = args.last).is_a?(Hash)
             options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -223,6 +223,11 @@ module ActiveRecord
         assert_equal [:remove_column, [:table, :column, :type, {}], nil], remove
       end
 
+      def test_invert_add_column_if_not_exists
+        remove = @recorder.inverse_of :add_column, [:table, :column, :type, if_not_exists: true]
+        assert_equal [:remove_column, [:table, :column, :type, if_exists: true], nil], remove
+      end
+
       def test_invert_change_column
         assert_raises(ActiveRecord::IrreversibleMigration) do
           @recorder.inverse_of :change_column, [:table, :column, :type, {}]


### PR DESCRIPTION
### Summary

Reverting `add_column(:table, :column, :type, if_not_exists: true)` produced `remove_column(:table, :column, :type, if_not_exists: true)`, passing an option `remove_column` does not accept.

### Behavior

```ruby
# inverse of add_column(:table, :column, :type, if_not_exists: true)
# before: remove_column(:table, :column, :type, if_not_exists: true)
# after:  remove_column(:table, :column, :type, if_exists: true)
```

### Why this is correct

`if_not_exists` guards the forward `add_column`; its inverse `remove_column` needs `if_exists` to stay idempotent on rollback. `add_index`, `add_foreign_key`, and `add_check_constraint` already perform exactly this translation when inverted; `add_column` is brought in line with them.