### PR TITLE
Drive result delivery through QueryIntent

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -77,6 +77,7 @@ module ActiveRecord
     autoload :PoolConfig
     autoload :PoolManager
     autoload :QueryIntent
+    autoload :RetryBudget
     autoload :SchemaCache
     autoload :BoundSchemaReflection, "active_record/connection_adapters/schema_cache"
     autoload :SchemaReflection, "active_record/connection_adapters/schema_cache"

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -644,36 +644,35 @@ module ActiveRecord
       end
 
       def perform_sync_attempt(intent) # :nodoc:
-        begin
-          result = perform_query(@raw_connection, intent)
-          query_completed = true
-        rescue ::RangeError
-          raise
-        rescue => error
-          translated = translate_exception_class(error, intent.processed_sql, intent.binds)
-          invalidate_transaction(translated)
-          intent.deliver_failure(translated)
-          return
-        rescue Exception
-          # A non-StandardError (a Timeout, or a fiber scheduler's cancel) abandoned
-          # the query partway through, so we mark the connection unverified, just as
-          # a failed query would, forcing a reconnect before it's used again.
-          @last_activity = nil
-          @verified = false
-          dirty_current_transaction if intent.materialize_transactions
-          raise
-        ensure
-          begin
-            handle_warnings(result, intent.processed_sql)
-          rescue
-            raise if query_completed
+        result = perform_query(@raw_connection, intent)
+        query_completed = true
+        warnings = collect_warnings(result)
+      rescue ::RangeError
+        raise
+      rescue => error
+        translated = translate_exception_class(error, intent.processed_sql, intent.binds)
+        invalidate_transaction(translated)
 
+        unless query_completed
+          begin
+            warnings = collect_warnings(nil)
+          rescue
             # The query failed, so we need to swallow this exception
-            # from handle_warnings to avoid masking the original.
+            # from collect_warnings to avoid masking the original.
           end
         end
 
-        intent.deliver_result(result)
+        intent.deliver_failure(translated, warnings: warnings)
+      rescue Exception
+        # A non-StandardError (a Timeout, or a fiber scheduler's cancel) abandoned
+        # the query partway through, so we mark the connection unverified, just as
+        # a failed query would, forcing a reconnect before it's used again.
+        @last_activity = nil
+        @verified = false
+        dirty_current_transaction if intent.materialize_transactions
+        raise
+      else
+        intent.deliver_result(result, warnings: warnings)
       end
 
       def start_intent_log(intent) # :nodoc:
@@ -746,6 +745,17 @@ module ActiveRecord
         end
       end
 
+      def handle_warnings(intent, warnings) # :nodoc:
+        return unless action = ActiveRecord.db_warnings_action
+
+        warnings&.each do |warning|
+          next if warning_ignored?(warning)
+
+          warning.sql = intent.processed_sql
+          action.call(warning)
+        end
+      end
+
       private
         DEFAULT_INSERT_VALUE = Arel.sql("DEFAULT").freeze
         private_constant :DEFAULT_INSERT_VALUE
@@ -754,7 +764,8 @@ module ActiveRecord
           raise NotImplementedError
         end
 
-        def handle_warnings(raw_result, sql)
+        def collect_warnings(raw_result)
+          []
         end
 
         # Receive a native adapter result object and returns an ActiveRecord::Result object.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -613,11 +613,9 @@ module ActiveRecord
       end
 
       # Lowest-level abstract execution of a query, called only from the intent itself.
-      # Final wrapper around the subclass-specific +perform_query+. Populates the calling
-      # intent's raw_result.
+      # Final wrapper around the subclass-specific +perform_query+. Delivers the outcome
+      # back to the calling intent.
       def execute_intent(intent) # :nodoc:
-        should_dirty = false
-
         if intent.materialize_transactions
           # These can raise locally (e.g., ReadOnlyError). Validate before BEGIN.
           intent.processed_sql
@@ -627,32 +625,55 @@ module ActiveRecord
 
         start_intent_log(intent)
         begin
-          with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false) do |conn|
-            should_dirty = intent.materialize_transactions
-            begin
-              result = perform_query(conn, intent)
-              intent.raw_result = result
+          @lock.synchronize do
+            reconnectable = ensure_connection_ready(
+              allow_retry: intent.allow_retry,
+              materialize_transactions: false
+            )
 
-              query_completed = true
-            ensure
-              begin
-                handle_warnings(result, intent.processed_sql)
-              rescue
-                raise if query_completed
+            intent.retry_budget ||= build_retry_budget(
+              allow_retry: intent.allow_retry, reconnectable: reconnectable
+            )
 
-                # The query failed, so we need to swallow this exception
-                # from handle_warnings to avoid masking the original.
-              end
-            end
+            perform_sync_attempt(intent)
           end
-          finish_intent_log(intent)
-        rescue => error
-          error.set_query(intent.processed_sql, intent.binds) if error.is_a?(StatementInvalid)
-          finish_intent_log(intent, exception: error)
+        rescue Exception => error
+          intent.finish_log(exception: error) unless intent.raw_result_available?
           raise
         end
-      ensure
-        dirty_current_transaction if should_dirty
+      end
+
+      def perform_sync_attempt(intent) # :nodoc:
+        begin
+          result = perform_query(@raw_connection, intent)
+          query_completed = true
+        rescue ::RangeError
+          raise
+        rescue => error
+          translated = translate_exception_class(error, intent.processed_sql, intent.binds)
+          invalidate_transaction(translated)
+          intent.deliver_failure(translated)
+          return
+        rescue Exception
+          # A non-StandardError (a Timeout, or a fiber scheduler's cancel) abandoned
+          # the query partway through, so we mark the connection unverified, just as
+          # a failed query would, forcing a reconnect before it's used again.
+          @last_activity = nil
+          @verified = false
+          dirty_current_transaction if intent.materialize_transactions
+          raise
+        ensure
+          begin
+            handle_warnings(result, intent.processed_sql)
+          rescue
+            raise if query_completed
+
+            # The query failed, so we need to swallow this exception
+            # from handle_warnings to avoid masking the original.
+          end
+        end
+
+        intent.deliver_result(result)
       end
 
       def start_intent_log(intent) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -625,8 +625,8 @@ module ActiveRecord
           materialize_transactions
         end
 
-        log(intent) do |notification_payload|
-          intent.notification_payload = notification_payload
+        start_intent_log(intent)
+        begin
           with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false) do |conn|
             should_dirty = intent.materialize_transactions
             begin
@@ -645,9 +645,52 @@ module ActiveRecord
               end
             end
           end
+          finish_intent_log(intent)
+        rescue => error
+          error.set_query(intent.processed_sql, intent.binds) if error.is_a?(StatementInvalid)
+          finish_intent_log(intent, exception: error)
+          raise
         end
       ensure
         dirty_current_transaction if should_dirty
+      end
+
+      def start_intent_log(intent) # :nodoc:
+        return if intent.log_handle
+
+        payload = {
+          sql:               intent.processed_sql,
+          name:              intent.name,
+          binds:             intent.binds,
+          type_casted_binds: intent.type_casted_binds,
+          async:             intent.ran_async,
+          allow_retry:       intent.allow_retry,
+          connection:        self,
+          transaction:       current_transaction.user_transaction.presence,
+          affected_rows:     0,
+          row_count:         0,
+        }
+        intent.notification_payload = payload
+
+        active_record_instrumenter = intent.event_buffer || instrumenter
+        handle = active_record_instrumenter.build_handle("sql.active_record", payload)
+        handle.start
+        intent.log_handle = handle
+      end
+
+      def finish_intent_log(intent, exception: nil) # :nodoc:
+        handle = intent.log_handle
+        return unless handle
+
+        intent.log_handle = nil
+
+        if exception
+          payload = intent.notification_payload
+          payload[:exception] = [exception.class.name, exception.message]
+          payload[:exception_object] = exception
+        end
+
+        handle.finish
       end
 
       # Executes SQL statements in the context of this connection without

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -697,6 +697,7 @@ module ActiveRecord
         handle = active_record_instrumenter.build_handle("sql.active_record", payload)
         handle.start
         intent.log_handle = handle
+        @unfinalized_intents << intent
       end
 
       def finish_intent_log(intent, exception: nil) # :nodoc:
@@ -704,6 +705,7 @@ module ActiveRecord
         return unless handle
 
         intent.log_handle = nil
+        @unfinalized_intents.delete(intent)
 
         if exception
           payload = intent.notification_payload
@@ -712,6 +714,17 @@ module ActiveRecord
         end
 
         handle.finish
+      end
+
+      def finalize_remaining_intents # :nodoc:
+        intents = @unfinalized_intents
+        @unfinalized_intents = []
+
+        intents.each do |intent|
+          next if intent.finalized?
+
+          intent.finish_log(exception: intent.error)
+        end
       end
 
       # Executes SQL statements in the context of this connection without

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -724,36 +724,35 @@ module ActiveRecord
       end
 
       def perform_sync_attempt(intent) # :nodoc:
-        begin
-          result = perform_query(@raw_connection, intent)
-          query_completed = true
-        rescue ::RangeError
-          raise
-        rescue => error
-          translated = translate_exception_class(error, intent.processed_sql, intent.binds)
-          invalidate_transaction(translated)
-          intent.deliver_failure(translated)
-          return
-        rescue Exception
-          # A non-StandardError (a Timeout, or a fiber scheduler's cancel) abandoned
-          # the query partway through, so we mark the connection unverified, just as
-          # a failed query would, forcing a reconnect before it's used again.
-          @last_activity = nil
-          @verified = false
-          dirty_current_transaction if intent.materialize_transactions
-          raise
-        ensure
-          begin
-            handle_warnings(result, intent.processed_sql)
-          rescue
-            raise if query_completed
+        result = perform_query(@raw_connection, intent)
+        query_completed = true
+        warnings = collect_warnings(result)
+      rescue ::RangeError
+        raise
+      rescue => error
+        translated = translate_exception_class(error, intent.processed_sql, intent.binds)
+        invalidate_transaction(translated)
 
+        unless query_completed
+          begin
+            warnings = collect_warnings(nil)
+          rescue
             # The query failed, so we need to swallow this exception
-            # from handle_warnings to avoid masking the original.
+            # from collect_warnings to avoid masking the original.
           end
         end
 
-        intent.deliver_result(result)
+        intent.deliver_failure(translated, warnings: warnings)
+      rescue Exception
+        # A non-StandardError (a Timeout, or a fiber scheduler's cancel) abandoned
+        # the query partway through, so we mark the connection unverified, just as
+        # a failed query would, forcing a reconnect before it's used again.
+        @last_activity = nil
+        @verified = false
+        dirty_current_transaction if intent.materialize_transactions
+        raise
+      else
+        intent.deliver_result(result, warnings: warnings)
       end
 
       def start_intent_log(intent) # :nodoc:
@@ -826,6 +825,17 @@ module ActiveRecord
         end
       end
 
+      def handle_warnings(intent, warnings) # :nodoc:
+        return unless action = ActiveRecord.db_warnings_action
+
+        warnings&.each do |warning|
+          next if warning_ignored?(warning)
+
+          warning.sql = intent.processed_sql
+          action.call(warning)
+        end
+      end
+
       private
         DEFAULT_INSERT_VALUE = Arel.sql("DEFAULT").freeze
         private_constant :DEFAULT_INSERT_VALUE
@@ -834,7 +844,8 @@ module ActiveRecord
           raise NotImplementedError
         end
 
-        def handle_warnings(raw_result, sql)
+        def collect_warnings(raw_result)
+          []
         end
 
         # Receive a native adapter result object and returns an ActiveRecord::Result object.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -777,6 +777,7 @@ module ActiveRecord
         handle = active_record_instrumenter.build_handle("sql.active_record", payload)
         handle.start
         intent.log_handle = handle
+        @unfinalized_intents << intent
       end
 
       def finish_intent_log(intent, exception: nil) # :nodoc:
@@ -784,6 +785,7 @@ module ActiveRecord
         return unless handle
 
         intent.log_handle = nil
+        @unfinalized_intents.delete(intent)
 
         if exception
           payload = intent.notification_payload
@@ -792,6 +794,17 @@ module ActiveRecord
         end
 
         handle.finish
+      end
+
+      def finalize_remaining_intents # :nodoc:
+        intents = @unfinalized_intents
+        @unfinalized_intents = []
+
+        intents.each do |intent|
+          next if intent.finalized?
+
+          intent.finish_log(exception: intent.error)
+        end
       end
 
       # Executes SQL statements in the context of this connection without

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -693,11 +693,9 @@ module ActiveRecord
       end
 
       # Lowest-level abstract execution of a query, called only from the intent itself.
-      # Final wrapper around the subclass-specific +perform_query+. Populates the calling
-      # intent's raw_result.
+      # Final wrapper around the subclass-specific +perform_query+. Delivers the outcome
+      # back to the calling intent.
       def execute_intent(intent) # :nodoc:
-        should_dirty = false
-
         if intent.materialize_transactions
           # These can raise locally (e.g., ReadOnlyError). Validate before BEGIN.
           intent.processed_sql
@@ -707,32 +705,55 @@ module ActiveRecord
 
         start_intent_log(intent)
         begin
-          with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false) do |conn|
-            should_dirty = intent.materialize_transactions
-            begin
-              result = perform_query(conn, intent)
-              intent.raw_result = result
+          @lock.synchronize do
+            reconnectable = ensure_connection_ready(
+              allow_retry: intent.allow_retry,
+              materialize_transactions: false
+            )
 
-              query_completed = true
-            ensure
-              begin
-                handle_warnings(result, intent.processed_sql)
-              rescue
-                raise if query_completed
+            intent.retry_budget ||= build_retry_budget(
+              allow_retry: intent.allow_retry, reconnectable: reconnectable
+            )
 
-                # The query failed, so we need to swallow this exception
-                # from handle_warnings to avoid masking the original.
-              end
-            end
+            perform_sync_attempt(intent)
           end
-          finish_intent_log(intent)
-        rescue => error
-          error.set_query(intent.processed_sql, intent.binds) if error.is_a?(StatementInvalid)
-          finish_intent_log(intent, exception: error)
+        rescue Exception => error
+          intent.finish_log(exception: error) unless intent.raw_result_available?
           raise
         end
-      ensure
-        dirty_current_transaction if should_dirty
+      end
+
+      def perform_sync_attempt(intent) # :nodoc:
+        begin
+          result = perform_query(@raw_connection, intent)
+          query_completed = true
+        rescue ::RangeError
+          raise
+        rescue => error
+          translated = translate_exception_class(error, intent.processed_sql, intent.binds)
+          invalidate_transaction(translated)
+          intent.deliver_failure(translated)
+          return
+        rescue Exception
+          # A non-StandardError (a Timeout, or a fiber scheduler's cancel) abandoned
+          # the query partway through, so we mark the connection unverified, just as
+          # a failed query would, forcing a reconnect before it's used again.
+          @last_activity = nil
+          @verified = false
+          dirty_current_transaction if intent.materialize_transactions
+          raise
+        ensure
+          begin
+            handle_warnings(result, intent.processed_sql)
+          rescue
+            raise if query_completed
+
+            # The query failed, so we need to swallow this exception
+            # from handle_warnings to avoid masking the original.
+          end
+        end
+
+        intent.deliver_result(result)
       end
 
       def start_intent_log(intent) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -705,8 +705,8 @@ module ActiveRecord
           materialize_transactions
         end
 
-        log(intent) do |notification_payload|
-          intent.notification_payload = notification_payload
+        start_intent_log(intent)
+        begin
           with_raw_connection(allow_retry: intent.allow_retry, materialize_transactions: false) do |conn|
             should_dirty = intent.materialize_transactions
             begin
@@ -725,9 +725,52 @@ module ActiveRecord
               end
             end
           end
+          finish_intent_log(intent)
+        rescue => error
+          error.set_query(intent.processed_sql, intent.binds) if error.is_a?(StatementInvalid)
+          finish_intent_log(intent, exception: error)
+          raise
         end
       ensure
         dirty_current_transaction if should_dirty
+      end
+
+      def start_intent_log(intent) # :nodoc:
+        return if intent.log_handle
+
+        payload = {
+          sql:               intent.processed_sql,
+          name:              intent.name,
+          binds:             intent.binds,
+          type_casted_binds: intent.type_casted_binds,
+          async:             intent.ran_async,
+          allow_retry:       intent.allow_retry,
+          connection:        self,
+          transaction:       current_transaction.user_transaction.presence,
+          affected_rows:     0,
+          row_count:         0,
+        }
+        intent.notification_payload = payload
+
+        active_record_instrumenter = intent.event_buffer || instrumenter
+        handle = active_record_instrumenter.build_handle("sql.active_record", payload)
+        handle.start
+        intent.log_handle = handle
+      end
+
+      def finish_intent_log(intent, exception: nil) # :nodoc:
+        handle = intent.log_handle
+        return unless handle
+
+        intent.log_handle = nil
+
+        if exception
+          payload = intent.notification_payload
+          payload[:exception] = [exception.class.name, exception.message]
+          payload[:exception_object] = exception
+        end
+
+        handle.finish
       end
 
       # Executes SQL statements in the context of this connection without

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -738,8 +738,7 @@ module ActiveRecord
       # connection with the database. Implementors should define private #reconnect
       # instead.
       def reconnect!(restore_transactions: false)
-        retries_available = connection_retries
-        deadline = retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline
+        budget = build_retry_budget(allow_retry: true, reconnectable: false)
 
         @lock.synchronize do
           attempt_configure_connection do
@@ -760,15 +759,10 @@ module ActiveRecord
             end
           rescue => original_exception
             translated_exception = translate_exception_class(original_exception, nil, nil)
-            retry_deadline_exceeded = deadline && deadline < Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-            if !retry_deadline_exceeded && retries_available > 0
-              retries_available -= 1
-
-              if retryable_connection_error?(translated_exception)
-                backoff(connection_retries - retries_available)
-                retry
-              end
+            if retryable_connection_error?(translated_exception) && budget.consume
+              backoff(budget.attempts_used)
+              retry
             end
 
             raise translated_exception
@@ -1051,6 +1045,27 @@ module ActiveRecord
       TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
       EXTENDED_TYPE_MAPS = Concurrent::Map.new
 
+      def retryable_failure?(exception, budget) # :nodoc:
+        budget&.available? &&
+          (retryable_query_error?(exception) ||
+            (budget.reconnectable? && retryable_connection_error?(exception)))
+      end
+
+      # Consume from +budget+ if +exception+ warrants another attempt. Query retries
+      # back off here; connection retries consume the reconnect allowance and rely
+      # on the caller to ensure connection readiness before executing again.
+      def attempt_retry(exception, budget) # :nodoc:
+        return false unless retryable_failure?(exception, budget) && budget.consume
+
+        if retryable_query_error?(exception)
+          backoff(budget.attempts_used)
+        else
+          budget.reconnect_consumed!
+        end
+
+        true
+      end
+
       private
         def reconnect_can_restore_state?
           transaction_manager.restorable? && !@raw_connection_dirty
@@ -1091,62 +1106,23 @@ module ActiveRecord
         #
         def with_raw_connection(allow_retry: false, materialize_transactions: true)
           @lock.synchronize do
-            connect! if !connected? && reconnect_can_restore_state?
+            reconnectable = ensure_connection_ready(allow_retry:, materialize_transactions:)
 
-            self.materialize_transactions if materialize_transactions
-
-            retries_available = allow_retry ? connection_retries : 0
-            deadline = retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline
-            reconnectable = reconnect_can_restore_state?
-
-            if @verified && !@needs_reconnect
-              # Cool, we're confident the connection's ready to use. (Note this might have
-              # become true during the above #materialize_transactions.)
-            elsif !@needs_reconnect && (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
-              # We haven't actually verified the connection since we acquired it, but it
-              # has been used very recently. We're going to assume it's still okay.
-            elsif reconnectable
-              if @needs_reconnect
-                # This connection has been flagged for replacement; don't trust
-                # it even when the upcoming query would be retryable.
-                verify!
-              elsif allow_retry
-                # Not sure about the connection yet, but if anything goes wrong we can
-                # just reconnect and re-run our query
-              else
-                # We can reconnect if needed, but we don't trust the upcoming query to be
-                # safely re-runnable: let's verify the connection to be sure
-                verify!
-              end
-            else
-              # We don't know whether the connection is okay, but it also doesn't matter:
-              # we wouldn't be able to reconnect anyway. We're just going to run our query
-              # and hope for the best.
-            end
+            budget = build_retry_budget(allow_retry:, reconnectable:)
 
             begin
               yield @raw_connection
             rescue => original_exception
               translated_exception = translate_exception_class(original_exception, nil, nil)
               invalidate_transaction(translated_exception)
-              retry_deadline_exceeded = deadline && deadline < Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-              if !retry_deadline_exceeded && retries_available > 0
-                retries_available -= 1
-
-                if retryable_query_error?(translated_exception)
-                  backoff(connection_retries - retries_available)
-                  retry
-                elsif reconnectable && retryable_connection_error?(translated_exception)
-                  reconnect!(restore_transactions: true)
-                  # Only allowed to reconnect once, because reconnect! has its own retry
-                  # loop
-                  reconnectable = false
-                  retry
-                end
-              end
-
               downgrade_connection_after_error(translated_exception)
+
+              if attempt_retry(translated_exception, budget)
+                if retryable_connection_error?(translated_exception)
+                  ensure_connection_ready(allow_retry:, materialize_transactions: false)
+                end
+                retry
+              end
 
               raise translated_exception
             rescue Exception
@@ -1200,6 +1176,44 @@ module ActiveRecord
             if retryable_connection_error?(exception)
               @needs_reconnect = true
             end
+          end
+        end
+
+        def build_retry_budget(allow_retry:, reconnectable:)
+          RetryBudget.new(
+            retries: allow_retry ? connection_retries : 0,
+            deadline: retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline,
+            reconnectable: reconnectable
+          )
+        end
+
+        # Ensure the connection is ready to execute a query.
+        # Returns whether reconnect-and-restore is available for retry decisions.
+        def ensure_connection_ready(allow_retry:, materialize_transactions:)
+          connect! if !connected? && reconnect_can_restore_state?
+          self.materialize_transactions if materialize_transactions
+
+          reconnectable = reconnect_can_restore_state?
+          verify! unless skip_verification?(allow_retry:, reconnectable:)
+          reconnectable
+        end
+
+        # Decide whether the connection can be used without verification.
+        def skip_verification?(allow_retry:, reconnectable:)
+          if @verified && connected? && !@needs_reconnect
+            true
+          elsif !@needs_reconnect && (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
+            true
+          elsif reconnectable
+            if @needs_reconnect
+              false
+            elsif allow_retry
+              true
+            else
+              false
+            end
+          else
+            true
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1066,6 +1066,20 @@ module ActiveRecord
         true
       end
 
+      def downgrade_connection_after_error(exception) # :nodoc:
+        unless retryable_query_error?(exception)
+          # Barring a known-retryable error inside the query (regardless of
+          # whether we were in a _position_ to retry it), we should infer that
+          # there's likely a real problem with the connection.
+          @last_activity = nil
+          @verified = false
+
+          if retryable_connection_error?(exception)
+            @needs_reconnect = true
+          end
+        end
+      end
+
       private
         def reconnect_can_restore_state?
           transaction_manager.restorable? && !@raw_connection_dirty
@@ -1163,20 +1177,6 @@ module ActiveRecord
           return false if current_transaction.invalidated?
 
           exception.is_a?(Deadlocked) || exception.is_a?(LockWaitTimeout)
-        end
-
-        def downgrade_connection_after_error(exception)
-          unless retryable_query_error?(exception)
-            # Barring a known-retryable error inside the query (regardless of
-            # whether we were in a _position_ to retry it), we should infer that
-            # there's likely a real problem with the connection.
-            @last_activity = nil
-            @verified = false
-
-            if retryable_connection_error?(exception)
-              @needs_reconnect = true
-            end
-          end
         end
 
         def build_retry_budget(allow_retry:, reconnectable:)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1273,53 +1273,28 @@ module ActiveRecord
           active_record_error
         end
 
-        def log(intent_or_sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)
-          if intent_or_sql.is_a?(QueryIntent)
-            intent = intent_or_sql
+        def log(sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
+            `log` is deprecated and will be removed in Rails 8.3.
+            Queries executed through a `QueryIntent` are instrumented automatically.
+          MSG
 
-            instrumenter.instrument(
-              "sql.active_record",
-              sql:               intent.processed_sql,
-              name:              intent.name,
-              binds:             intent.binds,
-              type_casted_binds: intent.type_casted_binds,
-              async:             intent.ran_async,
-              allow_retry:       intent.allow_retry,
-              connection:        self,
-              transaction:       current_transaction.user_transaction.presence,
-              affected_rows:     0,
-              row_count:         0,
-              &block
-            )
-          else
-            ActiveRecord.deprecator.warn(<<-MSG.squish)
-              Passing SQL strings to `log` is deprecated and will stop working in Rails 8.2.
-              Please pass a `QueryIntent` object instead.
-            MSG
-
-            sql = intent_or_sql
-
-            instrumenter.instrument(
-              "sql.active_record",
-              sql:               sql,
-              name:              name,
-              binds:             binds,
-              type_casted_binds: type_casted_binds,
-              async:             async,
-              allow_retry:       allow_retry,
-              connection:        self,
-              transaction:       current_transaction.user_transaction.presence,
-              affected_rows:     0,
-              row_count:         0,
-              &block
-            )
-          end
+          instrumenter.instrument(
+            "sql.active_record",
+            sql:               sql,
+            name:              name,
+            binds:             binds,
+            type_casted_binds: type_casted_binds,
+            async:             async,
+            allow_retry:       allow_retry,
+            connection:        self,
+            transaction:       current_transaction.user_transaction.presence,
+            affected_rows:     0,
+            row_count:         0,
+            &block
+          )
         rescue ActiveRecord::StatementInvalid => ex
-          if intent
-            raise ex.set_query(intent.processed_sql, intent.binds)
-          else
-            raise ex.set_query(sql, binds)
-          end
+          raise ex.set_query(sql, binds)
         end
 
         def instrumenter # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -198,6 +198,7 @@ module ActiveRecord
         @last_activity = nil
         @verified = false
         @needs_reconnect = false
+        @unfinalized_intents = []
 
         @pool_jitter = rand * max_jitter
       end
@@ -349,6 +350,8 @@ module ActiveRecord
               "it is owned by a different thread: #{@owner}. " \
               "Current thread: #{ActiveSupport::IsolatedExecutionState.context}."
           end
+
+          finalize_remaining_intents
 
           _run_checkin_callbacks do
             @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC) if update_idle

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1269,8 +1269,15 @@ module ActiveRecord
           active_record_error = translate_exception(
             native_error, message: message, sql: sql, binds: binds
           )
+          return active_record_error if active_record_error.equal?(native_error)
+
           active_record_error.set_backtrace(native_error.backtrace)
-          active_record_error
+
+          begin
+            raise active_record_error, cause: native_error
+          rescue => error
+            error
+          end
         end
 
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], async: false, allow_retry: false, &block)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -882,19 +882,17 @@ module ActiveRecord
           end
         end
 
-        def handle_warnings(_initial_result, sql)
-          return if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
+        def collect_warnings(_initial_result)
+          return [] if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
 
           warning_count = @raw_connection.warning_count
           result = @raw_connection.query("SHOW WARNINGS")
           result = [
             ["Warning", nil, "Query had warning_count=#{warning_count} but `SHOW WARNINGS` did not return the warnings. Check MySQL logs or database configuration."],
           ] if result.count == 0
-          result.each do |level, code, message|
-            warning = SQLWarning.new(message, code, level, sql, @pool)
-            next if warning_ignored?(warning)
 
-            ActiveRecord.db_warnings_action.call(warning)
+          result.map do |level, code, message|
+            SQLWarning.new(message, code, level, nil, @pool)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -885,19 +885,17 @@ module ActiveRecord
           end
         end
 
-        def handle_warnings(_initial_result, sql)
-          return if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
+        def collect_warnings(_initial_result)
+          return [] if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
 
           warning_count = @raw_connection.warning_count
           result = @raw_connection.query("SHOW WARNINGS")
           result = [
             ["Warning", nil, "Query had warning_count=#{warning_count} but `SHOW WARNINGS` did not return the warnings. Check MySQL logs or database configuration."],
           ] if result.count == 0
-          result.each do |level, code, message|
-            warning = SQLWarning.new(message, code, level, sql, @pool)
-            next if warning_ignored?(warning)
 
-            ActiveRecord.db_warnings_action.call(warning)
+          result.map do |level, code, message|
+            SQLWarning.new(message, code, level, nil, @pool)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -254,15 +254,9 @@ module ActiveRecord
             pk unless pk.is_a?(Array)
           end
 
-          def handle_warnings(result, sql)
+          def collect_warnings(_result)
             warnings, @notice_receiver_sql_warnings = @notice_receiver_sql_warnings, []
-
-            warnings.each do |warning|
-              next if warning_ignored?(warning)
-
-              warning.sql = sql
-              ActiveRecord.db_warnings_action.call(warning)
-            end
+            warnings
           end
 
           def warning_ignored?(warning)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -268,15 +268,9 @@ module ActiveRecord
             ["TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"]
           end
 
-          def handle_warnings(result, sql)
+          def collect_warnings(_result)
             warnings, @notice_receiver_sql_warnings = @notice_receiver_sql_warnings, []
-
-            warnings.each do |warning|
-              next if warning_ignored?(warning)
-
-              warning.sql = sql
-              ActiveRecord.db_warnings_action.call(warning)
-            end
+            warnings
           end
 
           def warning_ignored?(warning)

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -91,6 +91,9 @@ module ActiveRecord
         @notification_payload = nil
         @raw_result = nil
         @raw_result_available = false
+        @warnings = nil
+        @outcome_handled = false
+        @warning_error = nil
         @executed = false
         @write_query = nil
 
@@ -228,11 +231,12 @@ module ActiveRecord
         nil
       end
 
-      def deliver_result(value)
+      def deliver_result(value, warnings: nil)
         raise FinalizedError, "delivering result to a finalized intent" if @finalized
 
         adapter.lock.synchronize do
           @raw_result = value
+          @warnings = warnings
           @error = nil
 
           mark_transaction_dirty
@@ -243,11 +247,12 @@ module ActiveRecord
         finish_log
       end
 
-      def deliver_failure(exception)
+      def deliver_failure(exception, warnings: nil)
         raise FinalizedError, "delivering failure to a finalized intent" if @finalized
 
         adapter.lock.synchronize do
           @error = exception
+          @warnings = warnings
 
           adapter.downgrade_connection_after_error(exception)
           retryable = adapter.retryable_failure?(exception, @retry_budget)
@@ -262,6 +267,9 @@ module ActiveRecord
 
         @raw_result = nil
         @raw_result_available = false
+        @warnings = nil
+        @outcome_handled = false
+        @warning_error = nil
         @error = nil
       end
 
@@ -278,6 +286,12 @@ module ActiveRecord
 
       # Ensure the result is available, blocking if necessary
       def ensure_result
+        if @outcome_handled
+          raise @error if @error
+          raise @warning_error if @warning_error
+          return
+        end
+
         if @session
           # Async was scheduled: wait for result (sets lock_wait)
           execute_or_wait
@@ -288,11 +302,28 @@ module ActiveRecord
         @event_buffer&.flush
 
         if @error
+          begin
+            adapter.handle_warnings(self, @warnings)
+          rescue
+            # The query failed, so we need to swallow this exception
+            # from handle_warnings to avoid masking the original.
+          end
           finish_log(exception: @error)
+          @outcome_handled = true
           @event_buffer&.flush
           raise @error
         end
 
+        begin
+          adapter.handle_warnings(self, @warnings)
+        rescue => warning_error
+          @warning_error = warning_error
+          @outcome_handled = true
+          @event_buffer&.flush
+          raise
+        end
+
+        @outcome_handled = true
         @event_buffer&.flush
       end
 

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -20,6 +20,14 @@ module ActiveRecord
           end
         end
 
+        def build_handle(name, payload)
+          DeferredHandle.new(self, @instrumenter, name, payload)
+        end
+
+        def add_event(event)
+          @events << event
+        end
+
         def flush
           events, @events = @events, []
           events.each do |event|
@@ -27,12 +35,33 @@ module ActiveRecord
             ActiveSupport::Notifications.publish_event(event)
           end
         end
+
+        class DeferredHandle
+          def initialize(buffer, instrumenter, name, payload)
+            @buffer = buffer
+            @event = instrumenter.new_event(name, payload)
+          end
+
+          def start
+            @event.start!
+          end
+
+          def finish
+            @event.finish!
+            @buffer.add_event(@event)
+          end
+
+          def payload
+            @event.payload
+          end
+        end
       end
 
       attr_reader :arel, :name, :prepare, :allow_retry, :allow_async,
-                  :materialize_transactions, :batch, :pool, :session, :lock_wait
+                  :materialize_transactions, :batch, :pool, :session, :lock_wait,
+                  :event_buffer
       attr_writer :raw_sql, :session
-      attr_accessor :adapter, :binds, :ran_async, :notification_payload
+      attr_accessor :adapter, :binds, :ran_async, :notification_payload, :log_handle
 
       def initialize(adapter:, arel: nil, raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, allow_async: false,
                      allow_retry: false, materialize_transactions: true, batch: false)
@@ -66,6 +95,7 @@ module ActiveRecord
         @error = nil
         @lock_wait = nil
         @event_buffer = nil
+        @log_handle = nil
       end
 
       # Returns a hash representation of the QueryIntent for debugging/introspection

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -3,6 +3,10 @@
 module ActiveRecord
   module ConnectionAdapters
     class QueryIntent # :nodoc:
+      # Raised when attempting to deliver to or reset a finalized intent.
+      class FinalizedError < ActiveRecordError # :nodoc:
+      end
+
       # Buffers instrumentation events during background execution for later publishing
       class EventBuffer
         def initialize(intent, instrumenter)
@@ -59,9 +63,11 @@ module ActiveRecord
 
       attr_reader :arel, :name, :prepare, :allow_retry, :allow_async,
                   :materialize_transactions, :batch, :pool, :session, :lock_wait,
-                  :event_buffer
+                  :event_buffer, :error, :finalized
+      alias_method :finalized?, :finalized
       attr_writer :raw_sql, :session
-      attr_accessor :adapter, :binds, :ran_async, :notification_payload, :log_handle
+      attr_accessor :adapter, :binds, :ran_async, :notification_payload, :log_handle,
+                    :retry_budget
 
       def initialize(adapter:, arel: nil, raw_sql: nil, processed_sql: nil, name: "SQL", binds: [], prepare: false, allow_async: false,
                      allow_retry: false, materialize_transactions: true, batch: false)
@@ -96,6 +102,9 @@ module ActiveRecord
         @lock_wait = nil
         @event_buffer = nil
         @log_handle = nil
+        @finalized = false
+
+        @retry_budget = nil
       end
 
       # Returns a hash representation of the QueryIntent for debugging/introspection
@@ -141,6 +150,7 @@ module ActiveRecord
                 @adapter = connection
                 @ran_async = true
                 run_query!
+                pump_retries
               end
             rescue => error
               @error = error
@@ -218,10 +228,41 @@ module ActiveRecord
         nil
       end
 
-      # Internal setter for raw result
-      def raw_result=(value)
-        @raw_result = value
-        @raw_result_available = true
+      def deliver_result(value)
+        raise FinalizedError, "delivering result to a finalized intent" if @finalized
+
+        adapter.lock.synchronize do
+          @raw_result = value
+          @error = nil
+
+          mark_transaction_dirty
+
+          @raw_result_available = true
+        end
+
+        finish_log
+      end
+
+      def deliver_failure(exception)
+        raise FinalizedError, "delivering failure to a finalized intent" if @finalized
+
+        adapter.lock.synchronize do
+          @error = exception
+
+          adapter.downgrade_connection_after_error(exception)
+          retryable = adapter.retryable_failure?(exception, @retry_budget)
+          mark_transaction_dirty unless retryable
+
+          @raw_result_available = !retryable
+        end
+      end
+
+      def reset_for_retry
+        raise FinalizedError, "resetting a finalized intent" if @finalized
+
+        @raw_result = nil
+        @raw_result_available = false
+        @error = nil
       end
 
       # Check if result has been populated yet (without blocking)
@@ -243,9 +284,16 @@ module ActiveRecord
         end
 
         @event_buffer&.flush
+        pump_retries
+        @event_buffer&.flush
 
-        # Raise any error captured during deferred execution
-        raise @error if @error
+        if @error
+          finish_log(exception: @error)
+          @event_buffer&.flush
+          raise @error
+        end
+
+        @event_buffer&.flush
       end
 
       def cast_result
@@ -264,7 +312,40 @@ module ActiveRecord
         @affected_rows ||= adapter.send(:affected_rows, @raw_result)
       end
 
+      def finish_log(exception: nil) # :nodoc:
+        return if @finalized
+
+        settle_failure if exception
+        @finalized = true
+        adapter.finish_intent_log(self, exception: exception)
+      end
+
       private
+        # Retry a delivered failure while the adapter remains available. Scoped
+        # connection owners call this before releasing their connection; otherwise
+        # result observation takes responsibility for pumping retries.
+        def pump_retries
+          while !@finalized && @error && adapter.attempt_retry(@error, @retry_budget)
+            reset_for_retry
+            run_query!
+          end
+
+          settle_failure
+        end
+
+        def settle_failure
+          return unless @error && !@raw_result_available
+
+          adapter.lock.synchronize do
+            mark_transaction_dirty
+            @raw_result_available = true
+          end
+        end
+
+        def mark_transaction_dirty
+          adapter.send(:dirty_current_transaction) if @materialize_transactions
+        end
+
         def async_schedule!(session)
           if adapter.current_transaction.joinable?
             raise AsynchronousQueryInsideTransactionError, "Asynchronous queries are not allowed inside transactions"
@@ -334,6 +415,7 @@ module ActiveRecord
                 @adapter = connection
                 @ran_async = false  # Foreground fallback, not actually async
                 run_query!
+                pump_retries
               end
             else
               # Result was computed by background thread while we waited for mutex

--- a/activerecord/lib/active_record/connection_adapters/retry_budget.rb
+++ b/activerecord/lib/active_record/connection_adapters/retry_budget.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    # Tracks the remaining automatic-retry allowance for one unit of work
+    # against the database: a bounded number of attempts, an optional wall
+    # clock deadline, and whether a reconnect (permitted at most once, because
+    # reconnect! has its own internal retry loop) is still available.
+    class RetryBudget # :nodoc:
+      attr_reader :retries_remaining
+
+      def initialize(retries:, deadline:, reconnectable:)
+        @retries_total = retries
+        @retries_remaining = retries
+        @deadline = deadline
+        @reconnectable = reconnectable
+      end
+
+      def reconnectable?
+        @reconnectable
+      end
+
+      def reconnect_consumed!
+        @reconnectable = false
+      end
+
+      def expired?
+        @deadline ? @deadline < Process.clock_gettime(Process::CLOCK_MONOTONIC) : false
+      end
+
+      def available?
+        @retries_remaining > 0 && !expired?
+      end
+
+      def consume
+        return false unless available?
+
+        @retries_remaining -= 1
+        true
+      end
+
+      def attempts_used
+        @retries_total - @retries_remaining
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/retry_budget.rb
+++ b/activerecord/lib/active_record/connection_adapters/retry_budget.rb
@@ -6,6 +6,9 @@ module ActiveRecord
     # against the database: a bounded number of attempts, an optional wall
     # clock deadline, and whether a reconnect (permitted at most once, because
     # reconnect! has its own internal retry loop) is still available.
+    #
+    # Raw connection access and QueryIntent delivery share this bookkeeping,
+    # so one query draws on a single allowance wherever its retries occur.
     class RetryBudget # :nodoc:
       attr_reader :retries_remaining
 

--- a/activerecord/lib/active_record/connection_adapters/retry_budget.rb
+++ b/activerecord/lib/active_record/connection_adapters/retry_budget.rb
@@ -7,6 +7,9 @@ module ActiveRecord
     # against the database: a bounded number of attempts, an optional wall
     # clock deadline, and whether a reconnect (permitted at most once, because
     # reconnect! has its own internal retry loop) is still available.
+    #
+    # Raw connection access and QueryIntent delivery share this bookkeeping,
+    # so one query draws on a single allowance wherever its retries occur.
     class RetryBudget # :nodoc:
       attr_reader :retries_remaining
 

--- a/activerecord/lib/active_record/connection_adapters/retry_budget.rb
+++ b/activerecord/lib/active_record/connection_adapters/retry_budget.rb
@@ -1,0 +1,48 @@
+# :markup: markdown
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    # Tracks the remaining automatic-retry allowance for one unit of work
+    # against the database: a bounded number of attempts, an optional wall
+    # clock deadline, and whether a reconnect (permitted at most once, because
+    # reconnect! has its own internal retry loop) is still available.
+    class RetryBudget # :nodoc:
+      attr_reader :retries_remaining
+
+      def initialize(retries:, deadline:, reconnectable:)
+        @retries_total = retries
+        @retries_remaining = retries
+        @deadline = deadline
+        @reconnectable = reconnectable
+      end
+
+      def reconnectable?
+        @reconnectable
+      end
+
+      def reconnect_consumed!
+        @reconnectable = false
+      end
+
+      def expired?
+        @deadline ? @deadline < Process.clock_gettime(Process::CLOCK_MONOTONIC) : false
+      end
+
+      def available?
+        @retries_remaining > 0 && !expired?
+      end
+
+      def consume
+        return false unless available?
+
+        @retries_remaining -= 1
+        true
+      end
+
+      def attempts_used
+        @retries_total - @retries_remaining
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -293,6 +293,25 @@ module ActiveRecord
       assert_kind_of Exception, error.cause
     end
 
+    class MockDatabaseError < StandardError
+      def result
+        0
+      end
+
+      def error_number
+        0
+      end
+    end
+
+    def test_translated_exceptions_carry_their_cause_without_an_enclosing_rescue
+      native = MockDatabaseError.new("boom")
+
+      translated = @connection.send(:translate_exception_class, native, "SELECT 1", [])
+
+      assert_kind_of ActiveRecord::StatementInvalid, translated
+      assert_same native, translated.cause
+    end
+
     def test_select_all_always_return_activerecord_result
       result = @connection.select_all "SELECT * FROM posts"
       assert result.is_a?(ActiveRecord::Result)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -315,6 +315,25 @@ module ActiveRecord
       assert_kind_of Exception, error.cause
     end
 
+    class MockDatabaseError < StandardError
+      def result
+        0
+      end
+
+      def error_number
+        0
+      end
+    end
+
+    def test_translated_exceptions_carry_their_cause_without_an_enclosing_rescue
+      native = MockDatabaseError.new("boom")
+
+      translated = @connection.send(:translate_exception_class, native, "SELECT 1", [])
+
+      assert_kind_of ActiveRecord::StatementInvalid, translated
+      assert_same native, translated.cause
+    end
+
     def test_select_all_always_return_activerecord_result
       result = @connection.select_all "SELECT * FROM posts"
       assert result.is_a?(ActiveRecord::Result)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -945,6 +945,20 @@ module ActiveRecord
         assert_operator Post.count, :>, 0
       end
 
+      test "connection failures consume the reconnect allowance" do
+        budget = ActiveRecord::ConnectionAdapters::RetryBudget.new(
+          retries: 2, deadline: nil, reconnectable: true
+        )
+        failure = ActiveRecord::ConnectionFailed.new("connection failed")
+
+        assert @connection.attempt_retry(failure, budget)
+        assert_not_predicate budget, :reconnectable?
+        assert_equal 1, budget.attempts_used
+
+        assert_not @connection.attempt_retry(failure, budget)
+        assert_equal 1, budget.attempts_used
+      end
+
       test "can reconnect and retry queries under limit when retry deadline is set" do
         attempts = 0
         @connection.stub(:retry_deadline, 0.1) do

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1465,6 +1465,73 @@ module ActiveRecord
         end
       end
 
+      def test_delivered_query_intent_warnings_are_handled_when_result_is_observed
+        warning_sql = "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$"
+        warnings = []
+        warning_action = ->(warning) do
+          warnings << [warning.message, warning.sql]
+          raise warning
+        end
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: @connection,
+          raw_sql: warning_sql,
+          name: "WARNING"
+        )
+
+        with_db_warnings_action(warning_action) do
+          assert_nothing_raised do
+            intent.execute!
+          end
+          assert_equal [], warnings
+          assert intent.raw_result_available?
+
+          error = assert_raises(ActiveRecord::SQLWarning) do
+            intent.cast_result
+          end
+          assert_equal "PostgreSQL SQL warning", error.message
+          assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+
+          assert_same error, assert_raises(ActiveRecord::SQLWarning) { intent.cast_result }
+          assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+        end
+      ensure
+        raw_result = intent&.instance_variable_get(:@raw_result)
+        if raw_result.respond_to?(:clear) && (!raw_result.respond_to?(:cleared?) || !raw_result.cleared?)
+          raw_result.clear
+        end
+      end
+
+      def test_delivered_query_intent_warnings_do_not_mask_query_failure
+        warning_sql = "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; " \
+          "RAISE EXCEPTION 'PostgreSQL SQL error'; END; $$"
+        warnings = []
+        warning_action = ->(warning) do
+          warnings << [warning.message, warning.sql]
+          raise warning
+        end
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: @connection,
+          raw_sql: warning_sql,
+          name: "WARNING FAILURE"
+        )
+
+        with_db_warnings_action(warning_action) do
+          assert_nothing_raised do
+            intent.execute!
+          end
+          assert_equal [], warnings
+
+          error = assert_raises(ActiveRecord::StatementInvalid) do
+            intent.cast_result
+          end
+          assert_match(/PostgreSQL SQL error/, error.message)
+          assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+
+          assert_raises(ActiveRecord::StatementInvalid) { intent.cast_result }
+          assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+        end
+      end
+
       def test_allowlist_of_warnings_to_ignore
         with_db_warnings_action(:raise, [/PostgreSQL SQL warning/]) do
           result = @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1465,6 +1465,28 @@ module ActiveRecord
         end
       end
 
+      def test_query_intent_defers_warnings_until_result_is_observed
+        warning_sql = "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$"
+        warnings = []
+        warning_action = ->(warning) { warnings << [warning.message, warning.sql] }
+        intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: @connection,
+          raw_sql: warning_sql,
+          name: "WARNING"
+        )
+
+        with_db_warnings_action(warning_action) do
+          intent.execute!
+          assert_empty warnings
+
+          intent.cast_result
+          assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+
+          intent.cast_result
+          assert_equal [["PostgreSQL SQL warning", warning_sql]], warnings
+        end
+      end
+
       def test_allowlist_of_warnings_to_ignore
         with_db_warnings_action(:raise, [/PostgreSQL SQL warning/]) do
           result = @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -99,6 +99,128 @@ class AsynchronousQueriesTest < ActiveRecord::TestCase
     assert_not_nil event
     assert_equal @connection.supports_concurrent_connections?, event.payload[:async]
   end
+
+  def test_async_query_retries_query_failure
+    skip unless @connection.async_enabled?
+
+    failure = ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+    matching = ->(intent) { intent.name == "Async Retry" }
+
+    with_async_query_failures([failure], matching: matching) do |attempts|
+      future_result = @connection.select_all(
+        "SELECT 1 AS value", "Async Retry", async: true, allow_retry: true
+      )
+      wait_for_future_result(future_result)
+
+      assert_equal 2, attempts.value
+      assert_equal [[1]], future_result.result.rows
+    end
+  end
+
+  def test_async_query_reports_failure_after_retries_are_exhausted
+    skip unless @connection.async_enabled?
+    skip unless @connection.connection_retries > 0
+
+    failure = ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+    matching = ->(intent) { intent.name == "Async Retry Exhausted" }
+
+    with_async_query_failures([failure], matching: matching, repeat_last: true) do |attempts|
+      future_result = @connection.select_all(
+        "SELECT 1 AS value", "Async Retry Exhausted", async: true, allow_retry: true
+      )
+      wait_for_async_query(@connection)
+
+      assert_operator attempts.value, :>, 1
+      error = assert_raises(ActiveRecord::LockWaitTimeout) { future_result.result }
+      assert_equal "lock wait timeout", error.message
+    end
+  end
+
+  def test_async_query_retries_connection_failure
+    skip unless @connection.async_enabled?
+
+    failure = ActiveRecord::ConnectionFailed.new("connection failed")
+    matching = ->(intent) { intent.name == "Async Connection Retry" }
+
+    with_async_query_failures([failure], matching: matching) do |attempts|
+      future_result = @connection.select_all(
+        "SELECT 1 AS value", "Async Connection Retry", async: true, allow_retry: true
+      )
+      wait_for_future_result(future_result)
+
+      assert_equal 2, attempts.value
+      assert_equal [[1]], future_result.result.rows
+    end
+  end
+
+  def test_async_query_foreground_fallback_retries_query_failure
+    skip unless @connection.async_enabled?
+
+    failure = ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+    matching = ->(intent) { intent.name == "Async Fallback Retry" }
+
+    with_async_query_failures([failure], matching: matching) do |attempts|
+      @connection.pool.stub(:schedule_query, proc { }) do
+        future_result = @connection.select_all(
+          "SELECT 1 AS value", "Async Fallback Retry", async: true, allow_retry: true
+        )
+
+        assert_equal [[1]], future_result.result.rows
+      end
+
+      assert_equal 2, attempts.value
+    end
+  end
+
+  def test_load_async_retries_query_failure
+    skip unless @connection.async_enabled?
+
+    failure = ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+    matching = ->(intent) { intent.name == "Post Load" }
+
+    with_async_query_failures([failure], matching: matching) do |attempts|
+      deferred_posts = Post.where(id: -1).load_async
+      wait_for_async_query(@connection)
+
+      assert_equal 2, attempts.value
+      assert_empty deferred_posts.to_a
+    end
+  end
+
+  private
+    def with_async_query_failures(failures, matching:, repeat_last: false)
+      adapter_class = @connection.class
+      original_perform_query = adapter_class.instance_method(:perform_query)
+      visibility = if adapter_class.private_instance_methods(false).include?(:perform_query)
+        :private
+      elsif adapter_class.protected_instance_methods(false).include?(:perform_query)
+        :protected
+      elsif adapter_class.instance_methods(false).include?(:perform_query)
+        :public
+      end
+      attempts = Concurrent::AtomicFixnum.new
+
+      adapter_class.send(:define_method, :perform_query) do |raw_connection, intent|
+        if matching.call(intent)
+          attempt = attempts.increment
+          failure = failures[attempt - 1]
+          failure ||= failures.last if repeat_last
+          raise failure if failure
+        end
+
+        original_perform_query.bind_call(self, raw_connection, intent)
+      end
+      adapter_class.send(:private, :perform_query)
+
+      yield attempts
+    ensure
+      if visibility
+        adapter_class.send(:define_method, :perform_query, original_perform_query)
+        adapter_class.send(visibility, :perform_query)
+      else
+        adapter_class.send(:remove_method, :perform_query)
+      end
+    end
 end
 
 class AsynchronousQueriesWithTransactionalTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/connection_adapters/retry_budget_test.rb
+++ b/activerecord/test/cases/connection_adapters/retry_budget_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class RetryBudgetTest < ActiveRecord::TestCase
+      test "is exhausted by consumption" do
+        budget = RetryBudget.new(retries: 1, deadline: nil, reconnectable: true)
+
+        assert_predicate budget, :available?
+        assert budget.consume
+        assert_equal 1, budget.attempts_used
+        assert_not_predicate budget, :available?
+        assert_not budget.consume
+      end
+
+      test "is exhausted by deadline" do
+        expired = RetryBudget.new(
+          retries: 1,
+          deadline: Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1,
+          reconnectable: true
+        )
+
+        assert_predicate expired, :expired?
+        assert_not_predicate expired, :available?
+        assert_not expired.consume
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/connection_adapters/retry_budget_test.rb
+++ b/activerecord/test/cases/connection_adapters/retry_budget_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class RetryBudgetTest < ActiveRecord::TestCase
+      test "is exhausted by consumption" do
+        budget = RetryBudget.new(retries: 1, deadline: nil, reconnectable: true)
+
+        assert_predicate budget, :available?
+        assert budget.consume
+        assert_equal 1, budget.attempts_used
+        assert_not_predicate budget, :available?
+        assert_not budget.consume
+      end
+
+      test "is exhausted by deadline" do
+        expired = RetryBudget.new(
+          retries: 1,
+          deadline: Process.clock_gettime(Process::CLOCK_MONOTONIC) - 1,
+          reconnectable: true
+        )
+
+        assert_predicate expired, :expired?
+        assert_not_predicate expired, :available?
+        assert_not expired.consume
+      end
+
+      test "tracks reconnect allowance separately from retries" do
+        budget = RetryBudget.new(retries: 1, deadline: nil, reconnectable: true)
+
+        assert_predicate budget, :reconnectable?
+        budget.reconnect_consumed!
+        assert_not_predicate budget, :reconnectable?
+
+        assert_predicate budget, :available?
+        assert budget.consume
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -104,6 +104,36 @@ module ActiveRecord
         assert_equal 0, active_connections(pool).size
       end
 
+      def test_checkin_finalizes_unfinished_intent_logs
+        pool.with_connection { }
+        intent = nil
+        finalized_before_checkin_callbacks = nil
+        adapter_class = ActiveRecord::ConnectionAdapters::AbstractAdapter
+        checkin_callback = -> { finalized_before_checkin_callbacks = intent&.finalized? }
+        adapter_class.set_callback(:checkin, :before, checkin_callback)
+
+        events = capture_notifications("sql.active_record") do
+          pool.with_connection do |connection|
+            intent = QueryIntent.new(
+              adapter: connection,
+              raw_sql: "SELECT 1",
+              name: "SQL",
+              materialize_transactions: false
+            )
+            connection.start_intent_log(intent)
+
+            assert_not_predicate intent, :finalized?
+          end
+        end
+
+        event = events.find { |notification| notification.payload[:sql] == "SELECT 1" }
+        assert_predicate intent, :finalized?
+        assert_equal true, finalized_before_checkin_callbacks
+        assert_not_nil event
+      ensure
+        adapter_class&.skip_callback(:checkin, :before, checkin_callback) if checkin_callback
+      end
+
       def test_new_connection_no_query
         skip("Can't test with in-memory dbs") if in_memory_db?
         assert_equal 0, pool.connections.size

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -104,6 +104,36 @@ module ActiveRecord
         assert_equal 0, active_connections(pool).size
       end
 
+      def test_checkin_finalizes_unfinished_intent_logs_before_callbacks
+        pool.with_connection { }
+        intent = nil
+        finalized_before_checkin_callbacks = nil
+        adapter_class = ActiveRecord::ConnectionAdapters::AbstractAdapter
+        checkin_callback = -> { finalized_before_checkin_callbacks = intent&.finalized? }
+        adapter_class.set_callback(:checkin, :before, checkin_callback)
+
+        events = capture_notifications("sql.active_record") do
+          pool.with_connection do |connection|
+            intent = QueryIntent.new(
+              adapter: connection,
+              raw_sql: "SELECT 1",
+              name: "SQL",
+              materialize_transactions: false
+            )
+            connection.start_intent_log(intent)
+
+            assert_not_predicate intent, :finalized?
+          end
+        end
+
+        event = events.find { |notification| notification.payload[:sql] == "SELECT 1" }
+        assert_predicate intent, :finalized?
+        assert finalized_before_checkin_callbacks
+        assert_not_nil event
+      ensure
+        adapter_class&.skip_callback(:checkin, :before, checkin_callback) if checkin_callback
+      end
+
       def test_new_connection_no_query
         skip("Can't test with in-memory dbs") if in_memory_db?
         assert_equal 0, pool.connections.size

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -117,6 +117,21 @@ module ActiveRecord
       assert_equal 10, notification.payload[:row_count]
     end
 
+    def test_payload_exception_on_failed_query
+      notifications = []
+      subscriber = ->(notification) { notifications << notification }
+
+      assert_raises(ActiveRecord::StatementInvalid) do
+        ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+          ActiveRecord::Base.lease_connection.select_all("SELECT * FROM non_existent_table_for_notification")
+        end
+      end
+
+      notification = notifications.find { _1.payload[:sql].match?("non_existent_table_for_notification") }
+      assert_equal "ActiveRecord::StatementInvalid", notification.payload[:exception].first
+      assert_kind_of ActiveRecord::StatementInvalid, notification.payload[:exception_object]
+    end
+
     def test_payload_row_count_on_cache
       Book.create!(name: "row count book")
 

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -117,6 +117,19 @@ module ActiveRecord
       assert_equal 10, notification.payload[:row_count]
     end
 
+    def test_payload_exception_on_failed_query
+      error = nil
+      notifications = capture_notifications("sql.active_record") do
+        error = assert_raises(ActiveRecord::StatementInvalid) do
+          ActiveRecord::Base.lease_connection.select_all("SELECT * FROM non_existent_table_for_notification")
+        end
+      end
+
+      notification = notifications.find { _1.payload[:sql].match?("non_existent_table_for_notification") }
+      assert_equal [error.class.name, error.message], notification.payload[:exception]
+      assert_same error, notification.payload[:exception_object]
+    end
+
     def test_payload_row_count_on_cache
       Book.create!(name: "row count book")
 

--- a/activerecord/test/cases/query_intent_test.rb
+++ b/activerecord/test/cases/query_intent_test.rb
@@ -24,6 +24,26 @@ module ActiveRecord
       end
     end
 
+    test "warning collection failures are delivered through the intent" do
+      connection = Post.lease_connection
+      singleton_class = connection.singleton_class
+
+      singleton_class.define_method(:collect_warnings) do |_result|
+        raise ActiveRecord::StatementInvalid, "warning collection failed"
+      end
+
+      intent = build_intent(connection)
+      intent.execute!
+
+      assert_predicate intent, :raw_result_available?
+      error = assert_raises(ActiveRecord::StatementInvalid) do
+        intent.cast_result
+      end
+      assert_equal "warning collection failed", error.message
+    ensure
+      singleton_class.remove_method(:collect_warnings) if singleton_class&.instance_methods(false)&.include?(:collect_warnings)
+    end
+
     test "delivered outcomes dirty materialized transactions" do
       connection = Post.lease_connection
       dirty_count = 0
@@ -77,6 +97,27 @@ module ActiveRecord
     ensure
       singleton_class&.remove_method(:perform_query) if singleton_class&.instance_methods(false)&.include?(:perform_query)
       singleton_class&.remove_method(:dirty_current_transaction) if singleton_class&.instance_methods(false)&.include?(:dirty_current_transaction)
+    end
+
+    test "handled failures are not retried again when observed repeatedly" do
+      connection = Post.lease_connection
+      intent = build_intent(connection)
+      singleton_class = class << connection; self; end
+      retry_checks = 0
+      error = ActiveRecord::StatementInvalid.new("boom")
+
+      singleton_class.define_method(:attempt_retry) do |*|
+        retry_checks += 1
+        false
+      end
+
+      intent.deliver_failure(error)
+
+      assert_same error, assert_raises(ActiveRecord::StatementInvalid) { intent.raw_result }
+      assert_same error, assert_raises(ActiveRecord::StatementInvalid) { intent.raw_result }
+      assert_equal 1, retry_checks
+    ensure
+      singleton_class&.remove_method(:attempt_retry) if singleton_class&.method_defined?(:attempt_retry)
     end
 
     test "retry re-enters execute_intent" do

--- a/activerecord/test/cases/query_intent_test.rb
+++ b/activerecord/test/cases/query_intent_test.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+module ActiveRecord
+  class QueryIntentTest < ActiveRecord::TestCase
+    test "finalized intents cannot be delivered or reset" do
+      connection = Post.lease_connection
+      intent = build_intent(connection)
+
+      intent.execute!
+      intent.cast_result
+
+      assert_predicate intent, :finalized?
+      assert_raises(ActiveRecord::ConnectionAdapters::QueryIntent::FinalizedError) do
+        intent.deliver_result(nil)
+      end
+      assert_raises(ActiveRecord::ConnectionAdapters::QueryIntent::FinalizedError) do
+        intent.deliver_failure(ActiveRecord::StatementInvalid.new("boom"))
+      end
+      assert_raises(ActiveRecord::ConnectionAdapters::QueryIntent::FinalizedError) do
+        intent.reset_for_retry
+      end
+    end
+
+    test "delivered outcomes dirty materialized transactions" do
+      connection = Post.lease_connection
+      dirty_count = 0
+      singleton_class = connection.singleton_class
+
+      singleton_class.define_method(:dirty_current_transaction) do
+        dirty_count += 1
+      end
+
+      build_intent(connection, materialize_transactions: true).deliver_result(nil)
+      build_intent(connection, materialize_transactions: true).deliver_failure(ActiveRecord::StatementInvalid.new("boom"))
+      build_intent(connection, materialize_transactions: false).deliver_result(nil)
+      build_intent(connection, materialize_transactions: false).deliver_failure(ActiveRecord::StatementInvalid.new("boom"))
+
+      assert_equal 2, dirty_count
+    ensure
+      singleton_class.remove_method(:dirty_current_transaction) if singleton_class&.instance_methods(false)&.include?(:dirty_current_transaction)
+    end
+
+    test "non-StandardError interruptions downgrade the connection and dirty the transaction" do
+      connection = Post.lease_connection
+      connection.execute("SELECT 1")
+      intent = build_intent(connection, materialize_transactions: true)
+      singleton_class = connection.singleton_class
+      original_perform_query = connection.method(:perform_query)
+      interruption = Class.new(Exception)
+      dirty_count = 0
+
+      singleton_class.define_method(:perform_query) do |raw_connection, query_intent|
+        if query_intent.equal?(intent)
+          raise interruption
+        else
+          original_perform_query.call(raw_connection, query_intent)
+        end
+      end
+      singleton_class.define_method(:dirty_current_transaction) do
+        dirty_count += 1
+      end
+
+      events = capture_notifications("sql.active_record") do
+        assert_raises(interruption) { intent.execute! }
+      end
+
+      event = events.find { _1.payload[:sql] == "SELECT 1" }
+      assert_not_predicate connection, :verified?
+      assert_nil connection.instance_variable_get(:@last_activity)
+      assert_equal 1, dirty_count
+      assert_predicate intent, :finalized?
+      assert_not_nil event
+      assert_instance_of interruption, event.payload[:exception_object]
+    ensure
+      singleton_class&.remove_method(:perform_query) if singleton_class&.instance_methods(false)&.include?(:perform_query)
+      singleton_class&.remove_method(:dirty_current_transaction) if singleton_class&.instance_methods(false)&.include?(:dirty_current_transaction)
+    end
+
+    test "retry re-enters execute_intent" do
+      connection = Post.lease_connection
+      intent = build_intent(connection, allow_retry: true)
+      singleton_class = class << connection; self; end
+      execute_intent_calls = 0
+      perform_query_calls = 0
+      original_execute_intent = connection.method(:execute_intent)
+      original_perform_query = connection.method(:perform_query)
+
+      singleton_class.define_method(:backoff) { |_| }
+      singleton_class.define_method(:execute_intent) do |retry_intent|
+        execute_intent_calls += 1
+        original_execute_intent.call(retry_intent)
+      end
+      singleton_class.define_method(:perform_query) do |raw_connection, retry_intent|
+        perform_query_calls += 1
+        if perform_query_calls == 1
+          raise ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+        else
+          original_perform_query.call(raw_connection, retry_intent)
+        end
+      end
+
+      intent.execute!
+
+      assert_not_predicate intent, :raw_result_available?
+      assert_equal 1, execute_intent_calls
+
+      intent.cast_result
+
+      assert_predicate intent, :raw_result_available?
+      assert_equal 2, execute_intent_calls
+    ensure
+      singleton_class&.remove_method(:backoff) if singleton_class&.method_defined?(:backoff)
+      singleton_class&.remove_method(:execute_intent) if singleton_class&.method_defined?(:execute_intent)
+      singleton_class&.remove_method(:perform_query) if singleton_class&.method_defined?(:perform_query)
+    end
+
+    test "exhausted retries make the final failure available" do
+      connection = Post.lease_connection
+      intent = build_intent(connection, allow_retry: true)
+      singleton_class = class << connection; self; end
+      perform_query_calls = 0
+
+      singleton_class.define_method(:backoff) { |_| }
+      singleton_class.define_method(:perform_query) do |*, **|
+        perform_query_calls += 1
+        raise ActiveRecord::LockWaitTimeout, "lock wait timeout"
+      end
+
+      intent.execute!
+
+      assert_not_predicate intent, :raw_result_available?
+      error = assert_raises(ActiveRecord::LockWaitTimeout) { intent.cast_result }
+      assert_equal "lock wait timeout", error.message
+      assert_predicate intent, :raw_result_available?
+      assert_predicate intent, :finalized?
+      assert_equal 2, perform_query_calls
+    ensure
+      singleton_class&.remove_method(:backoff) if singleton_class&.method_defined?(:backoff)
+      singleton_class&.remove_method(:perform_query) if singleton_class&.method_defined?(:perform_query)
+    end
+
+    test "finalizing a provisional failure makes it available without retrying" do
+      connection = Post.lease_connection
+      intent = build_intent(connection, allow_retry: true)
+      intent.retry_budget = ActiveRecord::ConnectionAdapters::RetryBudget.new(
+        retries: 1, deadline: nil, reconnectable: false
+      )
+      singleton_class = class << connection; self; end
+      retry_checks = 0
+      error = ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+
+      singleton_class.define_method(:attempt_retry) do |*|
+        retry_checks += 1
+        true
+      end
+
+      intent.deliver_failure(error)
+      assert_not_predicate intent, :raw_result_available?
+
+      intent.finish_log(exception: error)
+
+      assert_predicate intent, :raw_result_available?
+      assert_predicate intent, :finalized?
+      assert_same error, assert_raises(ActiveRecord::LockWaitTimeout) { intent.raw_result }
+      assert_equal 0, retry_checks
+    ensure
+      singleton_class&.remove_method(:attempt_retry) if singleton_class&.method_defined?(:attempt_retry)
+    end
+
+    test "retryable failures dirty transactions only after final delivery" do
+      connection = Post.lease_connection
+      intent = build_intent(connection, allow_retry: true, materialize_transactions: true)
+      singleton_class = class << connection; self; end
+      dirty_count = 0
+      dirty_count_before_retry = nil
+      perform_query_calls = 0
+      original_perform_query = connection.method(:perform_query)
+
+      singleton_class.define_method(:backoff) { |_| }
+      singleton_class.define_method(:dirty_current_transaction) do
+        dirty_count += 1
+      end
+      singleton_class.define_method(:perform_query) do |raw_connection, retry_intent|
+        perform_query_calls += 1
+        if perform_query_calls == 1
+          raise ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+        else
+          dirty_count_before_retry = dirty_count
+          original_perform_query.call(raw_connection, retry_intent)
+        end
+      end
+
+      intent.execute!
+
+      assert_not_predicate intent, :raw_result_available?
+      assert_equal 0, dirty_count
+
+      intent.cast_result
+
+      assert_equal 0, dirty_count_before_retry
+      assert_equal 1, dirty_count
+    ensure
+      singleton_class&.remove_method(:backoff) if singleton_class&.method_defined?(:backoff)
+      singleton_class&.remove_method(:dirty_current_transaction) if singleton_class&.method_defined?(:dirty_current_transaction)
+      singleton_class&.remove_method(:perform_query) if singleton_class&.method_defined?(:perform_query)
+    end
+
+    private
+      def build_intent(connection, allow_retry: false, materialize_transactions: false)
+        ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: connection,
+          raw_sql: "SELECT 1",
+          name: "SQL",
+          allow_retry: allow_retry,
+          materialize_transactions: materialize_transactions
+        )
+      end
+  end
+end

--- a/activerecord/test/cases/query_intent_test.rb
+++ b/activerecord/test/cases/query_intent_test.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+module ActiveRecord
+  class QueryIntentTest < ActiveRecord::TestCase
+    def setup
+      super
+      @connection = ActiveRecord::Base.connection_pool.send(:new_connection)
+      @connection.connect!
+    end
+
+    def teardown
+      @connection.disconnect!
+      super
+    end
+
+    test "finalized intents cannot be delivered or reset" do
+      connection = @connection
+      intent = build_intent(connection)
+
+      intent.execute!
+      intent.cast_result
+
+      assert_predicate intent, :finalized?
+      assert_raises(ActiveRecord::ConnectionAdapters::QueryIntent::FinalizedError) do
+        intent.deliver_result(nil)
+      end
+      assert_raises(ActiveRecord::ConnectionAdapters::QueryIntent::FinalizedError) do
+        intent.deliver_failure(ActiveRecord::StatementInvalid.new("boom"))
+      end
+      assert_raises(ActiveRecord::ConnectionAdapters::QueryIntent::FinalizedError) do
+        intent.reset_for_retry
+      end
+    end
+
+    test "only delivered outcomes that materialize transactions dirty the transaction" do
+      connection = @connection
+      dirty_count = 0
+
+      connection.stub(:dirty_current_transaction, -> { dirty_count += 1 }) do
+        build_intent(connection, materialize_transactions: true).deliver_result(nil)
+        assert_equal 1, dirty_count
+
+        build_intent(connection, materialize_transactions: false).deliver_result(nil)
+        assert_equal 1, dirty_count
+
+        build_intent(connection, materialize_transactions: true)
+          .deliver_failure(ActiveRecord::StatementInvalid.new("boom"))
+        assert_equal 2, dirty_count
+
+        build_intent(connection, materialize_transactions: false)
+          .deliver_failure(ActiveRecord::StatementInvalid.new("boom"))
+        assert_equal 2, dirty_count
+      end
+    end
+
+    test "non-StandardError interruptions downgrade the connection and dirty the transaction" do
+      connection = @connection
+      connection.execute("SELECT 1")
+      intent = build_intent(connection, materialize_transactions: true)
+      interruption = Class.new(Exception)
+      dirty_count = 0
+      original_perform_query = connection.method(:perform_query)
+      perform_query = ->(raw_connection, query_intent) do
+        if query_intent.equal?(intent)
+          raise interruption
+        else
+          original_perform_query.call(raw_connection, query_intent)
+        end
+      end
+
+      events = connection.stub(:perform_query, perform_query) do
+        connection.stub(:dirty_current_transaction, -> { dirty_count += 1 }) do
+          capture_notifications("sql.active_record") do
+            assert_raises(interruption) { intent.execute! }
+          end
+        end
+      end
+
+      event = events.find { _1.payload[:sql] == "SELECT 1" }
+      assert_not_predicate connection, :verified?
+      assert_nil connection.instance_variable_get(:@last_activity)
+      assert_equal 1, dirty_count
+      assert_predicate intent, :finalized?
+      assert_not_nil event
+      assert_instance_of interruption, event.payload[:exception_object]
+    end
+
+    test "a retried query returns its result through one notification" do
+      connection = @connection
+      intent = build_intent(connection, allow_retry: true)
+      attempts = 0
+      original_perform_query = connection.method(:perform_query)
+      perform_query = ->(raw_connection, retry_intent) do
+        attempts += 1
+        if attempts == 1
+          raise ActiveRecord::LockWaitTimeout, "lock wait timeout"
+        else
+          original_perform_query.call(raw_connection, retry_intent)
+        end
+      end
+
+      events = connection.stub(:connection_retries, 1) do
+        connection.stub(:backoff, ->(_) { }) do
+          connection.stub(:perform_query, perform_query) do
+            capture_notifications("sql.active_record") do
+              intent.execute!
+
+              assert_not_predicate intent, :raw_result_available?
+              assert_equal [[1]], intent.cast_result.rows
+            end
+          end
+        end
+      end
+
+      query_events = events.select { _1.payload[:sql] == "SELECT 1" }
+      assert_equal 2, attempts
+      assert_equal 1, query_events.size
+      assert_not query_events.first.payload.key?(:exception)
+      assert_predicate intent, :finalized?
+    end
+
+    test "exhausted retries make the final failure available" do
+      connection = @connection
+      intent = build_intent(connection, allow_retry: true)
+      perform_query_calls = 0
+      perform_query = ->(*) do
+        perform_query_calls += 1
+        raise ActiveRecord::LockWaitTimeout, "lock wait timeout"
+      end
+
+      connection.stub(:connection_retries, 1) do
+        connection.stub(:backoff, ->(_) { }) do
+          connection.stub(:perform_query, perform_query) do
+            intent.execute!
+
+            assert_not_predicate intent, :raw_result_available?
+            error = assert_raises(ActiveRecord::LockWaitTimeout) { intent.cast_result }
+            assert_equal "lock wait timeout", error.message
+          end
+        end
+      end
+
+      assert_predicate intent, :raw_result_available?
+      assert_predicate intent, :finalized?
+      assert_equal 2, perform_query_calls
+    end
+
+    test "finalizing a provisional failure makes it available without retrying" do
+      connection = @connection
+      intent = build_intent(connection, allow_retry: true)
+      intent.retry_budget = ActiveRecord::ConnectionAdapters::RetryBudget.new(
+        retries: 1, deadline: nil, reconnectable: false
+      )
+      retry_checks = 0
+      error = ActiveRecord::LockWaitTimeout.new("lock wait timeout")
+      attempt_retry = ->(*) do
+        retry_checks += 1
+        true
+      end
+
+      connection.stub(:attempt_retry, attempt_retry) do
+        intent.deliver_failure(error)
+        assert_not_predicate intent, :raw_result_available?
+
+        intent.finish_log(exception: error)
+
+        assert_predicate intent, :raw_result_available?
+        assert_predicate intent, :finalized?
+        assert_same error, assert_raises(ActiveRecord::LockWaitTimeout) { intent.raw_result }
+      end
+
+      assert_equal 0, retry_checks
+    end
+
+    test "retryable failures dirty transactions only after final delivery" do
+      connection = @connection
+      intent = build_intent(connection, allow_retry: true, materialize_transactions: true)
+      dirty_count = 0
+      dirty_count_before_retry = nil
+      perform_query_calls = 0
+      original_perform_query = connection.method(:perform_query)
+      perform_query = ->(raw_connection, retry_intent) do
+        perform_query_calls += 1
+        if perform_query_calls == 1
+          raise ActiveRecord::LockWaitTimeout, "lock wait timeout"
+        else
+          dirty_count_before_retry = dirty_count
+          original_perform_query.call(raw_connection, retry_intent)
+        end
+      end
+
+      connection.stub(:connection_retries, 1) do
+        connection.stub(:backoff, ->(_) { }) do
+          connection.stub(:dirty_current_transaction, -> { dirty_count += 1 }) do
+            connection.stub(:perform_query, perform_query) do
+              intent.execute!
+
+              assert_not_predicate intent, :raw_result_available?
+              assert_equal 0, dirty_count
+
+              intent.cast_result
+            end
+          end
+        end
+      end
+
+      assert_equal 0, dirty_count_before_retry
+      assert_equal 1, dirty_count
+    end
+
+    private
+      def build_intent(connection, allow_retry: false, materialize_transactions: false)
+        ActiveRecord::ConnectionAdapters::QueryIntent.new(
+          adapter: connection,
+          raw_sql: "SELECT 1",
+          name: "SQL",
+          allow_retry: allow_retry,
+          materialize_transactions: materialize_transactions
+        )
+      end
+  end
+end

--- a/activerecord/test/cases/query_intent_test.rb
+++ b/activerecord/test/cases/query_intent_test.rb
@@ -35,6 +35,67 @@ module ActiveRecord
       end
     end
 
+    test "warning collection failures are delivered through the intent" do
+      connection = @connection
+      collect_warnings = ->(_result) { raise ActiveRecord::StatementInvalid, "warning collection failed" }
+
+      connection.stub(:collect_warnings, collect_warnings) do
+        intent = build_intent(connection)
+        intent.execute!
+
+        assert_predicate intent, :raw_result_available?
+        error = assert_raises(ActiveRecord::StatementInvalid) do
+          intent.cast_result
+        end
+        assert_equal "warning collection failed", error.message
+      end
+    end
+
+    test "delivered warnings are handled once when the result is observed" do
+      connection = @connection
+      intent = build_intent(connection)
+      warning = ActiveRecord::SQLWarning.new("warning")
+      handled_warnings = []
+      handle_warnings = ->(_intent, warnings) do
+        handled_warnings.concat(warnings)
+        raise warnings.first
+      end
+
+      connection.stub(:handle_warnings, handle_warnings) do
+        intent.deliver_result(nil, warnings: [warning])
+
+        assert_empty handled_warnings
+        assert_same warning, assert_raises(ActiveRecord::SQLWarning) { intent.raw_result }
+        assert_equal [warning], handled_warnings
+
+        assert_same warning, assert_raises(ActiveRecord::SQLWarning) { intent.raw_result }
+        assert_equal [warning], handled_warnings
+      end
+    end
+
+    test "delivered warnings do not mask a query failure" do
+      connection = @connection
+      intent = build_intent(connection)
+      warning = ActiveRecord::SQLWarning.new("warning")
+      query_error = ActiveRecord::StatementInvalid.new("query failed")
+      handled_warnings = []
+      handle_warnings = ->(_intent, warnings) do
+        handled_warnings.concat(warnings)
+        raise warnings.first
+      end
+
+      connection.stub(:handle_warnings, handle_warnings) do
+        intent.deliver_failure(query_error, warnings: [warning])
+
+        assert_empty handled_warnings
+        assert_same query_error, assert_raises(ActiveRecord::StatementInvalid) { intent.raw_result }
+        assert_equal [warning], handled_warnings
+
+        assert_same query_error, assert_raises(ActiveRecord::StatementInvalid) { intent.raw_result }
+        assert_equal [warning], handled_warnings
+      end
+    end
+
     test "only delivered outcomes that materialize transactions dirty the transaction" do
       connection = @connection
       dirty_count = 0
@@ -86,6 +147,26 @@ module ActiveRecord
       assert_predicate intent, :finalized?
       assert_not_nil event
       assert_instance_of interruption, event.payload[:exception_object]
+    end
+
+    test "handled failures are not retried again when observed repeatedly" do
+      connection = @connection
+      intent = build_intent(connection)
+      retry_checks = 0
+      error = ActiveRecord::StatementInvalid.new("boom")
+      attempt_retry = ->(*) do
+        retry_checks += 1
+        false
+      end
+
+      connection.stub(:attempt_retry, attempt_retry) do
+        intent.deliver_failure(error)
+
+        assert_same error, assert_raises(ActiveRecord::StatementInvalid) { intent.raw_result }
+        assert_same error, assert_raises(ActiveRecord::StatementInvalid) { intent.raw_result }
+      end
+
+      assert_equal 1, retry_checks
     end
 
     test "a retried query returns its result through one notification" do

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -155,17 +155,17 @@ module ActiveRecord
         latch1 = Concurrent::CountDownLatch.new
         latch2 = Concurrent::CountDownLatch.new
 
-        old_log = ActiveRecord::Base.connection.method(:log)
-        ActiveRecord::Base.connection.singleton_class.undef_method(:log)
+        connection = ActiveRecord::Base.connection
+        old_start_intent_log = connection.method(:start_intent_log)
+        connection.singleton_class.undef_method(:start_intent_log)
 
-        ActiveRecord::Base.connection.singleton_class.define_method(:log) do |intent, *args, **kwargs, &block|
-          unless intent.ran_async
-            return old_log.call(intent, *args, **kwargs, &block)
+        connection.singleton_class.define_method(:start_intent_log) do |intent|
+          if intent.ran_async
+            latch1.count_down
+            latch2.wait
           end
 
-          latch1.count_down
-          latch2.wait
-          old_log.call(intent, *args, **kwargs, &block)
+          old_start_intent_log.call(intent)
         end
 
         Post.async_count
@@ -176,8 +176,8 @@ module ActiveRecord
         end
       ensure
         latch2.count_down
-        ActiveRecord::Base.connection.singleton_class.undef_method(:log)
-        ActiveRecord::Base.connection.singleton_class.define_method(:log, old_log)
+        connection.singleton_class.undef_method(:start_intent_log)
+        connection.singleton_class.define_method(:start_intent_log, old_start_intent_log)
       end
     end
 

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -17,15 +17,25 @@ module ActiveRecord
       end
     end
 
+    def with_failing_query(connection)
+      singleton_class = connection.singleton_class
+      singleton_class.define_method(:perform_query) do |_raw_connection, _intent|
+        raise MockDatabaseError
+      end
+
+      yield
+    ensure
+      singleton_class.remove_method(:perform_query) if singleton_class&.instance_methods(false)&.include?(:perform_query)
+    end
+
     test "message contains no sql" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       connection = Book.lease_connection
       intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(adapter: connection, processed_sql: sql, name: Book.name)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        connection.send(:log, intent) do
-          connection.send(:with_raw_connection) do
-            raise MockDatabaseError
-          end
+        with_failing_query(connection) do
+          intent.execute!
+          intent.cast_result
         end
       end
       assert_not error.message.include?("SELECT")
@@ -37,10 +47,9 @@ module ActiveRecord
       connection = Book.lease_connection
       intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(adapter: connection, processed_sql: sql, name: Book.name, binds: binds)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        connection.send(:log, intent) do
-          connection.send(:with_raw_connection) do
-            raise MockDatabaseError
-          end
+        with_failing_query(connection) do
+          intent.execute!
+          intent.cast_result
         end
       end
       assert_equal error.sql, sql

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -7,6 +7,17 @@ module ActiveRecord
   class StatementInvalidTest < ActiveRecord::TestCase
     fixtures :books
 
+    def setup
+      super
+      @connection = ActiveRecord::Base.connection_pool.send(:new_connection)
+      @connection.connect!
+    end
+
+    def teardown
+      @connection.disconnect!
+      super
+    end
+
     class MockDatabaseError < StandardError
       def result
         0
@@ -19,13 +30,12 @@ module ActiveRecord
 
     test "message contains no sql" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
-      connection = Book.lease_connection
+      connection = @connection
       intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(adapter: connection, processed_sql: sql, name: Book.name)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        connection.send(:log, intent) do
-          connection.send(:with_raw_connection) do
-            raise MockDatabaseError
-          end
+        with_failing_query(connection) do
+          intent.execute!
+          intent.cast_result
         end
       end
       assert_not error.message.include?("SELECT")
@@ -34,17 +44,21 @@ module ActiveRecord
     test "statement and binds are set on select" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       binds = [123, 456]
-      connection = Book.lease_connection
+      connection = @connection
       intent = ActiveRecord::ConnectionAdapters::QueryIntent.new(adapter: connection, processed_sql: sql, name: Book.name, binds: binds)
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        connection.send(:log, intent) do
-          connection.send(:with_raw_connection) do
-            raise MockDatabaseError
-          end
+        with_failing_query(connection) do
+          intent.execute!
+          intent.cast_result
         end
       end
       assert_equal error.sql, sql
       assert_equal error.binds, binds
     end
+
+    private
+      def with_failing_query(connection, &block)
+        connection.stub(:perform_query, ->(*) { raise MockDatabaseError }, &block)
+      end
   end
 end


### PR DESCRIPTION
This turns result delivery into more of an active behaviour, rather than a passive outcome of execution.

No functional difference here, but it prepares us for supporting a more asynchronous execution model (query pipelining).