### PR TITLE
Deserialize a missing namespaced class as a cache miss in MessagePack

### DIFF
--- a/activesupport/lib/active_support/message_pack/extensions.rb
+++ b/activesupport/lib/active_support/message_pack/extensions.rb
@@ -273,11 +273,32 @@ module ActiveSupport
       def load_class(name)
         Object.const_get(name)
       rescue NameError => error
-        if error.name.to_s == name
+        if missing_class_name?(name, error)
           raise MissingClassError, "Missing class: #{name}"
         else
           raise
         end
+      end
+
+      # Whether +error+ was raised because +name+ itself (or one of its namespace
+      # segments) is undefined, as opposed to an unrelated NameError raised while
+      # loading a class that does exist. +error.name+ is only the missing constant
+      # (e.g. +:Admin+ for a missing +Admin::User+), so the fully-qualified name that
+      # failed to resolve is rebuilt from the error's receiver and compared against
+      # +name+.
+      def missing_class_name?(name, error)
+        return false unless error.name
+
+        begin
+          receiver = error.receiver
+        rescue ArgumentError
+          # A NameError raised without a receiver (e.g. a bare `raise NameError`)
+          # is never our missing-constant lookup.
+          return false
+        end
+
+        failing = receiver.equal?(Object) ? error.name.to_s : "#{receiver.name}::#{error.name}"
+        name == failing || name.start_with?("#{failing}::")
       end
 
       def write_class(klass, packer)

--- a/activesupport/test/message_pack/cache_serializer_test.rb
+++ b/activesupport/test/message_pack/cache_serializer_test.rb
@@ -36,6 +36,30 @@ class MessagePackCacheSerializerTest < ActiveSupport::TestCase
     assert_nil load(dumped)
   end
 
+  test "handles missing namespaced class gracefully" do
+    klass = Class.new(DefinesFromMsgpackExt)
+    def klass.name; "DoesNotActuallyExist::AlsoMissing"; end
+
+    dumped = dump(klass.new("foo"))
+    assert_not_nil dumped
+    assert_nil load(dumped)
+  end
+
+  module RaisesUnrelatedNameError
+    def self.const_missing(_name)
+      raise NameError, "unrelated failure while loading"
+    end
+  end
+
+  test "re-raises a NameError that is not the missing class itself" do
+    klass = Class.new(DefinesFromMsgpackExt)
+    def klass.name; "#{MessagePackCacheSerializerTest::RaisesUnrelatedNameError}::Boom"; end
+
+    dumped = dump(klass.new("foo"))
+    error = assert_raises(NameError) { load(dumped) }
+    assert_equal "unrelated failure while loading", error.message
+  end
+
   private
     def serializer
       ActiveSupport::MessagePack::CacheSerializer


### PR DESCRIPTION
### Summary

`ActiveSupport::MessagePack::CacheSerializer` is designed to treat a serialized object whose class no longer exists as a **cache miss**: reading such an entry returns `nil` and the value is recomputed rather than raising. This is what lets you rename or remove a model without every previously-cached entry blowing up.

That graceful handling only worked for **top-level** classes. For a namespaced class (`Admin::User`, `Billing::Invoice`, …) the missing-class detection failed to recognize the class as missing, so the `NameError` escaped and `Rails.cache.read` / `fetch` raised instead of recomputing.

### Before / After

```ruby
# A cache entry was written for an instance of Admin::User,
# which has since been removed/renamed.
Rails.cache.read(cache_key)
# before => raises NameError: uninitialized constant Admin
# after  => nil  (treated as a cache miss and recomputed)
```

### Why this is correct

- The intended contract — "a dumped class that can no longer be resolved is a cache miss" — is unchanged; this just makes it hold for namespaced classes too, matching the existing top-level behavior. The missing class is identified by rebuilding, from the error's receiver, the fully-qualified name that failed to resolve and confirming it is `name` (or a namespace prefix of it).
- Unrelated `NameError`s are still propagated: an error raised while loading a class that *does* exist — including one raised without a receiver (a bare `raise NameError`) — is re-raised unchanged rather than being swallowed as a cache miss.