### PR TITLE
Respect a limit set on the relation in `rails query`

### DIFF
--- a/railties/lib/rails/commands/query/query_command.rb
+++ b/railties/lib/rails/commands/query/query_command.rb
@@ -172,7 +172,11 @@ module Rails
         def tabular_result_parts_for(result, expression:, page:, per:)
           case result
           when ActiveRecord::Relation
-            relation = result.offset((page - 1) * per).limit(per + 1)
+            relation = if result.limit_value
+              result
+            else
+              result.offset((page - 1) * per).limit(per + 1)
+            end
             relation_sql = relation.to_sql
 
             with_readonly_connection_for(relation.model.connection_class_for_self) do |connection|

--- a/railties/test/commands/query_test.rb
+++ b/railties/test/commands/query_test.rb
@@ -90,6 +90,16 @@ class Rails::Command::QueryTest < ActiveSupport::TestCase
     assert_not_equal page1["rows"], page2["rows"]
   end
 
+  test "respects a limit set on the relation" do
+    rails "runner", '3.times { |i| Post.create!(title: "Post #{i}") }'
+
+    data = query_json("Post.limit(1)")
+
+    assert_equal 1, data.dig("meta", "row_count")
+    assert_not data.dig("meta", "has_more")
+    assert_match(/\bLIMIT 1\b/, data.dig("meta", "sql"))
+  end
+
   test "does not double-eval on connection failure" do
     app_file "app/models/counter.rb", <<-RUBY
       class Counter


### PR DESCRIPTION
An Active Record expression that already carries a limit (e.g. `bin/rails query "Post.limit(5)"`) had its limit silently replaced by the pagination window (`per + 1`), returning up to a full page instead of the requested 5 rows. When the relation already has a limit, this now executes it as-is and only applies the display truncation for pagination. This aligns with the raw `--sql` path (`execute_sql`), which preserves the user-specified `LIMIT`.

### Before / After
```
bin/rails query "Post.limit(5)"
# Before: LIMIT overwritten to 101 (up to a full page returned)
# After : LIMIT 5 honored
```