### PR TITLE
Elide redundant DISTINCT when it cannot remove rows

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Drop a redundant `DISTINCT` when it cannot remove any rows.
+
+    When a relation is marked `distinct`, selects from a single table (no joins,
+    eager loading, `from` subquery, or `GROUP BY`), and projects the whole row,
+    the primary key is present in every row, so the result is already distinct.
+    In that case the `DISTINCT` is omitted from the generated SQL, avoiding an
+    unnecessary sort. The result set is unchanged.
+
+    ```ruby
+    Post.distinct.to_sql
+    # before => SELECT DISTINCT "posts".* FROM "posts"
+    # after  => SELECT "posts".* FROM "posts"
+    ```
+
+    `COUNT(DISTINCT ...)` (e.g. `Post.distinct.count`) and any query with joins,
+    grouping, or an explicit column projection are unaffected.
+
+    *Siva Kilaru*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1839,11 +1839,45 @@ module ActiveRecord
 
         arel.optimizer_hints(*optimizer_hints_values) unless optimizer_hints_values.empty?
         arel.comment(*annotate_values) unless annotate_values.empty?
-        arel.distinct(distinct_value)
+        arel.distinct(distinct_value) unless distinct_value && redundant_distinct?
         arel.from(build_from) unless from_clause.empty?
         arel.lock(lock_value) if lock_value
 
         arel
+      end
+
+      # Whether the +DISTINCT+ requested on this relation cannot remove any rows,
+      # and can therefore be dropped. That is the case when the relation selects
+      # from a single table and projects the whole row: every row then carries a
+      # unique primary key, so the result is already distinct and +DISTINCT+ only
+      # adds a needless sort. Deliberately conservative -- any uncertainty keeps
+      # +DISTINCT+ (a false positive would silently drop rows).
+      def redundant_distinct?
+        joins_values.empty? &&
+          left_outer_joins_values.empty? &&
+          includes_values.empty? &&
+          references_values.empty? &&
+          !eager_loading? &&
+          from_clause.empty? &&
+          group_values.empty? &&
+          having_clause.empty? &&
+          model.primary_key &&
+          whole_row_select?
+      end
+
+      # True only when the projection is guaranteed to include the whole row (and
+      # thus the primary key): an empty select renders as +SELECT "table".*+ unless
+      # the model restricts the columns, or an explicit lone +*+ / +"table".*+.
+      def whole_row_select?
+        if select_values.empty?
+          model.only_columns.empty?
+        elsif select_values.one?
+          value = select_values.first
+          value == "*" || value == "#{table.name}.*" ||
+            (Arel::Nodes::SqlLiteral === value && value.to_s.strip == "*")
+        else
+          false
+        end
       end
 
       def build_cast_value(name, value)

--- a/activerecord/test/cases/relation/distinct_elision_test.rb
+++ b/activerecord/test/cases/relation/distinct_elision_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+require "models/author"
+
+module ActiveRecord
+  class DistinctElisionTest < ActiveRecord::TestCase
+    fixtures :posts, :comments, :authors
+
+    # --- DISTINCT is redundant and dropped: single table, whole-row projection ---
+
+    def test_drops_distinct_for_bare_relation
+      assert_no_match(/\bDISTINCT\b/, Post.distinct.to_sql)
+    end
+
+    def test_drops_distinct_with_where
+      assert_no_match(/\bDISTINCT\b/, Post.where(author_id: 1).distinct.to_sql)
+    end
+
+    def test_drops_distinct_for_table_star_select
+      assert_no_match(/\bDISTINCT\b/, Post.select("posts.*").distinct.to_sql)
+    end
+
+    def test_drops_distinct_for_star_select
+      assert_no_match(/\bDISTINCT\b/, Post.select("*").distinct.to_sql)
+    end
+
+    def test_drops_distinct_with_limit_and_order
+      # ORDER BY on a projected column (whole row) stays valid without DISTINCT.
+      assert_no_match(/\bDISTINCT\b/, Post.order(:id).limit(5).distinct.to_sql)
+    end
+
+    # --- DISTINCT is kept: it may actually collapse rows ---
+
+    def test_keeps_distinct_with_inner_join
+      assert_match(/\bDISTINCT\b/, Post.joins(:comments).distinct.to_sql)
+    end
+
+    def test_keeps_distinct_with_left_outer_join
+      assert_match(/\bDISTINCT\b/, Post.left_outer_joins(:comments).distinct.to_sql)
+    end
+
+    def test_keeps_distinct_with_eager_loading
+      assert_match(/\bDISTINCT\b/, Post.eager_load(:comments).distinct.to_sql)
+    end
+
+    def test_keeps_distinct_with_group
+      assert_match(/\bDISTINCT\b/, Post.group(:author_id).distinct.to_sql)
+    end
+
+    def test_keeps_distinct_with_from_subquery
+      relation = Post.from("(SELECT * FROM posts) posts").distinct
+      assert_match(/\bDISTINCT\b/, relation.to_sql)
+    end
+
+    def test_keeps_distinct_for_non_primary_key_projection
+      assert_match(/\bDISTINCT\b/, Post.select(:title).distinct.to_sql)
+    end
+
+    def test_keeps_distinct_for_explicit_primary_key_projection
+      # Tier 1 only elides the whole-row projection; an explicit primary-key
+      # select still keeps DISTINCT (a deliberately conservative scope).
+      assert_match(/\bDISTINCT\b/, Post.select(:id).distinct.to_sql)
+    end
+
+    def test_keeps_distinct_when_model_has_no_primary_key
+      no_pk = Class.new(ActiveRecord::Base) do
+        self.table_name = "posts"
+        self.primary_key = nil
+      end
+      assert_match(/\bDISTINCT\b/, no_pk.all.distinct.to_sql)
+    end
+
+    # --- COUNT(DISTINCT ...) must be unaffected (built via a separate path) ---
+
+    def test_count_distinct_still_uses_count_distinct
+      assert_queries_match(/COUNT\(DISTINCT/i, count: 1) do
+        Post.distinct.count
+      end
+    end
+
+    def test_count_distinct_with_join_still_uses_count_distinct
+      assert_queries_match(/COUNT\(DISTINCT/i, count: 1) do
+        Post.joins(:comments).distinct.count
+      end
+    end
+
+    # --- Behavioral equivalence: dropping the redundant DISTINCT changes nothing ---
+
+    def test_result_set_is_identical_without_distinct
+      assert_equal Post.order(:id).to_a, Post.order(:id).distinct.to_a
+    end
+
+    def test_count_is_identical_without_distinct
+      assert_equal Post.count, Post.distinct.count
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

When a relation is `distinct` but selects from a **single table** (no joins, eager loading, `from` subquery, or `GROUP BY`) and projects the whole row, every returned row already carries a unique primary key. The result is therefore already distinct, and `DISTINCT` only forces the database into an unnecessary sort/unique pass.

This pattern is common — e.g. a scope that adds `.distinct` defensively, or `Model.where(...).distinct`. On PostgreSQL it adds a `Unique` (+ `Sort`) node over the full, wide result set:

```
EXPLAIN ANALYZE, 1,000,000-row single table, warm cache:

  SELECT * FROM widgets           113 ms   Seq Scan
  SELECT DISTINCT * FROM widgets  383 ms   Unique + Incremental Sort
```

Both return the same 1,000,000 rows; the ~3x difference is pure overhead.

### Detail

`Relation#build_arel` now omits `DISTINCT` when it is provably a no-op:

- **single table** — no `joins`, `left_outer_joins`, `includes`/eager loading, `references`, `from` subquery, `GROUP BY`, or `HAVING`; **and**
- **whole-row projection** — an empty select (which renders as `SELECT "t".*`) or an explicit `*` / `"t".*`; **and**
- the model **has a primary key**.

```ruby
Post.distinct.to_sql
# before => SELECT DISTINCT "posts".* FROM "posts"
# after  => SELECT "posts".* FROM "posts"
```

The check is intentionally conservative — anything it cannot prove keeps `DISTINCT`. In particular:

- **Joins / eager loading** keep `DISTINCT` (fan-out can create duplicate rows).
- **No primary key** keeps `DISTINCT` — a keyless table can hold fully-identical rows, so `DISTINCT` is meaningful there.
- **Explicit non-whole-row selects** (`select(:name)`, and even `select(:id)`) keep `DISTINCT`; this PR only handles the whole-row projection (an explicit primary-key select could be a follow-up).
- **`COUNT(DISTINCT ...)`** (e.g. `Post.distinct.count`) is unaffected — it is built via `Calculations#perform_calculation`, which sets `distinct!(false)` before `build_arel` runs.

A false positive would silently drop rows, so the predicate errs entirely toward keeping `DISTINCT`; a false negative merely misses the optimization. The result set is never changed.

Complementary to #55029 / #55027, which target unnecessary `COUNT(DISTINCT)` on eager-loaded counts; this PR covers the non-count, top-level `DISTINCT`.

### Additional information

Tests in `activerecord/test/cases/relation/distinct_elision_test.rb` cover the elided cases, the kept cases (inner/left join, eager load, `group`, `from`, explicit-column select, no-primary-key model), `COUNT(DISTINCT)` preservation, and result-set / count equivalence. No regressions in the existing calculations, relations, `relation/`, and finder suites.
