### PR TITLE
Document schema version formatters

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -427,7 +427,8 @@ module ActiveRecord
 
   ##
   # :singleton-method: schema_versions_formatter
-  # Specify the formatter used by schema dumper to format versions information.
+  # Specify the migration versions formatter class used by the +:sql+ schema dumper
+  # and the +:ruby+ schema loader.
   singleton_class.attr_accessor :schema_versions_formatter
   self.schema_versions_formatter = Migration::DefaultSchemaVersionsFormatter
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1239,8 +1239,11 @@ By assigning to the adapter class, all migrations run through connections using 
 
 #### `config.active_record.schema_versions_formatter`
 
-Controls the formatter class used by schema dumper to format versions information. Custom class can be provided
-to change the default behavior:
+Schema version formatter classes implement `initialize` and `format`.
+
+`initialize` receives a database connection as argument.
+
+`format` receives an array of versions, which may be strings or integers. It must return a single semicolon-terminated SQL statement that inserts them all into the schema migrations table.
 
 ```ruby
 class CustomSchemaVersionsFormatter
@@ -1261,6 +1264,8 @@ end
 
 config.active_record.schema_versions_formatter = CustomSchemaVersionsFormatter
 ```
+
+The returned SQL is appended to `structure.sql` by the `:sql` schema dumper, and executed by the `:ruby` schema loader to populate the schema migrations table.
 
 #### `config.active_record.lock_optimistically`
 


### PR DESCRIPTION
Title says it all.

Please, note that the SQL returned by the formatter is executed by `db:schema:load` via `assume_migrated_upto_version`.

The proposed docs say that `format` has to return one single statement. This is technically only necessary for the `:ruby` schema loader, multiple statements would work in `structure.sql`, but I wrote it this way for simplicity.

Similarly, the trailing semicolon is needed by the `:sql` dumper, but not by the `:ruby` loader, but trying to keep things simple.