### PR TITLE
Interpolate a fixture label verbatim, without backreference expansion

### DIFF
--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -112,7 +112,7 @@ module ActiveRecord
         def interpolate_label
           # interpolate the fixture label
           @row.each do |key, value|
-            @row[key] = value.gsub("$LABEL", @label.to_s) if value.is_a?(String)
+            @row[key] = value.gsub("$LABEL") { @label.to_s } if value.is_a?(String)
           end
         end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1465,6 +1465,10 @@ class FoxyFixturesTest < ActiveRecord::TestCase
     assert_equal("X marks the spot!", pirates(:mark).catchphrase)
   end
 
+  def test_label_interpolation_inserts_the_label_verbatim
+    assert_equal("back\\&ref", parrots("back\\&ref").name)
+  end
+
   def test_supports_label_interpolation_for_integer_label
     assert_equal("#1 pirate!", pirates(1).catchphrase)
   end

--- a/activerecord/test/fixtures/parrots.yml
+++ b/activerecord/test/fixtures/parrots.yml
@@ -28,6 +28,11 @@ polly:
   treasures: sapphire, ruby
   <<: *DEAD_PARROT
 
+"back\\&ref":
+  name: $LABEL
+  parrot_sti_class: LiveParrot
+  breed: african
+
 DEFAULTS: &DEFAULTS
   treasures: sapphire, ruby
   parrot_sti_class: LiveParrot


### PR DESCRIPTION
### Summary

`$LABEL` in a fixture value is replaced with the fixture's label. The label was substituted as a string replacement, so a label containing a regexp replacement sequence (`\0`–`\9`, `\&`, `\k<...>`) was interpreted as a backreference rather than inserted literally. For example, a label containing `\&` expanded to the matched `$LABEL` text instead of the label itself, and a label containing `\1` was silently dropped.

The label is now inserted verbatim, whatever characters it contains.

### Before / After

For a fixture whose label is `back\&ref` with `name: $LABEL`:

- Before — `name` became `back$LABELref` (the `\&` expanded to the match).
- After — `name` is `back\&ref`, the label itself.

Ordinary identifier-style labels (the overwhelming majority) are unaffected.