### PR TITLE
Honor an explicit `:selected` option in `weekday_select`

### DIFF
--- a/actionview/lib/action_view/helpers/tags/weekday_select.rb
+++ b/actionview/lib/action_view/helpers/tags/weekday_select.rb
@@ -16,7 +16,7 @@ module ActionView
         def render
           select_content_tag(
             weekday_options_for_select(
-              value || @options[:selected],
+              @options.fetch(:selected) { value },
               index_as_value: @options.fetch(:index_as_value, false),
               day_format: @options.fetch(:day_format, :day_names),
               beginning_of_week: @options.fetch(:beginning_of_week, Date.beginning_of_week)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1649,6 +1649,20 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_weekday_select_under_fields_for_with_value_and_explicit_selected
+    @digest = Digest.new
+    @digest.send_day = "Monday"
+
+    output_buffer = fields_for :digest, @digest do |f|
+      concat f.weekday_select(:send_day, selected: "Friday")
+    end
+
+    assert_dom_equal(
+      "<select name=\"digest[send_day]\" id=\"digest_send_day\"><option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option selected=\"selected\" value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option></select>",
+      output_buffer
+    )
+  end
+
   def test_datalist_with_plain_array
     @post = Post.new
 


### PR DESCRIPTION
### Summary

`weekday_select` on an object that already holds a weekday ignored an explicitly passed `selected:` option and marked the object's value as selected instead.

### Behavior

```ruby
# @digest.send_day == "Monday"
f.weekday_select(:send_day, selected: "Friday")
```

Before, `Monday` (the object value) was selected and the explicit `Friday` was ignored. After, `Friday` (the explicit `:selected`) is selected.

### Why this is correct

Every other tag in the select family — `select`, `collection_select`, `grouped_collection_select`, `date_select` — lets an explicit `:selected` take precedence over the object's value. `weekday_select` was the lone outlier; this brings it in line with its siblings.