### PR TITLE
Join an Array `accept` in `file_field_tag`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Join an Array `:accept` option with commas in `file_field_tag`.
+
+    Previously, passing `accept: ["image/png", "image/gif"]` rendered
+    `accept="image/png image/gif"`, while the HTML `accept` attribute is a
+    comma-separated list. It now renders `accept="image/png,image/gif"`,
+    matching the object-based `file_field`.
+
+    *Kenta Ishizaki*
+
 *   `current_page?` matches HTTP QUERY requests
     ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) with
     `method: :query`. The default `method: :get` deliberately does not match

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Join an Array `:accept` option with commas in `file_field_tag`.
+
+    Previously, passing `accept: ["image/png", "image/gif"]` rendered
+    `accept="image/png image/gif"`, while the HTML `accept` attribute is a
+    comma-separated list. It now renders `accept="image/png,image/gif"`,
+    matching the object-based `file_field`.
+
+    *Kenta Ishizaki*
+
 *   Fix `search_field` raising `NameError` when passed `autosave: true`.
 
     *Hammad Khan*

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -345,9 +345,15 @@ module ActionView
       #   file_field_tag 'user_pic', accept: 'image/png,image/gif,image/jpeg'
       #   # => <input accept="image/png,image/gif,image/jpeg" id="user_pic" name="user_pic" type="file" />
       #
+      #   file_field_tag 'user_pic', accept: ['image/png', 'image/gif']
+      #   # => <input accept="image/png,image/gif" id="user_pic" name="user_pic" type="file" />
+      #
       #   file_field_tag 'file', accept: 'text/html', class: 'upload', value: 'index.html'
       #   # => <input accept="text/html" class="upload" id="file" name="file" type="file" value="index.html" />
       def file_field_tag(name, options = {})
+        if options[:accept].is_a?(Array)
+          options = options.merge(accept: options[:accept].join(","))
+        end
         text_field_tag(name, nil, convert_direct_upload_option_to_url(options.merge(type: :file)))
       end
 

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -412,6 +412,13 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\"/>", file_field_tag("picsplz", class: "pix")
   end
 
+  def test_file_field_tag_with_accept_array
+    assert_dom_equal(
+      "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" accept=\"image/png,image/gif\"/>",
+      file_field_tag("picsplz", accept: ["image/png", "image/gif"])
+    )
+  end
+
   def test_file_field_tag_with_direct_upload_when_rails_direct_uploads_url_is_not_defined
     assert_dom_equal(
       "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\"/>",


### PR DESCRIPTION
### Behavior

Passing an Array of MIME types to `file_field_tag`:

```ruby
file_field_tag("picture", accept: ["image/png", "image/gif"])
```

| | before | after |
| --- | --- | --- |
| rendered attribute | `accept="image/png image/gif"` | `accept="image/png,image/gif"` |

The `accept` attribute is a comma-separated list of tokens per the HTML specification, so the space-joined value produced before is not a valid `accept` value and browsers ignore the extra entries.

### Why this is correct

The object-based `file_field` already joins an Array `:accept` with commas before rendering (`ActionView::Helpers::Tags::FileField#render`), and both helpers document `:accept` identically as accepting "one or multiple mime-types". `file_field_tag`'s own doc example shows a comma-separated `accept`. The tag helper now conforms to its sibling, so the same Array input produces the same comma-joined attribute through both APIs. A single MIME type (String) is unaffected.