### PR TITLE
Skip the query for a grouped calculation on a contradictory relation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -534,6 +534,10 @@ module ActiveRecord
       end
 
       def execute_grouped_calculation(operation, column_name, distinct) # :nodoc:
+        if where_clause.contradiction?
+          return @async ? Promise::Complete.new({}) : {}
+        end
+
         group_fields = group_values
 
         if group_fields.size == 1 && group_fields.first.respond_to?(:to_sym)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -865,6 +865,18 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_no_queries_for_empty_relation_on_grouped_count
+    assert_no_queries do
+      assert_equal({}, Post.where(id: []).group(:author_id).count)
+    end
+  end
+
+  def test_no_queries_for_empty_relation_on_grouped_sum
+    assert_no_queries do
+      assert_equal({}, Post.where(id: []).group(:author_id).sum(:tags_count))
+    end
+  end
+
   def test_maximum_with_not_auto_table_name_prefix_if_column_included
     Company.create!(name: "test", contracts: [Contract.new(developer_id: 7)])
 


### PR DESCRIPTION
A grouped calculation on a relation whose `WHERE` clause can never match a row — `Post.where(id: []).group(:author_id).count` — always returns an empty hash, but it still sent a `SELECT COUNT(*) ... WHERE 1=0 GROUP BY ...` query to the database.

The ungrouped calculations (`count`/`sum`/`average`/`minimum`/`maximum`) already recognize a contradictory `where` clause and return without querying. The grouped path now short-circuits the same way.

Before: one wasted query, result `{}`.
After: zero queries, result `{}`.

Same class of change as #58004 (`none.ids` returning no rows without a query).