### PR TITLE
Account for `queue_name_prefix` in `assert_enqueued_email_with`

### DIFF
--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -152,7 +152,7 @@ module ActionMailer
       end
 
       args = Array(args) unless args.is_a?(Proc)
-      queue ||= mailer.deliver_later_queue_name || ActiveJob::Base.default_queue_name
+      queue ||= mailer.delivery_job.queue_name_from_part(mailer.deliver_later_queue_name)
 
       expected = ->(job_args) do
         job_kwargs = job_args.extract_options!

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -376,6 +376,21 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
+  def test_assert_enqueued_email_with_when_queue_name_prefix_is_configured
+    previous_prefix = ActiveJob::Base.queue_name_prefix
+    ActiveJob::Base.queue_name_prefix = "prefix"
+
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test do
+        silence_stream($stdout) do
+          TestHelperMailer.test.deliver_later
+        end
+      end
+    end
+  ensure
+    ActiveJob::Base.queue_name_prefix = previous_prefix
+  end
+
   def test_assert_enqueued_email_with_when_mailer_has_custom_deliver_later_queue
     assert_nothing_raised do
       assert_enqueued_email_with CustomQueueMailer, :test do


### PR DESCRIPTION
### Summary

With `ActiveJob::Base.queue_name_prefix` configured, `assert_enqueued_email_with` expected the bare mailer queue (e.g. `"mailers"`) while the delivery job is actually enqueued to the prefixed queue (e.g. `"prefix_mailers"`), so the assertion failed for a correctly delivered mail.

### Behavior

```ruby
config.active_job.queue_name_prefix = "prefix"

assert_enqueued_email_with(TestMailer, :test) do
  TestMailer.test.deliver_later
end
# before: fails (expected "mailers", job on "prefix_mailers")
# after:  passes
```

### Why this is correct

The expected queue is now derived the same way the delivery job derives its own queue at enqueue time, so the configured prefix (and suffix) are accounted for. `queue_name_prefix` is a standard, documented ActiveJob configuration.