### PR TITLE
Let dump_schema pass the given format down to schema_dump

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -448,7 +448,7 @@ module ActiveRecord
       end
 
       def dump_schema(db_config, format = db_config.schema_format) # :nodoc:
-        return unless db_config.schema_dump
+        return unless db_config.schema_dump(format)
 
         require "active_record/schema_dumper"
         filename = schema_dump_path(db_config, format)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -441,6 +441,29 @@ module ActiveRecord
       ActiveRecord::Base.clear_cache!
     end
 
+    def test_dump_schema_passes_the_given_format_to_check_schema_dump
+      db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary",
+        adapter: "sqlite3",
+        database: "my-db",
+        schema_format: :sql,
+      )
+
+      format = :ruby
+      assert_not_equal format, db_config.schema_format # precondition
+
+      dumped = false
+
+      ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, "db") do
+        db_config.stub(:schema_dump, ->(sf = db_config.schema_format) { "schema.rb" if sf == format }) do
+          ActiveRecord::Tasks::DatabaseTasks.stub(:with_temporary_pool, ->(*) { dumped = true }) do
+            ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, format)
+          end
+        end
+      end
+
+      assert dumped
+    end
+
     def test_dump_all_only_dumps_same_schema_once
       counter = 0
 


### PR DESCRIPTION
The implementation of the method `ActiveRecord::DatabaseTasks.dump_schema` starts this way:

```ruby
def dump_schema(db_config, format = db_config.schema_format) # :nodoc:
  return unless db_config.schema_dump
  ...
end
```

and `schema_dump` looks like this:

```ruby
def schema_dump(format = schema_format)
  ...
end
```

Since `dump_schema` accepts an arbitrary format, it is incorrect to assume the default format in the inner call, you have to pass the given `format` down.