### PR TITLE
Fix PWA rendering for requests without a format

### DIFF
--- a/railties/lib/rails/pwa_controller.rb
+++ b/railties/lib/rails/pwa_controller.rb
@@ -6,11 +6,11 @@ class Rails::PwaController < Rails::ApplicationController # :nodoc:
   skip_forgery_protection
 
   def service_worker
-    render template: "pwa/service-worker", layout: false
+    render template: "pwa/service-worker", layout: false, formats: :js
   end
 
   def manifest
-    render template: "pwa/manifest", layout: false
+    render template: "pwa/manifest", layout: false, formats: :json
   end
 
   def offline

--- a/railties/test/fixtures/views/pwa/manifest.json.erb
+++ b/railties/test/fixtures/views/pwa/manifest.json.erb
@@ -1,0 +1,5 @@
+{
+  "name": "<%= "TestApp" %>",
+  "display": "standalone",
+  "start_url": "/"
+}

--- a/railties/test/fixtures/views/pwa/service-worker.js
+++ b/railties/test/fixtures/views/pwa/service-worker.js
@@ -1,0 +1,1 @@
+self.addEventListener("fetch", (event) => {})

--- a/railties/test/rails_pwa_controller_test.rb
+++ b/railties/test/rails_pwa_controller_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class PwaControllerTest < ActionController::TestCase
+  tests Rails::PwaController
+
+  def setup
+    Rails.application.routes.draw do
+      get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+      get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+    end
+    @routes = Rails.application.routes
+    @controller.prepend_view_path File.expand_path("fixtures/views", __dir__)
+  end
+
+  test "manifest renders JSON when the request does not specify a format" do
+    get :manifest
+    assert_response :success
+    assert_equal "application/json", @response.media_type
+    assert_equal "TestApp", JSON.parse(@response.body)["name"]
+  end
+
+  test "service worker renders JavaScript when the request does not specify a format" do
+    get :service_worker
+    assert_response :success
+    assert_equal "text/javascript", @response.media_type
+    assert_includes @response.body, "addEventListener"
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Format-less PWA requests can raise `ActionView::MissingTemplate` because Rails defaults to HTML template lookup.

### Detail

Pin the manifest and service worker render formats and add regression tests.

This addresses the format handling issue discussed in #50815 at the controller level.
