### PR TITLE
Fix has_many autosave reentrantly inserting a record before its FKs are set

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Fix a `has_many` association reentrantly (and prematurely) inserting a new
+    record from a sibling `belongs_to` autosave, before that record's own
+    pending foreign keys had been set.
+
+    Before, saving a new record with two independent `belongs_to` associations,
+    where one of them was shared with a third not-yet-saved record, could
+    raise a spurious `NOT NULL` violation (or otherwise persist the record
+    with a missing foreign key), because the record got reentrantly saved
+    from inside its own `before_save` autosave callback chain:
+
+    ```ruby
+    class Order < ActiveRecord::Base
+      has_many :order_items
+      belongs_to :buyer, class_name: "User"
+    end
+
+    class OrderItem < ActiveRecord::Base
+      belongs_to :order
+      belongs_to :owner, class_name: "User", foreign_key: :user_id
+    end
+
+    buyer = User.new
+    order = Order.new(buyer: buyer)
+    order_item = OrderItem.new(owner: buyer, order: order)
+    order_item.save! # => raised ActiveRecord::NotNullViolation on order_items.order_id
+    ```
+
+    *Dan Sharp*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -19,24 +19,23 @@ module ActiveRecord::Associations
       end
     end
 
-    private
-      # Sets the owner attributes on the given record
-      def set_owner_attributes(record)
-        return if options[:through]
+    # Sets the owner attributes on the given record
+    def set_owner_attributes(record) # :nodoc:
+      return if options[:through]
 
-        primary_key_attribute_names = Array(reflection.join_primary_key)
-        foreign_key_attribute_names = Array(reflection.join_foreign_key)
+      primary_key_attribute_names = Array(reflection.join_primary_key)
+      foreign_key_attribute_names = Array(reflection.join_foreign_key)
 
-        primary_key_foreign_key_pairs = primary_key_attribute_names.zip(foreign_key_attribute_names)
+      primary_key_foreign_key_pairs = primary_key_attribute_names.zip(foreign_key_attribute_names)
 
-        primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-          value = owner._read_attribute(foreign_key)
-          record._write_attribute(primary_key, value)
-        end
-
-        if reflection.type
-          record._write_attribute(reflection.type, owner.class.polymorphic_name)
-        end
+      primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
+        value = owner._read_attribute(foreign_key)
+        record._write_attribute(primary_key, value)
       end
+
+      if reflection.type
+        record._write_attribute(reflection.type, owner.class.polymorphic_name)
+      end
+    end
   end
 end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -291,6 +291,13 @@ module ActiveRecord
       @autosaving_belongs_to_for[association]
     end
 
+    # Returns whether or not this record's own top-level save is currently
+    # paused inside one of its before_save autosave callbacks (waiting on a
+    # sibling association to finish saving).
+    def autosave_in_progress? # :nodoc:
+      @_already_called&.value?(true)
+    end
+
     private
       def init_internals
         super
@@ -446,6 +453,17 @@ module ActiveRecord
 
               if autosave != false && (new_record_before_save || record.new_record?)
                 association.set_inverse_instance(record)
+
+                if record.new_record? && record.autosave_in_progress?
+                  # record's own top-level save is paused inside one of its
+                  # before_save autosave callbacks (waiting on a sibling
+                  # association to finish saving). Link the foreign key now,
+                  # but don't insert yet: record's outer save may still have
+                  # other pending associations to resolve before it's ready
+                  # to be persisted, and inserting it here would be premature.
+                  association.set_owner_attributes(record) if association.respond_to?(:set_owner_attributes)
+                  next
+                end
 
                 if autosave
                   saved = association.insert_record(record, false)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1663,7 +1663,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     fall.sections << sections
     fall.save!
     fall.reload
-    assert_equal sections, fall.sections.sort_by(&:id)
+    # Sort by short_name, not id: which of the two circularly-autosaved
+    # records gets inserted (and thus assigned the lower id) first is an
+    # implementation detail, not something this test cares about.
+    assert_equal sections, fall.sections.sort_by(&:short_name)
   end
 
   def test_post_has_many_tags_through_association_with_composite_query_constraints

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -28,6 +28,9 @@ require "models/subscriber"
 require "models/book"
 require "models/branch"
 require "models/cpk"
+require "models/buyer"
+require "models/parcel"
+require "models/parcel_item"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars, :books
@@ -919,6 +922,35 @@ class InverseBelongsToTests < ActiveRecord::TestCase
       assert_equal 1, interest.human.interests.size
       interest.save!
       assert_equal 1, interest.human.interests.size
+    end
+  end
+
+  # Regression test for #44790: assigning two independent belongs_to
+  # associations on a new record, where one of them (buyer) is shared with
+  # a third not-yet-saved record (parcel), used to reentrantly save the
+  # record from inside its own before_save autosave callback chain — before
+  # its other foreign key (parcel_id) had been set.
+  def test_with_has_many_inversing_sets_foreign_keys_when_owner_is_shared_with_sibling_association
+    with_has_many_inversing do
+      buyer = Buyer.new
+      parcel = Parcel.new(buyer: buyer)
+      parcel_item = ParcelItem.new(owner: buyer, parcel: parcel)
+
+      assert_nothing_raised { parcel_item.save! }
+      assert_equal parcel.id, parcel_item.reload.parcel_id
+      assert_equal buyer.id, parcel_item.buyer_id
+    end
+  end
+
+  def test_with_has_many_inversing_sets_foreign_keys_regardless_of_assignment_order
+    with_has_many_inversing do
+      buyer = Buyer.new
+      parcel = Parcel.new(buyer: buyer)
+      parcel_item = ParcelItem.new(parcel: parcel, owner: buyer)
+
+      assert_nothing_raised { parcel_item.save! }
+      assert_equal parcel.id, parcel_item.reload.parcel_id
+      assert_equal buyer.id, parcel_item.buyer_id
     end
   end
 end

--- a/activerecord/test/models/buyer.rb
+++ b/activerecord/test/models/buyer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Buyer < ActiveRecord::Base
+  has_many :owned_parcel_items, class_name: "ParcelItem"
+  has_many :placed_parcels, class_name: "Parcel", inverse_of: :buyer
+end

--- a/activerecord/test/models/parcel.rb
+++ b/activerecord/test/models/parcel.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Parcel < ActiveRecord::Base
+  has_many :parcel_items
+  belongs_to :buyer, inverse_of: :placed_parcels
+end

--- a/activerecord/test/models/parcel_item.rb
+++ b/activerecord/test/models/parcel_item.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ParcelItem < ActiveRecord::Base
+  # Reproduces the automatic inverse_of gap real (default-config) apps hit:
+  # the test suite's global_config.rb flips this to true suite-wide, which
+  # would mask the bug this model exists to regression-test.
+  self.automatically_invert_plural_associations = false
+
+  belongs_to :parcel
+  belongs_to :owner, class_name: "Buyer", foreign_key: "buyer_id", inverse_of: :owned_parcel_items
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -194,6 +194,10 @@ ActiveRecord::Schema.define do
     t.string :color
   end
 
+  create_table :buyers, force: true do |t|
+    t.string :name
+  end
+
   create_table "CamelCase", force: true do |t|
     t.string :name
   end
@@ -917,6 +921,15 @@ ActiveRecord::Schema.define do
 
   create_table :paint_textures, force: true do |t|
     t.integer :non_poly_two_id
+  end
+
+  create_table :parcels, force: true do |t|
+    t.integer :buyer_id
+  end
+
+  create_table :parcel_items, force: true do |t|
+    t.integer :parcel_id, null: false
+    t.integer :buyer_id
   end
 
   disable_referential_integrity do


### PR DESCRIPTION
### Motivation / Background

This fixes [#44790](https://github.com/rails/rails/issues/44790): under `has_many_inversing` (on by default since `config.load_defaults 6.1`), a `has_many` autosave can reentrantly insert a new record before that record's own pending foreign keys have been set, causing a spurious `NOT NULL` violation (or, in a schema without that constraint, an extra duplicate INSERT that gets silently patched up by a following UPDATE).

Repro from the issue, still reproducible against current `main`:

```ruby
class User < ActiveRecord::Base
  has_many :owned_order_items, class_name: "OrderItem"
  has_many :buyer_orders, class_name: "Order", foreign_key: :buyer_id, inverse_of: :buyer
end

class Order < ActiveRecord::Base
  has_many :order_items
  belongs_to :buyer, class_name: "User", inverse_of: :buyer_orders
end

class OrderItem < ActiveRecord::Base
  belongs_to :order
  belongs_to :owner, class_name: "User", foreign_key: :user_id, inverse_of: :owned_order_items
end

buyer = User.new
order = Order.new(buyer: buyer)
order_item = OrderItem.new(owner: buyer, order: order)
order_item.save!
# => ActiveRecord::NotNullViolation: NOT NULL constraint failed: order_items.order_id
```

Note the shape matters here: `Order#order_items` / `OrderItem#order` have no explicit `inverse_of`, and Rails' automatic inverse detection has a real gap for this exact plural/singular pairing (see "Root cause" below). This isn't specific to `load_defaults 7.0` as the issue title says - I confirmed it's still live against today's `main`, since the config flag that would close this particular inverse-detection gap (`automatically_invert_plural_associations`) has never been wired into any `load_defaults` version, through 8.1.

### Root cause

1. `order_item.owner = buyer` triggers `set_inverse_instance`, which (because `has_many_inversing` is on) pushes the still-unsaved `order_item` into `buyer.owned_order_items`'s in-memory `target` array. This eager linking is intentional, added by #34533 to fix #33578.
2. `order_item.order = order` doesn't get an inverse established: `Reflection#automatic_inverse_of` (on the `belongs_to :order` side) derives its guess from `OrderItem`'s own class name ("order_item", singular), which doesn't match `Order`'s actual has_many reflection name (`order_items`, plural). The plural fallback only runs when `automatically_invert_plural_associations` is enabled, which defaults to false.
3. `order_item.save!` runs its before_save autosave chain in declaration order: `save_belongs_to_association(:order)` first, which saves `order`, whose own before_save saves `buyer` in turn.
4. `buyer`'s `after_create` runs `save_collection_association(:owned_order_items)`. Since `order_item` is already sitting in `buyer.owned_order_items.target` (step 1), it gets treated as ready to insert right now, and `HasManyAssociation#insert_record(order_item)` calls `order_item.save` - reentrantly, three frames deep, while the *outer* `order_item.save!` is still paused inside its own `:order` before_save.
5. The reentrant save re-runs `order_item`'s before_save callbacks, but the `@_already_called` non-cyclic-callback guard is already flagging the `:order` callback as in-progress (from the outer call), so it's silently skipped - meaning `order_item.order_id` never gets set on this pass.
6. The reentrant save proceeds straight to `INSERT` with `order_id` still `nil`.

There's existing precedent for this exact class of problem on the `has_one`/`belongs_to` side: #52412 (fixing #48688) added `autosaving_belongs_to_for?` guards to `save_has_one_association`/`validate_has_one_association`. The equivalent was never ported to the `has_many` side when #34533 made this reentrancy possible there too. A straight port of that guard doesn't catch this case, though, since here the reentrancy comes through a *different* `belongs_to` (`:order`) than the one whose inverse points back at the current `has_many` (`:owner`).

### The fix

Adds `autosave_in_progress?` to `AutosaveAssociation`, reporting whether any of a record's own autosave callbacks are currently paused mid-flight (`@_already_called&.value?(true)`). `save_collection_association`'s insert loop now checks it: if a new record's own save is already in progress elsewhere, its foreign key for *this* association gets linked immediately (via `set_owner_attributes`, now public on `ForeignAssociation` so it's callable from here) but the actual insert is deferred - it'll be persisted correctly once the record's own save resumes and finishes running through its remaining `before_save` callbacks.

I initially tried a simpler version that just skipped the record outright, but that broke an existing test (`test_should_save_with_non_nullable_foreign_keys`) - when a record is built via the collection side (`parent.children.build`) rather than through an explicit setter, the has_many-side `insert_record` call is the *only* place that ever sets its foreign key, so skipping it entirely loses the FK. Still linking the key before deferring covers both cases.

### Test coverage

I added two tests to `activerecord/test/cases/associations/inverse_associations_test.rb` covering both attribute assignment orders, using new small dedicated fixture models (`Buyer`/`Parcel`/`ParcelItem`) rather than repurposing existing shared fixtures, to keep the regression test isolated. `ParcelItem` explicitly sets `automatically_invert_plural_associations = false` since the test suite's own `global_config.rb` turns that on suite-wide, which would otherwise mask the bug.

One existing test (`test_circular_autosave_association_correctly_saves_multiple_records`) asserted on insertion order for a circular has_many-autosave case, which this fix legitimately changes (both records still save correctly, just not in the same order as before) - updated the assertion to sort by content instead of id.

Full suite, sqlite3_mem:
```
9234 runs, 31113 assertions, 0 failures, 0 errors, 37 skips
```

### Additional information

There's a second report on the issue thread (`alexadia`) describing `record.another_table_id = nil` raising `NotNullViolation` under a similar setup via `accepts_nested_attributes_for`. I checked it separately: it's the same root cause going through the collection-build path rather than direct assignment... already covered by this fix, so not a distinct bug.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
