### PR TITLE
Fix settings navigation test in authentication guide

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -1888,7 +1888,7 @@ class SettingsTest < ActionDispatch::IntegrationTest
     sign_in_as users(:one)
     get settings_profile_path
     assert_dom "h4", "Account Settings"
-    assert_not_dom "a", "Store Settings"
+    assert_not_dom "h4", "Store Settings"
   end
 
   test "admin settings nav" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because the guide checks for the absence of "Store Settings" using `assert_not_dom "a", "Store Settings"`.

However, in the guide, "Store Settings" is rendered as an `h4` heading rather than a link, so the selector should be `h4` to match the markup shown in the guide.

The current test still passes because no `<a>` element with the text "Store Settings" is rendered for either regular users or admin users. As a result, the assertion does not actually verify the intended behavior. The inconsistency is apparent because the following test correctly checks for an `h4` element when asserting that admin users can see "Store Settings".

### Detail

This Pull Request changes the selector in the guide test from `a` to `h4` so that the assertion matches the markup being rendered and verifies the intended expectation. This also makes the regular-user and admin-user examples consistent with one another.

### Additional information

The markup in the guide, uses `h4` not `a` for "Store Settings", screenshot attached:
<img width="867" height="650" alt="Screenshot 2026-07-12 at 18 31 59" src="https://github.com/user-attachments/assets/8a5a0a47-b1c3-4085-9c60-9a24d996bc63" />


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
