### PR TITLE
Anchor route-name validation to the whole string

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -641,7 +641,7 @@ module ActionDispatch
       end
 
       def add_route(mapping, name)
-        raise ArgumentError, "Invalid route name: '#{name}'" unless name.blank? || name.to_s.match(/^[_a-z]\w*$/i)
+        raise ArgumentError, "Invalid route name: '#{name}'" unless name.blank? || name.to_s.match(/\A[_a-z]\w*\z/i)
 
         if name && named_routes[name]
           raise ArgumentError, "Invalid route name, already in use: '#{name}' \n" \

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -54,6 +54,15 @@ module ActionDispatch
         end
       end
 
+      def test_route_name_with_an_embedded_newline_is_invalid
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        error = assert_raises(ArgumentError) do
+          mapper.match "/", to: "posts#index", via: :get, as: "main\ninjected"
+        end
+        assert_match(/Invalid route name/, error.message)
+      end
+
       def test_unscoped_formatted
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset


### PR DESCRIPTION
### Summary

`add_route` rejects an invalid route name using the pattern `/^[_a-z]\w*$/`. Because `^` and `$` match at line boundaries rather than string boundaries, a name with an embedded newline matched on its first line and passed validation instead of being rejected. The validation is now anchored with `\A` and `\z`, so it checks the entire name.

### Before / After

```ruby
# as: "main\ninjected"
```

- Before — accepted as a valid route name (matched `main` on the first line).
- After — raises `ArgumentError: Invalid route name: 'main\ninjected'`.

All well-formed route names continue to validate; only names that were never valid identifiers are now rejected.