### PR TITLE
Don't mutate the array passed to RedisCacheStore via `:client`

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -143,7 +143,7 @@ module ActiveSupport
           end
         end
 
-        clients.map! do |c|
+        clients = clients.map do |c|
           if c.respond_to?(:new_pool)
             c.new_pool(**(pool_options || {}))
           else

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -86,6 +86,13 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_kind_of ::RedisClient::Pooled, @cache.redis
     end
 
+    test "array of :client Configs is not mutated" do
+      clients = REDIS_URLS.map { |url| RedisClient.config(url: url) }.freeze
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(client: clients)
+      assert_kind_of ::RedisClient::HashRing, @cache.redis
+      assert clients.all?(::RedisClient::Config)
+    end
+
     test "deprecated :redis argument" do
       @cache = assert_deprecated(/Passing a Redis or ConnectionPool instance/, ActiveSupport.deprecator) do
         ActiveSupport::Cache::RedisCacheStore.new(redis: -> { Redis.new(url: REDIS_URL) })


### PR DESCRIPTION
## Summary

`ActiveSupport::Cache::RedisCacheStore.new` mutates the array the caller passes as the `:client` option, and raises `FrozenError` when that array is frozen. This affects the unreleased `redis-client` reimplementation (5843a7b7f2) and has never shipped in a release.

## Before

```ruby
configs = [RedisClient.config(url: url1), RedisClient.config(url: url2)]
ActiveSupport::Cache::RedisCacheStore.new(client: configs)
configs # => [#<RedisClient::Pooled ...>, #<RedisClient::Pooled ...>] — caller's configs replaced

ActiveSupport::Cache::RedisCacheStore.new(client: configs.freeze)
# => FrozenError: can't modify frozen Array
```

This is exactly the usage documented in the constructor rdoc:

```ruby
config.cache_store = :redis_cache_store, client: [RedisClient.config(...), RedisClient.config(...)]
```

## After

The store builds its own collection of pools; the caller's array and its `RedisClient::Config` elements are left untouched, and frozen input works. This matches 32d9437962, which gave the same treatment to the names array passed to `Cache::Store#delete_multi`.