### PR TITLE
Fold non-ASCII case in case-insensitive confirmation validation

### DIFF
--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -30,7 +30,7 @@ module ActiveModel
 
         def confirmation_value_equal?(record, attribute, value, confirmed)
           if !options[:case_sensitive] && value.is_a?(String)
-            value.casecmp(confirmed) == 0
+            value.casecmp?(confirmed)
           else
             value == confirmed
           end

--- a/activemodel/test/cases/validations/confirmation_validation_test.rb
+++ b/activemodel/test/cases/validations/confirmation_validation_test.rb
@@ -129,4 +129,11 @@ class ConfirmationValidationTest < ActiveModel::TestCase
     t = Topic.new(title: "title", title_confirmation: "Title")
     assert_predicate t, :valid?
   end
+
+  def test_title_confirmation_with_case_sensitive_option_false_folds_non_ascii_case
+    Topic.validates_confirmation_of(:title, case_sensitive: false)
+
+    t = Topic.new(title: "café", title_confirmation: "CAFÉ")
+    assert_predicate t, :valid?
+  end
 end


### PR DESCRIPTION
### Summary

`validates_confirmation_of` with `case_sensitive: false` compared the value and its confirmation using `String#casecmp`, which only case-folds ASCII letters. Non-ASCII pairs that differ only in case were therefore reported as not matching, contradicting the option's documented intent. `String#casecmp?` performs full Unicode case folding.

### Before / After

```ruby
Topic.validates_confirmation_of(:title, case_sensitive: false)

Topic.new(title: "café", title_confirmation: "CAFÉ").valid?
```

- Before — `false` (the accented pair was treated as different).
- After — `true`, consistent with the ASCII pair `"title"` / `"Title"`, which was already valid.