### PR TITLE
Honor `if_not_exists:` in SQLite3 `add_check_constraint` and `add_foreign_key`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Honor `if_not_exists:` in SQLite3 `add_check_constraint` and `add_foreign_key`.
+
+    *Kenta Ishizaki*
+
 *   Fix MySQL `POINT` and `MULTIPOINT` columns being misreported as integer columns.
 
     Both type names contain the substring "int", so they matched the generic

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -53,7 +53,10 @@ module ActiveRecord
           end
         end
 
-        def add_foreign_key(from_table, to_table, **options)
+        def add_foreign_key(from_table, to_table, if_not_exists: false, **options)
+          options = foreign_key_options(from_table, to_table, options)
+          return if if_not_exists && foreign_key_exists?(from_table, to_table, **options.slice(:column, :primary_key))
+
           assert_valid_deferrable(options[:deferrable])
 
           alter_table(from_table) do |definition|
@@ -94,7 +97,9 @@ module ActiveRecord
           end
         end
 
-        def add_check_constraint(table_name, expression, **options)
+        def add_check_constraint(table_name, expression, if_not_exists: false, **options)
+          return if if_not_exists && check_constraint_exists?(table_name, expression: expression, **options)
+
           alter_table(table_name) do |definition|
             definition.check_constraint(expression, **options)
           end

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -118,10 +118,13 @@ if ActiveRecord::Base.lease_connection.supports_check_constraints?
 
         def test_add_check_constraint_with_if_not_exists_options
           @connection.add_check_constraint :trades, "quantity > 0"
+          assert_equal 1, @connection.check_constraints("trades").size
 
           assert_nothing_raised do
             @connection.add_check_constraint :trades, "quantity > 0", if_not_exists: true
           end
+
+          assert_equal 1, @connection.check_constraints("trades").size
         end
 
         if supports_non_unique_constraint_name?

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -1122,6 +1122,8 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_nothing_raised do
             @connection.add_foreign_key :astronauts, :rockets, if_not_exists: true
           end
+
+          assert_equal 1, @connection.foreign_keys("astronauts").size
         end
 
         def test_add_foreign_key_preserves_existing_column_types


### PR DESCRIPTION
### Behavior

`add_check_constraint` and `add_foreign_key` accept `if_not_exists: true` so that adding one that already exists is a no-op rather than an error.

On SQLite3, with `if_not_exists: true` and the constraint / foreign key already present:

| | before | after |
| --- | --- | --- |
| `add_check_constraint(..., if_not_exists: true)` | duplicate added | no-op |
| `add_foreign_key(..., if_not_exists: true)` | duplicate added | no-op |

The SQLite3 overrides never declared `if_not_exists:`, so it fell into `**options` unused and a duplicate was added — whereas the abstract adapter (MySQL, Trilogy) and the SQLite3 `remove_check_constraint` / `remove_foreign_key` overrides all honor their existence option.

### Why this is correct

Both overrides now return early when the target already exists, matching the abstract adapter and the corresponding `remove_*` siblings in the same file. The foreign-key existence check resolves the default column via `foreign_key_options` before comparing (mirroring `AbstractAdapter#add_foreign_key`), so a second foreign key to the *same table on a different column* is still added and only a true duplicate is skipped. Without `if_not_exists:` the behavior is unchanged.

This also fixes rollback replay: reverting `remove_foreign_key(..., if_exists: true)` emits `add_foreign_key(..., if_not_exists: true)` (recorder inversion), which on the default SQLite3 adapter previously duplicated the foreign key instead of being idempotent.