### PR TITLE
Treat an empty id array as an empty set for composite primary keys

### DIFF
--- a/activerecord/lib/active_record/key.rb
+++ b/activerecord/lib/active_record/key.rb
@@ -146,9 +146,10 @@ module ActiveRecord
       end
 
       # A single composite id is itself an Array, so several ids are an Array of
-      # Arrays.
+      # Arrays. An empty Array carries no composite id, so it is treated as an
+      # empty set of ids.
       def expects_multiple_ids?(value)
-        value.is_a?(Array) && value.first.is_a?(Array)
+        value.is_a?(Array) && (value.empty? || value.first.is_a?(Array))
       end
 
       # When a composite key has the conventional [tenant_key, "id"] shape,

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -309,7 +309,7 @@ module ActiveRecord
         # two apart.
         def update_multiple_ids?(id)
           if composite_primary_key?
-            id.is_a?(Array) && id.first.is_a?(Array)
+            id.is_a?(Array) && (id.empty? || id.first.is_a?(Array))
           else
             id.is_a?(Array)
           end

--- a/activerecord/test/cases/key_test.rb
+++ b/activerecord/test/cases/key_test.rb
@@ -68,6 +68,7 @@ class KeyTest < ActiveRecord::TestCase
 
     assert_not pk.expects_multiple_ids?(5)
     assert pk.expects_multiple_ids?([1, 2, 3])
+    assert pk.expects_multiple_ids?([])
   end
 
   def test_expects_multiple_ids_for_composite_key
@@ -77,6 +78,8 @@ class KeyTest < ActiveRecord::TestCase
     assert_not pk.expects_multiple_ids?([1, 5])
     # ...so several ids are an Array of Arrays.
     assert pk.expects_multiple_ids?([[1, 5], [1, 6]])
+    # ...and an empty Array is an empty set of ids.
+    assert pk.expects_multiple_ids?([])
   end
 
   def test_inferred_id_picks_id_from_tenant_shaped_key

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -478,6 +478,16 @@ class PersistenceTest < ActiveRecord::TestCase
     end
   end
 
+  def test_destroy_with_empty_array_of_composite_primary_keys
+    assert_no_difference("Cpk::Book.count") do
+      assert_equal [], Cpk::Book.destroy([])
+    end
+  end
+
+  def test_update_with_empty_array_of_composite_primary_keys
+    assert_equal [], Cpk::Book.update([], [])
+  end
+
   def test_destroy_with_invalid_ids_for_a_model_that_expects_composite_keys
     books = [
       cpk_books(:cpk_great_author_first_book),


### PR DESCRIPTION
## Summary

`destroy([])` and `update([], [])` on a composite primary key model raise `NoMethodError` (`undefined method 'destroy'/'update' for an instance of Array`). The empty array is not recognized as "multiple ids" and falls through to the single-id branch, which attempts to operate on the empty result of `find([])`. This treats an empty array as an empty id set so both calls return `[]` as a safe no-op, matching how single primary key models already handle `destroy([])` and `update([], [])`.

### Before / After
```ruby
CompositePkModel.destroy([])       # Before: NoMethodError / After: []
CompositePkModel.update([], [])    # Before: NoMethodError / After: []
```

## Fix

Two separate code paths carry the same `first.is_a?(Array)` check:

- `Key::Composite#expects_multiple_ids?` (used by `Relation#destroy`)
- `Persistence::ClassMethods#update_multiple_ids?` (used by `update`/`update!`)

Both now short-circuit on `value.empty?` before the type check, symmetrically. `find_with_ids` already short-circuits on an empty array (`return [] if first_item.empty?`), so `find` behavior is unchanged.