### PR TITLE
Accept `Date` and numeric inputs in `relative_time_in_words`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Accept `Date` and `Numeric` inputs in `relative_time_in_words`.
+
+    Passing a `Date` or a `Numeric` raised `ArgumentError` instead of returning
+    a distance string, unlike `distance_of_time_in_words` which accepts them.
+
+    *Kenta Ishizaki*
+
 *   Support endless and beginless ranges in `number_field_tag` and
     `range_field_tag`.
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -196,6 +196,7 @@ module ActionView
       #
       # See also #time_ago_in_words
       def relative_time_in_words(from_time, options = {})
+        from_time = normalize_distance_of_time_argument_to_time(from_time)
         now = Time.now
         time = distance_of_time_in_words(from_time, now, options.except(:scope))
         key = from_time > now ? :future : :past

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -215,6 +215,16 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "less than 20 seconds ago", relative_time_in_words(10.seconds.ago, include_seconds: true)
   end
 
+  def test_relative_time_accepts_numeric_input
+    assert_equal "3 minutes ago", relative_time_in_words(3.minutes.ago.to_i)
+    assert_match(/\Ain /, relative_time_in_words(3.minutes.from_now.to_i))
+  end
+
+  def test_relative_time_accepts_date_input
+    assert_match(/ ago\z/, relative_time_in_words(Date.yesterday))
+    assert_match(/\Ain /, relative_time_in_words(Date.tomorrow))
+  end
+
   def test_select_day
     expected = +%(<select id="date_day" name="date[day]">\n)
     expected << %(<option value="1">1</option>\n<option value="2">2</option>\n<option value="3">3</option>\n<option value="4">4</option>\n<option value="5">5</option>\n<option value="6">6</option>\n<option value="7">7</option>\n<option value="8">8</option>\n<option value="9">9</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16" selected="selected">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n<option value="24">24</option>\n<option value="25">25</option>\n<option value="26">26</option>\n<option value="27">27</option>\n<option value="28">28</option>\n<option value="29">29</option>\n<option value="30">30</option>\n<option value="31">31</option>\n)


### PR DESCRIPTION
### Summary

`relative_time_in_words` (added in this release) is documented to behave like `time_ago_in_words`, whose argument may be a `Time`, `Date`, or `DateTime` object or an `Integer` number of seconds. It forwards the argument to `distance_of_time_in_words`, which normalizes all of those. But it also compares the **raw** argument against `Time.now` to pick the past/future translation key:

```ruby
def relative_time_in_words(from_time, options = {})
  now = Time.now
  time = distance_of_time_in_words(from_time, now, options.except(:scope))
  key = from_time > now ? :future : :past   # <- raw argument
  ...
end
```

So any non-`Time` argument raises before a string is returned:

```ruby
relative_time_in_words(Date.tomorrow)  # => ArgumentError: comparison of Date with Time failed
relative_time_in_words(180)            # => ArgumentError: comparison of Integer with Time failed
```

Note `distance_of_time_in_words` on the line above already accepted these inputs — only the comparison broke.

### Fix

Normalize the argument to a `Time` up front, the same way `distance_of_time_in_words` does (via the existing private `normalize_distance_of_time_argument_to_time`), so every documented input type works and the past/future key is chosen correctly.