### PR TITLE
Honor an explicit `value: nil` in `color_field`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Honor an explicit `value:` option in `color_field`, including `nil`.
+
+    Previously, passing `value: nil` was ignored and the field still pre-filled
+    from the model's stored color. Now an explicitly provided `value:` is
+    honored, and the stored color is only used when no `value:` option is given.
+
+    *Kenta Ishizaki*
+
 *   Calling `safe_join` in a view no longer fallbacks to the `$,` global variable.
 
     Previously, calling `safe_join` would use `$,` by default to separate elements.

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -6,7 +6,7 @@ module ActionView
       class ColorField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] ||= validate_color_string(value)
+          options["value"] = options.fetch("value") { validate_color_string(value) }
           @options = options
           super
         end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1158,6 +1158,11 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, color_field("car", "color", value: "#00FF00"))
   end
 
+  def test_color_field_with_explicit_nil_value
+    expected = %{<input id="car_color" name="car[color]" type="color" />}
+    assert_dom_equal(expected, color_field("car", "color", value: nil))
+  end
+
   def test_search_field
     expected = %{<input id="contact_notes_query" name="contact[notes_query]" type="search" />}
     assert_dom_equal(expected, search_field("contact", "notes_query"))


### PR DESCRIPTION
## Summary

`color_field` ignores an explicit `value: nil` option and pre-fills the input from the model's stored color anyway.

**Before:** `color_field("car", "color", value: nil)` renders `<input ... value="#000fff" />` (the stored color), even though the caller explicitly asked for no value.

**After:** the explicit `value:` is honored, including `nil`, so the same call renders `<input id="car_color" name="car[color]" type="color" />` with no pre-filled value. The stored color is still used when no `value:` option is passed.