### PR TITLE
Fix some FrozenErrors for ractorized application

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -63,6 +63,11 @@ module ActiveSupport
           end
         end
 
+        def initialize(...)
+          super
+          @local_cache_key = "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
+        end
+
         # Use a local cache for the duration of block.
         def with_local_cache(&block)
           use_temporary_local_cache(LocalStore.new, &block)
@@ -156,6 +161,8 @@ module ActiveSupport
         end
 
         private
+          attr_reader :local_cache_key
+
           def read_serialized_entry(key, raw: false, **options)
             if cache = local_cache
               if options[:delete]
@@ -227,10 +234,6 @@ module ActiveSupport
             else
               cache.delete_entry(name)
             end
-          end
-
-          def local_cache_key
-            @local_cache_key ||= "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
           end
 
           def use_temporary_local_cache(temporary_cache)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -672,6 +672,7 @@ module Rails
       warn "Ractor support in Rails is experimental and subject to change.", category: :experimental, uplevel: 1
 
       env_config
+      revision
       routes
 
       @autoloaders, @reloaders, @routes_reloader = nil, nil, nil

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -28,19 +28,32 @@ if RUBY_VERSION >= "4.0"
       test "ractorize! makes the app shareable in production mode" do
         app "production"
 
-        begin
-          @original_experimental_warning = Warning[:experimental]
-          Warning[:experimental] = false
-          Rails.application.ractorize!
-        ensure
-          Warning[:experimental] = @original_experimental_warning
-        end
+        ractorize!
 
         assert_ractor_shareable Rails.application
         assert_ractor_shareable Rails.event
         assert_ractor_shareable Rails.error
         assert_ractor_shareable Rails.backtrace_cleaner
       end
+
+      test "error reporting works after the application is ractorized" do
+        app "production"
+
+        ractorize!
+
+        assert_nothing_raised do
+          Rails.error.report(StandardError.new("test"))
+        end
+      end
+
+      private
+        def ractorize!
+          @original_experimental_warning = Warning[:experimental]
+          Warning[:experimental] = false
+          Rails.application.ractorize!
+        ensure
+          Warning[:experimental] = @original_experimental_warning
+        end
     end
   end
 end


### PR DESCRIPTION
When Rails.application.ractorize! is called it makes Rails.application shareable/frozen (which also recursively makes Rails.cache shareable/frozen). This can lead to FrozenErrors if Rails.cache implements LocalCache because LocalCache's local_cache_key currently isn't computed until LocalCache::Middleware first tries to create a LocalCache.

Additionally, the above Rails.cache FrozenError exposed that when the Rails.error reporter handles an error it will lazily initialize Rails.application.revision for the first time, which also raises a FrozenError when Rails.application is frozen.

This commit fixes both issues by eagerly computing the values: local_cache_key when the cache is instantiated, and revision inside an initializer.