### PR TITLE
Warn on broken links to other guides

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -18,6 +18,12 @@ module RailsGuides
   class Generator
     GUIDES_RE = /\.(?:erb|md)\z/
 
+    AnchorLink = Data.define(:file, :fragment, :source) do
+      def link
+        [file, fragment].join("#")
+      end
+    end
+
     def initialize(edge:, version:, all:, only:, epub:, language:, direction: nil, lint:, guides_dir: nil)
       @edge         = edge
       @version      = version
@@ -28,6 +34,8 @@ module RailsGuides
       @direction    = direction || "ltr"
       @digest_paths = {}
       @lint         = lint
+      @anchors      = {}
+      @anchor_links = Hash.new { |h, k| h[k] = [] }
       @warnings     = []
 
       if @epub
@@ -107,6 +115,8 @@ module RailsGuides
           output_file = output_file_for(guide)
           generate_guide(guide, output_file) if generate?(guide, output_file)
         end
+
+        warn_about_broken_anchor_links
       end
 
       def guides_to_generate
@@ -214,9 +224,15 @@ module RailsGuides
             epub:    @epub
           ).render(body)
 
-          broken = warn_about_broken_links(result)
-          if broken.any?
-            @warnings << "[WARN] BROKEN LINK(s): #{guide}: #{broken.join(", ")}"
+          # Extract anchors per guide.
+          @anchors[output_file] = extract_anchors(result)
+
+          # Extract anchor links per target guide.
+          extract_anchor_links(result).each do |file, fragment|
+            anchor_link = AnchorLink.new(file: file, fragment: fragment, source: output_file)
+            # If the link is internal, the target is the output_file.
+            target_file = file || output_file
+            @anchor_links[target_file] << anchor_link
           end
         end
 
@@ -225,9 +241,21 @@ module RailsGuides
         end if !dry_run?
       end
 
-      def warn_about_broken_links(html)
-        anchors = extract_anchors(html)
-        check_fragment_identifiers(html, anchors)
+      def warn_about_broken_anchor_links
+        # Loop over all anchor links and check if the anchor exists.
+        @anchor_links.each do |output_file, anchor_links|
+          existing_anchors = @anchors[output_file]
+          anchor_links.each do |anchor_link|
+            if existing_anchors&.exclude?(anchor_link.fragment)
+              warning = "[WARN] BROKEN LINK in #{anchor_link.source}: #{anchor_link.link}."
+              if guess = DidYouMean::SpellChecker.new(dictionary: existing_anchors).correct(anchor_link.fragment).first
+                guess_link = AnchorLink.new(file: anchor_link.file, fragment: guess, source: nil)
+                warning << "\n       Perhaps you meant #{guess_link.link}."
+              end
+              @warnings << warning
+            end
+          end
+        end
       end
 
       def extract_anchors(html)
@@ -247,20 +275,14 @@ module RailsGuides
         anchors
       end
 
-      def check_fragment_identifiers(html, anchors)
-        broken_links = []
-
-        html.scan(/<a\s+href="#([^"]+)/).flatten.each do |fragment_identifier|
-          next if fragment_identifier == "column-main" # in layout
-          next if fragment_identifier == "main-skip-link" # in layout
-          unless anchors.member?(CGI.unescape(fragment_identifier))
-            guess = DidYouMean::SpellChecker.new(dictionary: anchors).correct(fragment_identifier).first
-            puts "*** BROKEN LINK: ##{fragment_identifier}, perhaps you meant ##{guess}."
-            broken_links << "##{fragment_identifier}"
-          end
+      def extract_anchor_links(html)
+        anchor_links = []
+        html.scan(/<a\s+href="([a-z_]+.html)?#([^"]+)/).map do |file, fragment|
+          next if fragment == "column-main" # in layout
+          next if fragment == "main-skip-link" # in layout
+          anchor_links << [file, fragment]
         end
-
-        broken_links
+        anchor_links
       end
   end
 end

--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -69,7 +69,7 @@ Have a look at the
 [Spring README](https://github.com/rails/spring/blob/main/README.md) to
 see all available features.
 
-See the [Upgrading Ruby on Rails](upgrading_ruby_on_rails.html#spring)
+See the [Upgrading Ruby on Rails](https://guides.rubyonrails.org/v4.1/upgrading_ruby_on_rails.html#spring)
 guide on how to migrate existing applications to use this feature.
 
 ### `config/secrets.yml`

--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -89,7 +89,7 @@ for your application. You can configure a global default policy and then
 override it on a per-resource basis and even use lambdas to inject per-request
 values into the header such as account subdomains in a multi-tenant application.
 You can read more about this in the
-[Securing Rails Applications](security.html#content-security-policy)
+[Securing Rails Applications](https://guides.rubyonrails.org/v5.2/security.html#content-security-policy)
 guide.
 
 Railties

--- a/guides/source/active_record_composite_primary_keys.md
+++ b/guides/source/active_record_composite_primary_keys.md
@@ -143,12 +143,6 @@ And this `where` call behaves the same way:
 Order.where(id: 5)
 ```
 
-Take caution when using `find_by(id:)` on models where `:id` is not the primary
-key, such as composite primary key models. See the [Active Record Querying][]
-guide to learn more.
-
-[Active Record Querying]: active_record_querying.html#conditions-with-id
-
 Associations between Models with Composite Primary Keys
 -------------------------------------------------------
 

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -49,8 +49,6 @@ There are also numerous related guides that you may find useful:
   connection between Active Record models
 * [Composite Primary Keys](active_record_composite_primary_keys.html) - Learn
   how to work with composite primary keys
-* [Active Record Transactions](active_record_basics.html#transactions) - Learn
-  about database transactions
 
 A Bookstore Model Example
 -------------------------

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1440,7 +1440,7 @@ user.highlights.second.filename # => "town.jpg"
 
 Existing applications can opt in to this new behavior by setting [`config.active_storage.replace_on_assign_to_many`][] to `true`. The old behavior will be deprecated in Rails 7.0 and removed in Rails 7.1.
 
-[`config.active_storage.replace_on_assign_to_many`]: configuring.html#config-active-storage-replace-on-assign-to-many
+[`config.active_storage.replace_on_assign_to_many`]: https://guides.rubyonrails.org/v6.0/configuring.html#configuring-active-storage
 
 ### Custom exception handling applications
 


### PR DESCRIPTION
We already check for broken anchor links in the same guide.
We should also warn if an anchor link to another guide is broken to prevent broken links like: https://github.com/rails/rails/pull/58012

This change extends the warnings to also work for broken links to other guides:
```log
Generating command_line.md as command_line.html
Generating 5_2_release_notes.md as 5_2_release_notes.html
Generating 7_1_release_notes.md as 7_1_release_notes.html
[WARN] BROKEN LINK in active_record_composite_primary_keys.html: active_record_querying.html#conditions-with-id.
       Perhaps you meant active_record_querying.html#conditions-that-use-like.
```

Broken links have been updated to either the new anchor or an older guide, if a feature has been removed.

The link to the "Transactions" guide has been removed as I couldn't find a Rails version where active_record_basics.html described transactions.
A "Transactions" guide is in the works.

The link (and explaining paragraph) to active_record_querying.html#conditions-with-id was removed, as that whole section is now part of the "Composite Primary Keys" guide.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
