### PR TITLE
Preserve input order of unlisted elements in `Enumerable#in_order_of`

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -198,7 +198,7 @@ module Enumerable
     if filter
       group_by(&key).values_at(*series).compact.flatten(1)
     else
-      sort_by { |v| series.index(v.public_send(key)) || series.size }
+      each_with_index.sort_by { |v, i| [series.index(v.public_send(key)) || series.size, i] }.map(&:first)
     end
   end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -416,6 +416,12 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [ 1, 2, 3, nil ], values.in_order_of(:itself, [ 1, 2, 3 ], filter: false)
   end
 
+  def test_in_order_of_with_filter_false_preserves_input_order_of_unlisted_elements
+    values = (1..20).to_a
+    expected = [ 10 ] + (1..20).to_a.without(10)
+    assert_equal expected, values.in_order_of(:itself, [ 10 ], filter: false)
+  end
+
   def test_in_order_of_preserves_nil_elements_named_in_series
     values = [ 3, nil, 1, 2 ]
     assert_equal [ 1, nil, 2, 3 ], values.in_order_of(:itself, [ 1, nil, 2, 3 ])


### PR DESCRIPTION
### Summary

`in_order_of(key, series, filter: false)` keeps the elements whose key is **not** named in `series` and appends them after the ordered ones. The documentation says these "additional elements" are simply included; the natural expectation is that they keep their order from the receiver.

They didn't. Every unlisted element sorts under the same sort key, and because the underlying sort is not stable, their relative order was rearranged instead of preserved. The `filter: true` branch already preserves input order (it uses `group_by` / `values_at`), so the two branches disagreed.

### Before / After

```ruby
(1..20).to_a.in_order_of(:itself, [10], filter: false)
# before => [10, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 9, 8, 7, 6, 5, 4, 3, 2, 1]
# after  => [10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
```

The listed element (`10`) still comes first; the rest now follow in their original order.

### Why this is correct

- `filter: false` documents only that unlisted elements are *included*, and every existing test that exercised the branch used a single unlisted element, so ordering among several of them was never asserted. This makes the branch consistent with `filter: true`, which already preserves input order.
- Elements named in `series` are unaffected — their order is still driven by their position in `series`.