### PR TITLE
Fix ActionText::Attachment#to_plain_text override example signature

### DIFF
--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -100,7 +100,7 @@ module ActionText
     #     class Person < ApplicationRecord
     #       include ActionText::Attachable
     #
-    #       def attachable_plain_text_representation
+    #       def attachable_plain_text_representation(caption)
     #         "[#{name}]"
     #       end
     #     end


### PR DESCRIPTION
## Summary

The rdoc for `ActionText::Attachment#to_plain_text` shows how to override the plain-text presentation by implementing `attachable_plain_text_representation`. The example method is defined with no parameters, but the framework calls it with the caption argument, so the documented code cannot be copied verbatim.

## Behavior before / after

Before: the example defines `def attachable_plain_text_representation` (zero parameters). At runtime `#to_plain_text` calls `attachable_plain_text_representation(caption)` with one positional argument. A user who copies the example verbatim gets `ArgumentError: wrong number of arguments (given 1, expected 0)`.

After: the example defines `def attachable_plain_text_representation(caption)`, matching the runtime call. The documented override now works as shown.

## Why the new behavior is correct

The runtime contract is `attachable_plain_text_representation(caption)`. The parallel `#to_markdown` rdoc in the same file already documents its override hook with the caption argument — `def attachable_markdown_representation(caption, attachment_links: false)` — matching its own runtime call. This change brings the plain-text example into the same parity. Sibling reference: 8a55476cda.