### PR TITLE
Honor `template_path` in block-form `mail`

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Honor `template_path:` in block-form `mail`.
+
+    Passing `template_path:` to the block form of `mail` was ignored, so the
+    implicitly rendered template was always looked up under the mailer's
+    default path. It is now honored, matching the non-block form.
+
+    *Kenta Ishizaki*
+
 *   Add support for `config.action_mailer.raise_on_missing_callback_actions`
     when using `_deliver` callbacks with `only:` and `except:` options.
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -987,8 +987,15 @@ module ActionMailer
       end
 
       def collect_responses_from_block(headers)
+        templates_path = headers[:template_path]
         templates_name = headers[:template_name] || action_name
-        collector = ActionMailer::Collector.new(lookup_context) { render(templates_name) }
+        collector = ActionMailer::Collector.new(lookup_context) do
+          if templates_path
+            render(template: templates_name, prefixes: Array(templates_path))
+          else
+            render(templates_name)
+          end
+        end
         yield(collector)
         collector.responses
       end

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -659,6 +659,11 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("Welcome from another path", mail.body.encoded)
   end
 
+  test "you can specify the template path for a block-form mail" do
+    mail = BaseMailer.welcome_from_another_path_with_block("another.path/base_mailer").deliver_now
+    assert_equal("Welcome from another path", mail.body.encoded)
+  end
+
   test "assets tags should use ActionMailer's asset_host settings" do
     ActionMailer::Base.config.asset_host = "http://global.com"
     ActionMailer::Base.config.assets_dir = "global/"

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -21,6 +21,12 @@ class BaseMailer < ActionMailer::Base
     mail(template_name: "welcome", template_path: path)
   end
 
+  def welcome_from_another_path_with_block(path)
+    mail(template_name: "welcome", template_path: path) do |format|
+      format.text
+    end
+  end
+
   def welcome_without_deliveries(hash = {})
     mail({ template_name: "welcome" }.merge!(hash))
     mail.perform_deliveries = false


### PR DESCRIPTION
### Summary

`mail` documents `template_path:` to change the directory used for implicit template lookup:

```ruby
mail(template_path: "notifications", template_name: "another")
# looks for templates at app/views/notifications with name "another"
```

The template-collection path reads `template_path:` alongside its sibling `template_name:`. But when a block is passed, the block collector read only `template_name:` and always resolved the name against the mailer's own view paths — so `template_path:` was silently ignored and the mailer's own template was rendered instead:

```ruby
mail(template_path: "notifications", template_name: "welcome") do |format|
  format.text   # rendered <this_mailer>/welcome, not notifications/welcome
end
```

### Fix

When `template_path:` is given, the block collector now resolves the template within that path, matching the non-block path. Without `template_path:` the lookup is unchanged.