### PR TITLE
Forward identifying options in `remove_foreign_key`'s `if_exists` guard

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1327,7 +1327,8 @@ module ActiveRecord
       #   The name of the table that contains the referenced primary key.
       def remove_foreign_key(from_table, to_table = nil, **options)
         return unless use_foreign_keys?
-        return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table, **options.slice(:column))
+        to_table ||= options[:to_table]
+        return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table, **options.slice(:column, :name))
 
         fk_name_to_delete = foreign_key_for!(from_table, to_table: to_table, **options).name
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -63,9 +63,9 @@ module ActiveRecord
         end
 
         def remove_foreign_key(from_table, to_table = nil, **options)
-          return if options.delete(:if_exists) && !foreign_key_exists?(from_table, to_table, **options.slice(:column))
-
           to_table ||= options[:to_table]
+          return if options.delete(:if_exists) && !foreign_key_exists?(from_table, to_table, **options.slice(:column, :name))
+
           options = options.except(:name, :to_table, :validate)
           fkey = foreign_key_for!(from_table, to_table: to_table, **options)
 

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -465,6 +465,28 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_equal 1, @connection.foreign_keys("astronauts").size
         end
 
+        def test_remove_foreign_key_if_exists_with_non_matching_name
+          skip if current_adapter?(:SQLite3Adapter)
+
+          @connection.add_foreign_key :astronauts, :rockets
+          assert_equal 1, @connection.foreign_keys("astronauts").size
+
+          assert_nothing_raised do
+            @connection.remove_foreign_key :astronauts, name: "nonexistent_fk", if_exists: true
+          end
+          assert_equal 1, @connection.foreign_keys("astronauts").size
+        end
+
+        def test_remove_foreign_key_if_exists_with_non_matching_to_table
+          @connection.add_foreign_key :astronauts, :rockets
+          assert_equal 1, @connection.foreign_keys("astronauts").size
+
+          assert_nothing_raised do
+            @connection.remove_foreign_key :astronauts, to_table: :moons, if_exists: true
+          end
+          assert_equal 1, @connection.foreign_keys("astronauts").size
+        end
+
         def test_remove_foreign_non_existing_foreign_key_raises
           e = assert_raises ArgumentError do
             @connection.remove_foreign_key :astronauts, :rockets


### PR DESCRIPTION
## Summary

`remove_foreign_key(..., if_exists: true)` is meant to be a no-op when the targeted foreign key is absent. That guarantee held for the positional form (`remove_foreign_key :accounts, :branches, if_exists: true`) but broke for foreign keys identified by `:name` or `:to_table`, because the existence check forwarded only `:column`.

## Behavior before

With an unrelated foreign key present on the table:

```ruby
remove_foreign_key :accounts, name: :special_fk,  if_exists: true # => raises ArgumentError
remove_foreign_key :accounts, to_table: :owners,  if_exists: true # => raises ArgumentError
```

The existence check ran with no identifying options, so it matched any foreign key on the table, the guard failed to short-circuit, and the subsequent lookup for the named/referenced key raised `ArgumentError` — exactly in the idempotent migration scenario `if_exists` exists to support.

## Behavior after

Both forms are a no-op when no matching foreign key exists, matching the positional form and the documented intent of `if_exists`.

## Why correct

The existence check now forwards the same identifying options (referenced table and `:name`) used by the lookup that follows it, so the guard and the lookup agree on what "this foreign key" means. `foreign_key_exists?` / `ForeignKeyDefinition#defined_for?` already match on `:name` and `to_table` (that is how `foreign_key_exists?(:t, name: "x")` works today). The SQLite3 adapter override carried the same `:column`-only guard and is corrected in parity; SQLite foreign key definitions carry no name, so the `to_table` scoping is the observable fix there.

This mirrors e27a878f4a, which forwarded the identifying expression in the equivalent `remove_check_constraint` `if_exists` guard.