### PR TITLE
Fix action_cable_meta_tag with relative_url_root

### DIFF
--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -35,11 +35,25 @@ module ActionCable
       #
       def action_cable_meta_tag
         tag "meta", name: "action-cable-url", content: (
-          ActionCable.server.config.url ||
-          ActionCable.server.config.mount_path ||
+          config_url || config_mount_path ||
           raise("No Action Cable URL configured -- please configure this at config.action_cable.url")
         )
       end
+
+      private
+        def config_url
+          ActionCable.server.config.url
+        end
+
+        def config_mount_path
+          if (path = ActionCable.server.config.mount_path).present?
+            if (root = Rails.configuration.relative_url_root).present?
+              File.join(root, path).to_s
+            else
+              path
+            end
+          end
+        end
     end
   end
 end

--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -35,7 +35,9 @@ module ActionCable
       #
       def action_cable_meta_tag
         tag "meta", name: "action-cable-url", content: (
-          config_url || config_mount_path ||
+          ActionCable.server.config.url ||
+          (ActionCable.server.config.mount_path &&
+             File.join(Rails.configuration.relative_url_root || "/", ActionCable.server.config.mount_path)) ||
           raise("No Action Cable URL configured -- please configure this at config.action_cable.url")
         )
       end

--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -41,21 +41,6 @@ module ActionCable
           raise("No Action Cable URL configured -- please configure this at config.action_cable.url")
         )
       end
-
-      private
-        def config_url
-          ActionCable.server.config.url
-        end
-
-        def config_mount_path
-          if (path = ActionCable.server.config.mount_path).present?
-            if (root = Rails.configuration.relative_url_root).present?
-              File.join(root, path).to_s
-            else
-              path
-            end
-          end
-        end
     end
   end
 end

--- a/actioncable/test/helpers/action_cable_helper_test.rb
+++ b/actioncable/test/helpers/action_cable_helper_test.rb
@@ -1,36 +1,34 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require 'action_view/railtie'
+require "action_view/railtie"
 
 class ActionCable::Helpers::ActionCableHelperTest < ActionCable::TestCase
   include ActionCable::Helpers::ActionCableHelper
   include ActionView::Helpers::TagHelper
 
-  setup { ActionCable.server.config.mount_path = '/cable' }
+  setup { ActionCable.server.config.mount_path = "/cable" }
 
-  def with_mock_relative_url_root(value)
+  def with_mock_relative_url_root(value, &block)
     config = Minitest::Mock.new
     config.expect(:relative_url_root, value)
-    Rails.stub(:configuration, config) do
-      yield
-    end
+    Rails.stub(:configuration, config, &block)
   end
 
-  test 'action_cable_meta_tag mount_path without relative_url_root' do
+  test "action_cable_meta_tag mount_path without relative_url_root" do
     with_mock_relative_url_root(nil) do
       assert_equal(
-        action_cable_meta_tag,
-        %Q(<meta name="action-cable-url" content="/cable" />)
+        '<meta name="action-cable-url" content="/cable" />',
+        action_cable_meta_tag
       )
     end
   end
 
-  test 'action_cable_meta_tag mount_path with relative_url_root' do
-    with_mock_relative_url_root('/foo') do
+  test "action_cable_meta_tag mount_path with relative_url_root" do
+    with_mock_relative_url_root("/foo") do
       assert_equal(
-        action_cable_meta_tag,
-        %Q(<meta name="action-cable-url" content="/foo/cable" />)
+        '<meta name="action-cable-url" content="/foo/cable" />',
+        action_cable_meta_tag
       )
     end
   end

--- a/actioncable/test/helpers/action_cable_helper_test.rb
+++ b/actioncable/test/helpers/action_cable_helper_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require 'action_view/railtie'
+
+class ActionCable::Helpers::ActionCableHelperTest < ActionCable::TestCase
+  include ActionCable::Helpers::ActionCableHelper
+  include ActionView::Helpers::TagHelper
+
+  setup { ActionCable.server.config.mount_path = '/cable' }
+
+  def with_mock_relative_url_root(value)
+    config = Minitest::Mock.new
+    config.expect(:relative_url_root, value)
+    Rails.stub(:configuration, config) do
+      yield
+    end
+  end
+
+  test 'action_cable_meta_tag mount_path without relative_url_root' do
+    with_mock_relative_url_root(nil) do
+      assert_equal(
+        action_cable_meta_tag,
+        %Q(<meta name="action-cable-url" content="/cable" />)
+      )
+    end
+  end
+
+  test 'action_cable_meta_tag mount_path with relative_url_root' do
+    with_mock_relative_url_root('/foo') do
+      assert_equal(
+        action_cable_meta_tag,
+        %Q(<meta name="action-cable-url" content="/foo/cable" />)
+      )
+    end
+  end
+end


### PR DESCRIPTION
The ActionCable helper action_cable_meta_tag did not respect the Rails configuration option relative_url_root, this fixes that and so issue #57923 

### Motivation / Background

Minor Fix: action_cable_meta_tag now respects relative_url_root

### Detail

Just the single function in the ActionCable helper and a couple of tests.

### Additional information

There don't seem to be many tests which use `Rail.configuration`, and it seems a bad idea to modify it in tests, so I've mocked it. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
