### PR TITLE
Require enumerable core ext for Range#sole

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/sole.rb
+++ b/activesupport/lib/active_support/core_ext/range/sole.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/enumerable"
+
 class Range
   # Returns the sole item in the range. If there are no items, or more
   # than one item, raises Enumerable::SoleItemExpectedError.


### PR DESCRIPTION
## Summary

`active_support/core_ext/range/sole.rb` defines `Range#sole`, which delegates to `Enumerable#sole` via `super` and references `ActiveSupport::EnumerableCoreExt::SoleItemExpectedError`. Both of those live in `active_support/core_ext/enumerable`, but neither `sole.rb` nor `core_ext/range.rb` (nor anything else in the range require graph) loads that file. So the documented standalone cherry-pick `require "active_support/core_ext/range"` yields a `Range#sole` that always crashes.

## Behavior before / after

Standalone, from a clean `ruby -I lib`:

```
require "active_support/core_ext/range"
```

Before:

- `(1..1).sole` → `NoMethodError: super: no superclass method 'sole' for an instance of Range`
- `(..1).sole` → `NameError: uninitialized constant ActiveSupport::EnumerableCoreExt`

After:

- `(1..1).sole` → `1`
- `(2..1).sole` → `ActiveSupport::EnumerableCoreExt::SoleItemExpectedError: no item found`
- `(..1).sole` → `ActiveSupport::EnumerableCoreExt::SoleItemExpectedError: infinite range '..1' cannot represent a sole item`

Under a full Rails load, which already requires the enumerable core ext, behavior is unchanged.

## Why correct

`Range#sole` (added in 044d2eac9fe3, shipped in v8.1.0) depends on the enumerable core ext for both its superclass implementation and the error constant it raises; the file must require what it references. This mirrors a long line of missing-require fixes: e4de1ca9b5, 302fdb7677, 358ac36edf, a1c57cf69f.