### PR TITLE
Fix broken links in guides [ci skip]

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -216,7 +216,7 @@ successfully saved.
 NOTE: We use [`deliver_later`][] to enqueue the email to be sent later. This
 way, the controller action will continue without waiting for the email sending
 code to run. The `deliver_later` method is backed by [Active
-Job](active_job_basics.html#action-mailer).
+Job](active_job_basics.html#example-sending-email).
 
 ```ruby
 class UsersController < ApplicationController

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -78,7 +78,7 @@ Various features of Active Storage depend on third-party software. Rails does
 not install these by default so you will need to do so separately:
 
 * [libvips](https://github.com/libvips/libvips) or
-  [ImageMagick](https://imagemagick.org/index.php) - for image analysis and
+  [ImageMagick](https://imagemagick.org/) - for image analysis and
   transformations.
 * [ffmpeg](http://ffmpeg.org/) - for video previews and ffprobe for video/audio
   analysis.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -281,7 +281,7 @@ Old setting equivalent to `!config.enable_reloading`. Supported for backwards co
 
 #### `config.cache_store`
 
-Configures which cache store to use for Rails caching. Options include one of the symbols `:memory_store`, `:file_store`, `:mem_cache_store`, `:null_store`, `:redis_cache_store`, or an object that implements the cache API. Defaults to `:file_store`. See [Cache Stores](caching_with_rails.html#cache-stores) for per-store configuration options.
+Configures which cache store to use for Rails caching. Options include one of the symbols `:memory_store`, `:file_store`, `:mem_cache_store`, `:null_store`, `:redis_cache_store`, or an object that implements the cache API. Defaults to `:file_store`. See [Cache Stores](caching_with_rails.html#other-cache-stores) for per-store configuration options.
 
 #### `config.colorize_logging`
 


### PR DESCRIPTION
### Motivation / Background

Three references in the guides are broken — one external 404 and two internal anchors that don't exist, so clicking them scrolls nowhere:

1. The [Requirements section of the Active Storage Overview](https://edgeguides.rubyonrails.org/active_storage_overview.html#requirements) links [`https://imagemagick.org/index.php`](https://imagemagick.org/index.php), which returns 404 (the site root, [`https://imagemagick.org/`](https://imagemagick.org/), returns 200).
2. The [Action Mailer Basics guide](https://edgeguides.rubyonrails.org/action_mailer_basics.html#edit-the-controller) links `active_job_basics.html#action-mailer` — no such anchor exists in the Active Job guide.
3. The [`config.cache_store` entry in the Configuring guide](https://edgeguides.rubyonrails.org/configuring.html#config-cache-store) links `caching_with_rails.html#cache-stores` — no such anchor exists in the Caching guide.

### Detail

Smallest-change retargets, one line each:

* `active_storage_overview.md`: [`https://imagemagick.org/index.php`](https://imagemagick.org/index.php) → [`https://imagemagick.org/`](https://imagemagick.org/)
* `action_mailer_basics.md`: `active_job_basics.html#action-mailer` → [`active_job_basics.html#example-sending-email`](https://edgeguides.rubyonrails.org/active_job_basics.html#example-sending-email), the section documenting email delivery (`deliver_later`) via Active Job
* `configuring.md`: `caching_with_rails.html#cache-stores` → [`caching_with_rails.html#other-cache-stores`](https://edgeguides.rubyonrails.org/caching_with_rails.html#other-cache-stores), the section documenting exactly the stores the sentence enumerates (`:memory_store`, `:file_store`, `:mem_cache_store`, `:null_store`, `:redis_cache_store`)

### Additional information

Happy to split this into separate PRs if preferred — grouped here since all three are the same defect class (broken references), fixed one line each.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (Documentation-only change.)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. (Not needed for documentation changes.)
