### PR TITLE
Add `has_attribute?` to `ActiveModel::Attributes`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add `has_attribute?` to `ActiveModel::Attributes`.
+
+    Mirrors the class and instance methods of the same name in Active Record,
+    returning whether the given attribute (resolving aliases) is defined.
+
+    ```ruby
+    class Person
+      include ActiveModel::Attributes
+
+      attribute :name, :string
+      alias_attribute :full_name, :name
+    end
+
+    Person.has_attribute?(:name)         # => true
+    Person.has_attribute?(:full_name)    # => true
+    Person.new.has_attribute?(:nothing)  # => false
+    ```
+
+    *Kenta Ishizaki*
+
 *   Fix `normalizes` re-applying normalizations on every validation of an
     unpersisted record, and speed up validation of normalized attributes.
 

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -79,6 +79,25 @@ module ActiveModel
         attribute_types.keys
       end
 
+      # Returns true if the given attribute exists, otherwise false.
+      #
+      #   class Person
+      #     include ActiveModel::Attributes
+      #
+      #     attribute :name, :string
+      #     alias_attribute :new_name, :name
+      #   end
+      #
+      #   Person.has_attribute?('name')     # => true
+      #   Person.has_attribute?('new_name') # => true
+      #   Person.has_attribute?(:age)       # => false
+      #   Person.has_attribute?(:nothing)   # => false
+      def has_attribute?(attr_name)
+        attr_name = attr_name.to_s
+        attr_name = attribute_aliases[attr_name] || attr_name
+        attribute_types.key?(attr_name)
+      end
+
       ##
       # :method: type_for_attribute
       # :call-seq: type_for_attribute(attribute_name, &block)
@@ -149,6 +168,26 @@ module ActiveModel
     #   person.attribute_names # => ["name", "age"]
     def attribute_names
       @attributes.keys
+    end
+
+    # Returns +true+ if the given attribute is present, otherwise +false+.
+    #
+    #   class Person
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :name, :string
+    #     alias_attribute :new_name, :name
+    #   end
+    #
+    #   person = Person.new
+    #   person.has_attribute?(:name)     # => true
+    #   person.has_attribute?(:new_name) # => true
+    #   person.has_attribute?('age')     # => false
+    #   person.has_attribute?(:nothing)  # => false
+    def has_attribute?(attr_name)
+      attr_name = attr_name.to_s
+      attr_name = self.class.attribute_aliases[attr_name] || attr_name
+      @attributes.key?(attr_name)
     end
 
     def freeze # :nodoc:

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -183,5 +183,41 @@ module ActiveModel
 
       assert_equal with_alias.type_for_attribute(:integer_field), with_alias.type_for_attribute(:x)
     end
+
+    test ".has_attribute?" do
+      assert ModelForAttributesTest.has_attribute?("integer_field")
+      assert ModelForAttributesTest.has_attribute?(:integer_field)
+      assert_not ModelForAttributesTest.has_attribute?("nonexistent")
+      assert_not ModelForAttributesTest.has_attribute?(:nonexistent)
+    end
+
+    test ".has_attribute? supports attribute aliases" do
+      with_alias = Class.new(ModelForAttributesTest) do
+        alias_attribute :new_integer_field, :integer_field
+      end
+
+      assert with_alias.has_attribute?("new_integer_field")
+      assert with_alias.has_attribute?(:new_integer_field)
+    end
+
+    test "#has_attribute?" do
+      data = ModelForAttributesTest.new
+
+      assert data.has_attribute?("integer_field")
+      assert data.has_attribute?(:integer_field)
+      assert_not data.has_attribute?("nonexistent")
+      assert_not data.has_attribute?(:nonexistent)
+    end
+
+    test "#has_attribute? supports attribute aliases" do
+      with_alias = Class.new(ModelForAttributesTest) do
+        alias_attribute :new_integer_field, :integer_field
+      end
+
+      data = with_alias.new
+
+      assert data.has_attribute?("new_integer_field")
+      assert data.has_attribute?(:new_integer_field)
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

`attribute_names` was ported from ActiveRecord to `ActiveModel::Attributes` in #36059, explicitly modeled on the AR counterparts. However, `has_attribute?` was not included in that effort:

|                    | ActiveRecord | ActiveModel |
|--------------------|:---:|:---:|
| `attribute_names`  | ✓   | ✓   |
| `has_attribute?`   | ✓   | —   |

Today the only way to check for a specific attribute in AM is `attribute_names.include?("name")`, which does not resolve aliases and rebuilds the names array on every call.

### Detail

Add `has_attribute?` as both a class method and an instance method to `ActiveModel::Attributes`, mirroring the existing ActiveRecord counterparts. Like the AR versions, both methods resolve `alias_attribute` names before checking.

Prior discussion:
- https://discuss.rubyonrails.org/t/feature-proposal-add-method-has-attribute-for-activemodel-attributemethods-classmethods/88978
- https://discuss.rubyonrails.org/t/adding-has-attribute-to-activemodel-attributes/91296