### PR TITLE
Resolve `default_priority` lazily so a configured value is honored

### DIFF
--- a/activejob/lib/active_job/queue_priority.rb
+++ b/activejob/lib/active_job/queue_priority.rb
@@ -46,7 +46,7 @@ module ActiveJob
     end
 
     included do
-      class_attribute :priority, instance_accessor: false, default: default_priority
+      class_attribute :priority, instance_accessor: false, default: -> { self.class.default_priority }
     end
 
     # Returns the priority that the job will be created with

--- a/activejob/test/cases/queue_priority_test.rb
+++ b/activejob/test/cases/queue_priority_test.rb
@@ -10,7 +10,19 @@ class QueuePriorityTest < ActiveSupport::TestCase
   end
 
   test "priority unset by default" do
-    assert_nil HelloJob.priority
+    assert_nil HelloJob.new.priority
+  end
+
+  test "using a custom default_priority" do
+    original_default_priority = ActiveJob::Base.default_priority
+
+    begin
+      ActiveJob::Base.default_priority = 8
+
+      assert_equal 8, HelloJob.new.priority
+    ensure
+      ActiveJob::Base.default_priority = original_default_priority
+    end
   end
 
   test "uses given priority" do


### PR DESCRIPTION
Setting `ActiveJob::Base.default_priority = 10` in an initializer had no effect on any job. The `priority` class attribute captured the value of `default_priority` at the time the concern was included (before the initializer ran), so a later assignment was never observed. This resolves the default at the point a job reads its priority, so a `default_priority` set after load is honored. This aligns with `default_queue_name`, which already uses the same lambda-default pattern.

### Before / After
```ruby
ActiveJob::Base.default_priority = 10
SomeJob.new.priority   # Before: nil / After: 10
```