### PR TITLE
Preserve sub-second precision when coercing a `DateTime` in `Time.at`

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -47,7 +47,7 @@ class Time
         if time_or_number.is_a?(ActiveSupport::TimeWithZone)
           at_without_coercion(time_or_number.to_r).getlocal
         elsif time_or_number.is_a?(DateTime)
-          at_without_coercion(time_or_number.to_f).getlocal
+          at_without_coercion(time_or_number.to_i + time_or_number.sec_fraction).getlocal
         else
           at_without_coercion(time_or_number)
         end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -1177,6 +1177,14 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_at_with_datetime_sub_second_precision
+    dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(1, 1_000_000), "+0") # .000001s
+    assert_equal 1, Time.at(dt).usec
+
+    dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(123_457, 1_000_000), "+0")
+    assert_equal 123_457, Time.at(dt).usec
+  end
+
   def test_at_with_datetime_returns_local_time
     with_env_tz "US/Eastern" do
       dt = DateTime.civil(2000, 1, 1, 0, 0, 0, "+0")


### PR DESCRIPTION
### Summary

`Time.at` accepts an `ActiveSupport::TimeWithZone` or a `DateTime` as a single argument (ActiveSupport layers this on top of `Time.at`). The `TimeWithZone` branch converts via an exact rational timestamp (`to_r`), but the `DateTime` branch converted via a `Float` (`to_f`). A `Float` cannot represent every microsecond exactly, so the resulting `Time#usec` was wrong for roughly half of all sub-second `DateTime` values.

### Before / After

```ruby
dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(1, 1_000_000)) # .000001s
Time.at(dt).usec
# before => 0
# after  => 1

dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(123_457, 1_000_000))
Time.at(dt).usec
# before => 123456
# after  => 123457
```

### Why this is correct

- It brings the `DateTime` branch in line with the `TimeWithZone` sibling, which already passes an exact rational timestamp so precision survives the round-trip. The exact fractional second is `datetime.to_i + datetime.sec_fraction`.
- All other behavior is unchanged, verified across whole-second, offset (incl. DST), microsecond-boundary, and pre-epoch (negative timestamp) values: the resulting instant matches `datetime.to_i + datetime.sec_fraction` exactly, and the returned `Time` is still local (`getlocal`).