### PR TITLE
Ractor compatible Active Support Notifications

### DIFF
--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -736,23 +736,26 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_default_scopes_are_ractor_shareable
-    ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
-      model = Class.new(ActiveRecord::Base) do
-        def self.name = "ractor_safe_posts"
-        self.table_name = "posts"
+    old = ActiveSupport::Ractors.unshareable_proc_action
+    ActiveSupport::Ractors.unshareable_proc_action = :raise
 
-        default_scope -> { ractor_safe }
+    model = Class.new(ActiveRecord::Base) do
+      def self.name = "ractor_safe_posts"
+      self.table_name = "posts"
 
-        def self.ractor_safe
-          where(type: "ractor_safe")
-        end
+      default_scope -> { ractor_safe }
+
+      def self.ractor_safe
+        where(type: "ractor_safe")
       end
-
-      select_sql = capture_sql { model.all.to_a }.first
-
-      assert_match(/type/, select_sql)
-      assert_ractor_shareable model.default_scopes
     end
+
+    ActiveSupport::Ractors.unshareable_proc_action = old
+
+    select_sql = capture_sql { model.all.to_a }.first
+
+    assert_match(/type/, select_sql)
+    assert_ractor_shareable model.default_scopes
   end
 end
 

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -195,7 +195,24 @@ module ActiveSupport
   #
   module Notifications
     class << self
-      attr_accessor :notifier
+      attr_accessor :notifier_subscriptions # :nodoc:
+
+      def notifier
+        return @notifier if ActiveSupport::Ractors.main?
+
+        Ractor[:__notifier] ||= begin
+          fanout = Fanout.new
+          set_subscriptions(fanout)
+
+          fanout
+        end
+      end
+
+      def notifier=(notifier)
+        @notifier = notifier
+
+        record_subscriptions
+      end
 
       # Returns a singleton no-op instrumenter that executes blocks without
       # publishing any notifications. Useful for suppressing instrumentation
@@ -249,7 +266,10 @@ module ActiveSupport
       #   #=> ArgumentError (pattern must be specified as a String, Regexp or empty)
       #
       def subscribe(pattern = nil, callback = nil, prepend: false, &block)
-        notifier.subscribe(pattern, callback, monotonic: false, prepend: prepend, &block)
+        subscriber = notifier.subscribe(pattern, callback, monotonic: false, prepend: prepend, &block)
+        record_subscriptions
+
+        subscriber
       end
 
       # Performs the same functionality as #subscribe, but the +start+ and
@@ -259,7 +279,10 @@ module ActiveSupport
       # duration is important. For example, computing elapsed time between
       # two events.
       def monotonic_subscribe(pattern = nil, callback = nil, prepend: false, &block)
-        notifier.subscribe(pattern, callback, monotonic: true, prepend: prepend, &block)
+        subscriber = notifier.subscribe(pattern, callback, monotonic: true, prepend: prepend, &block)
+        record_subscriptions
+
+        subscriber
       end
 
       def subscribed(callback, pattern = nil, monotonic: false, &block)
@@ -270,7 +293,10 @@ module ActiveSupport
       end
 
       def unsubscribe(subscriber_or_name)
-        notifier.unsubscribe(subscriber_or_name)
+        subscriber = notifier.unsubscribe(subscriber_or_name)
+        record_subscriptions
+
+        subscriber
       end
 
       def instrumenter
@@ -280,6 +306,20 @@ module ActiveSupport
       private
         def registry
           ActiveSupport::IsolatedExecutionState[:active_support_notifications_registry] ||= {}
+        end
+
+        def record_subscriptions
+          subscriptions = {
+            string_subscribers: Hash[notifier.string_subscribers.keys.zip(notifier.string_subscribers.values)],
+            other_subscribers: notifier.other_subscribers,
+          }
+
+          self.notifier_subscriptions = ActiveSupport::Ractors.try_make_shareable(subscriptions, copy: true)
+        end
+
+        def set_subscriptions(fanout)
+          fanout.string_subscribers = notifier_subscriptions[:string_subscribers]
+          fanout.other_subscribers = notifier_subscriptions[:other_subscribers]
         end
     end
 

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -2,6 +2,7 @@
 
 require "concurrent/map"
 require "active_support/core_ext/object/try"
+require "active_support/ractors"
 
 module ActiveSupport
   module Notifications
@@ -53,6 +54,8 @@ module ActiveSupport
     #
     # This class is thread safe. All methods are reentrant.
     class Fanout
+      attr_accessor :string_subscribers, :other_subscribers # :nodoc:
+
       def initialize
         @mutex = Mutex.new
         @string_subscribers = Concurrent::Map.new { |h, k| h.compute_if_absent(k) { [] } }
@@ -67,6 +70,8 @@ module ActiveSupport
       end
 
       def subscribe(pattern = nil, callable = nil, monotonic: false, prepend: false, &block)
+        block = ActiveSupport::Ractors.try_shareable_proc(block) if block
+
         subscriber = Subscribers.new(pattern, callable || block, monotonic)
         @mutex.synchronize do
           case pattern

--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -46,10 +46,10 @@ module ActiveSupport
       #
       # :raise - The error is raised
       # :warn  - A deprecation warning is triggered and the original unshareable object is returned.
-      def try_make_shareable(obj)
+      def try_make_shareable(obj, **)
         return obj unless unshareable_proc_action
 
-        make_shareable(obj)
+        make_shareable(obj, **)
       rescue Ractor::IsolationError
         case unshareable_proc_action
         when :raise

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "abstract_unit"
 require "active_support/core_ext/module/delegation"
+require "active_support/testing/ractors_assertions"
 
 module Notifications
   class TestCase < ActiveSupport::TestCase
@@ -556,5 +557,59 @@ module Notifications
       def random_id
         @random_id ||= SecureRandom.hex(10)
       end
+  end
+
+  class NotificationSubscriptionTest < TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
+    def setup
+      super
+
+      ActiveSupport::Notifications.unsubscribe(@subscription)
+      ActiveSupport::Notifications.unsubscribe(@named_subscription)
+      @old_proc_action = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+    end
+
+    def teardown
+      ActiveSupport::Ractors.unshareable_proc_action = @old_proc_action
+
+      super
+    end
+
+    test "record and set subscriptions" do
+      ActiveSupport::Notifications.subscribe("active_record.sql") { |event| event.payload[:called] = true }
+
+      value = on_ractor do
+        payload = {}
+        ActiveSupport::Notifications.instrument("active_record.sql", payload)
+        payload
+      end
+
+      assert_equal({ called: true }, value)
+    end
+
+    test "record and set subscriptions when using a regexp" do
+      ActiveSupport::Notifications.subscribe("active_record.sql") { }
+      ActiveSupport::Notifications.subscribe(/.*/) { |event| event.payload[:called] = true }
+
+      value = on_ractor do
+        payload = {}
+        ActiveSupport::Notifications.instrument("active_record.sql", payload)
+        payload
+      end
+
+      assert_equal({ called: true }, value)
+    end
+
+    if RUBY_VERSION >= "4.0"
+      test "creating a subscription that's not ractor shareable raises an error" do
+        outer = []
+
+        assert_raises(Ractor::IsolationError) do
+          ActiveSupport::Notifications.subscribe("active_record.sql") { outer }
+        end
+      end
+    end
   end
 end

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -203,6 +203,55 @@ module ApplicationTests
       end
     end
 
+    if RUBY_VERSION >= "4.0"
+      test "notification subscriptions are recorded" do
+        add_to_config "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+
+        app_file "config/initializers/subscriptions.rb", <<-RUBY
+          WitnessError = Class.new(StandardError)
+
+          ActiveSupport::Notifications.subscribe("active_record.sql") { raise WitnessError }
+        RUBY
+
+        app("development")
+
+        # Main Ractor receives notifications
+        assert_raises(WitnessError) do
+          ActiveSupport::Notifications.instrument("active_record.sql")
+        end
+
+        previous_report_on_exception = Thread.report_on_exception
+        Thread.report_on_exception = false
+
+        # Worker Ractor received notifications
+        error = assert_raises(Ractor::RemoteError) do
+          Ractor.new do
+            ActiveSupport::Notifications.instrument("active_record.sql")
+          end.join
+        end
+
+        assert_instance_of(WitnessError, error.cause)
+      ensure
+        Thread.report_on_exception = previous_report_on_exception
+      end
+
+      test "Notification subscriptions can be added after boot" do
+        add_to_config "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+
+        app_file "config/initializers/subscriptions.rb", <<-RUBY
+          WitnessError = Class.new(StandardError)
+
+          ActiveSupport::Notifications.subscribe("active_record.sql") { raise WitnessError }
+        RUBY
+
+        app("development")
+
+        assert_nothing_raised do
+          ActiveSupport::Notifications.subscribe("sql.active_record") { }
+        end
+      end
+    end
+
     # AR
     test "active_record extensions are applied to ActiveRecord" do
       add_to_config "config.active_record.table_name_prefix = 'tbl_'"


### PR DESCRIPTION
### Motivation / Background

It is currently not possible to instrument code using ActiveSupport::Notifications inside Ractors.

The underlying notifier used (`AS::Fanout`) isn't Ractor safe.

### Detail

`AS::Fanout` caches the list of subscribers to notify whenever a notification is sent. The name of the notification can be anything (`sql.activerecord`, `foo.bar`) and can't be computed eagerly. The cache grows at runtime as different controller endpoint get hit and new notification name appear.

Because of this, making AS::Fanout Ractor safe isn't possible.

### Additional information

This commit implements a Notifier *per* Ractor. Whenever a new subscription (whenever code calls `AS::Notifications.subscribe`) is added, we snapshot the list of subscriptions.
When a Ractor needs to use a Notifier, one is instantiated and the subscriptions is set based on the frozen snapshot.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
