### PR TITLE
Fix has_many through deletion with composite source keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix deleting records from a `has_many :through` association when its source
+    uses a composite key that differs from the target model's query constraints.
+
+    This also fixes polymorphic through associations with composite source keys.
+
+    *Dan Robinson*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -62,8 +62,17 @@ module ActiveRecord
           if Array(association_primary_key) == reflection.klass.composite_query_constraints_list && !options[:source_type]
             join_attributes = { source_reflection.name => records }
           else
-            assoc_pk_values = records.map { |record| record._read_attribute(association_primary_key) }
-            join_attributes = { source_reflection.foreign_key => assoc_pk_values }
+            association_key = ActiveRecord::Key.for(association_primary_key)
+            assoc_pk_values = records.map { |record| association_key.value_of(record) }
+
+            if association_key.composite? && records.one?
+              # Keep single-record composite predicates keyed by individual columns so
+              # delete_through_records can match loaded through records by attribute name.
+              foreign_key = ActiveRecord::Key.for(source_reflection.foreign_key)
+              join_attributes = foreign_key.where_hash(assoc_pk_values.first).transform_values { |value| [value] }
+            else
+              join_attributes = { source_reflection.foreign_key => assoc_pk_values }
+            end
           end
 
           if options[:source_type]

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -42,6 +42,8 @@ require "models/seminar"
 require "models/session"
 require "models/sharded"
 require "models/cpk"
+require "models/shipment"
+require "models/adjustment"
 require "models/zine"
 require "models/interest"
 require "models/human"
@@ -458,6 +460,48 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     tag.orders.destroy_all
     assert_empty(tag.orders)
     assert_empty(tag.orders.reload)
+  end
+
+  def test_destroy_all_with_composite_source_key_on_non_cpk_model
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    tags = blog_post.unconstrained_tags.to_a
+    blog_post_tags = blog_post.blog_post_tags.load
+
+    assert_not_empty(tags)
+    assert_equal(tags.size, blog_post_tags.size)
+
+    assert_no_difference "Sharded::UnconstrainedTag.count" do
+      assert_difference "Sharded::BlogPostTag.count", -tags.size do
+        blog_post.unconstrained_tags.destroy_all
+      end
+    end
+
+    assert_empty(blog_post.unconstrained_tags.reload)
+    assert_empty(blog_post.blog_post_tags)
+  end
+
+  def test_destroy_all_with_polymorphic_composite_source_key
+    owner = Shipment.create!(region_id: 1)
+    targets = Array.new(2) { Shipment.create!(region_id: owner.region_id) }
+    region_adjustments = targets.map do |target|
+      Adjustment.create!(
+        region_id: target.region_id,
+        adjustable_id: target.id,
+        adjustable_type: "Shipment",
+      )
+    end
+
+    assert_equal(targets, owner.adjusted_shipments.order(:id).to_a)
+    assert_equal(region_adjustments, owner.region_adjustments.load)
+
+    assert_no_difference "Shipment.count" do
+      assert_difference "Adjustment.count", -2 do
+        owner.adjusted_shipments.destroy_all
+      end
+    end
+
+    assert_empty(owner.adjusted_shipments.reload)
+    assert_empty(owner.region_adjustments)
   end
 
   def test_composite_primary_key_join_table

--- a/activerecord/test/models/adjustment.rb
+++ b/activerecord/test/models/adjustment.rb
@@ -2,4 +2,9 @@
 
 class Adjustment < ActiveRecord::Base
   belongs_to :adjustable, polymorphic: true, inverse_of: :adjustments, autosave: true
+  belongs_to :composite_adjustable,
+    polymorphic: true,
+    primary_key: [:region_id, :id],
+    foreign_key: [:region_id, :adjustable_id],
+    foreign_type: :adjustable_type
 end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -13,6 +13,7 @@ module Sharded
 
     has_many :blog_post_tags
     has_many :tags, through: :blog_post_tags
+    has_many :unconstrained_tags, through: :blog_post_tags, source: :unconstrained_tag
 
     has_and_belongs_to_many :tags_with_composite_fk,
       class_name: "Sharded::Tag",

--- a/activerecord/test/models/sharded/blog_post_tag.rb
+++ b/activerecord/test/models/sharded/blog_post_tag.rb
@@ -7,5 +7,9 @@ module Sharded
 
     belongs_to :blog_post
     belongs_to :tag
+    belongs_to :unconstrained_tag,
+      class_name: "Sharded::UnconstrainedTag",
+      primary_key: [:blog_id, :id],
+      foreign_key: [:blog_id, :tag_id]
   end
 end

--- a/activerecord/test/models/sharded/tag.rb
+++ b/activerecord/test/models/sharded/tag.rb
@@ -8,4 +8,8 @@ module Sharded
     has_many :blog_post_tags
     has_many :blog_posts, through: :blog_post_tags
   end
+
+  class UnconstrainedTag < ActiveRecord::Base
+    self.table_name = :sharded_tags
+  end
 end

--- a/activerecord/test/models/shipment.rb
+++ b/activerecord/test/models/shipment.rb
@@ -6,4 +6,13 @@ class Shipment < ActiveRecord::Base
     foreign_key: [:region_id, :adjustable_id],
     primary_key: [:region_id, :id],
     inverse_of: :adjustable
+
+  has_many :region_adjustments,
+    class_name: "Adjustment",
+    primary_key: :region_id,
+    foreign_key: :region_id
+  has_many :adjusted_shipments,
+    through: :region_adjustments,
+    source: :composite_adjustable,
+    source_type: "Shipment"
 end


### PR DESCRIPTION
Given a `has_many :through` association where the source association uses a composite key that does not match the target model's query constraints:

```ruby
class Sharded::BlogPost < ActiveRecord::Base
  query_constraints :blog_id, :id

  has_many :blog_post_tags
  has_many :unconstrained_tags,
    through: :blog_post_tags,
    source: :unconstrained_tag
end

class Sharded::BlogPostTag < ActiveRecord::Base
  query_constraints :blog_id, :id

  belongs_to :blog_post
  belongs_to :unconstrained_tag,
    class_name: "Sharded::UnconstrainedTag",
    primary_key: [:blog_id, :id],
    foreign_key: [:blog_id, :tag_id]
end

class Sharded::UnconstrainedTag < ActiveRecord::Base
  self.table_name = :sharded_tags
end
```

It should be possible to delete the join records with:

```ruby
blog_post.unconstrained_tags.destroy_all
```

without destroying the target tag records.

This also applies to a polymorphic `source_type` association whose source uses a composite key:

```ruby
class Shipment < ActiveRecord::Base
  has_many :region_adjustments,
    class_name: "Adjustment",
    primary_key: :region_id,
    foreign_key: :region_id
  has_many :adjusted_shipments,
    through: :region_adjustments,
    source: :composite_adjustable,
    source_type: "Shipment"
end

class Adjustment < ActiveRecord::Base
  belongs_to :composite_adjustable,
    polymorphic: true,
    primary_key: [:region_id, :id],
    foreign_key: [:region_id, :adjustable_id],
    foreign_type: :adjustable_type
end
```

In this case, `shipment.adjusted_shipments.destroy_all` should delete the matching `adjustments` rows using both `region_id` and `adjustable_id`.

Fixes #57392.

### Implementation details

#47721 fixed the first branch of `ThroughAssociation#construct_join_attributes` by comparing `association_primary_key` with `composite_query_constraints_list` as arrays. That PR also noted that the `else` branch still needed to be addressed for associations with a custom `source_type` or query constraints that differ from the target model's query constraints.

This PR fixes that remaining branch.

On current `main`, `association_primary_key` can be an array in the `else` branch, but the code still reads it as if it were a single attribute:

```ruby
assoc_pk_values = records.map { |record| record._read_attribute(association_primary_key) }
join_attributes = { source_reflection.foreign_key => assoc_pk_values }
```

For a composite source key, that does not produce the array-of-key-values shape expected by `PredicateBuilder` for a composite foreign key. The regression test fails on `main` with:

```text
ArgumentError: Expected corresponding value for ["blog_id", "tag_id"] to be an Array
```

This PR uses `ActiveRecord::Key` for the source association primary key:

```ruby
association_key = ActiveRecord::Key.for(association_primary_key)
assoc_pk_values = records.map { |record| association_key.value_of(record) }
```

For multiple records, this gives `PredicateBuilder` the expected tuple shape:

```ruby
{ [:blog_id, :tag_id] => [[1, 2], [1, 3]] }
```

For a single composite record, the predicate is expanded back into individual foreign-key columns:

```ruby
{ "blog_id" => [1], "tag_id" => [2] }
```

That keeps the existing loaded-through-record cleanup path working, because `delete_through_records` calls `construct_join_attributes(record)` and compares loaded join records by calling their attribute readers.

Validated locally with:

* `bin/test test/cases/associations/has_many_through_associations_test.rb`
* `bin/test test/cases/associations/has_many_through_associations_test.rb -a postgresql`
* `bundle exec rake test:sqlite3`
* `bundle exec rubocop` on the changed files
