### PR TITLE
Test that `reverse_merge` takes the default from the other hash

### DIFF
--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -337,6 +337,32 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, merged
   end
 
+  def test_reverse_merge_takes_default_from_other_hash
+    hash = { a: 1 }.reverse_merge(Hash.new(0))
+
+    assert_equal 0, hash[:missing]
+  end
+
+  def test_reverse_merge_takes_default_proc_from_other_hash
+    hash = { a: 1 }.reverse_merge(Hash.new { |h, k| h[k] = [] })
+
+    assert_equal [], hash[:missing]
+  end
+
+  def test_reverse_merge_bang_takes_default_from_other_hash
+    hash = { a: 1 }
+    hash.reverse_merge!(Hash.new(0))
+
+    assert_equal 0, hash[:missing]
+  end
+
+  def test_reverse_merge_bang_takes_default_proc_from_other_hash
+    hash = { a: 1 }
+    hash.reverse_merge!(Hash.new { |h, k| h[k] = [] })
+
+    assert_equal [], hash[:missing]
+  end
+
   def test_slice_inplace
     original = { a: "x", b: "y", c: 10 }
     expected_return = { c: 10 }


### PR DESCRIPTION
### Summary

`Hash#reverse_merge` and `Hash#reverse_merge!` build the result on top of the argument hash (`other_hash.merge(self)`), so the result takes its `default` and `default_proc` from that argument hash rather than from the receiver:

```ruby
left  = Hash.new(:left)
right = Hash.new(:right)

left.reverse_merge(right)[:missing]   # => :right
left.reverse_merge!(right)
left[:missing]                        # => :right
```

This behavior was previously untested. This PR adds coverage for it (both the plain default value and a `default_proc`, for the non-destructive and destructive variants), locking the contract so it can't silently regress.

### Notes

Coverage-only; no production code changes. Follow-up to the discussion on #58056, where it was noted that this behavior isn't currently exercised by the suite.

Scope is the plain `Hash` core extension. `HashWithIndifferentAccess` has its own `reverse_merge!`/`replace` and default semantics and is left untouched.