### PR TITLE
Instrument the normalized key in `MemoryStore#increment`/`#decrement`

### DIFF
--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -149,7 +149,7 @@ module ActiveSupport
       #   cache.increment("baz") # => 6
       #
       def increment(name, amount = 1, **options)
-        instrument(:increment, name, amount: amount) do
+        instrument(:increment, normalize_key(name, options), amount: amount) do
           modify_value(name, amount, **options)
         end
       end
@@ -166,7 +166,7 @@ module ActiveSupport
       #   cache.decrement("baz") # => 4
       #
       def decrement(name, amount = 1, **options)
-        instrument(:decrement, name, amount: amount) do
+        instrument(:decrement, normalize_key(name, options), amount: amount) do
           modify_value(name, -amount, **options)
         end
       end

--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -120,24 +120,26 @@ module CacheInstrumentationBehavior
 
   def test_increment_instrumentation
     key_1 = SecureRandom.uuid
-    @cache.write(key_1, 0, raw: true)
+    options = { namespace: "foo" }
+    @cache.write(key_1, 0, raw: true, **options)
 
-    events = capture_notifications("cache_increment.active_support") { @cache.increment(key_1) }
+    events = capture_notifications("cache_increment.active_support") { @cache.increment(key_1, **options) }
 
     assert_equal %w[ cache_increment.active_support ], events.map(&:name)
-    assert_equal normalized_key(key_1), events[0].payload[:key]
+    assert_equal normalized_key(key_1, options), events[0].payload[:key]
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 
 
   def test_decrement_instrumentation
     key_1 = SecureRandom.uuid
-    @cache.write(key_1, 0, raw: true)
+    options = { namespace: "foo" }
+    @cache.write(key_1, 0, raw: true, **options)
 
-    events = capture_notifications("cache_decrement.active_support") { @cache.decrement(key_1) }
+    events = capture_notifications("cache_decrement.active_support") { @cache.decrement(key_1, **options) }
 
     assert_equal %w[ cache_decrement.active_support ], events.map(&:name)
-    assert_equal normalized_key(key_1), events[0].payload[:key]
+    assert_equal normalized_key(key_1, options), events[0].payload[:key]
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 


### PR DESCRIPTION
### Summary

`MemoryStore#increment` and `#decrement` emitted their `cache_increment`/`cache_decrement` notifications with the raw name as the payload `:key`, ignoring the store's namespace.

### Behavior

For a store built with `namespace: "myapp"`:

```ruby
cache.increment("counter")
# cache_increment.active_support payload[:key] => "counter"     (before)
# cache_increment.active_support payload[:key] => "myapp:counter" (after)
```

### Why this is correct

`FileStore`, `MemCacheStore`, and `RedisCacheStore` all instrument the normalized (namespaced) key, and `MemoryStore`'s own read/write events already do too. Only its increment/decrement events reported the un-namespaced name, so a subscriber received an inconsistent key for those two operations.