### PR TITLE
Read foreign key names from the schema on SQLite3

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Honor foreign key names on SQLite3.
+
+    SQLite3 did not read foreign key names, so `remove_foreign_key(name:)`
+    removed an arbitrary foreign key rather than the named one, and custom
+    names were lost when a later schema change rebuilt the table or the
+    schema was dumped. Names are now honored, matching the other adapters.
+
+    *Kenta Ishizaki*
+
 *   Honor `if_not_exists:` in SQLite3 `add_check_constraint` and `add_foreign_key`.
 
     *Kenta Ishizaki*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -69,7 +69,7 @@ module ActiveRecord
           to_table ||= options[:to_table]
           return if options.delete(:if_exists) && !foreign_key_exists?(from_table, to_table, **options.slice(:column, :name))
 
-          options = options.except(:name, :to_table, :validate)
+          options = options.except(:to_table, :validate)
           fkey = foreign_key_for!(from_table, to_table: to_table, **options)
 
           foreign_keys = foreign_keys(from_table)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -465,12 +465,14 @@ module ActiveRecord
       end
       alias :add_belongs_to :add_reference
 
+      FK_NAME_REGEX = /\ACONSTRAINT\s+"([^"]+)"/
       FK_REGEX = /.*FOREIGN KEY\s+\("([^"]+)"\)\s+REFERENCES\s+"(\w+)"\s+\("(\w+)"\)/
       DEFERRABLE_REGEX = /DEFERRABLE INITIALLY (\w+)/
       def foreign_keys(table_name)
         # SQLite returns 1 row for each column of composite foreign keys.
         fk_info = query_all("PRAGMA foreign_key_list(#{quote(table_name)})")
-        # Deferred or immediate foreign keys can only be seen in the CREATE TABLE sql
+        # Deferred or immediate foreign keys and the constraint name can only be
+        # seen in the CREATE TABLE sql.
         fk_defs = table_structure_sql(table_name)
                     .select do |column_string|
                       column_string.start_with?("CONSTRAINT") &&
@@ -479,17 +481,20 @@ module ActiveRecord
                     .to_h do |fk_string|
                       _, from, table, to = fk_string.match(FK_REGEX).to_a
                       _, mode = fk_string.match(DEFERRABLE_REGEX).to_a
+                      _, name = fk_string.match(FK_NAME_REGEX).to_a
                       deferred = mode&.downcase&.to_sym || false
-                      [[table, from, to], deferred]
+                      [[table, from, to], { deferrable: deferred, name: name }]
                     end
 
         grouped_fk = fk_info.group_by { |row| row["id"] }.values.each { |group| group.sort_by! { |row| row["seq"] } }
         grouped_fk.map do |group|
           row = group.first
+          fk_def = fk_defs[[row["table"], row["from"], row["to"]]]
           options = {
             on_delete: extract_foreign_key_action(row["on_delete"]),
             on_update: extract_foreign_key_action(row["on_update"]),
-            deferrable: fk_defs[[row["table"], row["from"], row["to"]]]
+            deferrable: fk_def && fk_def[:deferrable],
+            name: fk_def && fk_def[:name],
           }
 
           if group.one?

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -16,7 +16,7 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_equal "fk_test_has_pk", fk.to_table
           assert_equal "fk_id", fk.column
           assert_equal "pk_id", fk.primary_key
-          assert_equal "fk_name", fk.name unless current_adapter?(:SQLite3Adapter)
+          assert_equal "fk_name", fk.name
         end
       end
 
@@ -203,7 +203,7 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_equal "fk_test_has_pk", fk.to_table
           assert_equal "fk_id", fk.column
           assert_equal "pk_id", fk.primary_key
-          assert_equal "fk_name", fk.name unless current_adapter?(:SQLite3Adapter)
+          assert_equal "fk_name", fk.name
         end
 
         def test_add_foreign_key_inferes_column
@@ -217,7 +217,7 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_equal "rockets", fk.to_table
           assert_equal "rocket_id", fk.column
           assert_equal "id", fk.primary_key
-          assert_equal "fk_rails_78146ddd2e", fk.name unless current_adapter?(:SQLite3Adapter)
+          assert_equal "fk_rails_78146ddd2e", fk.name
         end
 
         def test_add_foreign_key_with_column
@@ -231,7 +231,7 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_equal "rockets", fk.to_table
           assert_equal "rocket_id", fk.column
           assert_equal "id", fk.primary_key
-          assert_equal "fk_rails_78146ddd2e", fk.name unless current_adapter?(:SQLite3Adapter)
+          assert_equal "fk_rails_78146ddd2e", fk.name
         end
 
         def test_add_foreign_key_with_if_not_exists_to_already_referenced_table
@@ -390,8 +390,6 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
         end
 
         def test_foreign_key_exists_by_name
-          skip if current_adapter?(:SQLite3Adapter)
-
           @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", name: "fancy_named_fk"
 
           assert @connection.foreign_key_exists?(:astronauts, name: "fancy_named_fk")
@@ -404,11 +402,8 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
 
             assert t.foreign_key_exists?(column: "rocket_id")
             assert_not t.foreign_key_exists?(column: "star_id")
-
-            unless current_adapter?(:SQLite3Adapter)
-              assert t.foreign_key_exists?(name: "fancy_named_fk")
-              assert_not t.foreign_key_exists?(name: "other_fancy_named_fk")
-            end
+            assert t.foreign_key_exists?(name: "fancy_named_fk")
+            assert_not t.foreign_key_exists?(name: "other_fancy_named_fk")
           end
         end
 
@@ -466,8 +461,6 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
         end
 
         def test_remove_foreign_key_if_exists_with_non_matching_name
-          skip if current_adapter?(:SQLite3Adapter)
-
           @connection.add_foreign_key :astronauts, :rockets
           assert_equal 1, @connection.foreign_keys("astronauts").size
 
@@ -485,6 +478,21 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
             @connection.remove_foreign_key :astronauts, to_table: :moons, if_exists: true
           end
           assert_equal 1, @connection.foreign_keys("astronauts").size
+        end
+
+        def test_remove_foreign_key_by_name_removes_only_the_named_key
+          @connection.add_column :astronauts, :backup_rocket_id, :bigint
+
+          @connection.add_foreign_key :astronauts, :rockets, column: :rocket_id, name: "fk_rocket"
+          @connection.add_foreign_key :astronauts, :rockets, column: :backup_rocket_id, name: "fk_backup_rocket"
+
+          assert_equal 2, @connection.foreign_keys("astronauts").size
+
+          @connection.remove_foreign_key :astronauts, name: "fk_rocket"
+
+          remaining = @connection.foreign_keys(:astronauts)
+          assert_equal ["fk_backup_rocket"], remaining.map(&:name)
+          assert_equal ["backup_rocket_id"], remaining.map(&:column)
         end
 
         def test_remove_foreign_non_existing_foreign_key_raises
@@ -931,11 +939,7 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
 
         def test_schema_dumping_with_options
           output = dump_table_schema "fk_test_has_fk"
-          if current_adapter?(:SQLite3Adapter)
-            assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "pk_id"$}, output
-          else
-            assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "pk_id", name: "fk_name"$}, output
-          end
+          assert_match %r{\s+add_foreign_key "fk_test_has_fk", "fk_test_has_pk", column: "fk_id", primary_key: "pk_id", name: "fk_name"$}, output
         end
 
         def test_schema_dumping_with_custom_fk_ignore_pattern


### PR DESCRIPTION
### Behavior

On SQLite3, `foreign_keys(table)` returned `nil` for every foreign key's `name`, because the constraint name was never read from the table definition. Given a table with two named foreign keys:

```ruby
add_foreign_key :crews, :ships, column: "ship_id",        name: "fk_ship"
add_foreign_key :crews, :ships, column: "backup_ship_id", name: "fk_backup_ship"
```

| | before | after |
| --- | --- | --- |
| `foreign_keys("crews").map(&:name)` | `[nil, nil]` | `["fk_ship", "fk_backup_ship"]` |
| `remove_foreign_key(:crews, name: "fk_ship")` | removes an arbitrary (the first) key | removes the `fk_ship` key |
| `remove_foreign_key(:crews, name: "nope", if_exists: true)` | removes a key | no-op |
| custom name after a later `add_foreign_key` / `add_column` (table rebuild) | regenerated to `fk_rails_...` | preserved |
| custom name in the schema dump | dropped | emitted |

Because the name was missing, `remove_foreign_key ..., name:` fell through to matching the first foreign key and destroyed the wrong one; and every `alter_table` rebuild (which recreates the foreign keys from `foreign_keys`) lost custom names, regenerating them to `fk_rails_...`.

### Why this is correct

`foreign_keys` now captures the constraint name from the `CONSTRAINT "..." FOREIGN KEY (...)` definition, and SQLite3 `remove_foreign_key` forwards `:name` to the matcher instead of stripping it. This mirrors the abstract adapter's `remove_foreign_key` (and MySQL/PostgreSQL, which already populate `:name`), so name-based lookup, `if_exists:` no-ops, and name preservation across table rebuilds all behave the same on every adapter.

Auto-generated `fk_rails_*` names match `SchemaDumper.fk_ignore_pattern`, so they are still omitted from the schema dump exactly as before — only genuinely custom names are now round-tripped.