### PR TITLE
Fix `bin/rails credentials:fetch` raising `Psych::AliasesNotEnabled`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -3,6 +3,11 @@
 
     *Gannon McGibbon*
 
+*   Fix `bin/rails credentials:fetch` raising `Psych::AliasesNotEnabled` when
+    the credentials file contains YAML aliases.
+
+    *Leon Vogt*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -63,13 +63,16 @@ module Rails
 
         if (yaml = credentials.read)
           begin
-            value = YAML.load(yaml)
+            value = YAML.load(yaml, aliases: true, filename: content_path)
             value = path.split(".").inject(value) do |doc, key|
               doc.fetch(key)
             end
             say value.to_s
           rescue KeyError, NoMethodError
             say_error "Invalid or missing credential path: #{path}"
+            exit 1
+          rescue Psych::SyntaxError => error
+            say_error "Invalid YAML in credentials: #{error.message}"
             exit 1
           end
         else

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -359,6 +359,26 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     assert_match(/42/, run_fetch_command("foo.bar.baz"))
   end
 
+  test "fetch value from credentials containing YAML aliases" do
+    write_credentials(<<~YAML)
+      defaults: &defaults
+        api_key: 123
+      production:
+        <<: *defaults
+    YAML
+
+    assert_match(/123/, run_fetch_command("production.api_key"))
+  end
+
+  test "fetch reports invalid YAML in credentials" do
+    write_credentials("foo: [unterminated")
+
+    stderr_output = capture(:stderr) { run_fetch_command("foo", stderr: true, allow_failure: true) }
+
+    assert_match("Invalid YAML in credentials", stderr_output)
+    assert_match("config/credentials.yml.enc", stderr_output)
+  end
+
   test "fetch missing key" do
     write_credentials({ "foo" => { "bar" => { "baz" => 42 } } }.to_yaml)
 


### PR DESCRIPTION
### Motivation / Background

I'm using Kamal and would like to use `rails credentials:fetch` to fetch my secrets:
```bash
S3_ACCESS_KEY=$(rails credentials:fetch s3_access_key)
```

This works.    
But: When you have a credentials file with YAML aliase (& and *) like this:
```yml
base: &BASE
  s3_access_key: xxx

production:
  <<: *BASE
  s3_access_key: yyy
```

it results in the following error:
```diff
rails credentials:fetch production.s3_access_key                                                                            

- /Users/leon/.local/share/mise/installs/ruby/3.4.9/lib/ruby/3.4.0/psych/visitors/to_ruby.rb:431:in 'Psych::Visitors::NoAliasRuby#visit_Psych_Nodes_Alias': Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`. (Psych::AliasesNotEnabled)
```

### Detail

Other parts of Rails Credentials already use `YAML.unsafe_load`. Therefore I would vote for also using `YAML.unsafe_load` inside `credentials:fetch`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
