### PR TITLE
Number ordered-list Markdown items by emitted position

### DIFF
--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -253,12 +253,14 @@ module ActionText
 
       def list_item_lines(list_node, child_values, prefix:)
         element_values = child_values_for_elements(list_node, child_values)
-        element_values.each_with_index.filter_map do |value, index|
+        emitted = 0
+        element_values.filter_map do |value|
           text = stringify(value)
           lines = text.split("\n").reject(&:blank?)
           next if lines.empty?
 
-          bullet = prefix.respond_to?(:call) ? prefix.call(index) : prefix
+          bullet = prefix.respond_to?(:call) ? prefix.call(emitted) : prefix
+          emitted += 1
           format_list_item(lines, bullet)
         end.join("\n")
       end

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -417,6 +417,13 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "ordered list numbering ignores skipped empty <li> tags" do
+    assert_converted_to(
+      "1. one\n2. three",
+      "<ol><li>one</li><li></li><li>three</li></ol>"
+    )
+  end
+
   test "nested <ul> tags are indented" do
     assert_converted_to(
       "- one\n  - nested\n- two",


### PR DESCRIPTION
### Summary

When converting rich text to Markdown, ordered-list numbering was derived from each list item's index in the source. Empty `<li>` items are dropped from the output, but they still advanced the index, so the numbering counted items that were never emitted.

### Before / After

```
<ol><li>one</li><li></li><li>three</li></ol>
```

- Before — `1. one` then `3. three` (skips `2.`).
- After — `1. one` then `2. three`.

An `<ol>` whose first item is empty likewise started at `2.` before, and at `1.` now. Unordered lists are unaffected (their bullet is a constant).