### PR TITLE
Fix `belongs_to` change tracking, counter cache, and touch for composite foreign keys

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -72,9 +72,16 @@ module ActiveRecord
           model_was = klass
         end
 
-        foreign_key_was = owner.attribute_before_last_save(reflection.foreign_key)
+        foreign_key = reflection.foreign_key
+        if foreign_key.is_a?(Array)
+          foreign_key_was = foreign_key.map { |fk| owner.attribute_before_last_save(fk) }
+          foreign_key_was_present = foreign_key_was.all?
+        else
+          foreign_key_was = owner.attribute_before_last_save(foreign_key)
+          foreign_key_was_present = foreign_key_was
+        end
 
-        if foreign_key_was && model_was < ActiveRecord::Base
+        if foreign_key_was_present && model_was && model_was < ActiveRecord::Base
           update_counters_via_scope(model_was, foreign_key_was, -1)
         end
       end
@@ -88,7 +95,7 @@ module ActiveRecord
       end
 
       def saved_change_to_target?
-        owner.saved_change_to_attribute?(reflection.foreign_key)
+        Array(reflection.foreign_key).any? { |fk| owner.saved_change_to_attribute?(fk) }
       end
 
       private
@@ -111,13 +118,21 @@ module ActiveRecord
             if target && !stale_target?
               target.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
             else
-              update_counters_via_scope(klass, owner._read_attribute(reflection.foreign_key), by)
+              foreign_key = reflection.foreign_key
+              if foreign_key.is_a?(Array)
+                foreign_key = foreign_key.map { |fk| owner._read_attribute(fk) }
+              else
+                foreign_key = owner._read_attribute(foreign_key)
+              end
+              update_counters_via_scope(klass, foreign_key, by)
             end
           end
         end
 
         def update_counters_via_scope(klass, foreign_key, by)
-          scope = klass.unscoped.where!(primary_key(klass) => foreign_key)
+          primary_key = primary_key(klass)
+          foreign_key = [foreign_key] if primary_key.is_a?(Array)
+          scope = klass.unscoped.where!(primary_key => foreign_key)
           scope.update_counters(reflection.counter_cache_column => by, touch: reflection.options[:touch])
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1807,6 +1807,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert book.order_previously_changed?
   end
 
+  test "saved change to target is tracked for a composite foreign key" do
+    old_order = Cpk::Order.create!(id: [1, 2])
+    new_order = Cpk::Order.create!(id: [1, 3])
+    book = Cpk::Book.create!(id: [3, 4], order: old_order)
+    book.reload
+
+    book.order = new_order
+    book.save!
+
+    assert book.association(:order).saved_change_to_target?
+  end
+
   class ShipRequired < ActiveRecord::Base
     self.table_name = "ships"
     belongs_to :developer, required: true

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -86,6 +86,20 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "reassigning a cpk parent moves the counter cache to the new parent" do
+    old_order = Cpk::Order.create!(id: [1, 2])
+    new_order = Cpk::Order.create!(id: [1, 3])
+    book = Cpk::Book.create!(id: [3, 4], order: old_order)
+
+    assert_equal 1, old_order.reload.books_count
+    assert_equal 0, new_order.reload.books_count
+
+    book.update!(order: new_order)
+
+    assert_equal 0, old_order.reload.books_count
+    assert_equal 1, new_order.reload.books_count
+  end
+
   test "reset counters" do
     # throw the count off by 1
     Topic.increment_counter(:replies_count, @topic.id)


### PR DESCRIPTION
### Behavior

For a `belongs_to` with a composite foreign key, reassigning the target to a different record and saving:

| | before | after |
| --- | --- | --- |
| `association(:order).saved_change_to_target?` | `false` (always) | `true` |
| counter cache on the old parent | not decremented | decremented |
| counter cache on the new parent | not incremented (via scope) | incremented |
| `touch:` on the old parent | not triggered | triggered |
| `touch:` on the new parent | triggered (via `touch_record` fallback) | triggered (via counter cache) |

Three related bugs prevented composite-key `belongs_to` associations from working correctly when both `counter_cache` and `touch` are enabled:

1. **`saved_change_to_target?`** returned `false` for every composite-key `belongs_to`, because the whole foreign-key array was passed to `saved_change_to_attribute?`, which stringifies the name and never matches a real attribute.

2. **`decrement_counters_before_last_save`** passed the foreign-key array to `attribute_before_last_save`, which also stringifies, returning `nil` — so the old parent was never found and neither its counter nor its timestamp was updated.

3. **`update_counters` / `update_counters_via_scope`** did not wrap composite foreign-key values for the tuple query that `where(composite_pk => value)` expects.

On `main`, bug 1 masked bugs 2 and 3: because `saved_change_to_target?` always returned `false`, the counter-cache callbacks never fired and touch fell through to `touch_record` (which already handles composite keys). Fixing bug 1 alone switched touch responsibility to the counter-cache path, exposing bugs 2 and 3.

### Why this is correct

All three fixes follow the same `Array()` / `is_a?(Array)` pattern already used by `target_changed?`, `target_previously_changed?`, and `touch_record`:

- `saved_change_to_target?` now checks each foreign-key column individually.
- `decrement_counters_before_last_save` reads each column's previous value individually and requires all columns present before looking up the old parent.
- `update_counters` reads each column individually when building the scope fallback, and `update_counters_via_scope` wraps the composite value in an array so `where([:shop_id, :id] => [[1, 2]])` produces the correct tuple query.