### PR TITLE
Translate `if_exists`/`if_not_exists` guards when inverting `remove_column` and `add_reference`/`remove_reference`

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -242,6 +242,9 @@ module ActiveRecord
           if args.size <= 2 || args[2].is_a?(Hash)
             raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type."
           end
+          if (options = args.last).is_a?(Hash)
+            options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
+          end
           super
         end
 
@@ -281,6 +284,20 @@ module ActiveRecord
           args << options unless options.empty?
 
           [:add_index, args]
+        end
+
+        def invert_add_reference(args)
+          if (options = args.last).is_a?(Hash)
+            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
+          end
+          super
+        end
+
+        def invert_remove_reference(args)
+          if (options = args.last).is_a?(Hash)
+            options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
+          end
+          super
         end
 
         alias :invert_add_belongs_to :invert_add_reference

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -294,6 +294,11 @@ module ActiveRecord
         assert_equal [:add_column, [:table, :column, :type, {}], nil], add
       end
 
+      def test_invert_remove_column_if_exists
+        add = @recorder.inverse_of :remove_column, [:table, :column, :string, if_exists: true]
+        assert_equal [:add_column, [:table, :column, :string, if_not_exists: true], nil], add
+      end
+
       def test_invert_remove_column_without_type
         assert_raises(ActiveRecord::IrreversibleMigration) do
           @recorder.inverse_of :remove_column, [:table, :column]
@@ -432,6 +437,16 @@ module ActiveRecord
       def test_invert_remove_belongs_to_alias
         add = @recorder.inverse_of :remove_belongs_to, [:table, :user]
         assert_equal [:add_reference, [:table, :user], nil], add
+      end
+
+      def test_invert_add_reference_if_not_exists
+        remove = @recorder.inverse_of :add_reference, [:table, :taggable, { polymorphic: true, if_not_exists: true }]
+        assert_equal [:remove_reference, [:table, :taggable, { polymorphic: true, if_exists: true }], nil], remove
+      end
+
+      def test_invert_remove_reference_if_exists
+        add = @recorder.inverse_of :remove_reference, [:table, :taggable, { polymorphic: true, if_exists: true }]
+        assert_equal [:add_reference, [:table, :taggable, { polymorphic: true, if_not_exists: true }], nil], add
       end
 
       def test_invert_enable_extension


### PR DESCRIPTION
## Summary

The command recorder already translates the `if_exists` ↔ `if_not_exists` idempotency guard for `add_column`, `add_index`, `add_foreign_key`/`remove_foreign_key`, and `add_check_constraint`/`remove_check_constraint`. Two command families were missed: `remove_column` and `add_reference`/`remove_reference` (plus the `add_belongs_to`/`remove_belongs_to` aliases).

### `remove_column`

**Before**

```ruby
inverse_of :remove_column, [:users, :nickname, :string, if_exists: true]
# => [:add_column, [:users, :nickname, :string, { if_exists: true }], nil]
```

`if_exists` is not a recognized option for `add_column`, so the rollback carried a meaningless option instead of the intended guard.

**After**

```ruby
inverse_of :remove_column, [:users, :nickname, :string, if_exists: true]
# => [:add_column, [:users, :nickname, :string, { if_not_exists: true }], nil]
```

### `add_reference` / `remove_reference`

**Before**

```ruby
inverse_of :add_reference, [:t, :u, if_not_exists: true]
# => [:remove_reference, [:t, :u, { if_not_exists: true }]]  (guard ignored)

inverse_of :remove_reference, [:t, :u, if_exists: true]
# => [:add_reference, [:t, :u, { if_exists: true }]]          (guard ignored)
```

The generated reversion swapped only the command name and passed the guard through verbatim, so the option landed on the inverse command unchanged and was silently dropped.

**After**

The guard is translated to its counterpart on the inverse command, so `add_reference(if_not_exists: true)` inverts to `remove_reference(if_exists: true)` and vice versa. The `add_belongs_to`/`remove_belongs_to` aliases share the corrected behavior.
