### PR TITLE
Define password reset token method only when token generation is available

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -204,7 +204,7 @@ module ActiveModel
           algorithm
         end
 
-        include InstanceMethodsOnActivation.new(attribute, reset_token: reset_token, algorithm: algorithm)
+        include InstanceMethodsOnActivation.new(attribute, reset_token: reset_token && respond_to?(:generates_token_for), algorithm: algorithm)
 
         if validations
           include ActiveModel::Validations

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -382,6 +382,12 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal 1.hour, @slow_pilot.password_reset_token_expires_in
   end
 
+  test "password reset token is not defined on a vanilla Active Model" do
+    assert_not_respond_to @visitor, :password_reset_token
+    assert_not_respond_to @visitor, :password_reset_token_expires_in
+    assert_not_respond_to Visitor, :find_by_password_reset_token
+  end
+
   test "password algorithm defaults to bcrypt" do
     assert_equal :bcrypt, @user.password_algorithm
   end


### PR DESCRIPTION
### Before

A vanilla Active Model that includes `ActiveModel::SecurePassword` and calls `has_secure_password` — a supported usage shown in the docs, e.g.

```ruby
class Account
  include ActiveModel::SecurePassword
  attr_accessor :password_digest
  has_secure_password
end
```

still had a `password_reset_token` instance method defined. `respond_to?` reported it as available, but calling it always raised `NoMethodError`, because a plain Active Model has no `generates_token_for`/`generate_token_for`. Meanwhile the companion class methods and helper — `find_by_password_reset_token`, `find_by_password_reset_token!`, and `password_reset_token_expires_in` — were correctly absent, leaving an inconsistent, always-failing method on the object.

### After

The reset-token instance method is defined only when the model can actually generate tokens. This mirrors the class-level guard that already gates the finders and expiry helper:

```ruby
# Only generate tokens for records that are capable of doing so
# (Active Records, not vanilla Active Models)
if reset_token && respond_to?(:generates_token_for)
```

A vanilla Active Model now consistently does not respond to `password_reset_token`, matching the already-absent finders. Active Record models, which do respond to `generates_token_for`, are unaffected and keep their reset-token method, finders, and expiry helper.