### PR TITLE
Preserve subsecond precision in the `DateTime.now` travel stub under `with_usec`

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -188,7 +188,7 @@ module ActiveSupport
         end
 
         stubs.stub_object(Date, :today) { jd(now.to_date.jd) }
-        stubs.stub_object(DateTime, :now) { jd(now.to_date.jd, now.hour, now.min, now.sec, Rational(now.utc_offset, 86400)) }
+        stubs.stub_object(DateTime, :now) { jd(now.to_date.jd, now.hour, now.min, now.sec + now.subsec, Rational(now.utc_offset, 86400)) }
 
         if block_given?
           begin

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -462,6 +462,19 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
+  def test_travel_to_with_usec_true_preserves_datetime_now_subsec
+    Time.stub(:now, Time.now) do
+      travel_to Time.utc(2014, 10, 10, 10, 10, 50, 999999), with_usec: true do
+        assert_equal 999999, DateTime.now.usec
+        assert_equal Rational(999999, 1000000), DateTime.now.sec_fraction
+      end
+
+      travel_to Time.utc(2014, 10, 10, 10, 10, 50, 999999) do
+        assert_equal 0, DateTime.now.usec
+      end
+    end
+  end
+
   def test_time_helper_travel_with_time_subclass
     assert_equal TimeSubclass, TimeSubclass.now.class
     assert_equal DateSubclass, DateSubclass.today.class


### PR DESCRIPTION
## Summary

`travel_to(time, with_usec: true)` is meant to freeze the clock with full subsecond fidelity — that is the whole reason the `with_usec:` option exists. The `Time.now` stub honors this and preserves the subsecond fraction of the frozen instant.

The sibling `DateTime.now` stub did not. Under `with_usec: true` it froze `DateTime.now` to a whole second and silently discarded the subsecond fraction, so a subsecond-sensitive timestamp read through `DateTime.now` came back truncated even though the same instant read through `Time.now` carried its fraction.

### Before

```ruby
travel_to Time.utc(2014, 10, 10, 10, 10, 50, 999999), with_usec: true do
  Time.now.usec      # => 999999
  DateTime.now.usec  # => 0        (fraction dropped)
end
```

### After

```ruby
travel_to Time.utc(2014, 10, 10, 10, 10, 50, 999999), with_usec: true do
  Time.now.usec      # => 999999
  DateTime.now.usec  # => 999999   (matches Time.now)
end
```

The default `with_usec: false` path is unchanged: `DateTime.now.usec` remains `0`, since the frozen instant has no subsecond fraction there.