### PR TITLE
Stop mutating the provided keys in ActiveSupport::Cache::Store#delete_multi

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `ActiveSupport::Cache::Store#delete_multi` so that it no longer mutates the provided `names` array.
+
+    *Michael Oberegger*
+
 *   Add `prepend: true` option to `ActiveSupport::Notifications.subscribe`.
 
       When `prepend: true` is passed, the subscriber is added to the front of

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -701,7 +701,7 @@ module ActiveSupport
         return 0 if names.empty?
 
         options = merged_options(options)
-        names.map! { |key| normalize_key(key, options) }
+        names = names.map { |key| normalize_key(key, options) }
 
         instrument_multi(:delete_multi, names, options) do
           delete_multi_entries(names, **options)

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -453,6 +453,14 @@ module CacheStoreBehavior
     assert_equal(0, @cache.delete_multi([]))
   end
 
+  def test_delete_multi_does_not_mutate_names
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    names = [key].freeze
+    @cache.delete_multi(names)
+    assert_equal [key], names
+  end
+
   def test_original_store_objects_should_not_be_immutable
     bar = +"bar"
     key = SecureRandom.alphanumeric


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

`ActiveSupport::Cache::Store#delete_multi` will currently mutate the `names` array that is provided. This is rather surprising and/or unexpected behaviour, and it is not documented. This can easily lead to gotchas and foot guns.

```ruby
def my_method
  keys = get_my_keys
  @cache.delete_multi(keys)
  # What would you expect keys to be here?
  do_other_thing(keys)
end
```

This means users of `delete_multi` have to put in some preventative measures (ex: `@cache.delete_multi(keys.dup)` above) or otherwise be aware that the keys will be mutated. This also means you can't use any frozen values as keys.

I can't think of a reason why the mutating behaviour would be preferred. This behaviour has existed since this was [first implemented](https://github.com/rails/rails/pull/36927) for 6.1, but I couldn't find a rationale for it. Perhaps this was intended as a performance optimization?

### Detail

The fix is to simply use `map` instead of `map!`. A test has been added to validate that the keys aren't mutated. I will admit that it feels odd to have a test specifically for this – the other cache interface tests don't test for this, for example – but I have included it for completeness.

It is worth acknowledging that this is technically a breaking change. It is possible that someone somewhere relies on this mutation behaviour.

### Additional information

`delete_multi` was first implemented in https://github.com/rails/rails/pull/36927 for 6.1. I wasn't able to find any other issues or PRs related to this key mutation behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
