### PR TITLE
Strip only the commented line when detecting a LIMIT in `rails query`

### DIFF
--- a/railties/lib/rails/commands/query/query_command.rb
+++ b/railties/lib/rails/commands/query/query_command.rb
@@ -150,7 +150,7 @@ module Rails
         end
 
         def execute_sql(connection:, sql:, page:, per:)
-          unless sql.gsub(/--.*$|\/\*.*?\*\//m, "").match?(/\bLIMIT\b/i)
+          unless sql.gsub(/--[^\n]*|\/\*.*?\*\//m, "").match?(/\bLIMIT\b/i)
             offset = (page - 1) * per
             sql = "#{sql.rstrip.chomp(';')} LIMIT #{per + 1}"
             sql += " OFFSET #{offset}" if offset > 0

--- a/railties/test/commands/query_test.rb
+++ b/railties/test/commands/query_test.rb
@@ -242,6 +242,14 @@ class Rails::Command::QueryTest < ActiveSupport::TestCase
     assert_equal 3, data.dig("meta", "row_count")
   end
 
+  test "detects an explicit LIMIT that follows a leading SQL comment" do
+    rails "runner", '3.times { |i| Post.create!(title: "Post #{i}") }'
+
+    data = query_json("--sql", "-- a leading comment\nSELECT * FROM posts ORDER BY id LIMIT 2")
+
+    assert_equal 2, data["rows"].length
+  end
+
   test "explain shows query plan" do
     data = query_json("explain", "Post.where(status: 0)")
 


### PR DESCRIPTION
### Summary

`rails query --sql` decides whether to append its own `LIMIT` clause by first removing comments from the SQL and checking for an existing `LIMIT`. The line-comment pattern was `--.*$` combined with the `/m` flag (added so block comments can span newlines). Under `/m`, `.` matches newlines, so a single `--` line comment greedily consumed the rest of the statement — including a real `LIMIT` that followed it. The command then appended a second `LIMIT`, producing invalid SQL.

### Before / After

```
rails query --sql $'-- a comment\nSELECT * FROM posts ORDER BY id LIMIT 2'
```

- Before — the comment hides the `LIMIT`, so the command builds `... LIMIT 2 LIMIT 101` and the database raises a syntax error.
- After — the existing `LIMIT` is detected and respected; no second `LIMIT` is appended.