### PR TITLE
Fix event timestamp type in EventReporter rdoc

### DIFF
--- a/activesupport/lib/active_support/event_reporter.rb
+++ b/activesupport/lib/active_support/event_reporter.rb
@@ -128,7 +128,7 @@ module ActiveSupport
   #   payload: Hash, Object (The payload of the event, or the event object itself)
   #   tags: Hash (The tags of the event)
   #   context: Hash (The context of the event)
-  #   timestamp: Float (The timestamp of the event, in nanoseconds)
+  #   timestamp: Integer (The timestamp of the event, in nanoseconds)
   #   source_location: Hash (The source location of the event, containing the filepath, lineno, and label)
   #
   # Subscribers are responsible for encoding events to their desired format before emitting them to their
@@ -306,7 +306,7 @@ module ActiveSupport
     #   payload: Hash, Object (The payload of the event, or the event object itself)
     #   tags: Hash (The tags of the event)
     #   context: Hash (The context of the event)
-    #   timestamp: Float (The timestamp of the event, in nanoseconds)
+    #   timestamp: Integer (The timestamp of the event, in nanoseconds)
     #   source_location: Hash (The source location of the event, containing the filepath, lineno, and label)
     #
     # An optional filter proc can be provided to only receive a subset of events:


### PR DESCRIPTION
The event hash documentation in `ActiveSupport::EventReporter` describes the `:timestamp` key as `Float (The timestamp of the event, in nanoseconds)`, at two sites: the class-level subscriber docs and the `#subscribe` docs.

### Before

Readers implementing a subscriber are told the timestamp is a Float.

### After

Both sites document the key as `Integer`, matching what subscribers actually receive: the reported event's timestamp comes from `Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)`, which returns epoch nanoseconds as an Integer. The example events throughout the same rdoc already show integer timestamps such as `1738964843208679035` — a value a Float cannot represent exactly (`1738964843208679035.to_f.to_i == 1738964843208679035` is `false`).

Follows up on documentation corrections to this file such as 27f4e99e51.