### PR TITLE
Fix typo in product_reviews.md [ci skip]

### DIFF
--- a/guides/source/product_reviews.md
+++ b/guides/source/product_reviews.md
@@ -4,7 +4,7 @@ Product Reviews
 ===============
 
 This guide covers adding Reviews to the e-commerce application you created in
-the [Getting Started Guide](getting_started.html)). We will use the code from
+the [Getting Started Guide](getting_started.html). We will use the code from
 the [Wishlists Guide](wishlists.html) as a starting place.
 
 After reading this guide, you will know how to:


### PR DESCRIPTION
Remove extra `)` in the product reviews page:

<img width="1757" height="995" alt="Screenshot 2026-07-11 at 15 01 06" src="https://github.com/user-attachments/assets/a740c406-9567-4f56-8e47-4db518102f17" />
