### PR TITLE
Support endless and beginless ranges in `number_field_tag`/`range_field_tag`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Support endless and beginless ranges in `number_field_tag` and
+    `range_field_tag`.
+
+    Previously, passing an endless (`18..`) or beginless (`..10`) range as the
+    `:in`/`:within` option raised `RangeError`. Now an endless range renders
+    `min` without `max`, and a beginless range renders `max` without `min`,
+    matching `number_field` and `range_field`.
+
+    *Kenta Ishizaki*
+
 *   Honor an explicit `value:` option in `color_field`, including `nil`.
 
     Previously, passing `value: nil` was ignored and the field still pre-filled

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -951,7 +951,7 @@ module ActionView
         options = options.stringify_keys
         options["type"] ||= "number"
         if range = options.delete("in") || options.delete("within")
-          options.update("min" => range.min, "max" => range.max)
+          options.update("min" => range.begin, "max" => (range.max if range.end))
         end
         text_field_tag(name, value, options)
       end

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -991,9 +991,29 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal(expected, number_field_tag("quantity", nil, in: 1...10))
   end
 
+  def test_number_field_tag_with_endless_range
+    expected = %{<input name="quantity" id="quantity" type="number" min="18" />}
+    assert_dom_equal(expected, number_field_tag("quantity", nil, in: 18..))
+  end
+
+  def test_number_field_tag_with_beginless_range
+    expected = %{<input name="quantity" max="10" id="quantity" type="number" />}
+    assert_dom_equal(expected, number_field_tag("quantity", nil, in: ..10))
+  end
+
   def test_range_input_tag
     expected = %{<input name="volume" step="0.1" max="11" id="volume" type="range" min="0" />}
     assert_dom_equal(expected, range_field_tag("volume", nil, in: 0..11, step: 0.1))
+  end
+
+  def test_range_input_tag_with_endless_range
+    expected = %{<input name="volume" id="volume" type="range" min="0" />}
+    assert_dom_equal(expected, range_field_tag("volume", nil, in: 0..))
+  end
+
+  def test_range_input_tag_with_beginless_range
+    expected = %{<input name="volume" max="11" id="volume" type="range" />}
+    assert_dom_equal(expected, range_field_tag("volume", nil, in: ..11))
   end
 
   def test_empty_datalist


### PR DESCRIPTION
### Summary

`number_field_tag` and `range_field_tag` raised `RangeError` when given an endless (`18..`) or beginless (`..10`) range as `:in`/`:within`:

```ruby
number_field_tag("quantity", nil, in: 18..)
# RangeError: cannot get the maximum of endless range

range_field_tag("volume", nil, in: ..11)
# RangeError: cannot get the minimum of beginless range
```

Now an endless range renders `min` with no `max` attribute, and a beginless range renders `max` with no `min` attribute:

```ruby
number_field_tag("quantity", nil, in: 18..)
# => <input name="quantity" id="quantity" type="number" min="18" />

range_field_tag("volume", nil, in: ..11)
# => <input name="volume" max="11" id="volume" type="range" />
```

Bounded ranges are unchanged, including exclusive ranges such as `1...10`, which still render `max="9"`.

This brings the tag helpers in line with `number_field`/`range_field`, which accept endless and beginless ranges since 530beb8550f140c21b790d6acdf990931e45e16b.