### PR TITLE
Return the current value for an unchanged store accessor's `_was`

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -172,7 +172,7 @@ module ActiveRecord
             end
 
             define_method("#{accessor_key}_was") do
-              return unless attribute_changed?(store_attribute)
+              return read_store_attribute(store_attribute, key) unless attribute_changed?(store_attribute)
               prev_store, _new_store = changes[store_attribute]
               accessor = store_accessor_for(store_attribute)
               accessor.get(prev_store, key)

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -138,6 +138,15 @@ class StoreTest < ActiveRecord::TestCase
     assert_not @john.color_changed?
   end
 
+  test "reading _was for an unchanged accessor returns the current value" do
+    assert_not @john.color_changed?
+    assert_equal "black", @john.color_was
+    assert_equal @john.color, @john.color_was
+
+    @john.color = "red"
+    assert_equal "black", @john.color_was
+  end
+
   test "changing one accessor does not report a change for a sibling accessor" do
     @john.homepage = "http://www.example.com"
     @john.save!


### PR DESCRIPTION
### Summary

For an unchanged store accessor, `<key>_was` returned `nil` instead of the current value.

### Behavior

```ruby
# record unchanged, record.color == "black"
record.color_was  # => nil     (before)
record.color_was  # => "black"  (after)
```

Once the value changes, `_was` still returns the prior value.

### Why this is correct

`ActiveModel::Dirty`'s `attribute_was` returns the current value when an attribute is unchanged. The store accessor's `_was` violated that contract, returning `nil`. The co-located `_change` accessor was already corrected for the unchanged case; this aligns `_was` with both.