### PR TITLE
Apply DISTINCT to `average`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -501,7 +501,7 @@ module ActiveRecord
 
           column = relation.aggregate_column(column_name)
           select_value = operation_over_aggregate_column(column, operation, distinct)
-          select_value.distinct = true if operation == "sum" && distinct
+          select_value.distinct = true if distinct && (operation == "sum" || operation == "average")
 
           relation.select_values = [select_value]
 
@@ -557,7 +557,7 @@ module ActiveRecord
           column = relation.aggregate_column(column_name)
           column_alias = column_alias_tracker.alias_for("#{operation} #{column_name.to_s.downcase}")
           select_value = operation_over_aggregate_column(column, operation, distinct)
-          select_value.distinct = true if operation == "sum" && distinct
+          select_value.distinct = true if distinct && (operation == "sum" || operation == "average")
           select_value = select_value.as(model.adapter_class.quote_column_name(column_alias))
 
           select_values = [select_value]

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -77,6 +77,16 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_async_equal 53.0, Account.async_average(Account.arel_table[:credit_limit])
   end
 
+  def test_should_average_distinct_field
+    Account.delete_all
+    Account.create!(firm_id: 1, credit_limit: 50)
+    Account.create!(firm_id: 1, credit_limit: 50)
+    Account.create!(firm_id: 1, credit_limit: 60)
+
+    assert_equal 55, Account.where(firm_id: 1).distinct.average(:credit_limit)
+    assert_equal({ 1 => 55 }, Account.where(firm_id: 1).group(:firm_id).distinct.average(:credit_limit))
+  end
+
   def test_should_resolve_aliased_attributes
     assert_equal 318, Account.sum(:available_credit)
   end


### PR DESCRIPTION
### Summary

On a distinct relation, `average` ignored the DISTINCT qualifier while `count` and `sum` honor it, silently averaging duplicate values.

**Before:** with credit limits `[50, 50, 60]` on a distinct relation, `distinct.sum(:credit_limit)` returns `110` and `distinct.count(:credit_limit)` returns `2`, but `distinct.average(:credit_limit)` returned `~53.33` (plain `AVG(credit_limit)`) instead of `55`. The same held for `group(:firm_id).distinct.average(:credit_limit)`.

**After:** `distinct.average` emits `AVG(DISTINCT column)` in both the ungrouped and grouped calculation paths, returning `55` and `{ 1 => 55 }` for the data above — consistent with `distinct.count` / `distinct.sum`.

DISTINCT stays omitted for `minimum`/`maximum`, where it does not change the result.

### Precedent

Same contract previously established for `sum`: 566f1fd068 (ungrouped, fixes #16791) and 00e399d315 (grouped, #57896). The long-standing symptom for `average` was reported in #39857 (closed stale).