### PR TITLE
Round-trip the `null: false` attribute modifier in `GeneratedAttribute#to_s`

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -261,17 +261,23 @@ module Rails
 
       private
         def print_attribute_options
-          if attr_options.empty?
-            ""
-          elsif attr_options[:size]
-            "{#{attr_options[:size]}}"
-          elsif attr_options[:limit]
-            "{#{attr_options[:limit]}}"
-          elsif attr_options[:precision] && attr_options[:scale]
-            "{#{attr_options[:precision]},#{attr_options[:scale]}}"
-          else
-            "{#{attr_options.keys.join(",")}}"
-          end
+          options = attr_options.except(:null)
+          modifier = "!" if attr_options[:null] == false
+
+          body =
+            if options.empty?
+              ""
+            elsif options[:size]
+              "{#{options[:size]}}"
+            elsif options[:limit]
+              "{#{options[:limit]}}"
+            elsif options[:precision] && options[:scale]
+              "{#{options[:precision]},#{options[:scale]}}"
+            else
+              "{#{options.keys.join(",")}}"
+            end
+
+          "#{body}#{modifier}"
         end
     end
   end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -263,4 +263,10 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     att = Rails::Generators::GeneratedAttribute.parse("name:references{polymorphic}")
     assert_equal "name:references{polymorphic}", att.to_s
   end
+
+  def test_generated_attribute_to_s_with_null_false_modifier
+    assert_equal "name:string!", Rails::Generators::GeneratedAttribute.parse("name:string!").to_s
+    assert_equal "name:integer{4}!", Rails::Generators::GeneratedAttribute.parse("name:integer{4}!").to_s
+    assert_equal "name:references{polymorphic}!", Rails::Generators::GeneratedAttribute.parse("name:references{polymorphic}!").to_s
+  end
 end


### PR DESCRIPTION
### Summary

The `!` modifier on a generator attribute is stored as `null: false` in `attr_options`, but `print_attribute_options` had no textual form for it. The option was mixed into the braces body alongside other options, producing output that either no longer parses as the original type or inverts the constraint.

### Before / After

```
name:string!          → name:string{null}          (no longer parses as that type)
name:integer{4}!      → name:integer{4}            (modifier silently dropped)
name:references{polymorphic}! → name:references{polymorphic,null}
                                                    (parses back as null: true)
```

After — all three round-trip to themselves.