### PR TITLE
Preserve the hash default in `Hash#reverse_merge!`

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
@@ -18,7 +18,10 @@ class Hash
 
   # Destructive +reverse_merge+.
   def reverse_merge!(other_hash)
-    replace(reverse_merge(other_hash))
+    merged = reverse_merge(other_hash)
+    merged.default      = default
+    merged.default_proc = default_proc if default_proc
+    replace(merged)
   end
   alias_method :reverse_update, :reverse_merge!
   alias_method :with_defaults!, :reverse_merge!

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -337,6 +337,24 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, merged
   end
 
+  def test_reverse_merge_bang_does_not_override_default
+    hash = Hash.new(0)
+    hash.update(a: 1, b: 2)
+
+    hash.reverse_merge!(a: 10, c: 3)
+
+    assert_equal 0, hash[:z]
+  end
+
+  def test_reverse_merge_bang_does_not_override_default_proc
+    hash = Hash.new { |h, k| h[k] = [] }
+    hash.update(a: 1, b: 2)
+
+    hash.reverse_merge!(a: 10, c: 3)
+
+    assert_equal [], hash[:z]
+  end
+
   def test_slice_inplace
     original = { a: "x", b: "y", c: 10 }
     expected_return = { c: 10 }


### PR DESCRIPTION
`Hash#reverse_merge!` (and its `reverse_update` / `with_defaults!` aliases) replaces the receiver with a plain hash, so the receiver's `default` and `default_proc` are lost:

```ruby
counts = Hash.new(0)
counts[:a] += 1
counts.reverse_merge!(b: 5)
counts[:missing]   # before: nil   after: 0
```

The sibling in-place method `Hash#slice!` already restores `default` and `default_proc` before replacing, and has dedicated tests (`test_slice_bang_does_not_override_default` / `_default_proc`) fixing that contract. `reverse_merge!` now conforms.

Scope: plain `Hash` core extension only (`HashWithIndifferentAccess` has its own `reverse_merge!`/`replace` and different default semantics — left untouched).