### PR TITLE
Make ActiveSupport::TimeZone shareable

### DIFF
--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -2772,7 +2772,7 @@ class DateHelperTest < ActionView::TestCase
     # The love zone is UTC+0
     mytz = Class.new(ActiveSupport::TimeZone) {
       attr_accessor :now
-    }.create("tenderlove", 0, ActiveSupport::TimeZone.find_tzinfo("UTC"))
+    }.create("tenderlove", 0, ActiveSupport::TimeZone.find_tzinfo("UTC")).dup
 
     now       = Time.mktime(2004, 6, 15, 16, 35, 0)
     mytz.now  = now

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -312,6 +312,8 @@ module ActiveSupport
       @name = name
       @utc_offset = utc_offset
       @tzinfo = tzinfo || TimeZone.find_tzinfo(name)
+
+      ActiveSupport::Ractors.make_shareable(self)
     end
     # :startdoc:
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -3,10 +3,12 @@
 require_relative "abstract_unit"
 require "active_support/time"
 require "active_support/core_ext/object/with"
+require "active_support/testing/ractors_assertions"
 require_relative "time_zone_test_helpers"
 require "yaml"
 
 class TimeZoneTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
   include TimeZoneTestHelpers
 
   def test_utc_to_local
@@ -431,7 +433,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_parse_with_incomplete_date
-    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"].dup
     zone.stub(:now, zone.local(1999, 12, 31)) do
       twz = zone.parse("19:00:00")
       assert_equal Time.utc(1999, 12, 31, 19), twz.time
@@ -464,7 +466,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_parse_with_missing_time_components
-    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"].dup
     zone.stub(:now, zone.local(1999, 12, 31, 12, 59, 59)) do
       twz = zone.parse("2012-12-01")
       assert_equal Time.utc(2012, 12, 1), twz.time
@@ -881,6 +883,10 @@ class TimeZoneTest < ActiveSupport::TestCase
 
   def test_new
     assert_equal ActiveSupport::TimeZone["Central Time (US & Canada)"], ActiveSupport::TimeZone.new("Central Time (US & Canada)")
+  end
+
+  def test_is_ractor_shareable
+    assert_ractor_shareable(ActiveSupport::TimeZone["Central Time (US & Canada)"])
   end
 
   def test_us_zones


### PR DESCRIPTION
### Motivation / Background

It's currently not possible to access a `ActiveSupport::TimeZone` object in a Ractor. Any method on a TimeWithZone object that ends up accessing the `ActiveSupport::TimeZone` instance will get a Ractor Isolation Error.

### Detail

It seems reasonable to freeze a AS::TimeZone object just after instantiation as there is no way that I could find to mutate it. The class also doesn't lazily set ivars at runtime.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
