### PR TITLE
Decouple schema loading from the versions formatter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1501,7 +1501,7 @@ module ActiveRecord
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
           sql = +"INSERT INTO #{sm_table} (version) VALUES "
-          sql << inserting.reverse.map { |v| "(#{quote(v)})" }.join(",")
+          sql << inserting.map { |v| "(#{quote(v)})" }.join(",")
           execute sql
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1500,7 +1500,9 @@ module ActiveRecord
           if (duplicate = inserting.detect { |v| inserting.count(v) > 1 })
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          execute insert_versions_sql(inserting)
+          sql = +"INSERT INTO #{sm_table} (version) VALUES "
+          sql << inserting.reverse.map { |v| "(#{quote(v)})" }.join(",")
+          execute sql
         end
       end
 


### PR DESCRIPTION
The `:ruby` schema loader needs to populate the schema migrations table, and `structure.sql` needs to include SQL to do the same when loaded.

In the past, the same private [SQL generator](https://github.com/rails/rails/blob/v8.0.0/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L1877-L1888) was used in both places. The `:ruby` schema loader to run `execute` on it, and the `:sql` schema dumper to append the generated SQL to `structure.sql`.

8.1 added support for version formatters to allow users to customize the generation of such SQL, having `structure.sql` in mind. However, by doing that, the fact that the `:ruby` schema loader uses the same SQL generator [leaks](https://github.com/rails/rails/pull/58089) into the contract for such formatters.

The easy way to solve that is to decouple them. Let the `:ruby` schema loader have its own private SQL, and then allow the contract for version formatters to be written assuming they are only used by the `:sql` schema dumper.

I'll document such contract in a different patch.