### PR TITLE
Support `log` on `ActiveSupport::ProxyLogger`

### DIFF
--- a/activesupport/lib/active_support/proxy_logger.rb
+++ b/activesupport/lib/active_support/proxy_logger.rb
@@ -124,6 +124,7 @@ module ActiveSupport
         true
       end
     end
+    alias_method :log, :add
 
     # Forward the given +msg+ to the underlying logger with no formatting
     # returns the number of characters written,

--- a/activesupport/test/proxy_logger_test.rb
+++ b/activesupport/test/proxy_logger_test.rb
@@ -64,23 +64,25 @@ module ActiveSupport
     end
 
     def test_all_delegators
+      @logger.log(::Logger::DEBUG, "LOG")
       @logger.debug("DEBUG")
       @logger.info("INFO")
       @logger.warn("WARN")
       @logger.error("ERROR")
       @logger.fatal("FATAL")
       @logger.unknown("UNKNOWN")
-      assert_equal %w(DEBUG INFO WARN ERROR FATAL UNKNOWN), @io.string.split("\n")
+      assert_equal %w(LOG DEBUG INFO WARN ERROR FATAL UNKNOWN), @io.string.split("\n")
     end
 
     def test_all_block_delegators
+      @logger.log(::Logger::DEBUG) { "LOG" }
       @logger.debug { "DEBUG" }
       @logger.info { "INFO" }
       @logger.warn { "WARN" }
       @logger.error { "ERROR" }
       @logger.fatal { "FATAL" }
       @logger.unknown { "UNKNOWN" }
-      assert_equal %w(DEBUG INFO WARN ERROR FATAL UNKNOWN), @io.string.split("\n")
+      assert_equal %w(LOG DEBUG INFO WARN ERROR FATAL UNKNOWN), @io.string.split("\n")
     end
   end
 end


### PR DESCRIPTION
`ProxyLogger` aims to support nearly the full standard `Logger` interface, and stdlib `Logger` exposes `log` as an alias for `add`. The sibling `BroadcastLogger` also forwards `log`. However, `ProxyLogger` does not define `log`, so calling it raises `NoMethodError`. This aliases `log` to `add` so the proxy accepts `log` while still respecting its own severity level.

### Before / After
```ruby
logger = ActiveSupport::ProxyLogger.new(Rails.logger, :error)
logger.log(Logger::ERROR, "msg")   # Before: NoMethodError / After: logged normally
```