### PR TITLE
Clear a stale `enqueue_error` when `perform_all_later` re-enqueues a job

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -73,6 +73,7 @@ module ActiveJob
         else
           adapter_jobs.each do |job|
             job.successfully_enqueued = false
+            job.enqueue_error = nil
             if job.scheduled_at
               queue_adapter.enqueue_at(job, job.scheduled_at.to_f)
             else

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -117,4 +117,19 @@ class QueuingTest < ActiveSupport::TestCase
 
     assert notification.payload[:adapter]
   end
+
+  test "perform_all_later clears a stale enqueue_error when the job is successfully enqueued" do
+    EnqueueErrorJob::EnqueueErrorAdapter.should_raise_sequence = [ true, false ]
+    job = EnqueueErrorJob.new
+
+    assert_equal false, job.enqueue
+    assert_equal ActiveJob::EnqueueError, job.enqueue_error.class
+
+    ActiveJob.perform_all_later(job)
+
+    assert job.successfully_enqueued?
+    assert_nil job.enqueue_error
+  ensure
+    EnqueueErrorJob::EnqueueErrorAdapter.should_raise_sequence = []
+  end
 end


### PR DESCRIPTION
### Summary

When the queue adapter does not implement `enqueue_all`, `perform_all_later` falls back to enqueuing each job individually. That path reset `successfully_enqueued` but left any previously set `enqueue_error` on the job.

### Behavior

A job that previously failed to enqueue and is then successfully re-enqueued via `perform_all_later` ended up reporting `successfully_enqueued? == true` while still carrying the old `enqueue_error`. After the change, a successfully enqueued job ends with `enqueue_error == nil`.

### Why this is correct

The single-job `enqueue` path already clears `enqueue_error` before each attempt. The `perform_all_later` fallback is the batch counterpart and resets `successfully_enqueued` symmetrically, so it should clear `enqueue_error` as well; otherwise a job can report a contradictory state.