### PR TITLE
Instrument the normalized key in `Cache#fetch` hit path

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -478,7 +478,7 @@ module ActiveSupport
           end
 
           if entry
-            get_entry_value(entry, name, options)
+            get_entry_value(entry, key, options)
           else
             save_block_result_to_cache(name, key, options, &block)
           end
@@ -1119,8 +1119,8 @@ module ActiveSupport
           entry
         end
 
-        def get_entry_value(entry, name, options)
-          instrument(:fetch_hit, name, options)
+        def get_entry_value(entry, key, options)
+          instrument(:fetch_hit, key, options)
           entry.value
         end
 

--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -143,6 +143,18 @@ module CacheInstrumentationBehavior
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 
+  def test_fetch_hit_instrumentation
+    key = SecureRandom.uuid
+    options = { namespace: "foo" }
+    @cache.write(key, SecureRandom.alphanumeric, **options)
+
+    events = capture_notifications("cache_fetch_hit.active_support") { @cache.fetch(key, options) { } }
+
+    assert_equal %w[ cache_fetch_hit.active_support ], events.map(&:name)
+    assert_equal normalized_key(key, options), events[0].payload[:key]
+    assert_equal @cache.class.name, events[0].payload[:store]
+  end
+
   private
     def normalized_key(key, options = nil)
       @cache.send(:normalize_key, key, options)


### PR DESCRIPTION
## Summary

`ActiveSupport::Cache::Store#fetch` emits a `cache_fetch_hit.active_support` notification when it serves a value from the cache. Its `payload[:key]` used the raw un-namespaced name, unlike every sibling cache event, which report the normalized/namespaced key.

## Behavior before / after

Given a store built with `namespace: "myapp"`:

- **Before:** a `fetch` **miss** reports `payload[:key] == "myapp:counter"`
  (via `cache_generate`/`cache_read`/`cache_write`), but a `fetch` **hit** reports `payload[:key] == "counter"` — the namespace is dropped.
- **After:** a `fetch` hit reports `payload[:key] == "myapp:counter"`,
  matching the miss path and the `cache_read`, `cache_write`, `cache_delete`, and `cache_exist?` events for the same lookup.

## Correctness

`payload[:key]` is documented and consumed as the actual cache key. Every other cache instrumentation event exposes the normalized key; the hit path was the lone exception, making per-key subscribers see two different keys for one logical entry depending on hit vs. miss. This restores parity with the sibling events. Follows c013352ff2 (MemoryStore `increment`/`decrement`) and #57915 (`Cache#exist?`).