### PR TITLE
Serialize continuation step cursors through Active Job arguments

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix continuation step cursors losing their type when a job is interrupted
+    and resumed.
+
+    Cursors are now serialized like job arguments, so a resumed step sees the
+    same object it set before the interruption — for example a `Date`, `Time`,
+    or an Active Record object — instead of a raw JSON string.
+
+    *Kenta Ishizaki*
+
 *   Add `ActiveJob::DeserializationError::RecordNotFound`, raised when argument
     deserialization fails because a referenced record could not be found, and not
     for any other reason.

--- a/activejob/lib/active_job/continuable.rb
+++ b/activejob/lib/active_job/continuable.rb
@@ -51,12 +51,12 @@ module ActiveJob
     end
 
     def serialize # :nodoc:
-      super.merge("continuation" => continuation.to_h, "resumptions" => resumptions)
+      super.merge("continuation" => serialize_continuation_if_needed, "resumptions" => resumptions)
     end
 
     def deserialize(job_data) # :nodoc:
       super
-      self.continuation = Continuation.new(self, job_data.fetch("continuation", {}))
+      @serialized_continuation = job_data.fetch("continuation", {})
       self.resumptions = job_data.fetch("resumptions", 0)
     end
 
@@ -73,6 +73,26 @@ module ActiveJob
     end
 
     private
+      # The continuation is deserialized at the same point as the job arguments,
+      # inside perform_now, so that a cursor that fails to deserialize raises
+      # where retry_on/discard_on/rescue_from handlers can handle the error.
+      def deserialize_arguments_if_needed
+        super
+
+        if continuation_serialized?
+          self.continuation = Continuation.new(self, @serialized_continuation)
+          @serialized_continuation = nil
+        end
+      end
+
+      def serialize_continuation_if_needed
+        continuation_serialized? ? @serialized_continuation : continuation.to_h
+      end
+
+      def continuation_serialized?
+        @serialized_continuation
+      end
+
       def continue(&block)
         if continuation.started?
           self.resumptions += 1

--- a/activejob/lib/active_job/continuation.rb
+++ b/activejob/lib/active_job/continuation.rb
@@ -231,7 +231,10 @@ module ActiveJob
     def initialize(job, serialized_progress) # :nodoc:
       @job = job
       @completed = serialized_progress.fetch("completed", []).map(&:to_sym)
-      @current = new_step(*serialized_progress["current"], resumed: true) if serialized_progress.key?("current")
+      if serialized_progress.key?("current")
+        name, cursor = serialized_progress["current"]
+        @current = new_step(name, Arguments.deserialize([cursor]).first, resumed: true)
+      end
       @encountered = []
       @advanced = false
       @running_step = false
@@ -252,7 +255,7 @@ module ActiveJob
     def to_h # :nodoc:
       {
         "completed" => completed.map(&:to_s),
-        "current" => current&.to_a,
+        "current" => serialized_current,
       }.compact
     end
 
@@ -297,6 +300,13 @@ module ActiveJob
 
       def new_step(*args, **options)
         Step.new(*args, job: job, **options)
+      end
+
+      def serialized_current
+        return unless current
+
+        name, cursor = current.to_a
+        [ name, Arguments.serialize([cursor]).first ]
       end
 
       def skip_step(name)

--- a/activejob/test/cases/continuation_test.rb
+++ b/activejob/test/cases/continuation_test.rb
@@ -6,6 +6,7 @@ require "active_support/testing/stream"
 require "active_support/core_ext/object/with"
 require "support/test_logger"
 require "support/do_not_perform_enqueued_jobs"
+require "models/person"
 
 return unless adapter_is?(:test)
 
@@ -759,5 +760,58 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
     end
 
     assert_equal [ "step_one", "step_two", "step_three", "step_four" ], IsolatedStepsJob.items
+  end
+
+  class SerializableCursorJob < ContinuableJob
+    cattr_accessor :cursor_value
+    cattr_accessor :serialized_job
+    cattr_accessor :resumed_cursor
+
+    def perform
+      step :scan do |step|
+        if step.resumed?
+          self.class.resumed_cursor = step.cursor
+        else
+          step.set! self.class.cursor_value
+          self.class.serialized_job = serialize
+        end
+      end
+    end
+  end
+
+  test "round-trips a non-primitive step cursor through Active Job argument serialization" do
+    SerializableCursorJob.cursor_value = Date.new(2026, 7, 6)
+    SerializableCursorJob.resumed_cursor = nil
+    SerializableCursorJob.perform_now
+
+    round_tripped = JSON.parse(JSON.generate(SerializableCursorJob.serialized_job))
+    ActiveJob::Base.execute(round_tripped)
+
+    assert_instance_of Date, SerializableCursorJob.resumed_cursor
+    assert_equal Date.new(2026, 7, 6), SerializableCursorJob.resumed_cursor
+  end
+
+  class DiscardableCursorJob < ContinuableJob
+    cattr_accessor :discarded_error
+
+    discard_on ActiveJob::DeserializationError do |job, error|
+      job.class.discarded_error = error
+    end
+
+    def perform
+      step :scan do |step|
+      end
+    end
+  end
+
+  test "cursor deserialization errors can be handled by the job's error handlers" do
+    DiscardableCursorJob.discarded_error = nil
+    job_data = DiscardableCursorJob.new.serialize.merge(
+      "continuation" => { "completed" => [], "current" => [ "scan", { "_aj_globalid" => Person.new(404).to_gid.to_s } ] }
+    )
+
+    ActiveJob::Base.execute(JSON.parse(JSON.generate(job_data)))
+
+    assert_kind_of ActiveJob::DeserializationError, DiscardableCursorJob.discarded_error
   end
 end

--- a/activejob/test/cases/structured_event_subscriber_test.rb
+++ b/activejob/test/cases/structured_event_subscriber_test.rb
@@ -62,7 +62,7 @@ module ActiveJob
           step :step do
           end
         when :resume_step
-          self.continuation = ActiveJob::Continuation.new(self, "completed" => [], "current" => ["step", { "job" => self, "resumed" => true }])
+          self.continuation = ActiveJob::Continuation.new(self, "completed" => [], "current" => ["step", nil])
           step :step do
           end
         end


### PR DESCRIPTION
An in-progress step's cursor is written to and read from the continuation data as raw JSON. After an interrupt/resume round-trip, a non-primitive cursor (`Date`, `Time`, `TimeWithZone`, `GlobalID`, …) comes back as a `String`, so cursor-typed resume logic such as `cursor.beginning_of_day` breaks on resume.

This routes the cursor through `ActiveJob::Arguments` on serialize and deserialize, so a resumed cursor keeps its original type. This mirrors `ActiveJob::Attributes`, which already persists values through `Arguments.serialize` / `deserialize`, and honors the Continuation docs, which state a cursor may be any Active Job serializable object.

Primitive cursors (Integer, String, Array of primitives) serialize byte-identically, so existing continuation data remains compatible.

An existing test constructed continuation state with a non-serializable object as the cursor; updated it to use `nil`, which matches the real serialization contract.

### Before

```ruby
# a Date cursor survives one run…
step.cursor        # => #<Date: 2026-07-06>
# …but after interrupt + resume it comes back as a String
step.cursor        # => "2026-07-06"
step.cursor.beginning_of_day   # NoMethodError
```

### After

```ruby
step.cursor        # => #<Date: 2026-07-06>   (type preserved across resume)
```