### PR TITLE
Add `delete_multi` method to batch deletes for memcached store if dalli's `delete_multi` is defined

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
-    dalli (5.0.0)
+    dalli (5.0.6)
       logger
     dante (0.2.0)
     dartsass-rails (0.5.1)
@@ -806,7 +806,7 @@ CHECKSUMS
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cssbundling-rails (1.4.1) sha256=4b21273d627b21890da9155c88c67efc9274373d8b0add09149c262cf56c7ce1
-  dalli (5.0.0) sha256=7d5ae821da3ef98cad68e77f09ae0e563244dc0f3995f5c8999c5a379fa3d468
+  dalli (5.0.6) sha256=01887253a3e788124b9e04e90b63dc54ea9ef69f981d6f5fa2a4debc9e62a456
   dante (0.2.0) sha256=939776f04b4d253ffbbcf53341631aa2ee6e6cf314dedade2e60ac43b40a6fe6
   dartsass-rails (0.5.1) sha256=f19510fb1b29c76c1739a06954d615f1d20ad653b6fc668dd7c68542bb303a1a
   date (3.4.1) sha256=bf268e14ef7158009bfeaec40b5fa3c7271906e88b196d958a89d4b408abe64f

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -244,6 +244,17 @@ module ActiveSupport
           rescue_error_with(false) { @data.with { |c| c.delete(key) } }
         end
 
+        if Dalli::Client.method_defined?(:delete_multi)
+          def delete_multi_entries(entries, **options)
+            return 0 if entries.empty?
+
+            rescue_error_with(0) do
+              result = @data.with { |c| c.delete_multi(entries) }
+              result.blank? ? 0 : entries.size
+            end
+          end
+        end
+
         def serialize_entry(entry, raw: false, **options)
           if raw
             entry.value.to_s

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -279,6 +279,17 @@ module ActiveSupport
           rescue_error_with(false) { @data.with { |c| c.delete(key) } }
         end
 
+        # Dalli's delete_multi doesn't return the deleted count before version 5.0.6.
+        if Gem::Version.new(Dalli::VERSION) >= Gem::Version.new("5.0.6")
+          def delete_multi_entries(entries, **options)
+            return 0 if entries.empty?
+
+            rescue_error_with(0) do
+              @data.with { |c| c.delete_multi(entries) }
+            end
+          end
+        end
+
         def serialize_entry(entry, raw: false, **options)
           if raw
             entry.value.to_s

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -132,6 +132,20 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     assert stub_called
   end
 
+  # Overrides test from CacheStoreBehavior to account for Dalli's delete_multi not returning
+  # per key result.
+  def test_delete_multi
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert @cache.exist?(key)
+    other_key = SecureRandom.alphanumeric
+    @cache.write(other_key, "world")
+    assert @cache.exist?(other_key)
+    assert_equal 3, @cache.delete_multi([key, SecureRandom.uuid, other_key])
+    assert_not @cache.exist?(key)
+    assert_not @cache.exist?(other_key)
+  end
+
   def test_short_key_normalization
     short_key = "a" * 250
     assert_equal short_key, @cache.send(:normalize_key, short_key, { namespace: nil })


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/58066

`dalli` added a `delete_multi` method in https://github.com/petergoldstein/dalli/pull/1059 which allows deleting multiple keys in a single roundtrip. Add a `delete_multi_entries` method that will use dalli's `delete_multi` if the used dalli version has the method available.

`dalli` does not return a per-key result for `delete_multi` (See https://github.com/petergoldstein/dalli/pull/1059/changes#diff-ca3d986f7be4b7658bcb0a37c6b2f1a3615b2a2b023f1ede6e514f67eb7f9f32R16-R32) so we instead return 0 on failure or the number of entries requested for deletion on success. Previously we were able to return the exact number of deleted keys because `delete_entry` reported the correct result for each attempt to delete a key. `test_delete_multi` is overridden in the memcached store test to account for that difference.

Additionally, when batch deleting keys `Dalli::RingError` is rescued here https://github.com/petergoldstein/dalli/blob/main/lib/dalli/ring.rb#L66-L73 and `delete_multi` returns an empty array and no exception reaches `rescue_error_with`, so we also need to check `result.blank?` and return 0 when the server is unavailable to account for https://github.com/rails/rails/blob/main/activesupport/test/cache/behaviors/failure_safety_behavior.rb#L94-L105.