### PR TITLE
Derive the expected queue from the delivery job in `assert_enqueued_email_with`

### DIFF
--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -152,7 +152,7 @@ module ActionMailer
       end
 
       args = Array(args) unless args.is_a?(Proc)
-      queue ||= mailer.delivery_job.queue_name_from_part(mailer.deliver_later_queue_name)
+      queue ||= mailer.delivery_job.new(mailer.name).queue_name
 
       expected = ->(job_args) do
         job_kwargs = job_args.extract_options!

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -38,6 +38,14 @@ class CustomDeliveryMailer < TestHelperMailer
   self.delivery_job = CustomDeliveryJob
 end
 
+class CustomQueueDeliveryJob < ActionMailer::MailDeliveryJob
+  queue_as :delivery_job_queue
+end
+
+class CustomQueueDeliveryMailer < TestHelperMailer
+  self.delivery_job = CustomQueueDeliveryJob
+end
+
 class CustomQueueMailer < TestHelperMailer
   self.deliver_later_queue_name = :custom_queue
 end
@@ -412,6 +420,16 @@ class TestHelperMailerTest < ActionMailer::TestCase
       assert_enqueued_email_with CustomDeliveryMailer, :test do
         silence_stream($stdout) do
           CustomDeliveryMailer.test.deliver_later
+        end
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_when_delivery_job_defines_its_own_queue
+    assert_nothing_raised do
+      assert_enqueued_email_with CustomQueueDeliveryMailer, :test do
+        silence_stream($stdout) do
+          CustomQueueDeliveryMailer.test.deliver_later
         end
       end
     end


### PR DESCRIPTION
### Summary

`assert_enqueued_email_with` derives its expected queue from the mailer's `deliver_later_queue_name`. When a mailer uses a custom `delivery_job` that declares its own `queue_as`, the mail is enqueued on the job's queue, so the assertion fails on a correctly enqueued mail:

```ruby
class RegistrationDeliveryJob < ActionMailer::MailDeliveryJob
  queue_as :notifications
end

class RegistrationMailer < ApplicationMailer
  self.delivery_job = RegistrationDeliveryJob
end

RegistrationMailer.welcome.deliver_later
assert_enqueued_email_with RegistrationMailer, :welcome
# => No enqueued job found with {job: RegistrationDeliveryJob, ..., queue: "mailers"}
#    Potential matches: {..., queue: "notifications", ...}
```

With this change the expected queue is derived from the delivery job itself, so a custom `queue_as` is honored, while the default and `queue_name_prefix` cases resolve to the same queue as before.

`#deliver_later` documents that when a custom delivery job is used, it controls the queue name; the assertion now matches that contract. Follow-up to #58009.