### PR TITLE
Forward a block to delegated_type's `build_<role>`

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -251,8 +251,8 @@ module ActiveRecord
           public_send("#{role}_class").model_name.singular.inquiry
         end
 
-        define_method "build_#{role}" do |*params|
-          public_send("#{role}=", public_send("#{role}_class").new(*params))
+        define_method "build_#{role}" do |*params, &block|
+          public_send("#{role}=", public_send("#{role}_class").new(*params, &block))
         end
 
         types.each do |type|

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -114,4 +114,12 @@ class DelegatedTypeTest < ActiveRecord::TestCase
     assert_respond_to Entry.new, :build_entryable
     assert_equal Message, Entry.new(entryable_type: "Message").build_entryable.class
   end
+
+  test "builder method yields the built record to a block" do
+    message = Entry.new(entryable_type: "Message").build_entryable do |m|
+      m.subject = "Hello from block"
+    end
+
+    assert_equal "Hello from block", message.subject
+  end
 end


### PR DESCRIPTION
## Summary

`delegated_type` defines a `build_<role>` method that instantiates the delegatee model. Unlike a normal record initializer, it does not accept or forward a block.

### Before

```ruby
entry.build_entryable(subject: "Hi") { |m| m.subject = "From block" }
# => the block is silently discarded; the delegatee's initializer never
#    yields, so the block's mutations are absent from the built record.
```

### After

```ruby
entry.build_entryable(subject: "Hi") { |m| m.subject = "From block" }
# => the delegatee's initializer yields the new record, so the block runs
#    and its mutations are present — just like `Model.new(attrs) { |m| ... }`.
```