### PR TITLE
Forward keyword arguments through deprecation proxies

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -23,6 +23,7 @@ module ActiveSupport
           warn caller_locations, called, args
           target.__send__(called, *args, &block)
         end
+        ruby2_keywords :method_missing
     end
 
     # DeprecatedObjectProxy transforms an object into a deprecated one. It takes an object, a deprecation message, and

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -126,6 +126,16 @@ class DeprecationTest < ActiveSupport::TestCase
     end
   end
 
+  test "DeprecatedObjectProxy forwards keyword arguments" do
+    object = Object.new
+    def object.kw(a:)
+      a
+    end
+    deprecated_object = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(object, ":bomb:", @deprecator)
+    result = assert_deprecated(/:bomb:/, @deprecator) { deprecated_object.kw(a: 42) }
+    assert_equal 42, result
+  end
+
   test "nil behavior is ignored" do
     @deprecator.behavior = nil
     assert_deprecated("fubar", @deprecator) { @deprecator.warn("fubar") }
@@ -306,6 +316,20 @@ class DeprecationTest < ActiveSupport::TestCase
 
     fubar_s = assert_deprecated("@fubar.to_s", @deprecator) { instance.fubar.to_s }
     assert_equal instance.foo_bar.to_s, fubar_s
+  end
+
+  test "DeprecatedInstanceVariableProxy forwards keyword arguments" do
+    instance = Deprecatee.new
+    instance.fubar = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(instance, :foo_bar, "@fubar", deprecator: @deprecator)
+    instance.foo_bar = Object.new
+    def (instance.foo_bar).kw(a:)
+      a
+    end
+
+    result = assert_deprecated(/@fubar\.kw\. Args: #{Regexp.escape([{ a: 42 }].inspect)}/, @deprecator) do
+      instance.fubar.kw(a: 42)
+    end
+    assert_equal 42, result
   end
 
   test "DeprecatedInstanceVariableProxy does not warn on inspect" do


### PR DESCRIPTION
## Summary

Calling a target method that requires keyword arguments through a `DeprecatedObjectProxy` or `DeprecatedInstanceVariableProxy` raises `ArgumentError` instead of reaching the method.

- **Before:** wrapping an object in `DeprecatedObjectProxy` (or an ivar in `DeprecatedInstanceVariableProxy`) and calling a method with a required keyword raises `ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: a)` — the trailing keyword hash is dispatched positionally to the target.
- **After:** the trailing keyword hash is forwarded as keywords, so the call reaches the target method and returns the expected value while still emitting the deprecation warning.

## Why this is correct

The sibling `DeprecatedConstantProxy#method_missing` in the same file already forwards keywords faithfully via `(...)` → `target.__send__(...)` since commit `946e46ebcc`. The base `DeprecationProxy`, from which the object and instance variable proxies inherit, was left on the older `(*args, &block)` form, which collapses keyword arguments under Ruby 3+ keyword-argument separation.

## Why `ruby2_keywords` rather than `*args, **kwargs`

The base `DeprecationProxy#method_missing` passes `args` to `warn`, and `DeprecatedInstanceVariableProxy#warn` embeds `args.inspect` in the deprecation message. Splitting into `*args, **kwargs` would drop keyword arguments from that message (e.g. `Args: [1]` instead of the current `Args: [1, {:a=>2}]`). `ruby2_keywords` keeps the keyword hash inside the `args` array with a flag, so the warning message is unchanged and `__send__` still forwards keywords correctly — a one-line fix with no signature changes.
