### PR TITLE
Honor an explicit `:selected` option in `time_zone_select`

### DIFF
--- a/actionview/lib/action_view/helpers/tags/time_zone_select.rb
+++ b/actionview/lib/action_view/helpers/tags/time_zone_select.rb
@@ -15,8 +15,10 @@ module ActionView
         end
 
         def render
+          selected = @options.fetch(:selected) { value || @options[:default] }
+
           select_content_tag(
-            time_zone_options_for_select(value || @options[:default], @priority_zones, @options[:model] || ActiveSupport::TimeZone), @options, @html_options
+            time_zone_options_for_select(selected, @priority_zones, @options[:model] || ActiveSupport::TimeZone), @options, @html_options
           )
         end
       end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1435,6 +1435,20 @@ class FormOptionsHelperTest < ActionView::TestCase
                   html
   end
 
+  def test_time_zone_select_with_selected_option
+    @firm = Firm.new("D")
+
+    html = time_zone_select("firm", "time_zone", nil, selected: "B")
+    assert_dom_equal "<select id=\"firm_time_zone\" name=\"firm[time_zone]\">" \
+                  "<option value=\"A\">A</option>\n" \
+                  "<option value=\"B\" selected=\"selected\">B</option>\n" \
+                  "<option value=\"C\">C</option>\n" \
+                  "<option value=\"D\">D</option>\n" \
+                  "<option value=\"E\">E</option>" \
+                  "</select>",
+                  html
+  end
+
   def test_options_for_select_with_element_attributes
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\" class=\"bold\">&lt;Denmark&gt;</option>\n<option value=\"USA\" onclick=\"alert(&#39;Hello World&#39;);\">USA</option>\n<option value=\"Sweden\">Sweden</option>\n<option value=\"Germany\">Germany</option>",


### PR DESCRIPTION
### Before

`time_zone_select` always marked the object's current value (or the `:default` fallback) as the selected zone, silently ignoring any explicit `:selected` option a caller passed:

```ruby
time_zone_select("firm", "time_zone", nil, selected: "B")
# => "B" is passed, but the option for the object's value is selected instead
```

### After

An explicit `:selected` option determines the selected zone. When no `:selected` is given, the object value and the existing `:default` fallback still apply, so current behavior is unchanged for callers that don't pass it.