### PR TITLE
Use NOT ENFORCED toggle in check_all_foreign_keys_valid! on PostgreSQL 18.4+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -390,8 +390,10 @@
     `FixtureSet.create_fixtures` to ensure all referenced rows are present when
     enforcement is restored.
 
-    `check_all_foreign_keys_valid!` skips `NOT ENFORCED` constraints on PostgreSQL 18.4+,
-    as `VALIDATE CONSTRAINT` cannot be applied to them.
+    `check_all_foreign_keys_valid!` revalidates foreign keys with the same
+    `NOT ENFORCED`/`ENFORCED` toggle on PostgreSQL 18.4+, likewise requiring only
+    table ownership rather than superuser privileges. Intentionally `NOT ENFORCED`
+    constraints are left unchecked.
 
     Unlike `SET CONSTRAINTS ALL DEFERRED` (the approach attempted in rails/rails#27636
     and reverted), `NOT ENFORCED` also suppresses referential actions such as

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -4,35 +4,9 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module ReferentialIntegrity # :nodoc:
-        def disable_referential_integrity # :nodoc:
+        def disable_referential_integrity(&block) # :nodoc:
           if supports_enforced_foreign_keys?
-            # Only toggle FKs that are currently `ENFORCED`; leave `NOT ENFORCED` ones unchanged.
-            # `conparentid = 0` excludes constraints inherited from a partitioned parent —
-            # `ALTER CONSTRAINT` must be issued on the parent and is propagated to partitions.
-            enforced_fks = query_all(<<~SQL)
-              SELECT n.nspname AS schema_name, t.relname AS table_name, c.conname AS constraint_name
-              FROM pg_constraint c
-              JOIN pg_class t ON c.conrelid = t.oid
-              JOIN pg_namespace n ON c.connamespace = n.oid
-              WHERE c.contype = 'f'
-                AND c.conenforced = true
-                AND c.conparentid = 0
-                AND n.nspname = ANY (current_schemas(false))
-            SQL
-
-            transaction(requires_new: true) do
-              enforced_fks.each do |fk|
-                execute("ALTER TABLE #{quote_table_name(fk["schema_name"])}.#{quote_table_name(fk["table_name"])} " \
-                        "ALTER CONSTRAINT #{quote_column_name(fk["constraint_name"])} NOT ENFORCED")
-              end
-
-              yield
-
-              enforced_fks.each do |fk|
-                execute("ALTER TABLE #{quote_table_name(fk["schema_name"])}.#{quote_table_name(fk["table_name"])} " \
-                        "ALTER CONSTRAINT #{quote_column_name(fk["constraint_name"])} ENFORCED")
-              end
-            end
+            toggle_foreign_key_enforcement(current_schemas_only: true, &block)
           else
             original_exception = nil
 
@@ -69,47 +43,69 @@ module ActiveRecord
         end
 
         def check_all_foreign_keys_valid! # :nodoc:
-          # Skip `NOT ENFORCED` constraints (PG 18.4+): `VALIDATE CONSTRAINT` cannot be
-          # applied to them and raises an error.
           if supports_enforced_foreign_keys?
-            enforced_join = <<~SQL
-              JOIN pg_catalog.pg_constraint c
-                ON c.conname = tc.constraint_name
-               AND c.conenforced = true
-              JOIN pg_catalog.pg_class cls ON cls.oid = c.conrelid
-               AND cls.relname = tc.table_name
-              JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace
-               AND ns.nspname = tc.table_schema
-               AND ns.nspname = tc.constraint_schema
+            toggle_foreign_key_enforcement
+          else
+            sql = <<~SQL
+              do $$
+                declare r record;
+              BEGIN
+              FOR r IN (
+                SELECT FORMAT(
+                  'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace AND conrelid::regclass = ''%3$I''::regclass; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
+                  constraint_name,
+                  table_schema,
+                  table_name
+                ) AS constraint_check
+                FROM information_schema.table_constraints tc
+                WHERE tc.constraint_type = 'FOREIGN KEY'
+              )
+                LOOP
+                  EXECUTE (r.constraint_check);
+                END LOOP;
+              END;
+              $$;
+            SQL
+
+            transaction(requires_new: true) do
+              execute(sql)
+            end
+          end
+        end
+
+        private
+          # conparentid = 0: a partition's child copy can't be ALTERed; the parent's ALTER cascades
+          def enforced_foreign_keys(current_schemas_only: false)
+            query_all(<<~SQL)
+              SELECT n.nspname AS schema_name, t.relname AS table_name, c.conname AS constraint_name
+              FROM pg_constraint c
+              JOIN pg_class t ON c.conrelid = t.oid
+              JOIN pg_namespace n ON c.connamespace = n.oid
+              WHERE c.contype = 'f'
+                AND c.conenforced = true
+                AND c.conparentid = 0
+                AND pg_catalog.pg_has_role(t.relowner, 'USAGE')
+                #{"AND n.nspname = ANY (current_schemas(false))" if current_schemas_only}
             SQL
           end
 
-          sql = <<~SQL
-            do $$
-              declare r record;
-            BEGIN
-            FOR r IN (
-              SELECT FORMAT(
-                'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace AND conrelid::regclass = ''%3$I''::regclass; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
-                constraint_name,
-                table_schema,
-                table_name
-              ) AS constraint_check
-              FROM information_schema.table_constraints tc
-              #{enforced_join}
-              WHERE tc.constraint_type = 'FOREIGN KEY'
-            )
-              LOOP
-                EXECUTE (r.constraint_check);
-              END LOOP;
-            END;
-            $$;
-          SQL
+          def toggle_foreign_key_enforcement(current_schemas_only: false)
+            fks = enforced_foreign_keys(current_schemas_only: current_schemas_only)
 
-          transaction(requires_new: true) do
-            execute(sql)
+            transaction(requires_new: true) do
+              fks.each { |fk| set_foreign_key_enforcement(fk, enforced: false) }
+
+              yield if block_given?
+
+              fks.each { |fk| set_foreign_key_enforcement(fk, enforced: true) }
+            end
           end
-        end
+
+          def set_foreign_key_enforcement(fk, enforced:)
+            table = "#{quote_column_name(fk["schema_name"])}.#{quote_column_name(fk["table_name"])}"
+            execute("ALTER TABLE #{table} ALTER CONSTRAINT #{quote_column_name(fk["constraint_name"])} " \
+                    "#{enforced ? "ENFORCED" : "NOT ENFORCED"}")
+          end
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -48,6 +48,9 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_table :ri_pp_children, if_exists: true
     @connection.drop_table :ri_pp_parents_0, if_exists: true
     @connection.drop_table :ri_pp_parents, if_exists: true
+    @connection.drop_table :partitioned_table_with_foreign_key, if_exists: true, force: :cascade
+    @connection.drop_table :table_referenced_by_partioned_table, if_exists: true
+    @connection.drop_schema :ri_offpath, if_exists: true
     reset_pool
     if ActiveRecord::Base.lease_connection.is_a?(MissingSuperuserPrivileges)
       raise "MissingSuperuserPrivileges patch was not removed"
@@ -366,6 +369,61 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   ensure
     @connection.drop_table "partitioned_table_with_foreign_key", if_exists: true, force: true
     @connection.drop_table "table_referenced_by_partioned_table", if_exists: true
+  end
+
+  def test_check_all_foreign_keys_valid_detects_violation_in_validated_foreign_key
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+
+    @connection.execute("ALTER TABLE ri_test_children DISABLE TRIGGER ALL")
+    @connection.execute("INSERT INTO ri_test_children (parent_id) VALUES (999)")
+    @connection.execute("ALTER TABLE ri_test_children ENABLE TRIGGER ALL")
+
+    assert_raises(ActiveRecord::InvalidForeignKey) do
+      @connection.check_all_foreign_keys_valid!
+    end
+
+    assert_equal true, @connection.select_value("SELECT conenforced FROM pg_constraint WHERE conname = 'ri_test_fk'"),
+      "the foreign key must be restored to ENFORCED after the rolled-back validation"
+  end
+
+  def test_check_all_foreign_keys_valid_detects_violation_in_partitioned_table
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.create_table :table_referenced_by_partioned_table
+
+    @connection.create_table :partitioned_table_with_foreign_key, primary_key: :company_id,
+      options: "PARTITION BY LIST (company_id)" do |t|
+      t.foreign_key :table_referenced_by_partioned_table, column: :company_id, name: :fk_reference
+    end
+    @connection.execute("CREATE TABLE partitioned_table_with_foreign_key_1 PARTITION OF partitioned_table_with_foreign_key FOR VALUES IN (1)")
+
+    @connection.execute("ALTER TABLE partitioned_table_with_foreign_key_1 DISABLE TRIGGER ALL")
+    @connection.execute("INSERT INTO partitioned_table_with_foreign_key (company_id) VALUES (1)")
+    @connection.execute("ALTER TABLE partitioned_table_with_foreign_key_1 ENABLE TRIGGER ALL")
+
+    assert_raises(ActiveRecord::InvalidForeignKey) do
+      @connection.check_all_foreign_keys_valid!
+    end
+  end
+
+  def test_check_all_foreign_keys_valid_raises_for_invalid_fk_in_non_search_path_schema
+    skip unless @connection.supports_enforced_foreign_keys?
+
+    @connection.execute("CREATE SCHEMA ri_offpath")
+    @connection.execute("CREATE TABLE ri_offpath.parents (id bigint PRIMARY KEY)")
+    @connection.execute("CREATE TABLE ri_offpath.children (id bigint PRIMARY KEY, parent_id bigint)")
+    @connection.execute("INSERT INTO ri_offpath.children (id, parent_id) VALUES (1, 999)")
+    @connection.execute(<<~SQL)
+      ALTER TABLE ri_offpath.children
+        ADD CONSTRAINT fk_children_parent FOREIGN KEY (parent_id)
+        REFERENCES ri_offpath.parents (id) NOT VALID
+    SQL
+
+    assert_raises(ActiveRecord::InvalidForeignKey) do
+      @connection.check_all_foreign_keys_valid!
+    end
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

Follow-up to #57378. `disable_referential_integrity` no longer requires
superuser privileges on PostgreSQL 18.4+, but `check_all_foreign_keys_valid!`
still executes `UPDATE pg_catalog.pg_constraint SET convalidated = false`,
which requires superuser privileges.

### Detail

- On PostgreSQL 18.4+, `check_all_foreign_keys_valid!` revalidates foreign
  keys by toggling each `ENFORCED` constraint `NOT ENFORCED` and back to
  `ENFORCED`: re-marking a constraint `ENFORCED` checks all existing rows
  natively, and a violating row raises `ActiveRecord::InvalidForeignKey`.
  The revalidation happens through plain `ALTER TABLE` statements instead of
  the direct `UPDATE pg_catalog.pg_constraint SET convalidated = false`, so
  the operation only needs table ownership rather than superuser privileges,
  matching `disable_referential_integrity` since #57378.
- The scope stays all schemas (no `search_path` filtering) but becomes
  limited to tables the connection user owns. `ALTER TABLE ... ALTER
  CONSTRAINT` can only be run by the table owner (directly or through role
  membership; ownership is not grantable), so the query selects foreign keys
  with the same test the `ALTER` itself applies — `pg_has_role(relowner,
  'USAGE')` — and skips tables where the user holds only DML grants.
  In practice nothing loses coverage: the previous implementation required
  superuser privileges anyway, and a superuser passes `pg_has_role` for
  every table, so it keeps verifying every foreign key.
- `NOT ENFORCED` constraints are left untouched, partitioned tables are
  toggled through the parent constraint, and versions before 18.4 keep the
  existing `UPDATE pg_catalog.pg_constraint` + `VALIDATE CONSTRAINT` path
  unchanged.

### Additional information

- `ALTER CONSTRAINT` takes an `ACCESS EXCLUSIVE` lock where the
  `VALIDATE CONSTRAINT` it replaces took `SHARE UPDATE EXCLUSIVE`. The only
  caller is fixture verification in the test environment, and
  `disable_referential_integrity` has taken the same locks since #57378.
- The `search_path` dependence of the unqualified `conrelid::regclass` cast,
  which the closed #57428 addressed, no longer exists on 18.4+: the `UPDATE`
  statement is gone and the `ALTER TABLE` statements are schema-qualified.
- Verified against PostgreSQL 18.4 (toggle path, also with a non-superuser
  role) and PostgreSQL 17.10 (existing path) with
  `activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb`
  and `activerecord/test/cases/fixtures_test.rb`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
