### PR TITLE
Fix typos and inconsistencies in documentation

### DIFF
--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -204,7 +204,7 @@ module ActionMailer
     #   end
     #
     # If the +:queue+ option is specified,
-    # then only the emails(s) enqueued to a specific queue will be performed.
+    # then only the email(s) enqueued to a specific queue will be performed.
     #
     #   def test_deliver_enqueued_emails_with_queue
     #     deliver_enqueued_emails queue: :external_mailers do

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -168,7 +168,7 @@ module ActionController # :nodoc:
       #     be added at the position of the protect_from_forgery call in your
       #     application. This means any callbacks added before are run first. This is
       #     useful when you want your forgery protection to depend on other callbacks,
-      #     like authentication methods (Oauth vs Cookie auth).
+      #     like authentication methods (OAuth vs Cookie auth).
       #
       #     If you need to add verification to the beginning of the callback chain,
       #     use `prepend: true`.
@@ -200,7 +200,7 @@ module ActionController # :nodoc:
       #       end
       #
       #       def handle_unverified_request
-      #         # Custom behavior for unverfied request
+      #         # Custom behavior for unverified request
       #       end
       #     end
       #

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -100,7 +100,7 @@ module ActionText
     #     class Person < ApplicationRecord
     #       include ActionText::Attachable
     #
-    #       def attachable_plain_text_representation
+    #       def attachable_plain_text_representation(caption)
     #         "[#{name}]"
     #       end
     #     end

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -41,7 +41,7 @@ class JobSerializationTest < ActiveSupport::TestCase
     end
   end
 
-  test "keeps scheduled_at around after deserialization if data doesnt include it" do
+  test "keeps scheduled_at around after deserialization if data doesn't include it" do
     freeze_time
 
     current_time = Time.now

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -34,12 +34,12 @@ module ActiveRecord
     # However, if there is a WHERE clause that spans across tables Active
     # Record will fall back to a slightly more resource-intensive single query:
     #
-    #   Author.includes(:books).where(books: {title: 'Illiad'}).to_a
+    #   Author.includes(:books).where(books: {title: 'Iliad'}).to_a
     #   # SELECT `authors`.`id` AS t0_r0, `authors`.`name` AS t0_r1, `authors`.`age` AS t0_r2,
     #   #        `books`.`id`   AS t1_r0, `books`.`title`  AS t1_r1, `books`.`sales` AS t1_r2
     #   # FROM `authors`
     #   # LEFT OUTER JOIN `books` ON `authors`.`id` =  `books`.`author_id`
-    #   # WHERE `books`.`title` = 'Illiad'
+    #   # WHERE `books`.`title` = 'Iliad'
     #
     # This could result in many rows that contain redundant data and it performs poorly at scale
     # and is therefore only used when necessary.

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -198,7 +198,7 @@ module ActiveRecord
       def sanitize_as_sql_comment(value) # :nodoc:
         # Sanitize a string to appear within an SQL comment
         # For compatibility, this also surrounding "/*+", "/*", and "*/"
-        # charcacters, possibly with single surrounding space.
+        # characters, possibly with single surrounding space.
         # Then follows that by replacing any internal "*/" or "/*" with
         # "* /" or "/ *"
         comment = value.to_s.dup

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -21,7 +21,7 @@ module ActiveRecord
         # * <tt>:key_provider</tt> - A key provider to provide encryption and decryption keys. Defaults to
         #   +ActiveRecord::Encryption.key_provider+.
         # * <tt>:key</tt> - A password to derive the key from. It's a shorthand for a +:key_provider+ that
-        #   serves derivated keys. Both options can't be used at the same time.
+        #   serves derived keys. Both options can't be used at the same time.
         # * <tt>:deterministic</tt> - By default, encryption is not deterministic. It will use a random
         #   initialization vector for each encryption operation. This means that encrypting the same content
         #   with the same key twice will generate different ciphertexts. When set to +true+, it will generate the

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -950,7 +950,7 @@ module ActiveRecord
     #
     # * +counter+ - A Hash containing the names of the fields to update as keys and the amount to update as values.
     # * <tt>:touch</tt> option - Touch the timestamp columns when updating.
-    # * If attributes names are passed, they are updated along with update_at/on attributes.
+    # * If attributes names are passed, they are updated along with updated_at/on attributes.
     #
     # ==== Examples
     #

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -223,7 +223,7 @@ module ActiveRecord
             if $1 == ":" # skip PostgreSQL casts
               match # return the whole match
             elsif $1 == "\\" # escaped literal colon
-              match[1..-1] # return match with escaping backlash char removed
+              match[1..-1] # return match with escaping backslash char removed
             elsif bind_vars.include?(match = $2.to_sym)
               replace_bind_variable(connection, bind_vars[match])
             else

--- a/activerecord/lib/active_record/testing/query_assertions.rb
+++ b/activerecord/lib/active_record/testing/query_assertions.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       #   assert_queries_count { Post.first }
       #
       # Any unmaterialized transactions will be materialized to ensure only
-      # queries attempted intside the block are counted.
+      # queries attempted inside the block are counted.
       #
       # If the +:include_schema+ option is provided, any queries (including
       # schema related) are counted. Setting this option also skips leasing a

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -25,7 +25,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
   has_secure_token :key, length: MINIMUM_TOKEN_LENGTH
 
   # FIXME: these property should never have been stored in the metadata.
-  # The blob table should be migrated to have dedicated columns for theses.
+  # The blob table should be migrated to have dedicated columns for these.
   PROTECTED_METADATA = %w(analyzed identified composed).freeze
   private_constant :PROTECTED_METADATA
   store :metadata, accessors: [ :analyzed, :identified, :composed ], coder: ActiveRecord::Coders::JSON

--- a/activesupport/lib/active_support/core_ext/string/strip.rb
+++ b/activesupport/lib/active_support/core_ext/string/strip.rb
@@ -5,7 +5,7 @@ require "strscan"
 class String
   # Strips indentation in heredocs.
   #
-  # Note that since Ruby 2.3, heredocs can directly created with their indentation striped
+  # Note that since Ruby 2.3, heredocs can directly created with their indentation stripped
   # by using the <tt><<~</tt> syntax instead of <tt><<-</tt>.
   # Hence the strip_heredoc method is rarely useful nowadays.
   #

--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -14,7 +14,7 @@ module ActiveSupport
     #    # => "AEroskobing"
     #
     # Default approximations are provided for Western/Latin characters,
-    # e.g, "ø", "ñ", "é", "ß", etc.
+    # e.g., "ø", "ñ", "é", "ß", etc.
     #
     # This method is I18n aware, so you can set up custom approximations for a
     # locale. This can be useful, for example, to transliterate German's "ü"

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -255,7 +255,7 @@ module ActiveSupport
       # Performs the same functionality as #subscribe, but the +start+ and
       # +finish+ block arguments are in monotonic time instead of wall-clock
       # time. Monotonic time will not jump forward or backward (due to NTP or
-      # Daylights Savings). Use +monotonic_subscribe+ when accuracy of time
+      # Daylight Savings). Use +monotonic_subscribe+ when accuracy of time
       # duration is important. For example, computing elapsed time between
       # two events.
       def monotonic_subscribe(pattern = nil, callback = nil, prepend: false, &block)

--- a/activesupport/lib/active_support/proxy_logger.rb
+++ b/activesupport/lib/active_support/proxy_logger.rb
@@ -17,7 +17,7 @@ module ActiveSupport
   #
   # Almost all of the standard Logger interface is supported.
   #
-  # Note that the proxy logger can only surpress some logs, if the proxy severity is lower
+  # Note that the proxy logger can only suppress some logs, if the proxy severity is lower
   # than the severity of the proxied logger, the logs won't be emitted.
   class ProxyLogger
     include LoggerSilence

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2137,7 +2137,7 @@ of these subscribers.
 Let's generate a model called Subscriber to store these email addresses and
 associate them with the respective product.
 
-NOTE: Here we are not specifying a type for `email` as rails automatically defaults to a `string` when a type is not given for migrations.
+NOTE: Here we are not specifying a type for `email` as Rails automatically defaults to a `string` when a type is not given for migrations.
 
 ```bash
 $ bin/rails generate model Subscriber product:belongs_to email

--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -46,7 +46,7 @@ will receive bug fixes until January 1, 2024. After that, it will be considered
 unsupported.
 
 Bug fixes are typically added to the main branch, and backported to the x-y-stable
-branch of the latest release series if there is sufficient need. When enough bugs
+branch of the latest release series if there is sufficient need. When enough bug
 fixes have been added to an x-y-stable branch, a new Patch release is built from it.
 For example, a theoretical 1.2.2 Patch release would be built from the 1-2-stable branch.
 

--- a/guides/source/product_reviews.md
+++ b/guides/source/product_reviews.md
@@ -90,7 +90,7 @@ $ bin/rails db:migrate
    -> 0.0036s
 -- add_column(:products, :reviews_count, :integer, {default: 0})
    -> 0.0005s
--- add_column(:products, :rating, :decimal, {precision: 2, scale: 1})
+-- add_column(:products, :rating, :decimal, {precision: 2, scale: 1, default: 0})
    -> 0.0004s
 == 20260421200530 CreateReviews: migrated (0.0045s) ===========================
 ```
@@ -361,7 +361,7 @@ is always set.
 
 ## Displaying Product Reviews
 
-We need to a way to view these product reviews next. Let's use a two-column
+We need a way to view these product reviews next. Let's use a two-column
 layout that shows an overview of ratings on the left and the reviews on the
 right.
 
@@ -566,7 +566,7 @@ average rating on the `Product`.
 
 To solve this, we can add a callback to the `Review` model to update the
 associated `Product` rating. This works very similarly to a counter cache, but
-instead we're calcuating an average.
+instead we're calculating an average.
 
 Let's add the callback to `app/models/review.rb`:
 
@@ -625,7 +625,8 @@ class Review < ApplicationRecord
 
   scope :rated, ->(rating) { rating.present? ? where(rating: rating.to_i) : all }
 
-  validates :body, :rating, presence: true
+  validates :body, presence: true
+  validates :rating, presence: true, numericality: { in: 1..5, only_integer: true }
 
   after_commit :update_product_rating
 
@@ -967,9 +968,9 @@ By default, Rails will replace all of the existing images when a new value is
 assigned. To preserve existing images when editing a review, we need to create
 hidden fields for each image that's already uploaded. These hidden fields use
 the image's `signed_id` to reference the existing ActiveRecord object and also
-ensures that it wasn't tampered with. We use `multiple: true` so Rails generates
+ensure that it wasn't tampered with. We use `multiple: true` so Rails generates
 the correct name to add the `images` param as an array. We also disable the `id`
-generated for this fields since it would generate duplicates and we don't need
+generated for these fields since it would generate duplicates and we don't need
 them.
 
 With that added, store admins can now view, edit, and delete reviews as needed.
@@ -1175,7 +1176,7 @@ $ bin/rails generate integration_test reviews
       create    test/integration/reviews_test.rb
 ```
 
-In `test/integrations/reviews_test.rb`, let's add a test that submits a review
+In `test/integration/reviews_test.rb`, let's add a test that submits a review
 as a logged-in user.
 
 ```ruby

--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -716,7 +716,7 @@ following:
 <%= button_to "Delete my account", settings_user_path, method: :delete, data: { turbo_confirm: "Are you sure? This cannot be undone." } %>
 ```
 
-And finally, we'll add a link to Account in the setting layout's sidebar.
+And finally, we'll add a link to Account in the settings layout's sidebar.
 
 ```erb#7
 <%= content_for :content do %>

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -464,7 +464,7 @@ versions, there are two scenarios to consider:
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
     ```
 
-    If all of your data was encrypted non-deterministicly (the default unless `encrypts` is passed `deterministic: true`, you can instead configure SHA-256 for Active Record Encryption as in scenario 2 below and also allow columns previously encrypted with SHA-1 to be decrypted by setting:
+    If all of your data was encrypted non-deterministically (the default unless `encrypts` is passed `deterministic: true`, you can instead configure SHA-256 for Active Record Encryption as in scenario 2 below and also allow columns previously encrypted with SHA-1 to be decrypted by setting:
 
     ```ruby
     config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true

--- a/guides/source/wishlists.md
+++ b/guides/source/wishlists.md
@@ -4,7 +4,7 @@ Wishlists
 =========
 
 This guide covers adding Wishlists to the e-commerce application you created in the
-[Getting Started Guide](getting_started.html)). We will use the code from the
+[Getting Started Guide](getting_started.html). We will use the code from the
 [Sign up and Settings Guide](sign_up_and_settings.html) as a starting place.
 
 After reading this guide, you will know how to:

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -215,7 +215,7 @@ module Rails
       end
 
       # Adds a load hook that makes sure the application is initialized before
-      # the a lazy loaded component is loaded. The load hook will avise how to use
+      # a lazy-loaded component is loaded. The load hook will advise how to use
       # load hooks to defer code until the application is fully loaded.
       def guard_load_hooks(*components)
         components.each do |component|


### PR DESCRIPTION
### Summary

Fixes typos and inconsistencies in documentation, and additionally sweeps spelling mistakes across the guides, API documentation and code comments. CHANGELOGs are intentionally left untouched.

This continues the typo cleanup in #58036 and folds in #58127.

### Wishlists guide

- An unmatched parenthesis after the Getting Started Guide link.

### Product Reviews guide

- The `db:migrate` sample output omitted the `default: 0` option that the migration above it declares (the sibling `reviews_count` line shows it).
- "We need to a way to view" → "We need a way to view".
- "calcuating" → "calculating".
- The current-state `review.rb` snippet in the Filtering section dropped the rating numericality validation introduced earlier and shown later, so it is restored to match.
- Subject/verb agreement: "these hidden fields … also ensures" → "ensure", and "this fields" → "these fields".
- The prose referenced `test/integrations/reviews_test.rb`; the generator output and run command both use `test/integration/`.

### Railtie

- Removed a duplicated article: "the a lazy loaded" → "a lazy-loaded".

### ProxyLogger

- "surpress" → "suppress" in the class comment.

### ActionText::Attachment

- The `#to_plain_text` RDoc example defines `attachable_plain_text_representation` with no parameters, but the method is called with the `caption` argument, so a user copying the example verbatim gets `ArgumentError`. The example now matches the runtime call, mirroring the sibling `#to_markdown` override example.

### Spelling sweep

Misspellings across the guides, API documentation and code comments, e.g.:

| before | after |
| --- | --- |
| `charcacters` | `characters` |
| `backlash` (char) | `backslash` |
| `Oauth` | `OAuth` |
| `Illiad` | `Iliad` |
| `derivated` | `derived` |
| `striped` (indentation) | `stripped` |
| `unverfied` | `unverified` |
| `avise` | `advise` |
| `theses` | `these` |
| `intside` | `inside` |

Spelling was checked with [codespell](https://github.com/codespell-project/codespell):

```sh
codespell --builtin clear,rare,code --skip='*/CHANGELOG.md'
```

codespell flags the dictionary-known misspellings; the remainder — misspelled identifiers and proper nouns such as `Oauth` and `Illiad` — were caught by proofreading. Only objective spelling mistakes are included; grammar and wording changes were deliberately left out, so every change here is one anyone can verify against a dictionary. All changes are comments, documentation, or a test description — no runtime behavior changes — hence `[ci skip]`.