### PR TITLE
Keep the line break of under-indented blank lines in `strip_heredoc`

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -46,7 +46,7 @@ class String
     end
 
     lines.each do |line|
-      line[0, min_indent_len] = "" unless line == "\n"
+      line.sub!(/\A[ \t]{#{min_indent_len}}/, "")
     end
 
     result = lines.join

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -56,6 +56,14 @@ class StringInflectionsTest < ActiveSupport::TestCase
     EOS
   end
 
+  def test_strip_heredoc_keeps_the_line_break_of_a_whitespace_only_line_shorter_than_the_margin
+    assert_equal "foo\n  \nbar\n", "    foo\n  \n    bar\n".strip_heredoc
+  end
+
+  def test_strip_heredoc_keeps_the_line_break_of_a_blank_crlf_line
+    assert_equal "foo\r\n\r\nbar\r\n", "    foo\r\n\r\n    bar\r\n".strip_heredoc
+  end
+
   def test_pluralize
     SingularToPlural.each do |singular, plural|
       assert_equal(plural, singular.pluralize)


### PR DESCRIPTION
A whitespace-only line whose indentation is shorter than the computed margin — a blank CRLF line, or a line of stray spaces — loses its trailing line break when `strip_heredoc` removes the margin. The following line is merged onto it and the blank line disappears from the output.

This removes at most the margin's worth of leading spaces or tabs from each line and leaves its line break intact, so under-indented blank lines survive as blank lines. This restores the output produced before the scanner-based rewrite of `strip_heredoc`.

### Before

```ruby
"    foo\n  \n    bar\n".strip_heredoc
# => "foo\nbar\n"        # the blank line vanished
```

### After

```ruby
"    foo\n  \n    bar\n".strip_heredoc
# => "foo\n  \nbar\n"    # the blank line is preserved
```