### PR TITLE
Strip the digest-type prefix from S3 SDK checksum upload params

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -147,7 +147,7 @@ module ActiveStorage
 
         {
           checksum_algorithm: default_digest_type,
-          "checksum_#{default_digest_type}": checksum
+          "checksum_#{default_digest_type}": checksum.split(":").last
         }
       end
 

--- a/activestorage/test/service/s3_service_checksum_test.rb
+++ b/activestorage/test/service/s3_service_checksum_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_storage/service/s3_service"
+
+class ActiveStorage::Service::S3ServiceChecksumTest < ActiveSupport::TestCase
+  def build_service(**options)
+    ActiveStorage::Service::S3Service.new(
+      bucket: "test-bucket",
+      region: "us-east-1",
+      access_key_id: "test",
+      secret_access_key: "test",
+      **options
+    )
+  end
+
+  test "sha256 SDK upload params carry the bare digest, not the algorithm-prefixed value" do
+    service = build_service(default_digest_type: :sha256)
+
+    # For non-MD5 digest types, compute_checksum prefixes the digest with "type:".
+    params = service.send(:s3_sdk_upload_params, "sha256:Zm9vYmFy")
+
+    assert_equal :sha256, params[:checksum_algorithm]
+    assert_equal "Zm9vYmFy", params[:checksum_sha256]
+  end
+
+  test "md5 SDK upload params pass the digest through as content_md5" do
+    service = build_service(default_digest_type: :md5)
+
+    assert_equal({ content_md5: "Zm9vYmFy" }, service.send(:s3_sdk_upload_params, "Zm9vYmFy"))
+  end
+end


### PR DESCRIPTION
### Summary

When an S3 service is configured with a non-MD5 `default_digest_type`, `S3Service#compute_checksum` prefixes the digest with `"<type>:"` (e.g. `"sha256:<base64>"`). The direct-upload **header** path strips that prefix before sending it, but `s3_sdk_upload_params` forwarded the checksum verbatim. So single-part uploads and presigned direct uploads sent
`checksum_sha256: "sha256:<base64>"` — an invalid base64 value that S3 rejects (`BadDigest`), and the presigned URL baked in a value the client's stripped header could not match.

`s3_sdk_upload_params` now sends the bare digest, matching the header path.

### Before / After

With `default_digest_type: :sha256`:

- Before — `s3_sdk_upload_params` returns `{ checksum_algorithm: :sha256, checksum_sha256: "sha256:<base64>" }`, and every single-part / presigned upload fails.
- After — `{ checksum_algorithm: :sha256, checksum_sha256: "<base64>" }`, and uploads succeed. The MD5 path (bare digest, no prefix) is unchanged.