### PR TITLE
Convert Symbol keys in a `HashWithIndifferentAccess#transform_keys` mapping

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -360,6 +360,7 @@ module ActiveSupport
           to_enum(:transform_keys)
         end
       else
+        hash = hash.transform_keys { |key| convert_key(key) } if hash.is_a?(Hash)
         self.class.new(super)
       end
     end

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -513,6 +513,16 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal(["x", "b"], hash.keys) # asserting that order of keys is unchanged
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
 
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys({ a: :x, y: :z })
+
+    assert_nil(hash["a"])
+    assert_equal(1, hash["x"])
+    assert_equal(2, hash["b"])
+    assert_nil(hash["y"])
+    assert_nil(hash["z"])
+    assert_equal(["x", "b"], hash.keys) # asserting that order of keys is unchanged
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
     hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys({ "a" => "A", "q" => "Q" }) { |k| k * 3 }
 
     assert_nil(hash["a"])
@@ -579,6 +589,17 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
 
     hash = ActiveSupport::HashWithIndifferentAccess.new(@strings)
     hash.transform_keys!({ "a" => "x", "y" => "z" })
+
+    assert_nil(hash["a"])
+    assert_equal(1, hash["x"])
+    assert_equal(2, hash["b"])
+    assert_nil(hash["y"])
+    assert_nil(hash["z"])
+    assert_equal(["x", "b"], hash.keys) # asserting that order of keys is unchanged
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    hash.transform_keys!({ a: :x, y: :z })
 
     assert_nil(hash["a"])
     assert_equal(1, hash["x"])


### PR DESCRIPTION
### Summary

`transform_keys` / `transform_keys!` accept a hash that maps old keys to new ones (matching Ruby's `Hash#transform_keys(hash)`, added to HWIA in #46846). Under indifferent access the mapping's keys were compared against the string-stored keys **without** conversion, so a `Symbol`-keyed mapping never matched anything and the rename was silently a no-op.

This is the odd one out: every other key-argument entry point on HWIA (`slice`, `dig`, `fetch`, `[]`) runs the key through `convert_key`, and a plain `Hash` renames the same way.

### Before / After

```ruby
{ a: 1, b: 2 }.with_indifferent_access.transform_keys(a: :x)
# before => { "a" => 1, "b" => 2 }   (unchanged — silent no-op)
# after  => { "x" => 1, "b" => 2 }

# string-keyed mapping already worked, and still does:
{ a: 1, b: 2 }.with_indifferent_access.transform_keys("a" => "x")
# => { "x" => 1, "b" => 2 }
```

`transform_keys!` had the same no-op and is fixed by the same change (it delegates to `transform_keys`).

### Why this is correct

- The mapping's keys are now run through `convert_key` before matching, exactly as `slice` already does, so a symbol mapping matches the string-stored keys.
- Verified unchanged: string-keyed mappings, block forms, the combined hash + block form (keys absent from the mapping still go through the block), receiver is not mutated by the non-bang form, and a non-hash argument (`nil`, `42`) still raises `TypeError`.