### PR TITLE
Add boolean argument to enum-generated scopes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Enum scopes now accept an optional boolean argument to toggle between positive and negative matching.
+
+    ```ruby
+    class Book < ActiveRecord::Base
+      enum :status, [ :proposed, :written, :published ]
+    end
+
+    Book.published       # WHERE status = 2
+    Book.published(true) # WHERE status = 2
+    Book.published(false) # WHERE status IS DISTINCT FROM 2 (equivalent to Book.not_published)
+
+    Book.not_published        # WHERE status IS DISTINCT FROM 2
+    Book.not_published(false) # WHERE status = 2 (equivalent to Book.published)
+    ```
+
+    *Bogdan Gusiev*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -311,13 +311,13 @@ module ActiveRecord
             end
 
             if scopes
-              # scope :active, -> { where(status: 0) }
+              # scope :active, -> (flag = true) { flag ? where(status: 0) : where.not(status: 0) }
               klass.send(:detect_enum_conflict!, name, value_method_name, true)
-              klass.scope value_method_name, -> { where(name => value) }
+              klass.scope value_method_name, ->(flag = true) { flag ? where(name => value) : where(predicate_builder[name, value, :is_distinct_from]) }
 
-              # scope :not_active, -> { where.not(status: 0) }
+              # scope :not_active, -> (flag = true) { active(!flag) }
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where(predicate_builder[name, value, :is_distinct_from]) }
+              klass.scope "not_#{value_method_name}", ->(flag = true) { public_send(value_method_name, !flag) }
             end
           end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -96,6 +96,12 @@ class EnumTest < ActiveRecord::TestCase
     assert Book.not_published.include?(rfr)
   end
 
+  test "scope accepts boolean argument to negate" do
+    assert_equal @book, Book.published(true).first
+    assert Book.published(false).exclude?(@book)
+    assert_equal Book.not_published.to_sql, Book.published(false).to_sql
+  end
+
   test "find via where with values" do
     published, written = Book.statuses[:published], Book.statuses[:written]
 


### PR DESCRIPTION
### Motivation / Background

Enum-generated scopes currently accept no arguments, so passing a boolean (e.g. `Book.published(false)`) raises `ArgumentError: wrong number of arguments (given 1, expected 0)`. This is a common pattern in Rails scopes where a boolean toggles the condition, and it's natural for enum scopes to support it too.

A typical use case is wiring a checkbox filter directly to a scope:

```ruby
# params[:published] comes from a checkbox as true/false
Book.published(params[:published])

# instead of the current workaround:
params[:published] ? Book.published : Book.not_published
```

### Detail

This Pull Request changes the enum-generated positive and negative scopes to accept an optional boolean argument (default `true`):

- `Book.published(true)` → same as `Book.published` (`WHERE status = 2`)
- `Book.published(false)` → same as `Book.not_published` (`WHERE status IS DISTINCT FROM 2`)
- `Book.not_published(false)` → same as `Book.published` (`WHERE status = 2`)

The `not_` scope delegates to the positive scope with a negated flag, keeping the logic in one place.

### Additional information

The negated branch uses `IS DISTINCT FROM` (rather than `!=`) to correctly include records where the column is `NULL`, consistent with the existing `not_` scope behavior.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.