### PR TITLE
Remove stale payload-based filter example in EventReporter#subscribe rdoc

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -312,7 +312,8 @@ module ActiveSupport
     # An optional filter proc can be provided to only receive a subset of events:
     #
     #   Rails.event.subscribe(subscriber) { |event| event[:name].start_with?("user.") }
-    #   Rails.event.subscribe(subscriber) { |event| event[:payload].is_a?(UserEvent) }
+    #
+    # Only the +:name+ key is available to filters, not the entire payload.
     #
     def subscribe(subscriber, &filter)
       unless subscriber.respond_to?(:emit)


### PR DESCRIPTION
The `#subscribe` rdoc lists two filter examples, one of which filters on `event[:payload]`:

```ruby
Rails.event.subscribe(subscriber) { |event| event[:payload].is_a?(UserEvent) }
```

Filters are invoked with a hash that contains only the event name, so `event[:payload]` inside a filter is always `nil`. A subscriber copied from this example would silently receive zero events.

The module-level "Filtered Subscriptions" section already documents this: "Note that only the +:name+ key is available to filters, not the entire payload." The `#subscribe` example contradicted that documented contract, so this removes the misleading payload example and mirrors the same note under `#subscribe`.

>[!NOTE]
>Documentation only.
