### PR TITLE
Fix tuple where conditions on a joined association's table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix tuple (multi-column) `where` conditions on a joined association's table.
+
+    Querying multiple columns of an associated table with the tuple syntax, e.g.
+    `Comment.left_joins(:post).where(post: { [:title, :id] => [["a", 1]] })`,
+    raised `TypeError: can't cast Array`. The nested condition's tuple key was
+    stringified along with the other keys, which lost the composite-key handling.
+    Array keys are now preserved so the grouped condition builds correctly.
+
+    Fixes #58013.
+
+    *Irvan Eksa Mahendra*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -97,8 +97,14 @@ module ActiveRecord
             end
             grouping_queries(queries)
           elsif value.is_a?(Hash) && !table.has_column?(key)
+            # Preserve composite (tuple) keys such as `[:x, :y]`; only string /
+            # symbol keys should be stringified. Calling +stringify_keys+ would
+            # turn an Array key into a String and lose the tuple handling above.
+            associated_predicates = value.transform_keys do |nested_key|
+              nested_key.is_a?(Array) ? nested_key : nested_key.to_s
+            end
             table.associated_table(key, &block)
-              .predicate_builder.expand_from_hash(value.stringify_keys)
+              .predicate_builder.expand_from_hash(associated_predicates)
           elsif (associated_reflection = table.associated_with(key))
             # Find the foreign key when using queries such as:
             # Post.where(author: author)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -116,6 +116,19 @@ module ActiveRecord
       assert_empty Cpk::Book.where([:author_id, :id] => [[1, 4], [3, 2]])
     end
 
+    def test_where_with_tuple_syntax_on_joined_association
+      post_one = Post.create!(title: "Tuple One", body: "one")
+      post_two = Post.create!(title: "Tuple Two", body: "two")
+      comment_one = Comment.create!(post: post_one, body: "c1")
+      comment_two = Comment.create!(post: post_two, body: "c2")
+
+      relation = Comment.left_joins(:post).where(
+        post: { [:title, :id] => [[post_one.title, post_one.id], [post_two.title, post_two.id]] }
+      )
+
+      assert_equal [comment_one, comment_two].sort, relation.sort
+    end
+
     def test_where_with_tuple_syntax_with_incorrect_arity
       error = assert_raise ArgumentError do
         Cpk::Book.where([:one, :two, :three] => [1, 2, 3])


### PR DESCRIPTION
Querying multiple columns of an associated table with the tuple syntax raised `TypeError: can't cast Array`, e.g.:

```ruby
Comment.left_joins(:post).where(post: { [:title, :id] => [["a", 1], ["b", 2]] })
```

### Motivation / Background

This Pull Request has been created because the tuple (multi-column) `where` syntax works on a model directly (`Model.where([:a, :b] => [...])`) but breaks when the columns belong to a joined association's table. As reported in #58013 it raises `TypeError: can't cast Array`.

Fixes #58013.

### Detail

When expanding a nested association hash, `ActiveRecord::PredicateBuilder#expand_from_hash` called `stringify_keys` on the nested conditions. That calls `to_s` on every key, turning a composite (tuple) Array key such as `[:title, :id]` into the String `"[:title, :id]"`. The recursive call then no longer matched the composite-key branch and tried to cast the array of tuples as a single value.

The nested keys are now transformed so Array (tuple) keys are preserved and only string/symbol keys are stringified. The query then builds the expected grouped SQL scoped to the joined table.

### Additional information

Added `test_where_with_tuple_syntax_on_joined_association`. `where_test`, `finder_test`, `relations_test`, and `relation/or_test` pass locally on SQLite.

Note: the issue also shows a variant using raw Arel attributes as tuple keys (`where([Model.arel_table[:x], ...] => [...])`). That goes through a different (top-level) code path and is a separate, deeper fix; this PR is scoped to the association-hash form.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why, and references the issue.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.