### PR TITLE
Raise on ignored `if_exists`/`if_not_exists` in `change_table` check constraints

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -927,6 +927,7 @@ module ActiveRecord
       #
       # See {connection.add_check_constraint}[rdoc-ref:SchemaStatements#add_check_constraint]
       def check_constraint(*args, **options)
+        raise_on_if_exist_options(options)
         @base.add_check_constraint(name, *args, **options)
       end
 
@@ -936,6 +937,7 @@ module ActiveRecord
       #
       # See {connection.remove_check_constraint}[rdoc-ref:SchemaStatements#remove_check_constraint]
       def remove_check_constraint(*args, **options)
+        raise_on_if_exist_options(options)
         @base.remove_check_constraint(name, *args, **options)
       end
 

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -427,6 +427,22 @@ module ActiveRecord
           end
         end
       end
+
+      def test_check_constraint_with_if_not_exists_raises_error
+        assert_raises(ArgumentError) do
+          with_change_table do |t|
+            t.check_constraint "price > 0", name: "price_check", if_not_exists: true
+          end
+        end
+      end
+
+      def test_remove_check_constraint_with_if_exists_raises_error
+        assert_raises(ArgumentError) do
+          with_change_table do |t|
+            t.remove_check_constraint name: "price_check", if_exists: true
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Inside a `change_table` block, `if_exists`/`if_not_exists` options are ignored (they only take effect on the top-level migration methods), so every operation in the block raises an `ArgumentError` that points at the conditional form instead — `column`, `index`, `references`, `foreign_key`, `remove_timestamps`, and the rest.

`t.check_constraint` and `t.remove_check_constraint` were the only two that didn't: they accepted the option and forwarded it, so it was silently dropped.

Before:

```ruby
change_table :products do |t|
  t.check_constraint "price > 0", name: "price_check", if_not_exists: true
  # option silently ignored
end
```

After: raises `ArgumentError` with the same guidance the sibling operations already give, so the mistake surfaces at migration time instead of being lost.

Follow-up to #57988 (the same guard for `remove_timestamps`).