### PR TITLE
Remove some duplication in ColorField

### DIFF
--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -4,14 +4,11 @@ module ActionView
   module Helpers
     module Tags # :nodoc:
       class ColorField < TextField # :nodoc:
-        def render
-          options = @options.stringify_keys
-          options["value"] = options.fetch("value") { validate_color_string(value) }
-          @options = options
-          super
-        end
-
         private
+          def fallback_value
+            validate_color_string(value)
+          end
+
           def validate_color_string(string)
             regex = /\A#[0-9a-fA-F]{6}\z/
             if regex.match?(string)

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -12,7 +12,7 @@ module ActionView
           options = @options.stringify_keys
           options["size"] = options["maxlength"] unless options.key?("size")
           options["type"] ||= field_type
-          options["value"] = options.fetch("value") { value_before_type_cast } unless field_type == "file"
+          options["value"] = options.fetch("value") { fallback_value } unless field_type == "file"
           add_default_name_and_field(options)
           tag("input", options)
         end
@@ -26,6 +26,10 @@ module ActionView
         private
           def field_type
             self.class.field_type
+          end
+
+          def fallback_value
+            value_before_type_cast
           end
       end
     end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1137,24 +1137,24 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_color_field_with_valid_hex_color_string
-    expected = %{<input id="car_color" name="car[color]" type="color" value="#000fff" />}
+    expected = %{<input type="color" value="#000fff" name="car[color]" id="car_color" />}
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
   def test_color_field_with_invalid_hex_color_string
-    expected = %{<input id="car_color" name="car[color]" type="color" value="#000000" />}
+    expected = %{<input type="color" value="#000000" name="car[color]" id="car_color" />}
     @car.color = "#1234TR"
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
   def test_color_field_with_string_containing_hex_color_substring
-    expected = %{<input id="car_color" name="car[color]" type="color" value="#000000" />}
+    expected = %{<input type="color" value="#000000" name="car[color]" id="car_color"  />}
     @car.color = "Not a color #123456 at all"
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
   def test_color_field_with_value_attr
-    expected = %{<input id="car_color" name="car[color]" type="color" value="#00FF00" />}
+    expected = %{<input type="color" value="#00FF00" name="car[color]" id="car_color" />}
     assert_dom_equal(expected, color_field("car", "color", value: "#00FF00"))
   end
 


### PR DESCRIPTION
`ColorField#render` sets the value attribute to `#000000` if no value is passed and ignores the attribute if the passed value is nil. It then calls super where TextField does the same thing, except the fallback value is set to `value_before_type_cast`.

We can remove the duplication in `ColorField#render`, including stringifying keys, but introducing a `TextField#fallback_value` method that gets overridden in `ColorField`.

This changes the order of the attributes, but makes the order more consistent with other fields.

This refactors some code added in the recent #58023.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
