### PR TITLE
Honor `remove_hidden_field_autocomplete` on date/time select hidden fields

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1192,10 +1192,10 @@ module ActionView
             type: "hidden",
             id: input_id_from_type(type),
             name: input_name_from_type(type),
-            value: value,
-            autocomplete: "off"
+            value: value
           }.merge!(@html_options.slice(:disabled))
           select_options[:disabled] = "disabled" if @options[:disabled]
+          select_options[:autocomplete] = "off" unless ActionView::Base.remove_hidden_field_autocomplete
 
           tag(:input, select_options) + "\n".html_safe
         end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -440,6 +440,22 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal "<input type=\"hidden\" id=\"date_mois\" name=\"date[mois]\" value=\"8\" autocomplete=\"off\" />\n", select_month(8, use_hidden: true, field_name: "mois")
   end
 
+  def test_select_month_with_hidden_omits_autocomplete_when_remove_hidden_field_autocomplete
+    original = ActionView::Base.remove_hidden_field_autocomplete
+    ActionView::Base.remove_hidden_field_autocomplete = true
+    assert_dom_equal "<input type=\"hidden\" id=\"date_month\" name=\"date[month]\" value=\"8\" />\n", select_month(8, use_hidden: true)
+  ensure
+    ActionView::Base.remove_hidden_field_autocomplete = original
+  end
+
+  def test_select_month_with_hidden_includes_autocomplete_off_in_legacy_mode
+    original = ActionView::Base.remove_hidden_field_autocomplete
+    ActionView::Base.remove_hidden_field_autocomplete = false
+    assert_dom_equal "<input type=\"hidden\" id=\"date_month\" name=\"date[month]\" value=\"8\" autocomplete=\"off\" />\n", select_month(8, use_hidden: true)
+  ensure
+    ActionView::Base.remove_hidden_field_autocomplete = original
+  end
+
   def test_select_month_with_html_options
     expected = +%(<select id="date_month" name="date[month]" class="selector" accesskey="M">\n)
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)


### PR DESCRIPTION
## Summary

`config.action_view.remove_hidden_field_autocomplete` is a global opt-out (introduced for 8.1) that suppresses the `autocomplete="off"` attribute Rails adds to the hidden inputs it generates. The date/time select helpers never consulted this setting, so their hidden inputs always emitted `autocomplete="off"` regardless of the app's configuration.

## Before / After

With `config.action_view.remove_hidden_field_autocomplete = true`:

```erb
<%= select_month(8, use_hidden: true) %>
```

Before:

```html
<input type="hidden" id="date_month" name="date[month]" value="8" autocomplete="off" />
```

After:

```html
<input type="hidden" id="date_month" name="date[month]" value="8" />
```

When the opt-out is disabled (the default), the hidden inputs continue to emit `autocomplete="off"` unchanged. The same applies to the hidden inputs produced by `date_select`/`datetime_select` for discarded parts and by `select_year`/`select_day`/`select_minute`/etc. with `use_hidden: true`.