### PR TITLE
Refactor assume_migrated_upto_version

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1485,23 +1485,25 @@ module ActiveRecord
 
       def assume_migrated_upto_version(version)
         version = version.to_i
-        sm_table = quote_table_name(pool.schema_migration.table_name)
-
         migration_context = pool.migration_context
-        migrated = migration_context.get_all_versions
-        versions = migration_context.migrations.map(&:version)
 
-        unless migrated.include?(version)
-          execute "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
+        schema_migrations_table       = migration_context.schema_migration.table_name
+        versions_in_schema_migrations = migration_context.get_all_versions
+        versions_in_db_migrate        = migration_context.migrations.map(&:version)
+
+        unless versions_in_schema_migrations.include?(version)
+          execute "INSERT INTO #{quote_table_name(schema_migrations_table)} (version) VALUES (#{quote(version)})"
         end
 
-        inserting = (versions - migrated).select { |v| v < version }
-        if inserting.any?
-          if (duplicate = inserting.detect { |v| inserting.count(v) > 1 })
+        versions_to_insert = (versions_in_db_migrate - versions_in_schema_migrations).select { |v| v < version }
+
+        if versions_to_insert.any?
+          if (duplicate = versions_to_insert.detect { |v| versions_to_insert.count(v) > 1 })
             raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
           end
-          sql = +"INSERT INTO #{sm_table} (version) VALUES "
-          sql << inserting.map { |v| "(#{quote(v)})" }.join(",")
+
+          sql = +"INSERT INTO #{quote_table_name(schema_migrations_table)} (version) VALUES "
+          sql << versions_to_insert.map { |v| "(#{quote(v)})" }.join(",")
           execute sql
         end
       end


### PR DESCRIPTION
This refactor was triggered by the `migrated` variable:

```ruby
migrated = migration_context.get_all_versions
```

which contains the versions in the schema migrations table when the method starts.

I find this name to be confusing because when you reset a database (arguably the main use case) the schema reflects some migrations have been migrated, and the schema migrations table is empty! `assume_migrated_upto_version` is precisely the method that populates it. Therefore `migrated` is empty. How can `migrated` mean what is migrated?

By contrast, `versions_in_schema_migrations` does not make you think, its meaning is obvious. It may have some, it may have none, and that is separate from "what has been migrated".

> [!NOTE]
> That is indeed a deeper problem with the current `:ruby` format I am thinking about these days. The dumper does not capture what has been migrated like `structure.sql` does. That information is lost. What has been migrated only remains implicit in `db/schema.rb`.

Since I was on it, I polished more things:

1. This method is based on the migration context, and the migration context already gives you the name of the schema migrations table, so make that access uniform instead of going through a different path. (That also saves an allocation, but that is not important here.)
1. `sm_table` is not a table or table name, it is a _quoted_ table name. At the same time, the existing SQL statements quote versions but do not quote the table, because it is already quoted. In the refactor, the table name is the table name, and quoting happens in the same place, uniform in all fronts: variable names and SQL.
1. `versions_in_db_migrate` is also a self-explanatory variable name compared to `versions`. It is also aligned with `versions_in_schema_migrations`.
1. It is then less important but coherent to use the same naming pattern for `versions_to_insert`, instead of "inserting".