### PR TITLE
Fix `number_field` / `range_field` crash on an exclusive `Float` range

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -951,7 +951,16 @@ module ActionView
         options = options.stringify_keys
         options["type"] ||= "number"
         if range = options.delete("in") || options.delete("within")
-          options.update("min" => range.begin, "max" => (range.max if range.end))
+          # Range#max raises for an exclusive range that isn't a pure Integer range
+          # (e.g. a Float range), so fall back to the end value in that case. The
+          # HTML max attribute is an inclusive bound regardless.
+          max =
+            begin
+              range.max if range.end
+            rescue TypeError
+              range.end
+            end
+          options.update("min" => range.begin, "max" => max)
         end
         text_field_tag(name, value, options)
       end

--- a/actionview/lib/action_view/helpers/tags/number_field.rb
+++ b/actionview/lib/action_view/helpers/tags/number_field.rb
@@ -8,12 +8,23 @@ module ActionView
           options = @options.stringify_keys
 
           if range = options.delete("in") || options.delete("within")
-            options.update("min" => range.begin, "max" => (range.max if range.end))
+            options.update("min" => range.begin, "max" => max_for_range(range))
           end
 
           @options = options
           super
         end
+
+        private
+          # Range#max raises for an exclusive range that isn't a pure Integer range
+          # (e.g. a Float range), so fall back to the end value in that case. The
+          # HTML max attribute is an inclusive bound regardless.
+          def max_for_range(range)
+            return unless range.end
+            range.max
+          rescue TypeError
+            range.end
+          end
       end
     end
   end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1509,6 +1509,14 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, number_field("order", "quantity", in: ..10))
   end
 
+  def test_number_field_with_exclusive_float_range
+    expected = %{<input name="order[quantity]" max="100.0" id="order_quantity" type="number" min="0.0" />}
+    assert_dom_equal(expected, number_field("order", "quantity", in: 0.0...100.0))
+
+    expected = %{<input name="order[quantity]" max="10" id="order_quantity" type="number" min="0.0" />}
+    assert_dom_equal(expected, number_field("order", "quantity", in: 0.0...10))
+  end
+
   def test_range_input
     expected = %{<input name="hifi[volume]" step="0.1" max="11" id="hifi_volume" type="range" min="0" />}
     assert_dom_equal(expected, range_field("hifi", "volume", in: 0..11, step: 0.1))

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -1016,6 +1016,14 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal(expected, range_field_tag("volume", nil, in: ..11))
   end
 
+  def test_range_input_tag_with_exclusive_float_range
+    expected = %{<input name="volume" max="1.0" id="volume" type="range" min="0.0" />}
+    assert_dom_equal(expected, range_field_tag("volume", nil, in: 0.0...1.0))
+
+    expected = %{<input name="volume" max="10" id="volume" type="range" min="0.0" />}
+    assert_dom_equal(expected, range_field_tag("volume", nil, in: 0.0...10))
+  end
+
   def test_empty_datalist
     actual = datalist_tag("countries_datalist")
     expected = %(<datalist id="countries_datalist"></datalist>)


### PR DESCRIPTION
### Summary

Passing an exclusive range whose values are not plain integers (e.g. a `Float` range, or a range with a `Float` bound) as `:in` / `:within` to the number/range field helpers raised `TypeError: cannot exclude non Integer end value`, aborting the render. This affects both the builder helpers (`number_field`, `range_field`) and the tag helpers (`number_field_tag`, `range_field_tag`), which share the same expression.

### Before / After

```ruby
range_field_tag("volume", nil, in: 0.0...1.0)
# before => raises TypeError: cannot exclude non Integer end value
# after  => <input type="range" name="volume" id="volume" min="0.0" max="1.0" />

number_field("order", "quantity", in: 0.0...100.0)
# before => raises TypeError
# after  => <input type="number" name="order[quantity]" ... min="0.0" max="100.0" />
```

### Why this is correct

- The HTML `min` / `max` attributes are inclusive bounds, and an exclusive non-integer range has no representable "largest included value", so the end value is the sensible bound to emit — and it removes the crash.
- All previously-working shapes are unchanged:
  - exclusive **Integer** range still reports `end - 1` (`1...10` → `max="9"`),
  - inclusive ranges (`0..11` → `max="11"`),
  - endless (`18..` → no `max`) and beginless (`..10` → `max="10"`) ranges.