### PR TITLE
Fix has_many through to cast owner-key predicates using the joined model’s attribute type

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -64,12 +64,12 @@ module ActiveRecord
           primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
           primary_key_foreign_key_pairs.each do |join_key, foreign_key|
             value = transform_value(owner._read_attribute(foreign_key))
-            scope = apply_scope(scope, table, join_key, value)
+            scope = apply_scope(scope, table, join_key, value, reflection.klass)
           end
 
           if reflection.type
             polymorphic_type = transform_value(owner.class.polymorphic_name)
-            scope = apply_scope(scope, table, reflection.type, polymorphic_type)
+            scope = apply_scope(scope, table, reflection.type, polymorphic_type, reflection.klass)
           end
 
           scope
@@ -93,7 +93,7 @@ module ActiveRecord
 
           if reflection.type
             value = transform_value(next_reflection.klass.polymorphic_name)
-            scope = apply_scope(scope, table, reflection.type, value)
+            scope = apply_scope(scope, table, reflection.type, value, reflection.klass)
           end
 
           scope.joins!(join(foreign_table, constraints))
@@ -160,11 +160,12 @@ module ActiveRecord
           scope
         end
 
-        def apply_scope(scope, table, key, value)
+        def apply_scope(scope, table, key, value, klass)
           if scope.table == table
             scope.where!(key => value)
           else
-            scope.where!(table.name => { key => value })
+            metadata = ActiveRecord::TableMetadata.new(klass, table)
+            scope.where!(metadata.predicate_builder[key, value])
           end
         end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -55,6 +55,45 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
            :sharded_blog_posts, :sharded_tags, :sharded_blog_posts_tags, :cpk_orders, :cpk_tags,
            :cpk_order_tags
 
+  class PlusOneThousandInteger < ActiveRecord::Type::Integer
+    def serialize(value)
+      value = super
+      value + 1000 if value
+    end
+  end
+
+  class BlogPostWithCustomTypedThroughFk < ActiveRecord::Base
+    self.table_name = :sharded_blog_posts
+    query_constraints :blog_id, :id
+
+    has_many :blog_post_tags,
+      class_name: "HasManyThroughAssociationsTest::BlogPostTagWithCustomTypedPostId",
+      primary_key: [:blog_id, :id],
+      foreign_key: [:blog_id, :blog_post_id]
+    has_many :tags, through: :blog_post_tags, source: :tag
+  end
+
+  class BlogPostTagWithCustomTypedPostId < ActiveRecord::Base
+    self.table_name = :sharded_blog_posts_tags
+    query_constraints :blog_id, :id
+
+    attribute :blog_post_id, PlusOneThousandInteger.new
+
+    belongs_to :blog_post,
+      class_name: "HasManyThroughAssociationsTest::BlogPostWithCustomTypedThroughFk",
+      primary_key: [:blog_id, :id],
+      foreign_key: [:blog_id, :blog_post_id]
+    belongs_to :tag,
+      class_name: "HasManyThroughAssociationsTest::TagWithCustomTypedThroughFk",
+      primary_key: [:blog_id, :id],
+      foreign_key: [:blog_id, :tag_id]
+  end
+
+  class TagWithCustomTypedThroughFk < ActiveRecord::Base
+    self.table_name = :sharded_tags
+    query_constraints :blog_id, :id
+  end
+
   # Dummies to force column loads so query counts are clean.
   def setup
     Person.create first_name: "gummy"
@@ -1681,6 +1720,19 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_not_empty(tag_ids)
     assert_equal(expected_tag_ids.sort, tag_ids.sort)
+  end
+
+  def test_has_many_through_association_scope_uses_through_model_type_for_owner_key
+    fixture = sharded_blog_posts(:great_post_blog_one)
+    blog_post = BlogPostWithCustomTypedThroughFk.find_by!(blog_id: fixture.blog_id, id: fixture.id)
+
+    queries = capture_sql_and_binds do
+      blog_post.tags.to_a
+    end
+    association_query = queries.find { |sql, _| sql.include?("sharded_blog_posts_tags") }
+
+    assert_not_nil association_query
+    assert_includes association_query.second, blog_post.id + 1000
   end
 
   def test_tags_has_manu_posts_through_association_with_composite_query_constraints


### PR DESCRIPTION
This matters for custom serialized FK types. In our case it's a UUID-as-integer attribute:

```ruby
class ModelUuidAsInteger < ActiveModel::Type::Value
  def serialize(value)
    return if value.nil?
    value.is_a?(Integer) ? int_to_uuid_string(value) : value
  end
end

class Product < ApplicationRecord
  attribute :some_id, ModelUuidAsInteger.new
end
```

Previously the through-table predicate could compare `some_id` with the raw integer owner id instead of the serialized UUID value.

@matthewd 