### PR TITLE
Carry the `form` attribute onto a multiple `select`'s hidden field

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -22,7 +22,7 @@ module ActionView
             select = content_tag("select", add_options(option_tags, options, value), html_options)
 
             if html_options["multiple"] && options.fetch(:include_hidden, true)
-              tag_options = { disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "" }
+              tag_options = { disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", form: html_options["form"] }
               tag_options[:autocomplete] = "off" unless ActionView::Base.remove_hidden_field_autocomplete
               tag("input", tag_options) + select
             else

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -756,6 +756,14 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_multiple_and_form_to_add_hidden_input_with_form
+    output_buffer = select(:post, :category, "", {}, { multiple: true, form: "my_form" })
+    assert_dom_equal(
+      "<input type=\"hidden\" name=\"post[category][]\" value=\"\" autocomplete=\"off\" form=\"my_form\"/><select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\" form=\"my_form\"></select>",
+      output_buffer
+    )
+  end
+
   def test_select_with_multiple_and_include_hidden
     output_buffer = select(:post, :category, "", { include_hidden: true }, { multiple: true })
     assert_dom_equal(


### PR DESCRIPTION
### Summary

A `multiple` `select` rendered with a `form:` attribute produces two elements: the `<select>` itself and a companion hidden `<input>` (so that deselecting every option still submits an empty value). The `<select>` was associated with the given form, but the hidden field was not:

```erb
<%= select :post, :category, [], {}, { multiple: true, form: "my_form" } %>
```

Before:

```html
<input type="hidden" name="post[category][]" value="" autocomplete="off">
<select multiple="multiple" name="post[category][]" id="post_category" form="my_form"></select>
```

After:

```html
<input type="hidden" name="post[category][]" value="" autocomplete="off" form="my_form">
<select multiple="multiple" name="post[category][]" id="post_category" form="my_form"></select>
```

When the `select` lives outside the `<form>` it targets via the `form` attribute, the browser only submits the hidden field if it is associated with that form too. Without it, clearing all options no longer sends an empty value, so the attribute can't be reset. The hidden field now mirrors the `select`'s `form`.

### Why this is correct

This matches the sibling hidden-field companions, which already carry `form`:

- `check_box` — `check_box.rb` slices `"name", "disabled", "form"` onto its hidden field.
- `collection_check_boxes` / `collection_radio_buttons` — `collection_helpers.rb` builds the hidden field with `form: @html_options[:form]`.

The `select` multiple hidden field was the only one omitting it. The change is purely additive: when no `form` is given the attribute is `nil` and the tag helper omits it, so existing output is unchanged.