### PR TITLE
Strip surrounding whitespace before parsing a duration in `Hash.from_xml`

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -68,7 +68,7 @@ module ActiveSupport
         "symbol"       => Proc.new { |symbol|  symbol.to_s.to_sym },
         "date"         => Proc.new { |date|    ::Date.strptime(date.to_s.strip, "%Y-%m-%d") },
         "datetime"     => Proc.new { |time|    Time.xmlschema(time).utc rescue ::DateTime.parse(time).utc },
-        "duration"     => Proc.new { |duration| Duration.parse(duration) },
+        "duration"     => Proc.new { |duration| Duration.parse(duration.to_s.strip) },
         "integer"      => Proc.new { |integer| integer.to_i },
         "float"        => Proc.new { |float|   float.to_f },
         "decimal"      => Proc.new do |number|

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -280,6 +280,7 @@ module XmlMiniTest
       assert_equal 1, parser.call("PT1S")
       assert_equal 1.minutes, parser.call("PT1M")
       assert_equal 3.years + 6.months + 4.days + 12.hours + 30.minutes + 5.seconds, parser.call("P3Y6M4DT12H30M5S")
+      assert_equal 1.hour, parser.call("\n  PT1H\n")
       assert_raises(ArgumentError) { parser.call("not really a duration") }
     end
 


### PR DESCRIPTION
### Before

Given pretty-printed / human-authored XML where a `type="duration"` element's value carries the newlines and indentation of the surrounding markup:

```ruby
Hash.from_xml(<<~XML)
  <event>
    <length type="duration">
      PT1H
    </length>
  </event>
XML
```

`Hash.from_xml` raises `ActiveSupport::Duration::ISO8601Parser::ParsingError` and the entire document fails to parse. The same document with a `type="date"`, `type="datetime"`, `type="integer"` or `type="boolean"` node parses fine.

### After

The duration value is stripped before parsing, so the node above yields the expected `ActiveSupport::Duration` (`1.hour`) and the document parses.