### PR TITLE
Persist database default for NOT NULL serialized columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Persist the database default for serialized columns that are `NOT NULL`.
+
+    Setting a serialized column to its coder's empty value (e.g. `{}` or `[]`)
+    previously wrote `NULL`, which raised `NotNullViolation` or discarded the
+    column's default on `NOT NULL` columns. The value is now serialized so the
+    default is respected. Nullable columns without a default are unchanged.
+
+    Fixes #46351.
+
+    *Irvan Eksa Mahendra*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -210,7 +210,12 @@ module ActiveRecord
             end
 
             cast_type = cast_type.subtype if Type::Serialized === cast_type
-            Type::Serialized.new(cast_type, column_serializer, comparable: comparable)
+            # Resolve the column's database default lazily and only for classes
+            # that actually have a table. Reading +columns_hash+ for an abstract
+            # or tableless class would fail here (rails/rails#47482), so the
+            # guard keeps serialized attributes working in abstract classes.
+            default = columns_hash[attr_name.to_s]&.default if table_exists?
+            Type::Serialized.new(cast_type, column_serializer, comparable: comparable, default: default)
           end
         end
 

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -9,10 +9,11 @@ module ActiveRecord
 
       attr_reader :subtype, :coder
 
-      def initialize(subtype, coder, comparable: false)
+      def initialize(subtype, coder, comparable: false, default: nil)
         @subtype = subtype
         @coder = coder
         @comparable = comparable
+        @default = default
         super(subtype)
       end
 
@@ -26,7 +27,12 @@ module ActiveRecord
 
       def serialize(value)
         return if value.nil?
-        unless default_value?(value)
+        # When the value matches the coder's empty value we normally persist
+        # +nil+ (so a nullable column stays NULL). But if the column has a
+        # non-null database default, collapsing to NULL would either violate a
+        # NOT NULL constraint or silently discard the default, so serialize the
+        # value normally instead. See rails/rails#46351.
+        unless default_value?(value) && @default.nil?
           super coder.dump(value)
         end
       end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -462,6 +462,35 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal [topic, topic2], Topic.where(content: nil).sort_by(&:id)
   end
 
+  # Regression test for https://github.com/rails/rails/issues/46351
+  # A serialized column that is NOT NULL with a DB default must persist its
+  # default value instead of NULL when set to the coder's empty value.
+  if !current_adapter?(:Mysql2Adapter) && !current_adapter?(:TrilogyAdapter)
+    def test_serialized_attribute_with_not_null_default_persists_default
+      ActiveRecord::Schema.define do
+        create_table :tmp_46351, force: true do |t|
+          t.text :content, null: false, default: "{}"
+        end
+      end
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "tmp_46351"
+        serialize :content, type: Hash
+      end
+
+      # Creating with the coder's empty value must not violate NOT NULL.
+      record = klass.create!(content: {})
+      assert_equal({}, record.reload.content)
+
+      # Updating an existing value back to the default must persist the
+      # default rather than NULL (the scenario reported in #46351).
+      record = klass.create!(content: { "key" => "value" })
+      record.update!(content: {})
+      assert_equal({}, record.reload.content)
+    ensure
+      ActiveRecord::Base.lease_connection.drop_table :tmp_46351, if_exists: true
+    end
+  end
+
   def test_serialized_attribute_can_be_defined_in_abstract_classes
     klass = Class.new(ActiveRecord::Base) do
       self.abstract_class = true


### PR DESCRIPTION
Setting a serialized column to its coder's empty value (e.g. `{}` or `[]`) previously serialized to `nil`, which persisted `NULL`. On a `NOT NULL` column with a database default this raised `NotNullViolation` (or silently discarded the default), as reported in #46351.

`ActiveRecord::Type::Serialized#serialize` now only collapses the empty value to `NULL` when the column has no non-null database default. The default is resolved from the column metadata at attribute-decoration time, guarded by `table_exists?` so abstract/tableless classes are unaffected (the regression that caused #47191 to be reverted in #47482).

Nullable serialized columns without a default keep their previous behaviour.

### Motivation / Background

This Pull Request has been created because setting a serialized attribute to its coder's empty value wrote `NULL` regardless of the column definition. On a `NOT NULL` column with a database default, this raised `ActiveRecord::NotNullViolation`; on a nullable column with a default it silently discarded the default. This is especially easy to hit with `partial_inserts = false`.

Fixes #46351.

### Detail

This Pull Request changes `ActiveRecord::Type::Serialized#serialize` so it only serializes the coder's empty value to `NULL` when the column has no non-null database default (`unless default_value?(value) && @default.nil?`). The column's default is passed into the type from the `serialize` attribute decorator via `columns_hash[attr_name]&.default`, guarded by `table_exists?`.

This mirrors the existing approach in `ActiveRecord::Encryption#encrypt_attribute`, which already passes `columns_hash[name]&.default` into `EncryptedAttributeType`. The `table_exists?` guard is what keeps abstract/tableless classes working — the regression that caused the earlier #47191 to be reverted in #47482, and which is covered by the existing `test_serialized_attribute_can_be_defined_in_abstract_classes`.

### Additional information

A regression test (`test_serialized_attribute_with_not_null_default_persists_default`) covers both create-with-default and update-to-default. Locally on SQLite, `serialized_attribute_test`, `store_test`, `dirty_test`, `persistence_test`, `inheritance_test`, and `attribute_methods_test` all pass. MySQL/Trilogy are skipped in the new test since those adapters don't support defaults on text columns (matching the reverted #47191's own skip).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.