### PR TITLE
Support endless and beginless ranges in `number_field`/`range_field`

### DIFF
--- a/actionview/lib/action_view/helpers/tags/number_field.rb
+++ b/actionview/lib/action_view/helpers/tags/number_field.rb
@@ -8,7 +8,7 @@ module ActionView
           options = @options.stringify_keys
 
           if range = options.delete("in") || options.delete("within")
-            options.update("min" => range.min, "max" => range.max)
+            options.update("min" => range.begin, "max" => (range.max if range.end))
           end
 
           @options = options

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1494,6 +1494,16 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, number_field("order", "quantity", size: 30, in: 1...10))
   end
 
+  def test_number_field_with_endless_range
+    expected = %{<input name="order[quantity]" id="order_quantity" type="number" min="18" />}
+    assert_dom_equal(expected, number_field("order", "quantity", in: 18..))
+  end
+
+  def test_number_field_with_beginless_range
+    expected = %{<input name="order[quantity]" max="10" id="order_quantity" type="number" />}
+    assert_dom_equal(expected, number_field("order", "quantity", in: ..10))
+  end
+
   def test_range_input
     expected = %{<input name="hifi[volume]" step="0.1" max="11" id="hifi_volume" type="range" min="0" />}
     assert_dom_equal(expected, range_field("hifi", "volume", in: 0..11, step: 0.1))


### PR DESCRIPTION
### Summary

`number_field` and `range_field` raised `RangeError` when given an endless (`18..`) or beginless (`..10`) range as `:in`/`:within`.

### Behavior

```ruby
number_field("order", "quantity", in: 18..)  # endless
# before: RangeError
# after:  <input ... type="number" min="18" />  (no max)

number_field("order", "quantity", in: ..10)   # beginless
# before: RangeError
# after:  <input ... type="number" max="10" />  (no min)
```

Bounded ranges are unchanged, including exclusive ranges such as `1...10`, which still render `max="9"`.

### Why this is correct

`:in`/`:within` is documented to accept a Range, and endless/beginless ranges are ordinary Ruby. An open bound simply omits the corresponding `min`/`max` attribute instead of raising, while bounded ranges keep their existing rendering.