### PR TITLE
Fix MySQL POINT and MULTIPOINT columns being misreported as integers

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix MySQL `POINT` and `MULTIPOINT` columns being misreported as integer columns.
+
+    Both type names contain the substring "int", so they matched the generic
+    `%r(int)i` rule in the abstract adapter's type map and came back with
+    `type: :integer`, instead of being treated as an unknown type like the
+    other spatial types (`GEOMETRY`, `POLYGON`, `LINESTRING`, ...).
+
+    *Ryosuke Okazuka*
+
 *   Report PostgreSQL default timestamp and time precision as 6.
 
     Bare PostgreSQL `timestamp` and `time` columns now use their effective

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -845,6 +845,10 @@ module ActiveRecord
 
             m.alias_type %r(year)i, "integer"
             m.alias_type %r(bit)i,  "binary"
+
+            # AbstractAdapter's generic type map matches POINT and MULTIPOINT against
+            # %r(int)i and misreports them as integers, so override them here.
+            m.register_type %r(^(?:point|multipoint))i, Type::Value.new
           end
 
           def register_integer_type(mapping, key, limit:)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/spatial_type_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/spatial_type_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class SpatialTypeTest < ActiveRecord::AbstractMysqlTestCase
+  self.use_transactional_tests = false
+
+  setup do
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.create_table("spatial_types", force: true) do |t|
+      t.column :coordinates, "point"
+      t.column :waypoints, "multipoint"
+    end
+  end
+
+  teardown do
+    @connection.drop_table "spatial_types", if_exists: true
+  end
+
+  test "POINT and MULTIPOINT columns are not misreported as integers" do
+    columns = @connection.columns("spatial_types").index_by(&:name)
+
+    assert_nil columns["coordinates"].type
+    assert_nil columns["waypoints"].type
+  end
+end


### PR DESCRIPTION
### Motivation / Background

  ActiveRecord misreports MySQL `POINT` and `MULTIPOINT` columns as integer columns:

  ```ruby
  connection = ActiveRecord::Base.lease_connection
  connection.execute("CREATE TABLE spots (loc POINT, locs MULTIPOINT, shape POLYGON)")
  columns = connection.columns("spots").index_by(&:name)
  columns["loc"].type    # => :integer (sql_type: "point")
  columns["locs"].type   # => :integer (sql_type: "multipoint")
  columns["shape"].type  # => nil      (sql_type: "polygon")
  ```

   Both type names contain the substring "int", so they match the unanchored
   generic rule `%r(int)i` in `AbstractAdapter`'s type map, instead of being
   treated as an unknown type like the other spatial types.

### Detail

  This Pull Request registers the two affected names explicitly in
  `AbstractMysqlAdapter#initialize_type_map`, so they resolve to `Type::Value` —
  the same unknown-type behavior the other spatial types already get via the
  type map's fallback.
  Notes on the shape of the fix:
  - The registration is added to the abstract MySQL adapter so that it covers both mysql2 and trilogy.
  - The generic `%r(int)i` rule itself is left untouched: unanchored matching is used deliberately elsewhere (e.g. SQLite's type affinity) — so this fix overrides it at the MySQL adapter level instead.
  - `POINT` and `MULTIPOINT` are the only spatial type names containing "int": the others already resolve to an unknown type via the type map's fallback.

### Additional information

  Found while building a MySQL→PostgreSQL schema sync tool (https://github.com/kyuuri1791/schema_ferry), where the misdetected integer silently produced a broken converted schema.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
