### PR TITLE
Return the current value for an unchanged store accessor's `_before_last_save`

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -194,7 +194,7 @@ module ActiveRecord
             end
 
             define_method("#{accessor_key}_before_last_save") do
-              return unless saved_change_to_attribute?(store_attribute)
+              return read_store_attribute(store_attribute, key) unless saved_change_to_attribute?(store_attribute)
               prev_store, _new_store = saved_changes[store_attribute]
               accessor = store_accessor_for(store_attribute)
               accessor.get(prev_store, key)

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -147,6 +147,15 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal "black", @john.color_was
   end
 
+  test "reading _before_last_save for an accessor unchanged in the last save returns the current value" do
+    @john.partner_name = "River"
+    @john.save!
+
+    assert_not @john.saved_change_to_color?
+    assert_equal "black", @john.color_before_last_save
+    assert_equal @john.color, @john.color_before_last_save
+  end
+
   test "changing one accessor does not report a change for a sibling accessor" do
     @john.homepage = "http://www.example.com"
     @john.save!


### PR DESCRIPTION
### Behavior

A store accessor exposes `<key>_before_last_save` to read the value a key held before the most recent save.

When the store column was **not** changed in the last save:

| accessor | before | after |
| --- | --- | --- |
| `record.color_before_last_save` (per-key) | `nil` | `"black"` |
| `record.attribute_before_last_save("settings")["color"]` (whole column) | `"black"` | `"black"` |
| `record.color_was` (sibling per-key) | `"black"` | `"black"` |

The per-key accessor returned `nil` for a key whose store column was untouched by the last save, disagreeing with both the whole-column `attribute_before_last_save` and its own sibling `<key>_was`.

### Why this is correct

`attribute_before_last_save` returns the current value for an attribute that was not changed in the last save. The per-key accessor now returns the stored value in that same case, so `<key>_before_last_save` reports the value as of the last save regardless of whether the surrounding store column was part of it — matching the whole-column accessor and the `<key>_was` sibling, which already behaves this way.