### PR TITLE
Fix ActionController::Live streams hanging on client disconnect

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `ActionController::Live` streams hanging on client disconnect.
+
+    `ActionController::Live::Buffer#abort` cleared the streaming queue but never
+    enqueued the terminator that `each_chunk` uses to exit, so a reader thread
+    blocked in `SizedQueue#pop` was never woken and the request thread hung
+    indefinitely. `#abort` now enqueues the terminator, mirroring `#close`.
+
+    *Winfield Peterson*
+
 *   Deprecated the ActionController::Renderers::RENDERERS constant.
 
     This constant was for internal usage but had a documentation and wasn't set

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -262,6 +262,12 @@ module ActionController
         synchronize do
           @aborted = true
           @buf.clear
+          # Wake a reader parked in each_chunk's `@buf.pop`. Without a terminator
+          # the reader can never observe @aborted and would block forever, wedging
+          # the request thread. A duplicate terminator (when #close ran too) is
+          # harmless: each_chunk stops at the first one.
+          @buf.push nil
+          @cv.broadcast
         end
       end
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -774,6 +774,44 @@ module ActionController
       response.each { |chunk| body << chunk }
       assert_equal "barbaz", body
     end
+
+    def test_abort_terminates_a_reader_blocked_on_the_buffer
+      response = ActionController::Live::Response.new
+      response.request = ActionDispatch::Request.empty
+      buf = response.stream
+
+      received = []
+      reader = Thread.new { response.each { |chunk| received << chunk } }
+
+      buf.write "hello"
+      Timeout.timeout(5) do
+        Thread.pass until received.any?             # reader drained the chunk...
+        Thread.pass until reader.status == "sleep"  # ...and is blocked on the queue
+      end
+
+      buf.abort
+
+      assert reader.join(5), "#abort did not release a reader blocked in each_chunk"
+      assert_equal ["hello"], received
+    ensure
+      reader&.kill
+    end
+
+    def test_close_then_abort_still_terminates_the_reader
+      response = ActionController::Live::Response.new
+      response.request = ActionDispatch::Request.empty
+      buf = response.stream
+
+      buf.write "final"
+      buf.close   # enqueues the terminator
+      buf.abort   # clears the queue, dropping the terminator close just enqueued
+
+      reader = Thread.new { response.each { } }
+
+      assert reader.join(5), "#abort after #close left the reader blocked in each_chunk"
+    ensure
+      reader&.kill
+    end
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Fixes #58047

`ActionController::Live::Buffer#abort` clears the streaming queue and sets `@aborted`, but never enqueues the `nil` terminator that the consumer loop (`each_chunk`) relies on to exit. `each_chunk` only breaks on a falsy pop and never inspects `@aborted`, and a reader thread already parked in `SizedQueue#pop` can only be woken by a push. So on client disconnect the reader can block forever and the request thread is never released. Under `RAILS_MAX_THREADS=1` a single wedged stream permanently consumes a worker.

There are two ways this happens:

1. The reader is parked in `pop` on an empty queue when `#abort` fires — `#abort` clears (already empty) and sets `@aborted`, but pushes nothing, so `pop` never returns.
2. `#close` enqueues the terminator and `#abort`'s `clear` immediately removes it (the close/abort race on a fast client disconnect), so the reader never sees a `nil`.

### Detail

`ActionController::Live::Buffer#abort` now enqueues the `nil` terminator and broadcasts after clearing the queue, mirroring `#close`, so `each_chunk` always unwinds regardless of the `close`/`abort` interleaving. The push runs after the `clear`, so it can't block on a full `SizedQueue`, and a duplicate terminator (when `#close` also ran) is harmless because the consumer stops at the first one.

### Additional information

Adds two regression tests to `ActionController::BufferTest`:

- a reader blocked in `each_chunk` is released after `#abort`;
- the `#close`-then-`#abort` race still terminates the reader.

Both fail on `main` (the reader hangs until the test's `join` timeout) and pass with this change. The full `actionpack/test/controller/live_stream_test.rb` suite passes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
